### PR TITLE
GitHub Actions macOS workflow for release created

### DIFF
--- a/.github/workflows/build_compiler.yaml
+++ b/.github/workflows/build_compiler.yaml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
 
 jobs:
   rustfmt:

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  release:
+    types: [created, published]
+
+jobs:
+  build_release_macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - run: $HOME/.cargo/bin/cargo build --release
+      - run: target/release/gleam --version
+      - id: create_archive
+        run: |
+          ARCHIVE=gleam-$TAG_NAME-macos.tar.gz
+          tar -czvf $ARCHIVE -C target/release gleam 
+          echo ::set-output name=ASSET::$ARCHIVE
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.create_archive.outputs.ASSET }}
+          asset_name: ${{ steps.create_archive.outputs.ASSET }}
+          asset_content_type: application/gzip


### PR DESCRIPTION
Closes #290 

This workflow runs only when:
- new release is created directly as public
- draft release is published

It would be nice if this workflow runs also after a new release is drafted, so @lpil can download the built release and perhaps test it manualy before publishing.
Unfortunately, GitHub's documentation for the **release** event is probably outdated. I already created a topic about this on community forum [here](https://github.community/t5/GitHub-Actions/Incorrect-documentation-for-release-event/m-p/36361#M2552)

I also changed the `on` rules for `build_compiler.yaml` workflow. Before the change it was running for every push and that included even tags. Now it runs only for new commits. This should help #310 although it doesn't solve it completely.