### PR TITLE
Cache Rust dependnecies in GitHub Actions

### DIFF
--- a/.github/workflows/build_compiler.yaml
+++ b/.github/workflows/build_compiler.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Cache Rust dependencies
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.1
         with:
           path: target
           key: ${{ runner.os }}-rust-target
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Cache Rust dependencies
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.1
         with:
           path: target
           key: ${{ runner.os }}-rust-target
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Cache Rust dependencies
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.1
         with:
           path: target
           key: ${{ runner.os }}-rust-target

--- a/.github/workflows/build_compiler.yaml
+++ b/.github/workflows/build_compiler.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v1.0.1
         with:
           path: target
-          key: ${{ runner.os }}-rust-target
+          key: ${{ runner.OS }}-build-${{ hashFiles('Cargo.lock')
       - run: cargo test
       - run: cargo build --release
       - run: target/release/gleam --version
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v1.0.1
         with:
           path: target
-          key: ${{ runner.os }}-rust-target
+          key: ${{ runner.OS }}-build-${{ hashFiles('Cargo.lock')
       - run: $HOME/.cargo/bin/cargo test
       - run: $HOME/.cargo/bin/cargo build --release
       - run: target/release/gleam --version
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v1.0.1
         with:
           path: target
-          key: ${{ runner.os }}-rust-target
+          key: ${{ runner.OS }}-build-${{ hashFiles('Cargo.lock')
 
       # commented out until tests on Windows are fixed
       # see: https://github.com/gleam-lang/gleam/issues/299

--- a/.github/workflows/build_compiler.yaml
+++ b/.github/workflows/build_compiler.yaml
@@ -54,6 +54,8 @@ jobs:
           path: target
           key: ${{ runner.os }}-rust-target
 
+      # commented out until tests on Windows are fixed
+      # see: https://github.com/gleam-lang/gleam/issues/299
       # - run: cargo test
       - run: cargo build --release
       - run: target/release/gleam --version

--- a/.github/workflows/build_compiler.yaml
+++ b/.github/workflows/build_compiler.yaml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Cache Rust dependencies
+        uses: actions/cache@preview
+        with:
+          path: target
+          key: ${{ runner.os }}-rust-target
       - run: cargo test
       - run: cargo build --release
       - run: target/release/gleam --version
@@ -29,6 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Cache Rust dependencies
+        uses: actions/cache@preview
+        with:
+          path: target
+          key: ${{ runner.os }}-rust-target
       - run: $HOME/.cargo/bin/cargo test
       - run: $HOME/.cargo/bin/cargo build --release
       - run: target/release/gleam --version
@@ -38,6 +48,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Cache Rust dependencies
+        uses: actions/cache@preview
+        with:
+          path: target
+          key: ${{ runner.os }}-rust-target
+
       # - run: cargo test
       - run: cargo build --release
       - run: target/release/gleam --version

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -27,3 +27,32 @@ jobs:
           asset_path: ${{ steps.create_archive.outputs.ASSET }}
           asset_name: ${{ steps.create_archive.outputs.ASSET }}
           asset_content_type: application/gzip
+
+  build_release_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - id: create_archive
+        run: |
+          CONTAINER_NAME=gleam-linux-builder
+          ARCHIVE=gleam-$TAG_NAME-linux-amd64.tar.gz
+          DOCKER_TAG=lpil/gleam:$(echo $TAG_NAME | tail -c +2)
+          docker build . -t $DOCKER_TAG
+          docker run --name $CONTAINER_NAME $DOCKER_TAG --version
+          TMP=$(mktemp -d)
+          cd $TMP
+          docker cp $CONTAINER_NAME:/gleam gleam
+          docker rm $CONTAINER_NAME
+          tar -czvf $ARCHIVE gleam 
+          echo ::set-output name=ASSET_NAME::"$ARCHIVE"
+          echo ::set-output name=ASSET_PATH::"$TMP/$ARCHIVE"
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.create_archive.outputs.ASSET_PATH }}
+          asset_name: ${{ steps.create_archive.outputs.ASSET_NAME }}
+          asset_content_type: application/gzip


### PR DESCRIPTION
Closes #288 

OK, GitHub increased the per-action limit to 400MB ([here](https://github.com/actions/cache/issues/6#issuecomment-550051416)), so our actions are now running with cache.

* [before](https://github.com/EskiMag/gleam/commit/c627de22fc102b4b0fff875c5a9d96deece066af/checks?check_suite_id=297886003) 9m 57s
* [after](https://github.com/EskiMag/gleam/commit/6088bd98ed1ce0143527872a186be5a747c58346/checks?check_suite_id=297898728) 2m 24s

Quite an improvement.

Just one thing I noticed is the _"Cache hit occurred on the primary key Linux-rust-target, not saving cache."_ notice [here](https://github.com/EskiMag/gleam/runs/290480288) in the _Post Cache Rust dependencies_ step.
I am not sure what that really means, but I think we probably need to use the `restore-keys` option as shown [here](https://github.com/actions/cache/blob/master/README.md).
But I don't know what file is used in Rust to something similar as `mix.lock` in Elixir for example.