### PR TITLE
Precompiled windows binary

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -56,3 +56,31 @@ jobs:
           asset_path: ${{ steps.create_archive.outputs.ASSET_PATH }}
           asset_name: ${{ steps.create_archive.outputs.ASSET_NAME }}
           asset_content_type: application/gzip
+
+  build_release_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust stable
+        run: |
+          rustup toolchain update --no-self-update stable
+          rustup default stable
+      - name: Build Gleam
+        run: |
+          cargo build --release
+          target\\release\\gleam --version
+      - id: create_archive
+        run: |
+          $ARCHIVE="gleam-$env:TAG_NAME-windows.zip"
+          Compress-Archive target\\release\\gleam.exe -DestinationPath $ARCHIVE
+          echo "::set-output name=ASSET::$ARCHIVE"
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.create_archive.outputs.ASSET }}
+          asset_name: ${{ steps.create_archive.outputs.ASSET }}
+          asset_content_type: application/gzip

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -71,7 +71,7 @@ jobs:
           target\\release\\gleam --version
       - id: create_archive
         run: |
-          $ARCHIVE="gleam-$env:TAG_NAME-windows.zip"
+          $ARCHIVE="gleam-$env:TAG_NAME-windows-64bit.zip"
           Compress-Archive target\\release\\gleam.exe -DestinationPath $ARCHIVE
           echo "::set-output name=ASSET::$ARCHIVE"
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where import paths would not be correctly resolved on Windows.
+- Added precompiled binary release for Windows for new versions.
 
 ## v0.6.0 - 2019-12-25 🎄
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where import paths would not be correctly resolved on Windows.
-- Added job to create precompiled binary for Windows when releasing.
+- Added job to create precompiled binary for 64-bit Windows when releasing.
 
 ## v0.6.0 - 2019-12-25 🎄
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where import paths would not be correctly resolved on Windows.
-- Added precompiled binary release for Windows for new versions.
+- Added job to create precompiled binary for Windows when releasing.
 
 ## v0.6.0 - 2019-12-25 🎄
 


### PR DESCRIPTION
closes #188 
Adds new job on new releases for creating windows binary.
I tested out with a random release version on my repo [here](https://github.com/thehabbos007/gleam/releases/tag/v0.6.4).
Do we keep the name as -windows.zip or do we specify 64-bit?