### PR TITLE
feat(type system): implement type alias statement

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -108,6 +108,14 @@ pub enum Statement<ValueConstructor, ModuleValueConstructor, PatternConstructor,
         return_annotation: Option<TypeAst>,
     },
 
+    TypeAlias {
+        meta: Meta,
+        alias: String,
+        args: Vec<String>,
+        resolved_type: TypeAst,
+        public: bool,
+    },
+
     CustomType {
         meta: Meta,
         name: String,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -92,6 +92,44 @@ pub enum TypeAst {
     },
 }
 
+impl TypeAst {
+    pub fn get_type_asts(&self) -> TypeAsts {
+        match self {
+            TypeAst::Constructor { args, .. } => TypeAsts {
+                asts: args.to_owned(),
+            },
+            TypeAst::Fn { args, .. } => TypeAsts {
+                asts: args.to_owned(),
+            },
+            TypeAst::Tuple { elems, .. } => TypeAsts {
+                asts: elems.to_owned(),
+            },
+            _ => TypeAsts { asts: vec![] },
+        }
+    }
+
+    pub fn get_type_vars(&self) -> Vec<String> {
+        match self {
+            TypeAst::Var { name, .. } => vec![name.to_owned()],
+            _ => self.get_type_asts().get_type_vars(),
+        }
+    }
+}
+
+pub struct TypeAsts {
+    asts: Vec<TypeAst>,
+}
+
+impl TypeAsts {
+    pub fn get_type_vars(&self) -> Vec<String> {
+        self.asts
+            .iter()
+            .map(|ta| ta.get_type_vars())
+            .collect::<Vec<_>>()
+            .concat()
+    }
+}
+
 pub type TypedStatement =
     Statement<ValueConstructor, ModuleValueConstructor, PatternConstructor, typ::Type>;
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -140,6 +140,7 @@ pub fn module(module: TypedModule) -> String {
 
 fn statement(statement: TypedStatement, module: &Vec<String>) -> Option<Document> {
     match statement {
+        Statement::TypeAlias { .. } => None,
         Statement::CustomType { .. } => None,
         Statement::Import { .. } => None,
         Statement::ExternalType { .. } => None,

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -17,6 +17,7 @@ fn module_test() {
             name: vec!["magic".to_string()],
             types: HashMap::new(),
             values: HashMap::new(),
+            type_aliases: HashMap::new(),
         },
         name: vec!["magic".to_string()],
         statements: vec![
@@ -111,6 +112,7 @@ map() ->
             name: vec!["term".to_string()],
             types: HashMap::new(),
             values: HashMap::new(),
+            type_aliases: HashMap::new(),
         },
         name: vec!["term".to_string()],
         statements: vec![
@@ -389,6 +391,7 @@ tup() ->
             name: vec!["term".to_string()],
             types: HashMap::new(),
             values: HashMap::new(),
+            type_aliases: HashMap::new(),
         },
         name: vec!["term".to_string()],
         statements: vec![Statement::Fn {
@@ -484,6 +487,7 @@ some_function(
             name: vec!["ok".to_string()],
             types: HashMap::new(),
             values: HashMap::new(),
+            type_aliases: HashMap::new(),
         },
         name: vec!["vars".to_string()],
         statements: vec![
@@ -593,6 +597,7 @@ moddy4() ->
             name: vec!["my_mod".to_string()],
             types: HashMap::new(),
             values: HashMap::new(),
+            type_aliases: HashMap::new(),
         },
         name: vec!["my_mod".to_string()],
         statements: vec![Statement::Fn {
@@ -738,6 +743,7 @@ go() ->
             name: vec!["funny".to_string()],
             types: HashMap::new(),
             values: HashMap::new(),
+            type_aliases: HashMap::new(),
         },
         name: vec!["funny".to_string()],
         statements: vec![

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -25,10 +25,21 @@ pub Module: UntypedModule = {
 
 Statement: UntypedStatement = {
     StatementFn => <>,
+    StatementTypeAlias => <>,
     StatementCustomType => <>,
     StatementExternalFn => <>,
     StatementExternalType => <>,
     StatementImport => <>,
+}
+
+StatementTypeAlias : UntypedStatement = {
+    <s:@L> <p:"pub"?> "type" <ta:TypeName> "=" <tr:Type> <e:@L> => Statement::TypeAlias {
+        meta: meta(s, e),
+        public: p.is_some(),
+        alias: ta.0,
+        args: ta.1,
+        resolved_type: tr,
+    }
 }
 
 StatementCustomType: UntypedStatement = {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1567,4 +1567,101 @@ fn module_test() {
         }),
         ModuleParser::new().parse("import one/two/three as something"),
     );
+
+    assert_eq!(
+        Ok(Module {
+            type_info: (),
+            name: vec![],
+            statements: vec![Statement::TypeAlias {
+                meta: Meta { start: 0, end: 27 },
+                public: false,
+                alias: "IntMap".to_string(),
+                args: vec![],
+                resolved_type: TypeAst::Constructor {
+                    meta: Meta { start: 14, end: 27 },
+                    module: None,
+                    name: "Map".to_string(),
+                    args: vec![
+                        TypeAst::Constructor {
+                            meta: Meta { start: 18, end: 21 },
+                            module: None,
+                            name: "Int".to_string(),
+                            args: vec![],
+                        },
+                        TypeAst::Constructor {
+                            meta: Meta { start: 23, end: 26 },
+                            module: None,
+                            name: "Int".to_string(),
+                            args: vec![],
+                        },
+                    ]
+                }
+            }]
+        }),
+        ModuleParser::new().parse("type IntMap = Map(Int, Int)"),
+    );
+
+    assert_eq!(
+        Ok(Module {
+            type_info: (),
+            name: vec![],
+            statements: vec![Statement::TypeAlias {
+                meta: Meta { start: 0, end: 31 },
+                public: true,
+                alias: "IntMap".to_string(),
+                args: vec![],
+                resolved_type: TypeAst::Constructor {
+                    meta: Meta { start: 18, end: 31 },
+                    module: None,
+                    name: "Map".to_string(),
+                    args: vec![
+                        TypeAst::Constructor {
+                            meta: Meta { start: 22, end: 25 },
+                            module: None,
+                            name: "Int".to_string(),
+                            args: vec![],
+                        },
+                        TypeAst::Constructor {
+                            meta: Meta { start: 27, end: 30 },
+                            module: None,
+                            name: "Int".to_string(),
+                            args: vec![],
+                        },
+                    ]
+                }
+            }]
+        }),
+        ModuleParser::new().parse("pub type IntMap = Map(Int, Int)"),
+    );
+
+    assert_eq!(
+        Ok(Module {
+            type_info: (),
+            name: vec![],
+            statements: vec![Statement::TypeAlias {
+                meta: Meta { start: 0, end: 38 },
+                public: true,
+                alias: "Option".to_string(),
+                args: vec!["a".to_string()],
+                resolved_type: TypeAst::Constructor {
+                    meta: Meta { start: 21, end: 38 },
+                    module: None,
+                    name: "Result".to_string(),
+                    args: vec![
+                        TypeAst::Var {
+                            meta: Meta { start: 28, end: 29 },
+                            name: "a".to_string(),
+                        },
+                        TypeAst::Constructor {
+                            meta: Meta { start: 31, end: 37 },
+                            module: None,
+                            name: "String".to_string(),
+                            args: vec![],
+                        },
+                    ]
+                }
+            }]
+        }),
+        ModuleParser::new().parse("pub type Option(a) = Result(a, String)"),
+    );
 }

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -932,6 +932,12 @@ fn infer_module_test() {
          pub fn ok_one() -> IntString { Ok(1) }",
         vec![("ok_one", "fn() -> Result(Int, String)")]
     );
+
+    assert_infer!(
+        "type Option(a) = Result(a, String)
+         pub fn ok_one() -> Option(Int) { Ok(1) }",
+        vec![("ok_one", "fn() -> Result(Int, String)")]
+    );
 }
 
 #[test]

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -178,6 +178,7 @@ fn infer_module_type_retention_test() {
             name: vec!["ok".to_string()],
             types: HashMap::new(), // Core type constructors like String and Int are not included
             values: HashMap::new(),
+            type_aliases: HashMap::new(),
         }
     );
 }
@@ -925,6 +926,12 @@ fn infer_module_test() {
         "pub type I { I(Num) } pub external type Num",
         vec![("I", "fn(Num) -> I")]
     );
+
+    assert_infer!(
+        "type IntString = Result(Int, String)
+         pub fn ok_one() -> IntString { Ok(1) }",
+        vec![("ok_one", "fn() -> Result(Int, String)")]
+    );
 }
 
 #[test]
@@ -1172,4 +1179,13 @@ pub fn x() { id(1, 1.0) }
     // Cases were we can't so easily check for equality-
     // i.e. because the contents of the error are non-deterministic.
     assert_error!("fn inc(x: a) { x + 1 }");
+
+    assert_error!(
+        "type IntMap = IllMap(Int, Int)",
+        Error::UnknownType {
+            meta: Meta { start: 14, end: 30 },
+            name: "IllMap".to_string(),
+            types: { Env::new(&HashMap::new()).module_types },
+        }
+    );
 }


### PR DESCRIPTION
right now, we can use `type IntMap = Map(Int, Int)` semantic in gleam :)

fix #71