### PR TITLE
GreaterThan guard clause for Integers

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -304,6 +304,13 @@ pub enum ClauseGuard<Type> {
         right: Box<Self>,
     },
 
+    GreaterThan {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>
+    },
+
     Or {
         location: SrcSpan,
         typ: Type,
@@ -333,6 +340,7 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::Var { location, .. } => location,
             ClauseGuard::Equals { location, .. } => location,
             ClauseGuard::NotEquals { location, .. } => location,
+            ClauseGuard::GreaterThan { location, ..} => location
         }
     }
 }
@@ -345,6 +353,7 @@ impl TypedClauseGuard {
             ClauseGuard::Var { typ, .. } => typ.clone(),
             ClauseGuard::Equals { typ, .. } => typ.clone(),
             ClauseGuard::NotEquals { typ, .. } => typ.clone(),
+            ClauseGuard::GreaterThan { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -304,7 +304,7 @@ pub enum ClauseGuard<Type> {
         right: Box<Self>,
     },
 
-    GreaterThan {
+    GtInt {
         location: SrcSpan,
         typ: Type,
         left: Box<Self>,
@@ -340,7 +340,7 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::Var { location, .. } => location,
             ClauseGuard::Equals { location, .. } => location,
             ClauseGuard::NotEquals { location, .. } => location,
-            ClauseGuard::GreaterThan { location, ..} => location
+            ClauseGuard::GtInt { location, .. } => location,
         }
     }
 }
@@ -353,7 +353,7 @@ impl TypedClauseGuard {
             ClauseGuard::Var { typ, .. } => typ.clone(),
             ClauseGuard::Equals { typ, .. } => typ.clone(),
             ClauseGuard::NotEquals { typ, .. } => typ.clone(),
-            ClauseGuard::GreaterThan { typ, .. } => typ.clone(),
+            ClauseGuard::GtInt { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -308,7 +308,7 @@ pub enum ClauseGuard<Type> {
         location: SrcSpan,
         typ: Type,
         left: Box<Self>,
-        right: Box<Self>
+        right: Box<Self>,
     },
 
     Or {

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -502,6 +502,10 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(" =/= ")
             .append(clause_guard(right.as_ref(), env)),
 
+        ClauseGuard::GreaterThan { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" > ")
+            .append(clause_guard(right.as_ref(), env)),
+
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
         ClauseGuard::Var { name, .. } => env.local_var_name(name.to_string()),
@@ -514,7 +518,8 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
         ClauseGuard::Or { .. }
         | ClauseGuard::And { .. }
         | ClauseGuard::Equals { .. }
-        | ClauseGuard::NotEquals { .. } => "("
+        | ClauseGuard::NotEquals { .. }
+        | ClauseGuard::GreaterThan { .. } => "("
             .to_doc()
             .append(bare_clause_guard(guard, env))
             .append(")"),

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -502,7 +502,7 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(" =/= ")
             .append(clause_guard(right.as_ref(), env)),
 
-        ClauseGuard::GreaterThan { left, right, .. } => clause_guard(left.as_ref(), env)
+        ClauseGuard::GtInt { left, right, .. } => clause_guard(left.as_ref(), env)
             .append(" > ")
             .append(clause_guard(right.as_ref(), env)),
 
@@ -519,7 +519,7 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
         | ClauseGuard::And { .. }
         | ClauseGuard::Equals { .. }
         | ClauseGuard::NotEquals { .. }
-        | ClauseGuard::GreaterThan { .. } => "("
+        | ClauseGuard::GtInt { .. } => "("
             .to_doc()
             .append(bare_clause_guard(guard, env))
             .append(")"),

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1498,6 +1498,31 @@ main(Args) ->
 
     assert_erl!(
         r#"
+pub fn main() {
+  case 1, 0 {
+    x, y if x > y -> 1
+    _, _ -> 0  
+  }
+} 
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {1, 0} of
+        {X, Y} when X > Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
 pub fn main(args) {
   case args {
     [x] | [x, _] if x -> 1

--- a/src/format.rs
+++ b/src/format.rs
@@ -485,7 +485,7 @@ impl Documentable for &UntypedClauseGuard {
                 left.as_ref().to_doc().append(" != ").append(right.as_ref())
             }
 
-            ClauseGuard::GreaterThan { left, right, .. } => {
+            ClauseGuard::GtInt { left, right, .. } => {
                 left.as_ref().to_doc().append(" > ").append(right.as_ref())
             }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -485,6 +485,10 @@ impl Documentable for &UntypedClauseGuard {
                 left.as_ref().to_doc().append(" != ").append(right.as_ref())
             }
 
+            ClauseGuard::GreaterThan { left, right, .. } => {
+                left.as_ref().to_doc().append(" > ").append(right.as_ref())
+            }
+
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }
     }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -300,7 +300,7 @@ ClauseGuard3: UntypedClauseGuard = {
 }
 
 ClauseGuard4: UntypedClauseGuard = {
-    <s:@L> <left:ClauseGuard4> ">" <right:ClauseGuard5> <e:@L> => ClauseGuard::GreaterThan {
+    <s:@L> <left:ClauseGuard4> ">" <right:ClauseGuard5> <e:@L> => ClauseGuard::GtInt {
         location: location(s, e),
         typ: (),
         left: Box::new(left),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -300,6 +300,17 @@ ClauseGuard3: UntypedClauseGuard = {
 }
 
 ClauseGuard4: UntypedClauseGuard = {
+    <s:@L> <left:ClauseGuard4> ">" <right:ClauseGuard5> <e:@L> => ClauseGuard::GreaterThan {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    ClauseGuard5 => <>,
+}
+
+ClauseGuard5: UntypedClauseGuard = {
     <s:@L> <name:VarName> <e:@L> => ClauseGuard::Var {
         location: location(s, e),
         typ: (),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2396,6 +2396,26 @@ fn infer_clause_guard(
                 right: Box::new(right),
             })
         }
+        
+        ClauseGuard::GreaterThan {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(int(), left.typ(), env)
+                .map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(int(), right.typ(), env)
+                .map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::GreaterThan {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
     }
 }
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2397,7 +2397,7 @@ fn infer_clause_guard(
             })
         }
         
-        ClauseGuard::GreaterThan {
+        ClauseGuard::GtInt {
             location,
             left,
             right,
@@ -2409,7 +2409,7 @@ fn infer_clause_guard(
             let right = infer_clause_guard(*right, level, env)?;
             unify(int(), right.typ(), env)
                 .map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::GreaterThan {
+            Ok(ClauseGuard::GtInt {
                 location,
                 typ: bool(),
                 left: Box::new(left),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2396,7 +2396,7 @@ fn infer_clause_guard(
                 right: Box::new(right),
             })
         }
-        
+
         ClauseGuard::GtInt {
             location,
             left,
@@ -2404,11 +2404,9 @@ fn infer_clause_guard(
             ..
         } => {
             let left = infer_clause_guard(*left, level, env)?;
-            unify(int(), left.typ(), env)
-                .map_err(|e| convert_unify_error(e, left.location()))?;
+            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
             let right = infer_clause_guard(*right, level, env)?;
-            unify(int(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
+            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::GtInt {
                 location,
                 typ: bool(),

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -659,6 +659,24 @@ fn infer_error_test() {
             given: float(),
         },
     );
+    
+    assert_error!(
+        "case [3.33], 1 { x, y if x > y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 25, end: 26 },
+            expected: int(),
+            given: list(float()) 
+        }
+    );
+
+    assert_error!(
+        "case 1, 2.22, \"three\" { x, _, y if x > y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 39, end: 40 },
+            expected: int(),
+            given: string()
+        }
+    );
 
     assert_error!(
         "case [1] { [x] | x -> 1 }",

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -659,13 +659,13 @@ fn infer_error_test() {
             given: float(),
         },
     );
-    
+
     assert_error!(
         "case [3.33], 1 { x, y if x > y -> 1 }",
         Error::CouldNotUnify {
             location: SrcSpan { start: 25, end: 26 },
             expected: int(),
-            given: list(float()) 
+            given: list(float())
         }
     );
 


### PR DESCRIPTION
This pull request is meant to solve Issue #455 meant to add greater than guard clauses for integer types:

```gleam
case 1, 0 {
  x, y if x > y -> True
  _, _ -> False
}
```

Adding the new operator was a very mechanical process :) thanks a lot for the thorough explanation.