### PR TITLE
Representing strings as utf8 binaries in erlang and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Strings are now encoded as utf8 binaries in erlang.
 - HTML documentation can now be generated from Gleam code by running `gleam
   build --doc`.
 - Gleam code can be formatted the `gleam format` command.

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -224,7 +224,7 @@ fn atom(value: String) -> Document {
 }
 
 fn string(value: &str) -> Document {
-    value.to_doc().surround("<<\"", "\">>")
+    value.to_doc().surround("<<\"", "\"/utf8>>")
 }
 
 fn tuple(elems: impl Iterator<Item = Document>) -> Document {

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -388,7 +388,7 @@ nil() ->
     [].
 
 string() ->
-    <<\"Hello there!\">>.
+    <<\"Hello there!\"/utf8>>.
 
 seq() ->
     1,
@@ -783,7 +783,7 @@ go() ->
         1.0 ->
             1;
 
-        <<\"hello\">> ->
+        <<\"hello\"/utf8>> ->
             1;
 
         [] ->
@@ -1249,7 +1249,7 @@ fn create_user(user_id) { User(age: 22, id: user_id, name: "") }
 -compile(no_auto_import).
 
 create_user(UserId) ->
-    {user, UserId, <<"">>, 22}.
+    {user, UserId, <<""/utf8>>, 22}.
 "#,
     );
 

--- a/test/core_language/.gitignore
+++ b/test/core_language/.gitignore
@@ -1,0 +1,2 @@
+_build
+gen/

--- a/test/core_language/README.md
+++ b/test/core_language/README.md
@@ -1,0 +1,15 @@
+# Gleam Core Language Tests
+
+This is a collection of basic tests and sanity checks of the core language written in gleam.
+
+# Running
+
+From this directory run `rebar3 eunit`.
+
+This will first build gleam from source, then compile the gleam modules in this project
+and then run the tests. You must have `rust`, `rebar3`, and `erlang` installed.
+
+# Adding Tests
+
+Any function ending in `_test` in a module in the `test` directory will get run as a test by
+eunit.

--- a/test/core_language/gleam.toml
+++ b/test/core_language/gleam.toml
@@ -1,0 +1,2 @@
+name = "core_language_tests"
+

--- a/test/core_language/rebar.config
+++ b/test/core_language/rebar.config
@@ -1,0 +1,12 @@
+{erl_opts, [debug_info, warnings_as_errors]}.
+{src_dirs, ["src", "gen/src"]}.
+
+{profiles, [
+    {test, [
+        {pre_hooks, [{compile, "cargo run -- build ."}]},
+        {src_dirs, ["src", "test", "gen/src", "gen/test"]}
+    ]}
+]}.
+
+{deps, []}.
+

--- a/test/core_language/src/core_language_tests.app.src
+++ b/test/core_language/src/core_language_tests.app.src
@@ -1,0 +1,11 @@
+{application,core_language_tests,
+             [{description,"Core language tests for the Gleam programming language"},
+              {vsn,"0.7.0"},
+              {registered,[]},
+              {applications,[kernel,stdlib]},
+              {env,[]},
+              {modules,[]},
+              {licenses,["Apache 2.0"]},
+              {links,[]},
+              {include_files, ["gleam.toml", "gen"]}]}.
+

--- a/test/core_language/test/gleam_should.erl
+++ b/test/core_language/test/gleam_should.erl
@@ -1,0 +1,8 @@
+-module(gleam_should).
+-include_lib("eunit/include/eunit.hrl").
+
+-export([should_equal/2, should_not_equal/2]).
+
+should_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
+should_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
+

--- a/test/core_language/test/should.gleam
+++ b/test/core_language/test/should.gleam
@@ -1,0 +1,5 @@
+pub external type Expectation;
+
+pub external fn equal(a, a) -> Expectation = "gleam_should" "should_equal";
+
+pub external fn not_equal(a, a) -> Expectation = "gleam_should" "should_not_equal";

--- a/test/core_language/test/should_test.gleam
+++ b/test/core_language/test/should_test.gleam
@@ -1,0 +1,12 @@
+import should
+
+pub fn equal_test() {
+    should.equal(1, 1)
+    should.equal(True, True)
+}
+
+pub fn not_equal_test() {
+    should.not_equal(1, 2)
+    should.not_equal(True, False)
+}
+

--- a/test/core_language/test/unicode_test.gleam
+++ b/test/core_language/test/unicode_test.gleam
@@ -1,0 +1,17 @@
+import should
+
+external fn to_graphemes(String) -> List(List(Int))
+ = "string" "to_graphemes"
+
+pub fn unicode_overflow_test() {
+    // In erlang, literally creating binaries can cause entries to overflow.
+    // For example `<<"🌵">> == <<"5">>` evaluates to true.
+    // This checks that we are not doing that.
+    // See: https://github.com/gleam-lang/gleam/issues/457
+    "🌵"
+    |> should.not_equal(_, "5")
+
+    "🤷‍♂️"
+    |> to_graphemes
+    |> should.equal(_, [[129335,8205,9794,65039]])
+}


### PR DESCRIPTION
This addresses the issue in #457 where high number Unicode strings can't be literally input correctly.

This chooses to represent them as utf8 strings in erlang by compiling the gleam `"🌵"` into the erlang `<<"🌵"/utf8>>`.

The current behavior of compiling to `<<"🌵">>` will actually overflow to `<<"5">>` making it impossible to correctly represent "🌵" in gleam.

With this we should be able to correctly literally input arbitrary unicode strings.

This also adds a `core_language` test suite written in gleam that you can run by:
  - `cd test/core_language`
  - `rebar3 eunit`

fixes #457 

Sorry if this is too much! Lemme know what works for y'all!