### PR TITLE
Don't treat source chars as single byte

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "strum_macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ strum_macros = "0.17"
 askama = "0.8"
 # Markdown in docs
 pulldown-cmark = "0.7.0"
+# Support unicode in gleam source
+unicode-segmentation = "1.6.0"
 
 [build-dependencies]
 lalrpop = "0.17"


### PR DESCRIPTION
`str.chars().enumerate()` ( https://github.com/gleam-lang/gleam/blob/master/src/parser.rs#L55 ) will enumerate over the count of chars, not their byte position. This means that if the count is ever used as a byte index in the original source (https://github.com/gleam-lang/gleam/blob/master/src/parser.rs#L125 ) not only could the position be incorrect, but it might index directly into a multibyte char causing Rust to panic. I have written a test in `test/core_language/test/unicode_test.gleam` that demonstrates this on an unchanged compiler. The panic output looks like:
```
thread 'main' panicked at 'byte index 2410 is not a char boundary; it is inside 'ð§' (bytes 2408..2412) of 

...source file

src/libcore/str/mod.rs:2154:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The three options here are:
 1. Only support ASCII in source
 1. use `char_indices()` which gives you the char and its byte offset
 1. use something like https://crates.io/crates/unicode-segmentation and treat source as a stream of grapheme clusters

To which my thoughts are:
  1. Not a good idea as then literal strings would also be limited to ascii
  1. Probably a fine solution if syntax is always going to be ascii
  1. Perhaps the most robust, possibly slower, would allow for non ascii syntax

I ran into this panic while adding string functions to the standard library after the recent support of erlang `<<""/utf8>>` binaries.

Happy to remove / change the test or add more info if needed!