### PR TITLE
Add >. guard clause for floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - There is a `todo` keyword for type checking functions that have not yet been
   implemented.
 - Tuples can be indexed into using the `var.1` syntax.
+- `>.`, `>=.`, `<.`, and `<=.` operators are now supported in case clause guards
+  and can be used to check the ordering of floats.
 
 ## v0.7.1 - 2020-03-03
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -318,6 +318,27 @@ pub enum ClauseGuard<Type> {
         right: Box<Self>,
     },
 
+    GtEqFloat {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    LtFloat {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    LtEqFloat {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
     Or {
         location: SrcSpan,
         typ: Type,
@@ -349,6 +370,9 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::NotEquals { location, .. } => location,
             ClauseGuard::GtInt { location, .. } => location,
             ClauseGuard::GtFloat { location, .. } => location,
+            ClauseGuard::GtEqFloat { location, .. } => location,
+            ClauseGuard::LtFloat { location, .. } => location,
+            ClauseGuard::LtEqFloat { location, .. } => location,
         }
     }
 }
@@ -363,6 +387,9 @@ impl TypedClauseGuard {
             ClauseGuard::NotEquals { typ, .. } => typ.clone(),
             ClauseGuard::GtInt { typ, .. } => typ.clone(),
             ClauseGuard::GtFloat { typ, .. } => typ.clone(),
+            ClauseGuard::GtEqFloat { typ, .. } => typ.clone(),
+            ClauseGuard::LtFloat { typ, .. } => typ.clone(),
+            ClauseGuard::LtEqFloat { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -311,6 +311,13 @@ pub enum ClauseGuard<Type> {
         right: Box<Self>,
     },
 
+    GtFloat {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
     Or {
         location: SrcSpan,
         typ: Type,
@@ -341,6 +348,7 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::Equals { location, .. } => location,
             ClauseGuard::NotEquals { location, .. } => location,
             ClauseGuard::GtInt { location, .. } => location,
+            ClauseGuard::GtFloat { location, .. } => location,
         }
     }
 }
@@ -354,6 +362,7 @@ impl TypedClauseGuard {
             ClauseGuard::Equals { typ, .. } => typ.clone(),
             ClauseGuard::NotEquals { typ, .. } => typ.clone(),
             ClauseGuard::GtInt { typ, .. } => typ.clone(),
+            ClauseGuard::GtFloat { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -510,6 +510,18 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(" >. ")
             .append(clause_guard(right.as_ref(), env)),
 
+        ClauseGuard::GtEqFloat { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" >=. ")
+            .append(clause_guard(right.as_ref(), env)),
+
+        ClauseGuard::LtFloat { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" <. ")
+            .append(clause_guard(right.as_ref(), env)),
+
+        ClauseGuard::LtEqFloat { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" <=. ")
+            .append(clause_guard(right.as_ref(), env)),
+
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
         ClauseGuard::Var { name, .. } => env.local_var_name(name.to_string()),
@@ -524,7 +536,10 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
         | ClauseGuard::Equals { .. }
         | ClauseGuard::NotEquals { .. }
         | ClauseGuard::GtInt { .. }
-        | ClauseGuard::GtFloat { .. } => "("
+        | ClauseGuard::GtFloat { .. }
+        | ClauseGuard::GtEqFloat { .. }
+        | ClauseGuard::LtFloat { .. }
+        | ClauseGuard::LtEqFloat { .. } => "("
             .to_doc()
             .append(bare_clause_guard(guard, env))
             .append(")"),

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -506,6 +506,10 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(" > ")
             .append(clause_guard(right.as_ref(), env)),
 
+        ClauseGuard::GtFloat { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" >. ")
+            .append(clause_guard(right.as_ref(), env)),
+
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
         ClauseGuard::Var { name, .. } => env.local_var_name(name.to_string()),
@@ -519,7 +523,8 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
         | ClauseGuard::And { .. }
         | ClauseGuard::Equals { .. }
         | ClauseGuard::NotEquals { .. }
-        | ClauseGuard::GtInt { .. } => "("
+        | ClauseGuard::GtInt { .. }
+        | ClauseGuard::GtFloat { .. } => "("
             .to_doc()
             .append(bare_clause_guard(guard, env))
             .append(")"),

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -507,19 +507,19 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(clause_guard(right.as_ref(), env)),
 
         ClauseGuard::GtFloat { left, right, .. } => clause_guard(left.as_ref(), env)
-            .append(" >. ")
+            .append(" > ")
             .append(clause_guard(right.as_ref(), env)),
 
         ClauseGuard::GtEqFloat { left, right, .. } => clause_guard(left.as_ref(), env)
-            .append(" >=. ")
+            .append(" >= ")
             .append(clause_guard(right.as_ref(), env)),
 
         ClauseGuard::LtFloat { left, right, .. } => clause_guard(left.as_ref(), env)
-            .append(" <. ")
+            .append(" < ")
             .append(clause_guard(right.as_ref(), env)),
 
         ClauseGuard::LtEqFloat { left, right, .. } => clause_guard(left.as_ref(), env)
-            .append(" <=. ")
+            .append(" =< ")
             .append(clause_guard(right.as_ref(), env)),
 
         // Only local variables are supported and the typer ensures that all

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1501,9 +1501,9 @@ main(Args) ->
 pub fn main() {
   case 1, 0 {
     x, y if x > y -> 1
-    _, _ -> 0  
+    _, _ -> 0
   }
-} 
+}
 "#,
         r#"-module(the_app).
 -compile(no_auto_import).
@@ -1513,6 +1513,31 @@ pub fn main() {
 main() ->
     case {1, 0} of
         {X, Y} when X > Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  case 1.0, 0.1 {
+    x, y if x >. y -> 1
+    _, _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {1.0, 0.1} of
+        {X, Y} when X >. Y ->
             1;
 
         {_, _} ->

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1548,6 +1548,81 @@ main() ->
 
     assert_erl!(
         r#"
+pub fn main() {
+  case 1.0, 0.1 {
+    x, y if x >=. y -> 1
+    _, _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {1.0, 0.1} of
+        {X, Y} when X >=. Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  case 0.1, 1.0 {
+    x, y if x <. y -> 1
+    _, _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {0.1, 1.0} of
+        {X, Y} when X <. Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  case 0.1, 1.0 {
+    x, y if x <=. y -> 1
+    _, _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {0.1, 1.0} of
+        {X, Y} when X <=. Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
 pub fn main(args) {
   case args {
     [x] | [x, _] if x -> 1

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1537,7 +1537,7 @@ pub fn main() {
 
 main() ->
     case {1.0, 0.1} of
-        {X, Y} when X >. Y ->
+        {X, Y} when X > Y ->
             1;
 
         {_, _} ->
@@ -1562,7 +1562,7 @@ pub fn main() {
 
 main() ->
     case {1.0, 0.1} of
-        {X, Y} when X >=. Y ->
+        {X, Y} when X >= Y ->
             1;
 
         {_, _} ->
@@ -1587,7 +1587,7 @@ pub fn main() {
 
 main() ->
     case {0.1, 1.0} of
-        {X, Y} when X <. Y ->
+        {X, Y} when X < Y ->
             1;
 
         {_, _} ->
@@ -1612,7 +1612,7 @@ pub fn main() {
 
 main() ->
     case {0.1, 1.0} of
-        {X, Y} when X <=. Y ->
+        {X, Y} when X =< Y ->
             1;
 
         {_, _} ->

--- a/src/format.rs
+++ b/src/format.rs
@@ -525,7 +525,7 @@ impl Documentable for &UntypedClauseGuard {
             }
 
             ClauseGuard::GtFloat { left, right, .. } => {
-                left.as_ref().to_doc().append(" >. ").append(right.as_ref())
+                left.as_ref().to_doc().append(" > ").append(right.as_ref())
             }
 
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),

--- a/src/format.rs
+++ b/src/format.rs
@@ -524,6 +524,10 @@ impl Documentable for &UntypedClauseGuard {
                 left.as_ref().to_doc().append(" > ").append(right.as_ref())
             }
 
+            ClauseGuard::GtFloat { left, right, .. } => {
+                left.as_ref().to_doc().append(" >. ").append(right.as_ref())
+            }
+
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -525,19 +525,19 @@ impl Documentable for &UntypedClauseGuard {
             }
 
             ClauseGuard::GtFloat { left, right, .. } => {
-                left.as_ref().to_doc().append(" > ").append(right.as_ref())
+                left.as_ref().to_doc().append(" >. ").append(right.as_ref())
             }
 
             ClauseGuard::GtEqFloat { left, right, .. } => {
-                left.as_ref().to_doc().append(" >= ").append(right.as_ref())
+                left.as_ref().to_doc().append(" >=. ").append(right.as_ref())
             }
 
             ClauseGuard::LtFloat { left, right, .. } => {
-                left.as_ref().to_doc().append(" < ").append(right.as_ref())
+                left.as_ref().to_doc().append(" <. ").append(right.as_ref())
             }
 
             ClauseGuard::LtEqFloat { left, right, .. } => {
-                left.as_ref().to_doc().append(" =< ").append(right.as_ref())
+                left.as_ref().to_doc().append(" <=. ").append(right.as_ref())
             }
 
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),

--- a/src/format.rs
+++ b/src/format.rs
@@ -528,6 +528,18 @@ impl Documentable for &UntypedClauseGuard {
                 left.as_ref().to_doc().append(" > ").append(right.as_ref())
             }
 
+            ClauseGuard::GtEqFloat { left, right, .. } => {
+                left.as_ref().to_doc().append(" >= ").append(right.as_ref())
+            }
+
+            ClauseGuard::LtFloat { left, right, .. } => {
+                left.as_ref().to_doc().append(" < ").append(right.as_ref())
+            }
+
+            ClauseGuard::LtEqFloat { left, right, .. } => {
+                left.as_ref().to_doc().append(" =< ").append(right.as_ref())
+            }
+
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -528,17 +528,21 @@ impl Documentable for &UntypedClauseGuard {
                 left.as_ref().to_doc().append(" >. ").append(right.as_ref())
             }
 
-            ClauseGuard::GtEqFloat { left, right, .. } => {
-                left.as_ref().to_doc().append(" >=. ").append(right.as_ref())
-            }
+            ClauseGuard::GtEqFloat { left, right, .. } => left
+                .as_ref()
+                .to_doc()
+                .append(" >=. ")
+                .append(right.as_ref()),
 
             ClauseGuard::LtFloat { left, right, .. } => {
                 left.as_ref().to_doc().append(" <. ").append(right.as_ref())
             }
 
-            ClauseGuard::LtEqFloat { left, right, .. } => {
-                left.as_ref().to_doc().append(" <=. ").append(right.as_ref())
-            }
+            ClauseGuard::LtEqFloat { left, right, .. } => left
+                .as_ref()
+                .to_doc()
+                .append(" <=. ")
+                .append(right.as_ref()),
 
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -311,6 +311,17 @@ ClauseGuard4: UntypedClauseGuard = {
 }
 
 ClauseGuard5: UntypedClauseGuard = {
+    <s:@L> <left:ClauseGuard5> ">." <right:ClauseGuard6> <e:@L> => ClauseGuard::GtFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    ClauseGuard6 => <>,
+}
+
+ClauseGuard6: UntypedClauseGuard = {
     <s:@L> <name:VarName> <e:@L> => ClauseGuard::Var {
         location: location(s, e),
         typ: (),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -322,6 +322,39 @@ ClauseGuard5: UntypedClauseGuard = {
 }
 
 ClauseGuard6: UntypedClauseGuard = {
+    <s:@L> <left:ClauseGuard6> ">=." <right:ClauseGuard7> <e:@L> => ClauseGuard::GtEqFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    ClauseGuard7 => <>,
+}
+
+ClauseGuard7: UntypedClauseGuard = {
+    <s:@L> <left:ClauseGuard7> "<." <right:ClauseGuard8> <e:@L> => ClauseGuard::LtFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    ClauseGuard8 => <>,
+}
+
+ClauseGuard8: UntypedClauseGuard = {
+    <s:@L> <left:ClauseGuard8> "<=." <right:ClauseGuard9> <e:@L> => ClauseGuard::LtEqFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    ClauseGuard9 => <>,
+}
+
+ClauseGuard9: UntypedClauseGuard = {
     <s:@L> <name:VarName> <e:@L> => ClauseGuard::Var {
         location: location(s, e),
         typ: (),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -307,54 +307,38 @@ ClauseGuard4: UntypedClauseGuard = {
         right: Box::new(right),
     },
 
+    <s:@L> <left:ClauseGuard4> ">." <right:ClauseGuard5> <e:@L> => ClauseGuard::GtFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    <s:@L> <left:ClauseGuard4> ">=." <right:ClauseGuard5> <e:@L> => ClauseGuard::GtEqFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    <s:@L> <left:ClauseGuard4> "<." <right:ClauseGuard5> <e:@L> => ClauseGuard::LtFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
+    <s:@L> <left:ClauseGuard4> "<=." <right:ClauseGuard5> <e:@L> => ClauseGuard::LtEqFloat {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+
     ClauseGuard5 => <>,
 }
 
 ClauseGuard5: UntypedClauseGuard = {
-    <s:@L> <left:ClauseGuard5> ">." <right:ClauseGuard6> <e:@L> => ClauseGuard::GtFloat {
-        location: location(s, e),
-        typ: (),
-        left: Box::new(left),
-        right: Box::new(right),
-    },
-
-    ClauseGuard6 => <>,
-}
-
-ClauseGuard6: UntypedClauseGuard = {
-    <s:@L> <left:ClauseGuard6> ">=." <right:ClauseGuard7> <e:@L> => ClauseGuard::GtEqFloat {
-        location: location(s, e),
-        typ: (),
-        left: Box::new(left),
-        right: Box::new(right),
-    },
-
-    ClauseGuard7 => <>,
-}
-
-ClauseGuard7: UntypedClauseGuard = {
-    <s:@L> <left:ClauseGuard7> "<." <right:ClauseGuard8> <e:@L> => ClauseGuard::LtFloat {
-        location: location(s, e),
-        typ: (),
-        left: Box::new(left),
-        right: Box::new(right),
-    },
-
-    ClauseGuard8 => <>,
-}
-
-ClauseGuard8: UntypedClauseGuard = {
-    <s:@L> <left:ClauseGuard8> "<=." <right:ClauseGuard9> <e:@L> => ClauseGuard::LtEqFloat {
-        location: location(s, e),
-        typ: (),
-        left: Box::new(left),
-        right: Box::new(right),
-    },
-
-    ClauseGuard9 => <>,
-}
-
-ClauseGuard9: UntypedClauseGuard = {
     <s:@L> <name:VarName> <e:@L> => ClauseGuard::Var {
         location: location(s, e),
         typ: (),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2414,6 +2414,25 @@ fn infer_clause_guard(
                 right: Box::new(right),
             })
         }
+
+        ClauseGuard::GtFloat {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(float(), right.typ(), env)
+                .map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::GtFloat {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
     }
 }
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2433,6 +2433,63 @@ fn infer_clause_guard(
                 right: Box::new(right),
             })
         }
+
+        ClauseGuard::GtEqFloat {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(float(), right.typ(), env)
+                .map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::GtEqFloat {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
+
+        ClauseGuard::LtFloat {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(float(), right.typ(), env)
+                .map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::LtFloat {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
+
+        ClauseGuard::LtEqFloat {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(float(), right.typ(), env)
+                .map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::LtEqFloat {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
     }
 }
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -695,6 +695,59 @@ fn infer_error_test() {
             given: string()
         }
     );
+    assert_error!(
+        "case [3], 1.1 { x, y if x >=. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 24, end: 25 },
+            expected: float(),
+            given: list(int())
+        }
+    );
+
+    assert_error!(
+        "case 2.22, 1, \"three\" { x, _, y if x >=. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 41, end: 42 },
+            expected: float(),
+            given: string()
+        }
+    );
+
+    assert_error!(
+        "case [3], 1.1 { x, y if x <. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 24, end: 25 },
+            expected: float(),
+            given: list(int())
+        }
+    );
+
+    assert_error!(
+        "case 2.22, 1, \"three\" { x, _, y if x <. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 40, end: 41 },
+            expected: float(),
+            given: string()
+        }
+    );
+
+    assert_error!(
+        "case [3], 1.1 { x, y if x <=. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 24, end: 25 },
+            expected: float(),
+            given: list(int())
+        }
+    );
+
+    assert_error!(
+        "case 2.22, 1, \"three\" { x, _, y if x <=. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 41, end: 42 },
+            expected: float(),
+            given: string()
+        }
+    );
 
     assert_error!(
         "case [1] { [x] | x -> 1 }",

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -679,6 +679,24 @@ fn infer_error_test() {
     );
 
     assert_error!(
+        "case [3], 1.1 { x, y if x >. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 24, end: 25 },
+            expected: float(),
+            given: list(int())
+        }
+    );
+
+    assert_error!(
+        "case 2.22, 1, \"three\" { x, _, y if x >. y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 40, end: 41 },
+            expected: float(),
+            given: string()
+        }
+    );
+
+    assert_error!(
         "case [1] { [x] | x -> 1 }",
         Error::CouldNotUnify {
             location: SrcSpan { start: 17, end: 18 },


### PR DESCRIPTION
This pull request adds the >. float guard mentioned in #455, and closely follows the GtInt version added in #458. Assuming this first one looks good I can add the other 3 float guards to this same PR.