### PR TITLE
Integer comparison guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - There is a `todo` keyword for type checking functions that have not yet been
   implemented.
 - Tuples can be indexed into using the `var.1` syntax.
+- `>`, `>=`, `<`, and `<=` operators are now supported in case clause guards
+  and can be used to check the ordering of integers.
 - `>.`, `>=.`, `<.`, and `<=.` operators are now supported in case clause guards
   and can be used to check the ordering of floats.
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -300,6 +300,27 @@ pub enum ClauseGuard<Type> {
         right: Box<Self>,
     },
 
+    GtEqInt {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    LtInt {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    LtEqInt {
+        location: SrcSpan,
+        typ: Type,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
     GtFloat {
         location: SrcSpan,
         typ: Type,
@@ -358,6 +379,9 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::Equals { location, .. } => location,
             ClauseGuard::NotEquals { location, .. } => location,
             ClauseGuard::GtInt { location, .. } => location,
+            ClauseGuard::GtEqInt { location, .. } => location,
+            ClauseGuard::LtInt { location, .. } => location,
+            ClauseGuard::LtEqInt { location, .. } => location,
             ClauseGuard::GtFloat { location, .. } => location,
             ClauseGuard::GtEqFloat { location, .. } => location,
             ClauseGuard::LtFloat { location, .. } => location,
@@ -375,6 +399,9 @@ impl TypedClauseGuard {
             ClauseGuard::Equals { typ, .. } => typ.clone(),
             ClauseGuard::NotEquals { typ, .. } => typ.clone(),
             ClauseGuard::GtInt { typ, .. } => typ.clone(),
+            ClauseGuard::GtEqInt { typ, .. } => typ.clone(),
+            ClauseGuard::LtInt { typ, .. } => typ.clone(),
+            ClauseGuard::LtEqInt { typ, .. } => typ.clone(),
             ClauseGuard::GtFloat { typ, .. } => typ.clone(),
             ClauseGuard::GtEqFloat { typ, .. } => typ.clone(),
             ClauseGuard::LtFloat { typ, .. } => typ.clone(),

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -506,6 +506,18 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(" > ")
             .append(clause_guard(right.as_ref(), env)),
 
+        ClauseGuard::GtEqInt { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" >= ")
+            .append(clause_guard(right.as_ref(), env)),
+
+        ClauseGuard::LtInt { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" < ")
+            .append(clause_guard(right.as_ref(), env)),
+
+        ClauseGuard::LtEqInt { left, right, .. } => clause_guard(left.as_ref(), env)
+            .append(" =< ")
+            .append(clause_guard(right.as_ref(), env)),
+
         ClauseGuard::GtFloat { left, right, .. } => clause_guard(left.as_ref(), env)
             .append(" > ")
             .append(clause_guard(right.as_ref(), env)),
@@ -536,6 +548,9 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
         | ClauseGuard::Equals { .. }
         | ClauseGuard::NotEquals { .. }
         | ClauseGuard::GtInt { .. }
+        | ClauseGuard::GtEqInt { .. }
+        | ClauseGuard::LtInt { .. }
+        | ClauseGuard::LtEqInt { .. }
         | ClauseGuard::GtFloat { .. }
         | ClauseGuard::GtEqFloat { .. }
         | ClauseGuard::LtFloat { .. }

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1520,6 +1520,81 @@ main() ->
     end.
 "#,
     );
+    
+    assert_erl!(
+        r#"
+pub fn main() {
+  case 1, 0 {
+    x, y if x >= y -> 1
+    _, _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {1, 0} of
+        {X, Y} when X >= Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  case 1, 0 {
+    x, y if x < y -> 1
+    _, _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {1, 0} of
+        {X, Y} when X < Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
+    
+    assert_erl!(
+        r#"
+pub fn main() {
+  case 1, 0 {
+    x, y if x <= y -> 1
+    _, _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    case {1, 0} of
+        {X, Y} when X =< Y ->
+            1;
+
+        {_, _} ->
+            0
+    end.
+"#,
+    );
 
     assert_erl!(
         r#"

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1520,7 +1520,7 @@ main() ->
     end.
 "#,
     );
-    
+
     assert_erl!(
         r#"
 pub fn main() {
@@ -1570,7 +1570,7 @@ main() ->
     end.
 "#,
     );
-    
+
     assert_erl!(
         r#"
 pub fn main() {

--- a/src/format.rs
+++ b/src/format.rs
@@ -529,6 +529,18 @@ impl Documentable for &UntypedClauseGuard {
                 left.as_ref().to_doc().append(" > ").append(right.as_ref())
             }
 
+            ClauseGuard::GtEqInt { left, right, .. } => {
+                left.as_ref().to_doc().append(" >= ").append(right.as_ref())
+            }
+
+            ClauseGuard::LtInt { left, right, .. } => {
+                left.as_ref().to_doc().append(" < ").append(right.as_ref())
+            }
+
+            ClauseGuard::LtEqInt { left, right, .. } => {
+                left.as_ref().to_doc().append(" <= ").append(right.as_ref())
+            }
+
             ClauseGuard::GtFloat { left, right, .. } => {
                 left.as_ref().to_doc().append(" >. ").append(right.as_ref())
             }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -306,6 +306,27 @@ ClauseGuard4: UntypedClauseGuard = {
         left: Box::new(left),
         right: Box::new(right),
     },
+    
+    <s:@L> <left:ClauseGuard4> ">=" <right:ClauseGuard5> <e:@L> => ClauseGuard::GtEqInt {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+    
+    <s:@L> <left:ClauseGuard4> "<" <right:ClauseGuard5> <e:@L> => ClauseGuard::LtInt {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
+    
+    <s:@L> <left:ClauseGuard4> "<=" <right:ClauseGuard5> <e:@L> => ClauseGuard::LtEqInt {
+        location: location(s, e),
+        typ: (),
+        left: Box::new(left),
+        right: Box::new(right),
+    },
 
     <s:@L> <left:ClauseGuard4> ">." <right:ClauseGuard5> <e:@L> => ClauseGuard::GtFloat {
         location: location(s, e),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2415,6 +2415,60 @@ fn infer_clause_guard(
             })
         }
 
+        ClauseGuard::GtEqInt {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::GtEqInt {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
+
+        ClauseGuard::LtInt {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::LtInt {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
+
+        ClauseGuard::LtEqInt {
+            location,
+            left,
+            right,
+            ..
+        } => {
+            let left = infer_clause_guard(*left, level, env)?;
+            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
+            let right = infer_clause_guard(*right, level, env)?;
+            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
+            Ok(ClauseGuard::LtEqInt {
+                location,
+                typ: bool(),
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        }
+
         ClauseGuard::GtFloat {
             location,
             left,

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -677,7 +677,7 @@ fn infer_error_test() {
             given: string()
         }
     );
-    
+
     assert_error!(
         "case [3.33], 1 { x, y if x >= y -> 1 }",
         Error::CouldNotUnify {
@@ -686,7 +686,7 @@ fn infer_error_test() {
             given: list(float())
         }
     );
-    
+
     assert_error!(
         "case 1, 2.22, \"three\" { x, _, y if x >= y -> 1 }",
         Error::CouldNotUnify {
@@ -695,7 +695,7 @@ fn infer_error_test() {
             given: string()
         }
     );
-    
+
     assert_error!(
         "case [3.33], 1 { x, y if x < y -> 1 }",
         Error::CouldNotUnify {
@@ -704,7 +704,7 @@ fn infer_error_test() {
             given: list(float())
         }
     );
-    
+
     assert_error!(
         "case 1, 2.22, \"three\" { x, _, y if x < y -> 1 }",
         Error::CouldNotUnify {
@@ -722,7 +722,7 @@ fn infer_error_test() {
             given: list(float())
         }
     );
-    
+
     assert_error!(
         "case 1, 2.22, \"three\" { x, _, y if x <= y -> 1 }",
         Error::CouldNotUnify {

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -677,6 +677,60 @@ fn infer_error_test() {
             given: string()
         }
     );
+    
+    assert_error!(
+        "case [3.33], 1 { x, y if x >= y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 25, end: 26 },
+            expected: int(),
+            given: list(float())
+        }
+    );
+    
+    assert_error!(
+        "case 1, 2.22, \"three\" { x, _, y if x >= y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 40, end: 41 },
+            expected: int(),
+            given: string()
+        }
+    );
+    
+    assert_error!(
+        "case [3.33], 1 { x, y if x < y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 25, end: 26 },
+            expected: int(),
+            given: list(float())
+        }
+    );
+    
+    assert_error!(
+        "case 1, 2.22, \"three\" { x, _, y if x < y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 39, end: 40 },
+            expected: int(),
+            given: string()
+        }
+    );
+
+    assert_error!(
+        "case [3.33], 1 { x, y if x <= y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 25, end: 26 },
+            expected: int(),
+            given: list(float())
+        }
+    );
+    
+    assert_error!(
+        "case 1, 2.22, \"three\" { x, _, y if x <= y -> 1 }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 40, end: 41 },
+            expected: int(),
+            given: string()
+        }
+    );
 
     assert_error!(
         "case [3], 1.1 { x, y if x >. y -> 1 }",
@@ -695,6 +749,7 @@ fn infer_error_test() {
             given: string()
         }
     );
+
     assert_error!(
         "case [3], 1.1 { x, y if x >=. y -> 1 }",
         Error::CouldNotUnify {


### PR DESCRIPTION
This pull request is meant to complete Issue #455 for comparison clauses with integer types. The `>=`, `<`, `<=` operators were added: 

```gleam
case 1, 0 {
  x, y, z if x < z -> True
  x, y, z if x <= z -> False
  x, y, z if x >= y -> True
}
```