### PR TITLE
Added support for int literals in guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/*.rs.bk
 /target/
 /tmp
+.idea/
+.idea/*

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -368,6 +368,12 @@ pub enum ClauseGuard<Type> {
         typ: Type,
         name: String,
     },
+
+    IntLiteral {
+        location: SrcSpan,
+        typ: Type,
+        value: String,
+    }
 }
 
 impl<A> ClauseGuard<A> {
@@ -386,6 +392,7 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::GtEqFloat { location, .. } => location,
             ClauseGuard::LtFloat { location, .. } => location,
             ClauseGuard::LtEqFloat { location, .. } => location,
+            ClauseGuard::IntLiteral { location, .. } => location,
         }
     }
 }
@@ -406,6 +413,7 @@ impl TypedClauseGuard {
             ClauseGuard::GtEqFloat { typ, .. } => typ.clone(),
             ClauseGuard::LtFloat { typ, .. } => typ.clone(),
             ClauseGuard::LtEqFloat { typ, .. } => typ.clone(),
+            ClauseGuard::IntLiteral { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -369,7 +369,7 @@ pub enum ClauseGuard<Type> {
         name: String,
     },
 
-    IntLiteral {
+    Int {
         location: SrcSpan,
         typ: Type,
         value: String,
@@ -392,7 +392,7 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::GtEqFloat { location, .. } => location,
             ClauseGuard::LtFloat { location, .. } => location,
             ClauseGuard::LtEqFloat { location, .. } => location,
-            ClauseGuard::IntLiteral { location, .. } => location,
+            ClauseGuard::Int { location, .. } => location,
         }
     }
 }
@@ -413,7 +413,7 @@ impl TypedClauseGuard {
             ClauseGuard::GtEqFloat { typ, .. } => typ.clone(),
             ClauseGuard::LtFloat { typ, .. } => typ.clone(),
             ClauseGuard::LtEqFloat { typ, .. } => typ.clone(),
-            ClauseGuard::IntLiteral { typ, .. } => typ.clone(),
+            ClauseGuard::Int { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -373,7 +373,7 @@ pub enum ClauseGuard<Type> {
         location: SrcSpan,
         typ: Type,
         value: String,
-    }
+    },
 }
 
 impl<A> ClauseGuard<A> {

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -562,8 +562,7 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(")"),
 
         // Values are not wrapped
-        ClauseGuard::Var { .. }
-        | ClauseGuard::IntLiteral { .. } => bare_clause_guard(guard, env),
+        ClauseGuard::Var { .. } | ClauseGuard::IntLiteral { .. } => bare_clause_guard(guard, env),
     }
 }
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -534,6 +534,8 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(" =< ")
             .append(clause_guard(right.as_ref(), env)),
 
+        ClauseGuard::IntLiteral { value, .. } => value.to_string().to_doc(),
+
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
         ClauseGuard::Var { name, .. } => env.local_var_name(name.to_string()),
@@ -560,7 +562,8 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(")"),
 
         // Values are not wrapped
-        ClauseGuard::Var { .. } => bare_clause_guard(guard, env),
+        ClauseGuard::Var { .. }
+        | ClauseGuard::IntLiteral { .. } => bare_clause_guard(guard, env),
     }
 }
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -534,7 +534,7 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(" =< ")
             .append(clause_guard(right.as_ref(), env)),
 
-        ClauseGuard::IntLiteral { value, .. } => value.to_string().to_doc(),
+        ClauseGuard::Int { value, .. } => value.to_string().to_doc(),
 
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
@@ -562,7 +562,7 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(")"),
 
         // Values are not wrapped
-        ClauseGuard::Var { .. } | ClauseGuard::IntLiteral { .. } => bare_clause_guard(guard, env),
+        ClauseGuard::Var { .. } | ClauseGuard::Int { .. } => bare_clause_guard(guard, env),
     }
 }
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1649,6 +1649,79 @@ main() ->
     assert_erl!(
         r#"
 pub fn main() {
+  let x = 0
+  case x {
+    0 -> 1
+    _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    X = 0,
+    case X of
+        0 ->
+            1;
+
+        _ ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  let x = 0
+  case x {
+    _ if x == 0 -> 1
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    X = 0,
+    case X of
+        _ when X =:= 0 ->
+            1
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  let x = 0
+  case x {
+    _ if 0 < x -> 1
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    X = 0,
+    case X of
+        _ when 0 < X ->
+            1
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
   case 0.1, 1.0 {
     x, y if x <. y -> 1
     _, _ -> 0

--- a/src/format.rs
+++ b/src/format.rs
@@ -769,6 +769,8 @@ impl Documentable for &UntypedClauseGuard {
                 .append(" <=. ")
                 .append(right.as_ref()),
 
+            ClauseGuard::IntLiteral { value, ..} => value.to_string().to_doc(),
+
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -769,7 +769,7 @@ impl Documentable for &UntypedClauseGuard {
                 .append(" <=. ")
                 .append(right.as_ref()),
 
-            ClauseGuard::IntLiteral { value, .. } => value.to_string().to_doc(),
+            ClauseGuard::Int { value, .. } => value.to_string().to_doc(),
 
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -769,7 +769,7 @@ impl Documentable for &UntypedClauseGuard {
                 .append(" <=. ")
                 .append(right.as_ref()),
 
-            ClauseGuard::IntLiteral { value, ..} => value.to_string().to_doc(),
+            ClauseGuard::IntLiteral { value, .. } => value.to_string().to_doc(),
 
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -365,7 +365,7 @@ ClauseGuard5: UntypedClauseGuard = {
         typ: (),
         name,
     },
-    <s:@L> <value:IntLiteral> <e:@L> => ClauseGuard::IntLiteral {
+    <s:@L> <value:IntLiteral> <e:@L> => ClauseGuard::Int {
         location: location(s, e),
         typ: (),
         value,

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -365,6 +365,11 @@ ClauseGuard5: UntypedClauseGuard = {
         typ: (),
         name,
     },
+    <s:@L> <value:IntLiteral> <e:@L> => ClauseGuard::IntLiteral {
+        location: location(s, e),
+        typ: (),
+        value,
+    },
 
     "{" <ClauseGuard> "}" => <>,
 }

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2546,16 +2546,12 @@ fn infer_clause_guard(
         }
 
         ClauseGuard::IntLiteral {
+            location, value, ..
+        } => Ok(ClauseGuard::IntLiteral {
             location,
             value,
-            ..
-        } => {
-            Ok(ClauseGuard::IntLiteral {
-                location,
-                value,
-                typ: int()
-            })
-        }
+            typ: int(),
+        }),
     }
 }
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2545,9 +2545,9 @@ fn infer_clause_guard(
             })
         }
 
-        ClauseGuard::IntLiteral {
+        ClauseGuard::Int {
             location, value, ..
-        } => Ok(ClauseGuard::IntLiteral {
+        } => Ok(ClauseGuard::Int {
             location,
             value,
             typ: int(),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2544,6 +2544,18 @@ fn infer_clause_guard(
                 right: Box::new(right),
             })
         }
+
+        ClauseGuard::IntLiteral {
+            location,
+            value,
+            ..
+        } => {
+            Ok(ClauseGuard::IntLiteral {
+                location,
+                value,
+                typ: int()
+            })
+        }
     }
 }
 


### PR DESCRIPTION
This pull request is meant to complete Issue #465, adding support for int literals within guards. As requested each type is going to be it's own separate merge request.

```
case x {
  _ if x == 1 -> "here we are using an Int literal"
}
```