### PR TITLE
Run tests for core_language in CI

### DIFF
--- a/.github/workflows/build_compiler.yaml
+++ b/.github/workflows/build_compiler.yaml
@@ -30,6 +30,10 @@ jobs:
       - run: cargo test
       - run: cargo build --release
       - run: target/release/gleam --version
+      - uses: actions/upload-artifact@v1
+        with:
+          name: gleam
+          path: target/release/gleam
 
   build_compiler_macos:
     needs: rustfmt
@@ -64,3 +68,26 @@ jobs:
       - run: cargo test
       - run: cargo build --release
       - run: target/release/gleam --version
+
+  test_core_language:
+    needs: build_compiler_linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - uses: gleam-lang/setup-erlang@v1.0.0
+        with:
+          otp-version: 22.1
+      - uses: actions/download-artifact@v1
+        with:
+          name: gleam
+          path: ./test/core_language
+      # Artifacts remove permissions
+      - name: Setup gleam compiler
+        run: |
+          chmod +x ./gleam
+          sed -i 's/cargo run --/.\/gleam/' rebar.config
+        working-directory: ./test/core_language
+      - run: rebar3 install_deps
+        working-directory: ./test/core_language
+      - run: rebar3 eunit
+        working-directory: ./test/core_language


### PR DESCRIPTION
Implements #460

As specified in the issue I added a separate job for that. Unfortunately, it comes with a drawback. We have to create an artifact of compiled binary to use it. The drawback is that there is currently no official action to remove the artifacts (they expired after 90days).

I can think about two possible solutions:
1. Run tests in the same job with built compiler.
2. Add one more job to clean artifacts...

Or maybe there is something I'm missing, feel free to point it out.