### PR TITLE
Remove superfluous typ fields from ClauseGuards

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -281,84 +281,72 @@ pub type TypedClauseGuard = ClauseGuard<Arc<typ::Type>>;
 pub enum ClauseGuard<Type> {
     Equals {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     NotEquals {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     GtInt {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     GtEqInt {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     LtInt {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     LtEqInt {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     GtFloat {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     GtEqFloat {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     LtFloat {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     LtEqFloat {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     Or {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
 
     And {
         location: SrcSpan,
-        typ: Type,
         left: Box<Self>,
         right: Box<Self>,
     },
@@ -371,7 +359,6 @@ pub enum ClauseGuard<Type> {
 
     Int {
         location: SrcSpan,
-        typ: Type,
         value: String,
     },
 }
@@ -400,20 +387,9 @@ impl<A> ClauseGuard<A> {
 impl TypedClauseGuard {
     pub fn typ(&self) -> Arc<typ::Type> {
         match self {
-            ClauseGuard::Or { typ, .. } => typ.clone(),
-            ClauseGuard::And { typ, .. } => typ.clone(),
             ClauseGuard::Var { typ, .. } => typ.clone(),
-            ClauseGuard::Equals { typ, .. } => typ.clone(),
-            ClauseGuard::NotEquals { typ, .. } => typ.clone(),
-            ClauseGuard::GtInt { typ, .. } => typ.clone(),
-            ClauseGuard::GtEqInt { typ, .. } => typ.clone(),
-            ClauseGuard::LtInt { typ, .. } => typ.clone(),
-            ClauseGuard::LtEqInt { typ, .. } => typ.clone(),
-            ClauseGuard::GtFloat { typ, .. } => typ.clone(),
-            ClauseGuard::GtEqFloat { typ, .. } => typ.clone(),
-            ClauseGuard::LtFloat { typ, .. } => typ.clone(),
-            ClauseGuard::LtEqFloat { typ, .. } => typ.clone(),
-            ClauseGuard::Int { typ, .. } => typ.clone(),
+            ClauseGuard::Int { .. } => typ::int(),
+            _ => typ::bool(),
         }
     }
 }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -262,7 +262,6 @@ ClauseGuard: UntypedClauseGuard = {
 ClauseGuard1: UntypedClauseGuard = {
     <s:@L> <left:ClauseGuard1> "||" <right:ClauseGuard2> <e:@L> => ClauseGuard::Or {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
@@ -273,7 +272,6 @@ ClauseGuard1: UntypedClauseGuard = {
 ClauseGuard2: UntypedClauseGuard = {
     <s:@L> <left:ClauseGuard2> "&&" <right:ClauseGuard3> <e:@L> => ClauseGuard::And {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
@@ -284,14 +282,12 @@ ClauseGuard2: UntypedClauseGuard = {
 ClauseGuard3: UntypedClauseGuard = {
     <s:@L> <left:ClauseGuard3> "==" <right:ClauseGuard4> <e:@L> => ClauseGuard::Equals {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
 
     <s:@L> <left:ClauseGuard3> "!=" <right:ClauseGuard4> <e:@L> => ClauseGuard::NotEquals {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
@@ -302,56 +298,48 @@ ClauseGuard3: UntypedClauseGuard = {
 ClauseGuard4: UntypedClauseGuard = {
     <s:@L> <left:ClauseGuard4> ">" <right:ClauseGuard5> <e:@L> => ClauseGuard::GtInt {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
-    
+
     <s:@L> <left:ClauseGuard4> ">=" <right:ClauseGuard5> <e:@L> => ClauseGuard::GtEqInt {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
-    
+
     <s:@L> <left:ClauseGuard4> "<" <right:ClauseGuard5> <e:@L> => ClauseGuard::LtInt {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
-    
+
     <s:@L> <left:ClauseGuard4> "<=" <right:ClauseGuard5> <e:@L> => ClauseGuard::LtEqInt {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
 
     <s:@L> <left:ClauseGuard4> ">." <right:ClauseGuard5> <e:@L> => ClauseGuard::GtFloat {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
 
     <s:@L> <left:ClauseGuard4> ">=." <right:ClauseGuard5> <e:@L> => ClauseGuard::GtEqFloat {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
 
     <s:@L> <left:ClauseGuard4> "<." <right:ClauseGuard5> <e:@L> => ClauseGuard::LtFloat {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
 
     <s:@L> <left:ClauseGuard4> "<=." <right:ClauseGuard5> <e:@L> => ClauseGuard::LtEqFloat {
         location: location(s, e),
-        typ: (),
         left: Box::new(left),
         right: Box::new(right),
     },
@@ -367,7 +355,6 @@ ClauseGuard5: UntypedClauseGuard = {
     },
     <s:@L> <value:IntLiteral> <e:@L> => ClauseGuard::Int {
         location: location(s, e),
-        typ: (),
         value,
     },
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2338,7 +2338,6 @@ fn infer_clause_guard(
                 .map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::And {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2357,7 +2356,6 @@ fn infer_clause_guard(
                 .map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::Or {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2374,7 +2372,6 @@ fn infer_clause_guard(
             unify(left.typ(), right.typ(), env).map_err(|e| convert_unify_error(e, &location))?;
             Ok(ClauseGuard::Equals {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2391,7 +2388,6 @@ fn infer_clause_guard(
             unify(left.typ(), right.typ(), env).map_err(|e| convert_unify_error(e, &location))?;
             Ok(ClauseGuard::NotEquals {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2409,7 +2405,6 @@ fn infer_clause_guard(
             unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::GtInt {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2427,7 +2422,6 @@ fn infer_clause_guard(
             unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::GtEqInt {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2445,7 +2439,6 @@ fn infer_clause_guard(
             unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::LtInt {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2463,7 +2456,6 @@ fn infer_clause_guard(
             unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::LtEqInt {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2482,7 +2474,6 @@ fn infer_clause_guard(
                 .map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::GtFloat {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2501,7 +2492,6 @@ fn infer_clause_guard(
                 .map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::GtEqFloat {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2520,7 +2510,6 @@ fn infer_clause_guard(
                 .map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::LtFloat {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2539,7 +2528,6 @@ fn infer_clause_guard(
                 .map_err(|e| convert_unify_error(e, right.location()))?;
             Ok(ClauseGuard::LtEqFloat {
                 location,
-                typ: bool(),
                 left: Box::new(left),
                 right: Box::new(right),
             })
@@ -2547,11 +2535,7 @@ fn infer_clause_guard(
 
         ClauseGuard::Int {
             location, value, ..
-        } => Ok(ClauseGuard::Int {
-            location,
-            value,
-            typ: int(),
-        }),
+        } => Ok(ClauseGuard::Int { location, value }),
     }
 }
 


### PR DESCRIPTION
Addresses #470

- `ClauseGuard::Var` still returns the stored `Type`
- `ClauseGuard::Int` always returns `int()`
- All the others always return `bool()`