### PR TITLE
Change list prepend syntax to use .. spread operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   and can be used to check the ordering of integers.
 - `>.`, `>=.`, `<.`, and `<=.` operators are now supported in case clause guards
   and can be used to check the ordering of floats.
+- The list prepend syntax is now [x, ..y]. The old [x | y] syntax is deprecated
+  but will continue to work for now. The formatter will output the new syntax.
 
 ## v0.7.1 - 2020-03-03
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1089,6 +1089,34 @@ modulo(X, Y) ->
 
     assert_erl!(
         r#"fn second(list) { case list { [x, y] -> y z -> 1 } }
+                    fn tail(list) { case list { [x, ..xs] -> xs z -> list } }
+            "#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+second(List) ->
+    case List of
+        [X, Y] ->
+            Y;
+
+        Z ->
+            1
+    end.
+
+tail(List) ->
+    case List of
+        [X | Xs] ->
+            Xs;
+
+        Z ->
+            List
+    end.
+"#,
+    );
+
+    // Deprecated syntax
+    assert_erl!(
+        r#"fn second(list) { case list { [x, y] -> y z -> 1 } }
                     fn tail(list) { case list { [x | xs] -> xs z -> list } }
             "#,
         r#"-module(the_app).

--- a/src/format.rs
+++ b/src/format.rs
@@ -822,8 +822,8 @@ fn list(elems: Document, tail: Option<Document>) -> Document {
         None => doc.nest(INDENT).append(break_(",", "")),
 
         Some(final_tail) => doc
-            .append(break_(",", " "))
-            .append("| ")
+            .append(break_(",", ", "))
+            .append("..")
             .append(final_tail)
             .nest(INDENT)
             .append(break_("", "")),

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -867,7 +867,7 @@ World"
 
     assert_format!(
         "fn main() {
-  [1, 2, 3 | x]
+  [1, 2, 3, ..x]
 }
 "
     );
@@ -878,7 +878,7 @@ World"
     really_long_variable_name,
     really_long_variable_name,
     really_long_variable_name,
-    | tail
+    ..tail
   ]
 }
 "
@@ -897,7 +897,7 @@ World"
       2,
       3,
       [1, 2, 3, 4],
-      | tail
+      ..tail
     ],
     really_long_variable_name,
   ]
@@ -1214,7 +1214,7 @@ World"
 
     assert_format!(
         r#"fn main() {
-  let [1, 2, 3, 4 | x] = 1
+  let [1, 2, 3, 4, ..x] = 1
   Nil
 }
 "#
@@ -1227,7 +1227,7 @@ World"
     really_long_variable_name,
     really_long_variable_name,
     [1, 2, 3, 4, xyz],
-    | thingy
+    ..thingy
   ] = 1
   Nil
 }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -480,7 +480,19 @@ Tuple: UntypedExpr = {
 }
 
 List: UntypedExpr = {
-    <s:@L> "[" <elems:Comma<OpOrSimpleExpr>> <tail:("|" <OpOrSimpleExpr>)?>"]" <e:@L> => {
+    // [x | y] preprend syntax is deprecated, [x, ..y] is the new one
+    <s:@L> "[" <elems:Comma<OpOrSimpleExpr>> <tail:("|" <OpOrSimpleExpr>)>"]" <e:@L> => {
+        elems.into_iter().rev().fold(
+            tail,
+            |t, h| UntypedExpr::ListCons {
+                location: t.location().clone(),
+                head: Box::new(h),
+                tail: Box::new(t),
+            }
+        )
+    },
+
+    <s:@L> "[" <elems:Comma<OpOrSimpleExpr>> <tail:(".." <OpOrSimpleExpr>)?>"]" <e:@L> => {
         let tail = tail.unwrap_or_else(|| UntypedExpr::ListNil {
             location: location(s, e),
         });
@@ -492,7 +504,7 @@ List: UntypedExpr = {
                 tail: Box::new(t),
             }
         )
-    }
+    },
 }
 
 Var: UntypedExpr = {
@@ -690,7 +702,19 @@ PatternVarOrDiscard: UntypedPattern = {
 }
 
 PatternList: UntypedPattern = {
-    <s:@L> "[" <elems:Comma<Pattern>> <tail:("|" <PatternVarOrDiscard>)?> "]" <e:@L> => {
+    // [x | y] preprend syntax is deprecated, [x, ..y] is the new one
+    <s:@L> "[" <elems:Comma<Pattern>> <tail:("|" <PatternVarOrDiscard>)> "]" <e:@L> => {
+        elems.into_iter().rev().fold(
+            tail,
+            |a, e| Pattern::Cons {
+                location: e.location().clone(),
+                head: Box::new(e),
+                tail: Box::new(a),
+            }
+        )
+    },
+
+    <s:@L> "[" <elems:Comma<Pattern>> <tail:(".." <PatternVarOrDiscard>)?> "]" <e:@L> => {
         let tail = tail.unwrap_or_else(|| Pattern::Nil {
             location: location(e - 1, e),
         });
@@ -702,7 +726,7 @@ PatternList: UntypedPattern = {
                 tail: Box::new(a),
             }
         )
-    }
+    },
 }
 
 Type: TypeAst = {

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -237,10 +237,15 @@ fn infer_test() {
     assert_infer!("[fn(x) { x + 1 }, fn(x) { x }]", "List(fn(Int) -> Int)");
     assert_infer!("[[], []]", "List(List(a))");
     assert_infer!("[[], [1]]", "List(List(Int))");
-    assert_infer!("[1 | [2 | []]]", "List(Int)");
-    assert_infer!("[fn(x) { x } | []]", "List(fn(a) -> a)");
+
+    assert_infer!("[1, ..[2, ..[]]]", "List(Int)");
+    assert_infer!("[1 | [2 | []]]", "List(Int)"); // Deprecated syntax
+    assert_infer!("[fn(x) { x }, ..[]]", "List(fn(a) -> a)");
+    assert_infer!("[fn(x) { x } | []]", "List(fn(a) -> a)"); // Deprecated syntax
+    assert_infer!("let x = [1, ..[]] [2, ..x]", "List(Int)");
+    assert_infer!("let x = [1 | []] [2 | x]", "List(Int)"); // Deprecated syntax
+
     assert_infer!("let f = fn(x) { x } [f, f]", "List(fn(a) -> a)");
-    assert_infer!("let x = [1 | []] [2 | x]", "List(Int)");
     assert_infer!("[tuple([], [])]", "List(tuple(List(a), List(b)))");
 
     // anon structs


### PR DESCRIPTION
Addresses #475.
The old syntax is still accepted by the parser, but the formatter renders the new syntax.