### PR TITLE
Add assert syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   and can be used to check the ordering of floats.
 - The list prepend syntax is now [x, ..y]. The old [x | y] syntax is deprecated
   but will continue to work for now. The formatter will output the new syntax.
+- Add new assert syntx for binding variables `assert Ok(x) = result`. In the future
+  this will allow you to use a pattern that does not match all values.
 
 ## v0.7.1 - 2020-03-03
 

--- a/src/ast/typed.rs
+++ b/src/ast/typed.rs
@@ -82,6 +82,7 @@ pub enum TypedExpr {
         value: Box<Self>,
         pattern: Pattern<PatternConstructor>,
         then: Box<Self>,
+        assert: bool,
     },
 
     Case {

--- a/src/ast/untyped.rs
+++ b/src/ast/untyped.rs
@@ -69,6 +69,7 @@ pub enum UntypedExpr {
         value: Box<Self>,
         pattern: Pattern<()>,
         then: Box<Self>,
+        assert: bool,
     },
 
     Case {

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -277,6 +277,7 @@ map() ->
                         },
                         name: "one_two".to_string(),
                     }),
+                    assert: false,
                 },
             },
             Statement::Fn {
@@ -981,6 +982,22 @@ go() ->
         r#"fn go() {
   let y = 1
   let y = 2
+  y
+}"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+go() ->
+    Y = 1,
+    Y1 = 2,
+    Y1.
+"#,
+    );
+
+    assert_erl!(
+        r#"fn go() {
+  assert y = 1
+  assert y = 2
   y
 }"#,
         r#"-module(the_app).

--- a/src/format.rs
+++ b/src/format.rs
@@ -354,9 +354,10 @@ impl<'a> Formatter<'a> {
                 value,
                 pattern,
                 then,
+                assert,
                 ..
             } => force_break()
-                .append("let ")
+                .append(if *assert { "assert " } else { "let " })
                 .append(pattern)
                 .append(" = ")
                 .append(self.hanging_expr(value.as_ref()))

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -1053,6 +1053,14 @@ World"
 
     assert_format!(
         r#"fn main() {
+  assert x = 1
+  Nil
+}
+"#
+    );
+
+    assert_format!(
+        r#"fn main() {
   let x = {
     let y = 1
     y

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -367,6 +367,15 @@ Let: UntypedExpr = {
         value: Box::new(v),
         pattern: p,
         then: Box::new(t),
+        assert: false,
+    },
+
+    <s:@L> "assert" <p:Pattern> "=" <v:OpOrSimpleExpr> <e:@L> <t:Expr> => UntypedExpr::Let {
+        location: location(s, e),
+        value: Box::new(v),
+        pattern: p,
+        then: Box::new(t),
+        assert: true,
     }
 }
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -1681,8 +1681,9 @@ pub fn infer(expr: UntypedExpr, level: usize, env: &mut Env) -> Result<TypedExpr
             pattern,
             value,
             then,
+            assert,
             ..
-        } => infer_let(pattern, *value, *then, level, location, env),
+        } => infer_let(pattern, *value, *then, assert, level, location, env),
 
         UntypedExpr::Case {
             location,
@@ -2055,6 +2056,7 @@ fn infer_let(
     pattern: UntypedPattern,
     value: UntypedExpr,
     then: UntypedExpr,
+    assert: bool,
     level: usize,
     location: SrcSpan,
     env: &mut Env,
@@ -2070,6 +2072,7 @@ fn infer_let(
         pattern,
         value: Box::new(value),
         then: Box::new(then),
+        assert: assert,
     })
 }
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -338,6 +338,19 @@ fn infer_test() {
     assert_infer!("let tuple(tag, x) = tuple(1.0, 1) x", "Int");
     assert_infer!("fn(x) { let tuple(a, b) = x a }", "fn(tuple(a, b)) -> a");
 
+    // assert
+    assert_infer!("assert [] = [] 1", "Int");
+    assert_infer!("assert [a] = [1] a", "Int");
+    assert_infer!("assert [a, 2] = [1] a", "Int");
+    assert_infer!("assert [a | b] = [1] a", "Int");
+    assert_infer!("assert [a | _] = [1] a", "Int");
+    assert_infer!("fn(x) { assert [a] = x a }", "fn(List(a)) -> a");
+    assert_infer!("fn(x) { assert [a] = x a + 1 }", "fn(List(Int)) -> Int");
+    assert_infer!("assert _x = 1 2.0", "Float");
+    assert_infer!("assert _ = 1 2.0", "Float");
+    assert_infer!("assert tuple(tag, x) = tuple(1.0, 1) x", "Int");
+    assert_infer!("fn(x) { assert tuple(a, b) = x a }", "fn(tuple(a, b)) -> a");
+
     // Nil
     assert_infer!("Nil", "Nil");
 


### PR DESCRIPTION
Addresses #473.
Assert is a new syntax for binding variables, that will in future allow you to use a pattern that does not match all values. For now it is essentially an alias for let, with an extra assert field set to true in its AST variant.