### PR TITLE
Check for tty for color codes in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   but will continue to work for now. The formatter will output the new syntax.
 - Add new assert syntx for binding variables `assert Ok(x) = result`. In the future
   this will allow you to use a pattern that does not match all values.
+- Color codes are now only emitted in error output for interactive terminal sessions.
 
 ## v0.7.1 - 2020-03-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ name = "gleam"
 version = "0.8.0-dev"
 dependencies = [
  "askama 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ askama = "0.8"
 pulldown-cmark = "0.7.0"
 # Support unicode in gleam source
 unicode-segmentation = "1.6.0"
+# Check for tty
+atty = "0.2.13"
 
 [build-dependencies]
 lalrpop = "0.17"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub type Src = String;
 pub type Name = String;
 
 pub fn fatal_compiler_bug(msg: &str) -> ! {
-    let buffer_writer = termcolor::BufferWriter::stderr(termcolor::ColorChoice::Always);
+    let buffer_writer = error_buffer_writer();
     let mut buffer = buffer_writer.buffer();
     use std::io::Write;
     use termcolor::{Color, ColorSpec, WriteColor};
@@ -1017,16 +1017,21 @@ but it cannot be found.",
     }
 
     pub fn pretty_print(&self) {
-        let color_choice = if atty::is(atty::Stream::Stderr) {
-            termcolor::ColorChoice::Auto
-        } else {
-            termcolor::ColorChoice::Never
-        };
-        let buffer_writer = termcolor::BufferWriter::stderr(color_choice);
+        let buffer_writer = error_buffer_writer();
         let mut buffer = buffer_writer.buffer();
         self.pretty(&mut buffer);
         buffer_writer.print(&buffer).unwrap();
     }
+}
+
+fn error_buffer_writer() -> termcolor::BufferWriter {
+    // Don't add color codes to the output if standard error isn't connected to a terminal
+    let color_choice = if atty::is(atty::Stream::Stderr) {
+        termcolor::ColorChoice::Auto
+    } else {
+        termcolor::ColorChoice::Never
+    };
+    termcolor::BufferWriter::stderr(color_choice)
 }
 
 fn std_io_error_kind_text(kind: &std::io::ErrorKind) -> String {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1017,7 +1017,12 @@ but it cannot be found.",
     }
 
     pub fn pretty_print(&self) {
-        let buffer_writer = termcolor::BufferWriter::stderr(termcolor::ColorChoice::Always);
+        let color_choice = if atty::is(atty::Stream::Stderr) {
+            termcolor::ColorChoice::Auto
+        } else {
+            termcolor::ColorChoice::Never
+        };
+        let buffer_writer = termcolor::BufferWriter::stderr(color_choice);
         let mut buffer = buffer_writer.buffer();
         self.pretty(&mut buffer);
         buffer_writer.print(&buffer).unwrap();


### PR DESCRIPTION
This is to address color codes being written out when there is no tty (#490). It isn't complete but I wanted to check that you're happy with the approach before trying to adjust other errors.

### Commit message

We use the "atty" crate which was already a transitive dependency to check whether standard-error is a tty before deciding whether or not to use colors for errors.

This attempts to follow the essence of the logic used in rustc at the moment:

  https://github.com/rust-lang/rust/blob/7f3df5772439eee1c512ed2eb540beef1124d236/src/librustc_errors/emitter.rs#L533-L544

Running `gleam build . | cat` still inserts color codes which is the same for `cargo build` but running `gleam build . 2>&1 | cat` does not as we're redirecting standard-error too. This also means that it does not insert color codes when run as part of a vim `:make` command which was the initial motivation for this change.

This doesn't cover all the error print outs but that can be done.