### PR TITLE
Added support for float values in guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   but will continue to work for now. The formatter will output the new syntax.
 - Add new assert syntx for binding variables `assert Ok(x) = result`. In the future
   this will allow you to use a pattern that does not match all values.
+ - Added support for int and float literals in guards
 
 ## v0.7.1 - 2020-03-03
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -364,6 +364,11 @@ pub enum ClauseGuard<Type> {
         location: SrcSpan,
         value: String,
     },
+
+    Float {
+        location: SrcSpan,
+        value: String,
+    },
 }
 
 impl<A> ClauseGuard<A> {
@@ -383,6 +388,7 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::LtFloat { location, .. } => location,
             ClauseGuard::LtEqFloat { location, .. } => location,
             ClauseGuard::Int { location, .. } => location,
+            ClauseGuard::Float { location, .. } => location,
         }
     }
 }
@@ -392,6 +398,7 @@ impl TypedClauseGuard {
         match self {
             ClauseGuard::Var { typ, .. } => typ.clone(),
             ClauseGuard::Int { .. } => typ::int(),
+            ClauseGuard::Float { .. } => typ::float(),
             _ => typ::bool(),
         }
     }

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -564,7 +564,9 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(")"),
 
         // Values are not wrapped
-        ClauseGuard::Var { .. } | ClauseGuard::Int { .. } | ClauseGuard::Float { .. } => bare_clause_guard(guard, env),
+        ClauseGuard::Var { .. } | ClauseGuard::Int { .. } | ClauseGuard::Float { .. } => {
+            bare_clause_guard(guard, env)
+        }
     }
 }
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -536,6 +536,8 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
 
         ClauseGuard::Int { value, .. } => value.to_string().to_doc(),
 
+        ClauseGuard::Float { value, .. } => value.to_string().to_doc(),
+
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
         ClauseGuard::Var { name, .. } => env.local_var_name(name.to_string()),
@@ -562,7 +564,7 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             .append(")"),
 
         // Values are not wrapped
-        ClauseGuard::Var { .. } | ClauseGuard::Int { .. } => bare_clause_guard(guard, env),
+        ClauseGuard::Var { .. } | ClauseGuard::Int { .. } | ClauseGuard::Float { .. } => bare_clause_guard(guard, env),
     }
 }
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1696,6 +1696,79 @@ main() ->
     assert_erl!(
         r#"
 pub fn main() {
+  let x = 0.123
+  case x {
+    99.9854 -> 1
+    _ -> 0
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    X = 0.123,
+    case X of
+        99.9854 ->
+            1;
+
+        _ ->
+            0
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  let x = 0.123
+  case x {
+    _ if x == 3.14 -> 1
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    X = 0.123,
+    case X of
+        _ when X =:= 3.14 ->
+            1
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
+  let x = 0.123
+  case x {
+    _ if 0.123 <. x -> 1
+  }
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    X = 0.123,
+    case X of
+        _ when 0.123 < X ->
+            1
+    end.
+"#,
+    );
+
+    assert_erl!(
+        r#"
+pub fn main() {
   let x = 0
   case x {
     0 -> 1

--- a/src/format.rs
+++ b/src/format.rs
@@ -826,6 +826,8 @@ impl Documentable for &UntypedClauseGuard {
 
             ClauseGuard::Int { value, .. } => value.to_string().to_doc(),
 
+            ClauseGuard::Float { value, .. } => value.to_string().to_doc(),
+
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }
     }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -358,6 +358,10 @@ ClauseGuard5: UntypedClauseGuard = {
         location: location(s, e),
         value,
     },
+    <s:@L> <value:FloatLiteral> <e:@L> => ClauseGuard::Float {
+        location: location(s, e),
+        value,
+    },
 
     "{" <ClauseGuard> "}" => <>,
 }
@@ -571,10 +575,14 @@ Int: UntypedExpr = {
     }
 }
 
+FloatLiteral: String = {
+    <pos:r"-?[0-9]+\.+[0-9]*"> => pos.to_string()
+}
+
 Float: UntypedExpr = {
-    <s:@L> <f:r"-?[0-9]+\.+[0-9]*"> <e:@L> => UntypedExpr::Float {
+    <s:@L> <value:FloatLiteral> <e:@L> => UntypedExpr::Float {
         location: location(s, e),
-        value: f.to_string(),
+        value
     }
 }
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2441,6 +2441,10 @@ fn infer_clause_guard(
         ClauseGuard::Int {
             location, value, ..
         } => Ok(ClauseGuard::Int { location, value }),
+
+        ClauseGuard::Float {
+            location, value, ..
+        } => Ok(ClauseGuard::Float { location, value }),
     }
 }
 


### PR DESCRIPTION
This pull request is meant to complete Issue #465, adding support for float literals within guards. As requested each type is going to be it's own separate merge request. I also retroactively updated the `CHANGELOG` to reflect previous changes.

```
case x {
  _ if x == 3.14 -> "here we are using an Float literal"
}
```