### PR TITLE
Implement --check flag for gleam format --stdin

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1061,7 +1061,7 @@ but it cannot be found.",
             Error::Format { problem_files } => {
                 let mut files: Vec<_> = problem_files
                     .iter()
-                    .flat_map(|formatted| formatted.path.to_str())
+                    .flat_map(|formatted| formatted.source.to_str())
                     .map(|p| format!("  - {}", p))
                     .collect();
                 files.sort();

--- a/src/format/command.rs
+++ b/src/format/command.rs
@@ -40,7 +40,7 @@ fn check_formatting(formatted_files: Vec<Formatted>) -> Result<(), Error> {
 fn write_formatted(formatted_files: Vec<Formatted>) -> Result<(), Error> {
     for formatted in formatted_files {
         let path = formatted.path;
-        let mut f = File::open(&path).map_err(|e| Error::FileIO {
+        let mut f = File::create(&path).map_err(|e| Error::FileIO {
             action: FileIOAction::Create,
             kind: FileKind::File,
             path: path.clone(),


### PR DESCRIPTION
The first commit also addresses some permission errors I was getting while trying to format files on Mac OS.

Here's what using the command looks like: https://gist.github.com/QuinnWilton/5fcb8b5a1ce8829dd851427f6cd150ff

I tried to keep my changes in `format::command` to a minimum, but if you'd like me to do some refactoring to DRY up some of the shared logic between the stdin and non-stdin case, let me know and I'm happy to :)

I also didn't see existing tests for the `format::command` anywhere, so I wasn't sure where to start with testing this. If you have suggestions I'm happy to give that a try.