### PR TITLE
Imported constructor bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   the old '|' syntax in lists and for todos.
 - Will give a clearer error when a function given as an argument to another
   function doesn't match the type of the parameter.
+- Fixed bug where imported type constructors had the incorrect arity.
+- Fixed bug where a doing an unqualified import of a type constructor and
+  giving it an alias would use the wrong name if it contained any values.
+- Fixed a bug trying to access an imported constructor which contained values.
 
 ## v0.8.0-rc1 - 2020-04-28
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -610,7 +610,7 @@ fn case(subjects: &[TypedExpr], cs: &[TypedClause], env: &mut Env) -> Document {
 fn call(fun: &TypedExpr, args: &[CallArg<TypedExpr>], env: &mut Env) -> Document {
     match fun {
         TypedExpr::ModuleSelect {
-            constructor: ModuleValueConstructor::Record { name },
+            constructor: ModuleValueConstructor::Record { name, .. },
             ..
         }
         | TypedExpr::Var {
@@ -740,9 +740,24 @@ fn expr(expression: &TypedExpr, env: &mut Env) -> Document {
         TypedExpr::Call { fun, args, .. } => call(fun, args, env),
 
         TypedExpr::ModuleSelect {
-            constructor: ModuleValueConstructor::Record { name },
+            constructor: ModuleValueConstructor::Record { name, arity: 0 },
             ..
         } => atom(name.to_snake_case()),
+
+        TypedExpr::ModuleSelect {
+            constructor: ModuleValueConstructor::Record { name, arity },
+            ..
+        } => {
+            let chars = incrementing_args_list(*arity);
+            "fun("
+                .to_doc()
+                .append(chars.clone())
+                .append(") -> {")
+                .append(name.to_snake_case())
+                .append(", ")
+                .append(chars)
+                .append("} end")
+        }
 
         TypedExpr::ModuleSelect {
             typ,

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -405,7 +405,7 @@ fn var(name: &str, constructor: &ValueConstructor, env: &mut Env) -> Document {
     match &constructor.variant {
         ValueConstructorVariant::Record { name, arity: 0, .. } => atom(name.to_snake_case()),
 
-        ValueConstructorVariant::Record { arity, .. } => {
+        ValueConstructorVariant::Record { name, arity, .. } => {
             let chars = incrementing_args_list(*arity);
             "fun("
                 .to_doc()

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -247,7 +247,6 @@ map() ->
                         variant: ValueConstructorVariant::Record {
                             name: "Nil".to_string(),
                             field_map: None,
-                            arity: 0,
                         },
                     },
                     name: "Nil".to_string(),

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -765,6 +765,7 @@ fn main() { C }"
             ]),
         },
 
+        // Unqualified and aliased type constructor imports use the correct name
         Case {
             input: vec![
                 Input {

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -730,6 +730,40 @@ type Two = Person"
                 },
             ]),
         },
+
+        // Imported type constructors have the correct arity
+        Case {
+            input: vec![
+                Input {
+                    origin: ModuleOrigin::Src,
+                    path: PathBuf::from("/src/one.gleam"),
+                    source_base_path: PathBuf::from("/src"),
+                    src: "pub type T(x) { C(a: Int, b: Int) }".to_string(),
+                },
+                Input {
+                    origin: ModuleOrigin::Src,
+                    path: PathBuf::from("/src/two.gleam"),
+                    source_base_path: PathBuf::from("/src"),
+                    src: "import one.{C}
+fn main() { C }"
+                        .to_string(),
+                },
+            ],
+            expected: Ok(vec![
+                OutputFile {
+                    path: PathBuf::from("/gen/src/one_C.hrl"),
+                    text: "-record(c, {a, b}).\n".to_string(),
+                },
+                OutputFile {
+                    path: PathBuf::from("/gen/src/one.erl"),
+                    text: "-module(one).\n-compile(no_auto_import).\n\n\n".to_string(),
+                },
+                OutputFile {
+                    path: PathBuf::from("/gen/src/two.erl"),
+                    text: "-module(two).\n-compile(no_auto_import).\n\nmain() ->\n    fun(A, B) -> {c, A, B} end.\n".to_string(),
+                },
+            ]),
+        },
     ];
 
     for Case { input, expected } in cases.into_iter() {

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -764,6 +764,43 @@ fn main() { C }"
                 },
             ]),
         },
+
+        Case {
+            input: vec![
+                Input {
+                    origin: ModuleOrigin::Src,
+                    path: PathBuf::from("/src/one.gleam"),
+                    source_base_path: PathBuf::from("/src"),
+                    src: "pub fn id(x) { x } pub type T { X(x: Int) }".to_string(),
+                },
+                Input {
+                    origin: ModuleOrigin::Src,
+                    path: PathBuf::from("/src/two.gleam"),
+                    source_base_path: PathBuf::from("/src"),
+                    src: "import one.{X as e, id as i} fn make() { i(e) }".to_string(),
+                },
+            ],
+            expected: Ok(vec![
+                OutputFile {
+                    path: PathBuf::from("/gen/src/one_X.hrl"),
+                    text: "-record(x, {x}).\n".to_string(),
+
+                },
+                OutputFile {
+                    path: PathBuf::from("/gen/src/one.erl"),
+                    text: "-module(one).\n-compile(no_auto_import).\n
+-export([id/1]).\n
+id(X) ->\n    X.\n"
+                        .to_string(),
+                },
+                OutputFile {
+                    path: PathBuf::from("/gen/src/two.erl"),
+                    text: "-module(two).\n-compile(no_auto_import).\n
+make() ->\n    one:id(fun(A) -> {x, A} end).\n"
+                        .to_string(),
+                },
+            ]),
+        },
     ];
 
     for Case { input, expected } in cases.into_iter() {

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -277,7 +277,6 @@ pub enum ValueConstructorVariant {
     Record {
         name: String,
         field_map: Option<FieldMap>,
-        arity: usize,
     },
 }
 
@@ -372,7 +371,6 @@ impl<'a, 'b> Env<'a, 'b> {
             ValueConstructorVariant::Record {
                 name: "True".to_string(),
                 field_map: None,
-                arity: 0,
             },
             bool(),
         );
@@ -381,7 +379,6 @@ impl<'a, 'b> Env<'a, 'b> {
             ValueConstructorVariant::Record {
                 name: "False".to_string(),
                 field_map: None,
-                arity: 0,
             },
             bool(),
         );
@@ -453,7 +450,6 @@ impl<'a, 'b> Env<'a, 'b> {
             ValueConstructorVariant::Record {
                 name: "Nil".to_string(),
                 field_map: None,
-                arity: 0,
             },
             nil(),
         );
@@ -476,7 +472,6 @@ impl<'a, 'b> Env<'a, 'b> {
             ValueConstructorVariant::Record {
                 name: "Ok".to_string(),
                 field_map: None,
-                arity: 1,
             },
             fn_(vec![ok.clone()], result(ok, error)),
         );
@@ -488,7 +483,6 @@ impl<'a, 'b> Env<'a, 'b> {
             ValueConstructorVariant::Record {
                 name: "Error".to_string(),
                 field_map: None,
-                arity: 1,
             },
             fn_(vec![error.clone()], result(ok, error)),
         );
@@ -1563,7 +1557,6 @@ pub fn infer_module(
                             origin: constructor.location.clone(),
                             variant: ValueConstructorVariant::Record {
                                 name: constructor.name.clone(),
-                                arity: constructor.args.len(),
                                 field_map: field_map.clone(),
                             },
                         },
@@ -1572,7 +1565,6 @@ pub fn infer_module(
                         constructor.name.clone(),
                         ValueConstructorVariant::Record {
                             name: constructor.name.clone(),
-                            arity: constructor.args.len(),
                             field_map,
                         },
                         typ,

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -283,9 +283,10 @@ pub enum ValueConstructorVariant {
 impl ValueConstructorVariant {
     fn to_module_value_constructor(&self) -> ModuleValueConstructor {
         match self {
-            ValueConstructorVariant::Record { name, .. } => {
-                ModuleValueConstructor::Record { name: name.clone() }
-            }
+            ValueConstructorVariant::Record { name, field_map } => ModuleValueConstructor::Record {
+                name: name.clone(),
+                arity: field_map.as_ref().map_or(0, |fm| fm.arity),
+            },
 
             ValueConstructorVariant::LocalVariable { .. }
             | ValueConstructorVariant::ModuleFn { .. } => ModuleValueConstructor::Fn,
@@ -295,7 +296,7 @@ impl ValueConstructorVariant {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ModuleValueConstructor {
-    Record { name: String },
+    Record { name: String, arity: usize },
     Fn,
 }
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -1563,7 +1563,7 @@ pub fn infer_module(
                             origin: constructor.location.clone(),
                             variant: ValueConstructorVariant::Record {
                                 name: constructor.name.clone(),
-                                arity: args.len(),
+                                arity: constructor.args.len(),
                                 field_map: field_map.clone(),
                             },
                         },


### PR DESCRIPTION
This is 3 bug fixes and a refactor in one PR, but they are split up into individual commits so it's possible to do them seperately if preferable. The changes are:

1. The arity of ValueConstructorVariant::Record was being set wrong in `infer_module()`, which meant that on importing one into another module it had the arity of its type instead, casuing incorrect erlang to be printed. Fixed by using the correct arity when creating them.

2. Importing a constructor with an unqualified alias ie `import one.{A as b}` would print the incorrect name when generating the erlang if the constructor had an arity > 0. Fixed by making the name printing code the same as for the arity == 0 case.

3. The arity field of ValueConstructorVariant::Record was only being used in one place in the erland printer, and could be calculated there instead. Refactored it out.

4. ModuleSelect expressions always printed just the atom for a constructor, even if it had args. Fix: Now uses the same logic as when printing a var.