### PR TITLE
Surround binary operator sub expressions with parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Numbers are now permitted in module names.
+- Emitted Erlang code correctly adds parentheses around binary subexpressions
+  to preserve precedence.
 
 ## v0.8.0 - 2020-05-07
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -279,7 +279,6 @@ fn seq(first: &TypedExpr, then: &TypedExpr, env: &mut Env) -> Document {
         .append(expr(then, env))
 }
 
-// TODO: Surround left or right in parens if required
 fn bin_op(name: &BinOp, left: &TypedExpr, right: &TypedExpr, env: &mut Env) -> Document {
     let op = match name {
         BinOp::And => "andalso",
@@ -301,11 +300,21 @@ fn bin_op(name: &BinOp, left: &TypedExpr, right: &TypedExpr, env: &mut Env) -> D
         BinOp::ModuloInt => "rem",
     };
 
-    expr(left, env)
+    let left_expr = match left {
+        TypedExpr::BinOp { .. } => expr(left, env).surround("(", ")"),
+        _ => expr(left, env),
+    };
+
+    let right_expr = match right {
+        TypedExpr::BinOp { .. } => expr(right, env).surround("(", ")"),
+        _ => expr(right, env),
+    };
+
+    left_expr
         .append(break_("", " "))
         .append(op)
         .append(" ")
-        .append(expr(right, env))
+        .append(right_expr)
 }
 
 fn pipe(value: &TypedExpr, fun: &TypedExpr, env: &mut Env) -> Document {

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2156,4 +2156,23 @@ apply(F, A) ->
     F(A, 1).
 "#,
     );
+
+    // Parentheses are added for binop subexpressions
+    assert_erl!(
+        r#"
+fn main() {
+    let a = 2 * {3 + 1} / 2
+    let b = 5 + 3 / 3 * 2 - 6 * 4
+    b
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+main() ->
+    A = (2 * (3 + 1)) div 2,
+    B = (5 + ((3 div 3) * 2)) - (6 * 4),
+    B.
+"#,
+    );
 }

--- a/test/core_language/.gitignore
+++ b/test/core_language/.gitignore
@@ -1,2 +1,3 @@
 _build
 gen/
+*.beam

--- a/test/core_language/test/binary_operators_test.gleam
+++ b/test/core_language/test/binary_operators_test.gleam
@@ -1,8 +1,13 @@
 import should
 
-// pub fn precedence_test() {
-//   should.equal(1 + 2 * 3, 7)
-//   should.equal(3 * 1 + 2, 5)
-//   should.equal({ 1 + 2 } * 3, 9)
-//   should.equal(3 * { 1 + 2 }, 9)
-// }
+pub fn precedence_test() {
+  should.equal(1 + 2 * 3, 7)
+  should.equal(3 * 1 + 2, 5)
+  should.equal({ 1 + 2 } * 3, 9)
+  should.equal(1 + 2 * 3, 7)
+  should.equal(3 * { 1 + 2 }, 9)
+  should.equal(1 + 2 * 3 + 4, 11)
+  should.equal(2 * 3 + 4 * 5, 26)
+  should.equal(2 * {3 + 1} / 2, 4)
+  should.equal(5 + 3 / 3 * 2 - 6 * 4, -17)
+}


### PR DESCRIPTION
Resolves #448 

I'm unconditionally adding parentheses around the sub expressions here, because it seemed like the simplest way of fixing the wrong behaviour. If you'd prefer being smarter about it I can look into doing that.