### PR TITLE
Escape record names and fields in hrl record definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Numbers are now permitted in module names.
 - Emitted Erlang code correctly adds parentheses around binary subexpressions
   to preserve precedence.
+- Record names and fields are now escaped in `.hrl` files if they conflict
+  with Erlang reserved words
 
 ## v0.8.0 - 2020-05-07
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -8,6 +8,12 @@ fn record_definition_test() {
         record_definition("PetCat", &[&"name", &"is_cute",]),
         "-record(pet_cat, {name, is_cute}).\n".to_string()
     );
+
+    // Reserved words are escaped in record names and fields
+    assert_eq!(
+        record_definition("div", &[&"receive", &"catch", &"unreserved"]),
+        "-record(\'div\', {\'receive\', \'catch\', unreserved}).\n".to_string()
+    );
 }
 
 #[test]


### PR DESCRIPTION
This resolves #564 

The example from the issue generates the following `hrl` file:

```
-record(self, {'receive'}).
```

Similarly, a reserved word in the name of the record, such as:

```
pub type receive {
  Self(foo: String)
}
```

Will generate as:

```
-record('receive', {foo}).
```

Was this what you had in mind for escaping the name?