### PR TITLE
Add the ability to define additional pages to add to the output of `gleam docs`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Record names and fields are now escaped in `.hrl` files if they conflict
   with Erlang reserved words
 - Annotations are now supported on `let` and `assert` expressions
+- Additional (arbitrary) documentation pages can now be added and built
+  with `docs build`
 
 ## v0.8.0 - 2020-05-07
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -20,6 +20,19 @@ pub const OUTPUT_DIR_NAME: &str = "gen";
 #[derive(Deserialize)]
 pub struct ProjectConfig {
     pub name: String,
+    pub docs: Option<DocsPages>,
+}
+
+#[derive(Deserialize)]
+pub struct DocsPages {
+    pub pages: Vec<DocsPage>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct DocsPage {
+    pub title: String,
+    pub path: String,
+    pub source: PathBuf,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This resolves #569 