### PR TITLE
Define crate::typ::Typer and move inference methods into it

### DIFF
--- a/src/typ.rs
+++ b/src/typ.rs
@@ -795,7 +795,7 @@ impl<'a, 'b> Typer<'a, 'b> {
 
             UntypedExpr::Int {
                 location, value, ..
-            } => infer_int(value, location),
+            } => self.infer_int(value, location),
 
             UntypedExpr::Seq { first, then, .. } => infer_seq(*first, *then, level, self),
 
@@ -1033,6 +1033,14 @@ impl<'a, 'b> Typer<'a, 'b> {
             location,
             value,
             typ: string(),
+        })
+    }
+
+    fn infer_int(&mut self, value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::Int {
+            location,
+            value,
+            typ: int(),
         })
     }
 
@@ -2070,14 +2078,6 @@ pub fn infer_module(
         }),
         warnings,
     )
-}
-
-fn infer_int(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::Int {
-        location,
-        value,
-        typ: int(),
-    })
 }
 
 fn infer_float(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -787,7 +787,7 @@ impl<'a, 'b> Typer<'a, 'b> {
     ///
     pub fn infer(&mut self, expr: UntypedExpr, level: usize) -> Result<TypedExpr, Error> {
         match expr {
-            UntypedExpr::ListNil { location, .. } => infer_nil(location, level, self),
+            UntypedExpr::ListNil { location, .. } => self.infer_nil(location, level),
 
             UntypedExpr::Todo { location, .. } => infer_todo(location, level, self),
 
@@ -1007,6 +1007,13 @@ impl<'a, 'b> Typer<'a, 'b> {
             typ,
             right,
             left,
+        })
+    }
+
+    fn infer_nil(&mut self, location: SrcSpan, level: usize) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::ListNil {
+            location,
+            typ: list(self.new_unbound_var(level)),
         })
     }
 
@@ -2044,13 +2051,6 @@ pub fn infer_module(
         }),
         warnings,
     )
-}
-
-fn infer_nil(location: SrcSpan, level: usize, typer: &mut Typer) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::ListNil {
-        location,
-        typ: list(typer.new_unbound_var(level)),
-    })
 }
 
 fn infer_todo(location: SrcSpan, level: usize, typer: &mut Typer) -> Result<TypedExpr, Error> {

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -789,7 +789,7 @@ impl<'a, 'b> Typer<'a, 'b> {
         match expr {
             UntypedExpr::ListNil { location, .. } => self.infer_nil(location, level),
 
-            UntypedExpr::Todo { location, .. } => infer_todo(location, level, self),
+            UntypedExpr::Todo { location, .. } => self.infer_todo(location, level),
 
             UntypedExpr::Var { location, name, .. } => infer_var(name, location, level, self),
 
@@ -1014,6 +1014,17 @@ impl<'a, 'b> Typer<'a, 'b> {
         Ok(TypedExpr::ListNil {
             location,
             typ: list(self.new_unbound_var(level)),
+        })
+    }
+
+    fn infer_todo(&mut self, location: SrcSpan, level: usize) -> Result<TypedExpr, Error> {
+        self.warnings.push(Warning::Todo {
+            location: location.clone(),
+        });
+
+        Ok(TypedExpr::Todo {
+            location,
+            typ: self.new_unbound_var(level),
         })
     }
 
@@ -2051,17 +2062,6 @@ pub fn infer_module(
         }),
         warnings,
     )
-}
-
-fn infer_todo(location: SrcSpan, level: usize, typer: &mut Typer) -> Result<TypedExpr, Error> {
-    typer.warnings.push(Warning::Todo {
-        location: location.clone(),
-    });
-
-    Ok(TypedExpr::Todo {
-        location,
-        typ: typer.new_unbound_var(level),
-    })
 }
 
 fn infer_string(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -865,7 +865,7 @@ impl<'a, 'b> Typer<'a, 'b> {
                 fun,
                 args,
                 ..
-            } => infer_call(*fun, args, level, location, self),
+            } => self.infer_call(*fun, args, level, location),
 
             UntypedExpr::BinOp {
                 location,
@@ -1089,6 +1089,22 @@ impl<'a, 'b> Typer<'a, 'b> {
             args,
             body: Box::new(body),
             return_annotation,
+        })
+    }
+
+    fn infer_call(
+        &mut self,
+        fun: UntypedExpr,
+        args: Vec<CallArg<UntypedExpr>>,
+        level: usize,
+        location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        let (fun, args, typ) = do_infer_call(fun, args, level, &location, self)?;
+        Ok(TypedExpr::Call {
+            location,
+            typ,
+            args,
+            fun: Box::new(fun),
         })
     }
 
@@ -2126,22 +2142,6 @@ pub fn infer_module(
         }),
         warnings,
     )
-}
-
-fn infer_call(
-    fun: UntypedExpr,
-    args: Vec<CallArg<UntypedExpr>>,
-    level: usize,
-    location: SrcSpan,
-    typer: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let (fun, args, typ) = do_infer_call(fun, args, level, &location, typer)?;
-    Ok(TypedExpr::Call {
-        location,
-        typ,
-        args,
-        fun: Box::new(fun),
-    })
 }
 
 fn infer_cons(

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -791,7 +791,7 @@ impl<'a, 'b> Typer<'a, 'b> {
 
             UntypedExpr::Todo { location, .. } => self.infer_todo(location, level),
 
-            UntypedExpr::Var { location, name, .. } => infer_var(name, location, level, self),
+            UntypedExpr::Var { location, name, .. } => self.infer_var(name, location, level),
 
             UntypedExpr::Int {
                 location, value, ..
@@ -889,6 +889,19 @@ impl<'a, 'b> Typer<'a, 'b> {
                 ..
             } => infer_tuple_index(*tuple, index, location, level, self),
         }
+    }
+    fn infer_var(
+        &mut self,
+        name: String,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let constructor = infer_value_constructor(&name, level, &location, self)?;
+        Ok(TypedExpr::Var {
+            constructor,
+            location,
+            name,
+        })
     }
 
     fn infer_pipe(
@@ -2189,19 +2202,6 @@ pub fn infer_module(
         }),
         warnings,
     )
-}
-fn infer_var(
-    name: String,
-    location: SrcSpan,
-    level: usize,
-    typer: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let constructor = infer_value_constructor(&name, level, &location, typer)?;
-    Ok(TypedExpr::Var {
-        constructor,
-        location,
-        name,
-    })
 }
 
 fn infer_field_access(

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -805,7 +805,7 @@ impl<'a, 'b> Typer<'a, 'b> {
 
             UntypedExpr::Float {
                 location, value, ..
-            } => infer_float(value, location),
+            } => self.infer_float(value, location),
 
             UntypedExpr::String {
                 location, value, ..
@@ -1041,6 +1041,14 @@ impl<'a, 'b> Typer<'a, 'b> {
             location,
             value,
             typ: int(),
+        })
+    }
+
+    fn infer_float(&mut self, value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::Float {
+            location,
+            value,
+            typ: float(),
         })
     }
 
@@ -2078,14 +2086,6 @@ pub fn infer_module(
         }),
         warnings,
     )
-}
-
-fn infer_float(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::Float {
-        location,
-        value,
-        typ: float(),
-    })
 }
 
 fn infer_seq(

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -809,7 +809,7 @@ impl<'a, 'b> Typer<'a, 'b> {
 
             UntypedExpr::String {
                 location, value, ..
-            } => infer_string(value, location),
+            } => self.infer_string(value, location),
 
             UntypedExpr::Pipe {
                 left,
@@ -1025,6 +1025,14 @@ impl<'a, 'b> Typer<'a, 'b> {
         Ok(TypedExpr::Todo {
             location,
             typ: self.new_unbound_var(level),
+        })
+    }
+
+    fn infer_string(&mut self, value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::String {
+            location,
+            value,
+            typ: string(),
         })
     }
 
@@ -2062,14 +2070,6 @@ pub fn infer_module(
         }),
         warnings,
     )
-}
-
-fn infer_string(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::String {
-        location,
-        value,
-        typ: string(),
-    })
 }
 
 fn infer_int(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -193,7 +193,7 @@ fn infer_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Env::new(&[], &HashMap::new()))
+            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
                 .expect("should successfully infer");
             assert_eq!(
                 ($src, printer.pretty_print(result.typ().as_ref(), 0),),
@@ -421,7 +421,7 @@ fn infer_error_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Env::new(&[], &HashMap::new()))
+            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
                 .expect_err("should infer an error");
             assert_eq!(($src, sort_options($error)), ($src, sort_options(result)));
         };
@@ -2200,7 +2200,7 @@ fn env_types_with(things: &[&str]) -> Vec<String> {
 }
 
 fn env_types() -> Vec<String> {
-    Env::new(&[], &HashMap::new())
+    Typer::new(&[], &HashMap::new())
         .module_types
         .keys()
         .map(|s| s.to_string())
@@ -2216,7 +2216,7 @@ fn env_vars_with(things: &[&str]) -> Vec<String> {
 }
 
 fn env_vars() -> Vec<String> {
-    Env::new(&[], &HashMap::new())
+    Typer::new(&[], &HashMap::new())
         .local_values
         .keys()
         .map(|s| s.to_string())

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -193,8 +193,9 @@ fn infer_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
-                .expect("should successfully infer");
+            let importable_modules = HashMap::new();
+            let mut typer = Typer::new(&[], &importable_modules);
+            let result = typer.infer(ast, 1).expect("should successfully infer");
             assert_eq!(
                 ($src, printer.pretty_print(result.typ().as_ref(), 0),),
                 ($src, $typ.to_string()),
@@ -421,8 +422,9 @@ fn infer_error_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
-                .expect_err("should infer an error");
+            let importable_modules = HashMap::new();
+            let mut typer = Typer::new(&[], &importable_modules);
+            let result = typer.infer(ast, 1).expect_err("should infer an error");
             assert_eq!(($src, sort_options($error)), ($src, sort_options(result)));
         };
     }


### PR DESCRIPTION
This is preliminary work for allowing the typer to track it's own
state, so that it's able to keep track of type variables, unused
types, etc, as described in #579 

This commit has no functional changes, and simply defines the
Typer struct, and moves the type inference functions into it
as methods.

I wanted to make sure I understood what you were suggesting
in #579 before getting too far into the refactor. Is this
approximately what you were hoping for?

I am interested in working on the larger issue, too, however if
you have some time at some point, I wouldn't mind chatting
with you to make sure I understand what your ideal solution
looks like.