### PR TITLE
Add support for custom type record literals in guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add lookup for Gleam source code in Mix's `deps` directory.
 - Newly generated Gleam projects use the GitHub action
   `gleam-lang/setup-erlang` v1.1.0.
+- Added support for custom type record literals in guards.
 
 ## v0.8.1 - 2020-05-19
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -422,6 +422,14 @@ pub enum ClauseGuard<Type> {
         elems: Vec<Self>,
         typ: Type,
     },
+
+    Constructor {
+        location: SrcSpan,
+        module: Option<String>,
+        name: String,
+        args: Vec<CallArg<Self>>,
+        typ: Type,
+    },
 }
 
 impl<A> ClauseGuard<A> {
@@ -443,6 +451,7 @@ impl<A> ClauseGuard<A> {
             ClauseGuard::Int { location, .. } => location,
             ClauseGuard::Float { location, .. } => location,
             ClauseGuard::Tuple { location, .. } => location,
+            ClauseGuard::Constructor { location, .. } => location,
         }
     }
 }
@@ -454,6 +463,7 @@ impl TypedClauseGuard {
             ClauseGuard::Int { .. } => typ::int(),
             ClauseGuard::Float { .. } => typ::float(),
             ClauseGuard::Tuple { typ, .. } => typ.clone(),
+            ClauseGuard::Constructor { typ, .. } => typ.clone(),
             _ => typ::bool(),
         }
     }

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -630,6 +630,17 @@ fn bare_clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
             tuple(elems.into_iter().map(|e| bare_clause_guard(e, env)))
         }
 
+        ClauseGuard::Constructor { name, args, .. } => {
+            if args.is_empty() {
+                atom(name.to_snake_case())
+            } else {
+                tuple(
+                    std::iter::once(atom(name.to_snake_case()))
+                        .chain(args.into_iter().map(|a| bare_clause_guard(&a.value, env))),
+                )
+            }
+        }
+
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
         ClauseGuard::Var { name, .. } => env.local_var_name(name.to_string()),
@@ -659,7 +670,8 @@ fn clause_guard(guard: &TypedClauseGuard, env: &mut Env) -> Document {
         ClauseGuard::Var { .. }
         | ClauseGuard::Int { .. }
         | ClauseGuard::Float { .. }
-        | ClauseGuard::Tuple { .. } => bare_clause_guard(guard, env),
+        | ClauseGuard::Tuple { .. }
+        | ClauseGuard::Constructor { .. } => bare_clause_guard(guard, env),
     }
 }
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1837,6 +1837,8 @@ main() ->
 "#,
     );
 
+    // Tuple literals in guards
+
     assert_erl!(
         r#"
 pub fn main() {
@@ -1895,6 +1897,8 @@ main() ->
 "#,
     );
 
+    // Int literals in guards
+
     assert_erl!(
         r#"
 pub fn main() {
@@ -1940,6 +1944,46 @@ main() ->
     end.
 "#,
     );
+
+    // Record literals in guards
+
+    assert_erl!(
+        r#"
+    type Test { Test(x: Int, y: Float) }
+    pub fn main() {
+      let x = Test(1, 3.0)
+      case x {
+        _ if x == Test(1, 1.0) -> 1
+        _ if x == Test(y: 2.0, x: 2) -> 2
+        _ if x != Test(2, 3.0) -> 2
+        _ -> 0
+      }
+    }
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+main() ->
+    X = {test, 1, 3.0},
+    case X of
+        _ when X =:= {test, 1, 1.0} ->
+            1;
+
+        _ when X =:= {test, 2, 2.0} ->
+            2;
+
+        _ when X =/= {test, 2, 3.0} ->
+            2;
+
+        _ ->
+            0
+    end.
+"#,
+    );
+
+    // Float vars in guards
 
     assert_erl!(
         r#"

--- a/src/format.rs
+++ b/src/format.rs
@@ -1049,9 +1049,53 @@ impl Documentable for &UntypedClauseGuard {
                 .to_doc()
                 .append(wrap_args(elems.iter().map(|e| e.to_doc()))),
 
+            ClauseGuard::Constructor {
+                name,
+                args,
+                module: None,
+                ..
+            } if args.is_empty() => name.to_string().to_doc(),
+
+            ClauseGuard::Constructor {
+                name,
+                args,
+                module: Some(m),
+                ..
+            } if args.is_empty() => m.to_string().to_doc().append(".").append(name.to_string()),
+
+            ClauseGuard::Constructor {
+                name,
+                args,
+                module: None,
+                ..
+            } => name
+                .to_string()
+                .to_doc()
+                .append(wrap_args(args.iter().map(|a| clause_guard_call_arg(&a)))),
+
+            ClauseGuard::Constructor {
+                name,
+                args,
+                module: Some(m),
+                ..
+            } => m
+                .to_string()
+                .to_doc()
+                .append(".")
+                .append(name.to_string())
+                .append(wrap_args(args.iter().map(|a| clause_guard_call_arg(&a)))),
+
             ClauseGuard::Var { name, .. } => name.to_string().to_doc(),
         }
     }
+}
+
+fn clause_guard_call_arg(arg: &CallArg<UntypedClauseGuard>) -> Document {
+    match &arg.label {
+        Some(s) => s.clone().to_doc().append(": "),
+        None => nil(),
+    }
+    .append(arg.value.to_doc())
 }
 
 fn categorise_list_expr(expr: &UntypedExpr) -> ListType<&UntypedExpr, &UntypedExpr> {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -1657,6 +1657,23 @@ World"
     );
 
     assert_format!(
+        r#"type Test {
+  Test(x: Int, y: Float)
+}
+
+pub fn main() {
+  let x = Test(1, 3.0)
+  case x {
+    _ if x == Test(1, 1.0) -> 1
+    _ if x == Test(y: 2.0, x: 2) -> 2
+    _ if x != Test(2, 3.0) -> 2
+    _ -> 0
+  }
+}
+"#
+    );
+
+    assert_format!(
         r#"fn main() {
   case 1 {
     _ if x != y -> Nil

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -387,7 +387,30 @@ ClauseGuard5: UntypedClauseGuard = {
         typ: (),
         elems,
     },
+    <s:@L> <module:(<VarName> ".")?> <name:UpName> <args:ClauseGuardConstructorArgs?> <e:@L> => {
+        let args = args.unwrap_or_else(|| vec![]);
+
+        ClauseGuard::Constructor {
+            location: location(s, e),
+            args: args,
+            module,
+            typ: (),
+            name,
+        }
+    },
     "{" <ClauseGuard> "}" => <>,
+}
+
+ClauseGuardConstructorArgs: Vec<CallArg<UntypedClauseGuard>> = {
+    "(" <args:Comma<ClauseGuardConstructorArg>> ")" => args
+}
+
+ClauseGuardConstructorArg: CallArg<UntypedClauseGuard> = {
+    <s:@L> <label:(<VarName> ":")?> <value:ClauseGuard> <e:@L> => CallArg {
+        location: location(s, e),
+        label,
+        value,
+    },
 }
 
 BindingKind: BindingKind = {

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2444,12 +2444,19 @@ fn infer_clause_guard(
                 }
             };
 
+            // Pretty much all the other infer functions operate on UntypedExpr
+            // or TypedExpr rather than ClauseGuard. To make things easier we
+            // build the TypedExpr equivalent of the constructor and use that
             let fun = TypedExpr::Var {
                 constructor,
                 location: location.clone(),
                 name: name.clone(),
             };
 
+            // This is basically the same code as do_infer_call_with_known_fun()
+            // except the args are typed with infer_clause_guard() here.
+            // This duplication is a bit awkward but it works!
+            // Potentially this could be improved later
             match get_field_map(&fun, env)
                 .map_err(|e| convert_get_value_constructor_error(e, &location))?
             {

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -2109,6 +2109,48 @@ fn main() {
         },
     );
 
+    // Constructor in guard clause errors
+
+    assert_error!(
+        r#"type X { X(a: Int, b: Float) }
+                    fn x() {
+                        case X(1, 2.0) { x if x == X(1) -> 1 }
+                    }"#,
+        Error::IncorrectArity {
+            location: SrcSpan {
+                start: 111,
+                end: 115
+            },
+            expected: 2,
+            given: 1,
+        },
+    );
+
+    assert_error!(
+        r#"type X { X(a: Int, b: Float) }
+                    fn x() {
+                        case X(1, 2.0) { x if x == X(2.0, 1) -> 1 }
+                    }"#,
+        Error::CouldNotUnify {
+            location: SrcSpan {
+                start: 113,
+                end: 116
+            },
+            expected: Arc::new(Type::App {
+                public: true,
+                module: vec![],
+                name: "Int".to_string(),
+                args: vec![],
+            }),
+            given: Arc::new(Type::App {
+                public: true,
+                module: vec![],
+                name: "Float".to_string(),
+                args: vec![],
+            }),
+        },
+    );
+
     // Cases were we can't so easily check for equality-
     // i.e. because the contents of the error are non-deterministic.
     assert_error!("fn inc(x: a) { x + 1 }");


### PR DESCRIPTION
Addresses #465 

This seems to work and passes the tests, but the typing of the `ClauseGuard::Constructor` is a massive hack.

All the inference functions that seem relevant expect `UntypedExpr` rather than `UntypedClauseGuard` so I can't call them directly. I ended up using `infer_value_constructor()` to make construct a `TypedExpr::Var` and then using that with code copied from `do_infer_call_with_known_fun()` but with various bits swapped out to use `ClauseGuard`.

The formatter and printer also end up being very similar to existing logic but with `ClauseGuard` instead of `Expr`.

Suggestions welcome!