### PR TITLE
Format public opaque types correctly.

### DIFF
--- a/src/docs.rs
+++ b/src/docs.rs
@@ -202,6 +202,7 @@ fn type_<'a>(statement: &'a TypedStatement) -> Option<Type<'a>> {
 
         Statement::CustomType {
             public: true,
+            opaque,
             name,
             args,
             doc,
@@ -211,7 +212,14 @@ fn type_<'a>(statement: &'a TypedStatement) -> Option<Type<'a>> {
         } => Some(Type {
             name,
             // TODO: Don't use the same printer for docs as for the formatter
-            definition: print(formatter.custom_type(true, name, args, cs.as_slice(), location)),
+            definition: print(formatter.custom_type(
+                true,
+                *opaque,
+                name,
+                args,
+                cs.as_slice(),
+                location,
+            )),
             documentation: markdown_documentation(doc),
             constructors: cs
                 .into_iter()

--- a/src/format.rs
+++ b/src/format.rs
@@ -165,8 +165,16 @@ impl<'a> Formatter<'a> {
                 public,
                 constructors,
                 location,
+                opaque,
                 ..
-            } => self.custom_type(*public, name, args.as_slice(), constructors, location),
+            } => self.custom_type(
+                *public,
+                *opaque,
+                name,
+                args.as_slice(),
+                constructors,
+                location,
+            ),
 
             Statement::ExternalFn {
                 public,
@@ -643,6 +651,7 @@ impl<'a> Formatter<'a> {
     pub fn custom_type(
         &mut self,
         public: bool,
+        opaque: bool,
         name: &str,
         args: &[String],
         constructors: &[RecordConstructor],
@@ -651,7 +660,7 @@ impl<'a> Formatter<'a> {
         self.pop_empty_lines(location.start);
         pub_(public)
             .to_doc()
-            .append("type ")
+            .append(if opaque { "opaque type " } else { "type " })
             .append(if args.is_empty() {
                 name.clone().to_doc()
             } else {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -347,6 +347,13 @@ pub external type Four
 "
     );
 
+    assert_format!(
+        "pub opaque type X {
+  X
+}
+"
+    );
+
     //
     // Expr::Fn
     //


### PR DESCRIPTION
🍨 