### PR TITLE
Formatter now preserves type annotations on let

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -411,6 +411,7 @@ impl<'a> Formatter<'a> {
         value: &UntypedExpr,
         then: &UntypedExpr,
         kind: BindingKind,
+        annotation: &Option<TypeAst>,
     ) -> Document {
         self.pop_empty_lines(pattern.location().end);
 
@@ -428,6 +429,11 @@ impl<'a> Formatter<'a> {
         force_break()
             .append(keyword)
             .append(self.pattern(pattern))
+            .append(
+                annotation
+                    .as_ref()
+                    .map(|a| ": ".to_doc().append(self.type_ast(a))),
+            )
             .append(" = ")
             .append(self.hanging_expr(value))
             .append(line)
@@ -484,10 +490,11 @@ impl<'a> Formatter<'a> {
             UntypedExpr::Let {
                 value,
                 pattern,
+                annotation,
                 then,
                 kind,
                 ..
-            } => self.let_(pattern, value, then, *kind),
+            } => self.let_(pattern, value, then, *kind, annotation),
 
             UntypedExpr::Case {
                 subjects, clauses, ..

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -401,6 +401,16 @@ pub external type Four
 
     assert_format!(
         r#"fn main() {
+  fn() {
+    let x: Int = 1
+    x
+  }
+}
+"#
+    );
+
+    assert_format!(
+        r#"fn main() {
   fn(_) {
     1
     2

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -64,6 +64,15 @@ impl Documentable for Vec<Document> {
     }
 }
 
+impl<D: Documentable> Documentable for Option<D> {
+    fn to_doc(self) -> Document {
+        match self {
+            Some(d) => d.to_doc(),
+            None => Document::Nil,
+        }
+    }
+}
+
 pub fn concat(mut docs: impl Iterator<Item = Document>) -> Document {
     let init = docs.next().unwrap_or_else(|| nil());
     docs.fold(init, |acc, doc| {


### PR DESCRIPTION
#601