### PR TITLE
Preserve type variables across scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Newly generated Gleam projects use the GitHub action
   `gleam-lang/setup-erlang` v1.1.0.
 - Added support for custom type record literals in guards.
+- Type variables are now correctly preserved within nested scopes.
 
 ## v0.8.1 - 2020-05-19
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -1452,17 +1452,19 @@ impl<'a, 'b> Typer<'a, 'b> {
             location,
         } = clause;
 
-        // Store the local scope so it can be reset after the clause
-        let vars = self.local_values.clone();
+        let mut clause_typer = self.new_scope();
 
         // Check the types
-        let (typed_pattern, typed_alternatives) =
-            self.infer_clause_pattern(pattern, alternative_patterns, subjects, &location)?;
-        let guard = self.infer_optional_clause_guard(guard)?;
-        let then = self.infer(then)?;
+        let (typed_pattern, typed_alternatives) = clause_typer.infer_clause_pattern(
+            pattern,
+            alternative_patterns,
+            subjects,
+            &location,
+        )?;
+        let guard = clause_typer.infer_optional_clause_guard(guard)?;
+        let then = clause_typer.infer(then)?;
 
-        // Reset the local vars now the clause scope is done
-        self.local_values = vars;
+        self.end_scope(&clause_typer);
 
         Ok(Clause {
             location,

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -68,7 +68,7 @@ impl Type {
         module: &[String],
         name: &str,
         arity: usize,
-        env: &mut Typer,
+        typer: &mut Typer,
     ) -> Option<Vec<Arc<Type>>> {
         match self {
             Type::App {
@@ -87,11 +87,11 @@ impl Type {
             Type::Var { typ } => {
                 let args: Vec<_> = match &*typ.borrow() {
                     TypeVar::Link { typ } => {
-                        return typ.get_app_args(public, module, name, arity, env);
+                        return typ.get_app_args(public, module, name, arity, typer);
                     }
 
                     TypeVar::Unbound { level, .. } => {
-                        (0..arity).map(|_| env.new_unbound_var(*level)).collect()
+                        (0..arity).map(|_| typer.new_unbound_var(*level)).collect()
                     }
 
                     TypeVar::Generic { .. } => return None,
@@ -342,7 +342,7 @@ impl<'a, 'b> Typer<'a, 'b> {
         current_module: &'b [String],
         importable_modules: &'a HashMap<String, Module>,
     ) -> Self {
-        let mut env = Self {
+        let mut typer = Self {
             uid: 0,
             annotated_generic_types: im::HashSet::new(),
             module_types: HashMap::new(),
@@ -355,19 +355,20 @@ impl<'a, 'b> Typer<'a, 'b> {
             current_module,
         };
 
-        env.insert_type_constructor(
-            "Int".to_string(),
-            TypeConstructor {
-                parameters: vec![],
-                typ: int(),
-                origin: Default::default(),
-                module: vec![],
-                public: true,
-            },
-        )
-        .gleam_expect("prelude inserting Int type");
+        typer
+            .insert_type_constructor(
+                "Int".to_string(),
+                TypeConstructor {
+                    parameters: vec![],
+                    typ: int(),
+                    origin: Default::default(),
+                    module: vec![],
+                    public: true,
+                },
+            )
+            .gleam_expect("prelude inserting Int type");
 
-        env.insert_variable(
+        typer.insert_variable(
             "True".to_string(),
             ValueConstructorVariant::Record {
                 name: "True".to_string(),
@@ -375,7 +376,7 @@ impl<'a, 'b> Typer<'a, 'b> {
             },
             bool(),
         );
-        env.insert_variable(
+        typer.insert_variable(
             "False".to_string(),
             ValueConstructorVariant::Record {
                 name: "False".to_string(),
@@ -383,70 +384,75 @@ impl<'a, 'b> Typer<'a, 'b> {
             },
             bool(),
         );
-        env.insert_type_constructor(
-            "Bool".to_string(),
-            TypeConstructor {
-                origin: Default::default(),
-                parameters: vec![],
-                typ: bool(),
-                module: vec![],
-                public: true,
-            },
-        )
-        .gleam_expect("prelude inserting Bool type");
+        typer
+            .insert_type_constructor(
+                "Bool".to_string(),
+                TypeConstructor {
+                    origin: Default::default(),
+                    parameters: vec![],
+                    typ: bool(),
+                    module: vec![],
+                    public: true,
+                },
+            )
+            .gleam_expect("prelude inserting Bool type");
 
-        let list_parameter = env.new_generic_var();
-        env.insert_type_constructor(
-            "List".to_string(),
-            TypeConstructor {
-                origin: Default::default(),
-                parameters: vec![list_parameter.clone()],
-                typ: list(list_parameter),
-                module: vec![],
-                public: true,
-            },
-        )
-        .gleam_expect("prelude inserting List type");
+        let list_parameter = typer.new_generic_var();
+        typer
+            .insert_type_constructor(
+                "List".to_string(),
+                TypeConstructor {
+                    origin: Default::default(),
+                    parameters: vec![list_parameter.clone()],
+                    typ: list(list_parameter),
+                    module: vec![],
+                    public: true,
+                },
+            )
+            .gleam_expect("prelude inserting List type");
 
-        env.insert_type_constructor(
-            "Float".to_string(),
-            TypeConstructor {
-                origin: Default::default(),
-                parameters: vec![],
-                typ: float(),
-                module: vec![],
-                public: true,
-            },
-        )
-        .gleam_expect("prelude inserting Float type");
+        typer
+            .insert_type_constructor(
+                "Float".to_string(),
+                TypeConstructor {
+                    origin: Default::default(),
+                    parameters: vec![],
+                    typ: float(),
+                    module: vec![],
+                    public: true,
+                },
+            )
+            .gleam_expect("prelude inserting Float type");
 
-        env.insert_type_constructor(
-            "String".to_string(),
-            TypeConstructor {
-                origin: Default::default(),
-                parameters: vec![],
-                typ: string(),
-                module: vec![],
-                public: true,
-            },
-        )
-        .gleam_expect("prelude inserting String type");
+        typer
+            .insert_type_constructor(
+                "String".to_string(),
+                TypeConstructor {
+                    origin: Default::default(),
+                    parameters: vec![],
+                    typ: string(),
+                    module: vec![],
+                    public: true,
+                },
+            )
+            .gleam_expect("prelude inserting String type");
 
-        let result_value = env.new_generic_var();
-        let result_error = env.new_generic_var();
-        env.insert_type_constructor(
-            "Result".to_string(),
-            TypeConstructor {
-                origin: Default::default(),
-                parameters: vec![result_value.clone(), result_error.clone()],
-                typ: result(result_value, result_error),
-                module: vec![],
-                public: true,
-            },
-        )
-        .gleam_expect("prelude inserting Result type");
+        let result_value = typer.new_generic_var();
+        let result_error = typer.new_generic_var();
+        typer
+            .insert_type_constructor(
+                "Result".to_string(),
+                TypeConstructor {
+                    origin: Default::default(),
+                    parameters: vec![result_value.clone(), result_error.clone()],
+                    typ: result(result_value, result_error),
+                    module: vec![],
+                    public: true,
+                },
+            )
+            .gleam_expect("prelude inserting Result type");
 
-        env.insert_variable(
+        typer.insert_variable(
             "Nil".to_string(),
             ValueConstructorVariant::Record {
                 name: "Nil".to_string(),
@@ -454,21 +460,22 @@ impl<'a, 'b> Typer<'a, 'b> {
             },
             nil(),
         );
-        env.insert_type_constructor(
-            "Nil".to_string(),
-            TypeConstructor {
-                origin: Default::default(),
-                parameters: vec![],
-                typ: nil(),
-                module: vec![],
-                public: true,
-            },
-        )
-        .gleam_expect("prelude inserting Nil type");
+        typer
+            .insert_type_constructor(
+                "Nil".to_string(),
+                TypeConstructor {
+                    origin: Default::default(),
+                    parameters: vec![],
+                    typ: nil(),
+                    module: vec![],
+                    public: true,
+                },
+            )
+            .gleam_expect("prelude inserting Nil type");
 
-        let ok = env.new_generic_var();
-        let error = env.new_generic_var();
-        env.insert_variable(
+        let ok = typer.new_generic_var();
+        let error = typer.new_generic_var();
+        typer.insert_variable(
             "Ok".to_string(),
             ValueConstructorVariant::Record {
                 name: "Ok".to_string(),
@@ -477,9 +484,9 @@ impl<'a, 'b> Typer<'a, 'b> {
             fn_(vec![ok.clone()], result(ok, error)),
         );
 
-        let ok = env.new_generic_var();
-        let error = env.new_generic_var();
-        env.insert_variable(
+        let ok = typer.new_generic_var();
+        let error = typer.new_generic_var();
+        typer.insert_variable(
             "Error".to_string(),
             ValueConstructorVariant::Record {
                 name: "Error".to_string(),
@@ -488,7 +495,7 @@ impl<'a, 'b> Typer<'a, 'b> {
             fn_(vec![error.clone()], result(ok, error)),
         );
 
-        env
+        typer
     }
 
     fn next_uid(&mut self) -> usize {
@@ -720,16 +727,16 @@ impl<'a, 'b> Typer<'a, 'b> {
                 let mut type_vars = hashmap![];
                 let mut parameter_types = Vec::with_capacity(parameters.len());
                 for typ in parameters {
-                    parameter_types.push(instantiate(typ, 0, &mut type_vars, self));
+                    parameter_types.push(self.instantiate(typ, 0, &mut type_vars));
                 }
-                let return_type = instantiate(return_type, 0, &mut type_vars, self);
+                let return_type = self.instantiate(return_type, 0, &mut type_vars);
 
                 // Unify argument types with instantiated parameter types so that the correct types
                 // are inserted into the return type
                 for (parameter, (location, argument)) in
                     parameter_types.iter().zip(argument_types.iter())
                 {
-                    unify(parameter.clone(), argument.clone(), self)
+                    self.unify(parameter.clone(), argument.clone())
                         .map_err(|e| convert_unify_error(e, &location))?;
                 }
 
@@ -773,6 +780,1552 @@ impl<'a, 'b> Typer<'a, 'b> {
 
     pub fn insert_accessors(&mut self, type_name: &str, accessors: AccessorsMap) {
         self.accessors.insert(type_name.to_string(), accessors);
+    }
+
+    /// Crawl the AST, annotating each node with the inferred type or
+    /// returning an error.
+    ///
+    pub fn infer(&mut self, expr: UntypedExpr, level: usize) -> Result<TypedExpr, Error> {
+        match expr {
+            UntypedExpr::ListNil { location, .. } => self.infer_nil(location, level),
+
+            UntypedExpr::Todo { location, .. } => self.infer_todo(location, level),
+
+            UntypedExpr::Var { location, name, .. } => self.infer_var(name, location, level),
+
+            UntypedExpr::Int {
+                location, value, ..
+            } => self.infer_int(value, location),
+
+            UntypedExpr::Seq { first, then, .. } => self.infer_seq(*first, *then, level),
+
+            UntypedExpr::Tuple {
+                location, elems, ..
+            } => self.infer_tuple(elems, location, level),
+
+            UntypedExpr::Float {
+                location, value, ..
+            } => self.infer_float(value, location),
+
+            UntypedExpr::String {
+                location, value, ..
+            } => self.infer_string(value, location),
+
+            UntypedExpr::Pipe {
+                left,
+                right,
+                location,
+            } => self.infer_pipe(*left, *right, location, level),
+
+            UntypedExpr::Fn {
+                location,
+                is_capture,
+                args,
+                body,
+                return_annotation,
+                ..
+            } => self.infer_fn(args, *body, is_capture, return_annotation, level, location),
+
+            UntypedExpr::Let {
+                location,
+                pattern,
+                value,
+                then,
+                kind,
+                annotation,
+                ..
+            } => self.infer_let(pattern, *value, *then, kind, &annotation, level, location),
+
+            UntypedExpr::Case {
+                location,
+                subjects,
+                clauses,
+                ..
+            } => self.infer_case(subjects, clauses, level, location),
+
+            UntypedExpr::ListCons {
+                location,
+                head,
+                tail,
+                deprecated_syntax,
+                ..
+            } => self.infer_cons(*head, *tail, deprecated_syntax, location, level),
+
+            UntypedExpr::Call {
+                location,
+                fun,
+                args,
+                ..
+            } => self.infer_call(*fun, args, level, location),
+
+            UntypedExpr::BinOp {
+                location,
+                name,
+                left,
+                right,
+                ..
+            } => self.infer_binop(name, *left, *right, level, location),
+
+            UntypedExpr::FieldAccess {
+                location,
+                label,
+                container,
+                ..
+            } => self.infer_field_access(*container, label, location, level),
+
+            UntypedExpr::TupleIndex {
+                location,
+                index,
+                tuple,
+                ..
+            } => self.infer_tuple_index(*tuple, index, location, level),
+        }
+    }
+
+    fn infer_pipe(
+        &mut self,
+        left: UntypedExpr,
+        right: UntypedExpr,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        match right {
+            // left |> right(..args)
+            UntypedExpr::Call { fun, args, .. } => {
+                let fun = self.infer(*fun, level)?;
+                match fun.typ().fn_arity() {
+                    // Rewrite as right(left, ..args)
+                    Some(arity) if arity == args.len() + 1 => {
+                        self.infer_insert_pipe(fun, args, left, level)
+                    }
+
+                    // Rewrite as right(..args)(left)
+                    _ => self.infer_apply_to_call_pipe(fun, args, left, location, level),
+                }
+            }
+
+            // right(left)
+            right => self.infer_apply_pipe(left, right, location, level),
+        }
+    }
+
+    /// Attempt to infer a |> b(..c) as b(..c)(a)
+    fn infer_apply_to_call_pipe(
+        &mut self,
+        fun: TypedExpr,
+        args: Vec<CallArg<UntypedExpr>>,
+        left: UntypedExpr,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let right_location = left.location().clone();
+        let (fun, args, typ) =
+            self.do_infer_call_with_known_fun(fun, args, level, &right_location)?;
+        let fun = TypedExpr::Call {
+            location: right_location,
+            typ,
+            args,
+            fun: Box::new(fun),
+        };
+        let args = vec![CallArg {
+            label: None,
+            location: left.location().clone(),
+            value: left,
+        }];
+        let (fun, args, typ) = self.do_infer_call_with_known_fun(fun, args, level, &location)?;
+        Ok(TypedExpr::Call {
+            location,
+            typ,
+            args,
+            fun: Box::new(fun),
+        })
+    }
+
+    /// Attempt to infer a |> b(c) as b(a, c)
+    fn infer_insert_pipe(
+        &mut self,
+        fun: TypedExpr,
+        args: Vec<CallArg<UntypedExpr>>,
+        left: UntypedExpr,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let location = left.location().clone();
+        let mut new_args = Vec::with_capacity(args.len() + 1);
+        new_args.push(CallArg {
+            label: None,
+            location: left.location().clone(),
+            value: left,
+        });
+        for arg in args {
+            new_args.push(arg.clone());
+        }
+        let (fun, args, typ) =
+            self.do_infer_call_with_known_fun(fun, new_args, level, &location)?;
+        Ok(TypedExpr::Call {
+            location,
+            typ,
+            args,
+            fun: Box::new(fun),
+        })
+    }
+
+    /// Attempt to infer a |> b as b(a)
+    fn infer_apply_pipe(
+        &mut self,
+        left: UntypedExpr,
+        right: UntypedExpr,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let left = Box::new(self.infer(left, level)?);
+        let right = Box::new(self.infer(right, level)?);
+        let typ = self.new_unbound_var(level);
+        let fn_typ = Arc::new(Type::Fn {
+            args: vec![left.typ()],
+            retrn: typ.clone(),
+        });
+        self.unify(right.typ(), fn_typ)
+            .map_err(|e| convert_unify_error(e, &location))?;
+
+        Ok(TypedExpr::Pipe {
+            location,
+            typ,
+            right,
+            left,
+        })
+    }
+
+    fn infer_nil(&mut self, location: SrcSpan, level: usize) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::ListNil {
+            location,
+            typ: list(self.new_unbound_var(level)),
+        })
+    }
+
+    fn infer_todo(&mut self, location: SrcSpan, level: usize) -> Result<TypedExpr, Error> {
+        self.warnings.push(Warning::Todo {
+            location: location.clone(),
+        });
+
+        Ok(TypedExpr::Todo {
+            location,
+            typ: self.new_unbound_var(level),
+        })
+    }
+
+    fn infer_string(&mut self, value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::String {
+            location,
+            value,
+            typ: string(),
+        })
+    }
+
+    fn infer_int(&mut self, value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::Int {
+            location,
+            value,
+            typ: int(),
+        })
+    }
+
+    fn infer_float(&mut self, value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
+        Ok(TypedExpr::Float {
+            location,
+            value,
+            typ: float(),
+        })
+    }
+
+    fn infer_seq(
+        &mut self,
+        first: UntypedExpr,
+        then: UntypedExpr,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let first = self.infer(first, level)?;
+        let then = self.infer(then, level)?;
+
+        match first.typ().as_ref() {
+            typ if typ.is_result() => {
+                self.warnings.push(Warning::ImplicitlyDiscardedResult {
+                    location: first.location().clone(),
+                });
+            }
+
+            _ => {}
+        }
+
+        Ok(TypedExpr::Seq {
+            typ: then.typ(),
+            first: Box::new(first),
+            then: Box::new(then),
+        })
+    }
+
+    fn infer_fn(
+        &mut self,
+        args: Vec<UntypedArg>,
+        body: UntypedExpr,
+        is_capture: bool,
+        return_annotation: Option<TypeAst>,
+        level: usize,
+        location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        let (args, body) = self.do_infer_fn(args, body, &return_annotation, level)?;
+        let args_types = args.iter().map(|a| a.typ.clone()).collect();
+        let typ = fn_(args_types, body.typ());
+        Ok(TypedExpr::Fn {
+            location,
+            typ,
+            is_capture,
+            args,
+            body: Box::new(body),
+            return_annotation,
+        })
+    }
+
+    fn do_infer_fn(
+        &mut self,
+        args: Vec<UntypedArg>,
+        body: UntypedExpr,
+        return_annotation: &Option<TypeAst>,
+        level: usize,
+    ) -> Result<(Vec<TypedArg>, TypedExpr), Error> {
+        // Construct an initial type for each argument of the function- either an unbound type variable
+        // or a type provided by an annotation.
+        let mut type_vars = hashmap![];
+        let args: Vec<_> = args
+            .into_iter()
+            .map(|arg| self.infer_arg(arg, &mut type_vars, level))
+            .collect::<Result<_, _>>()?;
+
+        // Record generic type variables that comes from type annotations.
+        // They cannot be instantiated so we need to keep track of them.
+        let previous_annotated_generic_types = self.annotated_generic_types.clone();
+        for (id, _type) in type_vars.values() {
+            self.annotated_generic_types.insert(*id);
+        }
+
+        // Insert arguments into function body scope.
+        let previous_vars = self.local_values.clone();
+        for (arg, t) in args.iter().zip(args.iter().map(|arg| arg.typ.clone())) {
+            match &arg.names {
+                ArgNames::Named { name } | ArgNames::NamedLabelled { name, .. } => self
+                    .insert_variable(name.to_string(), ValueConstructorVariant::LocalVariable, t),
+                ArgNames::Discard { .. } | ArgNames::LabelledDiscard { .. } => (),
+            };
+        }
+
+        let body = self.infer(body, level)?;
+
+        // Check that any return type annotation is accurate.
+        if let Some(ann) = return_annotation {
+            let ret_typ = self.type_from_ast(ann, &mut type_vars, NewTypeAction::MakeGeneric)?;
+            self.unify(ret_typ, body.typ())
+                .map_err(|e| convert_unify_error(e, body.location()))?;
+        }
+
+        // Reset the typer now that the scope of the function has ended.
+        self.local_values = previous_vars;
+        self.annotated_generic_types = previous_annotated_generic_types;
+        Ok((args, body))
+    }
+
+    fn infer_arg(
+        &mut self,
+        arg: UntypedArg,
+        type_vars: &mut im::HashMap<String, (usize, Arc<Type>)>,
+        level: usize,
+    ) -> Result<TypedArg, Error> {
+        let Arg {
+            names,
+            annotation,
+            location,
+            ..
+        } = arg;
+        let typ = annotation
+            .clone()
+            .map(|t| self.type_from_ast(&t, type_vars, NewTypeAction::MakeGeneric))
+            .unwrap_or_else(|| Ok(self.new_unbound_var(level)))?;
+        Ok(Arg {
+            names,
+            location,
+            annotation,
+            typ,
+        })
+    }
+
+    fn infer_call(
+        &mut self,
+        fun: UntypedExpr,
+        args: Vec<CallArg<UntypedExpr>>,
+        level: usize,
+        location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        let (fun, args, typ) = self.do_infer_call(fun, args, level, &location)?;
+        Ok(TypedExpr::Call {
+            location,
+            typ,
+            args,
+            fun: Box::new(fun),
+        })
+    }
+
+    fn infer_cons(
+        &mut self,
+        head: UntypedExpr,
+        tail: UntypedExpr,
+        deprecated_syntax: bool,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let head = self.infer(head, level)?;
+        let tail = self.infer(tail, level)?;
+        self.unify(tail.typ(), list(head.typ()))
+            .map_err(|e| convert_unify_error(e, &location))?;
+
+        if deprecated_syntax {
+            self.warnings.push(Warning::DeprecatedListPrependSyntax {
+                location: SrcSpan {
+                    start: location.start - 2,
+                    end: location.start - 1,
+                },
+            });
+        }
+
+        Ok(TypedExpr::ListCons {
+            location,
+            typ: tail.typ(),
+            head: Box::new(head),
+            tail: Box::new(tail),
+        })
+    }
+
+    fn infer_tuple(
+        &mut self,
+        elems: Vec<UntypedExpr>,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let elems = elems
+            .into_iter()
+            .map(|e| self.infer(e, level))
+            .collect::<Result<Vec<_>, _>>()?;
+        let typ = tuple(elems.iter().map(|e| e.typ()).collect());
+        Ok(TypedExpr::Tuple {
+            location,
+            elems,
+            typ,
+        })
+    }
+    fn infer_var(
+        &mut self,
+        name: String,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let constructor = self.infer_value_constructor(&name, level, &location)?;
+        Ok(TypedExpr::Var {
+            constructor,
+            location,
+            name,
+        })
+    }
+
+    fn infer_field_access(
+        &mut self,
+        container: UntypedExpr,
+        label: String,
+        access_location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        match container {
+            UntypedExpr::Var { name, location, .. } if !self.local_values.contains_key(&name) => {
+                self.infer_module_access(name.as_ref(), label, level, &location, access_location)
+            }
+
+            _ => self.infer_record_access(container, label, level, access_location),
+        }
+    }
+
+    fn infer_tuple_index(
+        &mut self,
+        tuple: UntypedExpr,
+        index: u64,
+        location: SrcSpan,
+        level: usize,
+    ) -> Result<TypedExpr, Error> {
+        let tuple = self.infer(tuple, level)?;
+
+        match tuple.typ().as_ref() {
+            Type::Tuple { elems } => {
+                let typ = elems
+                    .get(index as usize)
+                    .ok_or_else(|| Error::OutOfBoundsTupleIndex {
+                        location: location.clone(),
+                        index,
+                        size: elems.len(),
+                    })?
+                    .clone();
+                Ok(TypedExpr::TupleIndex {
+                    location,
+                    index,
+                    tuple: Box::new(tuple),
+                    typ,
+                })
+            }
+
+            typ if typ.is_unbound() => Err(Error::NotATupleUnbound {
+                location: tuple.location().clone(),
+            }),
+
+            _ => Err(Error::NotATuple {
+                location: tuple.location().clone(),
+                given: tuple.typ(),
+            }),
+        }
+    }
+
+    fn infer_binop(
+        &mut self,
+        name: BinOp,
+        left: UntypedExpr,
+        right: UntypedExpr,
+        level: usize,
+        location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        let (input_type, output_type) = match name {
+            BinOp::Eq | BinOp::NotEq => {
+                let left = self.infer(left, level)?;
+                let right = self.infer(right, level)?;
+                self.unify(left.typ(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+
+                return Ok(TypedExpr::BinOp {
+                    location,
+                    name,
+                    typ: bool(),
+                    left: Box::new(left),
+                    right: Box::new(right),
+                });
+            }
+            BinOp::And => (bool(), bool()),
+            BinOp::Or => (bool(), bool()),
+            BinOp::LtInt => (int(), bool()),
+            BinOp::LtEqInt => (int(), bool()),
+            BinOp::LtFloat => (float(), bool()),
+            BinOp::LtEqFloat => (float(), bool()),
+            BinOp::GtEqInt => (int(), bool()),
+            BinOp::GtInt => (int(), bool()),
+            BinOp::GtEqFloat => (float(), bool()),
+            BinOp::GtFloat => (float(), bool()),
+            BinOp::AddInt => (int(), int()),
+            BinOp::AddFloat => (float(), float()),
+            BinOp::SubInt => (int(), int()),
+            BinOp::SubFloat => (float(), float()),
+            BinOp::MultInt => (int(), int()),
+            BinOp::MultFloat => (float(), float()),
+            BinOp::DivInt => (int(), int()),
+            BinOp::DivFloat => (float(), float()),
+            BinOp::ModuloInt => (int(), int()),
+        };
+
+        let left = self.infer(left, level)?;
+        self.unify(input_type.clone(), left.typ())
+            .map_err(|e| convert_unify_error(e, left.location()))?;
+        let right = self.infer(right, level)?;
+        self.unify(input_type, right.typ())
+            .map_err(|e| convert_unify_error(e, right.location()))?;
+
+        Ok(TypedExpr::BinOp {
+            location,
+            name,
+            typ: output_type,
+            left: Box::new(left),
+            right: Box::new(right),
+        })
+    }
+
+    fn infer_let(
+        &mut self,
+        pattern: UntypedPattern,
+        value: UntypedExpr,
+        then: UntypedExpr,
+        kind: BindingKind,
+        annotation: &Option<TypeAst>,
+        level: usize,
+        location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        let value = self.infer(value, level + 1)?;
+        let try_value_type = self.new_unbound_var(level);
+        let try_error_type = self.new_unbound_var(level);
+
+        let value_typ = match kind {
+            // Ensure that the value is a result if this is a `try` binding
+            BindingKind::Try => {
+                let v = try_value_type.clone();
+                let e = try_error_type.clone();
+                self.unify(result(v, e), value.typ())
+                    .map_err(|e| convert_unify_error(e, value.location()))?;
+                try_value_type.clone()
+            }
+            _ => value.typ(),
+        };
+
+        let value_typ = generalise(value_typ, level + 1);
+
+        // Ensure the pattern matches the type of the value
+        let pattern = PatternTyper::new(self, level).unify(pattern, value_typ.clone())?;
+
+        // Check the type of the following code
+        let then = self.infer(then, level)?;
+        let typ = then.typ();
+
+        // Ensure that a Result with the right error type is returned for `try`
+        if kind == BindingKind::Try {
+            let value = self.new_unbound_var(level);
+            self.unify(result(value, try_error_type), typ.clone())
+                .map_err(|e| convert_unify_error(e, then.try_binding_location()))?;
+        }
+
+        // Check that any type annotation is accurate.
+        if let Some(ann) = annotation {
+            let ann_typ = self
+                .type_from_ast(ann, &mut hashmap![], NewTypeAction::MakeGeneric)
+                .map(|t| self.instantiate(t, level, &mut hashmap![]))?;
+            self.unify(ann_typ, value_typ)
+                .map_err(|e| convert_unify_error(e, value.location()))?;
+        }
+
+        Ok(TypedExpr::Let {
+            location,
+            typ,
+            kind,
+            pattern,
+            value: Box::new(value),
+            then: Box::new(then),
+        })
+    }
+
+    fn infer_case(
+        &mut self,
+        subjects: Vec<UntypedExpr>,
+        clauses: Vec<UntypedClause>,
+        level: usize,
+        location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        let subjects_count = subjects.len();
+        let mut typed_subjects = Vec::with_capacity(subjects_count);
+        let mut subject_types = Vec::with_capacity(subjects_count);
+        let mut typed_clauses = Vec::with_capacity(clauses.len());
+
+        let return_type = self.new_unbound_var(level);
+
+        for subject in subjects.into_iter() {
+            let subject = self.infer(subject, level + 1)?;
+            let subject_type = generalise(subject.typ(), level + 1);
+            typed_subjects.push(subject);
+            subject_types.push(subject_type);
+        }
+
+        for clause in clauses.into_iter() {
+            let typed_clause = self.infer_clause(clause, &subject_types, level)?;
+            self.unify(return_type.clone(), typed_clause.then.typ())
+                .map_err(|e| convert_unify_error(e, typed_clause.then.location()))?;
+            typed_clauses.push(typed_clause);
+        }
+        Ok(TypedExpr::Case {
+            location,
+            typ: return_type,
+            subjects: typed_subjects,
+            clauses: typed_clauses,
+        })
+    }
+
+    fn infer_clause(
+        &mut self,
+        clause: UntypedClause,
+        subjects: &[Arc<Type>],
+        level: usize,
+    ) -> Result<TypedClause, Error> {
+        let Clause {
+            pattern,
+            alternative_patterns,
+            guard,
+            then,
+            location,
+        } = clause;
+
+        // Store the local scope so it can be reset after the clause
+        let vars = self.local_values.clone();
+
+        // Check the types
+        let (typed_pattern, typed_alternatives) =
+            self.infer_clause_pattern(pattern, alternative_patterns, subjects, level, &location)?;
+        let guard = self.infer_optional_clause_guard(guard, level)?;
+        let then = self.infer(then, level)?;
+
+        // Reset the local vars now the clause scope is done
+        self.local_values = vars;
+
+        Ok(Clause {
+            location,
+            pattern: typed_pattern,
+            alternative_patterns: typed_alternatives,
+            guard,
+            then,
+        })
+    }
+
+    fn infer_clause_pattern(
+        &mut self,
+        pattern: UntypedMultiPattern,
+        alternatives: Vec<UntypedMultiPattern>,
+        subjects: &[Arc<Type>],
+        level: usize,
+        location: &SrcSpan,
+    ) -> Result<(TypedMultiPattern, Vec<TypedMultiPattern>), Error> {
+        let mut pattern_typer = PatternTyper::new(self, level);
+        let typed_pattern = pattern_typer.infer_multi_pattern(pattern, subjects, &location)?;
+
+        // Each case clause has one or more patterns that may match the
+        // subject in order for the clause to be selected, so we must type
+        // check every pattern.
+        let mut typed_alternatives = Vec::with_capacity(alternatives.len());
+        for m in alternatives {
+            typed_alternatives
+                .push(pattern_typer.infer_alternative_multi_pattern(m, subjects, &location)?);
+        }
+
+        Ok((typed_pattern, typed_alternatives))
+    }
+
+    fn infer_optional_clause_guard(
+        &mut self,
+        guard: Option<UntypedClauseGuard>,
+        level: usize,
+    ) -> Result<Option<TypedClauseGuard>, Error> {
+        match guard {
+            // If there is no guard we do nothing
+            None => Ok(None),
+
+            // If there is a guard we assert that it is of type Bool
+            Some(guard) => {
+                let guard = self.infer_clause_guard(guard, level)?;
+                self.unify(bool(), guard.typ())
+                    .map_err(|e| convert_unify_error(e, guard.location()))?;
+                Ok(Some(guard))
+            }
+        }
+    }
+
+    fn infer_clause_guard(
+        &mut self,
+        guard: UntypedClauseGuard,
+        level: usize,
+    ) -> Result<TypedClauseGuard, Error> {
+        match guard {
+            ClauseGuard::Var { location, name, .. } => {
+                let constructor = self.infer_value_constructor(&name, level, &location)?;
+
+                // We cannot support all values in guard expressions as the BEAM does not
+                match &constructor.variant {
+                    ValueConstructorVariant::LocalVariable => (),
+                    ValueConstructorVariant::ModuleFn { .. }
+                    | ValueConstructorVariant::Record { .. } => {
+                        return Err(Error::NonLocalClauseGuardVariable { location, name })
+                    }
+                };
+
+                Ok(ClauseGuard::Var {
+                    location,
+                    name,
+                    typ: constructor.typ,
+                })
+            }
+
+            ClauseGuard::Tuple {
+                location, elems, ..
+            } => {
+                let elems = elems
+                    .into_iter()
+                    .map(|x| self.infer_clause_guard(x, level))
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let typ = tuple(elems.iter().map(|e| e.typ()).collect());
+
+                Ok(ClauseGuard::Tuple {
+                    location,
+                    elems,
+                    typ,
+                })
+            }
+
+            ClauseGuard::Constructor {
+                module,
+                location,
+                name,
+                mut args,
+                ..
+            } => {
+                let constructor = self.infer_value_constructor(&name, level, &location)?;
+
+                match &constructor.variant {
+                    ValueConstructorVariant::Record { .. } => (),
+                    ValueConstructorVariant::ModuleFn { .. }
+                    | ValueConstructorVariant::LocalVariable => {
+                        return Err(Error::NonLocalClauseGuardVariable { location, name })
+                    }
+                };
+
+                // Pretty much all the other infer functions operate on UntypedExpr
+                // or TypedExpr rather than ClauseGuard. To make things easier we
+                // build the TypedExpr equivalent of the constructor and use that
+                let fun = TypedExpr::Var {
+                    constructor,
+                    location: location.clone(),
+                    name: name.clone(),
+                };
+
+                // This is basically the same code as do_infer_call_with_known_fun()
+                // except the args are typed with infer_clause_guard() here.
+                // This duplication is a bit awkward but it works!
+                // Potentially this could be improved later
+                match self
+                    .get_field_map(&fun)
+                    .map_err(|e| convert_get_value_constructor_error(e, &location))?
+                {
+                    // The fun has a field map so labelled arguments may be present and need to be reordered.
+                    Some(field_map) => field_map.reorder(&mut args, &location)?,
+
+                    // The fun has no field map and so we error if arguments have been labelled
+                    None => assert_no_labelled_arguments(&args)?,
+                }
+
+                let (mut args_types, return_type) = match_fun_type(fun.typ(), args.len(), self)
+                    .map_err(|e| convert_not_fun_error(e, fun.location(), &location))?;
+                let args = args_types
+                    .iter_mut()
+                    .zip(args)
+                    .map(
+                        |(
+                            typ,
+                            CallArg {
+                                label,
+                                value,
+                                location,
+                            },
+                        ): (&mut Arc<Type>, _)| {
+                            let value = self.infer_clause_guard(value, level)?;
+                            self.unify(typ.clone(), value.typ())
+                                .map_err(|e| convert_unify_error(e, value.location()))?;
+                            Ok(CallArg {
+                                label,
+                                value,
+                                location,
+                            })
+                        },
+                    )
+                    .collect::<Result<_, _>>()?;
+
+                Ok(ClauseGuard::Constructor {
+                    module,
+                    location,
+                    name,
+                    args,
+                    typ: return_type,
+                })
+            }
+
+            ClauseGuard::And {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(bool(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(bool(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::And {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::Or {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(bool(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(bool(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::Or {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::Equals {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(left.typ(), right.typ())
+                    .map_err(|e| convert_unify_error(e, &location))?;
+                Ok(ClauseGuard::Equals {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::NotEquals {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(left.typ(), right.typ())
+                    .map_err(|e| convert_unify_error(e, &location))?;
+                Ok(ClauseGuard::NotEquals {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::GtInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(int(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(int(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::GtInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::GtEqInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(int(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(int(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::GtEqInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::LtInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(int(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(int(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::LtInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::LtEqInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(int(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(int(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::LtEqInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::GtFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(float(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(float(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::GtFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::GtEqFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(float(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(float(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::GtEqFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::LtFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(float(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(float(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::LtFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::LtEqFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left, level)?;
+                self.unify(float(), left.typ())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right, level)?;
+                self.unify(float(), right.typ())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::LtEqFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::Int {
+                location, value, ..
+            } => Ok(ClauseGuard::Int { location, value }),
+
+            ClauseGuard::Float {
+                location, value, ..
+            } => Ok(ClauseGuard::Float { location, value }),
+
+            ClauseGuard::String {
+                location, value, ..
+            } => Ok(ClauseGuard::String { location, value }),
+        }
+    }
+
+    fn infer_module_access(
+        &mut self,
+        module_alias: &str,
+        label: String,
+        level: usize,
+        module_location: &SrcSpan,
+        select_location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        let (module_name, constructor) = {
+            let module_info =
+                self.imported_modules
+                    .get(&*module_alias)
+                    .ok_or_else(|| Error::UnknownModule {
+                        name: module_alias.to_string(),
+                        location: module_location.clone(),
+                        imported_modules: self
+                            .imported_modules
+                            .keys()
+                            .map(|t| t.to_string())
+                            .collect(),
+                    })?;
+
+            let constructor =
+                module_info
+                    .values
+                    .get(&label)
+                    .ok_or_else(|| Error::UnknownModuleValue {
+                        name: label.clone(),
+                        location: select_location.clone(),
+                        module_name: module_info.name.clone(),
+                        value_constructors: module_info
+                            .values
+                            .keys()
+                            .map(|t| t.to_string())
+                            .collect(),
+                    })?;
+
+            (module_info.name.clone(), constructor.clone())
+        };
+
+        Ok(TypedExpr::ModuleSelect {
+            label,
+            typ: self.instantiate(constructor.typ, level, &mut hashmap![]),
+            location: select_location,
+            module_name,
+            module_alias: module_alias.to_string(),
+            constructor: constructor.variant.to_module_value_constructor(),
+        })
+    }
+
+    fn infer_record_access(
+        &mut self,
+        record: UntypedExpr,
+        label: String,
+        level: usize,
+        location: SrcSpan,
+    ) -> Result<TypedExpr, Error> {
+        // Infer the type of the (presumed) record
+        let record = Box::new(self.infer(record, level)?);
+
+        // If we don't yet know the type of the record then we cannot use any accessors
+        if record.typ().is_unbound() {
+            return Err(Error::RecordAccessUnknownType {
+                location: record.location().clone(),
+            });
+        }
+
+        // Error constructor helper function
+        let unknown_field = |fields| Error::UnknownField {
+            typ: record.typ(),
+            location: location.clone(),
+            label: label.clone(),
+            fields,
+        };
+
+        // Check to see if it's a Type that can have accessible fields
+        let accessors = match collapse_links(record.typ()).as_ref() {
+            // A type in the current module which may have fields
+            Type::App { module, name, .. } if module.as_slice() == self.current_module => {
+                self.accessors.get(name)
+            }
+
+            // A type in another module which may have fields
+            Type::App { module, name, .. } => self
+                .importable_modules
+                .get(&module.join("/"))
+                .and_then(|module| module.accessors.get(name)),
+
+            _something_without_fields => return Err(unknown_field(vec![])),
+        }
+        .ok_or_else(|| unknown_field(vec![]))?;
+
+        // Find the accessor, if the type has one with the same label
+        let RecordAccessor {
+            index, label, typ, ..
+        } = accessors
+            .accessors
+            .get(&label)
+            .ok_or_else(|| {
+                unknown_field(accessors.accessors.keys().map(|t| t.to_string()).collect())
+            })?
+            .clone();
+
+        // Unify the record type with the accessor's stored copy of the record type.
+        // This ensure that the type parameters of the retrieved value have the correct
+        // types for this instance of the record.
+        let accessor_record_type = accessors.typ.clone();
+        let mut type_vars = hashmap![];
+        let accessor_record_type = self.instantiate(accessor_record_type, 0, &mut type_vars);
+        let typ = self.instantiate(typ, 0, &mut type_vars);
+        self.unify(accessor_record_type, record.typ())
+            .map_err(|e| convert_unify_error(e, record.location()))?;
+
+        Ok(TypedExpr::RecordAccess {
+            record,
+            label,
+            index,
+            location,
+            typ,
+        })
+    }
+
+    fn infer_value_constructor(
+        &mut self,
+        name: &str,
+        level: usize,
+        location: &SrcSpan,
+    ) -> Result<ValueConstructor, Error> {
+        let ValueConstructor {
+            public,
+            variant,
+            origin,
+            typ,
+        } = self
+            .get_variable(name)
+            .cloned()
+            .ok_or_else(|| Error::UnknownVariable {
+                location: location.clone(),
+                name: name.to_string(),
+                variables: self.local_values.keys().map(|t| t.to_string()).collect(),
+            })?;
+        let typ = self.instantiate(typ, level, &mut hashmap![]);
+        Ok(ValueConstructor {
+            public,
+            variant,
+            origin,
+            typ,
+        })
+    }
+
+    fn do_infer_call(
+        &mut self,
+        fun: UntypedExpr,
+        args: Vec<CallArg<UntypedExpr>>,
+        level: usize,
+        location: &SrcSpan,
+    ) -> Result<(TypedExpr, Vec<TypedCallArg>, Arc<Type>), Error> {
+        let fun = self.infer(fun, level)?;
+        let (fun, args, typ) = self.do_infer_call_with_known_fun(fun, args, level, location)?;
+        Ok((fun, args, typ))
+    }
+
+    fn do_infer_call_with_known_fun(
+        &mut self,
+        fun: TypedExpr,
+        mut args: Vec<CallArg<UntypedExpr>>,
+        level: usize,
+        location: &SrcSpan,
+    ) -> Result<(TypedExpr, Vec<TypedCallArg>, Arc<Type>), Error> {
+        match self
+            .get_field_map(&fun)
+            .map_err(|e| convert_get_value_constructor_error(e, location))?
+        {
+            // The fun has a field map so labelled arguments may be present and need to be reordered.
+            Some(field_map) => field_map.reorder(&mut args, location)?,
+
+            // The fun has no field map and so we error if arguments have been labelled
+            None => assert_no_labelled_arguments(&args)?,
+        }
+
+        let (mut args_types, return_type) = match_fun_type(fun.typ(), args.len(), self)
+            .map_err(|e| convert_not_fun_error(e, fun.location(), &location))?;
+        let args = args_types
+            .iter_mut()
+            .zip(args)
+            .map(
+                |(
+                    typ,
+                    CallArg {
+                        label,
+                        value,
+                        location,
+                    },
+                ): (&mut Arc<Type>, _)| {
+                    let value = self.infer(value, level)?;
+                    self.unify(typ.clone(), value.typ())
+                        .map_err(|e| convert_unify_error(e, value.location()))?;
+                    Ok(CallArg {
+                        label,
+                        value,
+                        location,
+                    })
+                },
+            )
+            .collect::<Result<_, _>>()?;
+        Ok((fun, args, return_type))
+    }
+
+    /// Instantiate converts generic variables into unbound ones.
+    ///
+    fn instantiate(
+        &mut self,
+        t: Arc<Type>,
+        ctx_level: usize,
+        ids: &mut im::HashMap<usize, Arc<Type>>,
+    ) -> Arc<Type> {
+        match &*t {
+            Type::App {
+                public,
+                name,
+                module,
+                args,
+            } => {
+                let args = args
+                    .iter()
+                    .map(|t| self.instantiate(t.clone(), ctx_level, ids))
+                    .collect();
+                Arc::new(Type::App {
+                    public: *public,
+                    name: name.clone(),
+                    module: module.clone(),
+                    args,
+                })
+            }
+
+            Type::Var { typ } => {
+                match &*typ.borrow() {
+                    TypeVar::Link { typ } => return self.instantiate(typ.clone(), ctx_level, ids),
+
+                    TypeVar::Unbound { .. } => return Arc::new(Type::Var { typ: typ.clone() }),
+
+                    TypeVar::Generic { id } => match ids.get(id) {
+                        Some(t) => return t.clone(),
+                        None => {
+                            if !self.annotated_generic_types.contains(id) {
+                                let v = self.new_unbound_var(ctx_level);
+                                ids.insert(*id, v.clone());
+                                return v;
+                            }
+                        }
+                    },
+                }
+                Arc::new(Type::Var { typ: typ.clone() })
+            }
+
+            Type::Fn { args, retrn, .. } => fn_(
+                args.iter()
+                    .map(|t| self.instantiate(t.clone(), ctx_level, ids))
+                    .collect(),
+                self.instantiate(retrn.clone(), ctx_level, ids),
+            ),
+
+            Type::Tuple { elems } => tuple(
+                elems
+                    .iter()
+                    .map(|t| self.instantiate(t.clone(), ctx_level, ids))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn make_type_vars(
+        &mut self,
+        args: &[String],
+        vars: &mut im::HashMap<String, (usize, Arc<Type>)>,
+        location: &SrcSpan,
+    ) -> Result<Vec<Arc<Type>>, Error> {
+        args.iter()
+            .map(|arg| TypeAst::Var {
+                location: location.clone(),
+                name: arg.to_string(),
+            })
+            .map(|ast| self.type_from_ast(&ast, vars, NewTypeAction::MakeGeneric))
+            .collect::<Result<_, _>>()
+    }
+
+    fn custom_type_accessors(
+        &mut self,
+        constructors: &[RecordConstructor],
+        type_vars: &mut im::HashMap<String, (usize, Arc<Type>)>,
+    ) -> Result<Option<HashMap<String, RecordAccessor>>, Error> {
+        let args = match constructors {
+            [constructor] if !constructor.args.is_empty() => &constructor.args,
+            _ => return Ok(None),
+        };
+
+        let mut fields = HashMap::with_capacity(args.len());
+        for (index, (label, arg, ..)) in args.iter().enumerate() {
+            if let Some(label) = label {
+                let typ = self.type_from_ast(arg, type_vars, NewTypeAction::Disallow)?;
+                fields.insert(
+                    label.to_string(),
+                    RecordAccessor {
+                        index: index as u64,
+                        label: label.to_string(),
+                        typ,
+                    },
+                );
+            }
+        }
+        Ok(Some(fields))
+    }
+
+    fn get_field_map(
+        &mut self,
+        constructor: &TypedExpr,
+    ) -> Result<Option<&FieldMap>, GetValueConstructorError> {
+        let (module, name) = match constructor {
+            TypedExpr::ModuleSelect {
+                module_alias,
+                label,
+                ..
+            } => (Some(module_alias), label),
+
+            TypedExpr::Var { name, .. } => (None, name),
+
+            _ => return Ok(None),
+        };
+
+        Ok(self.get_value_constructor(module, name)?.field_map())
+    }
+
+    fn unify(&mut self, t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
+        if t1 == t2 {
+            return Ok(());
+        }
+
+        // Collapse right hand side type links. Left hand side will be collapsed in the next block.
+        if let Type::Var { typ } = &*t2 {
+            if let TypeVar::Link { typ } = &*typ.borrow() {
+                return self.unify(t1, typ.clone());
+            }
+        }
+
+        if let Type::Var { typ } = &*t1 {
+            enum Action {
+                Unify(Arc<Type>),
+                CouldNotUnify,
+                Link,
+            }
+
+            let action = match &*typ.borrow() {
+                TypeVar::Link { typ } => Action::Unify(typ.clone()),
+
+                TypeVar::Unbound { id, level } => {
+                    update_levels(t2.clone(), *level, *id)?;
+                    Action::Link
+                }
+
+                TypeVar::Generic { id } => {
+                    if let Type::Var { typ } = &*t2 {
+                        if typ.borrow().is_unbound() {
+                            *typ.borrow_mut() = TypeVar::Generic { id: *id };
+                            return Ok(());
+                        }
+                    }
+                    Action::CouldNotUnify
+                }
+            };
+
+            return match action {
+                Action::Link => {
+                    *typ.borrow_mut() = TypeVar::Link { typ: t2 };
+                    Ok(())
+                }
+
+                Action::Unify(t) => self.unify(t, t2),
+
+                Action::CouldNotUnify => Err(UnifyError::CouldNotUnify {
+                    expected: t1.clone(),
+                    given: t2,
+                }),
+            };
+        }
+
+        if let Type::Var { .. } = *t2 {
+            return self.unify(t2, t1).map_err(flip_unify_error);
+        }
+
+        match (&*t1, &*t2) {
+            (
+                Type::App {
+                    module: m1,
+                    name: n1,
+                    args: args1,
+                    ..
+                },
+                Type::App {
+                    module: m2,
+                    name: n2,
+                    args: args2,
+                    ..
+                },
+            ) if m1 == m2 && n1 == n2 && args1.len() == args2.len() => {
+                for (a, b) in args1.iter().zip(args2) {
+                    unify_enclosed_type(t1.clone(), t2.clone(), self.unify(a.clone(), b.clone()))?;
+                }
+                Ok(())
+            }
+
+            (Type::Tuple { elems: elems1, .. }, Type::Tuple { elems: elems2, .. })
+                if elems1.len() == elems2.len() =>
+            {
+                for (a, b) in elems1.iter().zip(elems2) {
+                    unify_enclosed_type(t1.clone(), t2.clone(), self.unify(a.clone(), b.clone()))?;
+                }
+                Ok(())
+            }
+
+            (
+                Type::Fn {
+                    args: args1,
+                    retrn: retrn1,
+                    ..
+                },
+                Type::Fn {
+                    args: args2,
+                    retrn: retrn2,
+                    ..
+                },
+            ) if args1.len() == args2.len() => {
+                for (a, b) in args1.iter().zip(args2) {
+                    self.unify(a.clone(), b.clone())
+                        .map_err(|_| UnifyError::CouldNotUnify {
+                            expected: t1.clone(),
+                            given: t2.clone(),
+                        })?;
+                }
+                self.unify(retrn1.clone(), retrn2.clone())
+                    .map_err(|_| UnifyError::CouldNotUnify {
+                        expected: t1.clone(),
+                        given: t2.clone(),
+                    })
+            }
+
+            (_, _) => Err(UnifyError::CouldNotUnify {
+                expected: t1.clone(),
+                given: t2.clone(),
+            }),
+        }
     }
 }
 
@@ -1107,26 +2660,11 @@ fn convert_get_type_constructor_error(e: GetTypeConstructorError, location: &Src
     }
 }
 
-fn make_type_vars(
-    args: &[String],
-    vars: &mut im::HashMap<String, (usize, Arc<Type>)>,
-    location: &SrcSpan,
-    env: &mut Typer,
-) -> Result<Vec<Arc<Type>>, Error> {
-    args.iter()
-        .map(|arg| TypeAst::Var {
-            location: location.clone(),
-            name: arg.to_string(),
-        })
-        .map(|ast| env.type_from_ast(&ast, vars, NewTypeAction::MakeGeneric))
-        .collect::<Result<_, _>>()
-}
-
-/// Iterate over a module, registering any new types created by the module into the env
+/// Iterate over a module, registering any new types created by the module into the typer
 fn register_types(
     statement: &UntypedStatement,
     module: &[String],
-    env: &mut Typer,
+    typer: &mut Typer,
 ) -> Result<(), Error> {
     match statement {
         Statement::ExternalType {
@@ -1144,14 +2682,14 @@ fn register_types(
             ..
         } => {
             let mut type_vars = hashmap![];
-            let parameters = make_type_vars(args, &mut type_vars, location, env)?;
+            let parameters = typer.make_type_vars(args, &mut type_vars, location)?;
             let typ = Arc::new(Type::App {
                 public: *public,
                 module: module.to_owned(),
                 name: name.clone(),
                 args: parameters.clone(),
             });
-            env.insert_type_constructor(
+            typer.insert_type_constructor(
                 name.clone(),
                 TypeConstructor {
                     origin: location.clone(),
@@ -1172,9 +2710,10 @@ fn register_types(
             ..
         } => {
             let mut type_vars = hashmap![];
-            let parameters = make_type_vars(args, &mut type_vars, location, env)?;
-            let typ = env.type_from_ast(&resolved_type, &mut type_vars, NewTypeAction::Disallow)?;
-            env.insert_type_constructor(
+            let parameters = typer.make_type_vars(args, &mut type_vars, location)?;
+            let typ =
+                typer.type_from_ast(&resolved_type, &mut type_vars, NewTypeAction::Disallow)?;
+            typer.insert_type_constructor(
                 name.clone(),
                 TypeConstructor {
                     origin: location.clone(),
@@ -1198,7 +2737,7 @@ pub fn infer_module(
     module: UntypedModule,
     modules: &HashMap<String, Module>,
 ) -> (Result<TypedModule, Error>, Vec<Warning>) {
-    let mut env = Typer::new(module.name.as_slice(), modules);
+    let mut typer = Typer::new(module.name.as_slice(), modules);
     let module_name = &module.name;
 
     for s in module.statements.iter() {
@@ -1210,7 +2749,7 @@ pub fn infer_module(
                 ..
             } => {
                 // Find imported module
-                let module_info = env.importable_modules.get(&module.join("/")).expect(
+                let module_info = typer.importable_modules.get(&module.join("/")).expect(
                     "COMPILER BUG: Typer could not find a module being imported.
     This should not be possible. Please report this crash",
                 );
@@ -1236,7 +2775,7 @@ pub fn infer_module(
                     };
 
                     if let Some(value) = module_info.values.get(name) {
-                        env.insert_variable(
+                        typer.insert_variable(
                             imported_name.clone(),
                             value.variant.clone(),
                             value.typ.clone(),
@@ -1245,9 +2784,9 @@ pub fn infer_module(
                     }
 
                     if let Some(typ) = module_info.types.get(name) {
-                        match env.insert_type_constructor(imported_name.clone(), typ.clone()) {
+                        match typer.insert_type_constructor(imported_name.clone(), typ.clone()) {
                             Ok(_) => (),
-                            Err(e) => return (Err(e), env.warnings),
+                            Err(e) => return (Err(e), typer.warnings),
                         }
 
                         imported = true;
@@ -1270,13 +2809,14 @@ pub fn infer_module(
                                     .map(|t| t.to_string())
                                     .collect(),
                             }),
-                            env.warnings,
+                            typer.warnings,
                         );
                     }
                 }
 
                 // Insert imported module into scope
-                env.imported_modules
+                typer
+                    .imported_modules
                     .insert(module_name, module_info.clone());
             }
 
@@ -1287,9 +2827,9 @@ pub fn infer_module(
     // Register types so they can be used in constructors and functions
     // earlier in the file
     for s in module.statements.iter() {
-        match register_types(s, module_name, &mut env) {
+        match register_types(s, module_name, &mut typer) {
             Ok(_) => (),
-            Err(e) => return (Err(e), env.warnings),
+            Err(e) => return (Err(e), typer.warnings),
         }
     }
 
@@ -1323,8 +2863,8 @@ pub fn infer_module(
                 let field_map = field_map.into_option();
 
                 // Register a var for the function so that it can call itself recursively
-                let rec = env.new_unbound_var(level + 1);
-                env.insert_variable(
+                let rec = typer.new_unbound_var(level + 1);
+                typer.insert_variable(
                     name.clone(),
                     ValueConstructorVariant::ModuleFn {
                         name: name.clone(),
@@ -1336,17 +2876,18 @@ pub fn infer_module(
                 );
 
                 // Infer the type
-                let (args, body) =
-                    do_infer_fn(args, body, &return_annotation, level + 1, &mut env)?;
+                let (args, body) = typer.do_infer_fn(args, body, &return_annotation, level + 1)?;
                 let args_types = args.iter().map(|a| a.typ.clone()).collect();
                 let typ = fn_(args_types, body.typ());
 
                 // Assert that the inferred type matches the type of any recursive call
-                unify(rec, typ.clone(), &env).map_err(|e| convert_unify_error(e, &location))?;
+                typer
+                    .unify(rec, typ.clone())
+                    .map_err(|e| convert_unify_error(e, &location))?;
                 let typ = generalise(typ, level);
 
                 // Insert the function into the module's interface
-                env.insert_module_value(
+                typer.insert_module_value(
                     &name,
                     ValueConstructor {
                         public,
@@ -1361,8 +2902,8 @@ pub fn infer_module(
                     },
                 )?;
 
-                // Insert the function into the environment
-                env.insert_variable(
+                // Insert the function into the typerironment
+                typer.insert_variable(
                     name.clone(),
                     ValueConstructorVariant::ModuleFn {
                         name: name.clone(),
@@ -1401,12 +2942,15 @@ pub fn infer_module(
                 // Construct type of function from AST
                 let mut type_vars = hashmap![];
                 let return_type =
-                    env.type_from_ast(&retrn, &mut type_vars, NewTypeAction::MakeGeneric)?;
+                    typer.type_from_ast(&retrn, &mut type_vars, NewTypeAction::MakeGeneric)?;
                 let mut args_types = Vec::with_capacity(args.len());
                 let mut field_map = FieldMap::new(args.len());
                 for (i, arg) in args.iter().enumerate() {
-                    let t =
-                        env.type_from_ast(&arg.typ, &mut type_vars, NewTypeAction::MakeGeneric)?;
+                    let t = typer.type_from_ast(
+                        &arg.typ,
+                        &mut type_vars,
+                        NewTypeAction::MakeGeneric,
+                    )?;
                     args_types.push(t);
                     if let Some(label) = &arg.label {
                         field_map
@@ -1421,7 +2965,7 @@ pub fn infer_module(
                 let typ = fn_(args_types, return_type.clone());
 
                 // Insert function into module
-                env.insert_module_value(
+                typer.insert_module_value(
                     &name,
                     ValueConstructor {
                         public,
@@ -1437,7 +2981,7 @@ pub fn infer_module(
                 )?;
 
                 // Insert function into module's internal scope
-                env.insert_variable(
+                typer.insert_variable(
                     name.clone(),
                     ValueConstructorVariant::ModuleFn {
                         name: fun.clone(),
@@ -1469,7 +3013,7 @@ pub fn infer_module(
                 resolved_type,
                 ..
             } => {
-                let typ = env
+                let typ = typer
                     .get_type_constructor(&None, alias.as_str())
                     .gleam_expect("Could not find existing type for type alias")
                     .typ
@@ -1498,7 +3042,7 @@ pub fn infer_module(
 
                 // This custom type was inserted into the module types in the `register_types`
                 // pass, so we can expect this type to exist already.
-                let retrn = env
+                let retrn = typer
                     .module_types
                     .get(&name)
                     .gleam_expect("Type for custom type not found on constructor infer pass")
@@ -1519,14 +3063,14 @@ pub fn infer_module(
                 // If the custom type only has a single constructor then we can access the
                 // fields using the record.field syntax, so store any fields accessors.
                 if let Some(accessors) =
-                    custom_type_accessors(constructors.as_slice(), &mut type_vars, &mut env)?
+                    typer.custom_type_accessors(constructors.as_slice(), &mut type_vars)?
                 {
                     let map = AccessorsMap {
                         public: (public && !opaque),
                         accessors,
                         typ: retrn.clone(),
                     };
-                    env.insert_accessors(name.as_ref(), map)
+                    typer.insert_accessors(name.as_ref(), map)
                 }
 
                 // Check and register constructors
@@ -1534,7 +3078,8 @@ pub fn infer_module(
                     let mut field_map = FieldMap::new(constructor.args.len());
                     let mut args_types = Vec::with_capacity(constructor.args.len());
                     for (i, (label, arg, ..)) in constructor.args.iter().enumerate() {
-                        let t = env.type_from_ast(&arg, &mut type_vars, NewTypeAction::Disallow)?;
+                        let t =
+                            typer.type_from_ast(&arg, &mut type_vars, NewTypeAction::Disallow)?;
                         args_types.push(t);
                         if let Some(label) = label {
                             field_map.insert(label.clone(), i).map_err(|_| {
@@ -1553,7 +3098,7 @@ pub fn infer_module(
                     };
 
                     if !opaque {
-                        env.insert_module_value(
+                        typer.insert_module_value(
                             &constructor.name,
                             ValueConstructor {
                                 public,
@@ -1567,7 +3112,7 @@ pub fn infer_module(
                         )?;
                     }
 
-                    env.insert_variable(
+                    typer.insert_variable(
                         constructor.name.clone(),
                         ValueConstructorVariant::Record {
                             name: constructor.name.clone(),
@@ -1601,7 +3146,7 @@ pub fn infer_module(
                         location: location.clone(),
                         name: arg.to_string(),
                     };
-                    env.type_from_ast(&var, &mut type_vars, NewTypeAction::MakeGeneric)?;
+                    typer.type_from_ast(&var, &mut type_vars, NewTypeAction::MakeGeneric)?;
                 }
                 Ok(Statement::ExternalType {
                     doc,
@@ -1628,24 +3173,25 @@ pub fn infer_module(
 
     let statements = match statements_result {
         Ok(o) => o,
-        Err(e) => return (Err(e), env.warnings),
+        Err(e) => return (Err(e), typer.warnings),
     };
 
     // Remove private and imported types and values to create the public interface
-    env.module_types
+    typer
+        .module_types
         .retain(|_, info| info.public && &info.module == module_name);
-    env.module_values.retain(|_, info| info.public);
-    env.accessors.retain(|_, accessors| accessors.public);
+    typer.module_values.retain(|_, info| info.public);
+    typer.accessors.retain(|_, accessors| accessors.public);
 
     // Ensure no exported values have private types in their type signature
-    for (_, value) in env.module_values.iter() {
+    for (_, value) in typer.module_values.iter() {
         if let Some(leaked) = value.typ.find_private_type() {
             return (
                 Err(Error::PrivateTypeLeak {
                     location: value.origin.clone(),
                     leaked,
                 }),
-                env.warnings,
+                typer.warnings,
             );
         }
     }
@@ -1656,7 +3202,7 @@ pub fn infer_module(
         accessors,
         warnings,
         ..
-    } = env;
+    } = typer;
 
     (
         Ok(ast::Module {
@@ -1674,1170 +3220,8 @@ pub fn infer_module(
     )
 }
 
-fn custom_type_accessors(
-    constructors: &[RecordConstructor],
-    type_vars: &mut im::HashMap<String, (usize, Arc<Type>)>,
-    env: &mut Typer,
-) -> Result<Option<HashMap<String, RecordAccessor>>, Error> {
-    let args = match constructors {
-        [constructor] if !constructor.args.is_empty() => &constructor.args,
-        _ => return Ok(None),
-    };
-
-    let mut fields = HashMap::with_capacity(args.len());
-    for (index, (label, arg, ..)) in args.iter().enumerate() {
-        if let Some(label) = label {
-            let typ = env.type_from_ast(arg, type_vars, NewTypeAction::Disallow)?;
-            fields.insert(
-                label.to_string(),
-                RecordAccessor {
-                    index: index as u64,
-                    label: label.to_string(),
-                    typ,
-                },
-            );
-        }
-    }
-    Ok(Some(fields))
-}
-
-/// Crawl the AST, annotating each node with the inferred type or
-/// returning an error.
-///
-pub fn infer(expr: UntypedExpr, level: usize, env: &mut Typer) -> Result<TypedExpr, Error> {
-    match expr {
-        UntypedExpr::ListNil { location, .. } => infer_nil(location, level, env),
-
-        UntypedExpr::Todo { location, .. } => infer_todo(location, level, env),
-
-        UntypedExpr::Var { location, name, .. } => infer_var(name, location, level, env),
-
-        UntypedExpr::Int {
-            location, value, ..
-        } => infer_int(value, location),
-
-        UntypedExpr::Seq { first, then, .. } => infer_seq(*first, *then, level, env),
-
-        UntypedExpr::Tuple {
-            location, elems, ..
-        } => infer_tuple(elems, location, level, env),
-
-        UntypedExpr::Float {
-            location, value, ..
-        } => infer_float(value, location),
-
-        UntypedExpr::String {
-            location, value, ..
-        } => infer_string(value, location),
-
-        UntypedExpr::Pipe {
-            left,
-            right,
-            location,
-        } => infer_pipe(*left, *right, location, level, env),
-
-        UntypedExpr::Fn {
-            location,
-            is_capture,
-            args,
-            body,
-            return_annotation,
-            ..
-        } => infer_fn(
-            args,
-            *body,
-            is_capture,
-            return_annotation,
-            level,
-            location,
-            env,
-        ),
-
-        UntypedExpr::Let {
-            location,
-            pattern,
-            value,
-            then,
-            kind,
-            annotation,
-            ..
-        } => infer_let(
-            pattern,
-            *value,
-            *then,
-            kind,
-            &annotation,
-            level,
-            location,
-            env,
-        ),
-
-        UntypedExpr::Case {
-            location,
-            subjects,
-            clauses,
-            ..
-        } => infer_case(subjects, clauses, level, location, env),
-
-        UntypedExpr::ListCons {
-            location,
-            head,
-            tail,
-            deprecated_syntax,
-            ..
-        } => infer_cons(*head, *tail, deprecated_syntax, location, level, env),
-
-        UntypedExpr::Call {
-            location,
-            fun,
-            args,
-            ..
-        } => infer_call(*fun, args, level, location, env),
-
-        UntypedExpr::BinOp {
-            location,
-            name,
-            left,
-            right,
-            ..
-        } => infer_binop(name, *left, *right, level, location, env),
-
-        UntypedExpr::FieldAccess {
-            location,
-            label,
-            container,
-            ..
-        } => infer_field_access(*container, label, location, level, env),
-
-        UntypedExpr::TupleIndex {
-            location,
-            index,
-            tuple,
-            ..
-        } => infer_tuple_index(*tuple, index, location, level, env),
-    }
-}
-
-fn infer_pipe(
-    left: UntypedExpr,
-    right: UntypedExpr,
-    location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    match right {
-        // left |> right(..args)
-        UntypedExpr::Call { fun, args, .. } => {
-            let fun = infer(*fun, level, env)?;
-            match fun.typ().fn_arity() {
-                // Rewrite as right(left, ..args)
-                Some(arity) if arity == args.len() + 1 => {
-                    infer_insert_pipe(fun, args, left, level, env)
-                }
-
-                // Rewrite as right(..args)(left)
-                _ => infer_apply_to_call_pipe(fun, args, left, location, level, env),
-            }
-        }
-
-        // right(left)
-        right => infer_apply_pipe(left, right, location, level, env),
-    }
-}
-
-/// Attempt to infer a |> b(..c) as b(..c)(a)
-fn infer_apply_to_call_pipe(
-    fun: TypedExpr,
-    args: Vec<CallArg<UntypedExpr>>,
-    left: UntypedExpr,
-    location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let right_location = left.location().clone();
-    let (fun, args, typ) = do_infer_call_with_known_fun(fun, args, level, &right_location, env)?;
-    let fun = TypedExpr::Call {
-        location: right_location,
-        typ,
-        args,
-        fun: Box::new(fun),
-    };
-    let args = vec![CallArg {
-        label: None,
-        location: left.location().clone(),
-        value: left,
-    }];
-    let (fun, args, typ) = do_infer_call_with_known_fun(fun, args, level, &location, env)?;
-    Ok(TypedExpr::Call {
-        location,
-        typ,
-        args,
-        fun: Box::new(fun),
-    })
-}
-
-/// Attempt to infer a |> b(c) as b(a, c)
-fn infer_insert_pipe(
-    fun: TypedExpr,
-    args: Vec<CallArg<UntypedExpr>>,
-    left: UntypedExpr,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let location = left.location().clone();
-    let mut new_args = Vec::with_capacity(args.len() + 1);
-    new_args.push(CallArg {
-        label: None,
-        location: left.location().clone(),
-        value: left,
-    });
-    for arg in args {
-        new_args.push(arg.clone());
-    }
-    let (fun, args, typ) = do_infer_call_with_known_fun(fun, new_args, level, &location, env)?;
-    Ok(TypedExpr::Call {
-        location,
-        typ,
-        args,
-        fun: Box::new(fun),
-    })
-}
-
-/// Attempt to infer a |> b as b(a)
-fn infer_apply_pipe(
-    left: UntypedExpr,
-    right: UntypedExpr,
-    location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let left = Box::new(infer(left, level, env)?);
-    let right = Box::new(infer(right, level, env)?);
-    let typ = env.new_unbound_var(level);
-    let fn_typ = Arc::new(Type::Fn {
-        args: vec![left.typ()],
-        retrn: typ.clone(),
-    });
-    unify(right.typ(), fn_typ, env).map_err(|e| convert_unify_error(e, &location))?;
-
-    Ok(TypedExpr::Pipe {
-        location,
-        typ,
-        right,
-        left,
-    })
-}
-
-fn infer_nil(location: SrcSpan, level: usize, env: &mut Typer) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::ListNil {
-        location,
-        typ: list(env.new_unbound_var(level)),
-    })
-}
-
-fn infer_todo(location: SrcSpan, level: usize, env: &mut Typer) -> Result<TypedExpr, Error> {
-    env.warnings.push(Warning::Todo {
-        location: location.clone(),
-    });
-
-    Ok(TypedExpr::Todo {
-        location,
-        typ: env.new_unbound_var(level),
-    })
-}
-
-fn infer_string(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::String {
-        location,
-        value,
-        typ: string(),
-    })
-}
-
-fn infer_int(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::Int {
-        location,
-        value,
-        typ: int(),
-    })
-}
-
-fn infer_float(value: String, location: SrcSpan) -> Result<TypedExpr, Error> {
-    Ok(TypedExpr::Float {
-        location,
-        value,
-        typ: float(),
-    })
-}
-
-fn infer_seq(
-    first: UntypedExpr,
-    then: UntypedExpr,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let first = infer(first, level, env)?;
-    let then = infer(then, level, env)?;
-
-    match first.typ().as_ref() {
-        typ if typ.is_result() => {
-            env.warnings.push(Warning::ImplicitlyDiscardedResult {
-                location: first.location().clone(),
-            });
-        }
-
-        _ => {}
-    }
-
-    Ok(TypedExpr::Seq {
-        typ: then.typ(),
-        first: Box::new(first),
-        then: Box::new(then),
-    })
-}
-
-fn infer_fn(
-    args: Vec<UntypedArg>,
-    body: UntypedExpr,
-    is_capture: bool,
-    return_annotation: Option<TypeAst>,
-    level: usize,
-    location: SrcSpan,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let (args, body) = do_infer_fn(args, body, &return_annotation, level, env)?;
-    let args_types = args.iter().map(|a| a.typ.clone()).collect();
-    let typ = fn_(args_types, body.typ());
-    Ok(TypedExpr::Fn {
-        location,
-        typ,
-        is_capture,
-        args,
-        body: Box::new(body),
-        return_annotation,
-    })
-}
-
-fn infer_call(
-    fun: UntypedExpr,
-    args: Vec<CallArg<UntypedExpr>>,
-    level: usize,
-    location: SrcSpan,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let (fun, args, typ) = do_infer_call(fun, args, level, &location, env)?;
-    Ok(TypedExpr::Call {
-        location,
-        typ,
-        args,
-        fun: Box::new(fun),
-    })
-}
-
-fn infer_cons(
-    head: UntypedExpr,
-    tail: UntypedExpr,
-    deprecated_syntax: bool,
-    location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let head = infer(head, level, env)?;
-    let tail = infer(tail, level, env)?;
-    unify(tail.typ(), list(head.typ()), env).map_err(|e| convert_unify_error(e, &location))?;
-
-    if deprecated_syntax {
-        env.warnings.push(Warning::DeprecatedListPrependSyntax {
-            location: SrcSpan {
-                start: location.start - 2,
-                end: location.start - 1,
-            },
-        });
-    }
-
-    Ok(TypedExpr::ListCons {
-        location,
-        typ: tail.typ(),
-        head: Box::new(head),
-        tail: Box::new(tail),
-    })
-}
-
-fn infer_tuple(
-    elems: Vec<UntypedExpr>,
-    location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let elems = elems
-        .into_iter()
-        .map(|e| infer(e, level, env))
-        .collect::<Result<Vec<_>, _>>()?;
-    let typ = tuple(elems.iter().map(|e| e.typ()).collect());
-    Ok(TypedExpr::Tuple {
-        location,
-        elems,
-        typ,
-    })
-}
-fn infer_var(
-    name: String,
-    location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let constructor = infer_value_constructor(&name, level, &location, env)?;
-    Ok(TypedExpr::Var {
-        constructor,
-        location,
-        name,
-    })
-}
-
-fn infer_field_access(
-    container: UntypedExpr,
-    label: String,
-    access_location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    match container {
-        UntypedExpr::Var { name, location, .. } if !env.local_values.contains_key(&name) => {
-            infer_module_access(name.as_ref(), label, level, &location, access_location, env)
-        }
-
-        _ => infer_record_access(container, label, level, access_location, env),
-    }
-}
-
-fn infer_tuple_index(
-    tuple: UntypedExpr,
-    index: u64,
-    location: SrcSpan,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let tuple = infer(tuple, level, env)?;
-
-    match tuple.typ().as_ref() {
-        Type::Tuple { elems } => {
-            let typ = elems
-                .get(index as usize)
-                .ok_or_else(|| Error::OutOfBoundsTupleIndex {
-                    location: location.clone(),
-                    index,
-                    size: elems.len(),
-                })?
-                .clone();
-            Ok(TypedExpr::TupleIndex {
-                location,
-                index,
-                tuple: Box::new(tuple),
-                typ,
-            })
-        }
-
-        typ if typ.is_unbound() => Err(Error::NotATupleUnbound {
-            location: tuple.location().clone(),
-        }),
-
-        _ => Err(Error::NotATuple {
-            location: tuple.location().clone(),
-            given: tuple.typ(),
-        }),
-    }
-}
-
-fn infer_binop(
-    name: BinOp,
-    left: UntypedExpr,
-    right: UntypedExpr,
-    level: usize,
-    location: SrcSpan,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let (input_type, output_type) = match name {
-        BinOp::Eq | BinOp::NotEq => {
-            let left = infer(left, level, env)?;
-            let right = infer(right, level, env)?;
-            unify(left.typ(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
-
-            return Ok(TypedExpr::BinOp {
-                location,
-                name,
-                typ: bool(),
-                left: Box::new(left),
-                right: Box::new(right),
-            });
-        }
-        BinOp::And => (bool(), bool()),
-        BinOp::Or => (bool(), bool()),
-        BinOp::LtInt => (int(), bool()),
-        BinOp::LtEqInt => (int(), bool()),
-        BinOp::LtFloat => (float(), bool()),
-        BinOp::LtEqFloat => (float(), bool()),
-        BinOp::GtEqInt => (int(), bool()),
-        BinOp::GtInt => (int(), bool()),
-        BinOp::GtEqFloat => (float(), bool()),
-        BinOp::GtFloat => (float(), bool()),
-        BinOp::AddInt => (int(), int()),
-        BinOp::AddFloat => (float(), float()),
-        BinOp::SubInt => (int(), int()),
-        BinOp::SubFloat => (float(), float()),
-        BinOp::MultInt => (int(), int()),
-        BinOp::MultFloat => (float(), float()),
-        BinOp::DivInt => (int(), int()),
-        BinOp::DivFloat => (float(), float()),
-        BinOp::ModuloInt => (int(), int()),
-    };
-
-    let left = infer(left, level, env)?;
-    unify(input_type.clone(), left.typ(), env)
-        .map_err(|e| convert_unify_error(e, left.location()))?;
-    let right = infer(right, level, env)?;
-    unify(input_type, right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
-
-    Ok(TypedExpr::BinOp {
-        location,
-        name,
-        typ: output_type,
-        left: Box::new(left),
-        right: Box::new(right),
-    })
-}
-
-fn infer_let(
-    pattern: UntypedPattern,
-    value: UntypedExpr,
-    then: UntypedExpr,
-    kind: BindingKind,
-    annotation: &Option<TypeAst>,
-    level: usize,
-    location: SrcSpan,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let value = infer(value, level + 1, env)?;
-    let try_value_type = env.new_unbound_var(level);
-    let try_error_type = env.new_unbound_var(level);
-
-    let value_typ = match kind {
-        // Ensure that the value is a result if this is a `try` binding
-        BindingKind::Try => {
-            let v = try_value_type.clone();
-            let e = try_error_type.clone();
-            unify(result(v, e), value.typ(), env)
-                .map_err(|e| convert_unify_error(e, value.location()))?;
-            try_value_type.clone()
-        }
-        _ => value.typ(),
-    };
-
-    let value_typ = generalise(value_typ, level + 1);
-
-    // Ensure the pattern matches the type of the value
-    let pattern = PatternTyper::new(env, level).unify(pattern, value_typ.clone())?;
-
-    // Check the type of the following code
-    let then = infer(then, level, env)?;
-    let typ = then.typ();
-
-    // Ensure that a Result with the right error type is returned for `try`
-    if kind == BindingKind::Try {
-        let value = env.new_unbound_var(level);
-        unify(result(value, try_error_type), typ.clone(), env)
-            .map_err(|e| convert_unify_error(e, then.try_binding_location()))?;
-    }
-
-    // Check that any type annotation is accurate.
-    if let Some(ann) = annotation {
-        let ann_typ = env
-            .type_from_ast(ann, &mut hashmap![], NewTypeAction::MakeGeneric)
-            .map(|t| instantiate(t, level, &mut hashmap![], env))?;
-        unify(ann_typ, value_typ, env).map_err(|e| convert_unify_error(e, value.location()))?;
-    }
-
-    Ok(TypedExpr::Let {
-        location,
-        typ,
-        kind,
-        pattern,
-        value: Box::new(value),
-        then: Box::new(then),
-    })
-}
-
-fn infer_case(
-    subjects: Vec<UntypedExpr>,
-    clauses: Vec<UntypedClause>,
-    level: usize,
-    location: SrcSpan,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let subjects_count = subjects.len();
-    let mut typed_subjects = Vec::with_capacity(subjects_count);
-    let mut subject_types = Vec::with_capacity(subjects_count);
-    let mut typed_clauses = Vec::with_capacity(clauses.len());
-
-    let return_type = env.new_unbound_var(level);
-
-    for subject in subjects.into_iter() {
-        let subject = infer(subject, level + 1, env)?;
-        let subject_type = generalise(subject.typ(), level + 1);
-        typed_subjects.push(subject);
-        subject_types.push(subject_type);
-    }
-
-    for clause in clauses.into_iter() {
-        let typed_clause = infer_clause(clause, &subject_types, level, env)?;
-        unify(return_type.clone(), typed_clause.then.typ(), env)
-            .map_err(|e| convert_unify_error(e, typed_clause.then.location()))?;
-        typed_clauses.push(typed_clause);
-    }
-    Ok(TypedExpr::Case {
-        location,
-        typ: return_type,
-        subjects: typed_subjects,
-        clauses: typed_clauses,
-    })
-}
-
-fn infer_clause(
-    clause: UntypedClause,
-    subjects: &[Arc<Type>],
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedClause, Error> {
-    let Clause {
-        pattern,
-        alternative_patterns,
-        guard,
-        then,
-        location,
-    } = clause;
-
-    // Store the local scope so it can be reset after the clause
-    let vars = env.local_values.clone();
-
-    // Check the types
-    let (typed_pattern, typed_alternatives) = infer_clause_pattern(
-        pattern,
-        alternative_patterns,
-        subjects,
-        level,
-        &location,
-        env,
-    )?;
-    let guard = infer_optional_clause_guard(guard, level, env)?;
-    let then = infer(then, level, env)?;
-
-    // Reset the local vars now the clause scope is done
-    env.local_values = vars;
-
-    Ok(Clause {
-        location,
-        pattern: typed_pattern,
-        alternative_patterns: typed_alternatives,
-        guard,
-        then,
-    })
-}
-
-fn infer_clause_pattern(
-    pattern: UntypedMultiPattern,
-    alternatives: Vec<UntypedMultiPattern>,
-    subjects: &[Arc<Type>],
-    level: usize,
-    location: &SrcSpan,
-    env: &mut Typer,
-) -> Result<(TypedMultiPattern, Vec<TypedMultiPattern>), Error> {
-    let mut pattern_typer = PatternTyper::new(env, level);
-    let typed_pattern = pattern_typer.infer_multi_pattern(pattern, subjects, &location)?;
-
-    // Each case clause has one or more patterns that may match the
-    // subject in order for the clause to be selected, so we must type
-    // check every pattern.
-    let mut typed_alternatives = Vec::with_capacity(alternatives.len());
-    for m in alternatives {
-        typed_alternatives
-            .push(pattern_typer.infer_alternative_multi_pattern(m, subjects, &location)?);
-    }
-
-    Ok((typed_pattern, typed_alternatives))
-}
-
-fn infer_optional_clause_guard(
-    guard: Option<UntypedClauseGuard>,
-    level: usize,
-    env: &mut Typer,
-) -> Result<Option<TypedClauseGuard>, Error> {
-    match guard {
-        // If there is no guard we do nothing
-        None => Ok(None),
-
-        // If there is a guard we assert that it is of type Bool
-        Some(guard) => {
-            let guard = infer_clause_guard(guard, level, env)?;
-            unify(bool(), guard.typ(), env)
-                .map_err(|e| convert_unify_error(e, guard.location()))?;
-            Ok(Some(guard))
-        }
-    }
-}
-
-fn infer_clause_guard(
-    guard: UntypedClauseGuard,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedClauseGuard, Error> {
-    match guard {
-        ClauseGuard::Var { location, name, .. } => {
-            let constructor = infer_value_constructor(&name, level, &location, env)?;
-
-            // We cannot support all values in guard expressions as the BEAM does not
-            match &constructor.variant {
-                ValueConstructorVariant::LocalVariable => (),
-                ValueConstructorVariant::ModuleFn { .. }
-                | ValueConstructorVariant::Record { .. } => {
-                    return Err(Error::NonLocalClauseGuardVariable { location, name })
-                }
-            };
-
-            Ok(ClauseGuard::Var {
-                location,
-                name,
-                typ: constructor.typ,
-            })
-        }
-
-        ClauseGuard::Tuple {
-            location, elems, ..
-        } => {
-            let elems = elems
-                .into_iter()
-                .map(|x| infer_clause_guard(x, level, env))
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let typ = tuple(elems.iter().map(|e| e.typ()).collect());
-
-            Ok(ClauseGuard::Tuple {
-                location,
-                elems,
-                typ,
-            })
-        }
-
-        ClauseGuard::Constructor {
-            module,
-            location,
-            name,
-            mut args,
-            ..
-        } => {
-            let constructor = infer_value_constructor(&name, level, &location, env)?;
-
-            match &constructor.variant {
-                ValueConstructorVariant::Record { .. } => (),
-                ValueConstructorVariant::ModuleFn { .. }
-                | ValueConstructorVariant::LocalVariable => {
-                    return Err(Error::NonLocalClauseGuardVariable { location, name })
-                }
-            };
-
-            // Pretty much all the other infer functions operate on UntypedExpr
-            // or TypedExpr rather than ClauseGuard. To make things easier we
-            // build the TypedExpr equivalent of the constructor and use that
-            let fun = TypedExpr::Var {
-                constructor,
-                location: location.clone(),
-                name: name.clone(),
-            };
-
-            // This is basically the same code as do_infer_call_with_known_fun()
-            // except the args are typed with infer_clause_guard() here.
-            // This duplication is a bit awkward but it works!
-            // Potentially this could be improved later
-            match get_field_map(&fun, env)
-                .map_err(|e| convert_get_value_constructor_error(e, &location))?
-            {
-                // The fun has a field map so labelled arguments may be present and need to be reordered.
-                Some(field_map) => field_map.reorder(&mut args, &location)?,
-
-                // The fun has no field map and so we error if arguments have been labelled
-                None => assert_no_labelled_arguments(&args)?,
-            }
-
-            let (mut args_types, return_type) = match_fun_type(fun.typ(), args.len(), env)
-                .map_err(|e| convert_not_fun_error(e, fun.location(), &location))?;
-            let args = args_types
-                .iter_mut()
-                .zip(args)
-                .map(
-                    |(
-                        typ,
-                        CallArg {
-                            label,
-                            value,
-                            location,
-                        },
-                    ): (&mut Arc<Type>, _)| {
-                        let value = infer_clause_guard(value, level, env)?;
-                        unify(typ.clone(), value.typ(), env)
-                            .map_err(|e| convert_unify_error(e, value.location()))?;
-                        Ok(CallArg {
-                            label,
-                            value,
-                            location,
-                        })
-                    },
-                )
-                .collect::<Result<_, _>>()?;
-
-            Ok(ClauseGuard::Constructor {
-                module,
-                location,
-                name,
-                args,
-                typ: return_type,
-            })
-        }
-
-        ClauseGuard::And {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(bool(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(bool(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::And {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::Or {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(bool(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(bool(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::Or {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::Equals {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(left.typ(), right.typ(), env).map_err(|e| convert_unify_error(e, &location))?;
-            Ok(ClauseGuard::Equals {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::NotEquals {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(left.typ(), right.typ(), env).map_err(|e| convert_unify_error(e, &location))?;
-            Ok(ClauseGuard::NotEquals {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::GtInt {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::GtInt {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::GtEqInt {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::GtEqInt {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::LtInt {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::LtInt {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::LtEqInt {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(int(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(int(), right.typ(), env).map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::LtEqInt {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::GtFloat {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(float(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::GtFloat {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::GtEqFloat {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(float(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::GtEqFloat {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::LtFloat {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(float(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::LtFloat {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::LtEqFloat {
-            location,
-            left,
-            right,
-            ..
-        } => {
-            let left = infer_clause_guard(*left, level, env)?;
-            unify(float(), left.typ(), env).map_err(|e| convert_unify_error(e, left.location()))?;
-            let right = infer_clause_guard(*right, level, env)?;
-            unify(float(), right.typ(), env)
-                .map_err(|e| convert_unify_error(e, right.location()))?;
-            Ok(ClauseGuard::LtEqFloat {
-                location,
-                left: Box::new(left),
-                right: Box::new(right),
-            })
-        }
-
-        ClauseGuard::Int {
-            location, value, ..
-        } => Ok(ClauseGuard::Int { location, value }),
-
-        ClauseGuard::Float {
-            location, value, ..
-        } => Ok(ClauseGuard::Float { location, value }),
-
-        ClauseGuard::String {
-            location, value, ..
-        } => Ok(ClauseGuard::String { location, value }),
-    }
-}
-
-fn infer_module_access(
-    module_alias: &str,
-    label: String,
-    level: usize,
-    module_location: &SrcSpan,
-    select_location: SrcSpan,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    let (module_name, constructor) = {
-        let module_info =
-            env.imported_modules
-                .get(&*module_alias)
-                .ok_or_else(|| Error::UnknownModule {
-                    name: module_alias.to_string(),
-                    location: module_location.clone(),
-                    imported_modules: env.imported_modules.keys().map(|t| t.to_string()).collect(),
-                })?;
-
-        let constructor =
-            module_info
-                .values
-                .get(&label)
-                .ok_or_else(|| Error::UnknownModuleValue {
-                    name: label.clone(),
-                    location: select_location.clone(),
-                    module_name: module_info.name.clone(),
-                    value_constructors: module_info.values.keys().map(|t| t.to_string()).collect(),
-                })?;
-
-        (module_info.name.clone(), constructor.clone())
-    };
-
-    Ok(TypedExpr::ModuleSelect {
-        label,
-        typ: instantiate(constructor.typ, level, &mut hashmap![], env),
-        location: select_location,
-        module_name,
-        module_alias: module_alias.to_string(),
-        constructor: constructor.variant.to_module_value_constructor(),
-    })
-}
-
-fn infer_record_access(
-    record: UntypedExpr,
-    label: String,
-    level: usize,
-    location: SrcSpan,
-    env: &mut Typer,
-) -> Result<TypedExpr, Error> {
-    // Infer the type of the (presumed) record
-    let record = Box::new(infer(record, level, env)?);
-
-    // If we don't yet know the type of the record then we cannot use any accessors
-    if record.typ().is_unbound() {
-        return Err(Error::RecordAccessUnknownType {
-            location: record.location().clone(),
-        });
-    }
-
-    // Error constructor helper function
-    let unknown_field = |fields| Error::UnknownField {
-        typ: record.typ(),
-        location: location.clone(),
-        label: label.clone(),
-        fields,
-    };
-
-    // Check to see if it's a Type that can have accessible fields
-    let accessors = match collapse_links(record.typ()).as_ref() {
-        // A type in the current module which may have fields
-        Type::App { module, name, .. } if module.as_slice() == env.current_module => {
-            env.accessors.get(name)
-        }
-
-        // A type in another module which may have fields
-        Type::App { module, name, .. } => env
-            .importable_modules
-            .get(&module.join("/"))
-            .and_then(|module| module.accessors.get(name)),
-
-        _something_without_fields => return Err(unknown_field(vec![])),
-    }
-    .ok_or_else(|| unknown_field(vec![]))?;
-
-    // Find the accessor, if the type has one with the same label
-    let RecordAccessor {
-        index, label, typ, ..
-    } = accessors
-        .accessors
-        .get(&label)
-        .ok_or_else(|| unknown_field(accessors.accessors.keys().map(|t| t.to_string()).collect()))?
-        .clone();
-
-    // Unify the record type with the accessor's stored copy of the record type.
-    // This ensure that the type parameters of the retrieved value have the correct
-    // types for this instance of the record.
-    let accessor_record_type = accessors.typ.clone();
-    let mut type_vars = hashmap![];
-    let accessor_record_type = instantiate(accessor_record_type, 0, &mut type_vars, env);
-    let typ = instantiate(typ, 0, &mut type_vars, env);
-    unify(accessor_record_type, record.typ(), env)
-        .map_err(|e| convert_unify_error(e, record.location()))?;
-
-    Ok(TypedExpr::RecordAccess {
-        record,
-        label,
-        index,
-        location,
-        typ,
-    })
-}
-
 struct PatternTyper<'a, 'b, 'c> {
-    env: &'a mut Typer<'b, 'c>,
+    typer: &'a mut Typer<'b, 'c>,
     level: usize,
     mode: PatternMode,
     initial_pattern_vars: HashSet<String>,
@@ -2849,9 +3233,9 @@ enum PatternMode {
 }
 
 impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
-    pub fn new(env: &'a mut Typer<'b, 'c>, level: usize) -> Self {
+    pub fn new(typer: &'a mut Typer<'b, 'c>, level: usize) -> Self {
         Self {
-            env,
+            typer,
             level,
             mode: PatternMode::Initial,
             initial_pattern_vars: HashSet::new(),
@@ -2867,7 +3251,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                     });
                 }
                 self.initial_pattern_vars.insert(name.to_string());
-                self.env.insert_variable(
+                self.typer.insert_variable(
                     name.to_string(),
                     ValueConstructorVariant::LocalVariable,
                     typ,
@@ -2875,10 +3259,11 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                 Ok(())
             }
 
-            PatternMode::Alternative => match self.env.local_values.get(name) {
+            PatternMode::Alternative => match self.typer.local_values.get(name) {
                 // This variable was defined in the Initial multi-pattern
                 Some(initial) if self.initial_pattern_vars.contains(name) => {
-                    unify(initial.typ.clone(), typ, self.env)
+                    let initial_typ = initial.typ.clone();
+                    self.typer.unify(initial_typ, typ)
                 }
 
                 // This variable was not defined in the Initial multi-pattern
@@ -2926,7 +3311,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
 
     /// When we have an assignment or a case expression we unify the pattern with the
     /// inferred type of the subject in order to determine what variables to insert
-    /// into the environment (or to detect a type error).
+    /// into the typerironment (or to detect a type error).
     ///
     fn unify(&mut self, pattern: UntypedPattern, typ: Arc<Type>) -> Result<TypedPattern, Error> {
         match pattern {
@@ -2945,22 +3330,30 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
             }
 
             Pattern::Int { location, value } => {
-                unify(typ, int(), self.env).map_err(|e| convert_unify_error(e, &location))?;
+                self.typer
+                    .unify(typ, int())
+                    .map_err(|e| convert_unify_error(e, &location))?;
                 Ok(Pattern::Int { location, value })
             }
 
             Pattern::Float { location, value } => {
-                unify(typ, float(), self.env).map_err(|e| convert_unify_error(e, &location))?;
+                self.typer
+                    .unify(typ, float())
+                    .map_err(|e| convert_unify_error(e, &location))?;
                 Ok(Pattern::Float { location, value })
             }
 
             Pattern::String { location, value } => {
-                unify(typ, string(), self.env).map_err(|e| convert_unify_error(e, &location))?;
+                self.typer
+                    .unify(typ, string())
+                    .map_err(|e| convert_unify_error(e, &location))?;
                 Ok(Pattern::String { location, value })
             }
 
             Pattern::Nil { location } => {
-                unify(typ, list(self.env.new_unbound_var(self.level)), self.env)
+                let typ2 = list(self.typer.new_unbound_var(self.level));
+                self.typer
+                    .unify(typ, typ2)
                     .map_err(|e| convert_unify_error(e, &location))?;
                 Ok(Pattern::Nil { location })
             }
@@ -2970,13 +3363,13 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                 head,
                 tail,
                 deprecated_syntax,
-            } => match typ.get_app_args(true, &[], "List", 1, self.env) {
+            } => match typ.get_app_args(true, &[], "List", 1, self.typer) {
                 Some(args) => {
                     let head = Box::new(self.unify(*head, args[0].clone())?);
                     let tail = Box::new(self.unify(*tail, typ)?);
 
                     if deprecated_syntax {
-                        self.env
+                        self.typer
                             .warnings
                             .push(Warning::DeprecatedListPrependSyntax {
                                 location: SrcSpan {
@@ -2995,7 +3388,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                 }
 
                 None => Err(Error::CouldNotUnify {
-                    given: list(self.env.new_unbound_var(self.level)),
+                    given: list(self.typer.new_unbound_var(self.level)),
                     expected: typ.clone(),
                     location,
                 }),
@@ -3013,16 +3406,17 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
 
                 Type::Var { .. } => {
                     let elems_types = (0..(elems.len()))
-                        .map(|_| self.env.new_unbound_var(self.level))
+                        .map(|_| self.typer.new_unbound_var(self.level))
                         .collect();
-                    unify(tuple(elems_types), typ.clone(), self.env)
+                    self.typer
+                        .unify(tuple(elems_types), typ.clone())
                         .map_err(|e| convert_unify_error(e, &location))?;
                     self.unify(Pattern::Tuple { elems, location }, typ)
                 }
 
                 _ => {
                     let elems_types = (0..(elems.len()))
-                        .map(|_| self.env.new_unbound_var(self.level))
+                        .map(|_| self.typer.new_unbound_var(self.level))
                         .collect();
 
                     Err(Error::CouldNotUnify {
@@ -3042,7 +3436,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                 ..
             } => {
                 let cons = self
-                    .env
+                    .typer
                     .get_value_constructor(module.as_ref(), &name)
                     .map_err(|e| convert_get_value_constructor_error(e, &location))?;
 
@@ -3112,7 +3506,8 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                 };
 
                 let instantiated_constructor_type =
-                    instantiate(constructor_typ, self.level, &mut hashmap![], self.env);
+                    self.typer
+                        .instantiate(constructor_typ, self.level, &mut hashmap![]);
                 match &*instantiated_constructor_type {
                     Type::Fn { args, retrn } => {
                         if args.len() == pattern_args.len() {
@@ -3133,7 +3528,8 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                                     })
                                 })
                                 .collect::<Result<Vec<_>, _>>()?;
-                            unify(typ, retrn.clone(), self.env)
+                            self.typer
+                                .unify(typ, retrn.clone())
                                 .map_err(|e| convert_unify_error(e, &location))?;
                             Ok(Pattern::Constructor {
                                 location,
@@ -3154,7 +3550,8 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
 
                     Type::App { .. } => {
                         if pattern_args.is_empty() {
-                            unify(typ, instantiated_constructor_type, self.env)
+                            self.typer
+                                .unify(typ, instantiated_constructor_type)
                                 .map_err(|e| convert_unify_error(e, &location))?;
                             Ok(Pattern::Constructor {
                                 location,
@@ -3182,90 +3579,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
     }
 }
 
-fn infer_value_constructor(
-    name: &str,
-    level: usize,
-    location: &SrcSpan,
-    env: &mut Typer,
-) -> Result<ValueConstructor, Error> {
-    let ValueConstructor {
-        public,
-        variant,
-        origin,
-        typ,
-    } = env
-        .get_variable(name)
-        .cloned()
-        .ok_or_else(|| Error::UnknownVariable {
-            location: location.clone(),
-            name: name.to_string(),
-            variables: env.local_values.keys().map(|t| t.to_string()).collect(),
-        })?;
-    let typ = instantiate(typ, level, &mut hashmap![], env);
-    Ok(ValueConstructor {
-        public,
-        variant,
-        origin,
-        typ,
-    })
-}
-
 pub type TypedCallArg = CallArg<TypedExpr>;
-
-fn do_infer_call(
-    fun: UntypedExpr,
-    args: Vec<CallArg<UntypedExpr>>,
-    level: usize,
-    location: &SrcSpan,
-    env: &mut Typer,
-) -> Result<(TypedExpr, Vec<TypedCallArg>, Arc<Type>), Error> {
-    let fun = infer(fun, level, env)?;
-    let (fun, args, typ) = do_infer_call_with_known_fun(fun, args, level, location, env)?;
-    Ok((fun, args, typ))
-}
-
-fn do_infer_call_with_known_fun(
-    fun: TypedExpr,
-    mut args: Vec<CallArg<UntypedExpr>>,
-    level: usize,
-    location: &SrcSpan,
-    env: &mut Typer,
-) -> Result<(TypedExpr, Vec<TypedCallArg>, Arc<Type>), Error> {
-    match get_field_map(&fun, env).map_err(|e| convert_get_value_constructor_error(e, location))? {
-        // The fun has a field map so labelled arguments may be present and need to be reordered.
-        Some(field_map) => field_map.reorder(&mut args, location)?,
-
-        // The fun has no field map and so we error if arguments have been labelled
-        None => assert_no_labelled_arguments(&args)?,
-    }
-
-    let (mut args_types, return_type) = match_fun_type(fun.typ(), args.len(), env)
-        .map_err(|e| convert_not_fun_error(e, fun.location(), &location))?;
-    let args = args_types
-        .iter_mut()
-        .zip(args)
-        .map(
-            |(
-                typ,
-                CallArg {
-                    label,
-                    value,
-                    location,
-                },
-            ): (&mut Arc<Type>, _)| {
-                let value = infer(value, level, env)?;
-                unify(typ.clone(), value.typ(), env)
-                    .map_err(|e| convert_unify_error(e, value.location()))?;
-                Ok(CallArg {
-                    label,
-                    value,
-                    location,
-                })
-            },
-        )
-        .collect::<Result<_, _>>()?;
-    Ok((fun, args, return_type))
-}
 
 fn assert_no_labelled_arguments<A>(args: &[CallArg<A>]) -> Result<(), Error> {
     for arg in args {
@@ -3277,96 +3591,6 @@ fn assert_no_labelled_arguments<A>(args: &[CallArg<A>]) -> Result<(), Error> {
         }
     }
     Ok(())
-}
-
-fn get_field_map<'a>(
-    constructor: &TypedExpr,
-    env: &'a Typer,
-) -> Result<Option<&'a FieldMap>, GetValueConstructorError> {
-    let (module, name) = match constructor {
-        TypedExpr::ModuleSelect {
-            module_alias,
-            label,
-            ..
-        } => (Some(module_alias), label),
-
-        TypedExpr::Var { name, .. } => (None, name),
-
-        _ => return Ok(None),
-    };
-
-    Ok(env.get_value_constructor(module, name)?.field_map())
-}
-
-fn infer_arg(
-    arg: UntypedArg,
-    type_vars: &mut im::HashMap<String, (usize, Arc<Type>)>,
-    level: usize,
-    env: &mut Typer,
-) -> Result<TypedArg, Error> {
-    let Arg {
-        names,
-        annotation,
-        location,
-        ..
-    } = arg;
-    let typ = annotation
-        .clone()
-        .map(|t| env.type_from_ast(&t, type_vars, NewTypeAction::MakeGeneric))
-        .unwrap_or_else(|| Ok(env.new_unbound_var(level)))?;
-    Ok(Arg {
-        names,
-        location,
-        annotation,
-        typ,
-    })
-}
-
-fn do_infer_fn(
-    args: Vec<UntypedArg>,
-    body: UntypedExpr,
-    return_annotation: &Option<TypeAst>,
-    level: usize,
-    env: &mut Typer,
-) -> Result<(Vec<TypedArg>, TypedExpr), Error> {
-    // Construct an initial type for each argument of the function- either an unbound type variable
-    // or a type provided by an annotation.
-    let mut type_vars = hashmap![];
-    let args: Vec<_> = args
-        .into_iter()
-        .map(|arg| infer_arg(arg, &mut type_vars, level, env))
-        .collect::<Result<_, _>>()?;
-
-    // Record generic type variables that comes from type annotations.
-    // They cannot be instantiated so we need to keep track of them.
-    let previous_annotated_generic_types = env.annotated_generic_types.clone();
-    for (id, _type) in type_vars.values() {
-        env.annotated_generic_types.insert(*id);
-    }
-
-    // Insert arguments into function body scope.
-    let previous_vars = env.local_values.clone();
-    for (arg, t) in args.iter().zip(args.iter().map(|arg| arg.typ.clone())) {
-        match &arg.names {
-            ArgNames::Named { name } | ArgNames::NamedLabelled { name, .. } => {
-                env.insert_variable(name.to_string(), ValueConstructorVariant::LocalVariable, t)
-            }
-            ArgNames::Discard { .. } | ArgNames::LabelledDiscard { .. } => (),
-        };
-    }
-
-    let body = infer(body, level, env)?;
-
-    // Check that any return type annotation is accurate.
-    if let Some(ann) = return_annotation {
-        let ret_typ = env.type_from_ast(ann, &mut type_vars, NewTypeAction::MakeGeneric)?;
-        unify(ret_typ, body.typ(), env).map_err(|e| convert_unify_error(e, body.location()))?;
-    }
-
-    // Reset the env now that the scope of the function has ended.
-    env.local_values = previous_vars;
-    env.annotated_generic_types = previous_annotated_generic_types;
-    Ok((args, body))
 }
 
 fn convert_unify_error(e: UnifyError, location: &SrcSpan) -> Error {
@@ -3390,69 +3614,6 @@ fn convert_unify_error(e: UnifyError, location: &SrcSpan) -> Error {
         UnifyError::RecursiveType => Error::RecursiveType {
             location: location.clone(),
         },
-    }
-}
-
-/// Instantiate converts generic variables into unbound ones.
-///
-fn instantiate(
-    t: Arc<Type>,
-    ctx_level: usize,
-    ids: &mut im::HashMap<usize, Arc<Type>>,
-    env: &mut Typer,
-) -> Arc<Type> {
-    match &*t {
-        Type::App {
-            public,
-            name,
-            module,
-            args,
-        } => {
-            let args = args
-                .iter()
-                .map(|t| instantiate(t.clone(), ctx_level, ids, env))
-                .collect();
-            Arc::new(Type::App {
-                public: *public,
-                name: name.clone(),
-                module: module.clone(),
-                args,
-            })
-        }
-
-        Type::Var { typ } => {
-            match &*typ.borrow() {
-                TypeVar::Link { typ } => return instantiate(typ.clone(), ctx_level, ids, env),
-
-                TypeVar::Unbound { .. } => return Arc::new(Type::Var { typ: typ.clone() }),
-
-                TypeVar::Generic { id } => match ids.get(id) {
-                    Some(t) => return t.clone(),
-                    None => {
-                        if !env.annotated_generic_types.contains(id) {
-                            let v = env.new_unbound_var(ctx_level);
-                            ids.insert(*id, v.clone());
-                            return v;
-                        }
-                    }
-                },
-            }
-            Arc::new(Type::Var { typ: typ.clone() })
-        }
-
-        Type::Fn { args, retrn, .. } => fn_(
-            args.iter()
-                .map(|t| instantiate(t.clone(), ctx_level, ids, env))
-                .collect(),
-            instantiate(retrn.clone(), ctx_level, ids, env),
-        ),
-
-        Type::Tuple { elems } => tuple(
-            elems
-                .iter()
-                .map(|t| instantiate(t.clone(), ctx_level, ids, env))
-                .collect(),
-        ),
     }
 }
 
@@ -3487,123 +3648,6 @@ fn unify_enclosed_type(
         }),
 
         _ => result,
-    }
-}
-fn unify(t1: Arc<Type>, t2: Arc<Type>, env: &Typer) -> Result<(), UnifyError> {
-    if t1 == t2 {
-        return Ok(());
-    }
-
-    // Collapse right hand side type links. Left hand side will be collapsed in the next block.
-    if let Type::Var { typ } = &*t2 {
-        if let TypeVar::Link { typ } = &*typ.borrow() {
-            return unify(t1, typ.clone(), env);
-        }
-    }
-
-    if let Type::Var { typ } = &*t1 {
-        enum Action {
-            Unify(Arc<Type>),
-            CouldNotUnify,
-            Link,
-        }
-
-        let action = match &*typ.borrow() {
-            TypeVar::Link { typ } => Action::Unify(typ.clone()),
-
-            TypeVar::Unbound { id, level } => {
-                update_levels(t2.clone(), *level, *id)?;
-                Action::Link
-            }
-
-            TypeVar::Generic { id } => {
-                if let Type::Var { typ } = &*t2 {
-                    if typ.borrow().is_unbound() {
-                        *typ.borrow_mut() = TypeVar::Generic { id: *id };
-                        return Ok(());
-                    }
-                }
-                Action::CouldNotUnify
-            }
-        };
-
-        return match action {
-            Action::Link => {
-                *typ.borrow_mut() = TypeVar::Link { typ: t2 };
-                Ok(())
-            }
-
-            Action::Unify(t) => unify(t, t2, env),
-
-            Action::CouldNotUnify => Err(UnifyError::CouldNotUnify {
-                expected: t1.clone(),
-                given: t2,
-            }),
-        };
-    }
-
-    if let Type::Var { .. } = *t2 {
-        return unify(t2, t1, env).map_err(flip_unify_error);
-    }
-
-    match (&*t1, &*t2) {
-        (
-            Type::App {
-                module: m1,
-                name: n1,
-                args: args1,
-                ..
-            },
-            Type::App {
-                module: m2,
-                name: n2,
-                args: args2,
-                ..
-            },
-        ) if m1 == m2 && n1 == n2 && args1.len() == args2.len() => {
-            for (a, b) in args1.iter().zip(args2) {
-                unify_enclosed_type(t1.clone(), t2.clone(), unify(a.clone(), b.clone(), env))?;
-            }
-            Ok(())
-        }
-
-        (Type::Tuple { elems: elems1, .. }, Type::Tuple { elems: elems2, .. })
-            if elems1.len() == elems2.len() =>
-        {
-            for (a, b) in elems1.iter().zip(elems2) {
-                unify_enclosed_type(t1.clone(), t2.clone(), unify(a.clone(), b.clone(), env))?;
-            }
-            Ok(())
-        }
-
-        (
-            Type::Fn {
-                args: args1,
-                retrn: retrn1,
-                ..
-            },
-            Type::Fn {
-                args: args2,
-                retrn: retrn2,
-                ..
-            },
-        ) if args1.len() == args2.len() => {
-            for (a, b) in args1.iter().zip(args2) {
-                unify(a.clone(), b.clone(), env).map_err(|_| UnifyError::CouldNotUnify {
-                    expected: t1.clone(),
-                    given: t2.clone(),
-                })?;
-            }
-            unify(retrn1.clone(), retrn2.clone(), env).map_err(|_| UnifyError::CouldNotUnify {
-                expected: t1.clone(),
-                given: t2.clone(),
-            })
-        }
-
-        (_, _) => Err(UnifyError::CouldNotUnify {
-            expected: t1.clone(),
-            given: t2.clone(),
-        }),
     }
 }
 
@@ -3681,15 +3725,15 @@ fn update_levels(typ: Arc<Type>, own_level: usize, own_id: usize) -> Result<(), 
 fn match_fun_type(
     typ: Arc<Type>,
     arity: usize,
-    env: &mut Typer,
+    typer: &mut Typer,
 ) -> Result<(Vec<Arc<Type>>, Arc<Type>), MatchFunTypeError> {
     if let Type::Var { typ } = &*typ {
         let new_value = match &*typ.borrow() {
-            TypeVar::Link { typ, .. } => return match_fun_type(typ.clone(), arity, env),
+            TypeVar::Link { typ, .. } => return match_fun_type(typ.clone(), arity, typer),
 
             TypeVar::Unbound { level, .. } => {
-                let args: Vec<_> = (0..arity).map(|_| env.new_unbound_var(*level)).collect();
-                let retrn = env.new_unbound_var(*level);
+                let args: Vec<_> = (0..arity).map(|_| typer.new_unbound_var(*level)).collect();
+                let retrn = typer.new_unbound_var(*level);
                 Some((args, retrn))
             }
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -193,7 +193,8 @@ fn infer_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
+            let result = Typer::new(&[], &HashMap::new())
+                .infer(ast, 1)
                 .expect("should successfully infer");
             assert_eq!(
                 ($src, printer.pretty_print(result.typ().as_ref(), 0),),
@@ -421,7 +422,8 @@ fn infer_error_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
+            let result = Typer::new(&[], &HashMap::new())
+                .infer(ast, 1)
                 .expect_err("should infer an error");
             assert_eq!(($src, sort_options($error)), ($src, sort_options(result)));
         };

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -194,7 +194,7 @@ fn infer_test() {
                 .parse($src)
                 .expect("syntax error");
             let result = Typer::new(&[], &HashMap::new())
-                .infer(ast, 1)
+                .infer(ast)
                 .expect("should successfully infer");
             assert_eq!(
                 ($src, printer.pretty_print(result.typ().as_ref(), 0),),
@@ -423,7 +423,7 @@ fn infer_error_test() {
                 .parse($src)
                 .expect("syntax error");
             let result = Typer::new(&[], &HashMap::new())
-                .infer(ast, 1)
+                .infer(ast)
                 .expect_err("should infer an error");
             assert_eq!(($src, sort_options($error)), ($src, sort_options(result)));
         };

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -193,7 +193,7 @@ fn infer_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Env::new(&[], &HashMap::new()))
+            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
                 .expect("should successfully infer");
             assert_eq!(
                 ($src, printer.pretty_print(result.typ().as_ref(), 0),),
@@ -421,7 +421,7 @@ fn infer_error_test() {
             let ast = crate::grammar::ExprSequenceParser::new()
                 .parse($src)
                 .expect("syntax error");
-            let result = infer(ast, 1, &mut Env::new(&[], &HashMap::new()))
+            let result = infer(ast, 1, &mut Typer::new(&[], &HashMap::new()))
                 .expect_err("should infer an error");
             assert_eq!(($src, sort_options($error)), ($src, sort_options(result)));
         };
@@ -2251,7 +2251,7 @@ fn env_types_with(things: &[&str]) -> Vec<String> {
 }
 
 fn env_types() -> Vec<String> {
-    Env::new(&[], &HashMap::new())
+    Typer::new(&[], &HashMap::new())
         .module_types
         .keys()
         .map(|s| s.to_string())
@@ -2267,7 +2267,7 @@ fn env_vars_with(things: &[&str]) -> Vec<String> {
 }
 
 fn env_vars() -> Vec<String> {
-    Env::new(&[], &HashMap::new())
+    Typer::new(&[], &HashMap::new())
         .local_values
         .keys()
         .map(|s| s.to_string())


### PR DESCRIPTION
Resolves https://github.com/gleam-lang/gleam/issues/579

There's a lot of miscellaneous refactoring going on here to make the final change easier. I'm not completely happy with the end result yet, but it does work, so I wanted to PR what I have so that we can start testing 0.9 sooner than later.

In particular, I wish I had a better method for opening / closing new scopes. I don't like that the programmer needs to remember to call `end_scope` in order to keep `warnings` and `uids` in sync. Tests should fail immediately if they do forget, though, so it should be ok for now. For the future, I think if `new_scope` took a function as an argument it'd be able to automatically close the scope after calling it. That was a larger refactoring than I wanted to address now, however.