### PR TITLE
Track type variables in function signatures properly when printing docs

### DIFF
--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,4 +1,6 @@
 pub(crate) mod command;
+#[cfg(test)]
+mod tests;
 
 use crate::{
     ast::{Statement, TypedStatement},

--- a/src/docs/tests.rs
+++ b/src/docs/tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+use crate::project::{Input, OutputFile, ProjectConfig};
+
+#[test]
+fn module_docs_test() {
+    let src = r#"
+//// module comment
+
+/// doc comment
+// regular comment
+pub fn public_fun(x: Int) -> Int {
+  x
+}
+
+pub fn implicit_return() {
+  "testing"
+}
+
+fn private_fun() {
+  1
+}
+
+pub fn complicated_fun(
+  over thing: a,
+  from initial: b,
+  with fun: fn(a, b) -> b,
+) -> b {
+  fun(thing, initial)
+}
+  "#;
+
+    let input = Input {
+        origin: ModuleOrigin::Src,
+        path: PathBuf::from("/src/test.gleam"),
+        source_base_path: PathBuf::from("/src"),
+        src: src.to_string(),
+    };
+
+    let config = ProjectConfig {
+        name: "test".to_string(),
+        docs: None,
+    };
+
+    let analysed = crate::project::analysed(vec![input]).expect("Compilation failed");
+
+    let output_files = generate_html(&config, analysed.as_slice(), &[], &PathBuf::from("/docs"));
+    let module_page = output_files
+        .iter()
+        .find(|page| page.path == PathBuf::from("/docs/test/index.html"))
+        .expect("Missing docs page");
+
+    // Comments
+    module_page.should_contain("module comment");
+    module_page.should_contain("doc comment");
+    module_page.should_not_contain("regular comment");
+
+    // Functions
+    module_page.should_contain("pub fn public_fun(x: Int) -&gt; Int");
+    module_page.should_contain("pub fn implicit_return() -&gt; String");
+    module_page.should_not_contain("private_fun()");
+
+    module_page.should_contain(
+        "pub fn complicated_fun(
+  over thing: a,
+  from initial: b,
+  with fun: fn(a, b) -&gt; b,
+) -&gt; b",
+    );
+}
+
+impl OutputFile {
+    fn should_contain(&self, text: &str) {
+        assert!(
+            self.text.contains(&text.to_string()),
+            "Generated docs page did not contain: `{}`",
+            text
+        );
+    }
+
+    fn should_not_contain(&self, text: &str) {
+        assert!(
+            !self.text.contains(&text.to_string()),
+            "Generated docs page was not supposed to contain: `{}`",
+            text
+        );
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -812,17 +812,22 @@ impl<'a> Formatter<'a> {
         args: &[TypedArg],
         return_type: Arc<Type>,
     ) -> Document {
+        let mut printer = typ::pretty::Printer::new();
+
         pub_(public)
             .append("fn ")
-            .append(name.to_string())
-            .append(self.docs_fn_args(args))
+            .append(name)
+            .append(self.docs_fn_args(args, &mut printer))
             .append(" -> ".to_doc())
-            .append(typ::pretty::Printer::new().print(return_type.as_ref()))
+            .append(printer.print(return_type.as_ref()))
     }
 
     // Like fn_args but will always print the types, even if they were implicit in the original source
-    pub fn docs_fn_args(&mut self, args: &[TypedArg]) -> Document {
-        let mut printer = typ::pretty::Printer::new();
+    pub fn docs_fn_args(
+        &mut self,
+        args: &[TypedArg],
+        printer: &mut typ::pretty::Printer,
+    ) -> Document {
         wrap_args(args.iter().map(|arg| {
             arg.names
                 .to_doc()


### PR DESCRIPTION
As reported in #615. Stdlib docs will need to be regenerated to close the issue properly.

We should probably have some tests for docs generation!