### PR TITLE
Bit string fixes

### DIFF
--- a/src/erl.rs
+++ b/src/erl.rs
@@ -289,7 +289,19 @@ fn bitstring(elems: impl Iterator<Item = Document>) -> Document {
 }
 
 fn segment(value: &TypedExpr, options: Vec<TypedExprBinSegmentOption>, env: &mut Env) -> Document {
-    let mut document = expr(value, env);
+    let mut document = match value {
+        // Skip the normal <<value/utf8>> surrounds
+        TypedExpr::String { value, .. } => value.clone().to_doc().surround("\"", "\""),
+
+        // As normal
+        TypedExpr::Int { .. }
+        | TypedExpr::Float { .. }
+        | TypedExpr::Var { .. }
+        | TypedExpr::Bitstring { .. } => expr(value, env),
+
+        // Wrap anything else in parentheses
+        value => expr(value, env).surround("(", ")"),
+    };
 
     let mut size: Option<Document> = None;
     let mut unit: Option<Document> = None;

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -329,7 +329,16 @@ fn pattern_segment(
     options: Vec<TypedPatternBinSegmentOption>,
     env: &mut Env,
 ) -> Document {
-    let mut document = pattern(value, env);
+    let mut document = match value {
+        // Skip the normal <<value/utf8>> surrounds
+        Pattern::String { value, .. } => value.clone().to_doc().surround("\"", "\""),
+
+        // As normal
+        Pattern::Var { .. } | Pattern::Int { .. } | Pattern::Float { .. } => pattern(value, env),
+
+        // No other pattern variants are allowed in pattern bit string segments
+        _ => Document::Nil,
+    };
 
     let mut size: Option<Document> = None;
     let mut unit: Option<Document> = None;

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2390,4 +2390,23 @@ main() ->
     B.
 "#,
     );
+
+    assert_erl!(
+        r#"fn x() { 1 }
+fn main() {
+  let a = <<x():integer>>
+  a
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+x() ->
+    1.
+
+main() ->
+    A = <<(x())/integer>>,
+    A.
+"#,
+    );
 }

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2373,4 +2373,21 @@ main() ->
     B.
 "#,
     );
+
+    assert_erl!(
+        r#"fn main() {
+  let a = <<"test":utf8>>
+  let <<b:utf8, "st":utf8>> = a
+  b
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+main() ->
+    A = <<"test"/utf8>>,
+    <<B/utf8, "st"/utf8>> = A,
+    B.
+"#,
+    );
 }

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -1,5 +1,21 @@
 import should
 
+// Helpers
+
+fn integer_fn() {
+  1
+}
+
+// Valid values
+
+pub fn function_as_value_test() {
+  let <<a>> = <<integer_fn():integer>>
+
+  should.equal(a, 1)
+}
+
+// Strings
+
 pub fn string_test() {
   let a = "test"
   let <<b:2-binary, "st":utf8>> = a

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -1,0 +1,23 @@
+import should
+
+pub fn string_test() {
+  let a = "test"
+  let <<b:2-binary, "st":utf8>> = a
+
+  should.equal(b, <<"te":utf8>>)
+}
+
+pub fn explicit_utf8_test() {
+  let a = <<"test":utf8>>
+  let <<b:2-binary, "st":utf8>> = a
+
+  should.equal(b, <<"te":utf8>>)
+}
+
+pub fn emoji_test() {
+  let a = <<"😁😀":utf8>>
+  let <<b:4-binary, "😀":utf8>> = a
+
+  should.equal(b, <<"😁":utf8>>)
+}
+


### PR DESCRIPTION
These deal with the immediate string issue reported in #386 and another bug I discoveredwhile testing. It also adds core_language tests for these behaviours. These are pretty key bug fixes and so I'm opening this PR for them now, but sadly I've found quite a few more examples of bit strings that will compile successfully and then cause runtime errors in Erlang. We need to be quite a lot less permissive. I'll keep working on it and adding core_language tests as I go.