### PR TITLE
More bit string improvements

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -731,7 +731,7 @@ impl<A> BinSegmentOption<A> {
     pub fn label(&self) -> String {
         match self {
             BinSegmentOption::Binary { .. } => "binary".to_string(),
-            BinSegmentOption::Integer { .. } => "integer".to_string(),
+            BinSegmentOption::Integer { .. } => "int".to_string(),
             BinSegmentOption::Float { .. } => "float".to_string(),
             BinSegmentOption::Bitstring { .. } => "bitstring".to_string(),
             BinSegmentOption::UTF8 { .. } => "utf8".to_string(),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -507,6 +507,12 @@ pub enum Pattern<Constructor, Type> {
         name: String,
     },
 
+    VarCall {
+        location: SrcSpan,
+        name: String,
+        typ: Type,
+    },
+
     Let {
         name: String,
         pattern: Box<Self>,
@@ -553,6 +559,7 @@ impl<A, B> Pattern<A, B> {
             Pattern::Let { pattern, .. } => pattern.location(),
             Pattern::Int { location, .. } => location,
             Pattern::Var { location, .. } => location,
+            Pattern::VarCall { location, .. } => location,
             Pattern::Nil { location, .. } => location,
             Pattern::Cons { location, .. } => location,
             Pattern::Float { location, .. } => location,

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -497,6 +497,8 @@ fn pattern(p: &TypedPattern, env: &mut Env) -> Document {
 
         Pattern::Var { name, .. } => env.next_local_var_name(name.to_string()),
 
+        Pattern::VarCall { name, .. } => env.local_var_name(name.to_string()),
+
         Pattern::Int { value, .. } => value.as_str().to_doc(),
 
         Pattern::Float { value, .. } => float(value.as_ref()),

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2306,10 +2306,10 @@ main() ->
     assert_erl!(
         r#"fn main() {
   let a = 1
-  let simple = <<1:integer, a:integer>>
-  let complex = <<4:integer-unsigned-big, 5.0:little-float, 6:native-integer-signed>>
-  let <<7:2, 8:size(3), b:binary-size(4)>> = <<1:integer>>
-  let <<c:unit(1), d:binary-size(2)-unit(2)>> = <<1:integer>>
+  let simple = <<1, a>>
+  let complex = <<4:int-unsigned-big, 5.0:little-float, 6:native-int-signed>>
+  let <<7:2, 8:size(3), b:binary-size(4)>> = <<1>>
+  let <<c:unit(1), d:binary-size(2)-unit(2)>> = <<1>>
 
   simple
 }
@@ -2319,12 +2319,12 @@ main() ->
 
 main() ->
     A = 1,
-    Simple = <<1/integer, A/integer>>,
+    Simple = <<1, A>>,
     Complex = <<4/integer-unsigned-big,
                 5.0/little-float,
                 6/native-integer-signed>>,
-    <<7:2, 8:3, B:4/binary>> = <<1/integer>>,
-    <<C/:1, D:2/binary:2>> = <<1/integer>>,
+    <<7:2, 8:3, B:4/binary>> = <<1>>,
+    <<C/:1, D:2/binary:2>> = <<1>>,
     Simple.
 "#,
     );
@@ -2332,7 +2332,7 @@ main() ->
     assert_erl!(
         r#"fn main() {
   let a = 1
-  let <<b, 1>> = <<1:integer, a:integer>>
+  let <<b, 1>> = <<1, a>>
   b
 }
 "#,
@@ -2341,7 +2341,7 @@ main() ->
 
 main() ->
     A = 1,
-    <<B, 1>> = <<1/integer, A/integer>>,
+    <<B, 1>> = <<1, A>>,
     B.
 "#,
     );
@@ -2366,7 +2366,7 @@ main() ->
     assert_erl!(
         r#"fn x() { 1 }
 fn main() {
-  let a = <<x():integer>>
+  let a = <<x():int>>
   a
 }
 "#,

--- a/src/format.rs
+++ b/src/format.rs
@@ -671,7 +671,7 @@ impl<'a> Formatter<'a> {
             BinSegmentOption::Invalid { label, .. } => label.clone().to_doc(),
 
             BinSegmentOption::Binary { .. } => "binary".to_doc(),
-            BinSegmentOption::Integer { .. } => "integer".to_doc(),
+            BinSegmentOption::Integer { .. } => "int".to_doc(),
             BinSegmentOption::Float { .. } => "float".to_doc(),
             BinSegmentOption::Bitstring { .. } => "bitstring".to_doc(),
             BinSegmentOption::UTF8 { .. } => "utf8".to_doc(),
@@ -1086,7 +1086,7 @@ impl<'a> Formatter<'a> {
             BinSegmentOption::Invalid { label, .. } => label.clone().to_doc(),
 
             BinSegmentOption::Binary { .. } => "binary".to_doc(),
-            BinSegmentOption::Integer { .. } => "integer".to_doc(),
+            BinSegmentOption::Integer { .. } => "int".to_doc(),
             BinSegmentOption::Float { .. } => "float".to_doc(),
             BinSegmentOption::Bitstring { .. } => "bitstring".to_doc(),
             BinSegmentOption::UTF8 { .. } => "utf8".to_doc(),

--- a/src/format.rs
+++ b/src/format.rs
@@ -951,6 +951,8 @@ impl<'a> Formatter<'a> {
 
             Pattern::Var { name, .. } => name.to_string().to_doc(),
 
+            Pattern::VarCall { name, .. } => name.to_string().to_doc(),
+
             Pattern::Let { name, pattern, .. } => self
                 .pattern(&pattern)
                 .append(" as ")

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -741,6 +741,11 @@ Pattern: UntypedPattern = {
     PatternBitstring => <>,
 }
 
+PatternVarCallOrInt: UntypedPattern = {
+    PatternVarCall => <>,
+    PatternInt => <>,
+}
+
 PatternConstructor: UntypedPattern = {
     <s:@L> <module:(<VarName> ".")?> <name:UpName> <args:PatternConstructorArgs?> <e:@L> => {
         let (args, with_spread) = args.unwrap_or_else(|| (vec![], false));
@@ -807,6 +812,14 @@ PatternVar: UntypedPattern = {
     <s:@L> <v:VarName> <e:@L> => Pattern::Var {
         location: location(s, e),
         name: v,
+    }
+}
+
+PatternVarCall: UntypedPattern = {
+    <s:@L> <v:VarName> <e:@L> => Pattern::VarCall {
+        location: location(s, e),
+        name: v,
+        typ: (),
     }
 }
 
@@ -877,7 +890,7 @@ PatternBinSegment: UntypedPatternBinSegment = {
 }
 
 PatternBinSegmentOption: UntypedPatternBinSegmentOption = {
-    <s:@L> <o:VarName> "(" <value:Pattern> ")" <e:@L> => {
+    <s:@L> <o:VarName> "(" <value:PatternVarCallOrInt> ")" <e:@L> => {
         if o.as_str() == "unit" {
             BinSegmentOption::Unit {
                 location: location(s, e),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -622,7 +622,7 @@ BinSegmentOptionLiteral<T>: T = {
         match o.as_str() {
             "binary" => BinSegmentOption::Binary { location: location(s, e) },
             "bytes" => BinSegmentOption::Binary { location: location(s, e) },
-            "integer" => BinSegmentOption::Integer { location: location(s, e) },
+            "int" => BinSegmentOption::Integer { location: location(s, e) },
             "float" => BinSegmentOption::Float { location: location(s, e) },
             "bitstring" => BinSegmentOption::Bitstring { location: location(s, e) },
             "bits" => BinSegmentOption::Bitstring { location: location(s, e) },

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -1323,7 +1323,7 @@ impl<'a> Typer<'a> {
 
         let type_specifier = BinaryTypeSpecifier::new(&options, true)
             .map_err(|e| convert_binary_error(e, &location))?;
-        let typ = type_specifier.typ().unwrap_or_else(|| bitstring());
+        let typ = type_specifier.typ().unwrap_or_else(|| int());
 
         self.unify(typ.clone(), value.typ())
             .map_err(|e| convert_unify_error(e, value.location()))?;

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -440,7 +440,7 @@ macro_rules! assert_error {
 
 #[test]
 fn infer_bitstring_error_test() {
-    // Unify
+    // Values
 
     assert_error!(
         "case <<1>> { <<2.0, a>> -> 1 }",
@@ -475,24 +475,6 @@ fn infer_bitstring_error_test() {
             location: SrcSpan { start: 28, end: 39 },
             expected: bitstring(),
             given: string(),
-        },
-    );
-
-    assert_error!(
-        "let x = <<1:size(\"1\")>> x",
-        Error::CouldNotUnify {
-            location: SrcSpan { start: 17, end: 20 },
-            expected: int(),
-            given: string(),
-        },
-    );
-
-    assert_error!(
-        "case <<1>> { <<1:size(2.0)>> -> a }",
-        Error::CouldNotUnify {
-            location: SrcSpan { start: 22, end: 25 },
-            expected: int(),
-            given: float(),
         },
     );
 
@@ -592,6 +574,8 @@ fn infer_bitstring_error_test() {
         }
     );
 
+    // Size and unit options
+
     assert_error!(
         "let x = <<1:8-size(5)>> x",
         Error::ConflictingBinarySizeOptions {
@@ -638,6 +622,26 @@ fn infer_bitstring_error_test() {
             typ: "utf32".to_string(),
             location: SrcSpan { start: 23, end: 30 },
         }
+    );
+
+    // Size and unit values
+
+    assert_error!(
+        "let x = <<1:size(\"1\")>> x",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 17, end: 20 },
+            expected: int(),
+            given: string(),
+        },
+    );
+
+    assert_error!(
+        "let a = 2.0 case <<1>> { <<1:size(a)>> -> a }",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 34, end: 35 },
+            expected: int(),
+            given: float(),
+        },
     );
 }
 
@@ -2460,6 +2464,22 @@ fn main() {
                     typ: Arc::new(RefCell::new(TypeVar::Generic { id: 9 })),
                 })]
             }),
+        },
+    );
+
+    // Bit strings
+
+    assert_error!(
+        "fn x() { \"test\" }
+
+fn main() {
+    let a = <<1:size(x())>>
+    a
+}",
+        Error::CouldNotUnify {
+            location: SrcSpan { start: 52, end: 55 },
+            expected: int(),
+            given: string(),
         },
     );
 }

--- a/test/core_language/src/should.gleam
+++ b/test/core_language/src/should.gleam
@@ -1,5 +1,7 @@
-pub external type Expectation;
+pub external type Expectation
 
-pub external fn equal(a, a) -> Expectation = "gleam_should" "should_equal";
+pub external fn equal(a, a) -> Expectation =
+  "gleam_should" "should_equal"
 
-pub external fn not_equal(a, a) -> Expectation = "gleam_should" "should_not_equal";
+pub external fn not_equal(a, a) -> Expectation =
+  "gleam_should" "should_not_equal"

--- a/test/core_language/test/binary_operators_test.gleam
+++ b/test/core_language/test/binary_operators_test.gleam
@@ -8,6 +8,6 @@ pub fn precedence_test() {
   should.equal(3 * { 1 + 2 }, 9)
   should.equal(1 + 2 * 3 + 4, 11)
   should.equal(2 * 3 + 4 * 5, 26)
-  should.equal(2 * {3 + 1} / 2, 4)
+  should.equal(2 * { 3 + 1 } / 2, 4)
   should.equal(5 + 3 / 3 * 2 - 6 * 4, -17)
 }

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -9,7 +9,7 @@ fn integer_fn() {
 // Valid values
 
 pub fn function_as_value_test() {
-  let <<a>> = <<integer_fn():integer>>
+  let <<a>> = <<integer_fn():int>>
 
   should.equal(a, 1)
 }

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -1,21 +1,38 @@
 import should
 
 // Helpers
-
 fn integer_fn() {
   1
 }
 
 // Valid values
-
 pub fn function_as_value_test() {
   let <<a>> = <<integer_fn():int>>
 
   should.equal(a, 1)
 }
 
-// Strings
+pub fn integer_to_binary_test() {
+  let <<a, rest:binary>> = <<1, 17, 42:16>>
 
+  should.equal(a, 1)
+  should.equal(rest, <<17, 0, 42>>)
+}
+
+// Sizes
+pub fn size_variable_from_match_test() {
+  let <<
+    name_size:8,
+    name:binary-size(name_size),
+    " the ":utf8,
+    species:binary,
+  >> = <<5, "Frank the Walrus":utf8>>
+
+  should.equal(name, <<"Frank":utf8>>)
+  should.equal(species, <<"Walrus":utf8>>)
+}
+
+// Strings
 pub fn string_test() {
   let a = "test"
   let <<b:2-binary, "st":utf8>> = a
@@ -36,4 +53,3 @@ pub fn emoji_test() {
 
   should.equal(b, <<"😁":utf8>>)
 }
-

--- a/test/core_language/test/call_returned_function_test.gleam
+++ b/test/core_language/test/call_returned_function_test.gleam
@@ -10,7 +10,6 @@ pub fn call_record_access_function_test() {
   should.equal(5, b.f(5))
 }
 
-
 pub fn call_tuple_access_function_test() {
   let t = tuple(fn(x) { x })
 

--- a/test/core_language/test/should_test.gleam
+++ b/test/core_language/test/should_test.gleam
@@ -9,4 +9,3 @@ pub fn not_equal_test() {
   should.not_equal(1, 2)
   should.not_equal(True, False)
 }
-

--- a/test/core_language/test/unicode_test.gleam
+++ b/test/core_language/test/unicode_test.gleam
@@ -1,7 +1,7 @@
 import should
 
-external fn to_graphemes(String) -> List(List(Int))
- = "string" "to_graphemes"
+external fn to_graphemes(String) -> List(List(Int)) =
+  "string" "to_graphemes"
 
 pub fn unicode_overflow_test() {
   // In erlang, literally creating binaries can cause entries to overflow.
@@ -9,9 +9,9 @@ pub fn unicode_overflow_test() {
   // This checks that we are not doing that.
   // See: https://github.com/gleam-lang/gleam/issues/457
   "🌵"
-  |> should.not_equal(_, "5")
+  |> should.not_equal("5")
 
   "🤷‍♂️"
   |> to_graphemes
-  |> should.equal(_, [[129335,8205,9794,65039]])
+  |> should.equal([[129335, 8205, 9794, 65039]])
 }


### PR DESCRIPTION
Closes #634 
Closes #628

Additionally makes int the default type for all segments in bit strings, matching Elixir and Erlang.