### PR TITLE
Module constants

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -192,6 +192,15 @@ pub enum Statement<T, Expr> {
         as_name: Option<String>,
         unqualified: Vec<UnqualifiedImport>,
     },
+
+    ModuleConstant {
+        doc: Option<String>,
+        location: SrcSpan,
+        public: bool,
+        name: String,
+        value: Box<Expr>,
+        typ: T,
+    },
 }
 
 impl<A, B> Statement<A, B> {
@@ -202,7 +211,8 @@ impl<A, B> Statement<A, B> {
             | Statement::TypeAlias { location, .. }
             | Statement::CustomType { location, .. }
             | Statement::ExternalFn { location, .. }
-            | Statement::ExternalType { location, .. } => location,
+            | Statement::ExternalType { location, .. }
+            | Statement::ModuleConstant { location, .. } => location,
         }
     }
 
@@ -221,7 +231,8 @@ impl<A, B> Statement<A, B> {
             | Statement::TypeAlias { doc, .. }
             | Statement::CustomType { doc, .. }
             | Statement::ExternalFn { doc, .. }
-            | Statement::ExternalType { doc, .. } => {
+            | Statement::ExternalType { doc, .. }
+            | Statement::ModuleConstant { doc, .. } => {
                 std::mem::replace(doc, new_doc);
             }
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,8 +1,11 @@
+mod const_value;
 mod typed;
 mod untyped;
 
 pub use self::typed::TypedExpr;
 pub use self::untyped::UntypedExpr;
+
+pub use self::const_value::{ConstValue, TypedConstValue, UntypedConstValue};
 
 use crate::typ::{self, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor};
 use itertools::Itertools;
@@ -198,7 +201,7 @@ pub enum Statement<T, Expr> {
         location: SrcSpan,
         public: bool,
         name: String,
-        value: Box<Expr>,
+        value: Box<const_value::ConstValue<T>>,
         typ: T,
     },
 }

--- a/src/ast/const_value.rs
+++ b/src/ast/const_value.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+pub type TypedConstValue = ConstValue<Arc<Type>>;
+pub type UntypedConstValue = ConstValue<()>;
+#[derive(Debug, PartialEq, Clone)]
+pub enum ConstValue<T> {
+    Int {
+        location: SrcSpan,
+        typ: T,
+        value: String,
+    },
+    Float {
+        location: SrcSpan,
+        typ: T,
+        value: String,
+    },
+    String {
+        location: SrcSpan,
+        typ: T,
+        value: String,
+    },
+}
+
+impl TypedConstValue {
+    pub fn typ(&self) -> Arc<typ::Type> {
+        match self {
+            TypedConstValue::Int { typ, .. } => typ.clone(),
+            TypedConstValue::Float { typ, .. } => typ.clone(),
+            TypedConstValue::String { typ, .. } => typ.clone(),
+        }
+    }
+}

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -196,7 +196,8 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
         Statement::CustomType { .. } => None,
         Statement::Import { .. } => None,
         Statement::ExternalType { .. } => None,
-        Statement::ModuleConstant { .. } => None,
+
+        Statement::ModuleConstant { name, value, .. } => Some(mod_const(name, value, module)),
 
         Statement::Fn {
             args, name, body, ..
@@ -216,6 +217,15 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
             args.len(),
         )),
     }
+}
+
+fn mod_const(name: &str, value: &TypedExpr, module: &[String]) -> Document {
+    let mut env = Env::new(module);
+
+    atom(name.to_string())
+        .append("() -> ")
+        .append(expr(value, &mut env))
+        .append(".")
 }
 
 fn mod_fun(name: &str, args: &[TypedArg], body: &TypedExpr, module: &[String]) -> Document {

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -197,7 +197,12 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
         Statement::Import { .. } => None,
         Statement::ExternalType { .. } => None,
 
-        Statement::ModuleConstant { name, value, .. } => Some(mod_const(name, value, module)),
+        Statement::ModuleConstant {
+            public,
+            name,
+            value,
+            ..
+        } => mod_const(*public, name, value),
 
         Statement::Fn {
             args, name, body, ..
@@ -219,13 +224,22 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
     }
 }
 
-fn mod_const(name: &str, value: &TypedExpr, module: &[String]) -> Document {
-    let mut env = Env::new(module);
+fn mod_const(public: bool, name: &str, value: &TypedConstValue) -> Option<Document> {
+    if !public {
+        return None;
+    }
+    let value: &str = match value {
+        TypedConstValue::Int { value, .. } => value,
+        TypedConstValue::Float { value, .. } => value,
+        TypedConstValue::String { value, .. } => value,
+    };
 
-    atom(name.to_string())
-        .append("() -> ")
-        .append(expr(value, &mut env))
-        .append(".")
+    Some(
+        atom(name.to_string())
+            .append("() -> ")
+            .append(value)
+            .append("."),
+    )
 }
 
 fn mod_fun(name: &str, args: &[TypedArg], body: &TypedExpr, module: &[String]) -> Document {

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -196,6 +196,7 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
         Statement::CustomType { .. } => None,
         Statement::Import { .. } => None,
         Statement::ExternalType { .. } => None,
+        Statement::ModuleConstant { .. } => None,
 
         Statement::Fn {
             args, name, body, ..

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -823,6 +823,18 @@ go() ->
         },
         name: vec!["funny".to_string()],
         statements: vec![
+            Statement::ModuleConstant {
+                doc: None,
+                location: Default::default(),
+                name: "test".to_string(),
+                public: true,
+                typ: crate::typ::int(),
+                value: Box::new(TypedExpr::Int {
+                    typ: crate::typ::int(),
+                    location: Default::default(),
+                    value: "42".to_string(),
+                }),
+            },
             Statement::Fn {
                 doc: None,
                 return_type: typ::int(),
@@ -946,6 +958,8 @@ go() ->
     };
     let expected = "-module(funny).
 -compile(no_auto_import).
+
+test() -> 42.
 
 one() ->
     one_two(1).

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -829,7 +829,7 @@ go() ->
                 name: "test".to_string(),
                 public: true,
                 typ: crate::typ::int(),
-                value: Box::new(TypedExpr::Int {
+                value: Box::new(TypedConstValue::Int {
                     typ: crate::typ::int(),
                     location: Default::default(),
                     value: "42".to_string(),

--- a/src/format.rs
+++ b/src/format.rs
@@ -220,6 +220,16 @@ impl<'a> Formatter<'a> {
                 } else {
                     nil()
                 }),
+            Statement::ModuleConstant {
+                public,
+                name,
+                value,
+                ..
+            } => pub_(*public)
+                .append("const ")
+                .append(name.to_string())
+                .append(" = ")
+                .append(self.expr(value)),
         }
     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -229,8 +229,18 @@ impl<'a> Formatter<'a> {
                 .append("const ")
                 .append(name.to_string())
                 .append(" = ")
-                .append(self.expr(value)),
+                .append(self.const_expr(value)),
         }
+    }
+
+    fn const_expr(&mut self, value: &ConstValue<()>) -> Document {
+        match value {
+            ConstValue::Int { value, .. }
+            | ConstValue::Float { value, .. }
+            | ConstValue::String { value, .. } => value,
+        }
+        .clone()
+        .to_doc()
     }
 
     fn documented_statement(&mut self, s: &UntypedStatement) -> Document {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -34,6 +34,7 @@ Statement: UntypedStatement = {
     StatementExternalFn => <>,
     StatementExternalType => <>,
     StatementImport => <>,
+    StatementModuleConstant => <>,
 }
 
 StatementTypeAlias : UntypedStatement = {
@@ -123,6 +124,23 @@ StatementImport: UntypedStatement = {
             as_name,
         }
     }
+}
+
+StatementModuleConstant: UntypedStatement = {
+    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => UntypedStatement::ModuleConstant {
+        doc: None,
+        location: location(s, e),
+        public: p.is_some(),
+        name,
+        value: Box::new(lit),
+        typ: (),
+    }
+}
+
+LiteralExpr: UntypedExpr = {
+    Int => <>,
+    Float => <>,
+    String => <>,
 }
 
 UnqualifiedImport: UnqualifiedImport = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -7,7 +7,7 @@ use crate::ast::{
     UntypedPattern, BinOp, Clause, UntypedClause, RecordConstructor, Pattern, CallArg,
     ExternalFnArg, ArgNames, UnqualifiedImport, UntypedClauseGuard, ClauseGuard, BindingKind,
     UntypedExprBinSegment, UntypedPatternBinSegment, BinSegmentOption, UntypedExprBinSegmentOption,
-    UntypedPatternBinSegmentOption,
+    UntypedPatternBinSegmentOption, ConstValue
 
 };
 use crate::parser::*;
@@ -127,7 +127,7 @@ StatementImport: UntypedStatement = {
 }
 
 StatementModuleConstant: UntypedStatement = {
-    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => Statement::ModuleConstant {
+    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:ConstValue> <e:@L> => Statement::ModuleConstant {
         doc: None,
         location: location(s, e),
         public: p.is_some(),
@@ -137,10 +137,10 @@ StatementModuleConstant: UntypedStatement = {
     }
 }
 
-LiteralExpr: UntypedExpr = {
-    Int => <>,
-    Float => <>,
-    String => <>,
+ConstValue: ConstValue<()> = {
+    ConstInt => <>,
+    ConstFloat => <>,
+    ConstString => <>,
 }
 
 UnqualifiedImport: UnqualifiedImport = {
@@ -670,6 +670,14 @@ String: UntypedExpr = {
     }
 }
 
+ConstString: ConstValue<()> = {
+    <s:@L> <x:RawString> <e:@L> => ConstValue::<()>::String {
+        location: location(s, e),
+        typ: (),
+        value: x,
+    }
+}
+
 PositiveIntLiteral: String = {
     <pos:r"[0-9]+"> => pos.to_string()
 }
@@ -694,6 +702,14 @@ Int: UntypedExpr = {
     }
 }
 
+ConstInt: ConstValue<()> = {
+    <s:@L> <value:IntLiteral> <e:@L> => ConstValue::<()>::Int {
+        location: location(s, e),
+        typ: (),
+        value,
+    }
+}
+
 FloatLiteral: String = {
     <f:r"-?[0-9]+\.[0-9]*"> => f.to_string()
 }
@@ -702,6 +718,14 @@ Float: UntypedExpr = {
     <s:@L> <value:FloatLiteral> <e:@L> => UntypedExpr::Float {
         location: location(s, e),
         value
+    }
+}
+
+ConstFloat: ConstValue<()> = {
+    <s:@L> <value:FloatLiteral> <e:@L> => ConstValue::<()>::Float {
+        location: location(s, e),
+        typ: (),
+        value,
     }
 }
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -127,7 +127,7 @@ StatementImport: UntypedStatement = {
 }
 
 StatementModuleConstant: UntypedStatement = {
-    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => UntypedStatement::ModuleConstant {
+    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => Statement::ModuleConstant {
         doc: None,
         location: location(s, e),
         public: p.is_some(),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -3304,6 +3304,37 @@ pub fn infer_module(
                 as_name,
                 unqualified,
             }),
+
+            Statement::ModuleConstant {
+                doc,
+                location,
+                name,
+                public,
+                value,
+                ..
+            } => {
+                let typed_value = typer.infer(*value)?;
+                let typ = typed_value.typ();
+
+                typer.insert_module_value(
+                    &name,
+                    ValueConstructor {
+                        public: public,
+                        origin: location.clone(),
+                        variant: ValueConstructorVariant::LocalVariable,
+                        typ: typ.clone(),
+                    },
+                )?;
+
+                Ok(Statement::ModuleConstant {
+                    doc,
+                    location,
+                    name,
+                    public,
+                    value: Box::new(typed_value),
+                    typ,
+                })
+            }
         })
         .collect::<Result<Vec<_>, Error>>()?;
 


### PR DESCRIPTION
Draft PR for #577 

Constants can only be simple literals: ints, floats and strings in this draft.
Constants can be marked as public (I have yet to tackle what this will imply) and they are compiled to erl functions for now.

```rust
pub const hello = 5
const again = 7
```
```erlang
hello() -> 5.
again() -> 7.
```
I thought it was neat to have exported constants on top of private constants, is that sensible?
We could have private consts inline and public ones expose a function.

Any pointers/feedback is very much appreciated. This needs defintely more testing too :)