### PR TITLE
Bit string size and unit option fixes

### DIFF
--- a/src/erl.rs
+++ b/src/erl.rs
@@ -323,7 +323,16 @@ fn segment(value: &TypedExpr, options: Vec<TypedExprBinSegmentOption>, env: &mut
         BinSegmentOption::Big { .. } => others.push("big"),
         BinSegmentOption::Little { .. } => others.push("little"),
         BinSegmentOption::Native { .. } => others.push("native"),
-        BinSegmentOption::Size { value, .. } => size = Some(":".to_doc().append(expr(value, env))),
+        BinSegmentOption::Size { value, .. } => {
+            size = {
+                match &**value {
+                    TypedExpr::Int { .. } | TypedExpr::Var { .. } => {
+                        Some(":".to_doc().append(expr(value, env)))
+                    }
+                    _ => Some(":".to_doc().append(expr(value, env).surround("(", ")"))),
+                }
+            }
+        }
         BinSegmentOption::Unit { value, .. } => unit = Some(":".to_doc().append(expr(value, env))),
     });
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -333,16 +333,31 @@ fn segment(value: &TypedExpr, options: Vec<TypedExprBinSegmentOption>, env: &mut
                 }
             }
         }
-        BinSegmentOption::Unit { value, .. } => unit = Some(":".to_doc().append(expr(value, env))),
+        BinSegmentOption::Unit { value, .. } => {
+            unit = {
+                match &**value {
+                    TypedExpr::Int { .. } => Some("unit:".to_doc().append(expr(value, env))),
+                    _ => None,
+                }
+            }
+        }
     });
 
     document = document.append(size);
 
-    if !others.is_empty() || unit.is_some() {
+    if !others.is_empty() {
         document = document.append("/").append(others.join("-"));
     }
 
-    document.append(unit)
+    if unit.is_some() {
+        if !others.is_empty() {
+            document = document.append("-").append(unit)
+        } else {
+            document = document.append("/").append(unit)
+        }
+    }
+
+    document
 }
 
 // TODO: Merge segment() and pattern_segment() somehow
@@ -385,17 +400,30 @@ fn pattern_segment(
             size = Some(":".to_doc().append(pattern(value, env)))
         }
         BinSegmentOption::Unit { value, .. } => {
-            unit = Some(":".to_doc().append(pattern(value, env)))
+            unit = {
+                match &**value {
+                    Pattern::Int { .. } => Some("unit:".to_doc().append(pattern(value, env))),
+                    _ => None,
+                }
+            }
         }
     });
 
     document = document.append(size);
 
-    if !others.is_empty() || unit.is_some() {
+    if !others.is_empty() {
         document = document.append("/").append(others.join("-"));
     }
 
-    document.append(unit)
+    if unit.is_some() {
+        if !others.is_empty() {
+            document = document.append("-").append(unit)
+        } else {
+            document = document.append("/").append(unit)
+        }
+    }
+
+    document
 }
 
 fn seq(first: &TypedExpr, then: &TypedExpr, env: &mut Env) -> Document {

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2336,7 +2336,7 @@ main() ->
                 5.0/little-float,
                 6/native-integer-signed>>,
     <<7:2, 8:3, B:4/binary>> = <<1>>,
-    <<C/:1, D:2/binary:2>> = <<1>>,
+    <<C/unit:1, D:2/binary-unit:2>> = <<1>>,
     Simple.
 "#,
     );

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2342,6 +2342,28 @@ main() ->
     );
 
     assert_erl!(
+        r#"fn x() { 2 }
+fn main() {
+  let a = 1
+  let b = <<a:unit(2)-size(a * 2), a:size(3 + x())-unit(1)>>
+
+  b
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+x() ->
+    2.
+
+main() ->
+    A = 1,
+    B = <<A:(A * 2)/unit:2, A:(3 + x())/unit:1>>,
+    B.
+"#,
+    );
+
+    assert_erl!(
         r#"fn main() {
   let a = 1
   let <<b, 1>> = <<1, a>>

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -32,6 +32,13 @@ pub fn size_variable_from_match_test() {
   should.equal(species, <<"Walrus":utf8>>)
 }
 
+pub fn sizes_with_expressions() {
+  let a = 1
+  let b = <<a:unit(2)-size(a * 2), a:size(3 + integer_fn())-unit(1)>>
+
+  should.equal(b, <<1, 1>>)
+}
+
 // Strings
 pub fn string_test() {
   let a = "test"

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -32,11 +32,18 @@ pub fn size_variable_from_match_test() {
   should.equal(species, <<"Walrus":utf8>>)
 }
 
-pub fn sizes_with_expressions() {
+pub fn sizes_with_expressions_test() {
   let a = 1
-  let b = <<a:unit(2)-size(a * 2), a:size(3 + integer_fn())-unit(1)>>
+  let b = <<a:size(a * 2), a:size(3 + integer_fn())>>
 
-  should.equal(b, <<1, 1>>)
+  should.equal(b, <<1:2, 1:4>>)
+}
+
+// Units
+pub fn units_test() {
+  let a = <<1:size(1)-unit(8), 2:size(1)-unit(16)>>
+
+  should.equal(a, <<1, 0, 2>>)
 }
 
 // Strings


### PR DESCRIPTION
Closes #656 

Size options in bit string construction with anything other than Int literals or vars are now wrapped in parentheses.

Additionally, valid unit options now work properly. I'm going to do some more work on them to provide better error messages if you try and use invalid values, but that will be a separate PR.