### PR TITLE
Module constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Single letter module names are now permitted.
 - Added support for bit string syntax.
 - Support for the deprecated list prepend syntax has been removed.
+- Added module level constants that can contain int, float and string values and are inlined at compile time.
 
 ## v0.9.1 - 2020-06-12
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -193,6 +193,15 @@ pub enum Statement<T, Expr> {
         as_name: Option<String>,
         unqualified: Vec<UnqualifiedImport>,
     },
+
+    ModuleConstant {
+        doc: Option<String>,
+        location: SrcSpan,
+        public: bool,
+        name: String,
+        value: Box<Expr>,
+        typ: T,
+    },
 }
 
 impl<A, B> Statement<A, B> {
@@ -203,7 +212,8 @@ impl<A, B> Statement<A, B> {
             | Statement::TypeAlias { location, .. }
             | Statement::CustomType { location, .. }
             | Statement::ExternalFn { location, .. }
-            | Statement::ExternalType { location, .. } => location,
+            | Statement::ExternalType { location, .. }
+            | Statement::ModuleConstant { location, .. } => location,
         }
     }
 
@@ -222,7 +232,8 @@ impl<A, B> Statement<A, B> {
             | Statement::TypeAlias { doc, .. }
             | Statement::CustomType { doc, .. }
             | Statement::ExternalFn { doc, .. }
-            | Statement::ExternalType { doc, .. } => {
+            | Statement::ExternalType { doc, .. }
+            | Statement::ModuleConstant { doc, .. } => {
                 std::mem::replace(doc, new_doc);
             }
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,8 +1,11 @@
+mod const_value;
 mod typed;
 mod untyped;
 
 pub use self::typed::TypedExpr;
 pub use self::untyped::UntypedExpr;
+
+pub use self::const_value::{ConstValue, TypedConstValue, UntypedConstValue};
 
 use crate::typ::{self, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor};
 use itertools::Itertools;
@@ -199,7 +202,7 @@ pub enum Statement<T, Expr> {
         location: SrcSpan,
         public: bool,
         name: String,
-        value: Box<Expr>,
+        value: Box<const_value::ConstValue<T>>,
         typ: T,
     },
 }

--- a/src/ast/const_value.rs
+++ b/src/ast/const_value.rs
@@ -29,4 +29,12 @@ impl TypedConstValue {
             TypedConstValue::String { typ, .. } => typ.clone(),
         }
     }
+
+    pub fn location(&self) -> &SrcSpan {
+        match self {
+            TypedConstValue::Int { location, .. } => location,
+            TypedConstValue::Float { location, .. } => location,
+            TypedConstValue::String { location, .. } => location,
+        }
+    }
 }

--- a/src/ast/const_value.rs
+++ b/src/ast/const_value.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+pub type TypedConstValue = ConstValue<Arc<Type>>;
+pub type UntypedConstValue = ConstValue<()>;
+#[derive(Debug, PartialEq, Clone)]
+pub enum ConstValue<T> {
+    Int {
+        location: SrcSpan,
+        typ: T,
+        value: String,
+    },
+    Float {
+        location: SrcSpan,
+        typ: T,
+        value: String,
+    },
+    String {
+        location: SrcSpan,
+        typ: T,
+        value: String,
+    },
+}
+
+impl TypedConstValue {
+    pub fn typ(&self) -> Arc<typ::Type> {
+        match self {
+            TypedConstValue::Int { typ, .. } => typ.clone(),
+            TypedConstValue::Float { typ, .. } => typ.clone(),
+            TypedConstValue::String { typ, .. } => typ.clone(),
+        }
+    }
+}

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -197,6 +197,7 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
         Statement::CustomType { .. } => None,
         Statement::Import { .. } => None,
         Statement::ExternalType { .. } => None,
+        Statement::ModuleConstant { .. } => None,
 
         Statement::Fn {
             args, name, body, ..

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -197,7 +197,8 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
         Statement::CustomType { .. } => None,
         Statement::Import { .. } => None,
         Statement::ExternalType { .. } => None,
-        Statement::ModuleConstant { .. } => None,
+
+        Statement::ModuleConstant { name, value, .. } => Some(mod_const(name, value, module)),
 
         Statement::Fn {
             args, name, body, ..
@@ -217,6 +218,15 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
             args.len(),
         )),
     }
+}
+
+fn mod_const(name: &str, value: &TypedExpr, module: &[String]) -> Document {
+    let mut env = Env::new(module);
+
+    atom(name.to_string())
+        .append("() -> ")
+        .append(expr(value, &mut env))
+        .append(".")
 }
 
 fn mod_fun(name: &str, args: &[TypedArg], body: &TypedExpr, module: &[String]) -> Document {

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -1023,7 +1023,7 @@ fn expr(expression: &TypedExpr, env: &mut Env) -> Document {
         TypedExpr::ModuleSelect {
             constructor: ModuleValueConstructor::ConstValue { literal },
             ..
-        } => const_inline(literal), //module_select_fn(typ.clone(), module_name, label),
+        } => const_inline(literal),
 
         TypedExpr::ModuleSelect {
             constructor: ModuleValueConstructor::Record { name, arity },

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -197,13 +197,7 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
         Statement::CustomType { .. } => None,
         Statement::Import { .. } => None,
         Statement::ExternalType { .. } => None,
-
-        Statement::ModuleConstant {
-            public,
-            name,
-            value,
-            ..
-        } => mod_const(*public, name, value),
+        Statement::ModuleConstant { .. } => None,
 
         Statement::Fn {
             args, name, body, ..
@@ -223,24 +217,6 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
             args.len(),
         )),
     }
-}
-
-fn mod_const(public: bool, name: &str, value: &TypedConstValue) -> Option<Document> {
-    if !public {
-        return None;
-    }
-    let value: &str = match value {
-        TypedConstValue::Int { value, .. } => value,
-        TypedConstValue::Float { value, .. } => value,
-        TypedConstValue::String { value, .. } => value,
-    };
-
-    Some(
-        atom(name.to_string())
-            .append("() -> ")
-            .append(value)
-            .append("."),
-    )
 }
 
 fn mod_fun(name: &str, args: &[TypedArg], body: &TypedExpr, module: &[String]) -> Document {
@@ -685,6 +661,8 @@ fn var(name: &str, constructor: &ValueConstructor, env: &mut Env) -> Document {
 
         ValueConstructorVariant::LocalVariable => env.local_var_name(name.to_string()),
 
+        ValueConstructorVariant::ModuleConstValue { literal } => const_inline(literal),
+
         ValueConstructorVariant::ModuleFn {
             arity, ref module, ..
         } if module.as_slice() == env.module => "fun "
@@ -705,6 +683,14 @@ fn var(name: &str, constructor: &ValueConstructor, env: &mut Env) -> Document {
             .append(atom(name.to_string()))
             .append("/")
             .append(*arity),
+    }
+}
+
+fn const_inline(literal: &ConstValue<Arc<Type>>) -> Document {
+    match literal {
+        ConstValue::Int { value, .. } => value.to_string().to_doc(),
+        ConstValue::Float { value, .. } => value.to_string().to_doc(),
+        ConstValue::String { value, .. } => string(value),
     }
 }
 
@@ -1033,6 +1019,11 @@ fn expr(expression: &TypedExpr, env: &mut Env) -> Document {
             constructor: ModuleValueConstructor::Record { name, arity: 0 },
             ..
         } => atom(name.to_snake_case()),
+
+        TypedExpr::ModuleSelect {
+            constructor: ModuleValueConstructor::ConstValue { literal },
+            ..
+        } => const_inline(literal), //module_select_fn(typ.clone(), module_name, label),
 
         TypedExpr::ModuleSelect {
             constructor: ModuleValueConstructor::Record { name, arity },

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -823,18 +823,6 @@ go() ->
         },
         name: vec!["funny".to_string()],
         statements: vec![
-            Statement::ModuleConstant {
-                doc: None,
-                location: Default::default(),
-                name: "test".to_string(),
-                public: true,
-                typ: crate::typ::int(),
-                value: Box::new(TypedConstValue::Int {
-                    typ: crate::typ::int(),
-                    location: Default::default(),
-                    value: "42".to_string(),
-                }),
-            },
             Statement::Fn {
                 doc: None,
                 return_type: typ::int(),
@@ -958,8 +946,6 @@ go() ->
     };
     let expected = "-module(funny).
 -compile(no_auto_import).
-
-test() -> 42.
 
 one() ->
     one_two(1).

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -823,6 +823,18 @@ go() ->
         },
         name: vec!["funny".to_string()],
         statements: vec![
+            Statement::ModuleConstant {
+                doc: None,
+                location: Default::default(),
+                name: "test".to_string(),
+                public: true,
+                typ: crate::typ::int(),
+                value: Box::new(TypedExpr::Int {
+                    typ: crate::typ::int(),
+                    location: Default::default(),
+                    value: "42".to_string(),
+                }),
+            },
             Statement::Fn {
                 doc: None,
                 return_type: typ::int(),
@@ -946,6 +958,8 @@ go() ->
     };
     let expected = "-module(funny).
 -compile(no_auto_import).
+
+test() -> 42.
 
 one() ->
     one_two(1).

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -829,7 +829,7 @@ go() ->
                 name: "test".to_string(),
                 public: true,
                 typ: crate::typ::int(),
-                value: Box::new(TypedExpr::Int {
+                value: Box::new(TypedConstValue::Int {
                     typ: crate::typ::int(),
                     location: Default::default(),
                     value: "42".to_string(),

--- a/src/format.rs
+++ b/src/format.rs
@@ -235,12 +235,12 @@ impl<'a> Formatter<'a> {
 
     fn const_expr(&mut self, value: &ConstValue<()>) -> Document {
         match value {
-            ConstValue::Int { value, .. }
-            | ConstValue::Float { value, .. }
-            | ConstValue::String { value, .. } => value,
+            ConstValue::Int { value, .. } | ConstValue::Float { value, .. } => {
+                value.clone().to_doc()
+            }
+
+            ConstValue::String { value, .. } => value.clone().to_doc().surround("\"", "\""),
         }
-        .clone()
-        .to_doc()
     }
 
     fn documented_statement(&mut self, s: &UntypedStatement) -> Document {

--- a/src/format.rs
+++ b/src/format.rs
@@ -220,6 +220,16 @@ impl<'a> Formatter<'a> {
                 } else {
                     nil()
                 }),
+            Statement::ModuleConstant {
+                public,
+                name,
+                value,
+                ..
+            } => pub_(*public)
+                .append("const ")
+                .append(name.to_string())
+                .append(" = ")
+                .append(self.expr(value)),
         }
     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -229,8 +229,18 @@ impl<'a> Formatter<'a> {
                 .append("const ")
                 .append(name.to_string())
                 .append(" = ")
-                .append(self.expr(value)),
+                .append(self.const_expr(value)),
         }
+    }
+
+    fn const_expr(&mut self, value: &ConstValue<()>) -> Document {
+        match value {
+            ConstValue::Int { value, .. }
+            | ConstValue::Float { value, .. }
+            | ConstValue::String { value, .. } => value,
+        }
+        .clone()
+        .to_doc()
     }
 
     fn documented_statement(&mut self, s: &UntypedStatement) -> Document {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -2635,6 +2635,19 @@ pub fn two() {
 }
 ",
     );
+
+    //
+    // Module level constants
+    //
+
+    assert_format!(
+        "pub const str = \"a string\"
+
+pub const int = 4
+
+pub const float = 3.14
+"
+    );
 }
 
 #[test]

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -34,6 +34,7 @@ Statement: UntypedStatement = {
     StatementExternalFn => <>,
     StatementExternalType => <>,
     StatementImport => <>,
+    StatementModuleConstant => <>,
 }
 
 StatementTypeAlias : UntypedStatement = {
@@ -123,6 +124,23 @@ StatementImport: UntypedStatement = {
             as_name,
         }
     }
+}
+
+StatementModuleConstant: UntypedStatement = {
+    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => UntypedStatement::ModuleConstant {
+        doc: None,
+        location: location(s, e),
+        public: p.is_some(),
+        name,
+        value: Box::new(lit),
+        typ: (),
+    }
+}
+
+LiteralExpr: UntypedExpr = {
+    Int => <>,
+    Float => <>,
+    String => <>,
 }
 
 UnqualifiedImport: UnqualifiedImport = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -7,7 +7,7 @@ use crate::ast::{
     UntypedPattern, BinOp, Clause, UntypedClause, RecordConstructor, Pattern, CallArg,
     ExternalFnArg, ArgNames, UnqualifiedImport, UntypedClauseGuard, ClauseGuard, BindingKind,
     UntypedExprBinSegment, UntypedPatternBinSegment, BinSegmentOption, UntypedExprBinSegmentOption,
-    UntypedPatternBinSegmentOption,
+    UntypedPatternBinSegmentOption, ConstValue
 
 };
 use crate::parser::*;
@@ -127,7 +127,7 @@ StatementImport: UntypedStatement = {
 }
 
 StatementModuleConstant: UntypedStatement = {
-    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => Statement::ModuleConstant {
+    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:ConstValue> <e:@L> => Statement::ModuleConstant {
         doc: None,
         location: location(s, e),
         public: p.is_some(),
@@ -137,10 +137,10 @@ StatementModuleConstant: UntypedStatement = {
     }
 }
 
-LiteralExpr: UntypedExpr = {
-    Int => <>,
-    Float => <>,
-    String => <>,
+ConstValue: ConstValue<()> = {
+    ConstInt => <>,
+    ConstFloat => <>,
+    ConstString => <>,
 }
 
 UnqualifiedImport: UnqualifiedImport = {
@@ -670,6 +670,14 @@ String: UntypedExpr = {
     }
 }
 
+ConstString: ConstValue<()> = {
+    <s:@L> <x:RawString> <e:@L> => ConstValue::<()>::String {
+        location: location(s, e),
+        typ: (),
+        value: x,
+    }
+}
+
 PositiveIntLiteral: String = {
     <pos:r"[0-9]+"> => pos.to_string()
 }
@@ -694,6 +702,14 @@ Int: UntypedExpr = {
     }
 }
 
+ConstInt: ConstValue<()> = {
+    <s:@L> <value:IntLiteral> <e:@L> => ConstValue::<()>::Int {
+        location: location(s, e),
+        typ: (),
+        value,
+    }
+}
+
 FloatLiteral: String = {
     <f:r"-?[0-9]+\.[0-9]*"> => f.to_string()
 }
@@ -702,6 +718,14 @@ Float: UntypedExpr = {
     <s:@L> <value:FloatLiteral> <e:@L> => UntypedExpr::Float {
         location: location(s, e),
         value
+    }
+}
+
+ConstFloat: ConstValue<()> = {
+    <s:@L> <value:FloatLiteral> <e:@L> => ConstValue::<()>::Float {
+        location: location(s, e),
+        typ: (),
+        value,
     }
 }
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -127,7 +127,7 @@ StatementImport: UntypedStatement = {
 }
 
 StatementModuleConstant: UntypedStatement = {
-    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => UntypedStatement::ModuleConstant {
+    <s:@L> <p:"pub"?> "const" <name:VarName> "=" <lit:LiteralExpr> <e:@L> => Statement::ModuleConstant {
         doc: None,
         location: location(s, e),
         public: p.is_some(),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -273,6 +273,9 @@ pub enum ValueConstructorVariant {
     /// A locally defined variable or function parameter
     LocalVariable,
 
+    /// A module constant
+    ModuleConstValue { literal: ConstValue<Arc<Type>> },
+
     /// A function belonging to the module
     ModuleFn {
         name: String,
@@ -296,6 +299,12 @@ impl ValueConstructorVariant {
                 arity: field_map.as_ref().map_or(0, |fm| fm.arity),
             },
 
+            ValueConstructorVariant::ModuleConstValue { literal } => {
+                ModuleValueConstructor::ConstValue {
+                    literal: literal.clone(),
+                }
+            }
+
             ValueConstructorVariant::LocalVariable { .. }
             | ValueConstructorVariant::ModuleFn { .. } => ModuleValueConstructor::Fn,
         }
@@ -306,6 +315,7 @@ impl ValueConstructorVariant {
 pub enum ModuleValueConstructor {
     Record { name: String, arity: usize },
     Fn,
+    ConstValue { literal: ConstValue<Arc<Type>> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -625,6 +635,20 @@ impl<'a> Typer<'a> {
     ///
     pub fn get_variable(&self, name: &str) -> Option<&ValueConstructor> {
         self.local_values.get(name)
+    }
+
+    /// Lookup a module constant in the current scope.
+    ///
+    pub fn get_module_const(&self, name: &str) -> Option<&ValueConstructor> {
+        self.module_values
+            .get(name)
+            .filter(|ValueConstructor { variant, .. }| {
+                if let ValueConstructorVariant::ModuleConstValue { .. } = variant {
+                    true
+                } else {
+                    false
+                }
+            })
     }
 
     /// Map a type in the current scope.
@@ -1650,6 +1674,23 @@ impl<'a> Typer<'a> {
                     | ValueConstructorVariant::Record { .. } => {
                         return Err(Error::NonLocalClauseGuardVariable { location, name })
                     }
+
+                    ValueConstructorVariant::ModuleConstValue { literal } => {
+                        return Ok(match literal {
+                            TypedConstValue::Int { value, .. } => ClauseGuard::Int {
+                                location: literal.location().clone(),
+                                value: value.clone(),
+                            },
+                            TypedConstValue::Float { value, .. } => ClauseGuard::Float {
+                                location: literal.location().clone(),
+                                value: value.clone(),
+                            },
+                            TypedConstValue::String { value, .. } => ClauseGuard::String {
+                                location: literal.location().clone(),
+                                value: value.clone(),
+                            },
+                        })
+                    }
                 };
 
                 Ok(ClauseGuard::Var {
@@ -1690,6 +1731,23 @@ impl<'a> Typer<'a> {
                     ValueConstructorVariant::ModuleFn { .. }
                     | ValueConstructorVariant::LocalVariable => {
                         return Err(Error::NonLocalClauseGuardVariable { location, name })
+                    }
+
+                    ValueConstructorVariant::ModuleConstValue { literal } => {
+                        return Ok(match literal {
+                            TypedConstValue::Int { value, .. } => ClauseGuard::Int {
+                                location: literal.location().clone(),
+                                value: value.clone(),
+                            },
+                            TypedConstValue::Float { value, .. } => ClauseGuard::Float {
+                                location: literal.location().clone(),
+                                value: value.clone(),
+                            },
+                            TypedConstValue::String { value, .. } => ClauseGuard::String {
+                                location: literal.location().clone(),
+                                value: value.clone(),
+                            },
+                        })
                     }
                 };
 
@@ -2125,6 +2183,7 @@ impl<'a> Typer<'a> {
             typ,
         } = self
             .get_variable(name)
+            .or_else(|| self.get_module_const(name))
             .cloned()
             .ok_or_else(|| Error::UnknownVariable {
                 location: location.clone(),
@@ -2207,7 +2266,7 @@ impl<'a> Typer<'a> {
             },
             ConstValue::Float {
                 location, value, ..
-            } => ConstValue::Int {
+            } => ConstValue::Float {
                 location,
                 typ: float(),
                 value,
@@ -3356,9 +3415,11 @@ pub fn infer_module(
                 typer.insert_module_value(
                     &name,
                     ValueConstructor {
-                        public: public,
+                        public,
                         origin: location.clone(),
-                        variant: ValueConstructorVariant::LocalVariable,
+                        variant: ValueConstructorVariant::ModuleConstValue {
+                            literal: typed_expr.clone(),
+                        },
                         typ: typ.clone(),
                     },
                 )?;
@@ -3824,6 +3885,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         PatternConstructor::Record { name: name.clone() }
                     }
                     ValueConstructorVariant::LocalVariable
+                    | ValueConstructorVariant::ModuleConstValue { .. }
                     | ValueConstructorVariant::ModuleFn { .. } => crate::error::fatal_compiler_bug(
                         "Unexpected value constructor type for a constructor pattern.",
                     ),

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -3315,6 +3315,37 @@ pub fn infer_module(
                 as_name,
                 unqualified,
             }),
+
+            Statement::ModuleConstant {
+                doc,
+                location,
+                name,
+                public,
+                value,
+                ..
+            } => {
+                let typed_value = typer.infer(*value)?;
+                let typ = typed_value.typ();
+
+                typer.insert_module_value(
+                    &name,
+                    ValueConstructor {
+                        public: public,
+                        origin: location.clone(),
+                        variant: ValueConstructorVariant::LocalVariable,
+                        typ: typ.clone(),
+                    },
+                )?;
+
+                Ok(Statement::ModuleConstant {
+                    doc,
+                    location,
+                    name,
+                    public,
+                    value: Box::new(typed_value),
+                    typ,
+                })
+            }
         })
         .collect::<Result<Vec<_>, Error>>()?;
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -1327,7 +1327,7 @@ impl<'a> Typer<'a> {
             .map(|option| self.infer_segment_option(option))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let type_specifier = BinaryTypeSpecifier::new(&options, true)
+        let type_specifier = BinaryTypeSpecifier::new(&options, false)
             .map_err(|e| convert_binary_error(e, &location))?;
         let typ = type_specifier.typ().unwrap_or_else(|| int());
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -423,6 +423,10 @@ fn infer_test() {
         "let a = <<1>> let <<x:binary>> = <<1, a:2-binary>> x",
         "BitString"
     );
+    assert_infer!(
+        "let x = <<<<1>>:bit_string, <<2>>:bit_string>> x",
+        "BitString"
+    );
 }
 
 macro_rules! assert_error {
@@ -495,9 +499,9 @@ fn infer_bit_string_error_test() {
     );
 
     assert_error!(
-        "let x = <<1:binary>> x",
+        "case <<1>> { <<1:binary, _:binary>> -> 1 }",
         Error::BinarySegmentMustHaveSize {
-            location: SrcSpan { start: 10, end: 18 },
+            location: SrcSpan { start: 15, end: 23 },
         },
     );
 


### PR DESCRIPTION
PR for #577 

Constants can only be simple literals: ints, floats and strings, and are inlined at gleam compile time.

```rust
pub const hello = 5
pub const pi = 3.14
const again = "world"
```