### PR TITLE
Fix bug when reassigning variable names in alternative patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Error message diagnostic code previews for type errors when using the the
   pipe operator have been made more accurate.
 - Added support for list literals in clause guards.
+- Fixed bug when reassigning a variable inside a case clause with alternative
+  patterns.
 
 ## v0.9.1 - 2020-06-12
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -726,8 +726,7 @@ fn clause(clause: &TypedClause, env: &mut Env) -> Document {
         ..
     } = clause;
 
-    let mut pattern_already_printed = false;
-    let env_clone = &mut env.clone();
+    let mut then_doc = Document::Nil;
 
     let docs = std::iter::once(pat)
         .chain(alternative_patterns.into_iter())
@@ -741,28 +740,18 @@ fn clause(clause: &TypedClause, env: &mut Env) -> Document {
                 tuple(patterns.iter().map(|p| pattern(p, env)))
             };
 
-            let full_clause_doc = patterns_doc
-                .append(optional_clause_guard(guard.as_ref(), env))
-                .append(" ->")
-                .append(
-                    line()
-                        .append(expr(
-                            then,
-                            if pattern_already_printed {
-                                env_clone
-                            } else {
-                                env
-                            },
-                        ))
-                        .nest(INDENT)
-                        .group(),
-                );
+            if then_doc == Document::Nil {
+                then_doc = expr(then, env);
+            }
 
-            pattern_already_printed = true;
-
-            full_clause_doc
+            patterns_doc.append(
+                optional_clause_guard(guard.as_ref(), env)
+                    .append(" ->")
+                    .append(line().append(then_doc.clone()).nest(INDENT).group()),
+            )
         })
         .intersperse(";".to_doc().append(lines(2)));
+
     concat(docs)
 }
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2552,4 +2552,36 @@ main(Arg) ->
     end.
 "#,
     );
+
+    // reassigning name in alternative patterns
+    assert_erl!(
+        r#"
+pub fn test() {
+  let duplicate_name = 1
+
+  case 1 {
+    1 | 2 -> {
+      let duplicate_name = duplicate_name + 1
+      duplicate_name
+    }
+  }
+}"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([test/0]).
+
+test() ->
+    DuplicateName = 1,
+    case 1 of
+        1 ->
+            DuplicateName1 = DuplicateName + 1,
+            DuplicateName1;
+
+        2 ->
+            DuplicateName1 = DuplicateName + 1,
+            DuplicateName1
+    end.
+"#,
+    );
 }


### PR DESCRIPTION
The bodies of the duplicated clauses created by using alternative patterns were incorrectly incrementing the variable names if you reassigned them. For example:

```rust
pub fn test() {
  let test = 1

  case 1 {
    1 | 2 -> { let test = test + 1; test }
  }
}
```

would output

```erlang
test() ->
    Test = 1,
    case 1 of
        1 ->
            Test1 = Test + 1,
            Test1;

        2 ->
            Test2 = Test1 + 1,
            Test2
    end.
```

This commit changes it to use the same variable names in each clause.

However, it does so by cloning the whole env everytime you render a clause, regardless of whether you're even using alternative patterns at all. I'm not quite how big a deal this is in practice but it could certainly be improved. Thought it would be worth checking if you reckon this general approach is the right solution before spending time optimising it though.
