### PR TITLE
Fix unused return value warning in nightly

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -239,7 +239,7 @@ impl<A, B, C> Statement<A, B, C> {
             | Statement::ExternalFn { doc, .. }
             | Statement::ExternalType { doc, .. }
             | Statement::ModuleConstant { doc, .. } => {
-                std::mem::replace(doc, new_doc);
+                let _ = std::mem::replace(doc, new_doc);
             }
         }
     }


### PR DESCRIPTION
On Rust nightly, I get the following error:
![Screenshot from 2020-06-28 10-20-16](https://user-images.githubusercontent.com/801803/85950134-0496a280-b929-11ea-8466-d7a65ea29df8.png)

The PR fixes the warning