### PR TITLE
Add index.html to end of module doc path

### DIFF
--- a/src/docs.rs
+++ b/src/docs.rs
@@ -65,7 +65,7 @@ pub fn generate_html(
         .clone()
         .map(|m| {
             let name = m.name.join("/");
-            let path = [&name, "/"].concat();
+            let path = [&name, "/index.html"].concat();
             Link { path, name }
         })
         .collect();


### PR DESCRIPTION
Currently, module doc links show a directory listing page when viewed locally in the browser without using a web server.