### PR TITLE
Make let binding with a type that has multiple constructors an error

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -592,6 +592,7 @@ pub enum BindingKind {
     Let,
     Assert,
     Try,
+    Clause,
 }
 
 // BitStrings

--- a/src/error.rs
+++ b/src/error.rs
@@ -1176,6 +1176,33 @@ signed, unsigned, big, little, native, size, unit",
                     )
                     .unwrap();
                 }
+
+                NonExhaustiveLet {
+                    location,
+                    constructor,
+                    unhandled_constructors,
+                } => {
+                    let diagnostic = Diagnostic {
+                        title: "Non-exhaustive let binding".to_string(),
+                        label: "used here".to_string(),
+                        file: path.to_str().unwrap().to_string(),
+                        src: src.to_string(),
+                        location: location.clone(),
+                    };
+                    write(buffer, diagnostic, Severity::Error);
+                    writeln!(
+                        buffer,
+                        "You are handling the {} constructor, but this could also be one of:
+{}
+
+Either use a case expression to handle all possibilities, or use assert instead
+of let if you are sure you don't want to handle the others. This will cause a
+runtime error if they occur.",
+                        constructor,
+                        unhandled_constructors.join(", "),
+                    )
+                    .unwrap();
+                }
             },
 
             Error::Parse { path, src, error } => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1177,7 +1177,7 @@ signed, unsigned, big, little, native, size, unit",
                     .unwrap();
                 }
 
-                NonExhaustiveLet {
+                NonExhaustiveBinding {
                     location,
                     constructor,
                     unhandled_constructors,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1180,26 +1180,35 @@ signed, unsigned, big, little, native, size, unit",
                 NonExhaustiveBinding {
                     location,
                     constructor,
+                    kind,
                     unhandled_constructors,
                 } => {
                     let diagnostic = Diagnostic {
-                        title: "Non-exhaustive let binding".to_string(),
+                        title: "Non-exhaustive binding".to_string(),
                         label: "used here".to_string(),
                         file: path.to_str().unwrap().to_string(),
                         src: src.to_string(),
                         location: location.clone(),
                     };
                     write(buffer, diagnostic, Severity::Error);
+
+                    let suggestion = match kind {
+                        crate::ast::BindingKind::Let => "Either use a case expression to handle all possibilities, or use assert instead
+of let if you are sure you don't want to handle the others. This will cause a
+runtime error if they occur.",
+                        crate::ast::BindingKind::Try => "You will need to use a case expression to handle all possibilities.",
+                        _ => "Additionally, you have found a compiler bug. Sorry! Please submit a bug report on GitHub."
+                    };
+
                     writeln!(
                         buffer,
                         "You are handling the {} constructor, but this could also be one of:
 {}
 
-Either use a case expression to handle all possibilities, or use assert instead
-of let if you are sure you don't want to handle the others. This will cause a
-runtime error if they occur.",
+{}",
                         constructor,
                         unhandled_constructors.join(", "),
+                        suggestion
                     )
                     .unwrap();
                 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -520,6 +520,7 @@ impl<'a> Formatter<'a> {
             BindingKind::Let => "let ",
             BindingKind::Try => "try ",
             BindingKind::Assert => "assert ",
+            BindingKind::Clause => "",
         };
 
         let line = if self.pop_empty_lines(then.start_byte_index()) {

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -1112,6 +1112,7 @@ pub fn test(x) {
                 src: "import one.{Two}\npub fn test(x) {\n    let Two(y) = x\n    y\n}".to_string(),
                 error: crate::typ::Error::NonExhaustiveBinding {
                     location: crate::ast::SrcSpan { start: 42, end: 48 },
+                    kind: crate::ast::BindingKind::Let,
                     constructor: "Two".to_string(),
                     unhandled_constructors: vec!["One".to_string()]
                 }

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -1110,7 +1110,7 @@ pub fn test(x) {
             expected: Err(Error::Type {
                 path: PathBuf::from("/src/two.gleam"),
                 src: "import one.{Two}\npub fn test(x) {\n    let Two(y) = x\n    y\n}".to_string(),
-                error: crate::typ::Error::NonExhaustiveLet {
+                error: crate::typ::Error::NonExhaustiveBinding {
                     location: crate::ast::SrcSpan { start: 42, end: 48 },
                     constructor: "Two".to_string(),
                     unhandled_constructors: vec!["One".to_string()]

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -2795,6 +2795,7 @@ pub enum Error {
 
     NonExhaustiveBinding {
         location: SrcSpan,
+        kind: BindingKind,
         constructor: String,
         unhandled_constructors: Vec<String>,
     },
@@ -3902,6 +3903,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             return Err(Error::NonExhaustiveBinding {
                                 location: location.clone(),
                                 constructor: name.clone(),
+                                kind: self.binding_kind,
                                 unhandled_constructors: other_constructor_names.clone(),
                             });
                         }

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -1544,7 +1544,7 @@ impl<'a> Typer<'a> {
                 } = value_constructor.variant
                 {
                     if other_constructor_names.len() > 0 {
-                        return Err(Error::NonExhaustiveLet {
+                        return Err(Error::NonExhaustiveBinding {
                             location: pattern.location().clone(),
                             constructor: name.clone(),
                             unhandled_constructors: other_constructor_names.clone(),
@@ -2815,7 +2815,7 @@ pub enum Error {
         label: String,
     },
 
-    NonExhaustiveLet {
+    NonExhaustiveBinding {
         location: SrcSpan,
         constructor: String,
         unhandled_constructors: Vec<String>,

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -1423,7 +1423,7 @@ fn infer_error_test() {
 
     assert_error!(
         "let Ok(x) = Error(1) x",
-        Error::NonExhaustiveLet {
+        Error::NonExhaustiveBinding {
             location: SrcSpan { start: 4, end: 9 },
             constructor: "Ok".to_string(),
             unhandled_constructors: vec!["Error".to_string()]
@@ -2642,7 +2642,7 @@ fn test(x) {
     let Two(y) = x
     y
 }",
-        Error::NonExhaustiveLet {
+        Error::NonExhaustiveBinding {
             location: SrcSpan { start: 64, end: 70 },
             constructor: "Two".to_string(),
             unhandled_constructors: vec!["One".to_string()]

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -902,18 +902,18 @@ fn infer_error_test() {
     );
 
     assert_error!(
-        "let True(x) = 1 x",
+        "let Nil(x) = 1 x",
         Error::IncorrectArity {
-            location: SrcSpan { start: 4, end: 11 },
+            location: SrcSpan { start: 4, end: 10 },
             expected: 0,
             given: 1,
         },
     );
 
     assert_error!(
-        "let Ok(1, x) = 1 x",
+        "assert Ok(1, x) = 1 x",
         Error::IncorrectArity {
-            location: SrcSpan { start: 4, end: 12 },
+            location: SrcSpan { start: 7, end: 15 },
             expected: 1,
             given: 2,
         },
@@ -2645,7 +2645,23 @@ fn test(x) {
         Error::NonExhaustiveBinding {
             location: SrcSpan { start: 64, end: 70 },
             constructor: "Two".to_string(),
-            unhandled_constructors: vec!["One".to_string()]
+            unhandled_constructors: vec!["One".to_string()],
+        }
+    );
+
+    assert_error!(
+        "pub type Thing {
+  Thing(Result(Int, Int))
+};
+
+pub fn main(x) {
+  let Thing(Ok(y)) = x
+  y
+}",
+        Error::NonExhaustiveBinding {
+            location: SrcSpan { start: 76, end: 81 },
+            constructor: "Ok".to_string(),
+            unhandled_constructors: vec!["Error".to_string()],
         }
     );
 }

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -1426,6 +1426,7 @@ fn infer_error_test() {
         Error::NonExhaustiveBinding {
             location: SrcSpan { start: 4, end: 9 },
             constructor: "Ok".to_string(),
+            kind: crate::ast::BindingKind::Let,
             unhandled_constructors: vec!["Error".to_string()]
         }
     );
@@ -2645,6 +2646,7 @@ fn test(x) {
         Error::NonExhaustiveBinding {
             location: SrcSpan { start: 64, end: 70 },
             constructor: "Two".to_string(),
+            kind: crate::ast::BindingKind::Let,
             unhandled_constructors: vec!["One".to_string()],
         }
     );
@@ -2661,7 +2663,26 @@ pub fn main(x) {
         Error::NonExhaustiveBinding {
             location: SrcSpan { start: 76, end: 81 },
             constructor: "Ok".to_string(),
+            kind: crate::ast::BindingKind::Let,
             unhandled_constructors: vec!["Error".to_string()],
+        }
+    );
+
+    assert_error!(
+        "pub type Thing {
+  One(Int)
+  Two(Int)
+};
+
+pub fn main(x) {
+  try One(y) = x
+  Ok(y)
+}",
+        Error::NonExhaustiveBinding {
+            location: SrcSpan { start: 66, end: 72 },
+            constructor: "One".to_string(),
+            kind: crate::ast::BindingKind::Try,
+            unhandled_constructors: vec!["Two".to_string()],
         }
     );
 }


### PR DESCRIPTION
Closes #537

I was originally going to store a vec of all constructor names on the `TypeConstructor`, but it seems to be a massive faff getting the relevant one from the starting point of a `Pattern::Constructor`, and also meant that types like Int and String had these empty constructor lists on them too which seemed redundant.

Instead I've added a vec of other constructor names to `ValueConstructorVariant::Record`, which is much easier to access, and means only the custom record types have to deal with this extra list. The downside is that this means the list of alternatives is duplicated across each constructor, rather than being stored once. I think you'd need to define a type with a completely impractical number of constructors for this to make any real difference, but seemed worth mentioning. What do you think?