### PR TITLE
Bitstring pattern match correctly writes discarded variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
-- Fixed a bug where variables names would be incorrectly generated when using
-  alternative patterns.
+- Bugfixes:
+  - Fixed a bug where variables names would be incorrectly generated when using
+    alternative patterns.
+  - Discarding variables inside bitstring matches now works properly
 
 # v0.10.0-rc1 - 2020-06-29
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -370,8 +370,11 @@ fn pattern_segment(
         // As normal
         Pattern::Var { .. } | Pattern::Int { .. } | Pattern::Float { .. } => pattern(value, env),
 
+        // Discard pattern
+        Pattern::Discard { name, .. } => name.clone().to_doc().surround("", ""),
+
         // No other pattern variants are allowed in pattern bit string segments
-        _ => Document::Nil,
+        _ => crate::error::fatal_compiler_bug("Pattern segment match not recognized"),
     };
 
     let size = |value: &TypedPattern, env: &mut Env| Some(":".to_doc().append(pattern(value, env)));

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -549,7 +549,56 @@ main(Args) ->
     A1.
 "#,
     );
+    // https://github.com/gleam-lang/gleam/issues/704
 
+    assert_erl!(
+        r#"
+pub fn bitstring_discard(x: String) -> Bool {
+ case x {
+  <<_:utf8, rest:binary>> -> True
+   _ -> False
+ } 
+}
+                    "#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([bitstring_discard/1]).
+
+bitstring_discard(X) ->
+    case X of
+        <<_/utf8, Rest/binary>> ->
+            true;
+
+        _ ->
+            false
+    end.
+"#,
+    );
+    assert_erl!(
+        r#"
+pub fn bitstring_discard(x: String) -> Bool {
+ case x {
+  <<_Discardme:utf8, rest:binary>> -> True
+   _ -> False
+ } 
+}
+                    "#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export([bitstring_discard/1]).
+
+bitstring_discard(X) ->
+    case X of
+        <<_Discardme/utf8, Rest/binary>> ->
+            true;
+
+        _ ->
+            false
+    end.
+"#,
+    );
     // Clause guards
     assert_erl!(
         r#"


### PR DESCRIPTION
This fixes #704