### PR TITLE
Typer now returns an error if tuple arity doesn't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
+- Fixed a bug where the compiler failed to return an error when type checking
+  a tuple with the wrong arity in a pattern.
 
 # v0.10.0 - 2020-07-01
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -3727,6 +3727,14 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
 
             Pattern::Tuple { elems, location } => match &*collapse_links(typ.clone()) {
                 Type::Tuple { elems: type_elems } => {
+                    if elems.len() != type_elems.len() {
+                        return Err(Error::IncorrectArity {
+                            location,
+                            expected: type_elems.len(),
+                            given: elems.len(),
+                        });
+                    }
+
                     let elems = elems
                         .into_iter()
                         .zip(type_elems)

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -1212,6 +1212,16 @@ fn infer_error_test() {
         },
     );
 
+    // https://github.com/gleam-lang/gleam/issues/714
+    assert_error!(
+        "case tuple(1, 2) { tuple(1, _, _, _) -> 1 }",
+        Error::IncorrectArity {
+            location: SrcSpan { start: 19, end: 36 },
+            expected: 2,
+            given: 4,
+        },
+    );
+
     // Duplicate vars
 
     assert_error!(


### PR DESCRIPTION
Closes #714

The code given in the issue shouldn't actually compile at all! Apparently we weren't checking the arity of tuples in patterns. 