### PR TITLE
Fix eunit runner with multiple paths

### DIFF
--- a/src/eunit/eunit_runner.erl
+++ b/src/eunit/eunit_runner.erl
@@ -1,10 +1,11 @@
 #!/usr/bin/env erlang
 -mode(compile).
 
-main([Ebin, Args])->
+main([EbinPaths, AllModules])->
     true = code:add_patha(filename:dirname(escript:script_name())),
-    true = code:add_patha(Ebin),
-    Strings = string:tokens(Args, ","),
-    Modules = lists:map(fun(X) -> list_to_atom(X) end, Strings),
+    SeperatedEbinPaths = string:tokens(EbinPaths, ","),
+    ok = code:add_paths(SeperatedEbinPaths),
+    SeperatedModules = string:tokens(AllModules, ","),
+    Modules = lists:map(fun(X) -> list_to_atom(X) end, SeperatedModules),
     code:load_file(eunit_progress),
     halt(case eunit:test(Modules, [inparallel, verbose, no_tty, {report, {eunit_progress, [{colored, true}]}}]) of ok -> 0; error -> 1 end).


### PR DESCRIPTION
Closes #716 

My bad, forgot to split the ebins path like it's done for the modules. Guess I opened the PR a little too fast last time :)