### PR TITLE
Support updating records using a new spread syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - The error message for a duplicate module member now shows the location of
   both definitions.
 - Fix compiler bug where labelled arguments were being reordered incorrectly.
+- Support updating records with a new spread syntax
 
 # v0.10.0 - 2020-07-01
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -328,6 +328,27 @@ pub struct CallArg<A> {
     pub value: A,
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub struct RecordUpdateSpread {
+    pub name: String,
+    pub location: SrcSpan,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct UntypedRecordUpdateArg {
+    pub label: String,
+    pub location: SrcSpan,
+    pub value: UntypedExpr,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct TypedRecordUpdateArg {
+    pub label: String,
+    pub location: SrcSpan,
+    pub value: TypedExpr,
+    pub index: usize,
+}
+
 pub type MultiPattern<PatternConstructor, Type> = Vec<Pattern<PatternConstructor, Type>>;
 
 pub type UntypedMultiPattern = MultiPattern<(), ()>;

--- a/src/ast/typed.rs
+++ b/src/ast/typed.rs
@@ -133,6 +133,13 @@ pub enum TypedExpr {
         typ: Arc<Type>,
         segments: Vec<TypedExprBitStringSegment>,
     },
+
+    RecordUpdate {
+        location: SrcSpan,
+        typ: Arc<Type>,
+        spread: Box<Self>,
+        args: Vec<TypedRecordUpdateArg>,
+    },
 }
 
 impl TypedExpr {
@@ -157,6 +164,7 @@ impl TypedExpr {
             Self::ModuleSelect { location, .. } => location,
             Self::RecordAccess { location, .. } => location,
             Self::BitString { location, .. } => location,
+            Self::RecordUpdate { location, .. } => location,
         }
     }
 
@@ -187,6 +195,7 @@ impl TypedExpr {
             Self::ModuleSelect { location, .. } => location,
             Self::RecordAccess { location, .. } => location,
             Self::BitString { location, .. } => location,
+            Self::RecordUpdate { location, .. } => location,
         }
     }
 }
@@ -219,6 +228,7 @@ impl TypedExpr {
             Self::ModuleSelect { typ, .. } => typ.clone(),
             Self::RecordAccess { typ, .. } => typ.clone(),
             Self::BitString { typ, .. } => typ.clone(),
+            Self::RecordUpdate { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/ast/untyped.rs
+++ b/src/ast/untyped.rs
@@ -105,6 +105,13 @@ pub enum UntypedExpr {
         location: SrcSpan,
         segments: Vec<UntypedExprBitStringSegment>,
     },
+
+    RecordUpdate {
+        location: SrcSpan,
+        constructor: Box<Self>,
+        spread: RecordUpdateSpread,
+        args: Vec<UntypedRecordUpdateArg>,
+    },
 }
 
 impl UntypedExpr {
@@ -128,6 +135,7 @@ impl UntypedExpr {
             Self::TupleIndex { location, .. } => location,
             Self::FieldAccess { location, .. } => location,
             Self::BitString { location, .. } => location,
+            Self::RecordUpdate { location, .. } => location,
         }
     }
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1841,4 +1841,67 @@ main(Arg) ->
     end.
 "#,
     );
+
+    // Record updates
+    assert_erl!(
+        r#"
+pub type Person { Person(name: String, age: Int) }
+
+fn main() {
+    let p = Person("Quinn", 27)
+    let new_p = Person(..p, age: 28)
+    new_p
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+main() ->
+    P = {person, <<"Quinn"/utf8>>, 27},
+    NewP = erlang:setelement(3, P, 28),
+    NewP.
+"#,
+    );
+
+    // Record updates with field accesses
+    assert_erl!(
+        r#"
+pub type Person { Person(name: String, age: Int) }
+
+fn main() {
+    let p = Person("Quinn", 27)
+    let new_p = Person(..p, age: p.age + 1)
+    new_p
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+main() ->
+    P = {person, <<"Quinn"/utf8>>, 27},
+    NewP = erlang:setelement(3, P, erlang:element(3, P) + 1),
+    NewP.
+"#,
+    );
+
+    // Record updates with multiple fields
+    assert_erl!(
+        r#"
+pub type Person { Person(name: String, age: Int) }
+
+fn main() {
+    let p = Person("Quinn", 27)
+    let new_p = Person(..p, age: 28, name: "Riley")
+    new_p
+}
+"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+main() ->
+    P = {person, <<"Quinn"/utf8>>, 27},
+    NewP = erlang:setelement(2, erlang:setelement(3, P, 28), <<"Riley"/utf8>>),
+    NewP.
+"#,
+    );
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1179,8 +1179,24 @@ signed, unsigned, big, little, native, size, unit",
                     )
                     .unwrap();
                 }
-            },
 
+                RecordUpdateInvalidConstructor { location } => {
+                    let diagnostic = Diagnostic {
+                        title: "Invalid record constructor".to_string(),
+                        label: "This is not a record constructor".to_string(),
+                        file: path.to_str().unwrap().to_string(),
+                        src: src.to_string(),
+                        location: location.clone(),
+                    };
+                    write(buffer, diagnostic, Severity::Error);
+
+                    writeln!(
+                        buffer,
+                        "You are attempting to update a record using a value that is not a record constructor",
+                    )
+                    .unwrap();
+                }
+            },
             Error::Parse { path, src, error } => {
                 use lalrpop_util::ParseError::*;
 

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -2678,6 +2678,37 @@ pub const int = 4
 pub const float = 3.14
 "
     );
+
+    // Record update
+    assert_format!(
+        "pub type Counter {
+  Counter(a: Int, b: Int)
+}
+
+fn main() {
+  let c = Counter(0, 0)
+  let c = Counter(..c, a: c.a + 1, b: c.a + c.b)
+  c
+}
+"
+    );
+
+    // Long record updates are split onto multiple lines
+    assert_format!(
+        "pub type Counter {
+  Counter(loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: Int)
+}
+
+fn main() {
+  let c = Counter(0)
+  let c = Counter(
+    ..c,
+    loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: 1,
+  )
+  c
+}
+"
+    );
 }
 
 #[test]

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -4,11 +4,12 @@ use std::str::FromStr;
 
 use crate::ast::{
     UntypedExpr, UntypedArg, Arg, UntypedModule, Module, UntypedStatement, Statement, TypeAst,
-    UntypedPattern, BinOp, Clause, UntypedClause, RecordConstructor, Pattern, CallArg,
+    UntypedPattern, BinOp, Clause, UntypedClause, RecordConstructor, Pattern, RecordUpdateSpread, UntypedRecordUpdateArg, CallArg,
     ExternalFnArg, ArgNames, UnqualifiedImport, UntypedClauseGuard, ClauseGuard, BindingKind,
     BitStringSegment, BitStringSegmentOption, Constant, UntypedConstant,
 };
 use crate::parser::*;
+use lalrpop_util::ParseError;
 
 grammar;
 
@@ -562,56 +563,38 @@ ArgNames: ArgNames = {
 }
 
 Call: UntypedExpr = {
+    <s:@L> <constructor:SimpleExpr> "(" <spread:RecordUpdateSpread> ")" <e:@L> => UntypedExpr::RecordUpdate {
+        location: location(s, e),
+        constructor: Box::new(constructor),
+        spread: spread,
+        args: vec![],
+    },
+
+    <s:@L> <constructor:SimpleExpr> "(" <spread:RecordUpdateSpread> "," <args:Comma<RecordUpdateArg>> ")" <e:@L> => UntypedExpr::RecordUpdate {
+        location: location(s, e),
+        constructor: Box::new(constructor),
+        spread: spread,
+        args: args,
+    },
+
     <s:@L> <fun:SimpleExpr> "(" <args:Comma<CallArg>> ")" <e:@L> =>? {
-        let mut num_holes = 0;
-        let args = args
-            .into_iter()
-            .map(|a| match a {
-                Ok(arg) => arg,
-                Err((location, label)) => {
-                    num_holes += 1;
-                    CallArg {
-                        label,
-                        location: Default::default(),
-                        value: UntypedExpr::Var {
-                            location,
-                            name: crate::ast::CAPTURE_VARIABLE.to_string(),
-                        }
-                    }
-                }
-            })
-            .collect();
-        let call = UntypedExpr::Call {
-            location: location(s, e),
-            fun: Box::new(fun),
-            args,
-        };
-        match num_holes {
-            // A normal call
-            0 => Ok(call),
-
-            // An anon function using the capture syntax run(_, 1, 2)
-            1 => Ok(UntypedExpr::Fn {
-                location: call.location().clone(),
-                is_capture: true,
-                args: vec![Arg {
-                    location: location(0, 0),
-                    annotation: None,
-                    names: ArgNames::Named { name: crate::ast::CAPTURE_VARIABLE.to_string() },
-                    typ: (),
-                }],
-                body: Box::new(call),
-                return_annotation: None,
-            }),
-
-            count => Err(lalrpop_util::ParseError::User {
-                error: Error::TooManyHolesInCapture {
-                    location: call.location().clone(),
-                    count
-                },
-            })
-        }
+        make_call(fun, args, s, e).map_err(|e| ParseError::User { error: e })
     }
+}
+
+RecordUpdateSpread: RecordUpdateSpread = {
+    <s:@L> ".." <name:VarName> <e:@L> => RecordUpdateSpread {
+        name: name,
+        location: location(s, e),
+    }
+}
+
+RecordUpdateArg: UntypedRecordUpdateArg = {
+    <s:@L> <label:(<VarName> ":")> <value:OpOrSimpleExpr> <e:@L> => UntypedRecordUpdateArg {
+        label,
+        value,
+        location: location(s, e)
+    },
 }
 
 CallArg: Result<CallArg<UntypedExpr>, (crate::ast::SrcSpan, Option<String>)> = {

--- a/test/core_language/src/record_update.gleam
+++ b/test/core_language/src/record_update.gleam
@@ -1,0 +1,3 @@
+pub type Box(a) {
+  Box(value: a)
+}

--- a/test/core_language/test/record_update_test.gleam
+++ b/test/core_language/test/record_update_test.gleam
@@ -1,0 +1,22 @@
+import should
+import record_update
+
+pub type Person {
+  Person(
+    name: String,
+    age: Int,
+    country: String
+  )
+}
+
+pub fn record_update_test() {
+  let past = Person("Quinn", 27, "Canada")
+  let present = Person(..past, country: "USA", age: past.age + 1)
+
+  should.equal(present, Person("Quinn", 28, "USA"))
+
+  let module_box = record_update.Box(5)
+  let updated = record_update.Box(..module_box, value: 6)
+
+  should.equal(updated, record_update.Box(6))
+}


### PR DESCRIPTION
For example:

```
import should
import record_update

pub type Person {
  Person(
    name: String,
    age: Int,
    country: String
  )
}

pub fn record_update_test() {
  let past = Person("Quinn", 27, "Canada")
  let present = Person(..past, country: "USA", age: past.age + 1)

  should.equal(present, Person("Quinn", 28, "USA"))

  let module_box = record_update.Box(5)
  let updated = record_update.Box(..module_box, value: 6)

  should.equal(updated, record_update.Box(6))
}
```