### PR TITLE
Fix compiler bug where labelled arguments were being reordered incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   a tuple with the wrong arity in a pattern.
 - The error message for a duplicate module member now shows the location of
   both definitions.
+- Fix compiler bug where labelled arguments were being reordered incorrectly.
 
 # v0.10.0 - 2020-07-01
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -224,20 +224,30 @@ impl FieldMap {
         }
 
         for i in 0..args.len() {
-            let (label, location) = match &args[i].label {
-                // A labelled argument, we may need to reposition it in the array vector
-                Some(l) => {
+            match &args[i].label {
+                Some(_) => {
                     labelled_arguments_given = true;
-                    (l, &args[i].location)
                 }
 
-                // Not a labelled argument
                 None => {
                     if labelled_arguments_given {
                         return Err(Error::PositionalArgumentAfterLabelled {
                             location: args[i].location.clone(),
                         });
                     }
+                }
+            }
+        }
+
+        let mut i = 0;
+        while i < args.len() {
+            let (label, location) = match &args[i].label {
+                // A labelled argument, we may need to reposition it in the array vector
+                Some(l) => (l, &args[i].location),
+
+                // Not a labelled argument
+                None => {
+                    i = i + 1;
                     continue;
                 }
             };
@@ -254,6 +264,7 @@ impl FieldMap {
             };
 
             if *position == i {
+                i = i + 1;
                 continue;
             }
 
@@ -267,6 +278,7 @@ impl FieldMap {
             seen.insert(*position);
             args.swap(*position, i);
         }
+
         Ok(())
     }
 }

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -89,47 +89,6 @@ fn field_map_reorder_test() {
             },
             CallArg {
                 location: Default::default(),
-                label: Some("last".to_string()),
-                value: int("2"),
-            },
-            CallArg {
-                location: Default::default(),
-                label: None,
-                value: int("3"),
-            },
-        ],
-        expected_result: Ok(()),
-        expected_args: vec![
-            CallArg {
-                location: Default::default(),
-                label: None,
-                value: int("1"),
-            },
-            CallArg {
-                location: Default::default(),
-                label: None,
-                value: int("3"),
-            },
-            CallArg {
-                location: Default::default(),
-                label: Some("last".to_string()),
-                value: int("2"),
-            },
-        ],
-    }
-    .test();
-
-    Case {
-        arity: 3,
-        fields: [("last".to_string(), 2)].iter().cloned().collect(),
-        args: vec![
-            CallArg {
-                location: Default::default(),
-                label: None,
-                value: int("1"),
-            },
-            CallArg {
-                location: Default::default(),
                 label: None,
                 value: int("2"),
             },
@@ -1692,7 +1651,7 @@ fn infer_module_test() {
     );
     assert_infer!(
         "pub type Tup(a, b, c) { Tup(first: a, second: b, third: c) }
-         pub fn third(t) { let Tup(_, third: a, _) = t a }",
+         pub fn third(t) { let Tup(_ , _, third: a) = t a }",
         vec![
             ("Tup", "fn(a, b, c) -> Tup(a, b, c)"),
             ("third", "fn(Tup(a, b, c)) -> c"),
@@ -1895,6 +1854,21 @@ pub fn get(x: One) { x.name }",
             ("test_list", "List(Int)"),
             ("test_string", "String"),
             ("test_tuple", "tuple(String, Int)"),
+        ],
+    );
+
+    assert_infer!(
+        "
+pub type Box {
+  Box(a: Nil, b: Int, c: Int, d: Int)
+}
+
+pub fn main() {
+  Box(b: 1, c: 1, d: 1, a: Nil)
+}",
+        vec![
+            ("Box", "fn(Nil, Int, Int, Int) -> Box"),
+            ("main", "fn() -> Box"),
         ],
     );
 }


### PR DESCRIPTION
Closes #721 
There might be a more elegant way to sort this but the easiest seemed to be doing two passes over the args vec, firstly to check for `Error::PositionalArgumentAfterLabelled`, then again to do the reordering. This fixes the error reported in the issue, but also makes a couple of the existing tests fail, and so could be a breaking change for real code as well. Specifically some uses of a positional argument after a labelled argument will now fail to compile, e.g. `let Tup(_, third: a, _) = t a`.