### PR TITLE
Issue 729

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
 - Field access now works before the custom type is defined.
+- The error message returned by the compiler when the user tries to use unknown
+  labelled arguments now handles multiple labels at once, and does not suggest
+  labels they have already supplied.
 
 ## v0.10.1 - 2020-07-15
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -2609,11 +2609,11 @@ fn x() {
     let x = X(a: 1, c: 2.0)
     x
 }"#,
-        Error::UnknownLabels {
+        sort_options(Error::UnknownLabels {
             unknown: vec![("c".to_string(), SrcSpan { start: 60, end: 66 })],
             valid: vec!["a".to_string(), "b".to_string()],
             supplied: vec!["a".to_string()],
-        }
+        })
     );
 }
 
@@ -2737,6 +2737,19 @@ fn sort_options(e: Error) -> Error {
                 location,
                 name,
                 variables,
+            }
+        }
+
+        Error::UnknownLabels {
+            unknown,
+            mut valid,
+            supplied,
+        } => {
+            valid.sort();
+            Error::UnknownLabels {
+                unknown,
+                valid,
+                supplied,
             }
         }
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -2600,6 +2600,21 @@ fn main() {
             given: float(),
         },
     );
+
+    // Unknown label
+
+    assert_error!(
+        r#"type X { X(a: Int, b: Float) }
+fn x() {
+    let x = X(a: 1, c: 2.0)
+    x
+}"#,
+        Error::UnknownLabels {
+            unknown: vec![("c".to_string(), SrcSpan { start: 60, end: 66 })],
+            valid: vec!["a".to_string(), "b".to_string()],
+            supplied: vec!["a".to_string()],
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #729

I was originally going to do the "simple version", track the supplied labels and leave the everything else the same. However, it occurred to me that it would be annoying to remove labels supplied by the user before the unknown one, but continue suggesting any they supplied after. That meant continuing through the whole vec even if it finds an unknown label, which also raised the possibility of then finding additional unknown labels.

To deal with all this I've ended up refactoring `UnknownLabel` to be `UnknownLabels`, and it takes a vec of unknown labels with their locations, a vec of supplied valid labels, and the vec of all valid options. These all get printed out with the `MultiLineDiagnostic` I conveniently added last week. Like this:
 
<img width="548" alt="Screenshot 2020-07-17 at 19 02 31" src="https://user-images.githubusercontent.com/93559/87817364-b9edb380-c860-11ea-99fd-c66062757412.png">
