### PR TITLE
Fix `Previously defined` codespan

### DIFF
--- a/src/typ.rs
+++ b/src/typ.rs
@@ -1213,7 +1213,11 @@ pub fn register_import(s: &UntypedStatement, environment: &mut Environment) -> R
                 }
 
                 if let Some(typ) = module_info.1.types.get(name) {
-                    match environment.insert_type_constructor(imported_name.clone(), typ.clone()) {
+                    let typ_info = TypeConstructor {
+                        origin: location.clone(),
+                        ..typ.clone()
+                    };
+                    match environment.insert_type_constructor(imported_name.clone(), typ_info) {
                         Ok(_) => (),
                         Err(e) => return Err(e),
                     }


### PR DESCRIPTION
Closes #751 
Type info had to use unqualified import code span :)

```
error: Duplicate type definition with name `Option`
  ┌─ /home/ahmad/dev/gleam/gleam/test/hello_world/src/hello_world.gleam:1:15
  │
1 │ import other.{Option}
  │               ------ previously defined here
2 │
3 │ pub type Option {
  │ ^^^^^^^^^^^^^^^^ redefined here
```