### PR TITLE
Warn if all fields are updated

### DIFF
--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -220,6 +220,8 @@ pub enum Warning {
     ImplicitlyDiscardedResult { location: SrcSpan },
 
     NoFieldsRecordUpdate { location: SrcSpan },
+
+    AllFieldsRecordUpdate { location: SrcSpan },
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -1297,6 +1297,14 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                         });
                 }
 
+                if args.len() == field_map.arity {
+                    self.environment
+                        .warnings
+                        .push(Warning::AllFieldsRecordUpdate {
+                            location: location.clone(),
+                        });
+                }
+
                 return Ok(TypedExpr::RecordUpdate {
                     location,
                     typ: spread.typ(),

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -2997,6 +2997,25 @@ fn main() { let _ = foo(); 5 }",
             }
         }
     );
+
+    // All fields given in a record update emits warnings
+    assert_warning!(
+        "
+        pub type Person {
+            Person(name: String, age: Int)
+        };
+        pub fn update_person() {
+            let past = Person(\"Quinn\", 27)
+            let present = Person(..past, name: \"Quinn\", age: 28)
+            present
+        }",
+        Warning::AllFieldsRecordUpdate {
+            location: SrcSpan {
+                start: 183,
+                end: 221
+            }
+        }
+    );
 }
 
 fn env_types_with(things: &[&str]) -> Vec<String> {

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -72,6 +72,21 @@ variable _ if you are sure the error does not matter.")
 record without modification. Add some fields or remove this update.")
                     .unwrap();
                 }
+
+                AllFieldsRecordUpdate { location } => {
+                    let diagnostic = Diagnostic {
+                        title: "Redundant record update".to_string(),
+                        label: "".to_string(),
+                        file: path.to_str().unwrap().to_string(),
+                        src: src.to_string(),
+                        location: location.clone(),
+                    };
+                    write(buffer, diagnostic, Severity::Warning);
+                    writeln!(buffer,
+"All fields have been given in this record update, so it does not need to be
+be an update. Remove the update or remove fields that need to be copied.")
+                    .unwrap();
+                }
             },
         }
     }


### PR DESCRIPTION
Closes #740

Example output:
```
warning: Redundant record update
  ┌─ /home/ahmad/dev/gleam/gleam/test/hello_world/src/hello_world.gleam:6:3
  │
6 │   Person(..person, name: "Tim", age: 44)
  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

All fields have been given in this record update, so it does not need to be
be an update. Remove the update or remove fields that need to be copied.
```