### PR TITLE
Issue 757 : Include the inferred type of a `todo` in the warning

### DIFF
--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -215,10 +215,7 @@ pub enum Error {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Warning {
-    Todo {
-        location: SrcSpan,
-        typ: Arc<Type>,
-    },
+    Todo { location: SrcSpan, typ: Arc<Type> },
 
     ImplicitlyDiscardedResult { location: SrcSpan },
 

--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -215,7 +215,10 @@ pub enum Error {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Warning {
-    Todo { location: SrcSpan },
+    Todo {
+        location: SrcSpan,
+        typ: Arc<Type>,
+    },
 
     ImplicitlyDiscardedResult { location: SrcSpan },
 

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -283,14 +283,16 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
     }
 
     fn infer_todo(&mut self, location: SrcSpan, label: Option<String>) -> Result<TypedExpr, Error> {
+        let typ = self.new_unbound_var(self.environment.level);
         self.environment.warnings.push(Warning::Todo {
             location: location.clone(),
+            typ: typ.clone(),
         });
 
         Ok(TypedExpr::Todo {
             location,
             label,
-            typ: self.new_unbound_var(self.environment.level),
+            typ,
         })
     }
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -2952,7 +2952,10 @@ fn infer_module_warning_test() {
     assert_warning!(
         "fn main() { 1 == todo }",
         Warning::Todo {
-            location: SrcSpan { start: 17, end: 21 }
+            location: SrcSpan { start: 17, end: 21 },
+            typ: Arc::new(Type::Var {
+                typ: Arc::new(RefCell::new(TypeVar::Link { typ: int() })),
+            }),
         },
     );
 

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -39,11 +39,14 @@ impl Warning {
                     write(buffer, diagnostic, Severity::Warning);
                     let mut printer = Printer::new();
 
-                    writeln!(buffer,
-"I think this should be an `{}`.
+                    writeln!(
+                        buffer,
+                        "I think this should be an `{}`.
 
 This code will crash if it is run. Be sure to remove this todo before running
-your program.", printer.pretty_print(typ, 0))
+your program.",
+                        printer.pretty_print(typ, 0)
+                    )
                     .unwrap();
                 }
 

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,6 +1,7 @@
 use crate::{
     cli,
     diagnostic::{write, Diagnostic, Severity},
+    typ::pretty::Printer,
 };
 use std::path::PathBuf;
 use termcolor::Buffer;
@@ -27,7 +28,7 @@ impl Warning {
 
         match self {
             Warning::Type { path, src, warning } => match warning {
-                Todo { location } => {
+                Todo { location, typ } => {
                     let diagnostic = Diagnostic {
                         title: "Todo found".to_string(),
                         label: "".to_string(),
@@ -36,9 +37,13 @@ impl Warning {
                         location: location.clone(),
                     };
                     write(buffer, diagnostic, Severity::Warning);
+                    let mut printer = Printer::new();
+
                     writeln!(buffer,
-"This code will crash if it is run. Be sure to remove this todo before running
-your program.")
+"I think this should be an `{}`.
+
+This code will crash if it is run. Be sure to remove this todo before running
+your program.", printer.pretty_print(typ, 0))
                     .unwrap();
                 }
 


### PR DESCRIPTION
Closes #757 

output:
![Screen Shot 2563-08-13 at 15 28 26](https://user-images.githubusercontent.com/11692854/90112814-af004300-dd7a-11ea-8340-531eae4d32d6.png)
