### PR TITLE
Bit strings now allow string variables as segment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
-- Bit strings now allow string variables as segment values.
+- Bit strings now support non-literal strings as segment values.
 
 ## v0.11.0-rc2 - 2020-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
+- Bit strings now allow string variables as segment values.
 
 ## v0.11.0-rc2 - 2020-08-24
 

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -75,10 +75,22 @@ pub fn codepoint_conversion_test() {
   should.equal(snake_int, 128013)
 }
 
-pub fn string_variable_test() {
-  let x = "x"
-  let y = <<x:utf8, "ß↑e̊":utf8>>
-  let <<z:8, _:binary>> = y
+type StringHaver {
+  StringHaver(value: String)
+}
 
-  should.equal(z, 120) // x is unicode codepoint 120
+pub fn non_literal_strings_test() {
+  let v = "x"
+  let t = tuple("y")
+  let c = StringHaver(value: "z")
+  let f = fn() { "ß" }
+
+  let y = <<v:utf8, t.0:utf8, c.value:utf8, f():utf8, "↑":utf8>>
+  let <<var_out:8, tuple_out:8, custom_type_out:8, function_out:16, literal_out:24>> = y
+
+  should.equal(var_out, 120)
+  should.equal(tuple_out, 121)
+  should.equal(custom_type_out, 122)
+  should.equal(function_out, 50079) // "ß" is encoded as C3 9F in utf8
+  should.equal(literal_out, 14845585) // "↑" is encoded as E2 86 91 in utf8
 }

--- a/test/core_language/test/bit_string_test.gleam
+++ b/test/core_language/test/bit_string_test.gleam
@@ -74,3 +74,11 @@ pub fn codepoint_conversion_test() {
 
   should.equal(snake_int, 128013)
 }
+
+pub fn string_variable_test() {
+  let x = "x"
+  let y = <<x:utf8, "ß↑e̊":utf8>>
+  let <<z:8, _:binary>> = y
+
+  should.equal(z, 120) // x is unicode codepoint 120
+}


### PR DESCRIPTION
Closes #770 

The printer is now outputting a `binary` type specifier instead of `utf8` when the segment value is a string variable rather than a literal. Fixes the reported issue, let me know if you can think of any edge cases that seem worth explicitly having a test for.