### PR TITLE
Tweak documentation layout

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+[*.html]
+indent_style = space
+indent_size = 2

--- a/templates/documentation_layout.html
+++ b/templates/documentation_layout.html
@@ -25,45 +25,48 @@
             role="img"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 448 512"
-          >
+            >
             <path
               fill="#fff"
               d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
-            ></path>
+              >
+            </path>
           </svg>
         </a>
+        <div class="sidebar-top">
+          {% if !pages.is_empty() %}
+          <h2>Pages</h2>
+          <ul>
+          {% for page in pages %}
+            <li><a href="{{ unnest }}/{{ page.path }}">{{ page.name }}</a></li>
+          {% endfor %}
+          </ul>
+          {% endif %}
 
-        {% if !pages.is_empty() %}
-        <h2>Pages</h2>
-        <ul>
-        {% for page in pages %}
-          <li><a href="{{ unnest }}/{{ page.path }}">{{ page.name }}</a></li>
-        {% endfor %}
-        </ul>
-        {% endif %}
+          {% if !links.is_empty() %}
+          <h2>Pages</h2>
+          <ul>
+          {% for link in links %}
+            <li><a href="{{ unnest }}/{{ link.path }}">{{ link.name }}</a></li>
+          {% endfor %}
+          </ul>
+          {% endif %}
 
-        {% if !links.is_empty() %}
-        <h2>Pages</h2>
-        <ul>
-        {% for link in links %}
-          <li><a href="{{ unnest }}/{{ link.path }}">{{ link.name }}</a></li>
-        {% endfor %}
-        </ul>
-        {% endif %}
-
-        <h2>Modules</h2>
-        <ul>
-        {% for module in modules %}
-          <li><a href="{{ unnest }}/{{ module.path }}">{{ module.name }}</a></li>
-        {% endfor %}
-        </ul>
-
-        {% block sidebar_content %}{% endblock %}
+          <h2>Modules</h2>
+          <ul>
+          {% for module in modules %}
+            <li><a href="{{ unnest }}/{{ module.path }}">{{ module.name }}</a></li>
+          {% endfor %}
+          </ul>
+        </div>
+        <div class="sidebar-bottom">
+          {% block sidebar_content %}{% endblock %}
+        </div>
       </nav>
 
-      <div class="content">
+      <main class="content">
         {% block content %}{% endblock %}
-      </div>
+      </main>
     </div>
 
     <footer class="pride" onclick="document.querySelector('.pride').classList.toggle('show')">

--- a/templates/documentation_layout.html
+++ b/templates/documentation_layout.html
@@ -33,35 +33,33 @@
             </path>
           </svg>
         </a>
-        <div class="sidebar-top">
-          {% if !pages.is_empty() %}
-          <h2>Pages</h2>
-          <ul>
-          {% for page in pages %}
-            <li><a href="{{ unnest }}/{{ page.path }}">{{ page.name }}</a></li>
-          {% endfor %}
-          </ul>
-          {% endif %}
 
-          {% if !links.is_empty() %}
-          <h2>Pages</h2>
-          <ul>
-          {% for link in links %}
-            <li><a href="{{ unnest }}/{{ link.path }}">{{ link.name }}</a></li>
-          {% endfor %}
-          </ul>
-          {% endif %}
+        {% if !pages.is_empty() %}
+        <h2>Pages</h2>
+        <ul>
+        {% for page in pages %}
+          <li><a href="{{ unnest }}/{{ page.path }}">{{ page.name }}</a></li>
+        {% endfor %}
+        </ul>
+        {% endif %}
 
-          <h2>Modules</h2>
-          <ul>
-          {% for module in modules %}
-            <li><a href="{{ unnest }}/{{ module.path }}">{{ module.name }}</a></li>
-          {% endfor %}
-          </ul>
-        </div>
-        <div class="sidebar-bottom">
-          {% block sidebar_content %}{% endblock %}
-        </div>
+        {% if !links.is_empty() %}
+        <h2>Pages</h2>
+        <ul>
+        {% for link in links %}
+          <li><a href="{{ unnest }}/{{ link.path }}">{{ link.name }}</a></li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+
+        <h2>Modules</h2>
+        <ul>
+        {% for module in modules %}
+          <li><a href="{{ unnest }}/{{ module.path }}">{{ module.name }}</a></li>
+        {% endfor %}
+        </ul>
+
+        {% block sidebar_content %}{% endblock %}
       </nav>
 
       <main class="content">

--- a/templates/index.css
+++ b/templates/index.css
@@ -123,7 +123,6 @@ p code {
   color: var(--hard-black);
   background-color: var(--pink);
   padding: var(--small-gap) var(--gap);
-  margin-bottom: var(--gap);
   position: fixed;
   left: 0px;
   right: 0px;
@@ -148,10 +147,11 @@ p code {
   font-size: 0.95rem;
   max-height: calc(100vh - var(--header-height) - var(--gap));
   overflow-y: auto;
+  padding-top: var(--gap);
   padding-bottom: var(--gap);
   padding-left: var(--gap);
   position: fixed;
-  top: calc(var(--header-height) + var(--gap));
+  top: var(--header-height);
   transition: transform 0.5s ease;
   width: var(--sidebar-width);
   z-index: 100;
@@ -267,8 +267,6 @@ p code {
     height: 100vh;
     max-height: unset;
     overflow: visible;
-    padding-bottom: var(--gap);
-    padding-top: var(--gap);
     top: 0;
     transform: translate(var(--sidebar-width-inverted));
   }

--- a/templates/index.css
+++ b/templates/index.css
@@ -21,9 +21,10 @@
   --accent: var(--pink);
 
   /* Sizes */
-  --content-width: 680px;
+  --header-height: 60px;
   --sidebar-width: 240px;
   --sidebar-width-inverted: -240px;
+  --sidebar-top-height: 320px;
   --gap: 24px;
   --small-gap: calc(var(--gap) / 2);
   --tiny-gap: calc(var(--small-gap) / 2);
@@ -49,6 +50,11 @@ html {
   position: relative;
   min-height: 100vh;
   word-break: break-word;
+}
+
+html {
+  /* This is necessary so hash targets appear below the fixed header */
+  scroll-padding-top: 100px;
 }
 
 a,
@@ -102,23 +108,27 @@ p code {
 
 .page {
   display: flex;
-  justify-content: flex-start;
 }
 
 .content {
-  width: var(--content-width);
-  max-width: 100%;
-  padding: 0 var(--gap);
+  margin-left: var(--sidebar-width);
+  padding: calc(var(--header-height) + var(--gap)) var(--gap) 0 var(--gap);
+  width: calc(100% - var(--sidebar-width));
 }
 
 /* Page header */
 
 .page-header {
+  height: var(--header-height);
   color: black;
   color: var(--hard-black);
   background-color: var(--pink);
   padding: var(--small-gap) var(--gap);
   margin-bottom: var(--gap);
+  position: fixed;
+  left: 0px;
+  right: 0px;
+  top: 0px;
 }
 
 .page-header h2 {
@@ -136,11 +146,16 @@ p code {
 
 .sidebar {
   background-color: var(--background);
-  width: var(--sidebar-width);
-  padding: 0 var(--gap);
   font-size: 0.95rem;
   transition: transform 0.5s ease;
   z-index: 100;
+  max-height: calc(100vh - var(--header-height) - var(--gap));
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  top: calc(var(--header-height) + var(--gap));
+  width: var(--sidebar-width);
+  padding-left: var(--gap);
 }
 
 .sidebar h2 {
@@ -162,6 +177,18 @@ p code {
   display: none;
   transition: opacity 1s ease;
   opacity: 0;
+}
+
+.sidebar-top {
+  max-height: var(--sidebar-top-height);
+  position: relative;
+  overflow-y: auto;
+}
+
+.sidebar-bottom {
+  padding-top: var(--gap);
+  position: relative;
+  overflow-y: auto;
 }
 
 /* Module members (types, functions) */
@@ -246,12 +273,13 @@ p code {
 
   .content {
     width: unset;
+    margin-left: unset;
   }
 
   .sidebar {
-    padding: var(--gap);
-    position: absolute;
+    position: fixed;
     height: 100vh;
+    max-height: unset;
     top: 0;
     transform: translate(var(--sidebar-width-inverted));
     overflow: visible;
@@ -275,5 +303,13 @@ p code {
     left: calc(var(--small-gap) + var(--sidebar-width));
     height: var(--sidebar-toggle-size);
     width: var(--sidebar-toggle-size);
+  }
+
+  .sidebar-top {
+    padding-top: var(--gap);
+  }
+
+  .sidebar-bottom {
+    padding-top: var(--gap);
   }
 }

--- a/templates/index.css
+++ b/templates/index.css
@@ -24,7 +24,6 @@
   --header-height: 60px;
   --sidebar-width: 240px;
   --sidebar-width-inverted: -240px;
-  --sidebar-top-height: 320px;
   --gap: 24px;
   --small-gap: calc(var(--gap) / 2);
   --tiny-gap: calc(var(--small-gap) / 2);
@@ -147,15 +146,15 @@ p code {
 .sidebar {
   background-color: var(--background);
   font-size: 0.95rem;
-  transition: transform 0.5s ease;
-  z-index: 100;
   max-height: calc(100vh - var(--header-height) - var(--gap));
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  top: calc(var(--header-height) + var(--gap));
-  width: var(--sidebar-width);
+  overflow-y: auto;
+  padding-bottom: var(--gap);
   padding-left: var(--gap);
+  position: fixed;
+  top: calc(var(--header-height) + var(--gap));
+  transition: transform 0.5s ease;
+  width: var(--sidebar-width);
+  z-index: 100;
 }
 
 .sidebar h2 {
@@ -177,18 +176,6 @@ p code {
   display: none;
   transition: opacity 1s ease;
   opacity: 0;
-}
-
-.sidebar-top {
-  max-height: var(--sidebar-top-height);
-  position: relative;
-  overflow-y: auto;
-}
-
-.sidebar-bottom {
-  padding-top: var(--gap);
-  position: relative;
-  overflow-y: auto;
 }
 
 /* Module members (types, functions) */
@@ -277,12 +264,13 @@ p code {
   }
 
   .sidebar {
-    position: fixed;
     height: 100vh;
     max-height: unset;
+    overflow: visible;
+    padding-bottom: var(--gap);
+    padding-top: var(--gap);
     top: 0;
     transform: translate(var(--sidebar-width-inverted));
-    overflow: visible;
   }
 
   .sidebar:focus-within {
@@ -303,13 +291,5 @@ p code {
     left: calc(var(--small-gap) + var(--sidebar-width));
     height: var(--sidebar-toggle-size);
     width: var(--sidebar-toggle-size);
-  }
-
-  .sidebar-top {
-    padding-top: var(--gap);
-  }
-
-  .sidebar-bottom {
-    padding-top: var(--gap);
   }
 }


### PR DESCRIPTION
https://github.com/gleam-lang/gleam/issues/803

- This splits the left navigation in two panels. Each with an internal scrollbar.
- The header is fixed now. This is necessary so we have a known height for the navigation panels.

Wide looks like

<img width="588" alt="gleam:list - gleam_stdlib 2020-10-20 21-52-53" src="https://user-images.githubusercontent.com/1005498/96577384-45268b80-131f-11eb-923d-3329ccaf2d46.png">

Thin

<img width="379" alt="gleamlist - gleam_stdlib 2020-10-20 21-51-33" src="https://user-images.githubusercontent.com/1005498/96577438-5c657900-131f-11eb-94a2-b2134f6f0710.png">

<img width="422" alt="gleam:list - gleam_stdlib 2020-10-20 21-54-36" src="https://user-images.githubusercontent.com/1005498/96577448-5f606980-131f-11eb-84fd-068b9246f953.png">

