### PR TITLE
Bring back .content max-width in rendered HTML documentation

### DIFF
--- a/templates/index.css
+++ b/templates/index.css
@@ -21,6 +21,7 @@
   --accent: var(--pink);
 
   /* Sizes */
+  --content-width: 680px;
   --header-height: 60px;
   --sidebar-width: 240px;
   --sidebar-width-inverted: -240px;
@@ -113,6 +114,7 @@ p code {
   margin-left: var(--sidebar-width);
   padding: calc(var(--header-height) + var(--gap)) var(--gap) 0 var(--gap);
   width: calc(100% - var(--sidebar-width));
+  max-width: var(--content-width);
 }
 
 /* Page header */
@@ -263,6 +265,7 @@ p code {
 
   .content {
     width: unset;
+    max-width: unset;
     margin-left: unset;
   }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4972756/98039533-20eaa480-1e1f-11eb-9329-9579e5618f82.png)

After:
![image](https://user-images.githubusercontent.com/4972756/98039592-36f86500-1e1f-11eb-85d0-e7454146137f.png)

Closes #826 