### PR TITLE
Add language server support (#180)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,18 @@ dependencies = [
  "hermit-abi",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "auto_impl"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cbf586c80ada5e5ccdecae80d3ef0854f224e2dd74435f8d87e6831b8d0a38"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -243,12 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "chrono"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,10 +309,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.2"
+name = "const-random"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
+dependencies = [
+ "getrandom 0.2.0",
+ "proc-macro-hack",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -327,17 +356,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -347,19 +366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "const_fn",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -381,6 +388,17 @@ checksum = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
 dependencies = [
  "nix",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "num_cpus",
 ]
 
 [[package]]
@@ -486,7 +504,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -501,7 +519,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -519,7 +537,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -569,42 +587,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.5"
+name = "futures"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+
+[[package]]
+name = "futures-io"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
- "pin-project",
+ "memchr",
+ "pin-project 1.0.1",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -631,7 +693,18 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+dependencies = [
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -657,8 +730,6 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
- "lsp-server",
- "lsp-types",
  "petgraph",
  "pretty_assertions",
  "pulldown-cmark",
@@ -675,6 +746,7 @@ dependencies = [
  "termcolor",
  "tokio",
  "toml",
+ "tower-lsp",
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
@@ -811,7 +883,7 @@ dependencies = [
  "http-body",
  "httparse",
  "itoa",
- "pin-project",
+ "pin-project 0.4.23",
  "socket2",
  "time",
  "tokio",
@@ -850,7 +922,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -983,7 +1055,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
@@ -1000,26 +1072,14 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "lsp-server"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c85acaf36c53bf15da2b8b35afeea56747707261f59eb0b77229081dd72b04e"
-dependencies = [
- "crossbeam-channel",
- "log",
- "serde",
- "serde_json",
+ "cfg-if",
 ]
 
 [[package]]
 name = "lsp-types"
-version = "0.83.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e0bd4b95038f2c23bda332ba0ca684e8dda765db1f9bdb63dc4c3e01f3b456"
+checksum = "5e02724627e9ef8ba91f461ebc01d48aebbd13a4b7c9dc547a0a2890f53e2171"
 dependencies = [
  "base64",
  "bitflags",
@@ -1081,7 +1141,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1130,7 +1190,7 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "winapi 0.3.9",
 ]
@@ -1149,7 +1209,7 @@ checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "void",
 ]
@@ -1196,6 +1256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +1284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1280,7 +1350,16 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.23",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
 ]
 
 [[package]]
@@ -1288,6 +1367,17 @@ name = "pin-project-internal"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1367,10 +1457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.19"
+name = "proc-macro-nested"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -1427,7 +1523,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -1450,7 +1546,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
 ]
 
 [[package]]
@@ -1483,7 +1579,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -1595,7 +1691,7 @@ dependencies = [
  "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1775,7 +1871,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1868,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1895,7 +1991,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",
@@ -1991,6 +2087,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "slab",
 ]
@@ -2029,6 +2126,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-lsp"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75aeada84f07dfc4e81bc58a36a12b22c01c418af2180587cf80f9f3228acad"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "log",
+ "lsp-types",
+ "nom",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower-lsp-macros",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c51c24e3b5909be30d6ed472f934aa9b7d91abf2688013956b296b1d1e7b186"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,7 +2171,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "log",
  "tracing-attributes",
  "tracing-core",
@@ -2246,7 +2377,7 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -2273,7 +2404,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9021768bcce77296b64648cc7a7460e3df99979b97ed5c925c38d1cc83778d98"
+dependencies = [
+ "bytes",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +747,7 @@ dependencies = [
  "pretty_assertions",
  "pulldown-cmark",
  "regex",
+ "reqwest",
  "rpassword",
  "serde",
  "serde_derive",
@@ -1627,6 +1641,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +327,17 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -325,7 +347,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
@@ -452,7 +486,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -467,7 +501,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -485,7 +519,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -597,7 +631,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -623,6 +657,8 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
+ "lsp-server",
+ "lsp-types",
  "petgraph",
  "pretty_assertions",
  "pulldown-cmark",
@@ -630,6 +666,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_derive",
+ "serde_json",
  "strsim 0.10.0",
  "structopt",
  "strum",
@@ -813,7 +850,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "globset",
  "lazy_static",
  "log",
@@ -946,7 +983,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
 ]
@@ -963,7 +1000,33 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "lsp-server"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c85acaf36c53bf15da2b8b35afeea56747707261f59eb0b77229081dd72b04e"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.83.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0bd4b95038f2c23bda332ba0ca684e8dda765db1f9bdb63dc4c3e01f3b456"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -1018,7 +1081,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1067,7 +1130,7 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -1086,7 +1149,7 @@ checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -1151,7 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1532,7 +1595,7 @@ dependencies = [
  "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -1625,13 +1688,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1701,7 +1775,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1821,7 +1895,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -1966,7 +2040,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
  "tracing-attributes",
  "tracing-core",
@@ -2106,6 +2180,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2171,7 +2246,7 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -2198,7 +2273,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ tracing-subscriber = "0.2"
 tower-lsp = "0.13.3"
 # JSON parsing
 serde_json = "1.0.59"
+# HTTP client
+reqwest = { version = "0.10.8", features = ["blocking", "gzip"] }
 
 [build-dependencies]
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,11 @@ fs_extra = "1.1"
 # Logging
 tracing = "0.1"
 tracing-subscriber = "0.2"
+# Language server support
+lsp-server = "0.4.0"
+lsp-types = { version = "0.83.0", features = ["proposed"] }
+# JSON parsing
+serde_json = "1.0.59"
 
 [build-dependencies]
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hexpm = "1.1"
 # Allow user to type in sensitive information without showing it in the shell
 rpassword = "5.0"
 # Async runtime
-tokio = "0.2"
+tokio = { version = "0.2", features = ["io-std", "rt-threaded"] }
 # Creation of tar file archives
 tar = "0.4"
 # gzip compression
@@ -65,8 +65,7 @@ fs_extra = "1.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 # Language server support
-lsp-server = "0.4.0"
-lsp-types = { version = "0.83.0", features = ["proposed"] }
+tower-lsp = "0.13.3"
 # JSON parsing
 serde_json = "1.0.59"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,8 +144,6 @@ pub enum Error {
         name: String,
         reason: InvalidProjectNameReason,
     },
-
-    LSPError(String),
 }
 
 #[derive(Debug, PartialEq)]
@@ -1462,18 +1460,6 @@ but it cannot be found.",
                     label,
                 };
 
-                write_project(buffer, diagnostic);
-            }
-            Error::LSPError(err_string) => {
-                let diagnostic = ProjectErrorDiagnostic {
-                    title: "Language Server Error".to_string(),
-                    label: format!("There was a problem when running the language server.
-
-The error was:
-    {}",
-                        err_string
-                    ),
-                };
                 write_project(buffer, diagnostic);
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1469,7 +1469,8 @@ but it cannot be found.",
             Error::LspIoError { err } => {
                 let diagnostic = ProjectErrorDiagnostic {
                     title: "Language server failure".to_string(),
-                    label: format!("There was a problem starting the language server:
+                    label: format!(
+                        "There was a problem starting the language server:
                     
 The error given was:\n\n    {}\n",
                         std_io_error_kind_text(err),

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,10 @@ pub enum Error {
         name: String,
         reason: InvalidProjectNameReason,
     },
+
+    LspIoError {
+        err: std::io::ErrorKind,
+    },
 }
 
 #[derive(Debug, PartialEq)]
@@ -1460,6 +1464,17 @@ but it cannot be found.",
                     label,
                 };
 
+                write_project(buffer, diagnostic);
+            }
+            Error::LspIoError { err } => {
+                let diagnostic = ProjectErrorDiagnostic {
+                    title: "Language server failure".to_string(),
+                    label: format!("There was a problem starting the language server:
+                    
+The error given was:\n\n    {}\n",
+                        std_io_error_kind_text(err),
+                    ),
+                };
                 write_project(buffer, diagnostic);
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,8 @@ pub enum Error {
         name: String,
         reason: InvalidProjectNameReason,
     },
+
+    LSPError(String),
 }
 
 #[derive(Debug, PartialEq)]
@@ -1460,6 +1462,18 @@ but it cannot be found.",
                     label,
                 };
 
+                write_project(buffer, diagnostic);
+            }
+            Error::LSPError(err_string) => {
+                let diagnostic = ProjectErrorDiagnostic {
+                    title: "Language Server Error".to_string(),
+                    label: format!("There was a problem when running the language server.
+
+The error was:
+    {}",
+                        err_string
+                    ),
+                };
                 write_project(buffer, diagnostic);
             }
         }

--- a/src/language_server.rs
+++ b/src/language_server.rs
@@ -47,7 +47,7 @@ impl LanguageServer for ServerBackend {
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         // TODO: validate versioned changes
 
-        self.vfs.modify_document(&params.text_document.uri, |doc| doc.apply_content_changes(params.content_changes.clone()));
+        self.vfs.modify_document(&params.text_document.uri, |doc| doc.apply_content_changes(&params.content_changes));
     }
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         self.vfs.evict_document(&params.text_document.uri);

--- a/src/language_server.rs
+++ b/src/language_server.rs
@@ -1,0 +1,77 @@
+pub(crate) mod format;
+
+use crate::error::Error::LSPError;
+use crate::language_server::format::format_doc;
+
+use lsp_types::{
+    request::Formatting, InitializeParams, ServerCapabilities,
+};
+
+use lsp_server::{Connection, Message, Request, RequestId, Response};
+
+#[allow(unused_variables)]
+pub fn command(project_root: String) -> Result<(), crate::error::Error> {
+    match run_language_server() {
+        Ok(()) => Ok(()),
+        Err(e) => Err(LSPError(e.to_string())),
+    }
+}
+
+fn run_language_server() -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
+    tracing::info!("Starting language server");
+
+    let (connection, io_threads) = Connection::stdio();
+
+    let capabilities = serde_json::to_value(&ServerCapabilities::default()).unwrap();
+    let init_params_json = connection.initialize(capabilities)?;
+    let initialization_params = serde_json::from_value(init_params_json)?;
+
+    lsp_loop(&connection, &initialization_params)?;
+
+    io_threads.join()?;
+
+    tracing::info!("Shutting down language server");
+
+    Ok(())
+}
+
+#[allow(unused_variables)]
+fn lsp_loop(connection: &Connection, params: &InitializeParams) -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
+    for message in &connection.receiver {
+        match message {
+            Message::Request(request) => {
+                tracing::info!("Received request: {:?}", request);
+                if connection.handle_shutdown(&request)? {
+                    return Ok(())
+                }
+
+                match cast::<Formatting>(request) {
+                    Ok((id, params)) => {
+                        let result = format_doc(params.text_document, params.options);
+                        let result = serde_json::to_value(&result).unwrap();
+                        let response = Response { id, result: Some(result), error: None };
+                        connection.sender.send(Message::Response(response))?;
+                        continue;
+                    }
+                    Err(req) => req,
+                };
+            }
+            Message::Response(response) => {
+                tracing::info!("Received response: {:?}", response);
+            }
+            Message::Notification(notification) => {
+                tracing::info!("Received notification: {:?}", notification);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn cast<R>(req: Request) -> Result<(RequestId, R::Params), Request>
+where
+    R: lsp_types::request::Request,
+    R::Params: serde::de::DeserializeOwned,
+{
+    req.extract(R::METHOD)
+}

--- a/src/language_server.rs
+++ b/src/language_server.rs
@@ -1,16 +1,28 @@
-pub(crate) mod format;
+mod format;
 
 use crate::language_server::format::format;
 
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::runtime::Runtime;
 
 use tower_lsp::jsonrpc::{ Error, ErrorCode, Result };
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
+use std::sync::Arc;
+use std::sync::RwLock;
+
 #[derive(Debug)]
 struct ServerBackend {
     client: Client,
+
+    did_shutdown: Arc<RwLock<bool>>,
+}
+
+impl ServerBackend {
+    fn new(client: Client, did_shutdown: Arc<RwLock<bool>>) -> ServerBackend {
+        ServerBackend { client, did_shutdown }
+    }
 }
 
 #[tower_lsp::async_trait]
@@ -38,25 +50,55 @@ impl LanguageServer for ServerBackend {
         }
     }
     async fn shutdown(&self) -> Result<()> {
-        Ok(())
+        if let Ok(ref mut did_shutdown_ref) = self.did_shutdown.try_write() {
+            **did_shutdown_ref = true;
+            Ok(())
+        } else {
+            Err(Error { code: ErrorCode::InternalError, message: "Failed to lock did_shutdown_ref for writing".to_string(), data: None })
+        }
     }
 }
 
-pub fn command() -> std::result::Result<(), crate::error::Error> {
-
+// Runs the language server with the given input and output streams.
+// Returns true if the server shutdown safely before exiting, otherwise false.
+fn run_server<I,O>(stdin: I, stdout: O) -> bool
+where
+    I: AsyncRead + Unpin,
+    O: AsyncWrite,
+{
     let mut rt = Runtime::new().unwrap();
 
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
+    let did_shutdown = Arc::new(RwLock::new(false));
 
-    let (service, messages) = LspService::new(|client| ServerBackend { client });
+    let (service, messages) = LspService::new(|client| ServerBackend::new(client, did_shutdown.clone()));
 
     rt.block_on(async {
         Server::new(stdin, stdout)
                 .interleave(messages)
                 .serve(service)
                 .await;
-    });
+                
+        if let Ok(did_shutdown_value) = did_shutdown.read() {
+            *did_shutdown_value
+        } else {
+            // If read is not Ok, the lock is poisoned - writer panicked
+            // while the cell was locked for writing. We have to assume
+            // in that case that the shutdown failed.
 
-    Ok(())
+            false
+        }
+    })
+}
+
+pub fn command() -> std::result::Result<i32, crate::error::Error> {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+ 
+    let shutdown_before_exiting = run_server(stdin, stdout);
+
+    if shutdown_before_exiting {
+        Ok(0)
+    } else {
+        Ok(1)
+    }
 }

--- a/src/language_server.rs
+++ b/src/language_server.rs
@@ -2,14 +2,14 @@ mod document;
 mod format;
 mod vfs;
 
-use crate::error::Error::LspIoError;
 use self::format::format;
 use self::vfs::VFS;
+use crate::error::Error::LspIoError;
 
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::runtime::Runtime;
 
-use tower_lsp::jsonrpc::{ Error, ErrorCode, Result };
+use tower_lsp::jsonrpc::{Error, ErrorCode, Result};
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
@@ -26,7 +26,7 @@ struct ServerBackend {
 
 impl ServerBackend {
     fn new(client: Client, vfs: VFS, did_shutdown: Arc<RwLock<bool>>) -> ServerBackend {
-        ServerBackend { 
+        ServerBackend {
             client,
             vfs,
             did_shutdown,
@@ -42,27 +42,39 @@ impl LanguageServer for ServerBackend {
         Ok(result)
     }
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        self.vfs.create_document(&params.text_document.uri, &params.text_document.text);
+        self.vfs
+            .create_document(&params.text_document.uri, &params.text_document.text);
     }
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         // TODO: validate versioned changes
 
-        self.vfs.modify_document(&params.text_document.uri, |doc| doc.apply_content_changes(&params.content_changes));
+        self.vfs.modify_document(&params.text_document.uri, |doc| {
+            doc.apply_content_changes(&params.content_changes)
+        });
     }
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         self.vfs.evict_document(&params.text_document.uri);
     }
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         let doc_uri = params.text_document.uri;
-        
         let doc_contents = match self.vfs.get_document_contents(&doc_uri) {
             Ok(contents) => contents,
-            Err(io_error) => return Err(Error { code: ErrorCode::InternalError, message: io_error.to_string(), data: None }),
+            Err(io_error) => {
+                return Err(Error {
+                    code: ErrorCode::InternalError,
+                    message: io_error.to_string(),
+                    data: None,
+                })
+            }
         };
 
         match format(doc_contents) {
             Ok(x) => Ok(Some(x)),
-            Err(s) => Err(Error { code: ErrorCode::ParseError, message: s, data: None }),
+            Err(s) => Err(Error {
+                code: ErrorCode::ParseError,
+                message: s,
+                data: None,
+            }),
         }
     }
     async fn shutdown(&self) -> Result<()> {
@@ -70,14 +82,18 @@ impl LanguageServer for ServerBackend {
             **did_shutdown_ref = true;
             Ok(())
         } else {
-            Err(Error { code: ErrorCode::InternalError, message: "Failed to lock did_shutdown_ref for writing".to_string(), data: None })
+            Err(Error {
+                code: ErrorCode::InternalError,
+                message: "Failed to lock did_shutdown_ref for writing".to_string(),
+                data: None,
+            })
         }
     }
 }
 
 // Runs the language server with the given input and output streams.
 // Returns true if the server shutdown safely before exiting, otherwise false.
-fn run_server<I,O>(stdin: I, stdout: O) -> std::io::Result<bool>
+fn run_server<I, O>(stdin: I, stdout: O) -> std::io::Result<bool>
 where
     I: AsyncRead + Unpin,
     O: AsyncWrite,
@@ -88,14 +104,14 @@ where
 
     let vfs = VFS::new()?;
 
-    let (service, messages) = LspService::new(|client| ServerBackend::new(client, vfs, did_shutdown.clone()));
+    let (service, messages) =
+        LspService::new(|client| ServerBackend::new(client, vfs, did_shutdown.clone()));
 
     rt.block_on(async {
         Server::new(stdin, stdout)
-                .interleave(messages)
-                .serve(service)
-                .await;
-                
+            .interleave(messages)
+            .serve(service)
+            .await;
         if let Ok(did_shutdown_value) = did_shutdown.read() {
             Ok(*did_shutdown_value)
         } else {
@@ -111,7 +127,6 @@ where
 pub fn command() -> std::result::Result<i32, crate::error::Error> {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
- 
     let shutdown_before_exiting = match run_server(stdin, stdout) {
         Ok(b) => b,
         Err(err) => return Err(LspIoError { err: err.kind() }),

--- a/src/language_server/document.rs
+++ b/src/language_server/document.rs
@@ -14,7 +14,7 @@ impl Document {
         }
     }
 
-    pub fn apply_content_changes(&mut self, content_changes: Vec<TextDocumentContentChangeEvent>) {
+    pub fn apply_content_changes(&mut self, content_changes: &[TextDocumentContentChangeEvent]) {
         self.version += 1;
 
         self.contents = content_changes.iter().fold(self.contents().to_string(), |contents, change| apply_content_change(&contents,change));
@@ -166,5 +166,29 @@ mod test {
         let expected = "a\nb\n3, 4\ne";
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn apply_content_changes_second_insert_comes_first() {
+        let insert_pos = Position{
+            line: 0u64,
+            character: 0u64,
+        };
+        let change_1 = TextDocumentContentChangeEvent {
+            range: Some(Range { start: insert_pos, end: insert_pos }),
+            range_length: None,
+            text: "b".to_string(),
+        };
+        let change_2 = TextDocumentContentChangeEvent {
+            range: Some(Range { start: insert_pos, end: insert_pos }),
+            range_length: None,
+            text: "a".to_string(),
+        };
+        let mut original = Document::new("cdefg".to_string());
+        let expected = "abcdefg";
+        let changes = vec![change_1, change_2];
+        original.apply_content_changes(&changes);
+
+        assert_eq!(original.contents(), expected);
     }
 }

--- a/src/language_server/document.rs
+++ b/src/language_server/document.rs
@@ -17,7 +17,11 @@ impl Document {
     pub fn apply_content_changes(&mut self, content_changes: &[TextDocumentContentChangeEvent]) {
         self.version += 1;
 
-        self.contents = content_changes.iter().fold(self.contents().to_string(), |contents, change| apply_content_change(&contents,change));
+        self.contents = content_changes
+            .iter()
+            .fold(self.contents().to_string(), |contents, change| {
+                apply_content_change(&contents, change)
+            });
     }
 
     pub fn contents(&self) -> &str {
@@ -32,36 +36,33 @@ fn apply_content_change(contents: &str, change: &TextDocumentContentChangeEvent)
 
             let start_line = range.start.line as usize;
             let end_line = range.end.line as usize;
-        
             let start_col = range.start.character as usize;
             let end_col = range.end.character as usize;
-        
             let unchanged_init = lines[..start_line].join("\n");
-            let unchanged_tail = lines[end_line+1..].join("\n");
-        
+            let unchanged_tail = lines[end_line + 1..].join("\n");
             let changed_head = &lines[start_line][..start_col];
             let changed_last = &lines[end_line][end_col..];
-            
-            format!("{}{}{}{}{}{}{}",
+
+            format!(
+                "{}{}{}{}{}{}{}",
                 unchanged_init,
                 if unchanged_init.is_empty() { "" } else { "\n" },
                 changed_head,
                 change.text,
                 changed_last,
                 if unchanged_tail.is_empty() { "" } else { "\n" },
-                unchanged_tail)
-        },
-        None => {
-            change.text.clone()
+                unchanged_tail
+            )
         }
-    }    
+        None => change.text.clone(),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
 
-    use tower_lsp::lsp_types::{ Position, Range };
+    use tower_lsp::lsp_types::{Position, Range};
 
     #[test]
     fn apply_content_change_no_range_replaces_all_text() {
@@ -80,13 +81,16 @@ mod test {
 
     #[test]
     fn apply_content_change_empty_range_inserts_text() {
-        let comma_pos = Position{
+        let comma_pos = Position {
             line: 0u64,
             character: 5u64,
         };
 
         let change = TextDocumentContentChangeEvent {
-            range: Some(Range { start: comma_pos, end: comma_pos }),
+            range: Some(Range {
+                start: comma_pos,
+                end: comma_pos,
+            }),
             range_length: None,
             text: ",".to_string(),
         };
@@ -100,17 +104,20 @@ mod test {
 
     #[test]
     fn apply_content_change_empty_text_deletes_range() {
-        let comma_start = Position{
+        let comma_start = Position {
             line: 0u64,
             character: 5u64,
         };
-        let comma_end = Position{
+        let comma_end = Position {
             line: 0u64,
             character: 6u64,
         };
 
         let change = TextDocumentContentChangeEvent {
-            range: Some(Range { start: comma_start, end: comma_end }),
+            range: Some(Range {
+                start: comma_start,
+                end: comma_end,
+            }),
             range_length: None,
             text: "".to_string(),
         };
@@ -124,16 +131,19 @@ mod test {
 
     #[test]
     fn apply_content_change_replaces_range() {
-        let range_start = Position{
+        let range_start = Position {
             line: 0u64,
             character: 7u64,
         };
-        let range_end = Position{
+        let range_end = Position {
             line: 0u64,
             character: 12u64,
         };
         let change = TextDocumentContentChangeEvent {
-            range: Some(Range { start: range_start, end: range_end }),
+            range: Some(Range {
+                start: range_start,
+                end: range_end,
+            }),
             range_length: None,
             text: "everyone".to_string(),
         };
@@ -147,17 +157,20 @@ mod test {
 
     #[test]
     fn apply_content_change_replaces_range_multiline() {
-        let range_start = Position{
+        let range_start = Position {
             line: 2u64,
             character: 0u64,
         };
-        let range_end = Position{
+        let range_end = Position {
             line: 3u64,
             character: 1u64,
         };
 
         let change = TextDocumentContentChangeEvent {
-            range: Some(Range { start: range_start, end: range_end }),
+            range: Some(Range {
+                start: range_start,
+                end: range_end,
+            }),
             range_length: None,
             text: "3, 4".to_string(),
         };
@@ -170,17 +183,23 @@ mod test {
 
     #[test]
     fn apply_content_changes_second_insert_comes_first() {
-        let insert_pos = Position{
+        let insert_pos = Position {
             line: 0u64,
             character: 0u64,
         };
         let change_1 = TextDocumentContentChangeEvent {
-            range: Some(Range { start: insert_pos, end: insert_pos }),
+            range: Some(Range {
+                start: insert_pos,
+                end: insert_pos,
+            }),
             range_length: None,
             text: "b".to_string(),
         };
         let change_2 = TextDocumentContentChangeEvent {
-            range: Some(Range { start: insert_pos, end: insert_pos }),
+            range: Some(Range {
+                start: insert_pos,
+                end: insert_pos,
+            }),
             range_length: None,
             text: "a".to_string(),
         };

--- a/src/language_server/document.rs
+++ b/src/language_server/document.rs
@@ -37,18 +37,134 @@ fn apply_content_change(contents: &str, change: &TextDocumentContentChangeEvent)
             let end_col = range.end.character as usize;
         
             let unchanged_init = lines[..start_line].join("\n");
-            let unchanged_tail = lines[end_line..].join("\n");
+            let unchanged_tail = lines[end_line+1..].join("\n");
         
             let changed_head = &lines[start_line][..start_col];
             let changed_last = &lines[end_line][end_col..];
-
-            format!("{}{}{}{}{}", unchanged_init, changed_head, change.text, changed_last, unchanged_tail).to_string()
+            
+            format!("{}{}{}{}{}{}{}",
+                unchanged_init,
+                if unchanged_init.is_empty() { "" } else { "\n" },
+                changed_head,
+                change.text,
+                changed_last,
+                if unchanged_tail.is_empty() { "" } else { "\n" },
+                unchanged_tail)
         },
         None => {
             change.text.clone()
         }
+    }    
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use tower_lsp::lsp_types::{ Position, Range };
+
+    #[test]
+    fn apply_content_change_no_range_replaces_all_text() {
+        let change = TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: "Salut, tout la monde!".to_string(),
+        };
+
+        let original = "Hello, world!";
+        let result = apply_content_change(original, &change);
+        let expected = "Salut, tout la monde!";
+
+        assert_eq!(result, expected);
     }
 
+    #[test]
+    fn apply_content_change_empty_range_inserts_text() {
+        let comma_pos = Position{
+            line: 0u64,
+            character: 5u64,
+        };
 
-    
+        let change = TextDocumentContentChangeEvent {
+            range: Some(Range { start: comma_pos, end: comma_pos }),
+            range_length: None,
+            text: ",".to_string(),
+        };
+
+        let original = "Hello world!";
+        let result = apply_content_change(original, &change);
+        let expected = "Hello, world!";
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn apply_content_change_empty_text_deletes_range() {
+        let comma_start = Position{
+            line: 0u64,
+            character: 5u64,
+        };
+        let comma_end = Position{
+            line: 0u64,
+            character: 6u64,
+        };
+
+        let change = TextDocumentContentChangeEvent {
+            range: Some(Range { start: comma_start, end: comma_end }),
+            range_length: None,
+            text: "".to_string(),
+        };
+
+        let original = "Hello, world!";
+        let result = apply_content_change(original, &change);
+        let expected = "Hello world!";
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn apply_content_change_replaces_range() {
+        let range_start = Position{
+            line: 0u64,
+            character: 7u64,
+        };
+        let range_end = Position{
+            line: 0u64,
+            character: 12u64,
+        };
+        let change = TextDocumentContentChangeEvent {
+            range: Some(Range { start: range_start, end: range_end }),
+            range_length: None,
+            text: "everyone".to_string(),
+        };
+
+        let original = "Hello, world!";
+        let result = apply_content_change(original, &change);
+        let expected = "Hello, everyone!";
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn apply_content_change_replaces_range_multiline() {
+        let range_start = Position{
+            line: 2u64,
+            character: 0u64,
+        };
+        let range_end = Position{
+            line: 3u64,
+            character: 1u64,
+        };
+
+        let change = TextDocumentContentChangeEvent {
+            range: Some(Range { start: range_start, end: range_end }),
+            range_length: None,
+            text: "3, 4".to_string(),
+        };
+        let original = "a\nb\nc\nd\ne";
+        let result = apply_content_change(original, &change);
+        let expected = "a\nb\n3, 4\ne";
+
+        assert_eq!(result, expected);
+    }
 }

--- a/src/language_server/document.rs
+++ b/src/language_server/document.rs
@@ -1,0 +1,54 @@
+use tower_lsp::lsp_types::TextDocumentContentChangeEvent;
+
+#[derive(Debug)]
+pub struct Document {
+    version: i64,
+    contents: String,
+}
+
+impl Document {
+    pub fn new(contents: String) -> Self {
+        Document {
+            version: 0,
+            contents,
+        }
+    }
+
+    pub fn apply_content_changes(&mut self, content_changes: Vec<TextDocumentContentChangeEvent>) {
+        self.version += 1;
+
+        self.contents = content_changes.iter().fold(self.contents().to_string(), |contents, change| apply_content_change(&contents,change));
+    }
+
+    pub fn contents(&self) -> &str {
+        &self.contents
+    }
+}
+
+fn apply_content_change(contents: &str, change: &TextDocumentContentChangeEvent) -> String {
+    match change.range {
+        Some(range) => {
+            let lines: Vec<&str> = contents.lines().collect();
+
+            let start_line = range.start.line as usize;
+            let end_line = range.end.line as usize;
+        
+            let start_col = range.start.character as usize;
+            let end_col = range.end.character as usize;
+        
+            let unchanged_init = lines[..start_line].join("\n");
+            let unchanged_tail = lines[end_line..].join("\n");
+        
+            let changed_head = &lines[start_line][..start_col];
+            let changed_last = &lines[end_line][end_col..];
+
+            format!("{}{}{}{}{}", unchanged_init, changed_head, change.text, changed_last, unchanged_tail).to_string()
+        },
+        None => {
+            change.text.clone()
+        }
+    }
+
+
+    
+}

--- a/src/language_server/format.rs
+++ b/src/language_server/format.rs
@@ -1,0 +1,43 @@
+use lsp_types::{
+    Position, Range, TextDocumentIdentifier, FormattingOptions, TextEdit,
+};
+
+pub(crate) fn format_doc(doc: TextDocumentIdentifier, _options: FormattingOptions) -> Result<Vec<TextEdit>, String> {
+    if doc.uri.scheme() != "file" {
+        return Err("Invalid URI scheme".to_string());
+    }
+
+    let file_path = doc.uri.to_file_path().map_err(|_| "Invalid path")?;
+    let file_contents = std::fs::read_to_string(&file_path).map_err(|_| "File read error")?;
+
+    format(file_contents)
+}
+
+#[allow(dead_code)]
+pub(crate) fn format(src: String) -> Result<Vec<TextEdit>, String> {
+    let original = src;
+    let formatted = crate::format::pretty(&original).map_err(|_| "Parse error")?;
+
+    if original == formatted {
+        Ok (vec![])
+    } else {
+        // Temporary solution - just replace the entire document text with
+        // the formatted text in one go.
+        // Better solution - compute edit path and send vec of smaller edits?
+
+        let start_pos = Position { line: 0u64, character: 0u64 };
+        let end_pos = get_final_position(&formatted);
+        let whole_doc_range = Range { start: start_pos, end: end_pos };
+
+        Ok (vec![TextEdit{ range: whole_doc_range, new_text: formatted }])
+    }
+}
+
+#[allow(dead_code)]
+fn get_final_position(text: &str) -> Position {
+    let line_count = text.lines().fold(0u64, |acc, _| acc + 1u64);
+    let last_line_index = text.rfind("\n").unwrap_or(0usize);
+    let last_line_cols = text.len() - last_line_index;
+
+    Position { line: line_count - 1u64, character: last_line_cols as u64 }
+}

--- a/src/language_server/format.rs
+++ b/src/language_server/format.rs
@@ -1,7 +1,8 @@
-use lsp_types::{
+use tower_lsp::lsp_types::{
     Position, Range, TextDocumentIdentifier, FormattingOptions, TextEdit,
 };
 
+#[allow(dead_code)]
 pub(crate) fn format_doc(doc: TextDocumentIdentifier, _options: FormattingOptions) -> Result<Vec<TextEdit>, String> {
     if doc.uri.scheme() != "file" {
         return Err("Invalid URI scheme".to_string());
@@ -13,7 +14,6 @@ pub(crate) fn format_doc(doc: TextDocumentIdentifier, _options: FormattingOption
     format(file_contents)
 }
 
-#[allow(dead_code)]
 pub(crate) fn format(src: String) -> Result<Vec<TextEdit>, String> {
     let original = src;
     let formatted = crate::format::pretty(&original).map_err(|_| "Parse error")?;
@@ -33,7 +33,6 @@ pub(crate) fn format(src: String) -> Result<Vec<TextEdit>, String> {
     }
 }
 
-#[allow(dead_code)]
 fn get_final_position(text: &str) -> Position {
     let line_count = text.lines().fold(0u64, |acc, _| acc + 1u64);
     let last_line_index = text.rfind("\n").unwrap_or(0usize);

--- a/src/language_server/format.rs
+++ b/src/language_server/format.rs
@@ -2,18 +2,6 @@ use tower_lsp::lsp_types::{
     Position, Range, TextDocumentIdentifier, FormattingOptions, TextEdit,
 };
 
-#[allow(dead_code)]
-pub(crate) fn format_doc(doc: TextDocumentIdentifier, _options: FormattingOptions) -> Result<Vec<TextEdit>, String> {
-    if doc.uri.scheme() != "file" {
-        return Err("Invalid URI scheme".to_string());
-    }
-
-    let file_path = doc.uri.to_file_path().map_err(|_| "Invalid path")?;
-    let file_contents = std::fs::read_to_string(&file_path).map_err(|_| "File read error")?;
-
-    format(file_contents)
-}
-
 pub(crate) fn format(src: String) -> Result<Vec<TextEdit>, String> {
     let original = src;
     let formatted = crate::format::pretty(&original).map_err(|_| "Parse error")?;

--- a/src/language_server/format.rs
+++ b/src/language_server/format.rs
@@ -1,5 +1,5 @@
 use tower_lsp::lsp_types::{
-    Position, Range, TextDocumentIdentifier, FormattingOptions, TextEdit,
+    Position, Range, TextEdit,
 };
 
 pub(crate) fn format(src: String) -> Result<Vec<TextEdit>, String> {

--- a/src/language_server/format.rs
+++ b/src/language_server/format.rs
@@ -1,30 +1,40 @@
-use tower_lsp::lsp_types::{
-    Position, Range, TextEdit,
-};
+use tower_lsp::lsp_types::{Position, Range, TextEdit};
 
 pub(crate) fn format(src: String) -> Result<Vec<TextEdit>, String> {
     let original = src;
     let formatted = crate::format::pretty(&original).map_err(|_| "Parse error")?;
 
     if original == formatted {
-        Ok (vec![])
+        Ok(vec![])
     } else {
         // Temporary solution - just replace the entire document text with
         // the formatted text in one go.
         // Better solution - compute edit path and send vec of smaller edits?
 
-        let start_pos = Position { line: 0u64, character: 0u64 };
+        let start_pos = Position {
+            line: 0u64,
+            character: 0u64,
+        };
         let end_pos = get_final_position(&formatted);
-        let whole_doc_range = Range { start: start_pos, end: end_pos };
+        let whole_doc_range = Range {
+            start: start_pos,
+            end: end_pos,
+        };
 
-        Ok (vec![TextEdit{ range: whole_doc_range, new_text: formatted }])
+        Ok(vec![TextEdit {
+            range: whole_doc_range,
+            new_text: formatted,
+        }])
     }
 }
 
 fn get_final_position(text: &str) -> Position {
     let line_count = text.lines().fold(0u64, |acc, _| acc + 1u64);
-    let last_line_index = text.rfind("\n").unwrap_or(0usize);
+    let last_line_index = text.rfind('\n').unwrap_or(0usize);
     let last_line_cols = text.len() - last_line_index;
 
-    Position { line: line_count - 1u64, character: last_line_cols as u64 }
+    Position {
+        line: line_count - 1u64,
+        character: last_line_cols as u64,
+    }
 }

--- a/src/language_server/vfs.rs
+++ b/src/language_server/vfs.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::io;
+use std::io::ErrorKind;
+use std::sync::RwLock;
+
+use reqwest::blocking::Client;
+use tower_lsp::lsp_types::Url;
+
+#[derive(Debug)]
+pub struct VFS {
+    overlays: RwLock<HashMap<Url, String>>,
+
+    http_client: Client,
+}
+
+impl VFS {
+    pub fn new() -> io::Result<VFS> {
+        let client = Client::builder()
+            .gzip(true)
+            .build()
+            .map_err(categorise_reqwest_error)?;
+
+        Ok(
+            VFS {
+                overlays: RwLock::new(HashMap::new()),
+                http_client: client,
+            }
+        )
+    }
+
+    pub fn get_file_contents(&self, uri: &Url) -> io::Result<String> {
+        {
+            let hm = self.overlays.read().unwrap();
+
+            if let Some(contents) = hm.get(uri) {
+                return Ok(contents.clone());
+            };
+        }
+
+        let contents = self.read_file_from_uri(uri)?;
+        self.replace_file(uri, &contents);
+        Ok(contents)
+    }
+
+    pub fn replace_file(&self, uri: &Url, contents: &str) {
+        let mut hm = self.overlays.write().unwrap();
+        hm.insert(uri.clone(), contents.to_string());
+    }
+
+    fn read_file_from_uri(&self, uri: &Url) -> io::Result<String> {
+        let scheme = uri.scheme();
+    
+        if scheme == "file" {
+            if uri.host_str().unwrap_or("localhost") != "localhost" {
+                let contents = std::fs::read_to_string(uri.path())?;
+    
+                return Ok(contents);
+            } else {
+                return Err(io::Error::new(ErrorKind::AddrNotAvailable, "Remote host on file URI"));
+            };
+        };
+        
+        if scheme == "http" || scheme == "https" {
+            let response = self.http_client.get(uri.as_str()).send().map_err(categorise_reqwest_error)?;
+    
+            match response.error_for_status() {
+                Ok(res) => return res.text().map_err(categorise_reqwest_error),
+                Err(error) => return Err(categorise_reqwest_error(error)),
+            };
+        };
+        
+        Err(io::Error::new(ErrorKind::AddrNotAvailable, format!("Unsupported URI scheme: {}", scheme))) 
+    }
+}
+
+fn categorise_reqwest_error(error: reqwest::Error) -> io::Error {
+    if error.is_timeout() {
+        io::Error::new(ErrorKind::TimedOut, error)
+    } else if error.is_body() || error.is_decode() {
+        io::Error::new(ErrorKind::InvalidData, error)
+    } else if let Some(status) = error.status().map(|s| s.as_u16()) {
+        if status == 404 {
+            io::Error::new(ErrorKind::NotFound, error)
+        } else if status >= 401 && status <= 403 {
+            io::Error::new(ErrorKind::PermissionDenied, error)
+        } else {
+            io::Error::new(ErrorKind::Other, error)
+        }
+    } else {
+        io::Error::new(ErrorKind::Other, error)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #![allow(warnings)]
+
+    use super::*;
+
+    use std::error::Error;
+
+    type TestResult = Result<(), Box<dyn Error>>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,8 @@ enum Docs {
 fn main() {
     initialise_logger();
 
+    let mut exit_code = 0;
+
     let result = match Command::from_args() {
         Command::Build { project_root } => command_build(project_root),
 
@@ -233,12 +235,13 @@ fn main() {
 
         Command::Eunit { project_root } => eunit::command(project_root),
 
-        Command::LanguageServer => language_server::command(),
+        Command::LanguageServer => language_server::command().map(|code| { exit_code = code; }),
     };
 
     match result {
         Ok(_) => {
             tracing::info!("Successfully completed");
+            std::process::exit(exit_code);
         }
         Err(error) => {
             tracing::error!(error = ?error, "Failed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,10 +168,7 @@ enum Command {
         name = "language-server",
         about = "Start the Gleam language server",
     )]
-    LanguageServer {
-        #[structopt(help = "location of the project root", default_value = ".")]
-        project_root: String,
-    },
+    LanguageServer,
 }
 
 #[derive(StructOpt, Debug)]
@@ -236,7 +233,7 @@ fn main() {
 
         Command::Eunit { project_root } => eunit::command(project_root),
 
-        Command::LanguageServer { project_root } => language_server::command(project_root),
+        Command::LanguageServer => language_server::command(),
     };
 
     match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ mod error;
 mod eunit;
 mod format;
 mod fs;
+mod language_server;
 mod new;
 mod parser;
 mod pretty;
@@ -162,6 +163,15 @@ enum Command {
         #[structopt(help = "location of the project root", default_value = ".")]
         project_root: String,
     },
+
+    #[structopt(
+        name = "language-server",
+        about = "Start the Gleam language server",
+    )]
+    LanguageServer {
+        #[structopt(help = "location of the project root", default_value = ".")]
+        project_root: String,
+    },
 }
 
 #[derive(StructOpt, Debug)]
@@ -225,6 +235,8 @@ fn main() {
         Command::Shell { project_root } => shell::command(project_root),
 
         Command::Eunit { project_root } => eunit::command(project_root),
+
+        Command::LanguageServer { project_root } => language_server::command(project_root),
     };
 
     match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,10 +164,7 @@ enum Command {
         project_root: String,
     },
 
-    #[structopt(
-        name = "language-server",
-        about = "Start the Gleam language server",
-    )]
+    #[structopt(name = "language-server", about = "Start the Gleam language server")]
     LanguageServer,
 }
 
@@ -235,7 +232,9 @@ fn main() {
 
         Command::Eunit { project_root } => eunit::command(project_root),
 
-        Command::LanguageServer => language_server::command().map(|code| { exit_code = code; }),
+        Command::LanguageServer => language_server::command().map(|code| {
+            exit_code = code;
+        }),
     };
 
     match result {

--- a/test/language_server/messages/exit.txt
+++ b/test/language_server/messages/exit.txt
@@ -1,0 +1,6 @@
+Content-Length: 46
+
+{
+    "jsonrpc": "2.0",
+    "method": "exit"
+}

--- a/test/language_server/messages/format.txt
+++ b/test/language_server/messages/format.txt
@@ -1,0 +1,16 @@
+Content-Length: 280
+
+{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "textDocument/formatting",
+    "params": {
+        "textDocument": {
+            "uri": "file:///tmp/gleam_sample.gleam"
+        },
+        "options": {
+            "tabSize": 4,
+            "insertSpaces": true
+        }
+    }
+}

--- a/test/language_server/messages/initialize.txt
+++ b/test/language_server/messages/initialize.txt
@@ -1,0 +1,18 @@
+Content-Length: 319
+
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "processId": null,
+        "rootUri": null,
+        "capabilities": {
+            "textDocument": {
+                "formatting": {
+                    "dynamicRegistration": false
+                }
+            }
+        }
+    }
+}

--- a/test/language_server/messages/initialized.txt
+++ b/test/language_server/messages/initialized.txt
@@ -1,0 +1,6 @@
+Content-Length: 53
+
+{
+    "jsonrpc": "2.0",
+    "method": "initialized"
+}

--- a/test/language_server/messages/shutdown.txt
+++ b/test/language_server/messages/shutdown.txt
@@ -1,0 +1,7 @@
+Content-Length: 63
+
+{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "shutdown"
+}

--- a/test/language_server/run_langserv.sh
+++ b/test/language_server/run_langserv.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+cat > /tmp/gleam_sample.gleam <<EOF
+pub fn add(a, b) { a+b }
+
+pub fn main() {
+  1 |> add()
+}
+EOF
+
+content='{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "textDocument/formatting",
+    "params": {
+        "textDocument": {
+            "uri": "file:///tmp/gleam_sample.gleam"
+        },
+        "options": {
+            "tabSize": 4,
+            "insertSpaces": true
+        }
+    }
+}'
+
+message="Content-Length: ${#content}"$'\r\n\r\n'"$content"
+
+exec 3>&1
+(cat "messages/initialize.txt" && cat "messages/initialized.txt" && cat && cat "messages/shutdown.txt" && cat "messages/exit.txt") | (../../target/debug/gleam language-server 1>/tmp/gleam-language-server.log && echo "" && cat /tmp/gleam-language-server.log && rm /tmp/gleam-language-server.log)

--- a/test/language_server/test_format.sh
+++ b/test/language_server/test_format.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cat > /tmp/gleam_sample.gleam <<EOF
+pub fn add(a, b) { a+b }
+
+pub fn main() {
+  1 |> add()
+}
+EOF
+
+exec 3>&1
+sendMessages() {
+    cat "messages/initialize.txt";
+    cat "messages/initialized.txt";
+    cat "messages/format.txt";
+    cat "messages/shutdown.txt";
+    sleep 1;
+    cat "messages/exit.txt";
+}
+
+../../target/debug/gleam language-server < <(sendMessages) >&3


### PR DESCRIPTION
This PR adds the `language-server` command to the gleam tool (see issue #180)

The language server itself only has very minimal functionality but should be a good basis for future work.  However, I will not be continuing this code for a while, so I am submitting it here so that others can contribute.  It perhaps should have a separate branch while more functionality is added.

Currently, the language server supports:
* Basic functionality: initialization, shutdown, exit
* Text synchronisation notifications: didOpen, didChange, didClose
* Document formatting

At a minimum, I believe it should also have these features before being merged to main:
* Parse errors returned when applicable on didChange and formatting (publishDiagnostics)
* Syntax highlighting (documentColor)

Beyond this, it needs more testing.  This probably includes live integration testing via a language client in an editor such as VS Code, as well as further unit testing.

There is one known bug with the underlying library that could affect this in future - [tower-lsp#239](https://github.com/ebkalderon/tower-lsp/issues/239).  However, as the current implementation only supports standard input, this is bypassed by closing the input stream.