### PR TITLE
Treat lines with only spaces as empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The compiler can now discriminate between record access and module access
   for shadowed names
 - Check new project names against Erlang standard library modules to avoid clashes.
+- Formatter changed to treat lines with only spaces as empty.
 
 ## v0.12.0 - 2020-10-31
 

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -2623,6 +2623,20 @@ fn empty_lines() {
 "
     );
 
+    // Lines with only spaces are treated as empty
+    assert_format_rewrite!(
+        "pub fn main() {
+  let x = 1\n    \n  x
+}
+",
+        "pub fn main() {
+  let x = 1
+
+  x
+}
+"
+    );
+
     assert_format!(
         "pub fn main() {
   let inc = fn(a) { a + 1 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -184,12 +184,23 @@ fn chomp_newlines(
     comments: &mut ModuleComments<'_>,
     chars: &mut std::iter::Peekable<unicode_segmentation::GraphemeIndices<'_>>,
 ) {
-    if let Some((_, "\n")) | Some((_, "\r\n")) = chars.peek() {
-        comments.empty_lines.push(position + 1);
-        while let Some((_, grapheme @ "\r\n")) | Some((_, grapheme @ "\n")) = chars.peek() {
-            buffer.push_str(grapheme);
-            chars.next();
+    let mut found_new_line = false;
+    // Consume all spaces and new lines - mark this line as empty if we find at least one new line
+    // This considers a line to be empty if it only has spaces
+    while let Some((_, grapheme @ "\r\n"))
+    | Some((_, grapheme @ "\n"))
+    | Some((_, grapheme @ " ")) = chars.peek()
+    {
+        if let "\n" | "\r\n" = *grapheme {
+            found_new_line = true
         }
+
+        buffer.push_str(grapheme);
+        chars.next();
+    }
+
+    if found_new_line {
+        comments.empty_lines.push(position + 1);
     }
 }
 


### PR DESCRIPTION
I imagine this could use a test too but I wanted to see if it seemed acceptable. Manually tested with the code snippet #833.

----

We change the empty-line identifying logic to treat lines with only
spaces as also being empty. Previously they would not register as being
empty and then would be lost in the formatting as they have no
meaningful content.

As multiple empty lines are collapsed together this means that multiple
lines with nothing but spaces will also be collapsed together.

Closes #833 