### PR TITLE
Improve table styling in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   for shadowed names
 - Check new project names against Erlang standard library modules to avoid clashes.
 - Formatter changed to treat lines with only spaces as empty.
+- Improve clarity of HTML table display in documentation.
 
 ## v0.12.0 - 2020-10-31
 

--- a/templates/index.css
+++ b/templates/index.css
@@ -8,6 +8,7 @@
   --hot-pink: #d900b8;
   --white: #fff;
   --pink-white: #fff8fe;
+  --mid-grey: #dfe2e5;
   --light-grey: #f5f5f5;
   --boi-blue: #a6f0fc;
 
@@ -17,6 +18,8 @@
   --accented-background: var(--pink-white);
   --code-border: var(--pink);
   --code-background: var(--light-grey);
+  --table-border: var(--mid-grey);
+  --table-background: var(--pink-white);
   --links: var(--hot-pink);
   --accent: var(--pink);
 
@@ -205,6 +208,23 @@ p code {
 
 .constructor-name {
   margin-bottom: 0;
+}
+
+/* Tables */
+
+table {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+table td,
+table th {
+  padding: 6px 13px;
+  border: 1px solid var(--table-border);
+}
+
+table tr:nth-child(2n) {
+  background-color: var(--table-background);
 }
 
 /* Footer */


### PR DESCRIPTION
For tables created in markdown. Previously it was hard to see the
separate columns clearly due to the lack of spacing and borders.

This styling is heavily based on Github's table rendering but uses the
pink-white colouring for the alternate row background.

<img width="724" alt="Screenshot 2020-11-09 at 17 06 21" src="https://user-images.githubusercontent.com/5390/98572760-e5802800-22ad-11eb-9611-dc94f6ece533.png">

---

I worry about the top level `table` styles. It might be worth wrapping some kind of `rendered-markdown` class around all rendered markdown so that some of these styles can be scoped to just markdown areas. I'm not sure what the impacts of this change might be more generally. Are there other tables in the docs?