### PR TITLE
Add a 'source' link to the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Check new project names against Erlang standard library modules to avoid clashes.
 - Formatter changed to treat lines with only spaces as empty.
 - Improve clarity of HTML table display in documentation.
+- Provide example 'links' section in new gleam.toml files.
 
 ## v0.12.0 - 2020-10-31
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,10 @@ impl Default for BuildTool {
 
 #[derive(Deserialize, Default, Debug, PartialEq)]
 pub struct Docs {
+    #[serde(default)]
     pub pages: Vec<DocsPage>,
+    #[serde(default)]
+    pub links: Vec<DocsLink>,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]
@@ -43,6 +46,12 @@ pub struct DocsPage {
     pub title: String,
     pub path: String,
     pub source: PathBuf,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Clone)]
+pub struct DocsLink {
+    pub title: String,
+    pub href: String,
 }
 
 pub fn read_project_config(root: impl AsRef<Path>) -> Result<PackageConfig, Error> {

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -56,7 +56,15 @@ pub fn generate_html(
         })
         .collect::<Vec<_>>();
 
-    let links = &[];
+    let links = &project_config
+        .docs
+        .links
+        .iter()
+        .map(|doc_link| Link {
+            name: doc_link.title.clone(),
+            path: doc_link.href.clone(),
+        })
+        .collect::<Vec<Link>>()[..];
 
     // index.css
     let num_asset_files = 1;

--- a/src/new.rs
+++ b/src/new.rs
@@ -104,7 +104,16 @@ fn write(path: PathBuf, contents: &str) -> Result<(), Error> {
 }
 
 fn gleam_toml(name: &str) -> String {
-    format!("name = \"{}\"\n", name)
+    format!(
+        r#"name = "{}"
+
+# [docs]
+# links = [
+#   {{ title = 'GitHub', href = 'https://github.com/username/project_name' }}
+# ]
+"#,
+        name
+    )
 }
 
 fn readme(name: &str, description: &str) -> String {

--- a/templates/documentation_layout.html
+++ b/templates/documentation_layout.html
@@ -44,10 +44,10 @@
         {% endif %}
 
         {% if !links.is_empty() %}
-        <h2>Pages</h2>
+        <h2>Links</h2>
         <ul>
         {% for link in links %}
-          <li><a href="{{ unnest }}/{{ link.path }}">{{ link.name }}</a></li>
+          <li><a href="{{ link.path }}">{{ link.name }}</a></li>
         {% endfor %}
         </ul>
         {% endif %}


### PR DESCRIPTION
Provided that the project `gleam.toml` file provides a `repository` field that points to the source repository's webpage.

This provides a 'Source' link in the top right of the page at the end of the header. It is currently pink on pink which is no very accessible. We could change it to black but I wanted to validate the approach first.

Given that we're expecting the `repository` field to be an http(s) link it might make sense to use `repository_http` or `repository_web` or something. In case we'd like to have a ssh link or git protocol link as well. That said, Cargo seems to have used just "repository": https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field

I have no idea what I'm doing with strings and options and refs and everything. Hopefully there is a better way to do that.

Closes #842 