### PR TITLE
Link docs to source lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
 - Records defined in other modules can now be used in module constants.
+- Documentation can link from functions, types & constants to their source
+  code definitions on popular project hosting sites.
 
 ## v0.12.1 - 2020-11-15
 

--- a/src/build/erlang_code_generator.rs
+++ b/src/build/erlang_code_generator.rs
@@ -75,10 +75,7 @@ impl<'a> ErlangCodeGenerator<'a> {
             Some(module) => tuple("mod", format!("'{}'", module).as_str()),
         };
 
-        let version = match &self.config.version {
-            None => "".to_string(),
-            Some(version) => tuple("vsn", format!("\"{}\"", version).as_str()),
-        };
+        let version = tuple("vsn", format!("\"{}\"", &self.config.version).as_str());
 
         let mut modules: Vec<_> = self
             .modules

--- a/src/build/erlang_code_generator.rs
+++ b/src/build/erlang_code_generator.rs
@@ -75,8 +75,6 @@ impl<'a> ErlangCodeGenerator<'a> {
             Some(module) => tuple("mod", format!("'{}'", module).as_str()),
         };
 
-        let version = tuple("vsn", format!("\"{}\"", &self.config.version).as_str());
-
         let mut modules: Vec<_> = self
             .modules
             .iter()
@@ -91,7 +89,8 @@ impl<'a> ErlangCodeGenerator<'a> {
 
         let text = format!(
             r#"{{application, {package}, [
-{start_module}{version}    {{applications, [{applications}]}},
+{start_module}    {{vsn, "{version}"}},
+    {{applications, [{applications}]}},
     {{description, "{description}"}},
     {{modules, [{modules}]}},
     {{registered, []}},
@@ -102,7 +101,7 @@ impl<'a> ErlangCodeGenerator<'a> {
             modules = modules,
             package = self.config.name,
             start_module = start_module,
-            version = version,
+            version = self.config.version,
         );
 
         OutputFile { path, text }
@@ -110,5 +109,5 @@ impl<'a> ErlangCodeGenerator<'a> {
 }
 
 fn tuple(key: &str, value: &str) -> String {
-    format!("    {{{}, {}}}\n", key, value)
+    format!("    {{{}, {}}},\n", key, value)
 }

--- a/src/build/package_compilation_tests.rs
+++ b/src/build/package_compilation_tests.rs
@@ -40,7 +40,7 @@ fn package_app_file(modules: &[&str]) -> OutputFile {
     OutputFile {
         text: format!(
             r#"{{application, the_package, [
-    {{vsn, "1.1.0"}}
+    {{vsn, "1.1.0"}},
     {{applications, []}},
     {{description, "the description"}},
     {{modules, [{}]}},
@@ -1254,7 +1254,7 @@ fn config_compilation_test() {
         vec![],
         vec![OutputFile {
             text: r#"{application, the_package, [
-    {vsn, "1.0.0"}
+    {vsn, "1.0.0"},
     {applications, []},
     {description, ""},
     {modules, []},
@@ -1274,7 +1274,7 @@ fn config_compilation_test() {
         vec![],
         vec![OutputFile {
             text: r#"{application, the_package, [
-    {vsn, "1.3.5"}
+    {vsn, "1.3.5"},
     {applications, []},
     {description, ""},
     {modules, []},
@@ -1294,7 +1294,7 @@ fn config_compilation_test() {
         vec![],
         vec![OutputFile {
             text: r#"{application, the_package, [
-    {vsn, "1.0.0"}
+    {vsn, "1.0.0"},
     {applications, []},
     {description, "Very exciting"},
     {modules, []},
@@ -1322,7 +1322,7 @@ fn config_compilation_test() {
         vec![],
         vec![OutputFile {
             text: r#"{application, the_package, [
-    {vsn, "1.0.0"}
+    {vsn, "1.0.0"},
     {applications, [gleam_otp,
                     gleam_stdlib,
                     midas,

--- a/src/build/package_compilation_tests.rs
+++ b/src/build/package_compilation_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         project_root::ProjectRoot,
         Origin,
     },
-    config::{BuildTool, Docs, PackageConfig},
+    config::{BuildTool, Docs, PackageConfig, Repository},
     erl, typ,
 };
 use std::{path::PathBuf, sync::Arc};
@@ -17,8 +17,9 @@ macro_rules! assert_erlang_compile {
         let config = PackageConfig {
             dependencies: HashMap::new(),
             description: "the description".to_string(),
-            version: Some("1.1.0".to_string()),
+            version: "1.1.0".to_string(),
             name: "the_package".to_string(),
+            repository: Repository::None,
             docs: Default::default(),
             otp_start_module: None,
             tool: BuildTool::Gleam,
@@ -1239,8 +1240,9 @@ fn config_compilation_test() {
         PackageConfig {
             dependencies: HashMap::new(),
             description: "".to_string(),
-            version: None,
+            version: "1.0.0".to_string(),
             name: "the_package".to_string(),
+            repository: Repository::None,
             docs: Default::default(),
             otp_start_module: None,
             tool: BuildTool::Gleam,
@@ -1252,6 +1254,7 @@ fn config_compilation_test() {
         vec![],
         vec![OutputFile {
             text: r#"{application, the_package, [
+    {vsn, "1.0.0"}
     {applications, []},
     {description, ""},
     {modules, []},
@@ -1265,7 +1268,7 @@ fn config_compilation_test() {
 
     // Version is included if given
     let mut config = make_config();
-    config.version = Some("1.3.5".to_string());
+    config.version = "1.3.5".to_string();
     assert_config_compile!(
         config,
         vec![],
@@ -1291,6 +1294,7 @@ fn config_compilation_test() {
         vec![],
         vec![OutputFile {
             text: r#"{application, the_package, [
+    {vsn, "1.0.0"}
     {applications, []},
     {description, "Very exciting"},
     {modules, []},
@@ -1318,6 +1322,7 @@ fn config_compilation_test() {
         vec![],
         vec![OutputFile {
             text: r#"{application, the_package, [
+    {vsn, "1.0.0"}
     {applications, [gleam_otp,
                     gleam_stdlib,
                     midas,

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ impl Default for BuildTool {
 #[derive(Deserialize, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub enum Repository {
-    GitHub { url: String },
+    GitHub { user: String, repo: String },
     Other { url: String },
     None,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct PackageConfig {
     pub dependencies: HashMap<String, String>,
     #[serde(default)]
     pub otp_start_module: Option<String>,
+    #[serde(default)]
+    pub repository: Repository,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
@@ -30,6 +32,20 @@ pub enum BuildTool {
 impl Default for BuildTool {
     fn default() -> Self {
         Self::Other
+    }
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(tag = "type")]
+pub enum Repository {
+    GitHub { url: String },
+    Other { url: String },
+    None,
+}
+
+impl Default for Repository {
+    fn default() -> Self {
+        Self::None
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,9 @@ impl Default for BuildTool {
 #[serde(tag = "type")]
 pub enum Repository {
     GitHub { user: String, repo: String },
-    Other { url: String },
+    GitLab { user: String, repo: String },
+    BitBucket { user: String, repo: String },
+    Custom { url: String },
     None,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,7 @@ use std::path::{Path, PathBuf};
 #[derive(Deserialize, Debug, PartialEq, Default)]
 pub struct PackageConfig {
     pub name: String,
-    #[serde(default)]
-    pub version: Option<String>,
+    pub version: String,
     #[serde(default)]
     pub description: String,
     #[serde(default)]

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -100,7 +100,7 @@ pub fn generate_html(
             modules: &modules_links,
             project_name: &project_config.name,
             page_title: &project_config.name,
-            project_version: "", // TODO
+            project_version: &project_config.version,
             content: render_markdown(&content),
         };
 
@@ -126,7 +126,7 @@ pub fn generate_html(
             project_name: &project_config.name,
             page_title: &format!("{} - {}", name, project_config.name),
             module_name: name,
-            project_version: "", // TODO
+            project_version: &project_config.version,
             functions: {
                 let mut f: Vec<_> = module
                     .ast

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -115,7 +115,7 @@ pub fn generate_html(
         let name = module.name.join("/");
 
         // Read module src & create line number lookup structure
-        let source_links = source_links::build(&project_root, project_config, &module.path, &name);
+        let source_links = source_links::build(&project_root, project_config, &module);
 
         let template = ModuleTemplate {
             unnest: module.name.iter().map(|_| "..").intersperse("/").collect(),

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -114,37 +114,8 @@ pub fn generate_html(
         let name = module.name.join("/");
 
         // Read module src & create line number lookup structure
-        let src = std::fs::read_to_string(&module.path).unwrap_or_default();
-        let codespan_file = codespan_reporting::files::SimpleFile::new(name.clone(), src);
-
-        let source_url = |location: &SrcSpan| match &project_config.version {
-            Some(version) => match &project_config.repository {
-                Repository::GitHub { url } => {
-                    let start_line = codespan_file
-                        .line_index((), location.start)
-                        .unwrap_or_default()
-                        + 1;
-                    let end_line = codespan_file
-                        .line_index((), location.end)
-                        .unwrap_or_default()
-                        + 1;
-
-                    let relative_path = module
-                        .path
-                        .strip_prefix(&project_root)
-                        .map(|path| path.to_str())
-                        .unwrap_or_default()
-                        .unwrap_or_default();
-                    format!(
-                        "{}/blob/{}/{}#L{}-L{}",
-                        &url, &version, &relative_path, start_line, end_line,
-                    )
-                }
-                Repository::Other { url } => url.clone(),
-                Repository::None => "".to_string(),
-            },
-            None => "".to_string(),
-        };
+        let source_link_generator =
+            build_source_link_generator(&project_root, project_config, &module.path, &name);
 
         let template = ModuleTemplate {
             unnest: module.name.iter().map(|_| "..").intersperse("/").collect(),
@@ -161,7 +132,7 @@ pub fn generate_html(
                     .ast
                     .statements
                     .iter()
-                    .flat_map(|statement| function(source_url, &statement))
+                    .flat_map(|statement| function(&source_link_generator, &statement))
                     .collect();
                 f.sort();
                 f
@@ -200,8 +171,79 @@ pub fn generate_html(
     files
 }
 
+fn build_source_link_generator(
+    project_root: impl AsRef<Path>,
+    project_config: &PackageConfig,
+    module_path: &PathBuf,
+    name: &String,
+) -> Box<dyn SourceLinkGenerator> {
+    match (&project_config.version, &project_config.repository) {
+        (Some(version), Repository::GitHub { url }) => {
+            let relative_path = module_path
+                .strip_prefix(&project_root)
+                .map(|path| path.to_str())
+                .unwrap_or_default()
+                .unwrap_or_default();
+
+            let src = std::fs::read_to_string(&module_path).unwrap_or_default();
+            let codespan_file = codespan_reporting::files::SimpleFile::new(name.clone(), src);
+
+            Box::new(GitHubSourceLinkGenerator {
+                codespan_file,
+                relative_path: relative_path.to_string(),
+                url: url.clone(),
+                version: version.clone(),
+            })
+        }
+        // If we either don't have a version or aren't dealing with a GitHub repository then we
+        // can't generate source code links so we generate empty strings for the urls
+        _ => Box::new(EmptySourceLinkGenerator {}),
+    }
+}
+
+trait SourceLinkGenerator {
+    fn url(&self, location: &SrcSpan) -> String;
+}
+
+// Creates empty strings for the urls which are then ignored by the template
+struct EmptySourceLinkGenerator {}
+
+impl SourceLinkGenerator for EmptySourceLinkGenerator {
+    fn url(&self, _location: &SrcSpan) -> String {
+        String::new()
+    }
+}
+
+// Creates links to the GitHub repository with the #LN-LM anchor syntax for linking directly to a
+// range of line numbers
+struct GitHubSourceLinkGenerator {
+    codespan_file: codespan_reporting::files::SimpleFile<String, String>,
+    url: String,
+    version: String,
+    relative_path: String,
+}
+
+impl SourceLinkGenerator for GitHubSourceLinkGenerator {
+    fn url(&self, location: &SrcSpan) -> String {
+        let start_line = self
+            .codespan_file
+            .line_index((), location.start)
+            .unwrap_or_default()
+            + 1;
+        let end_line = self
+            .codespan_file
+            .line_index((), location.end)
+            .unwrap_or_default()
+            + 1;
+        format!(
+            "{}/blob/{}/{}#L{}-L{}",
+            &self.url, &self.version, &self.relative_path, start_line, end_line,
+        )
+    }
+}
+
 fn function<'a>(
-    source_url: impl Fn(&SrcSpan) -> String,
+    source_link_generator: &Box<dyn SourceLinkGenerator>,
     statement: &'a TypedStatement,
 ) -> Option<Function<'a>> {
     let mut formatter = format::Formatter::new();
@@ -218,7 +260,7 @@ fn function<'a>(
             name,
             signature: print(formatter.external_fn_signature(true, name, args, retrn)),
             documentation: markdown_documentation(doc),
-            source_url: source_url(location),
+            source_url: source_link_generator.url(location),
         }),
 
         Statement::Fn {
@@ -233,7 +275,7 @@ fn function<'a>(
             name,
             documentation: markdown_documentation(doc),
             signature: print(formatter.docs_fn_signature(true, name, args, ret.clone())),
-            source_url: source_url(location),
+            source_url: source_link_generator.url(location),
         }),
 
         _ => None,

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -106,18 +106,8 @@ pub fn generate_html(
     for module in modules {
         let name = module.name.join("/");
 
-        // Reconstruct path to module file
-        let mut extended_name = module.name.clone();
-        let last_element = extended_name.len() - 1;
-        extended_name[last_element] = extended_name[last_element].clone() + ".gleam";
-
-        let mut path = module.source_base_path.clone();
-        for segment in extended_name {
-            path.push(segment);
-        }
-
         // Read module src & create line number lookup structure
-        let src = std::fs::read_to_string(&path).unwrap_or_default();
+        let src = std::fs::read_to_string(&module.path).unwrap_or_default();
         let codespan_file = codespan_reporting::files::SimpleFile::new(name.clone(), src);
 
         let template = ModuleTemplate {

--- a/src/docs/source_links.rs
+++ b/src/docs/source_links.rs
@@ -52,8 +52,8 @@ pub fn build(
     project_config: &PackageConfig,
     module: &Analysed,
 ) -> Box<dyn SourceLinks> {
-    match (&project_config.version, &project_config.repository) {
-        (Some(version), Repository::GitHub { user, repo }) => {
+    match &project_config.repository {
+        Repository::GitHub { user, repo } => {
             let relative_path = module
                 .path
                 .strip_prefix(&project_root)
@@ -70,7 +70,7 @@ pub fn build(
                 codespan_file,
                 relative_path: relative_path.to_string(),
                 url: format!("https://github.com/{}/{}", &user, &repo),
-                version: version.clone(),
+                version: project_config.version.clone(),
             })
         }
         // If we either don't have a version or aren't dealing with a GitHub repository then we

--- a/src/docs/source_links.rs
+++ b/src/docs/source_links.rs
@@ -1,0 +1,77 @@
+use crate::{
+    ast::SrcSpan,
+    config::{PackageConfig, Repository},
+};
+use codespan_reporting::files::Files;
+use std::path::{Path, PathBuf};
+
+pub trait SourceLinks {
+    fn url(&self, location: &SrcSpan) -> Option<String>;
+}
+
+// Returns None for the urls which we can ignore in the template
+struct NoSourceLinks {}
+
+impl SourceLinks for NoSourceLinks {
+    fn url(&self, _location: &SrcSpan) -> Option<String> {
+        None
+    }
+}
+
+// Creates links to the GitHub repository with the #LN-LM anchor syntax for linking directly to a
+// range of line numbers
+struct GitHubSourceLinks {
+    codespan_file: codespan_reporting::files::SimpleFile<String, String>,
+    url: String,
+    version: String,
+    relative_path: String,
+}
+
+impl SourceLinks for GitHubSourceLinks {
+    fn url(&self, location: &SrcSpan) -> Option<String> {
+        let start_line = self
+            .codespan_file
+            .line_index((), location.start)
+            .unwrap_or_default()
+            + 1;
+        let end_line = self
+            .codespan_file
+            .line_index((), location.end)
+            .unwrap_or_default()
+            + 1;
+        Some(format!(
+            "{}/blob/{}/{}#L{}-L{}",
+            &self.url, &self.version, &self.relative_path, start_line, end_line,
+        ))
+    }
+}
+
+pub fn build(
+    project_root: impl AsRef<Path>,
+    project_config: &PackageConfig,
+    module_path: &PathBuf,
+    name: &String,
+) -> Box<dyn SourceLinks> {
+    match (&project_config.version, &project_config.repository) {
+        (Some(version), Repository::GitHub { url }) => {
+            let relative_path = module_path
+                .strip_prefix(&project_root)
+                .map(|path| path.to_str())
+                .unwrap_or_default()
+                .unwrap_or_default();
+
+            let src = std::fs::read_to_string(&module_path).unwrap_or_default();
+            let codespan_file = codespan_reporting::files::SimpleFile::new(name.clone(), src);
+
+            Box::new(GitHubSourceLinks {
+                codespan_file,
+                relative_path: relative_path.to_string(),
+                url: url.clone(),
+                version: version.clone(),
+            })
+        }
+        // If we either don't have a version or aren't dealing with a GitHub repository then we
+        // can't generate source code links
+        _ => Box::new(NoSourceLinks {}),
+    }
+}

--- a/src/docs/source_links.rs
+++ b/src/docs/source_links.rs
@@ -53,7 +53,7 @@ pub fn build(
     name: &String,
 ) -> Box<dyn SourceLinks> {
     match (&project_config.version, &project_config.repository) {
-        (Some(version), Repository::GitHub { url }) => {
+        (Some(version), Repository::GitHub { user, repo }) => {
             let relative_path = module_path
                 .strip_prefix(&project_root)
                 .map(|path| path.to_str())
@@ -66,7 +66,7 @@ pub fn build(
             Box::new(GitHubSourceLinks {
                 codespan_file,
                 relative_path: relative_path.to_string(),
-                url: url.clone(),
+                url: format!("https://github.com/{}/{}", &user, &repo),
                 version: version.clone(),
             })
         }

--- a/src/docs/tests.rs
+++ b/src/docs/tests.rs
@@ -44,6 +44,7 @@ pub fn complicated_fun(
         docs: Default::default(),
         tool: Default::default(),
         version: Default::default(),
+        repository: Default::default(),
         description: Default::default(),
         dependencies: Default::default(),
         otp_start_module: None,
@@ -51,7 +52,13 @@ pub fn complicated_fun(
 
     let analysed = crate::project::analysed(vec![input]).expect("Compilation failed");
 
-    let output_files = generate_html(&config, analysed.as_slice(), &[], &PathBuf::from("/docs"));
+    let output_files = generate_html(
+        PathBuf::from("."),
+        &config,
+        analysed.as_slice(),
+        &[],
+        &PathBuf::from("/docs"),
+    );
     let module_page = output_files
         .iter()
         .find(|page| page.path == PathBuf::from("/docs/test/index.html"))

--- a/src/error.rs
+++ b/src/error.rs
@@ -148,6 +148,11 @@ pub enum Error {
     UnableToFindProjectRoot {
         path: String,
     },
+
+    VersionDoesNotMatch {
+        toml_ver: String,
+        app_ver: String,
+    },
 }
 
 #[derive(Debug, PartialEq)]
@@ -269,6 +274,14 @@ and underscores.",
                 let diagnostic = ProjectErrorDiagnostic {
                     title: "Invalid project root".to_string(),
                     label: format!("We were unable to find the project root:\n\n  {}", path),
+                };
+                write_project(buffer, diagnostic);
+            }
+            Error::VersionDoesNotMatch { toml_ver, app_ver } => {
+                let diagnostic = ProjectErrorDiagnostic {
+                    title: "Version does not match".to_string(),
+                    label:
+                        format!("The version in gleam.toml \"{}\" does not match the version in your app.src file \"{}\"", toml_ver, app_ver),
                 };
                 write_project(buffer, diagnostic);
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,10 @@ pub enum Error {
         name: String,
         reason: InvalidProjectNameReason,
     },
+
+    UnableToFindProjectRoot {
+        path: String,
+    },
 }
 
 #[derive(Debug, PartialEq)]
@@ -258,6 +262,13 @@ with a lowercase latter and may only contain lowercase letters
 and underscores.",
                         }
                     ),
+                };
+                write_project(buffer, diagnostic);
+            }
+            Error::UnableToFindProjectRoot { path } => {
+                let diagnostic = ProjectErrorDiagnostic {
+                    title: "Invalid project root".to_string(),
+                    label: format!("We were unable to find the project root:\n\n  {}", path),
                 };
                 write_project(buffer, diagnostic);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,12 @@ fn main() {
     let result = match Command::from_args() {
         Command::Build { project_root } => command_build(project_root),
 
-        Command::Docs(Docs::Build { project_root, to }) => docs::command::build(project_root, to),
+        Command::Docs(Docs::Build { project_root, to }) => PathBuf::from(&project_root)
+            .canonicalize()
+            .map_err(|_| Error::UnableToFindProjectRoot {
+                path: project_root.clone(),
+            })
+            .and_then(|project_root| docs::command::build(project_root, to)),
 
         Command::Docs(Docs::Publish {
             project_root,

--- a/src/new.rs
+++ b/src/new.rs
@@ -104,8 +104,10 @@ fn write(path: PathBuf, contents: &str) -> Result<(), Error> {
 }
 
 fn gleam_toml(name: &str) -> String {
+    // version should match the one generated in app_src below
     format!(
         r#"name = "{}"
+version = "1.0.0"
 
 # [docs]
 # links = [
@@ -188,6 +190,7 @@ fn app_src(name: &str, description: &str, is_application: bool) -> String {
     } else {
         "".to_string()
     };
+    // Version should match the one generated in gleam_toml above
     format!(
         r#"{{application, {},
  [{{description, "{}"}},

--- a/src/project.rs
+++ b/src/project.rs
@@ -28,6 +28,7 @@ pub struct Input {
 pub struct Analysed {
     pub ast: TypedModule,
     pub name: Vec<String>,
+    pub path: PathBuf,
     pub origin: ModuleOrigin,
     pub type_info: typ::Module,
     pub source_base_path: PathBuf,
@@ -108,6 +109,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
         source_base_path: PathBuf,
         name_string: String,
         name: Vec<String>,
+        path: PathBuf,
         origin: ModuleOrigin,
         ast: TypedModule,
         warnings: Vec<Warning>,
@@ -151,6 +153,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
         compiled_modules.push(Out {
             name,
             name_string,
+            path,
             source_base_path,
             origin,
             ast,
@@ -164,6 +167,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
             let Out {
                 name,
                 source_base_path,
+                path,
                 name_string,
                 origin,
                 ast,
@@ -172,6 +176,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
             Analysed {
                 ast,
                 name,
+                path,
                 source_base_path,
                 origin,
                 type_info: modules_type_infos

--- a/src/project.rs
+++ b/src/project.rs
@@ -27,6 +27,7 @@ pub struct Input {
 #[derive(Debug, PartialEq)]
 pub struct Analysed {
     pub ast: TypedModule,
+    pub src: String,
     pub name: Vec<String>,
     pub path: PathBuf,
     pub origin: ModuleOrigin,
@@ -112,6 +113,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
         path: PathBuf,
         origin: ModuleOrigin,
         ast: TypedModule,
+        src: String,
         warnings: Vec<Warning>,
     }
 
@@ -157,6 +159,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
             source_base_path,
             origin,
             ast,
+            src,
             warnings,
         });
     }
@@ -171,10 +174,12 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
                 name_string,
                 origin,
                 ast,
+                src,
                 warnings,
             } = out;
             Analysed {
                 ast,
+                src,
                 name,
                 path,
                 source_base_path,

--- a/templates/documentation_module.html
+++ b/templates/documentation_module.html
@@ -95,11 +95,16 @@
  </a>
  {% for function in functions %}
  <div class="member">
-    <a href="#{{ function.name }}">
-      <h2 id="{{ function.name }}" class="member-name">
-        {{ function.name }}
+    <div class="member-name">
+      <h2 id="{{ function.name }}">
+        <a href="#{{ function.name }}">
+            {{ function.name }}
+        </a>
       </h2>
-    </a>
+      <a href="https://github.com/gleam-lang/http/blob/main/src/{{ module_name }}.gleam#L{{ function.start_line }}-L{{ function.end_line}}">
+        &lt;/&gt;
+      </a>
+    </div>
     <pre>{{ function.signature }}</pre>
     <div class="rendered-markdown">{{ function.documentation|safe }}</div>
   </div>

--- a/templates/documentation_module.html
+++ b/templates/documentation_module.html
@@ -41,11 +41,18 @@
 
   {% for typ in types %}
   <div class="member">
-    <a href="#{{ typ.name }}">
-      <h2 id="{{ typ.name }}" class="member-name">
-        {{ typ.name }}
+    <div class="member-name">
+      <h2 id="{{ typ.name }}">
+        <a href="#{{ typ.name }}">
+            {{ typ.name }}
+        </a>
       </h2>
-    </a>
+      {% if !typ.source_url.is_empty() %}
+      <a href="{{ typ.source_url }}">
+        &lt;/&gt;
+      </a>
+      {% endif %}
+    </div>
     <div class="custom-type-constructors">
       <div class="rendered-markdown">{{ typ.documentation|safe }}</div>
       <pre>{{ typ.definition }}</pre>
@@ -76,11 +83,18 @@
 
   {% for constant in constants %}
   <div class="member">
-    <a href="#{{ constant.name }}">
-      <h2 id="{{ constant.name }}" class="member-name">
-        {{ constant.name }}
+    <div class="member-name">
+      <h2 id="{{ constant.name }}">
+        <a href="#{{ constant.name }}">
+            {{ constant.name }}
+        </a>
       </h2>
-    </a>
+      {% if !constant.source_url.is_empty() %}
+      <a href="{{ constant.source_url }}">
+        &lt;/&gt;
+      </a>
+      {% endif %}
+    </div>
     <pre>{{ constant.definition }}</pre>
     <div class="rendered-markdown">{{ constant.documentation|safe }}</div>
   </div>

--- a/templates/documentation_module.html
+++ b/templates/documentation_module.html
@@ -101,9 +101,11 @@
             {{ function.name }}
         </a>
       </h2>
-      <a href="https://github.com/gleam-lang/http/blob/main/src/{{ module_name }}.gleam#L{{ function.start_line }}-L{{ function.end_line}}">
+      {% if !function.source_url.is_empty() %}
+      <a href="{{ function.source_url }}">
         &lt;/&gt;
       </a>
+      {% endif %}
     </div>
     <pre>{{ function.signature }}</pre>
     <div class="rendered-markdown">{{ function.documentation|safe }}</div>

--- a/templates/index.css
+++ b/templates/index.css
@@ -200,9 +200,19 @@ p code {
 }
 
 .member-name {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   border-left: 4px solid var(--accent);
   padding: var(--small-gap) var(--gap);
   background-color: var(--accented-background);
+}
+
+.member-name h2 {
+  margin: 0;
+}
+
+.member-name h2 a {
   color: var(--text);
 }
 

--- a/test/core_language/gleam.toml
+++ b/test/core_language/gleam.toml
@@ -1,2 +1,3 @@
 name = "core_language_tests"
+version = "0.7.0"
 


### PR DESCRIPTION
This is an attempt to explore having individual documentation entries link back to their source code in Github. Issues so far:

- ~~Reconstructing the module file path and~~ re-reading the source code. I've avoided adding more fields to structs to make them available in the docs code out of fear that it would impact the compilation itself but we can save work but passing references to the filename and source string through to this point.
- Not sure how to get the main Github URL to the doc page. Could look through the "links" in the `gleam.toml` and act if there is one called "GitHub" that references a "github.com" URL but perhaps we might benefit from moving to a `repository` entry in `gleam.toml` after all. **Edit**: I've experimented with this in a commit.
- ~~It might be sensible to only do this for release builds and so perhaps require that some kind of flags are passed to the `gleam docs build` command that suggest what tag to target on the Github side. It doesn't make sense to try if there are uncommitted changes in the repo or for general untagged releases, I imagine.~~ I'm using the `version` entry from the `gleam.toml` file.
- Should ideally work for other common git hosting solutions, eg. Gitlab, BitBucket, Gitea, SourceHut? Possibly can be delayed through due to the current size & spread of the Gleam community.
- It only does it for functions at the moment but that should be easy to extend to other entries.
- The `SrcSpan` `start` and `end` for functions seem to cover the function head and not the body so linking the start & end through to GitHub is slightly less satisfying than it could be as it only highlights the first line or two and not the whole body.

As ever, I don't really know what I'm doing with Rust with the language itself or the APIs so I'm sure there is lots to improve. 
