### PR TITLE
Variable names now only have 1st letter capitalized in erlang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Variable names now only have 1st letter capitalized when converted to erlang.
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -11,7 +11,7 @@ use crate::{
         ModuleValueConstructor, PatternConstructor, Type, ValueConstructor, ValueConstructorVariant,
     },
 };
-use heck::{CamelCase, SnakeCase};
+use heck::SnakeCase;
 use itertools::Itertools;
 use std::char;
 use std::default::Default;
@@ -74,10 +74,10 @@ impl<'a> Env<'a> {
             None => {
                 self.current_scope_vars.insert(name.clone(), 0);
                 self.erl_function_scope_vars.insert(name.clone(), 0);
-                name.to_camel_case().to_doc()
+                variable_name(name).to_doc()
             }
-            Some(0) => name.to_camel_case().to_doc(),
-            Some(n) => name.to_camel_case().to_doc().append("@").append(*n),
+            Some(0) => variable_name(name).to_doc(),
+            Some(n) => variable_name(name).to_doc().append("@").append(*n),
         }
     }
 
@@ -1238,6 +1238,14 @@ fn external_fun(name: &str, module: &str, fun: &str, arity: usize) -> Document {
         .append(atom(fun.to_string()))
         .append(format!("({}).", chars))
         .nest(INDENT)
+}
+
+fn variable_name(name: String) -> String {
+    let mut c = name.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().chain(c).collect(),
+    }
 }
 
 pub fn is_erlang_reserved_word(name: &str) -> bool {

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -492,8 +492,8 @@ fn create_user(user_id) { User(age: 22, id: user_id, name: "") }
         r#"-module(the_app).
 -compile(no_auto_import).
 
-create_user(UserId) ->
-    {user, UserId, <<""/utf8>>, 22}.
+create_user(User_id) ->
+    {user, User_id, <<""/utf8>>, 22}.
 "#,
     );
 
@@ -1333,8 +1333,8 @@ fn main() {
 
 main() ->
     Triple = {triple, 1, 2, 3},
-    {triple, TheA, _, _} = Triple,
-    TheA.
+    {triple, The_a, _, _} = Triple,
+    The_a.
 "#,
     );
 
@@ -1356,8 +1356,8 @@ fn main() {
 
 main() ->
     Triple = {triple, 1, 2, 3},
-    {triple, _, TheB, _} = Triple,
-    TheB.
+    {triple, _, The_b, _} = Triple,
+    The_b.
 "#,
     );
 
@@ -1379,8 +1379,8 @@ fn main() {
 
 main() ->
     Triple = {triple, 1, 2, 3},
-    {triple, TheA, _, TheC} = Triple,
-    TheC.
+    {triple, The_a, _, The_c} = Triple,
+    The_c.
 "#,
     );
 
@@ -1404,8 +1404,8 @@ fn main() {
 main() ->
     Triple = {triple, 1, 2, 3},
     case Triple of
-        {triple, _, TheB, _} ->
-            TheB
+        {triple, _, The_b, _} ->
+            The_b
     end.
 "#,
     );
@@ -1473,10 +1473,10 @@ fn main() {
 
 main() ->
     case {ok, 1} of
-        {error, GleamTryError} -> {error, GleamTryError};
+        {error, Gleam@try_error} -> {error, Gleam@try_error};
         {ok, A} ->
             case {ok, 2} of
-                {error, GleamTryError@1} -> {error, GleamTryError@1};
+                {error, Gleam@try_error@1} -> {error, Gleam@try_error@1};
                 {ok, B} ->
                     {ok, A + B}
             end
@@ -1812,15 +1812,15 @@ pub fn test() {
 -export([test/0]).
 
 test() ->
-    DuplicateName = 1,
+    Duplicate_name = 1,
     case 1 of
         1 ->
-            DuplicateName@1 = DuplicateName + 1,
-            DuplicateName@1;
+            Duplicate_name@1 = Duplicate_name + 1,
+            Duplicate_name@1;
 
         2 ->
-            DuplicateName@1 = DuplicateName + 1,
-            DuplicateName@1
+            Duplicate_name@1 = Duplicate_name + 1,
+            Duplicate_name@1
     end.
 "#,
     );
@@ -1840,11 +1840,11 @@ pub fn test() {
 
 test() ->
     case {ok, 1} of
-        {ok, DuplicateName} ->
-            DuplicateName;
+        {ok, Duplicate_name} ->
+            Duplicate_name;
 
-        {error, DuplicateName} ->
-            DuplicateName
+        {error, Duplicate_name} ->
+            Duplicate_name
     end.
 "#,
     );
@@ -1865,13 +1865,13 @@ pub fn test() {
 -export([test/0]).
 
 test() ->
-    DuplicateName = 1,
+    Duplicate_name = 1,
     case 1 of
-        1 when DuplicateName =:= 1 ->
-            DuplicateName;
+        1 when Duplicate_name =:= 1 ->
+            Duplicate_name;
 
-        2 when DuplicateName =:= 1 ->
-            DuplicateName
+        2 when Duplicate_name =:= 1 ->
+            Duplicate_name
     end.
 "#,
     );
@@ -1921,8 +1921,8 @@ fn main() {
 
 main() ->
     P = {person, <<"Quinn"/utf8>>, 27},
-    NewP = erlang:setelement(3, P, 28),
-    NewP.
+    New_p = erlang:setelement(3, P, 28),
+    New_p.
 "#,
     );
 
@@ -1942,8 +1942,8 @@ fn main() {
 
 main() ->
     P = {person, <<"Quinn"/utf8>>, 27},
-    NewP = erlang:setelement(3, P, erlang:element(3, P) + 1),
-    NewP.
+    New_p = erlang:setelement(3, P, erlang:element(3, P) + 1),
+    New_p.
 "#,
     );
 
@@ -1963,8 +1963,8 @@ fn main() {
 
 main() ->
     P = {person, <<"Quinn"/utf8>>, 27},
-    NewP = erlang:setelement(2, erlang:setelement(3, P, 28), <<"Riley"/utf8>>),
-    NewP.
+    New_p = erlang:setelement(2, erlang:setelement(3, P, 28), <<"Riley"/utf8>>),
+    New_p.
 "#,
     );
 
@@ -2119,6 +2119,31 @@ pub fn a() { A }",
 
 a() ->
     a.
+"
+    );
+}
+
+#[test]
+fn variable_name_underscores_preserved() {
+    assert_erl!(
+        "pub fn a(name_: String) -> String {
+    let name__ = name_
+    let name = name__
+    let one_1 = 1
+    let one1 = one_1
+    name
+}",
+        "-module(the_app).
+-compile(no_auto_import).
+
+-export([a/1]).
+
+a(Name_) ->
+    Name__ = Name_,
+    Name = Name__,
+    One_1 = 1,
+    One1 = One_1,
+    Name.
 "
     );
 }


### PR DESCRIPTION
Previously gleam was converting variable names to camel case when compiling from gleam to erlang. This causes ambiguity with certain valid gleam names on conversion to erlang names, see below for examples. With this PR, only the 1st letter of the variable name is capitalized when converting to erlang. This should be fine as valid gleam variable names are a subset of valid erlang variable names. Incidentally the old algorithm was also removing valid gleam and erlang characters like `@`, treating them as word breaks.


### Examples:

#### Before
| gleam | erlang|
|-|-|
|name_|Name|
|name__| Name|
|name|Name|
|one_1| One1|
|one1|One1|
|one_two_three|OneTwoThree|
|gleam@example|GleamExample|


#### Now
| gleam | erlang|
|-|-|
|name_|Name_|
|name__| Name__|
|name|Name|
|one_1| One_1|
|one1|One1|
|one_two_three|One_two_three|
|gleam@example|Gleam@example|


fixes #848 