### PR TITLE
Prevent double arrow from showing up in documentation version selector on Android

### DIFF
--- a/templates/index.css
+++ b/templates/index.css
@@ -148,6 +148,7 @@ p code {
   cursor: pointer;
   border: none;
   appearance: none;
+  -webkit-appearance: none;
   outline: 0px transparent;
   background-color: transparent;
   padding: 0.6rem 0.6rem;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4972756/99851747-e5223f80-2b7f-11eb-9b42-84ef1f18d861.png)

After:
![image](https://user-images.githubusercontent.com/4972756/99851859-1f8bdc80-2b80-11eb-9c7b-37c72831b749.png)
