### PR TITLE
Fix focusing sidebar toggle on Safari

### DIFF
--- a/templates/documentation_layout.html
+++ b/templates/documentation_layout.html
@@ -19,7 +19,7 @@
 
     <div class="page">
       <nav class="sidebar">
-        <a class="sidebar-toggle" href="#">
+        <a class="sidebar-toggle" href="#" tabindex="0">
           <svg
             aria-hidden="true"
             focusable="false"


### PR DESCRIPTION
closes #855

This is just a quick fix to allow the menu to be opened on mobile Safari. This (probably) does not fix all aspects of the sidebar menu being broken on mobile Safari. I don't have an iOS device but from my testing, once opened the menu will not be easy to close. I think this is progress, users can refresh when stuck inside the menu. But a better fix would still be welcome - maybe it's possible to sprinkle some more attributes to make mobile Safari happy, or maybe the menu will have to be re-done using a checkbox and sibling CSS styles (or javascript, IMO if necessary).