### PR TITLE
Lowercase the repository type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ impl Default for BuildTool {
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub enum Repository {
     GitHub { user: String, repo: String },
     GitLab { user: String, repo: String },


### PR DESCRIPTION
So that the config can have "github" and "bitbucket" instead of "GitHub"
and "BitBucket" as the latter feels less in the coding aesthetic.

(Again, very subjective.)