### PR TITLE
gleam format sorts imports alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- gleam format now sorts imports alphabetically
 - Variable names now only have 1st letter capitalized when converted to erlang.
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.

--- a/src/format.rs
+++ b/src/format.rs
@@ -85,11 +85,11 @@ impl<'a> Formatter<'a> {
         for statement in module.statements.iter() {
             let start = statement.location().start;
             match statement {
-                Statement::Import { .. } => {
+                Statement::Import { module, .. } => {
                     has_imports = true;
                     let comments = self.pop_comments(start);
                     let statement = self.statement(statement);
-                    imports.push(commented(statement, comments))
+                    imports.push((module, commented(statement, comments)))
                 }
 
                 _other => {
@@ -101,7 +101,8 @@ impl<'a> Formatter<'a> {
             }
         }
 
-        let imports = concat(imports.into_iter().intersperse(line()));
+        imports.sort_by(|(mod_l, _), (mod_r, _)| mod_l.cmp(mod_r));
+        let imports = concat(imports.into_iter().map(|(_, doc)| doc).intersperse(line()));
         let declarations = concat(declarations.into_iter().intersperse(lines(2)));
 
         let sep = if has_imports && has_declarations {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -20,7 +20,7 @@ fn imports() {
     assert_format!("import one\n");
     assert_format!("import one\nimport two\n");
     assert_format!("import one/two/three\n");
-    assert_format!("import one/two/three\nimport four/five\n");
+    assert_format!("import four/five\nimport one/two/three\n");
     assert_format!("import one.{fun, fun2, fun3}\n");
     assert_format!("import one.{One, Two, fun1, fun2}\n");
     assert_format!("import one.{main as entrypoint}\n");
@@ -41,14 +41,31 @@ fn imports() {
 }
 "
     );
+    assert_format_rewrite!(
+        "// comment for b_module
+import b_module
+// two lines of
+// comments for c_module
+import c_module
+// comment for a_module
+import a_module",
+        "// comment for a_module
+import a_module
+// comment for b_module
+import b_module
+// two lines of
+// comments for c_module
+import c_module
+"
+    )
 }
 
 #[test]
 fn multiple_statements_test() {
     assert_format!(
         r#"import one
-import two
 import three
+import two
 
 pub external type One
 


### PR DESCRIPTION
Not sure if this is something anyone but me wants but it was a low hanging fruit so I went for it.

`gleam format` will now sort imports alphabetically.

this:
```rust
// comment for b_module
import b_module
// two lines of
// comments for c_module
import c_module
// comment for a_module
import a_module
```

formats to:
```rust
// comment for a_module
import a_module
// comment for b_module
import b_module
// two lines of
// comments for c_module
import c_module
```