### PR TITLE
Mark source_url contents as safe

### DIFF
--- a/templates/documentation_module.html
+++ b/templates/documentation_module.html
@@ -48,7 +48,7 @@
         </a>
       </h2>
       {% if !typ.source_url.is_empty() %}
-      <a href="{{ typ.source_url }}">
+      <a href="{{ typ.source_url|safe }}">
         &lt;/&gt;
       </a>
       {% endif %}
@@ -90,7 +90,7 @@
         </a>
       </h2>
       {% if !constant.source_url.is_empty() %}
-      <a href="{{ constant.source_url }}">
+      <a href="{{ constant.source_url|safe }}">
         &lt;/&gt;
       </a>
       {% endif %}
@@ -116,7 +116,7 @@
         </a>
       </h2>
       {% if !function.source_url.is_empty() %}
-      <a href="{{ function.source_url }}">
+      <a href="{{ function.source_url|safe }}">
         &lt;/&gt;
       </a>
       {% endif %}


### PR DESCRIPTION
Otherwise they are escaped by the template engine and whilst firefox and maybe other browsers still handles the output, the urls look broken in the source code.

Sorry I failed to notice this before. I guess it also raises questions if anything in a gleam module name or project name can be unsafe for html but I image we don't allow modules called `javascript: fetch("./secure/details")` (or whatever scripting hacks look like.)