### PR TITLE
Infer constants before other statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   between `fn` and `(`.
 - Fixed a bug where the formatter would incorrectly remove blocks around some
   binary operators.
+- Constants can now be defined after they are used in functions
 
 ## v0.12.1 - 2020-11-15
 

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -366,8 +366,21 @@ pub fn infer_module(
     }
 
     // Infer the types of each statement in the module
+    // We first infer all the constants so they can be used in functions defined
+    // anywhere in the module.
     let mut statements = Vec::with_capacity(module.statements.len());
+    let mut not_consts = vec![];
     for statement in module.statements {
+        if matches!(statement, Statement::ModuleConstant { .. }) {
+            let statement =
+                infer_statement(statement, module_name, &mut hydrators, &mut environment)?;
+            statements.push(statement);
+        } else {
+            not_consts.push(statement)
+        }
+    }
+
+    for statement in not_consts {
         let statement = infer_statement(statement, module_name, &mut hydrators, &mut environment)?;
         statements.push(statement);
     }

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -64,7 +64,6 @@ macro_rules! assert_error {
 
 macro_rules! assert_module_infer {
     ($src:expr, $module:expr $(,)?) => {
-        // println!("\n\n\n\n\n\n{}", $src);
         let (src, _) = crate::parser::strip_extra($src);
         let ast = crate::grammar::ModuleParser::new()
             .parse(&src)
@@ -3203,6 +3202,15 @@ fn types_used_before_definition() {
         "pub type Y { Y(x: X) }
          pub external type X",
         vec![("Y", "fn(X) -> Y")],
+    );
+}
+
+#[test]
+fn consts_used_before_definition() {
+    assert_module_infer!(
+        "pub fn a() { b }
+        const b = 1",
+        vec![("a", "fn() -> Int")],
     );
 }
 


### PR DESCRIPTION
Not sure this is the preferred way to get this done. Happy to change it, or feel free to close this if it's off base!

This:
```rust
fn x() {
  a
}

fn z() {
  b + c
}

const a = 1
const b = 2
const c = 3
```

now compiles to this:
```erlang
x() ->
    1.

z() ->
    2 + 3.
```
fixes: #837 