### PR TITLE
Lex 1-1 as 1 - 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Constants can now be defined after they are used in functions
 - The parser has been rewitten from scratch, dramatically improving error 
   messages and compilation times.
+- `1-1` and `a-1` are now parsed as `1 - 1` and `a - 1`
 
 ## v0.12.1 - 2020-11-15
 

--- a/test/core_language/test/ints_test.gleam
+++ b/test/core_language/test/ints_test.gleam
@@ -11,3 +11,13 @@ pub fn bases_test() {
   should.equal(x, 15)
   should.equal(y, 15)
 }
+
+pub fn minus_lexing_test() {
+  // 1-1 should lex as 1 - 1
+  should.equal({1-1}, 0)
+  // a-1 should lex as a - 1
+  let a = 1
+  should.equal({a-1}, 0)
+  // 1- 1 should lex as 1 - 1
+  should.equal({1- 1}, 0)
+}


### PR DESCRIPTION
This partially covers the issues described in https://github.com/gleam-lang/gleam/issues/876

Namely this will now lex `1-1` as `1 - 1` and `a-1` as `a - 1` like so:
gleam:
```rust
fn a() {
  let a = 1-1
  let b = a-1
  b
}
```
erlang:
```erlang
a() ->
    A = 1 - 1,
    B = A - 1,
    B.
```


With float literal:
```
error: Type mismatch
  ┌─ /Users/a/Trash/parser_test/src/one.gleam:4:11
  │
4 │   let c = 1.0-1.0
  │           ^^^

Expected type:

    Int

Found type:

    Float
```
With float in variable:
```
error: Type mismatch
  ┌─ /Users/a/Trash/parser_test/src/one.gleam:5:3
  │
5 │   c-1.0
  │   ^

Expected type:

    Int

Found type:

    Float
```

Because this is done at the lexer level, the formater will also work accordingly and format this:
```rust
fn a() {
  let a = 1-1
  let b = a-1
  let c = 1.0
  c-1.0
  b
}
```
to this:
```rust
fn a() {
  let a = 1 - 1
  let b = a - 1
  let c = 1.0
  c - 1.0
  b
}
```

What this doesn't cover:
* anywhere else a `-` is seen with no whitespace before it, like `five()-1`
* things that still result in a term that is constructed that is never used like `1 -1`, that will result in an erlang compilation warning like `gen/test/ints_test.erl:16: a term is constructed, but never used `

Questions:
Is this the right place to put the tests for this?
How important is it that cases like `five()-1` be lexed as `five() - 1`
Is there some case I'm not thinking of where `name-1` should have a different behavior? Since dashes aren't allowed in names I don't think so.