### PR TITLE
Generate Erlang typespecs

### DIFF
--- a/schema.capnp
+++ b/schema.capnp
@@ -163,10 +163,6 @@ struct BitStringSegmentOption {
       value @17 :Constant;
       shortForm @18 :Bool;
     }
-
-    invalid :group {
-      label @19 :Text;
-    }
   }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -739,11 +739,6 @@ pub enum BitStringSegmentOption<Value> {
         value: Box<Value>,
         short_form: bool,
     },
-
-    Invalid {
-        location: SrcSpan,
-        label: String,
-    },
 }
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum SegmentOptionCategory {
@@ -752,7 +747,6 @@ pub enum SegmentOptionCategory {
     Signedness,
     Size,
     Unit,
-    Error,
 }
 
 impl<A> BitStringSegmentOption<A> {
@@ -774,8 +768,7 @@ impl<A> BitStringSegmentOption<A> {
             | BitStringSegmentOption::Little { location }
             | BitStringSegmentOption::Native { location }
             | BitStringSegmentOption::Size { location, .. }
-            | BitStringSegmentOption::Unit { location, .. }
-            | BitStringSegmentOption::Invalid { location, .. } => *location,
+            | BitStringSegmentOption::Unit { location, .. } => *location,
         }
     }
 
@@ -798,7 +791,6 @@ impl<A> BitStringSegmentOption<A> {
             BitStringSegmentOption::Native { .. } => SegmentOptionCategory::Endianness,
             BitStringSegmentOption::Size { .. } => SegmentOptionCategory::Size,
             BitStringSegmentOption::Unit { .. } => SegmentOptionCategory::Unit,
-            BitStringSegmentOption::Invalid { .. } => SegmentOptionCategory::Error,
         }
     }
 
@@ -821,7 +813,6 @@ impl<A> BitStringSegmentOption<A> {
             BitStringSegmentOption::Native { .. } => "native".to_string(),
             BitStringSegmentOption::Size { .. } => "size".to_string(),
             BitStringSegmentOption::Unit { .. } => "unit".to_string(),
-            BitStringSegmentOption::Invalid { label, .. } => label.clone(),
         }
     }
 }

--- a/src/bit_string.rs
+++ b/src/bit_string.rs
@@ -104,8 +104,6 @@ impl<T> BinaryTypeSpecifier<T> {
                         location: option.location(),
                     })
                 }
-
-                _ => Ok(bts),
             }
         })?;
 

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -8,7 +8,8 @@ use crate::{
     pretty::*,
     project::{self, Analysed},
     typ::{
-        ModuleValueConstructor, PatternConstructor, Type, ValueConstructor, ValueConstructorVariant,
+        ModuleValueConstructor, PatternConstructor, Type, TypeVar, ValueConstructor,
+        ValueConstructorVariant,
     },
     Result,
 };
@@ -77,10 +78,10 @@ impl<'a> Env<'a> {
             None => {
                 self.current_scope_vars.insert(name.clone(), 0);
                 self.erl_function_scope_vars.insert(name.clone(), 0);
-                variable_name(name).to_doc()
+                variable_name(&name).to_doc()
             }
-            Some(0) => variable_name(name).to_doc(),
-            Some(n) => variable_name(name).to_doc().append("@").append(*n),
+            Some(0) => variable_name(&name).to_doc(),
+            Some(n) => variable_name(&name).to_doc().append("@").append(*n),
         }
     }
 
@@ -142,30 +143,108 @@ pub fn record_definition(name: &str, fields: &[&str]) -> String {
 
 pub fn module(module: &TypedModule, writer: &mut impl Utf8Writer) -> Result<()> {
     let module_name = module.name.as_slice();
-    let exports = concat(
-        module
-            .statements
-            .iter()
-            .flat_map(|s| match s {
-                Statement::Fn {
-                    public: true,
-                    name,
-                    args,
-                    ..
-                } => Some((name.clone(), args.len())),
+    let mut exports = vec![];
+    let mut type_defs = vec![];
+    let mut type_exports = vec![];
+    for s in &module.statements {
+        match s {
+            Statement::Fn {
+                public: true,
+                name,
+                args,
+                ..
+            } => exports.push(atom(name.to_string()).append("/").append(args.len())),
+            Statement::ExternalFn {
+                public: true,
+                name,
+                args,
+                ..
+            } => exports.push(atom(name.to_string()).append("/").append(args.len())),
+            Statement::CustomType {
+                name,
+                parameters,
+                public,
+                constructors,
+                opaque,
+                ..
+            } => {
+                // Type Exports
+                if *public {
+                    type_exports.push(
+                        name.to_snake_case()
+                            .to_doc()
+                            .append("/")
+                            .append(parameters.len()),
+                    )
+                }
+                // Type definitions
+                let constructors = concat(
+                    constructors
+                        .iter()
+                        .map(|c| {
+                            // TODO more constructor stuff
+                            // {name, values, values, ...}
+                            let name = c.name.to_snake_case().to_doc();
+                            let constructor = if c.args.is_empty() {
+                                name
+                            } else {
+                                name.append(", ").append(concat(
+                                    c.args
+                                        .iter()
+                                        .map(|a| a.1.to_erlang_type_def())
+                                        .intersperse(", ".to_doc()),
+                                ))
+                            };
+                            "{".to_doc().append(constructor).append("}")
+                        })
+                        .intersperse(" | ".to_doc()),
+                )
+                .append(".");
+                let params = concat(
+                    parameters
+                        .iter()
+                        .map(|p| variable_name(p).to_doc())
+                        .intersperse(", ".to_doc()),
+                );
+                let doc = if *opaque { "-opaque " } else { "-type " }
+                    .to_doc()
+                    .append(name.to_snake_case())
+                    .append("(")
+                    .append(params)
+                    .append(") :: ")
+                    .append(constructors);
+                type_defs.push(doc);
+            }
 
-                Statement::ExternalFn {
-                    public: true,
-                    name,
-                    args,
-                    ..
-                } => Some((name.clone(), args.len())),
+            _ => {}
+        }
+    }
 
-                _ => None,
-            })
-            .map(|(n, a)| atom(n).append("/").append(a))
-            .intersperse(", ".to_doc()),
-    );
+    let exports = if exports.is_empty() {
+        nil()
+    } else {
+        "-export(["
+            .to_doc()
+            .append(concat(exports.into_iter().intersperse(", ".to_doc())))
+            .append("]).")
+            .append(lines(2))
+    };
+
+    let type_exports = if type_exports.is_empty() {
+        nil()
+    } else {
+        "-export_type(["
+            .to_doc()
+            .append(concat(type_exports.into_iter().intersperse(", ".to_doc())))
+            .append("]).")
+            .append(lines(2))
+    };
+
+    let type_defs = if type_defs.is_empty() {
+        nil()
+    } else {
+        concat(type_defs.into_iter().intersperse(line())).append(lines(2))
+    };
 
     let statements = concat(
         module
@@ -180,15 +259,9 @@ pub fn module(module: &TypedModule, writer: &mut impl Utf8Writer) -> Result<()> 
         .append(line())
         .append("-compile(no_auto_import).")
         .append(lines(2))
-        .append(if exports.is_nil() {
-            nil()
-        } else {
-            "-export(["
-                .to_doc()
-                .append(exports)
-                .append("]).")
-                .append(lines(2))
-        })
+        .append(exports)
+        .append(type_exports)
+        .append(type_defs)
         .append(statements)
         .append(line())
         .pretty_print(80, writer)
@@ -203,8 +276,18 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
         Statement::ModuleConstant { .. } => None,
 
         Statement::Fn {
-            args, name, body, ..
-        } => Some(mod_fun(name.as_ref(), args.as_slice(), body, module)),
+            args,
+            name,
+            body,
+            return_type,
+            ..
+        } => Some(mod_fun(
+            name.as_ref(),
+            args.as_slice(),
+            body,
+            module,
+            return_type,
+        )),
 
         Statement::ExternalFn { public: false, .. } => None,
         Statement::ExternalFn {
@@ -222,10 +305,33 @@ fn statement(statement: &TypedStatement, module: &[String]) -> Option<Document> 
     }
 }
 
-fn mod_fun(name: &str, args: &[TypedArg], body: &TypedExpr, module: &[String]) -> Document {
+fn mod_fun(
+    name: &str,
+    args: &[TypedArg],
+    body: &TypedExpr,
+    module: &[String],
+    return_type: &Arc<Type>,
+) -> Document {
     let mut env = Env::new(module);
+    // Type Spec
+    // pub type TypedArg = Arg<Arc<Type>>;
+    let return_spec = (&**return_type).to_erlang_type_spec();
+    let args_spec = concat(
+        args.iter()
+            .map(|a| (a.typ).to_erlang_type_spec())
+            .intersperse(", ".to_doc()),
+    );
+    let spec = "-spec "
+        .to_doc()
+        .append(name)
+        .append("(")
+        .append(args_spec)
+        .append(") -> ")
+        .append(return_spec)
+        .append(".")
+        .append(line());
 
-    atom(name.to_string())
+    spec.append(atom(name.to_string()))
         .append(fun_args(args, &mut env))
         .append(" ->")
         .append(line().append(expr(body, &mut env)).nest(INDENT).group())
@@ -1275,7 +1381,7 @@ fn external_fun(name: &str, module: &str, fun: &str, arity: usize) -> Document {
         .nest(INDENT)
 }
 
-fn variable_name(name: String) -> String {
+fn variable_name(name: &str) -> String {
     let mut c = name.chars();
     match c.next() {
         None => String::new(),
@@ -1379,4 +1485,164 @@ pub fn is_erlang_standard_library_module(name: &str) -> bool {
             | "win32reg"
             | "zip"
     )
+}
+
+impl TypeAst {
+    pub fn to_erlang_type_def(&self) -> Document {
+        // reference : https://erlang.org/doc/reference_manual/typespec.html
+        match self {
+            TypeAst::Var { name, .. } | TypeAst::Hole { name, .. } => variable_name(name).to_doc(),
+            TypeAst::Tuple { elems, .. } => "{"
+                .to_doc()
+                .append(concat(
+                    elems
+                        .iter()
+                        .map(|e| e.to_erlang_type_def())
+                        .intersperse(", ".to_doc()),
+                ))
+                .append("}"),
+
+            TypeAst::Constructor {
+                module, name, args, ..
+            } => {
+                let args = if args.is_empty() {
+                    nil()
+                } else {
+                    concat(
+                        args.iter()
+                            .map(|a| a.to_erlang_type_def())
+                            .intersperse(", ".to_doc()),
+                    )
+                };
+                if let Some(mod_name) = &module {
+                    let t = mod_name
+                        .clone()
+                        .to_doc()
+                        .append(".")
+                        .append(atom(name.clone()));
+                    if args.is_nil() {
+                        t.append("()")
+                    } else {
+                        t.append("(").append(args).append(")")
+                    }
+                } else {
+                    match name.as_str() {
+                        // TODO: more builtins ? Result?
+                        "Int" => "integer()".to_doc(),
+                        "String" => "string()".to_doc(),
+                        "Bool" => "boolean()".to_doc(),
+                        "Float" => "float()".to_doc(),
+                        "List" => "list(".to_doc().append(args).append(")"),
+                        _ => variable_name(name).to_doc(),
+                    }
+                }
+            }
+
+            TypeAst::Fn { args, retrn, .. } => {
+                let retrn = retrn.to_erlang_type_def();
+                let args = concat(
+                    args.iter()
+                        .map(|a| a.to_erlang_type_def())
+                        .intersperse(", ".to_doc()),
+                );
+                "fun(("
+                    .to_doc()
+                    .append(args)
+                    .append(") -> ")
+                    .append(retrn)
+                    .append(")")
+            }
+        }
+    }
+}
+
+impl Type {
+    pub fn to_erlang_type_spec(&self) -> Document {
+        tracing::trace!("spec_for_type: {:?}", &self);
+        match self {
+            Self::Var { typ } => match &*Arc::as_ref(typ).borrow() {
+                TypeVar::Generic { .. } => "any()".to_doc(),
+                TypeVar::Link { typ } => typ.to_erlang_type_spec(),
+                TypeVar::Unbound { .. } => "any()".to_doc(),
+            },
+            Self::App {
+                name, module, args, ..
+            } => {
+                if module.is_empty() {
+                    // built-ins
+                    // TODO: more builtins?
+                    match name.as_ref() {
+                        "Int" => "integer()".to_doc(),
+                        "String" => "binary()".to_doc(),
+                        "Bool" => "boolean()".to_doc(),
+                        "Float" => "float()".to_doc(),
+                        "List" => {
+                            let arg0 = args[0].to_erlang_type_spec();
+                            "list(".to_doc().append(arg0).append(")")
+                        }
+                        "Result" => {
+                            let arg0 = args[0].to_erlang_type_spec();
+                            let arg1 = args[1].to_erlang_type_spec();
+                            "{ok, "
+                                .to_doc()
+                                .append(arg0)
+                                .append("} | {error, ")
+                                .append(arg1)
+                                .append("}")
+                        }
+                        name => name.to_snake_case().to_doc().append("()"),
+                    }
+                } else {
+                    let args = concat(
+                        args.iter()
+                            .map(|a| a.to_erlang_type_spec())
+                            .intersperse(", ".to_doc()),
+                    );
+                    let mod_name = concat(
+                        module
+                            .iter()
+                            .map(|m| m.to_snake_case().to_doc())
+                            .intersperse(".".to_doc()),
+                    );
+
+                    mod_name
+                        .append(":")
+                        .append(name.to_snake_case())
+                        .append("(")
+                        .append(args)
+                        .append(")")
+                }
+            }
+
+            Self::Fn {
+                args,  //: Vec<Arc<Type>>,
+                retrn, //: Arc<Type>,
+            } => {
+                let args = concat(
+                    args.iter()
+                        .map(|a| a.to_erlang_type_spec())
+                        .intersperse(", ".to_doc()),
+                );
+                let retrn = retrn.to_erlang_type_spec();
+                "fun(("
+                    .to_doc()
+                    .append(args)
+                    .append(") -> ")
+                    .append(retrn)
+                    .append(")")
+            }
+
+            Self::Tuple {
+                elems, //Vec<Arc<Type>>,
+            } => {
+                let elems = concat(
+                    elems
+                        .iter()
+                        .map(|e| e.to_erlang_type_spec())
+                        .intersperse(", ".to_doc()),
+                );
+                "{".to_doc().append(elems).append("}")
+            }
+        }
+    }
 }

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -429,7 +429,6 @@ where
     };
 
     options.iter().for_each(|option| match option {
-        BitStringSegmentOption::Invalid { .. } => (),
         BitStringSegmentOption::Integer { .. } => others.push("integer"),
         BitStringSegmentOption::Float { .. } => others.push("float"),
         BitStringSegmentOption::Binary { .. } => others.push("binary"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1240,26 +1240,6 @@ at the end of a bin pattern",
                     .unwrap();
                 }
 
-                TypeError::InvalidBinarySegmentOption { label, location } => {
-                    let diagnostic = Diagnostic {
-                        title: "Invalid bit string segment option".to_string(),
-                        label: "specified here".to_string(),
-                        file: path.to_str().unwrap().to_string(),
-                        src: src.to_string(),
-                        location: *location,
-                    };
-                    write(buffer, diagnostic, Severity::Error);
-                    writeln!(
-                        buffer,
-                        "{} is not a valid option for a bit string segment.
-Valid options are: binary, int, float, bit_string,
-utf8, utf16, utf32, utf8_codepoint, utf16_codepoint, utf32_codepoint,
-signed, unsigned, big, little, native, size, unit",
-                        label
-                    )
-                    .unwrap();
-                }
-
                 TypeError::RecordUpdateInvalidConstructor { location } => {
                     let diagnostic = Diagnostic {
                         title: "Invalid record constructor".to_string(),

--- a/src/format.rs
+++ b/src/format.rs
@@ -1519,8 +1519,6 @@ where
     ToDoc: FnMut(&Value) -> Document,
 {
     match option {
-        BitStringSegmentOption::Invalid { label, .. } => label.clone().to_doc(),
-
         BitStringSegmentOption::Binary { .. } => "binary".to_doc(),
         BitStringSegmentOption::Integer { .. } => "int".to_doc(),
         BitStringSegmentOption::Float { .. } => "float".to_doc(),

--- a/src/metadata/module_builder.rs
+++ b/src/metadata/module_builder.rs
@@ -290,8 +290,6 @@ impl<'a> ModuleBuilder<'a> {
                 self.build_constant(builder.reborrow().init_value(), value);
                 builder.set_short_form(*short_form);
             }
-
-            Opt::Invalid { label, .. } => builder.init_invalid().set_label(label),
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2065,10 +2065,10 @@ where
                             value: Box::new(value),
                             short_form: false,
                         })),
-                        _ => Ok(Some(BitStringSegmentOption::Invalid {
-                            label: name,
-                            location: SrcSpan { start, end },
-                        })),
+                        _ => parse_error(
+                            ParseErrorType::InvalidBitStringSegment,
+                            SrcSpan { start, end },
+                        ),
                     }
                 } else {
                     str_to_bit_string_segment_option(&name, SrcSpan { start, end })

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -984,10 +984,6 @@ where
     Typer: FnMut(UntypedValue, Arc<Type>) -> Result<TypedValue, Error>,
 {
     match segment_option {
-        BitStringSegmentOption::Invalid {
-            label, location, ..
-        } => Err(Error::InvalidBinarySegmentOption { label, location }),
-
         BitStringSegmentOption::Size {
             value,
             location,

--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -209,11 +209,6 @@ pub enum Error {
         location: SrcSpan,
     },
 
-    InvalidBinarySegmentOption {
-        location: SrcSpan,
-        label: String,
-    },
-
     UnexpectedTypeHole {
         location: SrcSpan,
     },


### PR DESCRIPTION
Draft code for generating Erlang typespecs. Looking for feedback on anything in general but also specifically:
* Hows the code structure look?
* How's the usage of `pretty::` functions look?
* How do the generated type specs look?
* Anyone willing to give this a try on a project, run the dializer and report back?
* Does gleam want a compiler flag to turn these on and off?

Tests aren't passing because I haven't factored the typespecs in yet.

<hr>

#### Example

This Gleam:
```rust
pub type A {
  A
  B(String)
  C(tuple(Int, Float))
  F(fn(String) -> Int)
}

fn a() {
  C(tuple(1, 1.0))
}

fn aa() {
  B
}

pub opaque type X(a) {
  X(a)
}

fn x(a) {
  X(a)
}

fn xx() {
  X
}

fn r() {
  case True {
    True -> Ok(1)
    False -> Error(False)
  }
}
```

results in this erlang:
```erlang
-module(one).
-compile(no_auto_import).

-export_type([a/0, x/1]).

-type a() :: {a} | {b, string()} | {c, {integer(), float()}} | {f, fun((string()) -> integer())}.
-opaque x(A) :: {x, A}.

-spec a() -> one:a().
a() ->
    {c, {1, 1.0}}.

-spec aa() -> fun((binary()) -> one:a()).
aa() ->
    fun(A) -> {b, A} end.

-spec x(any()) -> one:x(any()).
x(A) ->
    {x, A}.

-spec xx() -> fun((any()) -> one:x(any())).
xx() ->
    fun(A) -> {x, A} end.

-spec r() -> {ok, integer()} | {error, boolean()}.
r() ->
    case true of
        true ->
            {ok, 1};

        false ->
            {error, false}
    end.
```

The only erlang errors on compilation are of unused functions... so that's good.

maybe closes: #632 