### PR TITLE
Warn on unused literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "gleam"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "askama",
  "atty",

--- a/src/ast/untyped.rs
+++ b/src/ast/untyped.rs
@@ -159,6 +159,10 @@ impl UntypedExpr {
     pub fn is_simple_constant(&self) -> bool {
         matches!(self, Self::String { .. } | Self::Int { .. } | Self::Float { .. })
     }
+
+    pub fn is_literal(&self) -> bool {
+        matches!(self, Self::Int {..} | Self::Float {..} | Self::ListNil {..} | Self::ListCons {..} | Self::Tuple {..} | Self::String {.. } | Self::BitString {..})
+    }
 }
 
 impl HasLocation for UntypedExpr {

--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -225,6 +225,8 @@ pub enum Warning {
 
     ImplicitlyDiscardedResult { location: SrcSpan },
 
+    UnusedLiteral { location: SrcSpan },
+
     NoFieldsRecordUpdate { location: SrcSpan },
 
     AllFieldsRecordUpdate { location: SrcSpan },

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -339,7 +339,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
     }
 
     fn infer_seq(&mut self, first: UntypedExpr, then: UntypedExpr) -> Result<TypedExpr, Error> {
-        if first.is_simple_constant() {
+        if first.is_literal() {
             self.environment.warnings.push(Warning::UnusedLiteral {
                 location: first.location(),
             });

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -339,19 +339,21 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
     }
 
     fn infer_seq(&mut self, first: UntypedExpr, then: UntypedExpr) -> Result<TypedExpr, Error> {
+        if first.is_simple_constant() {
+            self.environment.warnings.push(Warning::UnusedLiteral {
+                location: first.location(),
+            });
+        }
+
         let first = self.infer(first)?;
         let then = self.infer(then)?;
 
-        match first.typ().as_ref() {
-            typ if typ.is_result() => {
-                self.environment
-                    .warnings
-                    .push(Warning::ImplicitlyDiscardedResult {
-                        location: first.location(),
-                    });
-            }
-
-            _ => {}
+        if first.typ().as_ref().is_result() {
+            self.environment
+                .warnings
+                .push(Warning::ImplicitlyDiscardedResult {
+                    location: first.location(),
+                });
         }
 
         Ok(TypedExpr::Seq {

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -3112,6 +3112,64 @@ fn main() { let _ = foo(); 5 }",
 }
 
 #[test]
+fn unused_literal_warning_test() {
+    // Test int
+    assert_warning!(
+        "fn main() { 1; 2 }",
+        Warning::UnusedLiteral {
+            location: SrcSpan { start: 12, end: 13 }
+        }
+    );
+    // Test float
+    assert_warning!(
+        "fn main() { 1.0; 2 }",
+        Warning::UnusedLiteral {
+            location: SrcSpan { start: 12, end: 15 }
+        }
+    );
+    // Test string
+    assert_warning!(
+        "
+    fn main() { 
+        \"1\"; 2 
+    }",
+        Warning::UnusedLiteral {
+            location: SrcSpan { start: 26, end: 29 }
+        }
+    );
+    // Test bit string
+    assert_warning!(
+        "
+    fn main() { 
+        <<3>>; 2 
+    }",
+        Warning::UnusedLiteral {
+            location: SrcSpan { start: 26, end: 31 }
+        }
+    );
+    // Test tuple
+    assert_warning!(
+        "
+    fn main() { 
+        tuple(1.0, \"Hello world\"); 2 
+    }",
+        Warning::UnusedLiteral {
+            location: SrcSpan { start: 26, end: 51 }
+        }
+    );
+    // Test list
+    assert_warning!(
+        "
+    fn main() { 
+        [1, 2, 3]; 2 
+    }",
+        Warning::UnusedLiteral {
+            location: SrcSpan { start: 26, end: 35 }
+        }
+    );
+}
+
+#[test]
 fn record_update_warnings_test() {
     // Some fields are given in a record update do not emit warnings
     assert_no_warnings!(

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -66,6 +66,20 @@ variable _ if you are sure the error does not matter.")
                     .unwrap();
                 }
 
+                Warning::UnusedLiteral { location } => {
+                    let diagnostic = Diagnostic {
+                        title: "Unused literal".to_string(),
+                        label: "".to_string(),
+                        file: path.to_str().unwrap().to_string(),
+                        src: src.to_string(),
+                        location: *location,
+                    };
+                    write(buffer, diagnostic, Severity::Warning);
+                    writeln!(buffer,
+"The literal expression in this code is not being used, so its value is being silently ignored. Use it in an expression or remove it entirely if it is unneeded.")
+                    .unwrap();
+                }
+
                 Warning::NoFieldsRecordUpdate { location } => {
                     let diagnostic = Diagnostic {
                         title: "Fieldless record update".to_string(),


### PR DESCRIPTION
Fixes #876 

Warns on sequential statements where the first expression is a simple constant.
Adds a warning "UnusedLiteral"
Also slightly refactors infer_seq to make it more idiomatic

This is my first Gleam PR so let me know if there are any issues!