### PR TITLE
Use unused results

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ pub fn ask(question: &str) -> Result<String, Error> {
     print!("{}: ", question);
     std::io::stdout().flush().unwrap();
     let mut answer = String::new();
-    std::io::stdin()
+    let _ = std::io::stdin()
         .read_line(&mut answer)
         .map_err(|e| Error::StandardIO {
             action: StandardIOAction::Read,

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -86,8 +86,8 @@ impl<'env> Env<'env> {
     pub fn local_var_name<'a>(&mut self, name: String) -> Document<'a> {
         match self.current_scope_vars.get(&name) {
             None => {
-                self.current_scope_vars.insert(name.clone(), 0);
-                self.erl_function_scope_vars.insert(name.clone(), 0);
+                let _ = self.current_scope_vars.insert(name.clone(), 0);
+                let _ = self.erl_function_scope_vars.insert(name.clone(), 0);
                 Document::String(variable_name(name))
             }
             Some(0) => Document::String(variable_name(name)),
@@ -97,8 +97,8 @@ impl<'env> Env<'env> {
 
     pub fn next_local_var_name<'a>(&mut self, name: String) -> Document<'a> {
         let next = self.erl_function_scope_vars.get(&name).map_or(0, |i| i + 1);
-        self.erl_function_scope_vars.insert(name.clone(), next);
-        self.current_scope_vars.insert(name.clone(), next);
+        let _ = self.erl_function_scope_vars.insert(name.clone(), next);
+        let _ = self.current_scope_vars.insert(name.clone(), next);
         self.local_var_name(name)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1408,7 +1408,7 @@ When matching you need to use the `{}_codepoint` specifier instead.",
                     ),
                     ParseErrorType::UnexpectedToken { expected } => {
                         let mut messages = expected.clone();
-                        messages
+                        let _ = messages
                             .first_mut()
                             .map(|s| *s = format!("Expected one of: {}", *s));
 

--- a/src/eunit.rs
+++ b/src/eunit.rs
@@ -54,25 +54,25 @@ pub fn command(root_string: String) -> Result<(), Error> {
 
     // compile eunit runner dependencies in the build path
     let mut compile_command = Command::new("erlc");
-    compile_command.arg("-o");
-    compile_command.arg(root.build_path());
+    let _ = compile_command.arg("-o");
+    let _ = compile_command.arg(root.build_path());
 
     eunit_files
         .iter()
         .filter(|&file| file.should_be_compiled)
         .for_each(|file| {
-            compile_command.arg(file.path.clone());
+            let _ = compile_command.arg(file.path.clone());
         });
 
     tracing::trace!("Running OS process {:?}", compile_command);
-    compile_command.status().map_err(|e| Error::ShellCommand {
+    let _ = compile_command.status().map_err(|e| Error::ShellCommand {
         command: "erlc".to_string(),
         err: Some(e.kind()),
     })?;
 
     // Prepare the escript command for running tests
     let mut command = Command::new("escript");
-    command.arg(root.build_path().join("eunit_runner.erl"));
+    let _ = command.arg(root.build_path().join("eunit_runner.erl"));
 
     let ebin_paths: String = crate::fs::read_dir(root.default_build_lib_path())?
         .filter_map(Result::ok)
@@ -80,8 +80,8 @@ pub fn command(root_string: String) -> Result<(), Error> {
         .join(",");
 
     // we supply two parameters to the escript. First is a comma seperated
-    command.arg(ebin_paths);
-    command.arg(test_modules);
+    let _ = command.arg(ebin_paths);
+    let _ = command.arg(test_modules);
 
     // Run the shell
     tracing::trace!("Running OS process {:?}", command);

--- a/src/format.rs
+++ b/src/format.rs
@@ -543,7 +543,7 @@ impl<'comments> Formatter<'comments> {
         force_break()
             .append({
                 let doc = self.expr(first).group();
-                self.pop_empty_lines(first.location().end);
+                let _ = self.pop_empty_lines(first.location().end);
                 doc
             })
             .append(if self.pop_empty_lines(then.start_byte_index()) {
@@ -562,7 +562,7 @@ impl<'comments> Formatter<'comments> {
         kind: BindingKind,
         annotation: &'a Option<TypeAst>,
     ) -> Document<'a> {
-        self.pop_empty_lines(pattern.location().end);
+        let _ = self.pop_empty_lines(pattern.location().end);
 
         let keyword = match kind {
             BindingKind::Let => "let ",
@@ -937,7 +937,7 @@ impl<'comments> Formatter<'comments> {
         constructors: &'a [RecordConstructor],
         location: &'a SrcSpan,
     ) -> Document<'a> {
-        self.pop_empty_lines(location.start);
+        let _ = self.pop_empty_lines(location.start);
         pub_(public)
             .to_doc()
             .append(if opaque { "opaque type " } else { "type " })
@@ -970,7 +970,7 @@ impl<'comments> Formatter<'comments> {
         args: &'a [String],
         location: &'a SrcSpan,
     ) -> Document<'a> {
-        self.pop_empty_lines(location.start);
+        let _ = self.pop_empty_lines(location.start);
         pub_(public)
             .to_doc()
             .append("opaque type ")
@@ -1105,7 +1105,7 @@ impl<'comments> Formatter<'comments> {
         };
 
         // Remove any unused empty lines within the clause
-        self.pop_empty_lines(after_position);
+        let _ = self.pop_empty_lines(after_position);
 
         if index == 0 {
             clause_doc

--- a/src/format/command.rs
+++ b/src/format/command.rs
@@ -113,7 +113,7 @@ fn format_file(problem_files: &mut Vec<Unformatted>, path: PathBuf) -> Result<()
 
 pub fn read_stdin() -> Result<String> {
     let mut src = String::new();
-    std::io::stdin()
+    let _ = std::io::stdin()
         .read_to_string(&mut src)
         .map_err(|e| Error::StandardIO {
             action: StandardIOAction::Read,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,7 @@
     nonstandard_style,
     unused_import_braces,
     unused_qualifications,
-    // TODO: Fix all examples that violate this
-    // unused_results
+    unused_results
 )]
 
 #[macro_use]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -118,8 +118,8 @@ where
             tok1: None,
             extra: ModuleExtra::new(),
         };
-        parser.next_tok();
-        parser.next_tok();
+        let _ = parser.next_tok();
+        let _ = parser.next_tok();
         parser
     }
 
@@ -174,36 +174,36 @@ where
         let statement = match (self.tok0.take(), self.tok1.as_ref()) {
             // Imports
             (Some((_, Tok::Import, _)), _) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 self.parse_import()
             }
             // Module Constants
             (Some((_, Tok::Const, _)), _) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 self.parse_module_const(false)
             }
             (Some((_, Tok::Pub, _)), Some((_, Tok::Const, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 self.parse_module_const(true)
             }
 
             // External Type
             (Some((start, Tok::External, _)), Some((_, Tok::Type, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 self.parse_external_type(start, false)
             }
             // External Function
             (Some((start, Tok::External, _)), Some((_, Tok::Fn, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 self.parse_external_fn(start, false)
             }
             // Pub External type or fn
             (Some((start, Tok::Pub, _)), Some((_, Tok::External, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 match self.next_tok() {
                     Some((_, Tok::Type, _)) => self.parse_external_type(start, true),
                     Some((_, Tok::Fn, _)) => self.parse_external_fn(start, true),
@@ -215,29 +215,29 @@ where
 
             // function
             (Some((start, Tok::Fn, _)), _) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 self.parse_function(start, false, false)
             }
             (Some((start, Tok::Pub, _)), Some((_, Tok::Fn, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 self.parse_function(start, true, false)
             }
 
             // Custom Types, and Type Aliases
             (Some((start, Tok::Type, _)), _) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 self.parse_custom_type(start, false, false)
             }
             (Some((start, Tok::Pub, _)), Some((_, Tok::Opaque, _))) => {
-                self.next_tok();
-                self.next_tok();
-                self.expect_one(&Tok::Type)?;
+                let _ = self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.expect_one(&Tok::Type)?;
                 self.parse_custom_type(start, true, true)
             }
             (Some((start, Tok::Pub, _)), Some((_, Tok::Type, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 self.parse_custom_type(start, true, false)
             }
 
@@ -283,10 +283,10 @@ where
             if let Some((op_s, t, op_e)) = self.tok0.take() {
                 if let Some(p) = precedence(&t) {
                     // Is Op
-                    self.next_tok();
+                    let _ = self.next_tok();
                     last_op_start = op_s;
                     last_op_end = op_e;
-                    handle_op(
+                    let _ = handle_op(
                         Some(((op_s, t, op_e), p)),
                         &mut opstack,
                         &mut estack,
@@ -316,14 +316,14 @@ where
     fn parse_expression_unit(&mut self) -> Result<Option<UntypedExpr>, ParseError> {
         let mut expr = match self.tok0.take() {
             Some((start, Tok::String { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 UntypedExpr::String {
                     location: SrcSpan { start, end },
                     value,
                 }
             }
             Some((start, Tok::Int { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 UntypedExpr::Int {
                     location: SrcSpan { start, end },
                     value,
@@ -331,14 +331,14 @@ where
             }
 
             Some((start, Tok::Float { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 UntypedExpr::Float {
                     location: SrcSpan { start, end },
                     value,
                 }
             }
             Some((start, Tok::ListNil, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
 
                 UntypedExpr::ListNil {
                     location: SrcSpan { start, end },
@@ -346,14 +346,14 @@ where
             }
             // var lower_name and UpName
             Some((start, Tok::Name { name }, end)) | Some((start, Tok::UpName { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 UntypedExpr::Var {
                     location: SrcSpan { start, end },
                     name,
                 }
             }
             Some((start, Tok::Todo, mut end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let mut label = None;
                 if self.maybe_one(&Tok::Lpar).is_some() {
                     let (_, l, _) = self.expect_string()?;
@@ -367,8 +367,8 @@ where
                 }
             }
             Some((start, Tok::Tuple, _)) => {
-                self.next_tok();
-                self.expect_one(&Tok::Lpar)?;
+                let _ = self.next_tok();
+                let _ = self.expect_one(&Tok::Lpar)?;
                 let elems = Parser::series_of(self, &Parser::parse_expression, Some(&Tok::Comma))?;
                 let (_, end) = self.expect_one(&Tok::Rpar)?;
                 UntypedExpr::Tuple {
@@ -378,12 +378,12 @@ where
             }
             // list
             Some((start, Tok::Lsqb, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let elems = Parser::series_of(self, &Parser::parse_expression, Some(&Tok::Comma))?;
                 let mut tail0 = None;
                 if self.maybe_one(&Tok::DotDot).is_some() {
                     tail0 = self.parse_expression()?;
-                    self.maybe_one(&Tok::Comma);
+                    let _ = self.maybe_one(&Tok::Comma);
                 }
                 let (_, end) = self.expect_one(&Tok::Rsqb)?;
                 let tail = tail0.unwrap_or(UntypedExpr::ListNil {
@@ -401,7 +401,7 @@ where
             }
             // Bitstring
             Some((start, Tok::LtLt, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let segments = Parser::series_of(
                     self,
                     &|s| {
@@ -421,7 +421,7 @@ where
                 }
             }
             Some((start, Tok::Fn, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 match self.parse_function(start, false, true)? {
                     Some(Statement::Fn {
                         location,
@@ -447,7 +447,7 @@ where
 
             // expression group  "{" "}"
             Some((start, Tok::Lbrace, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let expr = self.parse_expression_seq()?;
                 let (_, end) = self.expect_one(&Tok::Rbrace)?;
                 if let Some((expr, _)) = expr {
@@ -459,10 +459,10 @@ where
 
             // case
             Some((start, Tok::Case, case_e)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let subjects =
                     Parser::series_of(self, &Parser::parse_expression, Some(&Tok::Comma))?;
-                self.expect_one(&Tok::Lbrace)?;
+                let _ = self.expect_one(&Tok::Lbrace)?;
                 let clauses = Parser::series_of(self, &Parser::parse_case_clause, None)?;
                 let (_, end) = self.expect_one(&Tok::Rbrace)?;
                 if subjects.is_empty() {
@@ -499,7 +499,7 @@ where
                 match self.tok0.take() {
                     // tuple access
                     Some((_, Tok::Int { value }, end)) => {
-                        self.next_tok();
+                        let _ = self.next_tok();
                         let v = value.replace("_", "");
                         if let Ok(index) = u64::from_str(&v) {
                             expr = UntypedExpr::TupleIndex {
@@ -516,7 +516,7 @@ where
                     }
 
                     Some((_, Tok::Name { name: label }, end)) => {
-                        self.next_tok();
+                        let _ = self.next_tok();
                         expr = UntypedExpr::FieldAccess {
                             location: SrcSpan { start, end },
                             label,
@@ -525,7 +525,7 @@ where
                     }
 
                     Some((_, Tok::UpName { name: label }, end)) => {
-                        self.next_tok();
+                        let _ = self.next_tok();
                         expr = UntypedExpr::FieldAccess {
                             location: SrcSpan { start, end },
                             label,
@@ -664,15 +664,15 @@ where
     fn maybe_binding_start(&mut self) -> Option<(usize, BindingKind)> {
         match self.tok0 {
             Some((start, Tok::Let, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Some((start, BindingKind::Let))
             }
             Some((start, Tok::Assert, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Some((start, BindingKind::Assert))
             }
             Some((start, Tok::Try, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Some((start, BindingKind::Try))
             }
             _ => None,
@@ -684,7 +684,7 @@ where
         let pattern = match self.tok0.take() {
             // Pattern::Var or Pattern::Constructor start
             Some((start, Tok::Name { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 if self.maybe_one(&Tok::Dot).is_some() {
                     self.expect_constructor_pattern(Some((start, name, end)))?
                 } else {
@@ -700,42 +700,42 @@ where
                 self.expect_constructor_pattern(None)?
             }
             Some((start, Tok::DiscardName { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Pattern::Discard {
                     location: SrcSpan { start, end },
                     name,
                 }
             }
             Some((start, Tok::String { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Pattern::String {
                     location: SrcSpan { start, end },
                     value,
                 }
             }
             Some((start, Tok::Int { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Pattern::Int {
                     location: SrcSpan { start, end },
                     value,
                 }
             }
             Some((start, Tok::Float { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Pattern::Float {
                     location: SrcSpan { start, end },
                     value,
                 }
             }
             Some((start, Tok::ListNil, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Pattern::Nil {
                     location: SrcSpan { start, end },
                 }
             }
             Some((start, Tok::Tuple, _)) => {
-                self.next_tok();
-                self.expect_one(&Tok::Lpar)?;
+                let _ = self.next_tok();
+                let _ = self.expect_one(&Tok::Lpar)?;
                 let elems = Parser::series_of(self, &Parser::parse_pattern, Some(&Tok::Comma))?;
                 let (_, end) = self.expect_one(&Tok::Rpar)?;
                 Pattern::Tuple {
@@ -745,7 +745,7 @@ where
             }
             // Bitstring
             Some((start, Tok::LtLt, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let segments = Parser::series_of(
                     self,
                     &|s| {
@@ -766,12 +766,12 @@ where
             }
             // List
             Some((start, Tok::Lsqb, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let elems = Parser::series_of(self, &Parser::parse_pattern, Some(&Tok::Comma))?;
                 let tail = if let Some((_, Tok::DotDot, _)) = self.tok0 {
-                    self.next_tok();
+                    let _ = self.next_tok();
                     let pat = self.parse_pattern()?;
-                    self.maybe_one(&Tok::Comma);
+                    let _ = self.maybe_one(&Tok::Comma);
                     Some(pat)
                 } else {
                     None
@@ -820,7 +820,7 @@ where
         };
 
         if let Some((_, Tok::As, _)) = self.tok0 {
-            self.next_tok();
+            let _ = self.next_tok();
             let (_, name, _) = self.expect_name()?;
             Ok(Some(Pattern::Let {
                 name,
@@ -907,10 +907,10 @@ where
                 if let Some((op_s, t, op_e)) = self.tok0.take() {
                     if let Some(p) = &t.guard_precedence() {
                         // Is Op
-                        self.next_tok();
+                        let _ = self.next_tok();
                         last_op_start = op_s;
                         last_op_end = op_e;
-                        handle_op(
+                        let _ = handle_op(
                             Some(((op_s, t, op_e), *p)),
                             &mut opstack,
                             &mut estack,
@@ -940,7 +940,7 @@ where
     fn parse_case_clause_guard_unit(&mut self) -> Result<Option<UntypedClauseGuard>, ParseError> {
         match self.tok0.take() {
             Some((start, Tok::Name { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 if let Some((dot_s, _)) = self.maybe_one(&Tok::Dot) {
                     match self.next_tok() {
                         Some((_, Tok::Int { value }, int_e)) => {
@@ -982,9 +982,9 @@ where
             }
             Some((_, Tok::Lbrace, _)) => {
                 // Nested guard expression
-                self.next_tok();
+                let _ = self.next_tok();
                 let guard = self.parse_case_clause_guard(true);
-                self.expect_one(&Tok::Rbrace)?;
+                let _ = self.expect_one(&Tok::Rbrace)?;
                 guard
             }
             t0 => {
@@ -1034,7 +1034,7 @@ where
             )?;
             let with_spread = self.maybe_one(&Tok::DotDot).is_some();
             if with_spread {
-                self.maybe_one(&Tok::Comma);
+                let _ = self.maybe_one(&Tok::Comma);
             }
             let (_, end) = self.expect_one(&Tok::Rpar)?;
             Ok((args, with_spread, end))
@@ -1052,8 +1052,8 @@ where
         match (self.tok0.take(), self.tok1.take()) {
             // named arg
             (Some((start, Tok::Name { name }, _)), Some((col_s, Tok::Colon, col_e))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 if let Some(value) = self.parse_pattern()? {
                     Ok(Some(CallArg {
                         location: SrcSpan {
@@ -1094,7 +1094,7 @@ where
     //   a: expr
     fn parse_record_update_arg(&mut self) -> Result<Option<UntypedRecordUpdateArg>, ParseError> {
         if let Some((start, label, _)) = self.maybe_name() {
-            self.expect_one(&Tok::Colon)?;
+            let _ = self.expect_one(&Tok::Colon)?;
             let value = self.parse_expression()?;
             if let Some(value) = value {
                 Ok(Some(UntypedRecordUpdateArg {
@@ -1133,11 +1133,11 @@ where
             let (_, n, _) = self.expect_name()?;
             name = n;
         }
-        self.expect_one(&Tok::Lpar)?;
+        let _ = self.expect_one(&Tok::Lpar)?;
         let args = Parser::series_of(self, &Parser::parse_fn_param, Some(&Tok::Comma))?;
         let (_, rpar_e) = self.expect_one(&Tok::Rpar)?;
         let return_annotation = self.parse_type_annotation(&Tok::RArrow, false)?;
-        self.expect_one(&Tok::Lbrace)?;
+        let _ = self.expect_one(&Tok::Lbrace)?;
         if let Some((body, _)) = self.parse_expression_seq()? {
             let (_, rbr_e) = self.expect_one(&Tok::Rbrace)?;
             let end = return_annotation
@@ -1171,12 +1171,12 @@ where
         public: bool,
     ) -> Result<Option<UntypedStatement>, ParseError> {
         let (_, name, _) = self.expect_name()?;
-        self.expect_one(&Tok::Lpar)?;
+        let _ = self.expect_one(&Tok::Lpar)?;
         let args = Parser::series_of(self, &Parser::parse_external_fn_param, Some(&Tok::Comma))?;
-        self.expect_one(&Tok::Rpar)?;
+        let _ = self.expect_one(&Tok::Rpar)?;
         let (arr_s, arr_e) = self.expect_one(&Tok::RArrow)?;
         let return_annotation = self.parse_type(false)?;
-        self.expect_one(&Tok::Equal)?;
+        let _ = self.expect_one(&Tok::Equal)?;
         let (_, module, _) = self.expect_string()?;
         let (_, fun, end) = self.expect_string()?;
 
@@ -1214,8 +1214,8 @@ where
         let mut end = 0;
         match (self.tok0.take(), self.tok1.take()) {
             (Some((s, Tok::Name { name }, _)), Some((_, Tok::Colon, e))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 start = s;
                 label = Some(name);
                 end = e;
@@ -1264,26 +1264,26 @@ where
                 Some((start, Tok::Name { name: label }, _)),
                 Some((_, Tok::DiscardName { name }, end)),
             ) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 (start, ArgNames::LabelledDiscard { name, label }, end)
             }
             // discard
             (Some((start, Tok::DiscardName { name }, end)), t1) => {
                 self.tok1 = t1;
-                self.next_tok();
+                let _ = self.next_tok();
                 (start, ArgNames::Discard { name }, end)
             }
             // labeled name
             (Some((start, Tok::Name { name: label }, _)), Some((_, Tok::Name { name }, end))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 (start, ArgNames::NamedLabelled { name, label }, end)
             }
             // name
             (Some((start, Tok::Name { name }, end)), t1) => {
                 self.tok1 = t1;
-                self.next_tok();
+                let _ = self.next_tok();
                 (start, ArgNames::Named { name }, end)
             }
             (t0, t1) => {
@@ -1329,8 +1329,8 @@ where
         let mut start = 0;
         let label = match (self.tok0.take(), self.tok1.as_ref()) {
             (Some((s, Tok::Name { name }, _)), Some((_, Tok::Colon, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 start = s;
                 Some(name)
             }
@@ -1418,7 +1418,7 @@ where
                 // No separator
                 None,
             )?;
-            self.expect_one(&Tok::Rbrace)?;
+            let _ = self.expect_one(&Tok::Rbrace)?;
             if constructors.is_empty() {
                 parse_error(ParseErrorType::NoConstructors, SrcSpan { start, end })
             } else {
@@ -1494,8 +1494,8 @@ where
                 self,
                 &|p| match (p.tok0.take(), p.tok1.take()) {
                     (Some((start, Tok::Name { name }, _)), Some((_, Tok::Colon, end))) => {
-                        Parser::next_tok(p);
-                        Parser::next_tok(p);
+                        let _ = Parser::next_tok(p);
+                        let _ = Parser::next_tok(p);
                         match Parser::parse_type(p, false)? {
                             Some(type_ast) => {
                                 Ok(Some((Some(name), type_ast, SrcSpan { start, end })))
@@ -1555,7 +1555,7 @@ where
         match self.tok0.take() {
             // Type hole
             Some((start, Tok::DiscardName { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Ok(Some(TypeAst::Hole {
                     location: SrcSpan { start, end },
                     name,
@@ -1564,7 +1564,7 @@ where
 
             // Tuple
             Some((start, Tok::Tuple, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let _ = self.expect_one(&Tok::Lpar)?;
                 let elems = self.parse_types(for_const)?;
                 let _ = self.expect_one(&Tok::Rpar)?;
@@ -1576,17 +1576,17 @@ where
 
             // Function
             Some((start, Tok::Fn, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 if for_const {
                     parse_error(ParseErrorType::NotConstType, SrcSpan { start, end })
                 } else {
-                    self.expect_one(&Tok::Lpar)?;
+                    let _ = self.expect_one(&Tok::Lpar)?;
                     let args = Parser::series_of(
                         self,
                         &|x| Parser::parse_type(x, for_const),
                         Some(&Tok::Comma),
                     )?;
-                    self.expect_one(&Tok::Rpar)?;
+                    let _ = self.expect_one(&Tok::Rpar)?;
                     let (arr_s, arr_e) = self.expect_one(&Tok::RArrow)?;
                     let retrn = self.parse_type(for_const)?;
                     if let Some(retrn) = retrn {
@@ -1612,13 +1612,13 @@ where
 
             // Constructor function
             Some((start, Tok::UpName { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 self.parse_type_name_finish(for_const, start, None, name, end)
             }
 
             // Constructor Module or type Variable
             Some((start, Tok::Name { name: mod_name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 if self.maybe_one(&Tok::Dot).is_some() {
                     let (_, upname, upname_e) = self.expect_upname()?;
                     self.parse_type_name_finish(for_const, start, Some(mod_name), upname, upname_e)
@@ -1719,9 +1719,9 @@ where
         // Gather imports
         let mut unqualified = vec![];
         if self.maybe_one(&Tok::Dot).is_some() {
-            self.expect_one(&Tok::Lbrace)?;
+            let _ = self.expect_one(&Tok::Lbrace)?;
             unqualified = self.parse_unqualified_imports()?;
-            self.expect_one(&Tok::Rbrace)?;
+            let _ = self.expect_one(&Tok::Rbrace)?;
         }
 
         // Parse as_name
@@ -1746,7 +1746,7 @@ where
             match self.tok0.take() {
                 Some((start, Tok::Name { name }, end))
                 | Some((start, Tok::UpName { name }, end)) => {
-                    self.next_tok();
+                    let _ = self.next_tok();
                     let location = SrcSpan { start, end };
                     let mut import = UnqualifiedImport {
                         name,
@@ -1767,7 +1767,7 @@ where
             // parse comma
             match self.tok0 {
                 Some((_, Tok::Comma, _)) => {
-                    self.next_tok();
+                    let _ = self.next_tok();
                 }
                 _ => break,
             }
@@ -1818,7 +1818,7 @@ where
     fn parse_const_value(&mut self) -> Result<Option<UntypedConstant>, ParseError> {
         match self.tok0.take() {
             Some((start, Tok::String { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Ok(Some(Constant::String {
                     value,
                     location: SrcSpan { start, end },
@@ -1826,7 +1826,7 @@ where
             }
 
             Some((start, Tok::Float { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Ok(Some(Constant::Float {
                     value,
                     location: SrcSpan { start, end },
@@ -1834,7 +1834,7 @@ where
             }
 
             Some((start, Tok::Int { value }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Ok(Some(Constant::Int {
                     value,
                     location: SrcSpan { start, end },
@@ -1842,8 +1842,8 @@ where
             }
 
             Some((start, Tok::Tuple, _)) => {
-                self.next_tok();
-                self.expect_one(&Tok::Lpar)?;
+                let _ = self.next_tok();
+                let _ = self.expect_one(&Tok::Lpar)?;
                 let elements =
                     Parser::series_of(self, &Parser::parse_const_value, Some(&Tok::Comma))?;
                 let (_, end) = self.expect_one(&Tok::Rpar)?;
@@ -1854,7 +1854,7 @@ where
             }
 
             Some((start, Tok::Lsqb, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let elements =
                     Parser::series_of(self, &Parser::parse_const_value, Some(&Tok::Comma))?;
                 let (_, end) = self.expect_one(&Tok::Rsqb)?;
@@ -1866,7 +1866,7 @@ where
             }
             // Bitstring
             Some((start, Tok::LtLt, _)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 let segments = Parser::series_of(
                     self,
                     &|s| {
@@ -1887,12 +1887,12 @@ where
             }
 
             Some((start, Tok::UpName { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 self.parse_const_record_finish(start, None, name, end)
             }
 
             Some((start, Tok::Name { name }, end)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 if self.expect_one(&Tok::Dot).is_ok() {
                     let (_, upname, end) = self.expect_upname()?;
                     self.parse_const_record_finish(start, Some(name), upname, end)
@@ -1956,8 +1956,8 @@ where
         let name = match (self.tok0.take(), self.tok1.as_ref()) {
             // Named arg
             (Some((start, Tok::Name { name }, end)), Some((_, Tok::Colon, _))) => {
-                self.next_tok();
-                self.next_tok();
+                let _ = self.next_tok();
+                let _ = self.next_tok();
                 Some((start, name, end))
             }
 
@@ -2194,7 +2194,7 @@ where
     fn maybe_one(&mut self, tok: &Tok) -> Option<(usize, usize)> {
         match self.tok0.take() {
             Some((s, t, e)) if t == *tok => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Some((s, e))
             }
 
@@ -2232,7 +2232,7 @@ where
     fn maybe_name(&mut self) -> Option<(usize, String, usize)> {
         match self.tok0.take() {
             Some((s, Tok::Name { name }, e)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Some((s, name, e))
             }
             t0 => {
@@ -2246,7 +2246,7 @@ where
     fn maybe_upname(&mut self) -> Option<(usize, String, usize)> {
         match self.tok0.take() {
             Some((s, Tok::UpName { name }, e)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Some((s, name, e))
             }
             t0 => {
@@ -2260,7 +2260,7 @@ where
     fn maybe_discard_name(&mut self) -> Option<(usize, String, usize)> {
         match self.tok0.take() {
             Some((s, Tok::DiscardName { name }, e)) => {
-                self.next_tok();
+                let _ = self.next_tok();
                 Some((s, name, e))
             }
             t0 => {

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -59,8 +59,8 @@ where
             chr0: None,
             chr1: None,
         };
-        nlh.shift();
-        nlh.shift();
+        let _ = nlh.shift();
+        let _ = nlh.shift();
         nlh
     }
 
@@ -83,7 +83,7 @@ where
         while let Some((i, '\r')) = self.chr0 {
             if let Some((_, '\n')) = self.chr1 {
                 // Transform windows EOL into \n
-                self.shift();
+                let _ = self.shift();
             } else {
                 // Transform MAC EOL into \n
                 self.chr0 = Some((i, '\n'))
@@ -108,8 +108,8 @@ where
             loc0: 0,
             loc1: 0,
         };
-        lxr.next_char();
-        lxr.next_char();
+        let _ = lxr.next_char();
+        let _ = lxr.next_char();
         lxr.location = 0;
         lxr
     }
@@ -167,10 +167,10 @@ where
             }
             '=' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 match self.chr0 {
                     Some('=') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::EqualEqual, tok_end));
                     }
@@ -182,9 +182,9 @@ where
             }
             '+' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 if let Some('.') = self.chr0 {
-                    self.next_char();
+                    let _ = self.next_char();
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Tok::PlusDot, tok_end));
                 } else {
@@ -194,10 +194,10 @@ where
             }
             '*' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 match self.chr0 {
                     Some('.') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::StarDot, tok_end));
                     }
@@ -209,15 +209,15 @@ where
             }
             '/' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 match self.chr0 {
                     Some('.') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::SlashDot, tok_end));
                     }
                     Some('/') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let comment = self.lex_comment()?;
                         self.emit(comment);
                     }
@@ -229,19 +229,19 @@ where
             }
             '%' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 let tok_end = self.get_pos();
                 self.emit((tok_start, Tok::Percent, tok_end));
             }
             '|' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 if let Some('|') = self.chr0 {
-                    self.next_char();
+                    let _ = self.next_char();
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Tok::VbarVbar, tok_end));
                 } else if let Some('>') = self.chr0 {
-                    self.next_char();
+                    let _ = self.next_char();
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Tok::Pipe, tok_end));
                 } else {
@@ -251,9 +251,9 @@ where
             }
             '&' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 if let Some('&') = self.chr0 {
-                    self.next_char();
+                    let _ = self.next_char();
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Tok::AmperAmper, tok_end));
                 } else {
@@ -265,15 +265,15 @@ where
             }
             '-' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 match self.chr0 {
                     Some('.') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::MinusDot, tok_end));
                     }
                     Some('>') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::RArrow, tok_end));
                     }
@@ -285,9 +285,9 @@ where
             }
             '!' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 if let Some('=') = self.chr0 {
-                    self.next_char();
+                    let _ = self.next_char();
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Tok::NotEqual, tok_end));
                 } else {
@@ -306,8 +306,8 @@ where
             '[' => {
                 let tok_start = self.get_pos();
                 if let Some(']') = self.chr1 {
-                    self.next_char();
-                    self.next_char();
+                    let _ = self.next_char();
+                    let _ = self.next_char();
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Tok::ListNil, tok_end));
                 } else {
@@ -328,23 +328,23 @@ where
             }
             '<' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 match self.chr0 {
                     Some('<') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::LtLt, tok_end));
                     }
                     Some('.') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::LessDot, tok_end));
                     }
                     Some('=') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         match self.chr0 {
                             Some('.') => {
-                                self.next_char();
+                                let _ = self.next_char();
                                 let tok_end = self.get_pos();
                                 self.emit((tok_start, Tok::LessEqualDot, tok_end));
                             }
@@ -362,23 +362,23 @@ where
             }
             '>' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 match self.chr0 {
                     Some('>') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::GtGt, tok_end));
                     }
                     Some('.') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         let tok_end = self.get_pos();
                         self.emit((tok_start, Tok::GreaterDot, tok_end));
                     }
                     Some('=') => {
-                        self.next_char();
+                        let _ = self.next_char();
                         match self.chr0 {
                             Some('.') => {
-                                self.next_char();
+                                let _ = self.next_char();
                                 let tok_end = self.get_pos();
                                 self.emit((tok_start, Tok::GreaterEqualDot, tok_end));
                             }
@@ -399,9 +399,9 @@ where
             }
             '.' => {
                 let tok_start = self.get_pos();
-                self.next_char();
+                let _ = self.next_char();
                 if let Some('.') = &self.chr0 {
-                    self.next_char();
+                    let _ = self.next_char();
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Tok::DotDot, tok_end));
                 } else {
@@ -410,12 +410,12 @@ where
                 }
             }
             '\n' => {
-                self.next_char();
+                let _ = self.next_char();
                 let tok_start = self.get_pos();
                 while let Some(c) = self.chr0 {
                     match c {
                         ' ' | '\t' | '\x0C' => {
-                            self.next_char();
+                            let _ = self.next_char();
                         }
                         '\n' => {
                             let tok_end = self.get_pos();
@@ -428,7 +428,7 @@ where
             }
             ' ' | '\t' | '\x0C' | ';' => {
                 // Skip whitespaces and semicolons
-                self.next_char();
+                let _ = self.next_char();
             }
 
             c => {
@@ -484,18 +484,18 @@ where
         let num = if self.chr0 == Some('0') {
             if self.chr1 == Some('x') || self.chr1 == Some('X') {
                 // Hex!
-                self.next_char();
-                self.next_char();
+                let _ = self.next_char();
+                let _ = self.next_char();
                 self.lex_number_radix(start_pos, 16, "0x")?
             } else if self.chr1 == Some('o') || self.chr1 == Some('O') {
                 // Octal!
-                self.next_char();
-                self.next_char();
+                let _ = self.next_char();
+                let _ = self.next_char();
                 self.lex_number_radix(start_pos, 8, "0o")?
             } else if self.chr1 == Some('b') || self.chr1 == Some('B') {
                 // Binary!
-                self.next_char();
-                self.next_char();
+                let _ = self.next_char();
+                let _ = self.next_char();
                 self.lex_number_radix(start_pos, 2, "0b")?
             } else {
                 self.lex_normal_number()?
@@ -569,7 +569,7 @@ where
                 value_text.push(c);
             } else if self.chr0 == Some('_') && Lexer::<T>::is_digit_of_radix(self.chr1, radix) {
                 value_text.push('_');
-                self.next_char();
+                let _ = self.next_char();
             } else {
                 break;
             }
@@ -607,19 +607,19 @@ where
     fn lex_comment(&mut self) -> LexResult {
         let kind = match (self.chr0, self.chr1) {
             (Some('/'), Some('/')) => {
-                self.next_char();
-                self.next_char();
+                let _ = self.next_char();
+                let _ = self.next_char();
                 Tok::CommentModule
             }
             (Some('/'), _) => {
-                self.next_char();
+                let _ = self.next_char();
                 Tok::CommentDoc
             }
             _ => Tok::CommentNormal,
         };
         let start_pos = self.get_pos();
         while Some('\n') != self.chr0 && None != self.chr0 {
-            self.next_char();
+            let _ = self.next_char();
         }
         let end_pos = self.get_pos();
         Ok((start_pos, kind, end_pos))
@@ -637,11 +637,11 @@ where
                     if self.chr0 == Some('"') {
                         string_content.push('\\');
                         string_content.push('"');
-                        self.next_char();
+                        let _ = self.next_char();
                     } else if self.chr0 == Some('\\') {
                         string_content.push('\\');
                         string_content.push('\\');
-                        self.next_char();
+                        let _ = self.next_char();
                     } else {
                         string_content.push('\\');
                     }
@@ -694,7 +694,7 @@ where
     // advance the stream and emit a token
     fn eat_single_char(&mut self, ty: Tok) {
         let tok_start = self.get_pos();
-        self.next_char().unwrap();
+        let _ = self.next_char().unwrap();
         let tok_end = self.get_pos();
         self.emit((tok_start, ty, tok_end));
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -208,7 +208,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
             error,
         })?;
 
-        modules_type_infos.insert(
+        let _ = modules_type_infos.insert(
             name_string.clone(),
             (origin.to_origin(), ast.type_info.clone()),
         );

--- a/src/project/source_tree.rs
+++ b/src/project/source_tree.rs
@@ -35,7 +35,7 @@ impl SourceTree {
     fn import_cycle(&mut self, cycle: Cycle<NodeIndex>) -> Error {
         let origin = cycle.node_id();
         let mut path = vec![];
-        self.find_cycle(origin, origin, &mut path, &mut HashSet::new());
+        let _ = self.find_cycle(origin, origin, &mut path, &mut HashSet::new());
         let modules: Vec<_> = path
             .iter()
             .map(|index| {
@@ -57,7 +57,7 @@ impl SourceTree {
         path: &mut Vec<NodeIndex>,
         seen: &mut HashSet<NodeIndex>,
     ) -> bool {
-        seen.insert(parent);
+        let _ = seen.insert(parent);
         for node in self.graph.neighbors_directed(parent, Direction::Outgoing) {
             if node == origin {
                 path.push(node);
@@ -118,7 +118,7 @@ impl SourceTree {
                     });
                 }
 
-                self.graph.add_edge(*dep_index, *module_index, ());
+                let _ = self.graph.add_edge(*dep_index, *module_index, ());
             }
         }
         Ok(())
@@ -161,8 +161,8 @@ impl SourceTree {
 
         // Register the module
         let index = self.graph.add_node(name.clone());
-        self.indexes.insert(name, index);
-        self.modules.insert(
+        let _ = self.indexes.insert(name, index);
+        let _ = self.modules.insert(
             index,
             Module {
                 src: input.src,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -11,7 +11,7 @@ pub fn command(root_string: String) -> Result<(), Error> {
     let config = root.root_config()?;
 
     // Build project
-    build::main(config, root_path)?;
+    let _ = build::main(config, root_path)?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell
     ctrlc::set_handler(move || {}).gleam_expect("Error setting Ctrl-C handler");
@@ -21,8 +21,8 @@ pub fn command(root_string: String) -> Result<(), Error> {
 
     // Specify locations of .beam files
     for entry in crate::fs::read_dir(root.default_build_lib_path())?.filter_map(Result::ok) {
-        command.arg("-pa");
-        command.arg(entry.path().join("ebin"));
+        let _ = command.arg("-pa");
+        let _ = command.arg(entry.path().join("ebin"));
     }
 
     crate::cli::print_running("erl");

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -480,7 +480,7 @@ fn register_values<'a>(
             ..
         } => {
             assert_unique_value_name(names, name, location)?;
-            environment.ungeneralised_functions.insert(name.to_string());
+            let _ = environment.ungeneralised_functions.insert(name.to_string());
 
             // Create the field map so we can reorder labels for usage of this function
             let mut field_map = FieldMap::new(args.len());
@@ -508,7 +508,7 @@ fn register_values<'a>(
             // Keep track of which types we create from annotations so we can know
             // which generic types not to instantiate later when performing
             // inference of the function body.
-            hydrators.insert(name.clone(), hydrator);
+            let _ = hydrators.insert(name.clone(), hydrator);
 
             // Insert the function into the environment
             environment.insert_variable(
@@ -800,7 +800,7 @@ fn infer_statement(
 
             // Generalise the function if safe to do so
             let typ = if safe_to_generalise {
-                environment.ungeneralised_functions.remove(name.as_str());
+                let _ = environment.ungeneralised_functions.remove(name.as_str());
                 let typ = generalise(typ, 0);
                 environment.insert_variable(
                     name.clone(),
@@ -919,7 +919,7 @@ fn infer_statement(
                     location,
                     name: arg.to_string(),
                 };
-                hydrator.type_from_ast(&var, environment)?;
+                let _ = hydrator.type_from_ast(&var, environment)?;
             }
             Ok(Statement::ExternalType {
                 doc,
@@ -1273,7 +1273,7 @@ fn custom_type_accessors(
     for (index, (label, arg, ..)) in args.iter().enumerate() {
         if let Some(label) = label {
             let typ = hydrator.type_from_ast(arg, environment)?;
-            fields.insert(
+            let _ = fields.insert(
                 label.to_string(),
                 RecordAccessor {
                     index: index as u64,
@@ -1328,7 +1328,7 @@ pub fn register_types<'a>(
 
             // Keep track of private types so we can tell if they are later unused
             if !public {
-                environment
+                let _ = environment
                     .unused_private_types
                     .insert(name.clone(), *location);
             }
@@ -1352,7 +1352,7 @@ pub fn register_types<'a>(
                 name: name.clone(),
                 args: parameters.clone(),
             });
-            hydrators.insert(name.to_string(), hydrator);
+            let _ = hydrators.insert(name.to_string(), hydrator);
 
             environment.insert_type_constructor(
                 name.clone(),
@@ -1398,7 +1398,7 @@ pub fn register_types<'a>(
 
             // Keep track of private types so we can tell if they are later unused
             if !public {
-                environment
+                let _ = environment
                     .unused_private_types
                     .insert(name.clone(), *location);
             }
@@ -1473,11 +1473,11 @@ pub fn register_import(
                 }
 
                 if value_imported && type_imported {
-                    environment
+                    let _ = environment
                         .unused_private_mixed_constructors
                         .insert(imported_name.clone(), *location);
                 } else if type_imported {
-                    environment
+                    let _ = environment
                         .unused_private_types
                         .insert(imported_name.clone(), *location);
                 } else if !value_imported {
@@ -1504,7 +1504,7 @@ pub fn register_import(
 
             // Insert imported module into scope
             // TODO: use a refernce to the module to avoid copying
-            environment
+            let _ = environment
                 .imported_modules
                 .insert(module_name, module_info.clone());
             Ok(())

--- a/src/typ/environment.rs
+++ b/src/typ/environment.rs
@@ -137,7 +137,7 @@ impl<'a, 'b> Environment<'a, 'b> {
         variant: ValueConstructorVariant,
         typ: Arc<Type>,
     ) {
-        self.local_values.insert(
+        let _ = self.local_values.insert(
             name,
             ValueConstructor {
                 public: false,
@@ -152,7 +152,7 @@ impl<'a, 'b> Environment<'a, 'b> {
     /// Errors if the module already has a value with that name.
     ///
     pub fn insert_module_value(&mut self, name: &str, value: ValueConstructor) {
-        self.module_values.insert(name.to_string(), value);
+        let _ = self.module_values.insert(name.to_string(), value);
     }
 
     /// Lookup a variable in the current scope.
@@ -276,7 +276,7 @@ impl<'a, 'b> Environment<'a, 'b> {
     }
 
     pub fn insert_accessors(&mut self, type_name: &str, accessors: AccessorsMap) {
-        self.accessors.insert(type_name.to_string(), accessors);
+        let _ = self.accessors.insert(type_name.to_string(), accessors);
     }
 
     /// Instantiate converts generic variables into unbound ones.
@@ -321,7 +321,7 @@ impl<'a, 'b> Environment<'a, 'b> {
                             if !hydrator.is_created_generic_type(id) {
                                 // Check this in the hydrator, i.e. is it a created type
                                 let v = self.new_unbound_var(ctx_level);
-                                ids.insert(*id, v.clone());
+                                let _ = ids.insert(*id, v.clone());
                                 return v;
                             }
                         }
@@ -486,11 +486,11 @@ impl<'a, 'b> Environment<'a, 'b> {
     }
 
     pub fn type_used(&mut self, name: &str) {
-        self.unused_private_mixed_constructors.remove(name);
-        self.unused_private_types.remove(name);
+        let _ = self.unused_private_mixed_constructors.remove(name);
+        let _ = self.unused_private_types.remove(name);
     }
 
     pub fn value_used(&mut self, name: &str) {
-        self.unused_private_mixed_constructors.remove(name);
+        let _ = self.unused_private_mixed_constructors.remove(name);
     }
 }

--- a/src/typ/fields.rs
+++ b/src/typ/fields.rs
@@ -93,7 +93,7 @@ impl FieldMap {
 
             // If the argument is already in the right place
             if position == i {
-                seen_labels.insert(label.clone());
+                let _ = seen_labels.insert(label.clone());
                 i += 1;
             } else {
                 if seen_labels.contains(label) {
@@ -102,7 +102,7 @@ impl FieldMap {
                         label: label.to_string(),
                     });
                 }
-                seen_labels.insert(label.clone());
+                let _ = seen_labels.insert(label.clone());
 
                 args.swap(position, i);
             }
@@ -123,7 +123,7 @@ impl FieldMap {
         let mut given = HashSet::with_capacity(args.len());
         for arg in args {
             if let Some(label) = &arg.label {
-                given.insert(label.as_ref());
+                let _ = given.insert(label.as_ref());
             }
         }
         self.fields

--- a/src/typ/hydrator.rs
+++ b/src/typ/hydrator.rs
@@ -168,9 +168,11 @@ impl Hydrator {
 
                     None if self.permit_new_type_variables => {
                         let var = environment.new_generic_var();
-                        self.created_type_variable_ids
+                        let _ = self
+                            .created_type_variable_ids
                             .insert(environment.previous_uid());
-                        self.created_type_variables
+                        let _ = self
+                            .created_type_variables
                             .insert(name.clone(), var.clone());
                         Ok(var)
                     }

--- a/src/typ/pattern.rs
+++ b/src/typ/pattern.rs
@@ -41,7 +41,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                         name: name.to_string(),
                     });
                 }
-                self.initial_pattern_vars.insert(name.to_string());
+                let _ = self.initial_pattern_vars.insert(name.to_string());
                 self.environment.insert_variable(
                     name.to_string(),
                     ValueConstructorVariant::LocalVariable,

--- a/src/typ/pretty.rs
+++ b/src/typ/pretty.rs
@@ -84,7 +84,7 @@ impl Printer {
             Some(n) => Document::String(n.clone()),
             None => {
                 let n = self.next_letter();
-                self.names.insert(id, n.clone());
+                let _ = self.names.insert(id, n.clone());
                 Document::String(n)
             }
         }

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -34,7 +34,7 @@ macro_rules! assert_module_error {
 
     ($src:expr) => {
         let (ast, _) = crate::parse::parse_module($src).expect("syntax error");
-        infer_module(&mut 0, ast, &HashMap::new(), &mut vec![]).expect_err("should infer an error");
+        let _ = infer_module(&mut 0, ast, &HashMap::new(), &mut vec![]).expect_err("should infer an error");
     };
 }
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -34,7 +34,8 @@ macro_rules! assert_module_error {
 
     ($src:expr) => {
         let (ast, _) = crate::parse::parse_module($src).expect("syntax error");
-        let _ = infer_module(&mut 0, ast, &HashMap::new(), &mut vec![]).expect_err("should infer an error");
+        let _ = infer_module(&mut 0, ast, &HashMap::new(), &mut vec![])
+            .expect_err("should infer an error");
     };
 }
 


### PR DESCRIPTION
Warns on unused_results,
fixes all currently unused results with `let _ =`