### PR TITLE
Fix rebar dependencies link in generated READMEs

### DIFF
--- a/src/new.rs
+++ b/src/new.rs
@@ -346,7 +346,7 @@ rebar3 shell
 
 ## Installation
 
-If [available in Hex](https://www.rebar3.org/docs/dependencies#section-declaring-dependencies)
+If [available in Hex](https://rebar3.org/docs/configuration/dependencies/#declaring-dependencies)
 this package can be installed by adding `{name}` to your `rebar.config` dependencies:
 
 ```erlang


### PR DESCRIPTION
`gleam new` produces a README with an installation section that links to
the rebar3 documentation:

> If [available in Hex](https://www.rebar3.org/docs/dependencies#section-declaring-dependencies)
> this package can be installed by adding `test` to your `rebar.config` dependencies:

This link, like other links to https://www.rebar3.org/docs, produces a
404 as it was moved without a redirect. The page now at
https://www.rebar3.org/docs/dependencies#section-declaring-dependencies.

This patch fixes the link in READMEs for newly generated projects.