### PR TITLE
Minimal string escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Automatically generate a link to repository in docs if available.
 - Gleam now generates Erlang typespecs.
 - Code in HTML documentation is has highlighted syntax.
+- Gleam now only supports `\r`, `\n`, `\t`, `\"`, and `\\` string escapes.
 
 ## v0.13.2 - 2020-01-14
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2393,3 +2393,22 @@ fn build_in_erlang_type_escaping() {
 "
     );
 }
+
+#[test]
+fn allowed_string_escapes() {
+    assert_erl!(
+        r#"fn a() { "\n" "\r" "\t" "\\" "\"" "\\^" }"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-spec a() -> binary().
+a() ->
+    <<"\n"/utf8>>,
+    <<"\r"/utf8>>,
+    <<"\t"/utf8>>,
+    <<"\\"/utf8>>,
+    <<"\""/utf8>>,
+    <<"\\^"/utf8>>.
+"#
+    );
+}

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -8,9 +8,10 @@ pub struct LexicalError {
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum LexicalErrorType {
+    BadStringEscape,       // string contains an unescaped slash
     DigitOutOfRadix,       // 0x012 , 2 is out of radix
     NumTrailingUnderscore, // 1_000_ is not allowed
-    RadixIntNoValue,       // 0x, 0x, 0o without a value
+    RadixIntNoValue,       // 0x, 0b, 0o without a value
     UnexpectedStringEnd,   // Unterminated string literal
     UnrecognizedToken { tok: char },
 }
@@ -55,6 +56,13 @@ pub enum ParseErrorType {
 impl LexicalError {
     pub fn to_parse_error_info(&self) -> (&str, Vec<String>) {
         match self.error {
+            LexicalErrorType::BadStringEscape => (
+                "This is an unescaped backslash.",
+                vec![
+                    "Hint: Add another backslash before it.".to_string(),
+                    "See: https://gleam.run/book/tour/strings.html#escape-sequences".to_string(),
+                ],
+            ),
             LexicalErrorType::DigitOutOfRadix => {
                 ("This digit is too big for the specified radix.", vec![])
             }

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -63,3 +63,34 @@ fn int_tests() {
         }
     );
 }
+
+#[test]
+fn string_tests() {
+    // bad character escape
+    assert_error!(
+        r#""\g""#,
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::BadStringEscape,
+                    location: 1,
+                }
+            },
+            location: SrcSpan { start: 1, end: 1 },
+        }
+    );
+
+    // still bad character escape
+    assert_error!(
+        r#""\\\g""#,
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::BadStringEscape,
+                    location: 3,
+                }
+            },
+            location: SrcSpan { start: 3, end: 3 },
+        }
+    );
+}


### PR DESCRIPTION
Changes Gleam to only support a base set of string escapes. `\r`, `\n`,`\t`, `\\` and `\"`.

Realized that with these minimal string escapes, since they are supported as-is by essentially any target, the work can all be done in the lexer.

This PR treats any other escape as the character itself, so `\x` compiles to `x` as will any character other than the escapes above.

Another valid strategy would be to auto escape slashes so `\x` would compile to `\\x`. I chose the strategy in this PR as it's the same way erlang and javascript handle escapes that aren't recognized and it means that having a slash show up in the output is always consistently two slashes.

Since Gleam is pre 1.0 it's probably fine but it should be noted this is a backwards incompatible change. If anyone is relying on other erlang escape sequences they will no longer work.

Fixes: #902 