### PR TITLE
Stricter clippy lints

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,6 +7,7 @@ pub use self::untyped::UntypedExpr;
 
 pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 
+use crate::GleamExpect;
 use crate::typ::{self, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor};
 use std::sync::Arc;
 
@@ -50,7 +51,7 @@ impl<A, B, C, D> Module<A, B, C, D> {
 #[test]
 fn module_dependencies_test() {
     let (module, _) =
-        crate::parse::parse_module("import foo import bar import foo_bar").expect("syntax error");
+        crate::parse::parse_module("import foo import bar import foo_bar").gleam_expect("syntax error");
 
     assert_eq!(
         vec![

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,8 +7,8 @@ pub use self::untyped::UntypedExpr;
 
 pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 
-use crate::GleamExpect;
 use crate::typ::{self, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor};
+use crate::GleamExpect;
 use std::sync::Arc;
 
 pub const CAPTURE_VARIABLE: &str = "gleam@capture_variable";
@@ -50,8 +50,8 @@ impl<A, B, C, D> Module<A, B, C, D> {
 
 #[test]
 fn module_dependencies_test() {
-    let (module, _) =
-        crate::parse::parse_module("import foo import bar import foo_bar").gleam_expect("syntax error");
+    let (module, _) = crate::parse::parse_module("import foo import bar import foo_bar")
+        .gleam_expect("syntax error");
 
     assert_eq!(
         vec![
@@ -300,7 +300,7 @@ pub enum BinOp {
 }
 
 impl BinOp {
-    pub fn precedence(&self) -> u8 {
+    pub fn precedence(self) -> u8 {
         match self {
             Self::Or => 1,
 
@@ -502,8 +502,7 @@ impl<A, B> ClauseGuard<A, B> {
 impl TypedClauseGuard {
     pub fn typ(&self) -> Arc<Type> {
         match self {
-            ClauseGuard::Var { typ, .. } => typ.clone(),
-            ClauseGuard::TupleIndex { typ, .. } => typ.clone(),
+            ClauseGuard::Var { typ, .. } | ClauseGuard::TupleIndex { typ, .. } => typ.clone(),
             ClauseGuard::Constant(constant) => constant.typ(),
 
             ClauseGuard::Or { .. }
@@ -775,21 +774,22 @@ impl<A> BitStringSegmentOption<A> {
 
     pub fn category(&self) -> SegmentOptionCategory {
         match self {
-            BitStringSegmentOption::Binary { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::Integer { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::Float { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::BitString { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF8 { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF16 { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF32 { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF8Codepoint { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF16Codepoint { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF32Codepoint { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::Signed { .. } => SegmentOptionCategory::Signedness,
-            BitStringSegmentOption::Unsigned { .. } => SegmentOptionCategory::Signedness,
-            BitStringSegmentOption::Big { .. } => SegmentOptionCategory::Endianness,
-            BitStringSegmentOption::Little { .. } => SegmentOptionCategory::Endianness,
-            BitStringSegmentOption::Native { .. } => SegmentOptionCategory::Endianness,
+            BitStringSegmentOption::Binary { .. }
+            | BitStringSegmentOption::Integer { .. }
+            | BitStringSegmentOption::Float { .. }
+            | BitStringSegmentOption::BitString { .. }
+            | BitStringSegmentOption::UTF8 { .. }
+            | BitStringSegmentOption::UTF16 { .. }
+            | BitStringSegmentOption::UTF32 { .. }
+            | BitStringSegmentOption::UTF8Codepoint { .. }
+            | BitStringSegmentOption::UTF16Codepoint { .. }
+            | BitStringSegmentOption::UTF32Codepoint { .. } => SegmentOptionCategory::Type,
+            BitStringSegmentOption::Signed { .. } | BitStringSegmentOption::Unsigned { .. } => {
+                SegmentOptionCategory::Signedness
+            }
+            BitStringSegmentOption::Big { .. }
+            | BitStringSegmentOption::Little { .. }
+            | BitStringSegmentOption::Native { .. } => SegmentOptionCategory::Endianness,
             BitStringSegmentOption::Size { .. } => SegmentOptionCategory::Size,
             BitStringSegmentOption::Unit { .. } => SegmentOptionCategory::Unit,
         }

--- a/src/ast/constant.rs
+++ b/src/ast/constant.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{Arc, BitStringSegment, CallArg, HasLocation, SrcSpan, Type};
 use crate::typ::HasType;
 
 pub type TypedConstant = Constant<Arc<Type>, String>;
@@ -53,11 +53,10 @@ impl TypedConstant {
             Constant::Int { .. } => crate::typ::int(),
             Constant::Float { .. } => crate::typ::float(),
             Constant::String { .. } => crate::typ::string(),
-            Constant::List { typ, .. } => typ.clone(),
-            Constant::Record { typ, .. } => typ.clone(),
+            Constant::List { typ, .. } | Constant::Record { typ, .. } => typ.clone(),
             Constant::BitString { .. } => crate::typ::bit_string(),
             Constant::Tuple { elements, .. } => {
-                crate::typ::tuple(elements.iter().map(|e| e.typ()).collect())
+                crate::typ::tuple(elements.iter().map(Constant::typ).collect())
             }
         }
     }
@@ -83,7 +82,10 @@ impl<A, B> Constant<A, B> {
     }
 
     pub fn is_simple(&self) -> bool {
-        matches!(self, Self::Int { .. } | Self::Float { .. } | Self::String { .. })
+        matches!(
+            self,
+            Self::Int { .. } | Self::Float { .. } | Self::String { .. }
+        )
     }
 }
 

--- a/src/ast/typed.rs
+++ b/src/ast/typed.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    Arc, Arg, BinOp, BindingKind, CallArg, Clause, GleamExpect, HasLocation,
+    ModuleValueConstructor, Pattern, PatternConstructor, SrcSpan, TypeAst,
+    TypedExprBitStringSegment, TypedRecordUpdateArg, ValueConstructor,
+};
 use crate::typ::{HasType, Type};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -146,7 +150,8 @@ impl TypedExpr {
     pub fn non_zero_compile_time_number(&self) -> bool {
         use regex::Regex;
         lazy_static! {
-            static ref NON_ZERO: Regex = Regex::new(r"[1-9]").gleam_expect("Invalid regular expression");
+            static ref NON_ZERO: Regex =
+                Regex::new(r"[1-9]").gleam_expect("Invalid regular expression");
         }
         match self {
             Self::Int { value, .. } | Self::Float { value, .. } => NON_ZERO.is_match(value),
@@ -218,26 +223,26 @@ impl HasLocation for TypedExpr {
 impl TypedExpr {
     fn typ(&self) -> Arc<Type> {
         match self {
-            Self::Fn { typ, .. } => typ.clone(),
-            Self::ListNil { typ, .. } => typ.clone(),
-            Self::Let { typ, .. } => typ.clone(),
-            Self::Int { typ, .. } => typ.clone(),
             Self::Seq { then, .. } => then.typ(),
-            Self::Todo { typ, .. } => typ.clone(),
-            Self::Case { typ, .. } => typ.clone(),
-            Self::ListCons { typ, .. } => typ.clone(),
-            Self::Call { typ, .. } => typ.clone(),
-            Self::Pipe { typ, .. } => typ.clone(),
-            Self::Float { typ, .. } => typ.clone(),
-            Self::BinOp { typ, .. } => typ.clone(),
-            Self::Tuple { typ, .. } => typ.clone(),
-            Self::String { typ, .. } => typ.clone(),
-            Self::TupleIndex { typ, .. } => typ.clone(),
             Self::Var { constructor, .. } => constructor.typ.clone(),
-            Self::ModuleSelect { typ, .. } => typ.clone(),
-            Self::RecordAccess { typ, .. } => typ.clone(),
-            Self::BitString { typ, .. } => typ.clone(),
-            Self::RecordUpdate { typ, .. } => typ.clone(),
+            Self::Fn { typ, .. }
+            | Self::ListNil { typ, .. }
+            | Self::Let { typ, .. }
+            | Self::Int { typ, .. }
+            | Self::Todo { typ, .. }
+            | Self::Case { typ, .. }
+            | Self::ListCons { typ, .. }
+            | Self::Call { typ, .. }
+            | Self::Pipe { typ, .. }
+            | Self::Float { typ, .. }
+            | Self::BinOp { typ, .. }
+            | Self::Tuple { typ, .. }
+            | Self::String { typ, .. }
+            | Self::TupleIndex { typ, .. }
+            | Self::ModuleSelect { typ, .. }
+            | Self::RecordAccess { typ, .. }
+            | Self::BitString { typ, .. }
+            | Self::RecordUpdate { typ, .. } => typ.clone(),
         }
     }
 }

--- a/src/ast/typed.rs
+++ b/src/ast/typed.rs
@@ -146,7 +146,7 @@ impl TypedExpr {
     pub fn non_zero_compile_time_number(&self) -> bool {
         use regex::Regex;
         lazy_static! {
-            static ref NON_ZERO: Regex = Regex::new(r"[1-9]").unwrap();
+            static ref NON_ZERO: Regex = Regex::new(r"[1-9]").gleam_expect("Invalid regular expression");
         }
         match self {
             Self::Int { value, .. } | Self::Float { value, .. } => NON_ZERO.is_match(value),

--- a/src/ast/untyped.rs
+++ b/src/ast/untyped.rs
@@ -1,4 +1,7 @@
-use super::*;
+use super::{
+    Arg, BinOp, BindingKind, CallArg, Clause, HasLocation, Pattern, RecordUpdateSpread, SrcSpan,
+    TypeAst, UntypedExprBitStringSegment, UntypedRecordUpdateArg,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum UntypedExpr {
@@ -117,8 +120,7 @@ pub enum UntypedExpr {
 impl UntypedExpr {
     pub fn location(&self) -> SrcSpan {
         match self {
-            Self::Seq { then, .. } => then.location(),
-            Self::Let { then, .. } => then.location(),
+            Self::Seq { then, .. } | Self::Let { then, .. } => then.location(),
             Self::Pipe { right, .. } => right.location(),
             Self::Fn { location, .. }
             | Self::Var { location, .. }
@@ -157,13 +159,23 @@ impl UntypedExpr {
     }
 
     pub fn is_simple_constant(&self) -> bool {
-        matches!(self, Self::String { .. } | Self::Int { .. } | Self::Float { .. })
+        matches!(
+            self,
+            Self::String { .. } | Self::Int { .. } | Self::Float { .. }
+        )
     }
 
     pub fn is_literal(&self) -> bool {
-        matches!(self,
-            Self::Int { .. } | Self::Float { .. } | Self::ListNil { .. } | Self::ListCons { .. }
-            | Self::Tuple { .. } | Self::String { .. } | Self::BitString { .. })
+        matches!(
+            self,
+            Self::Int { .. }
+                | Self::Float { .. }
+                | Self::ListNil { .. }
+                | Self::ListCons { .. }
+                | Self::Tuple { .. }
+                | Self::String { .. }
+                | Self::BitString { .. }
+        )
     }
 }
 

--- a/src/bit_string.rs
+++ b/src/bit_string.rs
@@ -12,6 +12,7 @@ pub struct BinaryTypeSpecifier<T> {
 }
 
 impl<T> BinaryTypeSpecifier<T> {
+    #[allow(clippy::too_many_lines)]
     pub fn new(options: &[BitStringSegmentOption<T>], must_have_size: bool) -> Result<Self, Error>
     where
         T: Clone,
@@ -136,16 +137,14 @@ impl<T> BinaryTypeSpecifier<T> {
         match self.typ {
             Some(BitStringSegmentOption::Integer { .. }) => Some(crate::typ::int()),
             Some(BitStringSegmentOption::Float { .. }) => Some(crate::typ::float()),
-            Some(BitStringSegmentOption::Binary { .. }) => Some(crate::typ::bit_string()),
-            Some(BitStringSegmentOption::BitString { .. }) => Some(crate::typ::bit_string()),
-            Some(BitStringSegmentOption::UTF8 { .. }) => Some(crate::typ::string()),
-            Some(BitStringSegmentOption::UTF16 { .. }) => Some(crate::typ::string()),
-            Some(BitStringSegmentOption::UTF32 { .. }) => Some(crate::typ::string()),
-            Some(BitStringSegmentOption::UTF8Codepoint { .. }) => Some(crate::typ::utf_codepoint()),
-            Some(BitStringSegmentOption::UTF16Codepoint { .. }) => {
-                Some(crate::typ::utf_codepoint())
-            }
-            Some(BitStringSegmentOption::UTF32Codepoint { .. }) => {
+            Some(BitStringSegmentOption::Binary { .. })
+            | Some(BitStringSegmentOption::BitString { .. }) => Some(crate::typ::bit_string()),
+            Some(BitStringSegmentOption::UTF8 { .. })
+            | Some(BitStringSegmentOption::UTF16 { .. })
+            | Some(BitStringSegmentOption::UTF32 { .. }) => Some(crate::typ::string()),
+            Some(BitStringSegmentOption::UTF8Codepoint { .. })
+            | Some(BitStringSegmentOption::UTF16Codepoint { .. })
+            | Some(BitStringSegmentOption::UTF32Codepoint { .. }) => {
                 Some(crate::typ::utf_codepoint())
             }
             _ => None,
@@ -193,10 +192,11 @@ pub enum Error {
 
 impl<A> BitStringSegmentOption<A> {
     pub fn unit_is_allowed(&self) -> bool {
-        !matches!(self,
+        !matches!(
+            self,
             BitStringSegmentOption::UTF8 { .. }
-            | BitStringSegmentOption::UTF16 { .. }
-            | BitStringSegmentOption::UTF32 { .. }
+                | BitStringSegmentOption::UTF16 { .. }
+                | BitStringSegmentOption::UTF32 { .. }
         )
     }
 }

--- a/src/bit_string.rs
+++ b/src/bit_string.rs
@@ -12,7 +12,6 @@ pub struct BinaryTypeSpecifier<T> {
 }
 
 impl<T> BinaryTypeSpecifier<T> {
-    #[allow(clippy::too_many_lines)]
     pub fn new(options: &[BitStringSegmentOption<T>], must_have_size: bool) -> Result<Self, Error>
     where
         T: Clone,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,13 @@
 use crate::error::{Error, StandardIOAction};
+use crate::GleamExpect;
 use std::io::Write;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 pub fn ask(question: &str) -> Result<String, Error> {
     print!("{}: ", question);
-    std::io::stdout().flush().unwrap();
+    std::io::stdout()
+        .flush()
+        .gleam_expect("Stdout::flush() failed to flush");
     let mut answer = String::new();
     let _ = std::io::stdin()
         .read_line(&mut answer)
@@ -38,11 +41,15 @@ pub fn print_green_prefix(prefix: &str, text: &str) {
     let mut buffer = buffer_writer.buffer();
     buffer
         .set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Green)))
-        .unwrap();
-    write!(buffer, "{}", prefix).unwrap();
-    buffer.set_color(&ColorSpec::new()).unwrap();
-    writeln!(buffer, " {}", text).unwrap();
-    buffer_writer.print(&buffer).unwrap();
+        .gleam_expect("BufferWriter::set_color() failed to set color");
+    write!(buffer, "{}", prefix).gleam_expect("BufferWriter::write() failed to write");
+    buffer
+        .set_color(&ColorSpec::new())
+        .gleam_expect("BufferWriter::set_color() failed to set color");
+    writeln!(buffer, " {}", text).gleam_expect("BufferWriter::write() failed to write");
+    buffer_writer
+        .print(&buffer)
+        .gleam_expect("BufferWriter::print() failed to print");
 }
 
 pub fn stderr_buffer_writer() -> BufferWriter {

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -43,7 +43,7 @@ impl<'a> Erlang<'a> {
         module: &Module,
         erl_name: &str,
     ) -> Result<()> {
-        for (name, text) in erl::records(&module.ast).into_iter() {
+        for (name, text) in &erl::records(&module.ast) {
             let name = format!("{}_{}.hrl", erl_name, name);
             tracing::trace!(name = ?name, "Generated Erlang header");
             writer

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -43,7 +43,7 @@ impl<'a> Erlang<'a> {
         module: &Module,
         erl_name: &str,
     ) -> Result<()> {
-        for (name, text) in &erl::records(&module.ast) {
+        for (name, text) in erl::records(&module.ast).into_iter() {
             let name = format!("{}_{}.hrl", erl_name, name);
             tracing::trace!(name = ?name, "Generated Erlang header");
             writer

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -3,6 +3,8 @@ pub use codespan_reporting::diagnostic::{LabelStyle, Severity};
 use codespan_reporting::{diagnostic::Label, term::emit};
 use termcolor::Buffer;
 
+use crate::GleamExpect;
+
 pub struct DiagnosticLabel {
     pub style: LabelStyle,
     pub location: crate::ast::SrcSpan,
@@ -56,7 +58,7 @@ pub fn write_diagnostic(mut buffer: &mut Buffer, d: MultiLineDiagnostic, severit
         .with_labels(labels);
 
     let config = codespan_reporting::term::Config::default();
-    emit(&mut buffer, &config, &files, &diagnostic).unwrap();
+    emit(&mut buffer, &config, &files, &diagnostic).gleam_expect("Failed to emit diagnostic");
 }
 
 /// Describes an error encountered while compiling the project (eg. a name collision
@@ -72,17 +74,23 @@ pub fn write_title(buffer: &mut Buffer, title: &str) {
     use termcolor::{Color, ColorSpec, WriteColor};
     buffer
         .set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Red)))
-        .unwrap();
-    write!(buffer, "error").unwrap();
-    buffer.set_color(ColorSpec::new().set_bold(true)).unwrap();
-    write!(buffer, ": {}\n\n", title).unwrap();
-    buffer.set_color(&ColorSpec::new()).unwrap();
+        .gleam_expect("Buffer::set_color() failed to set color");
+    write!(buffer, "error").gleam_expect("write!() failed to write");
+    buffer
+        .set_color(ColorSpec::new().set_bold(true))
+        .gleam_expect("Buffer::set_color() failed to set color");
+    write!(buffer, ": {}\n\n", title).gleam_expect("write!() failed to write");
+    buffer
+        .set_color(&ColorSpec::new())
+        .gleam_expect("Buffer::set_color() failed to set color");
 }
 
 pub fn write_project(buffer: &mut Buffer, d: ProjectErrorDiagnostic) {
     use std::io::Write;
     use termcolor::{ColorSpec, WriteColor};
     write_title(buffer, d.title.as_ref());
-    buffer.set_color(&ColorSpec::new()).unwrap();
-    writeln!(buffer, "{}", d.label).unwrap();
+    buffer
+        .set_color(&ColorSpec::new())
+        .gleam_expect("Buffer::set_color() failed to set color");
+    writeln!(buffer, "{}", d.label).gleam_expect("writeln!() failed to write");
 }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -85,7 +85,7 @@ pub fn write_title(buffer: &mut Buffer, title: &str) {
         .gleam_expect("Buffer::set_color() failed to set color");
 }
 
-pub fn write_project(buffer: &mut Buffer, d: ProjectErrorDiagnostic) {
+pub fn write_project(buffer: &mut Buffer, d: &ProjectErrorDiagnostic) {
     use std::io::Write;
     use termcolor::{ColorSpec, WriteColor};
     write_title(buffer, d.title.as_ref());

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -140,7 +140,7 @@ pub fn generate_html(
         let name = module.name.join("/");
 
         // Read module src & create line number lookup structure
-        let source_links = SourceLinker::new(&project_root, project_config, &module);
+        let source_links = SourceLinker::new(&project_root, project_config, module);
 
         let template = ModuleTemplate {
             unnest: module.name.iter().map(|_| "..").intersperse("/").collect(),
@@ -157,7 +157,7 @@ pub fn generate_html(
                     .ast
                     .statements
                     .iter()
-                    .flat_map(|statement| function(&source_links, &statement))
+                    .flat_map(|statement| function(&source_links, statement))
                     .collect();
                 f.sort();
                 f
@@ -167,7 +167,7 @@ pub fn generate_html(
                     .ast
                     .statements
                     .iter()
-                    .flat_map(|statement| type_(&source_links, &statement))
+                    .flat_map(|statement| type_(&source_links, statement))
                     .collect();
                 t.sort();
                 t
@@ -177,7 +177,7 @@ pub fn generate_html(
                     .ast
                     .statements
                     .iter()
-                    .flat_map(|statement| constant(&source_links, &statement))
+                    .flat_map(|statement| constant(&source_links, statement))
                     .collect();
                 c.sort();
                 c
@@ -253,6 +253,7 @@ fn markdown_documentation(doc: &Option<String>) -> String {
     }
 }
 
+#[allow(clippy::integer_division)]
 fn render_markdown(text: &str) -> String {
     let mut s = String::with_capacity(text.len() * 3 / 2);
     let p = pulldown_cmark::Parser::new_ext(&*text, pulldown_cmark::Options::all());
@@ -468,7 +469,7 @@ fn check_app_file_version_matches(
                 // Error if we've found the version and it doesn't match
                 Err(Error::VersionDoesNotMatch {
                     toml_ver: project_config.version.clone(),
-                    app_ver: version.to_string(),
+                    app_ver: version,
                 })
             }
         })

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -146,8 +146,7 @@ pub fn generate_html(
         let source_links = SourceLinker::new(&project_root, project_config, module);
 
         let template = ModuleTemplate {
-            unnest: itertools::Itertools::intersperse(module.name.iter().map(|_| ".."), "/")
-                .collect(),
+            unnest: module.name.iter().map(|_| "..").intersperse("/").collect(),
             links: &links,
             pages: &pages,
             documentation: render_markdown(module.ast.documentation.iter().join("\n").as_str()),

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -377,7 +377,7 @@ fn constant<'a>(
 }
 
 fn print(doc: pretty::Document<'_>) -> String {
-    doc.to_pretty_string(MAX_COLUMNS)
+    doc.into_pretty_string(MAX_COLUMNS)
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -63,7 +63,6 @@ pub fn build_project(
     Ok((config, outputs))
 }
 
-#[allow(clippy::too_many_lines)]
 pub fn generate_html(
     project_root: impl AsRef<Path>,
     project_config: &PackageConfig,

--- a/src/docs/command.rs
+++ b/src/docs/command.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 static TOKEN_NAME: &str = concat!(env!("CARGO_PKG_NAME"), " (", env!("CARGO_PKG_VERSION"), ")");
 static DOCS_DIR_NAME: &str = "docs";
 
-pub fn remove(package: String, version: String) -> Result<(), Error> {
+pub fn remove(package: &str, version: &str) -> Result<(), Error> {
     // Start event loop so we can run async functions to call the Hex API
     let runtime =
         tokio::runtime::Runtime::new().gleam_expect("Unable to start Tokio async runtime");
@@ -25,7 +25,7 @@ pub fn remove(package: String, version: String) -> Result<(), Error> {
             .authenticate(username.as_str(), password.as_str(), TOKEN_NAME)
             .await
             .map_err(|e| Error::Hex(e.to_string()))?
-            .remove_docs(package.as_str(), version.as_str())
+            .remove_docs(package, version)
             .await
             .map_err(|e| Error::Hex(e.to_string()))
     })?;
@@ -38,21 +38,24 @@ pub fn remove(package: String, version: String) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn build(project_root: String, version: String, to: Option<String>) -> Result<(), Error> {
+pub fn build(project_root: &str, version: &str, to: Option<String>) -> Result<(), Error> {
     let project_root = PathBuf::from(&project_root).canonicalize().map_err(|_| {
         Error::UnableToFindProjectRoot {
-            path: project_root.clone(),
+            path: project_root.to_owned(),
         }
     })?;
 
-    let output_dir = to.map(PathBuf::from).unwrap_or_else(|| {
-        project_root
-            .join(project::OUTPUT_DIR_NAME)
-            .join(DOCS_DIR_NAME)
-    });
+    let output_dir = to.map_or_else(
+        || {
+            project_root
+                .join(project::OUTPUT_DIR_NAME)
+                .join(DOCS_DIR_NAME)
+        },
+        PathBuf::from,
+    );
 
     // Build
-    let (config, outputs) = super::build_project(&project_root, version, &output_dir)?;
+    let (config, outputs) = super::build_project(&project_root, version.to_owned(), &output_dir)?;
 
     // Write
     crate::fs::delete_dir(&output_dir)?;
@@ -67,11 +70,11 @@ pub fn build(project_root: String, version: String, to: Option<String>) -> Resul
     Ok(())
 }
 
-pub fn publish(project_root: impl AsRef<Path>, version: String) -> Result<(), Error> {
+pub fn publish(project_root: impl AsRef<Path>, version: &str) -> Result<(), Error> {
     let output_dir = PathBuf::new();
 
     // Build
-    let (config, outputs) = super::build_project(&project_root, version.clone(), &output_dir)?;
+    let (config, outputs) = super::build_project(&project_root, version.to_owned(), &output_dir)?;
 
     // Create gzipped tarball of docs
     let archive = crate::fs::create_tar_archive(outputs)?;
@@ -90,7 +93,7 @@ pub fn publish(project_root: impl AsRef<Path>, version: String) -> Result<(), Er
             .authenticate(username.as_str(), password.as_str(), TOKEN_NAME)
             .await
             .map_err(|e| Error::Hex(e.to_string()))?
-            .publish_docs(config.name.as_str(), version.as_str(), Bytes::from(archive))
+            .publish_docs(config.name.as_str(), version, Bytes::from(archive))
             .await
             .map_err(|e| Error::Hex(e.to_string()))
     })?;

--- a/src/docs/source_links.rs
+++ b/src/docs/source_links.rs
@@ -3,7 +3,7 @@ use crate::{
     config::{PackageConfig, Repository},
     project::Analysed,
 };
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub struct SourceLinker {
     line_starts: Vec<usize>,
@@ -80,7 +80,7 @@ fn line_no(line_starts: &[usize], byte_index: usize) -> usize {
         + 1
 }
 
-fn get_path_in_repo(project_root: impl AsRef<Path>, path: &PathBuf) -> String {
+fn get_path_in_repo(project_root: impl AsRef<Path>, path: &Path) -> String {
     path.strip_prefix(&project_root)
         .ok()
         .and_then(Path::to_str)

--- a/src/docs/source_links.rs
+++ b/src/docs/source_links.rs
@@ -73,7 +73,7 @@ fn line_starts(src: &str) -> Vec<usize> {
 }
 
 // get the line number for a byte index
-fn line_no(line_starts: &Vec<usize>, byte_index: usize) -> usize {
+fn line_no(line_starts: &[usize], byte_index: usize) -> usize {
     line_starts
         .binary_search(&byte_index)
         .unwrap_or_else(|next_line| next_line - 1)

--- a/src/docs/tests.rs
+++ b/src/docs/tests.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::*;
 use crate::{config::PackageConfig, fs::OutputFile, project::Input};
 
@@ -41,19 +43,19 @@ pub fn complicated_fun(
 
     let config = PackageConfig {
         name: "test".to_string(),
-        docs: Default::default(),
-        tool: Default::default(),
-        version: Default::default(),
-        repository: Default::default(),
-        description: Default::default(),
-        dependencies: Default::default(),
+        docs: crate::config::Docs::default(),
+        tool: crate::config::BuildTool::default(),
+        version: String::default(),
+        repository: crate::config::Repository::default(),
+        description: String::default(),
+        dependencies: std::collections::HashMap::default(),
         otp_start_module: None,
     };
 
-    let mut analysed = crate::project::analysed(vec![input]).gleam_expect("Compilation failed");
+    let mut analysed = crate::project::analysed(&[input]).gleam_expect("Compilation failed");
     analysed
         .iter_mut()
-        .for_each(|a| a.attach_doc_and_module_comments());
+        .for_each(crate::project::Analysed::attach_doc_and_module_comments);
 
     let output_files = generate_html(
         PathBuf::from("."),

--- a/src/docs/tests.rs
+++ b/src/docs/tests.rs
@@ -43,13 +43,7 @@ pub fn complicated_fun(
 
     let config = PackageConfig {
         name: "test".to_string(),
-        docs: crate::config::Docs::default(),
-        tool: crate::config::BuildTool::default(),
-        version: String::default(),
-        repository: crate::config::Repository::default(),
-        description: String::default(),
-        dependencies: std::collections::HashMap::default(),
-        otp_start_module: None,
+        ..Default::default()
     };
 
     let mut analysed = crate::project::analysed(&[input]).gleam_expect("Compilation failed");

--- a/src/docs/tests.rs
+++ b/src/docs/tests.rs
@@ -49,7 +49,7 @@ pub fn complicated_fun(
     let mut analysed = crate::project::analysed(&[input]).gleam_expect("Compilation failed");
     analysed
         .iter_mut()
-        .for_each(crate::project::Analysed::attach_doc_and_module_comments);
+        .for_each(|a| a.attach_doc_and_module_comments());
 
     let output_files = generate_html(
         PathBuf::from("."),

--- a/src/docs/tests.rs
+++ b/src/docs/tests.rs
@@ -50,7 +50,7 @@ pub fn complicated_fun(
         otp_start_module: None,
     };
 
-    let mut analysed = crate::project::analysed(vec![input]).expect("Compilation failed");
+    let mut analysed = crate::project::analysed(vec![input]).gleam_expect("Compilation failed");
     analysed
         .iter_mut()
         .for_each(|a| a.attach_doc_and_module_comments());
@@ -65,7 +65,7 @@ pub fn complicated_fun(
     let module_page = output_files
         .iter()
         .find(|page| page.path == PathBuf::from("/docs/test/index.html"))
-        .expect("Missing docs page");
+        .gleam_expect("Missing docs page");
 
     // Comments
     module_page.should_contain("module comment");

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -33,7 +33,7 @@ pub fn generate_erlang(analysed: &[Analysed]) -> Vec<OutputFile> {
     {
         let gen_dir = source_base_path
             .parent()
-            .unwrap()
+            .gleam_expect("The source base path terminates in a root or prefix")
             .join(project::OUTPUT_DIR_NAME)
             .join(origin.dir_name());
         let erl_module_name = name.join("@");
@@ -56,7 +56,7 @@ pub fn generate_erlang(analysed: &[Analysed]) -> Vec<OutputFile> {
     files
 }
 
-fn module_name_join<'a>(module: &'a [String]) -> Document<'a> {
+fn module_name_join(module: &[String]) -> Document<'_> {
     let mut name = Vec::with_capacity(module.len() * 2);
     for (i, segment) in module.iter().enumerate() {
         if i != 0 {
@@ -275,7 +275,7 @@ where
 fn atom<'a>(value: String) -> Document<'a> {
     use regex::Regex;
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"^[a-z][a-z0-9_@]*$").unwrap();
+        static ref RE: Regex = Regex::new(r"^[a-z][a-z0-9_@]*$").gleam_expect("Invalid regular expression");
     }
 
     match &*value {
@@ -290,7 +290,7 @@ fn atom<'a>(value: String) -> Document<'a> {
     }
 }
 
-fn string<'a>(value: &'a str) -> Document<'a> {
+fn string(value: &str) -> Document<'_> {
     value.to_doc().surround("<<\"", "\"/utf8>>")
 }
 
@@ -726,7 +726,7 @@ where
     elems.to_doc().nest_current().surround("[", "]").group()
 }
 
-fn collect_cons<'a, F, E, T>(e: T, elems: &'a mut Vec<E>, f: F) -> Option<T>
+fn collect_cons<F, E, T>(e: T, elems: &mut Vec<E>, f: F) -> Option<T>
 where
     F: Fn(T) -> ListType<E, T>,
 {
@@ -1160,7 +1160,7 @@ fn record_update<'a>(
 
 /// Wrap a document in begin end
 ///
-fn begin_end<'a>(document: Document<'a>) -> Document<'a> {
+fn begin_end(document: Document<'_>) -> Document<'_> {
     force_break()
         .append("begin")
         .append(line().append(document).nest(INDENT))

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::truncate;
+use crate::num_util::to_u8;
 use crate::{
     ast::{
         ArgNames, BinOp, BindingKind, BitStringSegmentOption, CallArg, Clause, ClauseGuard,
@@ -1316,7 +1316,7 @@ fn fun<'a>(args: &'a [TypedArg], body: &'a TypedExpr, env: &mut Env<'_>) -> Docu
 fn incrementing_args_list(arity: usize) -> String {
     Itertools::intersperse(
         (65..(65 + arity))
-            .map(|x| char::from(truncate!(x, u8)))
+            .map(|x| char::from(to_u8(x)))
             .map(|c| c.to_string()),
         ", ".to_string(),
     )

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -90,7 +90,7 @@ impl<'env> Env<'env> {
     }
 
     pub fn local_var_name<'a>(&mut self, name: &str) -> Document<'a> {
-        match self.current_scope_vars.get(&name.to_owned()) {
+        match self.current_scope_vars.get(name) {
             None => {
                 let _ = self.current_scope_vars.insert(name.to_owned(), 0);
                 let _ = self.erl_function_scope_vars.insert(name.to_owned(), 0);
@@ -102,10 +102,7 @@ impl<'env> Env<'env> {
     }
 
     pub fn next_local_var_name<'a>(&mut self, name: &str) -> Document<'a> {
-        let next = self
-            .erl_function_scope_vars
-            .get(&name.to_owned())
-            .map_or(0, |i| i + 1);
+        let next = self.erl_function_scope_vars.get(name).map_or(0, |i| i + 1);
         let _ = self.erl_function_scope_vars.insert(name.to_owned(), next);
         let _ = self.current_scope_vars.insert(name.to_owned(), next);
         self.local_var_name(name)

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -3,13 +3,13 @@ use super::*;
 #[test]
 fn record_definition_test() {
     assert_eq!(
-        record_definition("PetCat", &[&"name", &"is_cute",]),
+        record_definition("PetCat", &["name", "is_cute",]),
         "-record(pet_cat, {name, is_cute}).\n".to_string()
     );
 
     // Reserved words are escaped in record names and fields
     assert_eq!(
-        record_definition("div", &[&"receive", &"catch", &"unreserved"]),
+        record_definition("div", &["receive", "catch", "unreserved"]),
         "-record(\'div\', {\'receive\', \'catch\', unreserved}).\n".to_string()
     );
 }

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -123,6 +123,7 @@ go() ->
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn integration_test() {
     assert_erl!(
         r#"fn go() {
@@ -625,6 +626,7 @@ main(Args) ->
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn bit_string_discard() {
     // https://github.com/gleam-lang/gleam/issues/704
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -123,7 +123,6 @@ go() ->
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
 fn integration_test() {
     assert_erl!(
         r#"fn go() {
@@ -626,7 +625,6 @@ main(Args) ->
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
 fn bit_string_discard() {
     // https://github.com/gleam-lang/gleam/issues/704
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -246,7 +246,7 @@ fn did_you_mean(name: &str, options: &mut Vec<String>, alt: &'static str) -> Str
 }
 
 impl Error {
-    #[allow(clippy::unwrap_used, clippy::too_many_lines)]
+    #[allow(clippy::unwrap_used)]
     pub fn pretty(&self, buffer: &mut Buffer) {
         use crate::typ::Error as TypeError;
         use std::io::Write;
@@ -1722,7 +1722,6 @@ fn std_io_error_kind_text(kind: std::io::ErrorKind) -> String {
     }
 }
 
-#[allow(clippy::non_ascii_literal)]
 fn import_cycle(buffer: &mut Buffer, modules: &[String]) {
     use std::io::Write;
     use termcolor::{Color, ColorSpec, WriteColor};

--- a/src/eunit.rs
+++ b/src/eunit.rs
@@ -27,8 +27,13 @@ pub fn command(root_string: String) -> Result<(), Error> {
     let test_modules = packages
         .into_iter()
         .flat_map(|(_, p)| p.modules.into_iter())
-        .filter(|m| m.origin == Origin::Test)
-        .map(|m| m.name.replace("/", "@"))
+        .filter_map(|m| {
+            if m.origin == Origin::Test {
+                Some(m.name.replace("/", "@"))
+            } else {
+                None
+            }
+        })
         .join(",");
 
     // Prepare eunit runner and its dependencies.
@@ -75,8 +80,13 @@ pub fn command(root_string: String) -> Result<(), Error> {
     let _ = command.arg(root.build_path().join("eunit_runner.erl"));
 
     let ebin_paths: String = crate::fs::read_dir(root.default_build_lib_path())?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path().join("ebin").as_path().display().to_string())
+        .filter_map(|entry| {
+            if let Ok(entry) = entry {
+                Some(entry.path().join("ebin").as_path().display().to_string())
+            } else {
+                None
+            }
+        })
         .join(",");
 
     // we supply two parameters to the escript. First is a comma seperated

--- a/src/format/command.rs
+++ b/src/format/command.rs
@@ -63,10 +63,10 @@ fn check_files(files: Vec<String>) -> Result<()> {
 }
 
 fn format_files(files: Vec<String>) -> Result<()> {
-    for file in &unformatted_files(files)? {
+    for file in unformatted_files(files)?.into_iter() {
         crate::fs::write_output(&OutputFile {
-            path: file.destination.clone(),
-            text: file.output.clone(),
+            path: file.destination,
+            text: file.output,
         })?;
     }
     Ok(())

--- a/src/format/command.rs
+++ b/src/format/command.rs
@@ -63,10 +63,10 @@ fn check_files(files: Vec<String>) -> Result<()> {
 }
 
 fn format_files(files: Vec<String>) -> Result<()> {
-    for file in unformatted_files(files)?.into_iter() {
+    for file in &unformatted_files(files)? {
         crate::fs::write_output(&OutputFile {
-            path: file.destination,
-            text: file.output,
+            path: file.destination.clone(),
+            text: file.output.clone(),
         })?;
     }
     Ok(())
@@ -84,7 +84,7 @@ pub fn unformatted_files(files: Vec<String>) -> Result<Vec<Unformatted>> {
         })?;
 
         if path.is_dir() {
-            for path in crate::fs::gleam_files_excluding_gitignore(&path).into_iter() {
+            for path in crate::fs::gleam_files_excluding_gitignore(&path) {
                 format_file(&mut problem_files, path)?;
             }
         } else {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -140,6 +140,7 @@ external fn x(a, b, c) -> tuple(a, b, c) =
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn type_alias() {
     assert_format!(
         "type Option(a) =
@@ -885,6 +886,7 @@ pub fn try_map(
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn binary_operators() {
     assert_format!(
         r#"fn main() {
@@ -1112,6 +1114,7 @@ World"
 "#
     );
 }
+
 #[test]
 fn expr_seq() {
     assert_format!(
@@ -1132,6 +1135,7 @@ fn expr_seq() {
     );
 }
 #[test]
+#[allow(clippy::too_many_lines)]
 fn expr_lists() {
     assert_format!(
         "fn main() {
@@ -1255,6 +1259,7 @@ fn expr_lists() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn expr_pipe() {
     assert_format!(
         r#"fn main() {
@@ -1392,6 +1397,7 @@ fn expr_pipe() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn expr_let() {
     assert_format!(
         r#"fn main() {
@@ -2134,6 +2140,7 @@ type Whatever {
 }
 
 #[test]
+#[allow(clippy::too_many_lines, clippy::non_ascii_literal)]
 fn comments() {
     assert_format!(
         r#"import one

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -140,7 +140,7 @@ external fn x(a, b, c) -> tuple(a, b, c) =
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn type_alias() {
     assert_format!(
         "type Option(a) =
@@ -886,7 +886,7 @@ pub fn try_map(
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn binary_operators() {
     assert_format!(
         r#"fn main() {
@@ -1135,7 +1135,7 @@ fn expr_seq() {
     );
 }
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn expr_lists() {
     assert_format!(
         "fn main() {
@@ -1259,7 +1259,7 @@ fn expr_lists() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn expr_pipe() {
     assert_format!(
         r#"fn main() {
@@ -1397,7 +1397,7 @@ fn expr_pipe() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn expr_let() {
     assert_format!(
         r#"fn main() {
@@ -2140,7 +2140,6 @@ type Whatever {
 }
 
 #[test]
-#[allow(clippy::too_many_lines, clippy::non_ascii_literal)]
 fn comments() {
     assert_format!(
         r#"import one

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -20,7 +20,7 @@ pub trait FileSystemWriter: Debug {
     fn open<'a>(&self, path: &'a Path) -> Result<WrappedWriter<'a>, Error>;
 }
 
-/// A FileWriter implementation that writes to the file system.
+/// A `FileWriter` implementation that writes to the file system.
 #[derive(Debug)]
 pub struct FileSystemAccessor;
 
@@ -60,7 +60,7 @@ impl FileSystemWriter for FileSystemAccessor {
 }
 
 pub trait Utf8Writer: std::fmt::Write {
-    /// A wrapper around fmt::Write that has Gleam's error handling.
+    /// A wrapper around `fmt::Write` that has Gleam's error handling.
     fn str_write(&mut self, str: &str) -> Result<(), Error> {
         let res = self.write_str(str);
         self.wrap_result(res)
@@ -85,7 +85,7 @@ impl Utf8Writer for String {
 }
 
 pub trait Writer: Write + Utf8Writer {
-    /// A wrapper around io::Write that has Gleam's error handling.
+    /// A wrapper around `io::Write` that has Gleam's error handling.
     fn write(&mut self, bytes: &[u8]) -> Result<(), Error> {
         let res = std::io::Write::write(self, bytes);
         self.wrap_result(res)

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@
     clippy::indexing_slicing,
     clippy::mem_forget
 )]
-#![allow(clippy::module_name_repetitions, clippy::non_ascii_literal)]
+#![allow(clippy::module_name_repetitions, clippy::non_ascii_literal, clippy::too_many_lines)]
 
 #[macro_use]
 mod pretty;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,8 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::non_ascii_literal,
-    clippy::too_many_lines
+    clippy::too_many_lines,
+    clippy::explicit_into_iter_loop
 )]
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@
     clippy::todo,
     clippy::empty_enum,
     clippy::enum_glob_use,
-    clippy::mem_forget,
     // TODO: enable once the false positive bug is solved
     // clippy::use_self,
     clippy::filter_map_next,
@@ -14,7 +13,6 @@
     clippy::needless_borrow,
     clippy::match_wildcard_for_single_variants,
     clippy::if_let_mutex,
-    clippy::mismatched_target_os,
     clippy::await_holding_lock,
     clippy::match_on_vec_items,
     clippy::imprecise_flops,
@@ -33,7 +31,6 @@
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
-    unstable_features,
     nonstandard_style,
     unused_import_braces,
     unused_qualifications,
@@ -43,7 +40,6 @@
     clippy::unimplemented,
     clippy::expect_used,
     clippy::unwrap_used,
-    clippy::ok_expect,
     clippy::integer_division,
     clippy::indexing_slicing,
     clippy::mem_forget

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,9 @@
     clippy::too_many_lines,
     clippy::explicit_into_iter_loop,
     clippy::default_trait_access,
-    unstable_name_collisions
+    unstable_name_collisions,
+    clippy::map_unwrap_or,
+    clippy::redundant_closure_for_method_calls
 )]
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@
     clippy::default_trait_access,
     unstable_name_collisions,
     clippy::map_unwrap_or,
-    clippy::redundant_closure_for_method_calls
+    clippy::redundant_closure_for_method_calls,
+    clippy::shadow_unrelated
 )]
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,11 @@
     clippy::indexing_slicing,
     clippy::mem_forget
 )]
-#![allow(clippy::module_name_repetitions, clippy::non_ascii_literal, clippy::too_many_lines)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::non_ascii_literal,
+    clippy::too_many_lines
+)]
 
 #[macro_use]
 mod pretty;
@@ -53,6 +57,7 @@ mod format;
 mod fs;
 mod metadata;
 mod new;
+mod num_util;
 mod parse;
 mod project;
 mod shell;
@@ -326,22 +331,4 @@ fn initialise_logger() {
         .with_target(false)
         .without_time()
         .init();
-}
-
-/// Explicitly truncates a larger int type to a smaller int type
-#[macro_export]
-macro_rules! truncate {
-    ($input:expr, $ty:ident) => {{
-        use std::convert::TryFrom;
-        $ty::try_from($input).unwrap_or($ty::MAX)
-    }};
-}
-
-/// Explicitly wraps an unsigned int type to a signed int type
-#[macro_export]
-macro_rules! wrap {
-    ($input:expr, $ty:ident) => {{
-        use std::convert::TryFrom;
-        $ty::try_from($input).unwrap_or(-1)
-    }};
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@
     clippy::module_name_repetitions,
     clippy::non_ascii_literal,
     clippy::too_many_lines,
-    clippy::explicit_into_iter_loop
+    clippy::explicit_into_iter_loop,
+    clippy::default_trait_access
 )]
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,8 @@
     clippy::non_ascii_literal,
     clippy::too_many_lines,
     clippy::explicit_into_iter_loop,
-    clippy::default_trait_access
+    clippy::default_trait_access,
+    unstable_name_collisions
 )]
 
 #[macro_use]

--- a/src/metadata/module_builder.rs
+++ b/src/metadata/module_builder.rs
@@ -1,23 +1,23 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::sync::Arc;
+use std::{cell::RefCell, collections::HashMap, convert::TryFrom, sync::Arc};
 
-use crate::ast::{
-    BitStringSegmentOption, Constant, TypedConstant, TypedConstantBitStringSegment,
-    TypedConstantBitStringSegmentOption, TypedExprBitStringSegment,
+use crate::{
+    ast::{
+        BitStringSegmentOption, Constant, TypedConstant, TypedConstantBitStringSegment,
+        TypedConstantBitStringSegmentOption, TypedExprBitStringSegment,
+    },
+    fs::Writer,
+    num_util::{to_u16, to_u32},
+    schema_capnp::{
+        accessors_map, bit_string_segment, bit_string_segment_option, constant, field_map, module,
+        option, record_accessor, type_, type_constructor, value_constructor,
+        value_constructor_variant,
+    },
+    typ::{
+        self, AccessorsMap, FieldMap, RecordAccessor, Type, TypeConstructor, TypeVar,
+        ValueConstructor, ValueConstructorVariant,
+    },
+    GleamExpect,
 };
-use crate::fs::Writer;
-use crate::num_util::{to_u16, to_u32};
-use crate::schema_capnp::{
-    accessors_map, bit_string_segment, bit_string_segment_option, constant, field_map, module,
-    option, record_accessor, type_, type_constructor, value_constructor, value_constructor_variant,
-};
-use crate::typ::{
-    self, AccessorsMap, FieldMap, RecordAccessor, Type, TypeConstructor, TypeVar, ValueConstructor,
-    ValueConstructorVariant,
-};
-use crate::GleamExpect;
 
 pub struct ModuleBuilder<'a> {
     data: &'a typ::Module,

--- a/src/new.rs
+++ b/src/new.rs
@@ -8,10 +8,10 @@ use std::io::Write;
 use std::path::PathBuf;
 use strum_macros::{Display, EnumString, EnumVariantNames};
 
-const GLEAM_STDLIB_VERSION: &'static str = "0.13.0";
-const GLEAM_OTP_VERSION: &'static str = "0.1.0";
-const ERLANG_OTP_VERSION: &'static str = "22.1";
-const PROJECT_VERSION: &'static str = "1.0.0";
+const GLEAM_STDLIB_VERSION: &str = "0.13.0";
+const GLEAM_OTP_VERSION: &str = "0.1.0";
+const ERLANG_OTP_VERSION: &str = "22.1";
+const PROJECT_VERSION: &str = "1.0.0";
 
 #[derive(Debug, Serialize, Deserialize, Display, EnumString, EnumVariantNames, Clone, Copy)]
 #[strum(serialize_all = "kebab_case")]
@@ -445,7 +445,7 @@ The rebar3 program can be used to compile and test it.
     rebar3 eunit
 ",
         creator.options.name,
-        creator.root.to_str().expect("Unable to display path")
+        creator.root.to_str().gleam_expect("Unable to display path")
     );
     Ok(())
 }
@@ -453,7 +453,7 @@ The rebar3 program can be used to compile and test it.
 fn write(path: PathBuf, contents: &str) -> Result<()> {
     println!(
         "* creating {}",
-        path.to_str().expect("Unable to display write path")
+        path.to_str().gleam_expect("Unable to display write path")
     );
     let mut f = File::create(&*path).map_err(|err| Error::FileIO {
         kind: FileKind::File,

--- a/src/new.rs
+++ b/src/new.rs
@@ -488,15 +488,15 @@ fn validate_name(name: &str) -> Result<(), Error> {
             name: name.to_string(),
             reason: InvalidProjectNameReason::GleamReservedWord,
         })
-    } else if !regex::Regex::new("^[a-z_]+$")
+    } else if regex::Regex::new("^[a-z_]+$")
         .gleam_expect("new name regex could not be compiled")
         .is_match(name)
     {
+        Ok(())
+    } else {
         Err(Error::InvalidProjectName {
             name: name.to_string(),
             reason: InvalidProjectNameReason::Format,
         })
-    } else {
-        Ok(())
     }
 }

--- a/src/num_util.rs
+++ b/src/num_util.rs
@@ -1,0 +1,32 @@
+use crate::GleamExpect;
+use std::convert::TryInto;
+
+pub fn to_u32<X: TryInto<u32>>(x: X) -> u32 {
+    x.try_into()
+        .map_err(|_| ())
+        .gleam_expect("x was larger than u32::MAX")
+}
+
+pub fn to_u16<X: TryInto<u16>>(x: X) -> u16 {
+    x.try_into()
+        .map_err(|_| ())
+        .gleam_expect("x was larger than u16::MAX")
+}
+
+pub fn to_u8<X: TryInto<u8>>(x: X) -> u8 {
+    x.try_into()
+        .map_err(|_| ())
+        .gleam_expect("x was larger than u8::MAX")
+}
+
+pub fn to_isize<X: TryInto<isize>>(x: X) -> isize {
+    x.try_into()
+        .map_err(|_| ())
+        .gleam_expect("x was larger than isize::MAX")
+}
+
+pub fn to_usize<X: TryInto<usize>>(x: X) -> usize {
+    x.try_into()
+        .map_err(|_| ())
+        .gleam_expect("x was larger than usize::MAX")
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -315,7 +315,6 @@ where
     //   unit().unit().unit()
     //   A(a.., label: tuple(1))
     //   { expression_sequence }
-    #[allow(clippy::too_many_lines)]
     fn parse_expression_unit(&mut self) -> Result<Option<UntypedExpr>, ParseError> {
         let mut expr = match self.tok0.take() {
             Some((start, Tok::String { value }, end)) => {
@@ -674,7 +673,6 @@ where
     }
 
     // The left side of an "=" or a "->"
-    #[allow(clippy::too_many_lines)]
     fn parse_pattern(&mut self) -> Result<Option<UntypedPattern>, ParseError> {
         let pattern = match self.tok0.take() {
             // Pattern::Var or Pattern::Constructor start

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -541,7 +541,7 @@ where
                     }
                 }
             } else if self.maybe_one(&Tok::Lpar).is_some() {
-                let start = expr.location().start.clone();
+                let start = expr.location().start;
                 if let Some((dot_s, _)) = self.maybe_one(&Tok::DotDot) {
                     // Record update
                     let (_, name, name_e) = self.expect_name()?;
@@ -1486,6 +1486,7 @@ where
     //   *no args*
     //   ()
     //   (a, b)
+    #[allow(clippy::type_complexity)]
     fn parse_type_constructor_args(
         &mut self,
     ) -> Result<(Vec<(Option<String>, TypeAst, SrcSpan)>, usize), ParseError> {
@@ -1623,7 +1624,7 @@ where
                     let (_, upname, upname_e) = self.expect_upname()?;
                     self.parse_type_name_finish(for_const, start, Some(mod_name), upname, upname_e)
                 } else if for_const {
-                    return parse_error(ParseErrorType::NotConstType, SrcSpan { start, end });
+                    parse_error(ParseErrorType::NotConstType, SrcSpan { start, end })
                 } else {
                     Ok(Some(TypeAst::Var {
                         location: SrcSpan { start, end },
@@ -2077,7 +2078,7 @@ where
                             error: ParseErrorType::InvalidBitStringSegment,
                             location: SrcSpan { start, end },
                         })
-                        .map(|v| Some(v))
+                        .map(Some)
                 }
             }
             // int segment

--- a/src/parse/extra.rs
+++ b/src/parse/extra.rs
@@ -1,3 +1,4 @@
+use crate::GleamExpect;
 use crate::ast::SrcSpan;
 
 #[derive(Debug, PartialEq)]
@@ -29,7 +30,10 @@ impl<'a> From<(&SrcSpan, &'a str)> for Comment<'a> {
     fn from(src: (&SrcSpan, &'a str)) -> Comment<'a> {
         Comment {
             start: src.0.start,
-            content: &src.1[src.0.start..src.0.end],
+            content: src
+                .1
+                .get(src.0.start..src.0.end)
+                .gleam_expect("(src.0.start..src.0.end) is out of bounds for src.1"),
         }
     }
 }

--- a/src/parse/extra.rs
+++ b/src/parse/extra.rs
@@ -1,5 +1,5 @@
-use crate::GleamExpect;
 use crate::ast::SrcSpan;
+use crate::GleamExpect;
 
 #[derive(Debug, PartialEq)]
 pub struct ModuleExtra {

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -160,7 +160,6 @@ where
         Ok(())
     }
 
-    #[allow(clippy::too_many_lines)]
     fn consume_character(&mut self, c: char) -> Result<(), LexicalError> {
         match c {
             '"' => {

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -100,12 +100,8 @@ impl Tok {
 impl fmt::Display for Tok {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            Tok::Name { name } => name,
-            Tok::UpName { name } => name,
-            Tok::DiscardName { name } => name,
-            Tok::Int { value } => value,
-            Tok::Float { value } => value,
-            Tok::String { value } => value,
+            Tok::Name { name } | Tok::UpName { name } | Tok::DiscardName { name } => name,
+            Tok::Int { value } | Tok::Float { value } | Tok::String { value } => value,
             Tok::Lpar => "(",
             Tok::Rpar => ")",
             Tok::Lsqb => "[",

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -304,6 +304,7 @@ impl<'a> Document<'a> {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_pretty_string(self, limit: isize) -> String {
         let mut buffer = String::new();
         self.pretty_print(limit, &mut buffer)

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -306,8 +306,7 @@ impl<'a> Document<'a> {
         }
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_pretty_string(self, limit: isize) -> String {
+    pub fn into_pretty_string(self, limit: isize) -> String {
         let mut buffer = String::new();
         self.pretty_print(limit, &mut buffer)
             .gleam_expect("Writing to string buffer failed");

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -15,7 +15,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::wrap;
+use crate::num_util::to_isize;
 use crate::{fs::Utf8Writer, GleamExpect, Result};
 
 macro_rules! docvec {
@@ -167,12 +167,12 @@ fn fits(mut limit: isize, mut docs: im::Vector<(isize, Mode, Document<'_>)>) -> 
 
             Document::Group(doc) => docs.push_front((indent, Mode::Unbroken, *doc)),
 
-            Document::Str(s) => limit -= wrap!(s.len(), isize),
-            Document::String(s) => limit -= wrap!(s.len(), isize),
+            Document::Str(s) => limit -= to_isize(s.len()),
+            Document::String(s) => limit -= to_isize(s.len()),
 
             Document::Break { unbroken, .. } => match mode {
                 Mode::Broken => return true,
-                Mode::Unbroken => limit -= wrap!(unbroken.len(), isize),
+                Mode::Unbroken => limit -= to_isize(unbroken.len()),
             },
 
             Document::Vec(vec) => {
@@ -208,7 +208,7 @@ fn fmt(
                 width = match mode {
                     Mode::Unbroken => {
                         writer.str_write(unbroken)?;
-                        width + wrap!(unbroken.len(), isize)
+                        width + to_isize(unbroken.len())
                     }
                     Mode::Broken => {
                         writer.str_write(broken)?;
@@ -222,12 +222,12 @@ fn fmt(
             }
 
             Document::String(s) => {
-                width += wrap!(s.len(), isize);
+                width += to_isize(s.len());
                 writer.str_write(s.as_str())?;
             }
 
             Document::Str(s) => {
-                width += wrap!(s.len(), isize);
+                width += to_isize(s.len());
                 writer.str_write(s)?;
             }
 

--- a/src/pretty/tests.rs
+++ b/src/pretty/tests.rs
@@ -1,5 +1,5 @@
-use super::Document::*;
-use super::Mode::*;
+use super::Document::{Break, ForceBreak, Line, Nest, NestCurrent, Nil, String};
+use super::Mode::{Broken, Unbroken};
 use super::*;
 
 #[test]

--- a/src/pretty/tests.rs
+++ b/src/pretty/tests.rs
@@ -3,7 +3,7 @@ use super::Mode::{Broken, Unbroken};
 use super::*;
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn fits_test() {
     // Negative limits never fit
     assert!(!fits(-1, vector![]));

--- a/src/pretty/tests.rs
+++ b/src/pretty/tests.rs
@@ -3,6 +3,7 @@ use super::Mode::{Broken, Unbroken};
 use super::*;
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn fits_test() {
     // Negative limits never fit
     assert!(!fits(-1, vector![]));
@@ -185,7 +186,7 @@ fn format_test() {
 #[test]
 fn let_left_side_fits_test() {
     let elems = break_("", "").append("1").nest(2).append(break_("", ""));
-    let list = "[".to_doc().append(elems).append("]").group();
+    let list = "[".into_doc().append(elems).append("]").group();
     let doc = list.clone().append(" = ").append(list);
 
     assert_eq!(

--- a/src/pretty/tests.rs
+++ b/src/pretty/tests.rs
@@ -143,44 +143,44 @@ fn fits_test() {
 #[test]
 fn format_test() {
     let doc = String("Hi".to_string());
-    assert_eq!("Hi".to_string(), doc.to_pretty_string(10));
+    assert_eq!("Hi".to_string(), doc.into_pretty_string(10));
 
     let doc = String("Hi".to_string()).append(String(", world!".to_string()));
-    assert_eq!("Hi, world!".to_string(), doc.to_pretty_string(10));
+    assert_eq!("Hi, world!".to_string(), doc.into_pretty_string(10));
 
     let doc = Nil;
-    assert_eq!("".to_string(), doc.to_pretty_string(10));
+    assert_eq!("".to_string(), doc.into_pretty_string(10));
 
     let doc = Break {
         broken: "broken",
         unbroken: "unbroken",
     }
     .group();
-    assert_eq!("unbroken".to_string(), doc.to_pretty_string(10));
+    assert_eq!("unbroken".to_string(), doc.into_pretty_string(10));
 
     let doc = Break {
         broken: "broken",
         unbroken: "unbroken",
     }
     .group();
-    assert_eq!("broken\n".to_string(), doc.to_pretty_string(5));
+    assert_eq!("broken\n".to_string(), doc.into_pretty_string(5));
 
     let doc = Nest(
         2,
         Box::new(String("1".to_string()).append(Line(1).append(String("2".to_string())))),
     );
-    assert_eq!("1\n  2".to_string(), doc.to_pretty_string(1));
+    assert_eq!("1\n  2".to_string(), doc.into_pretty_string(1));
 
     let doc = String("111".to_string()).append(NestCurrent(Box::new(
         Line(1).append(String("2".to_string())),
     )));
-    assert_eq!("111\n   2".to_string(), doc.to_pretty_string(1));
+    assert_eq!("111\n   2".to_string(), doc.into_pretty_string(1));
 
     let doc = ForceBreak.append(Break {
         broken: "broken",
         unbroken: "unbroken",
     });
-    assert_eq!("broken\n".to_string(), doc.to_pretty_string(100));
+    assert_eq!("broken\n".to_string(), doc.into_pretty_string(100));
 }
 
 #[test]
@@ -193,7 +193,7 @@ fn let_left_side_fits_test() {
         "[1] = [
   1
 ]",
-        doc.clone().to_pretty_string(7)
+        doc.clone().into_pretty_string(7)
     );
 
     assert_eq!(
@@ -202,8 +202,8 @@ fn let_left_side_fits_test() {
 ] = [
   1
 ]",
-        doc.clone().to_pretty_string(2)
+        doc.clone().into_pretty_string(2)
     );
 
-    assert_eq!("[1] = [1]", doc.clone().to_pretty_string(16));
+    assert_eq!("[1] = [1]", doc.clone().into_pretty_string(16));
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -86,7 +86,7 @@ fn comments_before<'a>(
     let mut comments = vec![];
     while let Some(SrcSpan { start, .. }) = comment_spans.peek() {
         if start <= &byte {
-            let comment = comment_spans.next().unwrap();
+            let comment = comment_spans.next().gleam_expect("reached end of comment_spans");
             comments.push(Comment::from((comment, src)).content)
         } else {
             break;

--- a/src/project/source_tree.rs
+++ b/src/project/source_tree.rs
@@ -129,12 +129,17 @@ impl SourceTree {
         let name = input
             .path
             .strip_prefix(&input.source_base_path)
-            .unwrap()
+            .gleam_expect("the path does not start with the source base path")
             .parent()
-            .unwrap()
-            .join(input.path.file_stem().unwrap())
+            .gleam_expect("the stripped path terminates in root or a prefix")
+            .join(
+                input
+                    .path
+                    .file_stem()
+                    .gleam_expect("the path did not have a filename"),
+            )
             .to_str()
-            .unwrap()
+            .gleam_expect("the path is not valid Unicode")
             .to_string()
             .replace("\\", "/");
 

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -1076,9 +1076,8 @@ main(Arg1, Arg2, Arg3) ->
         },
     ];
 
-    for Case { input, expected } in &cases {
-        let actual =
-            analysed(&input.clone()).map(|analysed| erl::generate_erlang(analysed.as_slice()));
-        assert_eq!(expected, &actual);
+    for Case { input, expected } in cases.into_iter() {
+        let actual = analysed(&input).map(|analysed| erl::generate_erlang(analysed.as_slice()));
+        assert_eq!(expected, actual);
     }
 }

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -3,7 +3,7 @@ use crate::{erl, fs::OutputFile};
 use std::sync::Arc;
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn compile_test() {
     struct Case {
         input: Vec<Input>,

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -3,6 +3,7 @@ use crate::{erl, fs::OutputFile};
 use std::sync::Arc;
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn compile_test() {
     struct Case {
         input: Vec<Input>,
@@ -1075,8 +1076,9 @@ main(Arg1, Arg2, Arg3) ->
         },
     ];
 
-    for Case { input, expected } in cases.into_iter() {
-        let actual = analysed(input).map(|analysed| erl::generate_erlang(analysed.as_slice()));
-        assert_eq!(expected, actual);
+    for Case { input, expected } in &cases {
+        let actual =
+            analysed(&input.clone()).map(|analysed| erl::generate_erlang(analysed.as_slice()));
+        assert_eq!(expected, &actual);
     }
 }

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -479,8 +479,6 @@ fn assert_unique_type_name<'a>(
     }
 }
 
-#[allow(clippy::too_many_lines)]
-
 fn register_values<'a>(
     s: &'a UntypedStatement,
     module_name: &[String],
@@ -763,7 +761,6 @@ fn generalise_statement(
     }
 }
 
-#[allow(clippy::too_many_lines)]
 fn infer_statement(
     s: UntypedStatement,
     module_name: &[String],

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -408,7 +408,7 @@ pub fn infer_module(
     for (_, value) in environment.module_values.iter() {
         if let Some(leaked) = value.typ.find_private_type() {
             return Err(Error::PrivateTypeLeak {
-                location: value.origin.clone(),
+                location: value.origin,
                 leaked,
             });
         }
@@ -1429,7 +1429,7 @@ pub fn register_import(
 
             // Determine local alias of imported module
             let module_name = match &as_name {
-                None => module[module.len() - 1].clone(),
+                None => module.get(module.len() - 1).gleam_expect("module did not have a last element").clone(),
                 Some(name) => name.clone(),
             };
 

--- a/src/typ/environment.rs
+++ b/src/typ/environment.rs
@@ -370,7 +370,7 @@ impl<'a, 'b> Environment<'a, 'b> {
     ///
     /// It two types are found to not be the same an error is returned.
     ///
-    #[allow(clippy::too_many_lines)]
+    
     pub fn unify(&mut self, t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
         if t1 == t2 {
             return Ok(());

--- a/src/typ/environment.rs
+++ b/src/typ/environment.rs
@@ -181,7 +181,7 @@ impl<'a, 'b> Environment<'a, 'b> {
         info: TypeConstructor,
     ) -> Result<(), Error> {
         let name = type_name.clone();
-        let location = info.origin.clone();
+        let location = info.origin;
         match self.module_types.insert(type_name, info) {
             None => Ok(()),
             Some(prelude_type) if prelude_type.module.is_empty() => Ok(()),

--- a/src/typ/environment.rs
+++ b/src/typ/environment.rs
@@ -370,7 +370,7 @@ impl<'a, 'b> Environment<'a, 'b> {
     ///
     /// It two types are found to not be the same an error is returned.
     ///
-    
+
     pub fn unify(&mut self, t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
         if t1 == t2 {
             return Ok(());

--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -498,6 +498,7 @@ impl UnifyError {
         self.with_unify_error_situation(UnifyErrorSituation::ReturnAnnotationMismatch)
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_error(self, location: SrcSpan) -> Error {
         match self {
             Self::CouldNotUnify {

--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -500,8 +500,7 @@ impl UnifyError {
         self.with_unify_error_situation(UnifyErrorSituation::ReturnAnnotationMismatch)
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_error(self, location: SrcSpan) -> Error {
+    pub fn into_error(self, location: SrcSpan) -> Error {
         match self {
             Self::CouldNotUnify {
                 expected,
@@ -584,5 +583,5 @@ pub fn convert_binary_error(e: crate::bit_string::Error, location: &SrcSpan) -> 
 }
 
 pub fn convert_unify_error(e: UnifyError, location: SrcSpan) -> Error {
-    e.to_error(location)
+    e.into_error(location)
 }

--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -237,6 +237,7 @@ pub enum Warning {
 }
 
 #[derive(Debug, PartialEq)]
+#[allow(clippy::pub_enum_variant_names)]
 pub enum GetValueConstructorError {
     UnknownVariable {
         name: String,
@@ -289,6 +290,7 @@ pub fn convert_get_value_constructor_error(
 }
 
 #[derive(Debug, PartialEq)]
+#[allow(clippy::pub_enum_variant_names)]
 pub enum GetTypeConstructorError {
     UnknownType {
         name: String,
@@ -443,7 +445,7 @@ pub enum UnifyErrorSituation {
 }
 
 impl UnifyErrorSituation {
-    pub fn description(&self) -> &'static str {
+    pub fn description(self) -> &'static str {
         match self {
             Self::CaseClauseMismatch => {
                 "This case clause was found to return a different type than the previous

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -850,7 +850,6 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     fn infer_clause_guard(&mut self, guard: UntypedClauseGuard) -> Result<TypedClauseGuard, Error> {
         match guard {
             ClauseGuard::Var { location, name, .. } => {
@@ -1493,7 +1492,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
 
     // TODO: extract the type annotation checking into a infer_module_const
     // function that uses this function internally
-    #[allow(clippy::too_many_lines)]
+
     pub fn infer_const(
         &mut self,
         annotation: &Option<TypeAst>,

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -78,17 +78,17 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
     ///
     pub fn infer(&mut self, expr: UntypedExpr) -> Result<TypedExpr, Error> {
         match expr {
-            UntypedExpr::ListNil { location, .. } => Ok(self.infer_nil(location)),
+            UntypedExpr::ListNil { location, .. } => Ok(self.make_nil(location)),
 
             UntypedExpr::Todo {
                 location, label, ..
-            } => Ok(self.infer_todo(location, label)),
+            } => Ok(self.make_todo(location, label)),
 
             UntypedExpr::Var { location, name, .. } => self.infer_var(name, location),
 
             UntypedExpr::Int {
                 location, value, ..
-            } => Ok(Self::infer_int(value, location)),
+            } => Ok(Self::make_int(value, location)),
 
             UntypedExpr::Seq { first, then, .. } => self.infer_seq(*first, *then),
 
@@ -98,11 +98,11 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
 
             UntypedExpr::Float {
                 location, value, ..
-            } => Ok(Self::infer_float(value, location)),
+            } => Ok(Self::make_float(value, location)),
 
             UntypedExpr::String {
                 location, value, ..
-            } => Ok(Self::infer_string(value, location)),
+            } => Ok(Self::make_string(value, location)),
 
             UntypedExpr::Pipe {
                 left,
@@ -302,14 +302,14 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         })
     }
 
-    fn infer_nil(&mut self, location: SrcSpan) -> TypedExpr {
+    fn make_nil(&mut self, location: SrcSpan) -> TypedExpr {
         TypedExpr::ListNil {
             location,
             typ: list(self.new_unbound_var(self.environment.level)),
         }
     }
 
-    fn infer_todo(&mut self, location: SrcSpan, label: Option<String>) -> TypedExpr {
+    fn make_todo(&mut self, location: SrcSpan, label: Option<String>) -> TypedExpr {
         let typ = self.new_unbound_var(self.environment.level);
         self.environment.warnings.push(Warning::Todo {
             location,
@@ -323,7 +323,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         }
     }
 
-    fn infer_string(value: String, location: SrcSpan) -> TypedExpr {
+    fn make_string(value: String, location: SrcSpan) -> TypedExpr {
         TypedExpr::String {
             location,
             value,
@@ -331,7 +331,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         }
     }
 
-    fn infer_int(value: String, location: SrcSpan) -> TypedExpr {
+    fn make_int(value: String, location: SrcSpan) -> TypedExpr {
         TypedExpr::Int {
             location,
             value,
@@ -339,7 +339,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         }
     }
 
-    fn infer_float(value: String, location: SrcSpan) -> TypedExpr {
+    fn make_float(value: String, location: SrcSpan) -> TypedExpr {
         TypedExpr::Float {
             location,
             value,

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -1258,7 +1258,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         // Find the accessor, if the type has one with the same label
         let RecordAccessor { index, label, typ } = accessors
             .accessors
-            .get(&label.to_owned())
+            .get(label)
             .ok_or_else(|| {
                 unknown_field(
                     accessors

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -14,7 +14,7 @@ use crate::ast::{
     UntypedClause, UntypedClauseGuard, UntypedConstant, UntypedConstantBitStringSegment,
     UntypedExpr, UntypedExprBitStringSegment, UntypedMultiPattern, UntypedPattern,
 };
-use crate::truncate;
+use crate::num_util::to_usize;
 
 pub struct ExprTyper<'a, 'b, 'c> {
     environment: &'a mut Environment<'b, 'c>,
@@ -513,7 +513,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         match tuple.typ().as_ref() {
             Type::Tuple { elems } => {
                 let typ = elems
-                    .get(truncate!(index, usize))
+                    .get(to_usize(index))
                     .ok_or_else(|| Error::OutOfBoundsTupleIndex {
                         location: SrcSpan {
                             start: tuple.location().end,
@@ -885,7 +885,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                 match tuple.typ().as_ref() {
                     Type::Tuple { elems } => {
                         let typ = elems
-                            .get(truncate!(index, usize))
+                            .get(to_usize(index))
                             .ok_or_else(|| Error::OutOfBoundsTupleIndex {
                                 location,
                                 index,

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -761,7 +761,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         for clause in clauses {
             let typed_clause = self.infer_clause(clause.clone(), &subject_types)?;
             self.unify(return_type.clone(), typed_clause.then.typ())
-                .map_err(|e| e.case_clause_mismatch().to_error(typed_clause.location()))?;
+                .map_err(|e| e.case_clause_mismatch().into_error(typed_clause.location()))?;
             typed_clauses.push(typed_clause);
         }
         Ok(TypedExpr::Case {
@@ -1827,7 +1827,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         // Check that any return type type is accurate.
         if let Some(return_type) = return_type {
             self.unify(return_type, body.typ())
-                .map_err(|e| e.return_annotation_mismatch().to_error(body.location()))?;
+                .map_err(|e| e.return_annotation_mismatch().into_error(body.location()))?;
         }
 
         Ok((args, body))

--- a/src/typ/fields.rs
+++ b/src/typ/fields.rs
@@ -1,6 +1,6 @@
 use super::Error;
-use crate::GleamExpect;
 use crate::ast::{CallArg, SrcSpan};
+use crate::GleamExpect;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 
@@ -116,7 +116,11 @@ impl FieldMap {
             Ok(())
         } else {
             Err(Error::UnknownLabels {
-                valid: self.fields.keys().map(|t| t.to_string()).collect(),
+                valid: self
+                    .fields
+                    .keys()
+                    .map(std::string::ToString::to_string)
+                    .collect(),
                 unknown: unknown_labels,
                 supplied: seen_labels.into_iter().collect(),
             })

--- a/src/typ/fields.rs
+++ b/src/typ/fields.rs
@@ -1,4 +1,5 @@
 use super::Error;
+use crate::GleamExpect;
 use crate::ast::{CallArg, SrcSpan};
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
@@ -70,9 +71,12 @@ impl FieldMap {
 
         let mut i = 0;
         while i < args.len() {
-            let (label, location) = match &args[i].label {
+            let (label, location) = match &args.get(i).gleam_expect("could not get args[i]").label {
                 // A labelled argument, we may need to reposition it in the array vector
-                Some(l) => (l, &args[i].location),
+                Some(l) => (
+                    l,
+                    &args.get(i).gleam_expect("could not get args[i]").location,
+                ),
 
                 // Not a labelled argument
                 None => {

--- a/src/typ/hydrator.rs
+++ b/src/typ/hydrator.rs
@@ -1,4 +1,7 @@
-use super::*;
+use super::{
+    convert_get_type_constructor_error, convert_unify_error, fn_, tuple, Environment, Error, Type,
+    TypeConstructor,
+};
 use crate::ast::TypeAst;
 use std::sync::Arc;
 
@@ -66,8 +69,8 @@ impl Hydrator {
         self.permit_holes = flag
     }
 
-    pub fn is_created_generic_type(&self, id: &usize) -> bool {
-        self.created_type_variable_ids.contains(id)
+    pub fn is_created_generic_type(&self, id: usize) -> bool {
+        self.created_type_variable_ids.contains(&id)
     }
 
     pub fn type_from_option_ast<'a, 'b>(
@@ -133,11 +136,11 @@ impl Hydrator {
                 let mut type_vars = hashmap![];
                 let mut parameter_types = Vec::with_capacity(parameters.len());
                 for typ in parameters {
-                    let t = environment.instantiate(typ, 0, &mut type_vars, self);
+                    let t = environment.instantiate(&typ, 0, &mut type_vars, self);
 
                     parameter_types.push(t);
                 }
-                let return_type = environment.instantiate(return_type, 0, &mut type_vars, self);
+                let return_type = environment.instantiate(&return_type, 0, &mut type_vars, self);
 
                 // Unify argument types with instantiated parameter types so that the correct types
                 // are inserted into the return type
@@ -174,10 +177,10 @@ impl Hydrator {
 
                     None if self.permit_new_type_variables => {
                         let var = environment.new_generic_var();
-                        let _ = self
+                        let _old = self
                             .created_type_variable_ids
                             .insert(environment.previous_uid());
-                        let _ = self
+                        let _old = self
                             .created_type_variables
                             .insert(name.clone(), var.clone());
                         Ok(var)
@@ -189,7 +192,7 @@ impl Hydrator {
                         types: environment
                             .module_types
                             .keys()
-                            .map(|t| t.to_string())
+                            .map(std::string::ToString::to_string)
                             .collect(),
                     }),
                 }

--- a/src/typ/hydrator.rs
+++ b/src/typ/hydrator.rs
@@ -28,14 +28,20 @@ pub struct ScopeResetData {
     created_type_variable_ids: im::HashSet<usize>,
 }
 
-impl Hydrator {
-    pub fn new() -> Self {
+impl Default for Hydrator {
+    fn default() -> Self {
         Self {
             created_type_variables: im::hashmap![],
             created_type_variable_ids: im::hashset![],
             permit_new_type_variables: true,
             permit_holes: false,
         }
+    }
+}
+
+impl Hydrator {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn open_new_scope(&mut self) -> ScopeResetData {

--- a/src/typ/pattern.rs
+++ b/src/typ/pattern.rs
@@ -178,7 +178,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
     /// inferred type of the subject in order to determine what variables to insert
     /// into the environment (or to detect a type error).
     ///
-    
+
     pub fn unify(
         &mut self,
         pattern: UntypedPattern,

--- a/src/typ/pattern.rs
+++ b/src/typ/pattern.rs
@@ -178,7 +178,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
     /// inferred type of the subject in order to determine what variables to insert
     /// into the environment (or to detect a type error).
     ///
-    #[allow(clippy::too_many_lines)]
+    
     pub fn unify(
         &mut self,
         pattern: UntypedPattern,

--- a/src/typ/pattern.rs
+++ b/src/typ/pattern.rs
@@ -148,7 +148,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                 Pattern::Var { .. } if typed_segment.typ() == Some(string()) => {
                     Err(Error::UTFVarInBitStringSegment {
                         location,
-                        option: typed_segment.typ.unwrap().label(),
+                        option: typed_segment.typ.gleam_expect("typed_segment lacked a type").label(),
                     })
                 }
                 _ => Ok(typed_segment.typ().unwrap_or_else(int)),
@@ -259,7 +259,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                 tail,
             } => match typ.get_app_args(true, &[], "List", 1, self.environment) {
                 Some(args) => {
-                    let head = Box::new(self.unify(*head, args[0].clone())?);
+                    let head = Box::new(self.unify(*head, args.get(0).gleam_expect("args is empty").clone())?);
                     let tail = Box::new(self.unify(*tail, typ)?);
 
                     Ok(Pattern::Cons {
@@ -377,9 +377,9 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                                 let new_call_arg = CallArg {
                                     value: Pattern::Discard {
                                         name: "_".to_string(),
-                                        location: spread_location.clone(),
+                                        location: spread_location,
                                     },
-                                    location: spread_location.clone(),
+                                    location: spread_location,
                                     label: None,
                                 };
 

--- a/src/typ/prelude.rs
+++ b/src/typ/prelude.rs
@@ -1,4 +1,5 @@
 use super::{Environment, Type, TypeConstructor, ValueConstructorVariant};
+use crate::ast::SrcSpan;
 use crate::error::GleamExpect;
 use std::sync::Arc;
 
@@ -91,6 +92,7 @@ pub fn utf_codepoint() -> Arc<Type> {
     })
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'a, 'b> {
     typer
         .insert_type_constructor(
@@ -98,7 +100,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
             TypeConstructor {
                 parameters: vec![],
                 typ: int(),
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 module: vec![],
                 public: true,
             },
@@ -127,7 +129,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "Bool".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![],
                 typ: bool(),
                 module: vec![],
@@ -141,7 +143,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "List".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![list_parameter.clone()],
                 typ: list(list_parameter),
                 module: vec![],
@@ -154,7 +156,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "Float".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![],
                 typ: float(),
                 module: vec![],
@@ -167,7 +169,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "String".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![],
                 typ: string(),
                 module: vec![],
@@ -182,7 +184,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "Result".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![result_value.clone(), result_error.clone()],
                 typ: result(result_value, result_error),
                 module: vec![],
@@ -204,7 +206,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "Nil".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![],
                 typ: nil(),
                 module: vec![],
@@ -217,7 +219,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "BitString".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![],
                 typ: bit_string(),
                 module: vec![],
@@ -230,7 +232,7 @@ pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'
         .insert_type_constructor(
             "UtfCodepoint".to_string(),
             TypeConstructor {
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![],
                 typ: utf_codepoint(),
                 module: vec![],

--- a/src/typ/prelude.rs
+++ b/src/typ/prelude.rs
@@ -92,7 +92,6 @@ pub fn utf_codepoint() -> Arc<Type> {
     })
 }
 
-
 pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'a, 'b> {
     typer
         .insert_type_constructor(

--- a/src/typ/prelude.rs
+++ b/src/typ/prelude.rs
@@ -92,7 +92,7 @@ pub fn utf_codepoint() -> Arc<Type> {
     })
 }
 
-#[allow(clippy::too_many_lines)]
+
 pub fn register_prelude<'a, 'b>(mut typer: Environment<'a, 'b>) -> Environment<'a, 'b> {
     typer
         .insert_type_constructor(

--- a/src/typ/pretty.rs
+++ b/src/typ/pretty.rs
@@ -214,7 +214,7 @@ fn next_letter_test() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn pretty_print_test() {
     macro_rules! assert_string {
         ($src:expr, $typ:expr $(,)?) => {

--- a/src/typ/pretty.rs
+++ b/src/typ/pretty.rs
@@ -117,8 +117,8 @@ impl Printer {
         if args.is_empty() {
             nil()
         } else {
-            let args = concat(Itertools::intersperse(
-                args.iter().map(|t| self.print(t).group()),
+            let args = concat(
+                args.iter().map(|t| self.print(t).group()).intersperse(
                 break_(",", ", "),
             ));
             break_("", "")

--- a/src/typ/pretty.rs
+++ b/src/typ/pretty.rs
@@ -35,7 +35,7 @@ impl Printer {
             .into_doc()
             .append(self.print(typ))
             .nest(to_isize(initial_indent))
-            .to_pretty_string(80)
+            .into_pretty_string(80)
     }
 
     // TODO: have this function return a Document that borrows from the Type.

--- a/src/typ/pretty.rs
+++ b/src/typ/pretty.rs
@@ -1,6 +1,6 @@
 use super::{Type, TypeVar};
+use crate::num_util::{to_isize, to_u8};
 use crate::pretty::{break_, concat, nil, Document, Documentable};
-use crate::{truncate, wrap};
 use itertools::Itertools;
 use std::sync::Arc;
 
@@ -34,7 +34,7 @@ impl Printer {
         buffer
             .into_doc()
             .append(self.print(typ))
-            .nest(wrap!(initial_indent, isize))
+            .nest(to_isize(initial_indent))
             .to_pretty_string(80)
     }
 
@@ -101,7 +101,7 @@ impl Printer {
         loop {
             n = rest % alphabet_length;
             rest /= alphabet_length;
-            chars.push((truncate!(n, u8) + char_offset) as char);
+            chars.push(char::from(to_u8(n) + char_offset));
 
             if rest == 0 {
                 break;

--- a/src/typ/test_helpers.rs
+++ b/src/typ/test_helpers.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn env_types_with(things: &[&str]) -> Vec<String> {
     let mut types: Vec<_> = env_types();
-    for thing in things {
+    for &thing in things {
         types.push(thing.to_string());
     }
     types
@@ -18,7 +18,7 @@ pub fn env_types() -> Vec<String> {
 
 pub fn env_vars_with(things: &[&str]) -> Vec<String> {
     let mut types: Vec<_> = env_vars();
-    for thing in things {
+    for &thing in things {
         types.push(thing.to_string());
     }
     types

--- a/src/typ/test_helpers.rs
+++ b/src/typ/test_helpers.rs
@@ -12,7 +12,7 @@ pub fn env_types() -> Vec<String> {
     Environment::new(&mut 0, &[], &HashMap::new(), &mut vec![])
         .module_types
         .keys()
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
         .collect()
 }
 
@@ -28,7 +28,7 @@ pub fn env_vars() -> Vec<String> {
     Environment::new(&mut 0, &[], &HashMap::new(), &mut vec![])
         .local_values
         .keys()
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
         .collect()
 }
 

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -85,7 +85,10 @@ macro_rules! assert_warning {
         let _ = infer_module(&mut 0, ast, &HashMap::new(), &mut warnings);
 
         assert!(!warnings.is_empty());
-        assert_eq!($warning, warnings[0]);
+        assert_eq!(
+            &($warning),
+            warnings.get(0).gleam_expect("warnings is empty")
+        );
     };
 }
 
@@ -230,8 +233,8 @@ fn infer_module_type_retention_test() {
         type_info: (),
     };
     let mut uid = 0;
-    let module =
-        infer_module(&mut uid, module, &HashMap::new(), &mut vec![]).expect("Should infer OK");
+    let module = infer_module(&mut uid, module, &HashMap::new(), &mut vec![])
+        .gleam_expect("Should infer OK");
 
     assert_eq!(
         module.type_info,

--- a/src/typ/tests.rs
+++ b/src/typ/tests.rs
@@ -110,7 +110,7 @@ macro_rules! assert_no_warnings {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn field_map_reorder_test() {
     struct Case {
         arity: usize,
@@ -568,7 +568,7 @@ fn main() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn infer_bit_string_error_test() {
     assert_error!(
         "case <<1>> { <<2.0, a>> -> 1 }",
@@ -974,7 +974,7 @@ fn annotated_functions_unification_error() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn the_rest() {
     assert_error!(
         "case tuple(1, 2, 3) { x if x == tuple(1, 1.0) -> 1 }",
@@ -1590,7 +1590,7 @@ fn the_rest() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn infer_module_test() {
     assert_module_infer!(
         "pub fn repeat(i, x) {
@@ -2082,7 +2082,7 @@ pub fn main() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn infer_module_error_test() {
     assert_module_error!(
         "fn go() { 1 + 2.0 }",
@@ -2856,7 +2856,7 @@ fn x() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+
 fn module_update() {
     // A variable of the wrong type given to a record update
     assert_module_error!(

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,3 +1,4 @@
+use crate::GleamExpect;
 use crate::{
     cli,
     diagnostic::{write, Diagnostic, Severity},
@@ -24,7 +25,7 @@ impl Warning {
 
         buffer
             .write_all(b"\n")
-            .expect("error pretty buffer write space before");
+            .gleam_expect("Buffer::write() could not write");
 
         match self {
             Self::Type { path, src, warning } => match warning {
@@ -32,7 +33,10 @@ impl Warning {
                     let diagnostic = Diagnostic {
                         title: "Todo found".to_string(),
                         label: "".to_string(),
-                        file: path.to_str().unwrap().to_string(),
+                        file: path
+                            .to_str()
+                            .gleam_expect("path was not valid Unicode")
+                            .to_string(),
                         src: src.to_string(),
                         location: *location,
                     };
@@ -54,7 +58,10 @@ your program.",
                     let diagnostic = Diagnostic {
                         title: "Unused result value".to_string(),
                         label: "".to_string(),
-                        file: path.to_str().unwrap().to_string(),
+                        file: path
+                            .to_str()
+                            .gleam_expect("path was not valid Unicode")
+                            .to_string(),
                         src: src.to_string(),
                         location: *location,
                     };
@@ -70,7 +77,10 @@ variable _ if you are sure the error does not matter.")
                     let diagnostic = Diagnostic {
                         title: "Unused literal".to_string(),
                         label: "".to_string(),
-                        file: path.to_str().unwrap().to_string(),
+                        file: path
+                            .to_str()
+                            .gleam_expect("path was not valid Unicode")
+                            .to_string(),
                         src: src.to_string(),
                         location: *location,
                     };
@@ -86,7 +96,10 @@ variable _ if you are sure the error does not matter.")
                     let diagnostic = Diagnostic {
                         title: "Fieldless record update".to_string(),
                         label: "".to_string(),
-                        file: path.to_str().unwrap().to_string(),
+                        file: path
+                            .to_str()
+                            .gleam_expect("path was not valid Unicode")
+                            .to_string(),
                         src: src.to_string(),
                         location: *location,
                     };
@@ -101,7 +114,10 @@ record without modification. Add some fields or remove this update.")
                     let diagnostic = Diagnostic {
                         title: "Redundant record update".to_string(),
                         label: "".to_string(),
-                        file: path.to_str().unwrap().to_string(),
+                        file: path
+                            .to_str()
+                            .gleam_expect("path was not valid Unicode")
+                            .to_string(),
                         src: src.to_string(),
                         location: *location,
                     };
@@ -116,7 +132,10 @@ be an update. Remove the update or remove fields that need to be copied.")
                     let diagnostic = Diagnostic {
                         title: "Unused type".to_string(),
                         label: "".to_string(),
-                        file: path.to_str().unwrap().to_string(),
+                        file: path
+                            .to_str()
+                            .gleam_expect("path was not valid Unicode")
+                            .to_string(),
                         src: src.to_string(),
                         location: *location,
                     };
@@ -133,7 +152,10 @@ be an update. Remove the update or remove fields that need to be copied.")
                     let diagnostic = Diagnostic {
                         title: "Unused constructor".to_string(),
                         label: "".to_string(),
-                        file: path.to_str().unwrap().to_string(),
+                        file: path
+                            .to_str()
+                            .gleam_expect("path was not valid Unicode")
+                            .to_string(),
                         src: src.to_string(),
                         location: *location,
                     };
@@ -153,7 +175,7 @@ be an update. Remove the update or remove fields that need to be copied.")
         let buffer_writer = cli::stderr_buffer_writer();
         let mut buffer = buffer_writer.buffer();
         self.pretty(&mut buffer);
-        buffer_writer.print(&buffer).unwrap();
+        buffer_writer.print(&buffer).gleam_expect("BufferWriter::print() failed to print");
     }
 }
 

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -19,7 +19,6 @@ pub enum Warning {
 }
 
 impl Warning {
-    #[allow(clippy::too_many_lines)]
     pub fn pretty(&self, buffer: &mut Buffer) {
         use crate::typ::Warning;
         use std::io::Write;

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -19,6 +19,7 @@ pub enum Warning {
 }
 
 impl Warning {
+    #[allow(clippy::too_many_lines)]
     pub fn pretty(&self, buffer: &mut Buffer) {
         use crate::typ::Warning;
         use std::io::Write;
@@ -175,13 +176,15 @@ be an update. Remove the update or remove fields that need to be copied.")
         let buffer_writer = cli::stderr_buffer_writer();
         let mut buffer = buffer_writer.buffer();
         self.pretty(&mut buffer);
-        buffer_writer.print(&buffer).gleam_expect("BufferWriter::print() failed to print");
+        buffer_writer
+            .print(&buffer)
+            .gleam_expect("BufferWriter::print() failed to print");
     }
 }
 
 pub fn print_all(analysed: &[crate::project::Analysed]) {
-    for a in analysed.iter() {
-        for w in a.warnings.iter() {
+    for a in analysed {
+        for w in &a.warnings {
             w.pretty_print()
         }
     }


### PR DESCRIPTION
Large PR but mostly many small changes rather than big changes

Fixes all current clippy lints
Removes duplicate lints
Removes explicitly warning/denying on lints that are warn-by-default or deny-by-default
Adds warn/deny for clippy::pedantic
Fixes all new clippy lints
Makes implicit truncation and wrapping explicit

Let me know if any of the changes don't sit right or don't make sense.