### PR TITLE
Adding more checks to bit string segment options

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -759,17 +759,8 @@ pub enum BitStringSegmentOption<Value> {
 
     Unit {
         location: SrcSpan,
-        value: Box<Value>,
-        short_form: bool,
+        value: Box<usize>,
     },
-}
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum SegmentOptionCategory {
-    Type,
-    Endianness,
-    Signedness,
-    Size,
-    Unit,
 }
 
 impl<A> BitStringSegmentOption<A> {
@@ -792,28 +783,6 @@ impl<A> BitStringSegmentOption<A> {
             | BitStringSegmentOption::Native { location }
             | BitStringSegmentOption::Size { location, .. }
             | BitStringSegmentOption::Unit { location, .. } => *location,
-        }
-    }
-
-    pub fn category(&self) -> SegmentOptionCategory {
-        match self {
-            BitStringSegmentOption::Binary { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::Integer { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::Float { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::BitString { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF8 { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF16 { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF32 { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF8Codepoint { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF16Codepoint { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::UTF32Codepoint { .. } => SegmentOptionCategory::Type,
-            BitStringSegmentOption::Signed { .. } => SegmentOptionCategory::Signedness,
-            BitStringSegmentOption::Unsigned { .. } => SegmentOptionCategory::Signedness,
-            BitStringSegmentOption::Big { .. } => SegmentOptionCategory::Endianness,
-            BitStringSegmentOption::Little { .. } => SegmentOptionCategory::Endianness,
-            BitStringSegmentOption::Native { .. } => SegmentOptionCategory::Endianness,
-            BitStringSegmentOption::Size { .. } => SegmentOptionCategory::Size,
-            BitStringSegmentOption::Unit { .. } => SegmentOptionCategory::Unit,
         }
     }
 

--- a/src/bit_string.rs
+++ b/src/bit_string.rs
@@ -1,202 +1,276 @@
-use crate::ast::{BitStringSegmentOption, SegmentOptionCategory as Category, SrcSpan};
+use crate::ast::{BitStringSegmentOption, SrcSpan};
 use crate::typ::Type;
 use std::sync::Arc;
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct BinaryTypeSpecifier<T> {
-    pub typ: Option<BitStringSegmentOption<T>>,
-    signedness: Option<BitStringSegmentOption<T>>,
-    endianness: Option<BitStringSegmentOption<T>>,
-    unit: Option<BitStringSegmentOption<T>>,
-    size: Option<BitStringSegmentOption<T>>,
+//
+//  Public Interface
+//
+
+pub fn type_options_for_value<T>(
+    input_options: &[BitStringSegmentOption<T>],
+) -> Result<Arc<Type>, Error> {
+    type_options(input_options, true, false)
 }
 
-impl<T> BinaryTypeSpecifier<T> {
-    pub fn new(options: &[BitStringSegmentOption<T>], must_have_size: bool) -> Result<Self, Error>
-    where
-        T: Clone,
-    {
-        let empty_bts = BinaryTypeSpecifier {
+pub fn type_options_for_pattern<T>(
+    input_options: &[BitStringSegmentOption<T>],
+    must_have_size: bool,
+) -> Result<Arc<Type>, Error> {
+    type_options(input_options, false, must_have_size)
+}
+
+struct SegmentOptionCategories<'a, T> {
+    typ: Option<&'a BitStringSegmentOption<T>>,
+    signed: Option<&'a BitStringSegmentOption<T>>,
+    endian: Option<&'a BitStringSegmentOption<T>>,
+    unit: Option<&'a BitStringSegmentOption<T>>,
+    size: Option<&'a BitStringSegmentOption<T>>,
+}
+
+impl<T> SegmentOptionCategories<'_, T> {
+    fn new() -> Self {
+        SegmentOptionCategories {
             typ: None,
-            signedness: None,
-            endianness: None,
+            signed: None,
+            endian: None,
             unit: None,
             size: None,
-        };
-
-        let parsed_bts = options.iter().try_fold(empty_bts, |mut bts, option| {
-            match (option.category(), &bts) {
-                (Category::Type, Self { typ: None, .. }) => {
-                    bts.typ = Some(option.clone());
-                    Ok(bts)
-                }
-
-                (Category::Type, Self { typ: Some(t), .. }) => Err(Error::ConflictingTypeOptions {
-                    previous_location: t.location(),
-                    location: option.location(),
-                    name: t.label(),
-                }),
-
-                (
-                    Category::Signedness,
-                    Self {
-                        signedness: None, ..
-                    },
-                ) => {
-                    bts.signedness = Some(option.clone());
-                    Ok(bts)
-                }
-
-                (
-                    Category::Signedness,
-                    Self {
-                        signedness: Some(s),
-                        ..
-                    },
-                ) => Err(Error::ConflictingSignednessOptions {
-                    previous_location: s.location(),
-                    location: option.location(),
-                    name: s.label(),
-                }),
-
-                (
-                    Category::Endianness,
-                    Self {
-                        endianness: None, ..
-                    },
-                ) => {
-                    bts.endianness = Some(option.clone());
-                    Ok(bts)
-                }
-
-                (
-                    Category::Endianness,
-                    Self {
-                        endianness: Some(e),
-                        ..
-                    },
-                ) => Err(Error::ConflictingEndiannessOptions {
-                    previous_location: e.location(),
-                    location: option.location(),
-                    name: e.label(),
-                }),
-
-                (Category::Size, Self { size: None, .. }) => {
-                    bts.size = Some(option.clone());
-                    Ok(bts)
-                }
-
-                (Category::Size, Self { size: Some(s), .. }) => {
-                    Err(Error::ConflictingSizeOptions {
-                        previous_location: s.location(),
-                        location: option.location(),
-                    })
-                }
-
-                (Category::Unit, Self { unit: None, .. }) => {
-                    bts.unit = Some(option.clone());
-                    Ok(bts)
-                }
-
-                (Category::Unit, Self { unit: Some(u), .. }) => {
-                    Err(Error::ConflictingUnitOptions {
-                        previous_location: u.location(),
-                        location: option.location(),
-                    })
-                }
-            }
-        })?;
-
-        match parsed_bts {
-            Self {
-                typ: Some(t),
-                unit: Some(u),
-                ..
-            } if !t.unit_is_allowed() => Err(Error::TypeDoesNotAllowUnit {
-                location: u.location(),
-                typ: t.label(),
-            }),
-
-            Self {
-                size: None,
-                typ: Some(BitStringSegmentOption::Binary { .. }),
-                ..
-            }
-            | Self {
-                size: None,
-                typ: Some(BitStringSegmentOption::BitString { .. }),
-                ..
-            } if must_have_size => Err(Error::SegmentMustHaveSize),
-
-            _ => Ok(parsed_bts),
         }
     }
 
-    pub fn typ(&self) -> Option<Arc<Type>> {
+    fn segment_type(&self) -> Arc<Type> {
         match self.typ {
-            Some(BitStringSegmentOption::Integer { .. }) => Some(crate::typ::int()),
-            Some(BitStringSegmentOption::Float { .. }) => Some(crate::typ::float()),
-            Some(BitStringSegmentOption::Binary { .. }) => Some(crate::typ::bit_string()),
-            Some(BitStringSegmentOption::BitString { .. }) => Some(crate::typ::bit_string()),
-            Some(BitStringSegmentOption::UTF8 { .. }) => Some(crate::typ::string()),
-            Some(BitStringSegmentOption::UTF16 { .. }) => Some(crate::typ::string()),
-            Some(BitStringSegmentOption::UTF32 { .. }) => Some(crate::typ::string()),
-            Some(BitStringSegmentOption::UTF8Codepoint { .. }) => Some(crate::typ::utf_codepoint()),
-            Some(BitStringSegmentOption::UTF16Codepoint { .. }) => {
-                Some(crate::typ::utf_codepoint())
-            }
-            Some(BitStringSegmentOption::UTF32Codepoint { .. }) => {
-                Some(crate::typ::utf_codepoint())
-            }
-            _ => None,
+            Some(BitStringSegmentOption::Integer { .. }) => crate::typ::int(),
+            Some(BitStringSegmentOption::Float { .. }) => crate::typ::float(),
+            Some(BitStringSegmentOption::Binary { .. }) => crate::typ::bit_string(),
+            Some(BitStringSegmentOption::BitString { .. }) => crate::typ::bit_string(),
+            Some(BitStringSegmentOption::UTF8 { .. }) => crate::typ::string(),
+            Some(BitStringSegmentOption::UTF16 { .. }) => crate::typ::string(),
+            Some(BitStringSegmentOption::UTF32 { .. }) => crate::typ::string(),
+            Some(BitStringSegmentOption::UTF8Codepoint { .. }) => crate::typ::utf_codepoint(),
+            Some(BitStringSegmentOption::UTF16Codepoint { .. }) => crate::typ::utf_codepoint(),
+            Some(BitStringSegmentOption::UTF32Codepoint { .. }) => crate::typ::utf_codepoint(),
+            None => crate::typ::int(),
+            Some(_) => crate::error::fatal_compiler_bug(
+                "Tried to type a non type kind BitString segment option.",
+            ),
         }
     }
+}
+
+fn type_options<T>(
+    input_options: &[BitStringSegmentOption<T>],
+    value_mode: bool,
+    must_have_size: bool,
+) -> Result<Arc<Type>, Error> {
+    let mut categories = SegmentOptionCategories::new();
+    // Basic category checking
+    for option in input_options.iter() {
+        match option {
+            BitStringSegmentOption::Binary { .. }
+            | BitStringSegmentOption::Integer { .. }
+            | BitStringSegmentOption::Float { .. }
+            | BitStringSegmentOption::BitString { .. }
+            | BitStringSegmentOption::UTF8 { .. }
+            | BitStringSegmentOption::UTF16 { .. }
+            | BitStringSegmentOption::UTF32 { .. }
+            | BitStringSegmentOption::UTF8Codepoint { .. }
+            | BitStringSegmentOption::UTF16Codepoint { .. }
+            | BitStringSegmentOption::UTF32Codepoint { .. } => {
+                if let Some(previous) = categories.typ {
+                    return err(
+                        ErrorType::ConflictingTypeOptions {
+                            existing_type: previous.label(),
+                        },
+                        option.location(),
+                    );
+                } else {
+                    categories.typ = Some(option.clone());
+                }
+            }
+            BitStringSegmentOption::Signed { .. } | BitStringSegmentOption::Unsigned { .. } => {
+                if let Some(previous) = categories.signed {
+                    return err(
+                        ErrorType::ConflictingSignednessOptions {
+                            existing_signed: previous.label(),
+                        },
+                        option.location(),
+                    );
+                } else {
+                    categories.signed = Some(option.clone());
+                }
+            }
+            BitStringSegmentOption::Big { .. }
+            | BitStringSegmentOption::Little { .. }
+            | BitStringSegmentOption::Native { .. } => {
+                if let Some(previous) = categories.endian {
+                    return err(
+                        ErrorType::ConflictingEndiannessOptions {
+                            existing_endianness: previous.label(),
+                        },
+                        option.location(),
+                    );
+                } else {
+                    categories.endian = Some(option.clone());
+                }
+            }
+
+            BitStringSegmentOption::Size { .. } => {
+                if let Some(_) = categories.size {
+                    return err(ErrorType::ConflictingSizeOptions, option.location());
+                } else {
+                    categories.size = Some(option.clone());
+                }
+            }
+
+            BitStringSegmentOption::Unit { .. } => {
+                if let Some(_) = categories.unit {
+                    return err(ErrorType::ConflictingUnitOptions, option.location());
+                } else {
+                    categories.unit = Some(option.clone());
+                }
+            }
+        };
+    }
+
+    // Some options are not allowed in value mode
+    if value_mode == true {
+        match categories {
+            SegmentOptionCategories {
+                signed: Some(opt), ..
+            }
+            | SegmentOptionCategories {
+                typ: Some(opt @ BitStringSegmentOption::Binary { .. }),
+                ..
+            } => return err(ErrorType::OptionNotAllowedInValue, opt.location()),
+
+            _ => {}
+        }
+    }
+
+    // All but the last segment in a pattern must have an exact size
+    if must_have_size {
+        match categories.typ {
+            Some(opt @ BitStringSegmentOption::Binary { .. })
+            | Some(opt @ BitStringSegmentOption::BitString { .. }) => {
+                if categories.size.is_none() {
+                    return err(ErrorType::SegmentMustHaveSize, opt.location());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Endianness is only valid for int, utf6, utf32 and float
+    if let Some(endian) = categories.endian {
+        match categories.typ {
+            None
+            | Some(BitStringSegmentOption::Integer { .. })
+            | Some(BitStringSegmentOption::UTF16 { .. })
+            | Some(BitStringSegmentOption::UTF32 { .. })
+            | Some(BitStringSegmentOption::Float { .. }) => {}
+
+            _ => return err(ErrorType::InvalidEndianness, endian.location()),
+        }
+    };
+
+    // signed and unsigned can only be used with int types
+    match categories.typ {
+        None | Some(BitStringSegmentOption::Integer { .. }) => {}
+
+        Some(opt) => {
+            if let Some(sign) = categories.signed {
+                return err(
+                    ErrorType::SignednessUsedOnNonInt { typ: opt.label() },
+                    sign.location(),
+                );
+            }
+        }
+    };
+
+    // utf8, utf16, utf32 exclude unit and size
+    match categories {
+        SegmentOptionCategories {
+            typ: Some(typ),
+            unit: Some(_),
+            ..
+        } => {
+            if is_unicode(typ) {
+                return err(
+                    ErrorType::TypeDoesNotAllowUnit { typ: typ.label() },
+                    typ.location().clone(),
+                );
+            }
+        }
+        SegmentOptionCategories {
+            typ: Some(typ),
+            size: Some(_),
+            ..
+        } => {
+            if is_unicode(typ) {
+                return err(
+                    ErrorType::TypeDoesNotAllowSize { typ: typ.label() },
+                    typ.location().clone(),
+                );
+            }
+        }
+        _ => {}
+    }
+
+    // if unit specified, size must be specified
+    if let Some(unit) = categories.unit {
+        if categories.size.is_none() {
+            return err(ErrorType::UnitMustHaveSize, unit.location().clone());
+        };
+    };
+
+    // size cannot be used with float
+    match categories {
+        SegmentOptionCategories {
+            typ: Some(BitStringSegmentOption::Float { .. }),
+            size: Some(opt),
+            ..
+        } => return err(ErrorType::FloatWithSize, opt.location().clone()),
+        _ => {}
+    }
+
+    Ok(categories.segment_type())
+}
+
+fn is_unicode<T>(opt: &BitStringSegmentOption<T>) -> bool {
+    matches!(opt,
+        BitStringSegmentOption::UTF8 { .. }
+        | BitStringSegmentOption::UTF16 { .. }
+        | BitStringSegmentOption::UTF32 { .. }
+        | BitStringSegmentOption::UTF8Codepoint { .. }
+        | BitStringSegmentOption::UTF16Codepoint { .. }
+        | BitStringSegmentOption::UTF32Codepoint { .. }
+    )
+}
+
+fn err<A>(error: ErrorType, location: SrcSpan) -> Result<A, Error> {
+    Err(Error { location, error })
+}
+
+pub struct Error {
+    pub location: SrcSpan,
+    pub error: ErrorType,
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum Error {
-    ConflictingTypeOptions {
-        location: SrcSpan,
-        previous_location: SrcSpan,
-        name: String,
-    },
-
-    ConflictingSignednessOptions {
-        location: SrcSpan,
-        previous_location: SrcSpan,
-        name: String,
-    },
-
-    ConflictingEndiannessOptions {
-        location: SrcSpan,
-        previous_location: SrcSpan,
-        name: String,
-    },
-
-    ConflictingSizeOptions {
-        location: SrcSpan,
-        previous_location: SrcSpan,
-    },
-
-    ConflictingUnitOptions {
-        location: SrcSpan,
-        previous_location: SrcSpan,
-    },
-
-    TypeDoesNotAllowUnit {
-        location: SrcSpan,
-        typ: String,
-    },
-
+pub enum ErrorType {
+    ConflictingEndiannessOptions { existing_endianness: String },
+    ConflictingSignednessOptions { existing_signed: String },
+    ConflictingSizeOptions,
+    ConflictingTypeOptions { existing_type: String },
+    ConflictingUnitOptions,
+    FloatWithSize,
+    InvalidEndianness,
+    OptionNotAllowedInValue,
     SegmentMustHaveSize,
-}
-
-impl<A> BitStringSegmentOption<A> {
-    pub fn unit_is_allowed(&self) -> bool {
-        !matches!(self,
-            BitStringSegmentOption::UTF8 { .. }
-            | BitStringSegmentOption::UTF16 { .. }
-            | BitStringSegmentOption::UTF32 { .. }
-        )
-    }
+    SignednessUsedOnNonInt { typ: String },
+    TypeDoesNotAllowSize { typ: String },
+    TypeDoesNotAllowUnit { typ: String },
+    UnitMustHaveSize,
+    VaribleUTFSegmentInPatten,
 }

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -546,7 +546,11 @@ fn expr_segment<'a>(
             let inner_expr = expr(expression, env).surround("(", ")");
             // The value of size must be a non-negative integer, we use lists:max here to ensure
             // it is at least 0;
-            let value_guard = ":(lists:max([".to_doc().append(inner_expr).append(", 0]))");
+            let value_guard = ":(lists:max(["
+                .to_doc()
+                .append(inner_expr)
+                .append(", 0]))")
+                .group();
             Some(value_guard)
         }
     };

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1727,10 +1727,8 @@ x() ->
 -spec main() -> bitstring().
 main() ->
     A = -1,
-    B = <<A:(lists:max([(A
-          * 2), 0]))/unit:2,
-          A:(lists:max([(3
-          + x()), 0]))/unit:1>>,
+    B = <<A:(lists:max([(A * 2), 0]))/unit:2,
+          A:(lists:max([(3 + x()), 0]))/unit:1>>,
     B.
 "#,
     );

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1687,9 +1687,9 @@ main() ->
         r#"fn main() {
   let a = 1
   let simple = <<1, a>>
-  let complex = <<4:int-unsigned-big, 5.0:little-float, 6:native-int-signed>>
+  let complex = <<4:int-big, 5.0:little-float, 6:native-int>>
   let <<7:2, 8:size(3), b:binary-size(4)>> = <<1>>
-  let <<c:unit(1), d:binary-size(2)-unit(2)>> = <<1>>
+  let <<c:8-unit(1), d:binary-size(2)-unit(2)>> = <<1>>
 
   simple
 }
@@ -1701,11 +1701,9 @@ main() ->
 main() ->
     A = 1,
     Simple = <<1, A>>,
-    Complex = <<4/integer-unsigned-big,
-                5.0/little-float,
-                6/native-integer-signed>>,
+    Complex = <<4/integer-big, 5.0/little-float, 6/native-integer>>,
     <<7:2, 8:3, B:4/binary>> = <<1>>,
-    <<C/unit:1, D:2/binary-unit:2>> = <<1>>,
+    <<C:8/unit:1, D:2/binary-unit:2>> = <<1>>,
     Simple.
 "#,
     );
@@ -1713,7 +1711,7 @@ main() ->
     assert_erl!(
         r#"fn x() { 2 }
 fn main() {
-  let a = 1
+  let a = -1
   let b = <<a:unit(2)-size(a * 2), a:size(3 + x())-unit(1)>>
 
   b
@@ -1728,8 +1726,11 @@ x() ->
 
 -spec main() -> bitstring().
 main() ->
-    A = 1,
-    B = <<A:(A * 2)/unit:2, A:(3 + x())/unit:1>>,
+    A = -1,
+    B = <<A:(lists:max([(A
+          * 2), 0]))/unit:2,
+          A:(lists:max([(3
+          + x()), 0]))/unit:1>>,
     B.
 "#,
     );

--- a/src/format.rs
+++ b/src/format.rs
@@ -1576,21 +1576,11 @@ where
             ..
         } => to_doc(value.as_ref()),
 
-        BitStringSegmentOption::Unit {
-            value,
-            short_form: false,
-            ..
-        } => "unit"
+        BitStringSegmentOption::Unit { value, .. } => "unit"
             .to_doc()
             .append("(")
-            .append(to_doc(value.as_ref()))
+            .append(Document::String(format!("{}", value)))
             .append(")"),
-
-        BitStringSegmentOption::Unit {
-            value,
-            short_form: true,
-            ..
-        } => to_doc(value.as_ref()),
     }
 }
 

--- a/src/metadata/module_encoder.rs
+++ b/src/metadata/module_encoder.rs
@@ -301,12 +301,15 @@ impl<'a> ModuleEncoder<'a> {
                 builder.set_short_form(*short_form);
             }
 
-            Opt::Unit {
-                value, short_form, ..
-            } => {
+            Opt::Unit { value, location } => {
                 let mut builder = builder.init_unit();
-                self.build_constant(builder.reborrow().init_value(), value);
-                builder.set_short_form(*short_form);
+                self.build_constant(
+                    builder.reborrow().init_value(),
+                    &Constant::Int {
+                        value: format!("{}", value),
+                        location: *location,
+                    },
+                );
             }
         }
     }

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -36,18 +36,20 @@ pub enum ParseErrorType {
     IncorrectName,           // UpName or DiscardName used when Name was expected
     IncorrectUpName,         // Name or DiscardName used when UpName was expected
     InvalidBitStringSegment, // <<7:hello>> `hello` is an invalid bitstring segment
+    InvalidBitStringUnit,    // in <<1:unit(x)>> x must be 1 <= x <= 256
     InvalidTailPattern,      // only name and _name are allowed after ".." in list pattern
     InvalidTupleAccess,      // only positive int literals for tuple access
     LexError { error: LexicalError },
-    ListNilNotAllowed, // [] is not allowed here
-    NoConstructors,    // A type "A {}" must have at least one constructor
-    NoCaseClause,      // a case with no claueses
-    NoExpression,      // between "{" and "}" in expression position, there must be an expression
+    ListNilNotAllowed,      // [] is not allowed here
+    NestedBitStringPattern, // <<<<1>>, 2>>, <<1>> is not allowed in there
+    NoConstructors,         // A type "A {}" must have at least one constructor
+    NoCaseClause,           // a case with no claueses
+    NoExpression, // between "{" and "}" in expression position, there must be an expression
     NoValueAfterEqual, // = <something other than a value>
-    NotConstType,      // :fn(), name, _  are not valid const types
-    OpNakedRight,      // Operator with no value to the right
-    OpaqueTypeAlias,   // Type aliases cannot be opaque
-    TooManyArgHoles,   // a function call can have at most 1 arg hole
+    NotConstType, // :fn(), name, _  are not valid const types
+    OpNakedRight, // Operator with no value to the right
+    OpaqueTypeAlias, // Type aliases cannot be opaque
+    TooManyArgHoles, // a function call can have at most 1 arg hole
     UnexpectedEOF,
     UnexpectedReservedWord, // reserved word used when a name was expected
     UnexpectedToken { expected: Vec<String> },

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -94,3 +94,32 @@ fn string_tests() {
         }
     );
 }
+
+#[test]
+fn bit_string_tests() {
+    // non int value in BitString unit option
+    assert_error!(
+        "let x = <<1:unit(0)>> x",
+        ParseError {
+            error: ParseErrorType::InvalidBitStringUnit,
+            location: SrcSpan { start: 17, end: 18 }
+        }
+    );
+
+    assert_error!(
+        "let x = <<1:unit(257)>> x",
+        ParseError {
+            error: ParseErrorType::InvalidBitStringUnit,
+            location: SrcSpan { start: 17, end: 20 }
+        }
+    );
+
+    // patterns cannot be nested
+    assert_error!(
+        "case <<>> { <<<<1>>:bit_string>> -> 1 }",
+        ParseError {
+            error: ParseErrorType::NestedBitStringPattern,
+            location: SrcSpan { start: 14, end: 19 }
+        }
+    );
+}

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -25,7 +25,7 @@ use crate::{
         TypedStatement, UnqualifiedImport, UntypedModule, UntypedMultiPattern, UntypedPattern,
         UntypedRecordUpdateArg, UntypedStatement,
     },
-    bit_string::BinaryTypeSpecifier,
+    bit_string,
     build::Origin,
     error::GleamExpect,
 };
@@ -1071,19 +1071,11 @@ where
         }
 
         BitStringSegmentOption::Unit {
-            value,
+            value, location, ..
+        } => Ok(BitStringSegmentOption::Unit {
             location,
-            short_form,
-            ..
-        } => {
-            let value = type_check(*value, int())?;
-
-            Ok(BitStringSegmentOption::Unit {
-                location,
-                short_form,
-                value: Box::new(value),
-            })
-        }
+            value: value,
+        }),
 
         BitStringSegmentOption::Binary { location } => {
             Ok(BitStringSegmentOption::Binary { location })

--- a/src/typ/error.rs
+++ b/src/typ/error.rs
@@ -1,9 +1,13 @@
-use crate::{ast::SrcSpan, bit_string::Error as BinaryError, typ::Type};
+use crate::{ast::SrcSpan, typ::Type};
 
 use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
+    BitStringSegmentError {
+        error: crate::bit_string::ErrorType,
+        location: SrcSpan,
+    },
     UnknownLabels {
         unknown: Vec<(String, SrcSpan)>,
         valid: Vec<String>,
@@ -172,50 +176,8 @@ pub enum Error {
         location: SrcSpan,
     },
 
-    ConflictingBinaryTypeOptions {
-        previous_location: SrcSpan,
-        location: SrcSpan,
-        name: String,
-    },
-
-    ConflictingBinarySignednessOptions {
-        previous_location: SrcSpan,
-        location: SrcSpan,
-        name: String,
-    },
-
-    ConflictingBinaryEndiannessOptions {
-        previous_location: SrcSpan,
-        location: SrcSpan,
-        name: String,
-    },
-
-    ConflictingBinarySizeOptions {
-        previous_location: SrcSpan,
-        location: SrcSpan,
-    },
-
-    ConflictingBinaryUnitOptions {
-        previous_location: SrcSpan,
-        location: SrcSpan,
-    },
-
-    BinaryTypeDoesNotAllowUnit {
-        location: SrcSpan,
-        typ: String,
-    },
-
-    BinarySegmentMustHaveSize {
-        location: SrcSpan,
-    },
-
     UnexpectedTypeHole {
         location: SrcSpan,
-    },
-
-    UTFVarInBitStringSegment {
-        location: SrcSpan,
-        option: String,
     },
 }
 
@@ -519,64 +481,6 @@ impl UnifyError {
 
             Self::RecursiveType => Error::RecursiveType { location },
         }
-    }
-}
-
-pub fn convert_binary_error(e: crate::bit_string::Error, location: &SrcSpan) -> Error {
-    match e {
-        BinaryError::ConflictingSignednessOptions {
-            location,
-            previous_location,
-            name,
-        } => Error::ConflictingBinarySignednessOptions {
-            location,
-            previous_location,
-            name,
-        },
-
-        BinaryError::ConflictingEndiannessOptions {
-            location,
-            previous_location,
-            name,
-        } => Error::ConflictingBinaryEndiannessOptions {
-            location,
-            previous_location,
-            name,
-        },
-
-        BinaryError::ConflictingTypeOptions {
-            location,
-            previous_location,
-            name,
-        } => Error::ConflictingBinaryTypeOptions {
-            location,
-            previous_location,
-            name,
-        },
-
-        BinaryError::ConflictingSizeOptions {
-            location,
-            previous_location,
-        } => Error::ConflictingBinarySizeOptions {
-            location,
-            previous_location,
-        },
-
-        BinaryError::ConflictingUnitOptions {
-            location,
-            previous_location,
-        } => Error::ConflictingBinaryUnitOptions {
-            location,
-            previous_location,
-        },
-
-        BinaryError::TypeDoesNotAllowUnit { location, typ } => {
-            Error::BinaryTypeDoesNotAllowUnit { location, typ }
-        }
-
-        BinaryError::SegmentMustHaveSize => Error::BinarySegmentMustHaveSize {
-            location: *location,
-        },
     }
 }
 

--- a/src/typ/expr.rs
+++ b/src/typ/expr.rs
@@ -595,9 +595,12 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
             .map(infer_option)
             .collect::<Result<Vec<_>, _>>()?;
 
-        let type_specifier = BinaryTypeSpecifier::new(&options, false)
-            .map_err(|e| convert_binary_error(e, &location))?;
-        let typ = type_specifier.typ().unwrap_or_else(int);
+        let typ = crate::bit_string::type_options_for_value(&options).map_err(|error| {
+            Error::BitStringSegmentError {
+                error: error.error,
+                location: error.location,
+            }
+        })?;
 
         self.unify(typ.clone(), value.typ())
             .map_err(|e| convert_unify_error(e, value.location()))?;


### PR DESCRIPTION
Fixes #949 
(the linked documentation PR) fixes: #709

## Changes
### Size option now has a guard on non int literals and is guaranteed to be non-negative.
Previously things like this could crash at runtime:
```rust
let a = -1
<<1:size(a)>>
let a = fn() { -1 }
<<1:size(a())>>
```

now the generated erlang has a "guard" in the form of `lists:max([_, 0])`
```erlang
A = -1,
<<1:(lists:max([(A), 0]))>>,
A@1 = fun() -> -1 end,
<<1:(lists:max([(A@1()), 0]))>>.
```

Integer literals are checked at compile time:
`<<1:-1>>` becomes `<<1:0>>` and `<<1:1>>` stays `<<1:1>>`

### Unit now must be an integer literal >= 1 and <= 256
Previously it allowed many erroneous values either ignoring them or crashing at runtime. Checked at compile time.

```
error: Syntax error
  ┌─ /Users/a/parser_test/src/a.gleam:2:20
  │
2 │   <<1:size(1)-unit(0)>>
  │                    ^ This is not a valid BitString unit value.

Hint: unit must be an integer literal >= 1 and <= 256
See: https://gleam.run/book/tour/bit-strings
```

a non int value is an unexpected token error.

### BitString patterns cannot be nested
This used to be a compiler panic, now syntax error

```
error: Syntax error
  ┌─ /Users/a/parser_test/src/a.gleam:2:9
  │
2 │   let <<<<1>>:bit_string>> = <<<<1>>:bit_string>>
  │         ^^^^^ BitString patterns cannot be nested.

See: https://gleam.run/book/tour/patterns
```

### Options that have no effect are disallowed
Hopefully helps people learn more about BitStrings

```
error: BitString Segment Error
  ┌─ /Users/a/parser_test/src/a.gleam:2:7
  │
2 │   <<1:signed>>
  │       ^^^^^^ This option is only allowed in BitString patterns.

Hint: This option has no effect in BitString values.
See: https://gleam.run/book/tour/bit-strings.html
```

### Binary is disallowed in values 
Gleam has no `Binary` type and the `bit_string` or `utfX` options cover existing types

```
error: BitString Segment Error
  ┌─ /Users/a/Trash/parser_test/src/a.gleam:2:10
  │
2 │   <<"hi":binary>>
  │          ^^^^^^ This option is only allowed in BitString patterns.

Hint: This option has no effect in BitString values.
See: https://gleam.run/book/tour/bit-strings.html
```