### PR TITLE
Better errors for malformed names (fixes #956)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - A set of OCI container images are built automatically for each release.
 - New compile time checks for invalid bit string literals and patterns have 
   been added.
+- Better error messages for malformed names.
 
 ## v0.13.2 - 2020-01-14
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -148,13 +148,7 @@ where
         if let Some(error) = self.lex_errors.pop() {
             // Lex errors first
             let location = error.location;
-            parse_error(
-                ParseErrorType::LexError { error },
-                SrcSpan {
-                    start: location,
-                    end: location,
-                },
-            )
+            parse_error(ParseErrorType::LexError { error }, location)
         } else if parse_result.is_err() {
             // Then parse errors
             parse_result

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -1,4 +1,5 @@
 use crate::ast::SrcSpan;
+use heck::CamelCase;
 use heck::SnakeCase;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -17,6 +18,7 @@ pub enum LexicalErrorType {
     UnrecognizedToken { tok: char },
     BadName { name: String },
     BadDiscardName { name: String },
+    BadUpname { name: String },
 }
 
 #[derive(Debug, PartialEq)]
@@ -96,6 +98,14 @@ impl LexicalError {
                 vec![
                     "Hint: Discard names start with _ and contain a-z, 0-9, or _.".to_string(),
                     format!("Try: _{}", name.to_snake_case()),
+                ],
+            ),
+            LexicalErrorType::BadUpname { name } => (
+                "This is not a valid upname.",
+                vec![
+                    "Hint: Upnames start with an uppercase letter and contain".to_string(),
+                    "only lowercase letters, numbers, and uppercase letters.".to_string(),
+                    format!("Try: {}", name.to_camel_case()),
                 ],
             ),
         }

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -3,7 +3,7 @@ use crate::ast::SrcSpan;
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct LexicalError {
     pub error: LexicalErrorType,
-    pub location: usize,
+    pub location: SrcSpan,
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -15,7 +15,7 @@ pub enum LexicalErrorType {
     RadixIntNoValue,       // 0x, 0b, 0o without a value
     UnexpectedStringEnd,   // Unterminated string literal
     UnrecognizedToken { tok: char },
-    CamelCaseName { name: String },
+    BadName { name: String },
 }
 
 #[derive(Debug, PartialEq)]
@@ -82,7 +82,7 @@ impl LexicalError {
                 "I can't figure out what to do with this character.",
                 vec!["Hint: Is it a typo?".to_string()],
             ),
-	        LexicalErrorType::CamelCaseName { name } => (
+	        LexicalErrorType::BadName { name } => (
 		        "This is not a valid name.",
 		        vec![
 			        "Hint: In Gleam names must start with a lowercase letter and contain only lowercase letters, numbers, and '_'.".to_string(),

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -1,12 +1,13 @@
 use crate::ast::SrcSpan;
+use heck::SnakeCase;
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct LexicalError {
     pub error: LexicalErrorType,
     pub location: SrcSpan,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum LexicalErrorType {
     BadStringEscape,       // string contains an unescaped slash
     DigitOutOfRadix,       // 0x012 , 2 is out of radix
@@ -14,6 +15,7 @@ pub enum LexicalErrorType {
     RadixIntNoValue,       // 0x, 0b, 0o without a value
     UnexpectedStringEnd,   // Unterminated string literal
     UnrecognizedToken { tok: char },
+    CamelCaseName { name: String },
 }
 
 #[derive(Debug, PartialEq)]
@@ -57,7 +59,7 @@ pub enum ParseErrorType {
 
 impl LexicalError {
     pub fn to_parse_error_info(&self) -> (&str, Vec<String>) {
-        match self.error {
+        match &self.error {
             LexicalErrorType::BadStringEscape => (
                 "I don't understand this escape code",
                 vec![
@@ -80,6 +82,13 @@ impl LexicalError {
                 "I can't figure out what to do with this character.",
                 vec!["Hint: Is it a typo?".to_string()],
             ),
+	        LexicalErrorType::CamelCaseName { name } => (
+		        "This is not a valid name.",
+		        vec![
+			        "Hint: In Gleam names must start with a lowercase letter and contain only lowercase letters, numbers, and '_'.".to_string(),
+			        format!("Try: {}", name.to_snake_case())
+		        ]
+	        ),
         }
     }
 }

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -16,6 +16,7 @@ pub enum LexicalErrorType {
     UnexpectedStringEnd,   // Unterminated string literal
     UnrecognizedToken { tok: char },
     BadName { name: String },
+    BadDiscardName { name: String },
 }
 
 #[derive(Debug, PartialEq)]
@@ -82,13 +83,21 @@ impl LexicalError {
                 "I can't figure out what to do with this character.",
                 vec!["Hint: Is it a typo?".to_string()],
             ),
-	        LexicalErrorType::BadName { name } => (
-		        "This is not a valid name.",
-		        vec![
-			        "Hint: In Gleam names must start with a lowercase letter and contain only lowercase letters, numbers, and '_'.".to_string(),
-			        format!("Try: {}", name.to_snake_case())
-		        ]
-	        ),
+            LexicalErrorType::BadName { name } => (
+                "This is not a valid name.",
+                vec![
+                    "Hint: Names start with a lowercase letter and contain a-z, 0-9, or _."
+                        .to_string(),
+                    format!("Try: {}", name.to_snake_case()),
+                ],
+            ),
+            LexicalErrorType::BadDiscardName { name } => (
+                "This is not a valid discard name.",
+                vec![
+                    "Hint: Discard names start with _ and contain a-z, 0-9, or _.".to_string(),
+                    format!("Try: _{}", name.to_snake_case()),
+                ],
+            ),
         }
     }
 }

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -1,3 +1,4 @@
+use crate::ast::SrcSpan;
 use crate::parse::error::{LexicalError, LexicalErrorType};
 use crate::parse::token::Tok;
 use std::char;
@@ -259,7 +260,10 @@ where
                 } else {
                     return Err(LexicalError {
                         error: LexicalErrorType::UnrecognizedToken { tok: '&' },
-                        location: tok_start,
+                        location: SrcSpan {
+                            start: tok_start,
+                            end: tok_start,
+                        },
                     });
                 }
             }
@@ -293,7 +297,10 @@ where
                 } else {
                     return Err(LexicalError {
                         error: LexicalErrorType::UnrecognizedToken { tok: '!' },
-                        location: tok_start,
+                        location: SrcSpan {
+                            start: tok_start,
+                            end: tok_start,
+                        },
                     });
                 }
             }
@@ -435,7 +442,10 @@ where
                 let location = self.get_pos();
                 return Err(LexicalError {
                     error: LexicalErrorType::UnrecognizedToken { tok: c },
-                    location,
+                    location: SrcSpan {
+                        start: location,
+                        end: location,
+                    },
                 });
             }
         }
@@ -505,9 +515,13 @@ where
         };
 
         if Some('_') == self.chr0 {
+            let location = self.get_pos();
             Err(LexicalError {
                 error: LexicalErrorType::NumTrailingUnderscore,
-                location: self.get_pos(),
+                location: SrcSpan {
+                    start: location,
+                    end: location,
+                },
             })
         } else {
             Ok(num)
@@ -518,14 +532,22 @@ where
     fn lex_number_radix(&mut self, start_pos: usize, radix: u32, prefix: &str) -> LexResult {
         let num = self.radix_run(radix);
         if num.is_empty() {
+            let location = self.get_pos() - 1;
             Err(LexicalError {
                 error: LexicalErrorType::RadixIntNoValue,
-                location: self.get_pos() - 1,
+                location: SrcSpan {
+                    start: location,
+                    end: location,
+                },
             })
         } else if radix < 16 && Lexer::<T>::is_digit_of_radix(self.chr0, 16) {
+            let location = self.get_pos();
             Err(LexicalError {
                 error: LexicalErrorType::DigitOutOfRadix,
-                location: self.get_pos(),
+                location: SrcSpan {
+                    start: location,
+                    end: location,
+                },
             })
         } else {
             let value = format!("{}{}", prefix, num);
@@ -645,14 +667,20 @@ where
                             _ => {
                                 return Err(LexicalError {
                                     error: LexicalErrorType::BadStringEscape,
-                                    location: slash_pos,
+                                    location: SrcSpan {
+                                        start: slash_pos,
+                                        end: slash_pos,
+                                    },
                                 });
                             }
                         }
                     } else {
                         return Err(LexicalError {
                             error: LexicalErrorType::BadStringEscape,
-                            location: slash_pos,
+                            location: SrcSpan {
+                                start: slash_pos,
+                                end: slash_pos,
+                            },
                         });
                     }
                 }
@@ -661,7 +689,10 @@ where
                 None => {
                     return Err(LexicalError {
                         error: LexicalErrorType::UnexpectedStringEnd,
-                        location: start_pos,
+                        location: SrcSpan {
+                            start: start_pos,
+                            end: start_pos,
+                        },
                     });
                 }
             }

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -469,13 +469,23 @@ where
                 name.push(self.next_char().unwrap())
             }
             let end_pos = self.get_pos();
-            return Err(LexicalError {
-                error: LexicalErrorType::BadName { name: name },
-                location: SrcSpan {
-                    start: start_pos,
-                    end: end_pos,
-                },
-            });
+            if name.starts_with('_') {
+                return Err(LexicalError {
+                    error: LexicalErrorType::BadDiscardName { name: name },
+                    location: SrcSpan {
+                        start: start_pos,
+                        end: end_pos,
+                    },
+                });
+            } else {
+                return Err(LexicalError {
+                    error: LexicalErrorType::BadName { name: name },
+                    location: SrcSpan {
+                        start: start_pos,
+                        end: end_pos,
+                    },
+                });
+            }
         }
 
         let end_pos = self.get_pos();

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -462,6 +462,22 @@ where
         while self.is_name_continuation() {
             name.push(self.next_char().unwrap());
         }
+
+        // Throw a lexical error if a name is in "camel case".
+        if self.is_upname_continuation() {
+            while self.is_upname_continuation() {
+                name.push(self.next_char().unwrap())
+            }
+            let end_pos = self.get_pos();
+            return Err(LexicalError {
+                error: LexicalErrorType::CamelCaseName { name: name },
+                location: SrcSpan {
+                    start: start_pos,
+                    end: end_pos,
+                },
+            });
+        }
+
         let end_pos = self.get_pos();
 
         if let Some(tok) = str_to_keyword(&name) {

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -506,6 +506,22 @@ where
         while self.is_upname_continuation() {
             name.push(self.next_char().unwrap());
         }
+
+        // Finish lexing the upname and return an error if an underscore is used
+        if self.is_name_error_continuation() {
+            while self.is_name_error_continuation() {
+                name.push(self.next_char().unwrap())
+            }
+            let end_pos = self.get_pos();
+            return Err(LexicalError {
+                error: LexicalErrorType::BadUpname { name: name },
+                location: SrcSpan {
+                    start: start_pos,
+                    end: end_pos,
+                },
+            });
+        }
+
         let end_pos = self.get_pos();
 
         if let Some(tok) = str_to_keyword(&name) {

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -463,14 +463,14 @@ where
             name.push(self.next_char().unwrap());
         }
 
-        // Throw a lexical error if a name is in "camel case".
-        if self.is_upname_continuation() {
-            while self.is_upname_continuation() {
+        // Finish lexing the name and return an error if an uppercase letter is used
+        if self.is_name_error_continuation() {
+            while self.is_name_error_continuation() {
                 name.push(self.next_char().unwrap())
             }
             let end_pos = self.get_pos();
             return Err(LexicalError {
-                error: LexicalErrorType::CamelCaseName { name: name },
+                error: LexicalErrorType::BadName { name: name },
                 location: SrcSpan {
                     start: start_pos,
                     end: end_pos,
@@ -745,6 +745,12 @@ where
     fn is_upname_continuation(&self) -> bool {
         self.chr0
             .map(|c| matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z'))
+            .unwrap_or(false)
+    }
+
+    fn is_name_error_continuation(&self) -> bool {
+        self.chr0
+            .map(|c| matches!(c, '_' | '0'..='9' | 'a'..='z' | 'A'..='Z'))
             .unwrap_or(false)
     }
 

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -155,4 +155,19 @@ fn name_tests() {
             location: SrcSpan { start: 4, end: 7 },
         }
     );
+
+    assert_error!(
+        "type S_m = String",
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::BadUpname {
+                        name: "S_m".to_string()
+                    },
+                    location: SrcSpan { start: 5, end: 8 },
+                }
+            },
+            location: SrcSpan { start: 5, end: 8 },
+        }
+    );
 }

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -140,4 +140,19 @@ fn name_tests() {
             location: SrcSpan { start: 4, end: 6 },
         }
     );
+
+    assert_error!(
+        "let _xS = 1",
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::BadDiscardName {
+                        name: "_xS".to_string()
+                    },
+                    location: SrcSpan { start: 4, end: 7 },
+                }
+            },
+            location: SrcSpan { start: 4, end: 7 },
+        }
+    );
 }

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -17,7 +17,7 @@ fn int_tests() {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::DigitOutOfRadix,
-                    location: 4,
+                    location: SrcSpan { start: 4, end: 4 },
                 }
             },
             location: SrcSpan { start: 4, end: 4 },
@@ -30,7 +30,7 @@ fn int_tests() {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::DigitOutOfRadix,
-                    location: 9,
+                    location: SrcSpan { start: 9, end: 9 },
                 }
             },
             location: SrcSpan { start: 9, end: 9 },
@@ -43,7 +43,7 @@ fn int_tests() {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::RadixIntNoValue,
-                    location: 1,
+                    location: SrcSpan { start: 1, end: 1 },
                 }
             },
             location: SrcSpan { start: 1, end: 1 },
@@ -56,7 +56,7 @@ fn int_tests() {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::NumTrailingUnderscore,
-                    location: 5,
+                    location: SrcSpan { start: 5, end: 5 },
                 }
             },
             location: SrcSpan { start: 5, end: 5 },
@@ -73,7 +73,7 @@ fn string_tests() {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::BadStringEscape,
-                    location: 1,
+                    location: SrcSpan { start: 1, end: 1 },
                 }
             },
             location: SrcSpan { start: 1, end: 1 },
@@ -87,7 +87,7 @@ fn string_tests() {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::BadStringEscape,
-                    location: 3,
+                    location: SrcSpan { start: 3, end: 3 },
                 }
             },
             location: SrcSpan { start: 3, end: 3 },

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -131,7 +131,7 @@ fn name_tests() {
         ParseError {
             error: ParseErrorType::LexError {
                 error: LexicalError {
-                    error: LexicalErrorType::CamelCaseName {
+                    error: LexicalErrorType::BadName {
                         name: "xS".to_string()
                     },
                     location: SrcSpan { start: 4, end: 6 },

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -123,3 +123,21 @@ fn bit_string_tests() {
         }
     );
 }
+
+#[test]
+fn name_tests() {
+    assert_error!(
+        "let xS = 1",
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::CamelCaseName {
+                        name: "xS".to_string()
+                    },
+                    location: SrcSpan { start: 4, end: 6 },
+                }
+            },
+            location: SrcSpan { start: 4, end: 6 },
+        }
+    );
+}


### PR DESCRIPTION
This patch adds a new LexicalErrorType (`LexicalErrorType::CamelCaseName`) and throws it if the lexer encounters a "camel case" name. 

To implement this change it also allows LexicalErrors to pass `SrcSpan`'s as locations and it removes the `Copy`  train from the traits of `LexicalErrorType` and `LexicalError`. 

This fixes #956.