### PR TITLE
Warnings as errors compiler build flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed a bug where bit string patterns would not correctly unify with the
   subject being pattern matches on.
 - Documentation dark mode.
+- `--warnings-as-errors` flag added to `gleam build` command.
 
 ## v0.13.2 - 2021-01-14
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -7,6 +7,8 @@ pub struct DiagnosticLabel {
     pub location: crate::ast::SrcSpan,
     pub label: String,
 }
+
+#[derive(Debug, PartialEq, Clone)]
 pub struct Diagnostic {
     pub file: String,
     pub location: crate::ast::SrcSpan,

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,6 +160,10 @@ pub enum Error {
     MetadataDecodeError {
         error: Option<String>,
     },
+
+    GenericFileDiagnostics {
+        diagnostics: Vec<(Diagnostic, String)>,
+    },
 }
 
 impl From<capnp::Error> for Error {
@@ -1562,6 +1566,15 @@ but it cannot be found.",
                 };
 
                 write_project(buffer, diagnostic);
+            }
+
+            Error::GenericFileDiagnostics { diagnostics } => {
+                for (diagnostic, extra) in diagnostics {
+                    write(buffer, diagnostic.clone(), Severity::Error);
+                    if !extra.is_empty() {
+                        writeln!(buffer, "{}\n", extra).expect("error pretty buffer write");
+                    }
+                }
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,8 +161,8 @@ pub enum Error {
         error: Option<String>,
     },
 
-    GenericFileDiagnostics {
-        diagnostics: Vec<(Diagnostic, String)>,
+    ForbiddenWarnings {
+        count: usize,
     },
 }
 
@@ -1568,13 +1568,18 @@ but it cannot be found.",
                 write_project(buffer, diagnostic);
             }
 
-            Error::GenericFileDiagnostics { diagnostics } => {
-                for (diagnostic, extra) in diagnostics {
-                    write(buffer, diagnostic.clone(), Severity::Error);
-                    if !extra.is_empty() {
-                        writeln!(buffer, "{}\n", extra).expect("error pretty buffer write");
-                    }
-                }
+            Error::ForbiddenWarnings { count } => {
+                let word_warning = match count {
+                    1 => "warning",
+                    _ => "warnings",
+                };
+                let diagnostic = ProjectErrorDiagnostic {
+                    title: format!("{} {} generated.", count, word_warning),
+                    label: "Your project was compiled with the `--warnings-as-errors` flag.
+Fix the warnings and try again!"
+                        .to_string(),
+                };
+                write_project(buffer, diagnostic);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,11 +321,14 @@ fn command_build(root: String, warnings_as_errors: bool) -> Result<(), Error> {
     // Generate Erlang code
     let output_files = erl::generate_erlang(analysed.as_slice());
 
-    // Print warnings or exit if warnings_as_errors and warnings
-    if warnings_as_errors {
-        warning::as_errors(analysed.as_slice())?;
-    } else {
-        warning::print_all(analysed.as_slice());
+    // Print warnings
+    let warning_count = warning::print_all(analysed.as_slice());
+
+    //exit if warnings_as_errors and warnings
+    if warnings_as_errors && warning_count > 0 {
+        return Err(Error::ForbiddenWarnings {
+            count: warning_count,
+        });
     }
 
     // Reset output directory

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,7 +1,6 @@
 use crate::{
     cli,
     diagnostic::{write, Diagnostic, Severity},
-    error::Error,
     typ,
     typ::pretty::Printer,
 };
@@ -207,27 +206,13 @@ your program.",
     }
 }
 
-pub fn print_all(analysed: &[crate::project::Analysed]) {
+pub fn print_all(analysed: &[crate::project::Analysed]) -> usize {
+    let mut warning_count = 0;
     for a in analysed.iter() {
         for w in a.warnings.iter() {
-            w.pretty_print()
+            w.pretty_print();
+            warning_count += 1;
         }
     }
-}
-
-pub fn as_errors(analysed: &[crate::project::Analysed]) -> Result<(), Error> {
-    let mut warnings = vec![];
-    for a in analysed.iter() {
-        for w in a.warnings.iter() {
-            warnings.push(w.to_diagnostic());
-        }
-    }
-
-    if warnings.is_empty() {
-        Ok(())
-    } else {
-        Err(Error::GenericFileDiagnostics {
-            diagnostics: warnings,
-        })
-    }
+    warning_count
 }


### PR DESCRIPTION
Adds a `--warnings-as-errors` flag to the `build` command. Which optionally turns compile time warnings into compile time errors.

Closes https://github.com/gleam-lang/gleam/issues/967

Side question: Is there a reason why the `build` command is hidden from the `help` message?
