### PR TITLE
Version strings for local static assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - New compile time warnings on unused types, functions and variables.
 - The runtime error emitted by the `todo` keyword now carries additional
   information.
+- Documentation dark mode.
 
 ## v0.13.2 - 2021-01-14
 

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use std::path::{Path, PathBuf};
 
 const MAX_COLUMNS: isize = 65;
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn build_project(
     project_root: impl AsRef<Path>,
@@ -112,6 +113,7 @@ pub fn generate_html(
         let content = std::fs::read_to_string(&page.source).unwrap_or_default();
 
         let temp = PageTemplate {
+            gleam_version: VERSION,
             unnest: ".".to_string(),
             links: &links,
             pages: &pages,
@@ -136,6 +138,7 @@ pub fn generate_html(
         let source_links = SourceLinker::new(&project_root, project_config, &module);
 
         let template = ModuleTemplate {
+            gleam_version: VERSION,
             unnest: module.name.iter().map(|_| "..").intersperse("/").collect(),
             links: &links,
             pages: &pages,
@@ -416,6 +419,7 @@ struct Constant<'a> {
 #[derive(Template)]
 #[template(path = "documentation_page.html")]
 struct PageTemplate<'a> {
+    gleam_version: &'a str,
     unnest: String,
     page_title: &'a str,
     project_name: &'a str,
@@ -429,6 +433,7 @@ struct PageTemplate<'a> {
 #[derive(Template)]
 #[template(path = "documentation_module.html")]
 struct ModuleTemplate<'a> {
+    gleam_version: &'a str,
     unnest: String,
     page_title: &'a str,
     module_name: String,

--- a/templates/documentation_layout.html
+++ b/templates/documentation_layout.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page_title }}</title>
-    <link rel="stylesheet" href="{{ unnest }}/index.css" type="text/css" />
+    <link rel="stylesheet" href="{{ unnest }}/index.css?v={{ gleam_version }}" type="text/css" />
     <!-- The docs_config.js file is provided by HexDocs and shared
          between multiple versions of the same package. -->
     <script src="{{ unnest }}/docs_config.js"></script>
@@ -262,8 +262,8 @@
 
     <script src="https://unpkg.com/@highlightjs/cdn-assets@10.5.0/languages/elixir.min.js"></script>
 
-    <script src="{{ unnest }}/highlightjs-gleam.js"></script>
+    <script src="{{ unnest }}/highlightjs-gleam.js?v={{ gleam_version }}"></script>
 
-    <script src="{{ unnest }}/gleam.js"></script>
+    <script src="{{ unnest }}/gleam.js?v={{ gleam_version }}"></script>
   </body>
 </html>


### PR DESCRIPTION
Following up on #965, added the compiler's version string to local static assets for cache busting purposes.
Updated the changelog.