### PR TITLE
Fix template: version and description

### DIFF
--- a/src/new.rs
+++ b/src/new.rs
@@ -241,7 +241,7 @@ pub fn stop(_state: Dynamic) {
   {{links, []}}
 ]}}.
 "#,
-                self.options.name, PROJECT_VERSION, &self.options.description, module,
+                self.options.name, &self.options.description, PROJECT_VERSION, module,
             ),
         )
     }


### PR DESCRIPTION
Previously, running `gleam new mygleam_app` generated a template file `src/mygleam_app.app.src`:
```
{application, mygleam_app,
 [{description, "1.0.0"},
  {vsn, "A Gleam project"},
  {registered, []},
  {applications,
...
```

Now the default version is swapped with the default project description:
```
{application, mygleam_app,
 [{description, "A Gleam project"},
  {vsn, "1.0.0"},
  {registered, []},
  {applications,
...
```