### PR TITLE
Allow numbers in project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
+- Project names can now contain numbers.
 
 ## v0.14.1 - 2021-02-27
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -309,8 +309,8 @@ Please try again with a different project name.",
                                 "a reserved word in Gleam.",
                             InvalidProjectNameReason::Format =>
                                 "does not have the correct format. Project names must start
-with a lowercase letter and may only contain lowercase letters
-and underscores.",
+with a lowercase letter and may only contain lowercase letters,
+numbers and underscores.",
                         }
                     ),
                 };

--- a/src/new.rs
+++ b/src/new.rs
@@ -491,7 +491,7 @@ fn validate_name(name: &str) -> Result<(), Error> {
             name: name.to_string(),
             reason: InvalidProjectNameReason::GleamReservedWord,
         })
-    } else if !regex::Regex::new("^[a-z_]+$")
+    } else if !regex::Regex::new("^[a-z][a-z0-9_]*$")
         .gleam_expect("new name regex could not be compiled")
         .is_match(name)
     {


### PR DESCRIPTION
This change also prevents `_` being the first character in a project name, which is what the error message already says.