### PR TITLE
Error message for string concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
+- Added an error hint when joining string using the `+` or `+.` operator.
 
 ## v0.14.2 - 2021-03-02
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -777,9 +777,8 @@ But this argument has this type:
                         given = printer.pretty_print(given, 4),
                     )
                     .unwrap();
-                    if let Some((alt, t)) = hint_alternative_operator(&op, given.as_ref()) {
-                        writeln!(buf, "Hint: the {} operator can be used with {}s\n", alt, t)
-                            .unwrap();
+                    if let Some(t) = hint_alternative_operator(&op, given.as_ref()) {
+                        writeln!(buf, "Hint: {}\n", t).unwrap();
                     }
                 }
 
@@ -1672,26 +1671,37 @@ fn import_cycle(buffer: &mut Buffer, modules: &[String]) {
     writeln!(buffer, "    └─────┘\n").unwrap();
 }
 
-fn hint_alternative_operator(op: &BinOp, given: &Type) -> Option<(&'static str, &'static str)> {
+fn hint_alternative_operator(op: &BinOp, given: &Type) -> Option<String> {
     match op {
-        BinOp::AddInt if given.is_float() => Some(("+.", "Float")),
-        BinOp::DivInt if given.is_float() => Some(("/.", "Float")),
-        BinOp::GtEqInt if given.is_float() => Some((">=", "Float")),
-        BinOp::GtInt if given.is_float() => Some((">", "Float")),
-        BinOp::LtEqInt if given.is_float() => Some(("<=.", "Float")),
-        BinOp::LtInt if given.is_float() => Some(("<.", "Float")),
-        BinOp::MultInt if given.is_float() => Some(("*.", "Float")),
-        BinOp::SubInt if given.is_float() => Some(("-.", "Float")),
+        BinOp::AddInt if given.is_float() => Some(hint_numeric_message("+.", "Float")),
+        BinOp::DivInt if given.is_float() => Some(hint_numeric_message("/.", "Float")),
+        BinOp::GtEqInt if given.is_float() => Some(hint_numeric_message(">=", "Float")),
+        BinOp::GtInt if given.is_float() => Some(hint_numeric_message(">", "Float")),
+        BinOp::LtEqInt if given.is_float() => Some(hint_numeric_message("<=.", "Float")),
+        BinOp::LtInt if given.is_float() => Some(hint_numeric_message("<.", "Float")),
+        BinOp::MultInt if given.is_float() => Some(hint_numeric_message("*.", "Float")),
+        BinOp::SubInt if given.is_float() => Some(hint_numeric_message("-.", "Float")),
 
-        BinOp::AddFloat if given.is_int() => Some(("+", "Int")),
-        BinOp::DivFloat if given.is_int() => Some(("/", "Int")),
-        BinOp::GtEqFloat if given.is_int() => Some((">=.", "Int")),
-        BinOp::GtFloat if given.is_int() => Some((">.", "Int")),
-        BinOp::LtEqFloat if given.is_int() => Some(("<=", "Int")),
-        BinOp::LtFloat if given.is_int() => Some(("<", "Int")),
-        BinOp::MultFloat if given.is_int() => Some(("*", "Int")),
-        BinOp::SubFloat if given.is_int() => Some(("-", "Int")),
+        BinOp::AddFloat if given.is_int() => Some(hint_numeric_message("+", "Int")),
+        BinOp::DivFloat if given.is_int() => Some(hint_numeric_message("/", "Int")),
+        BinOp::GtEqFloat if given.is_int() => Some(hint_numeric_message(">=.", "Int")),
+        BinOp::GtFloat if given.is_int() => Some(hint_numeric_message(">.", "Int")),
+        BinOp::LtEqFloat if given.is_int() => Some(hint_numeric_message("<=", "Int")),
+        BinOp::LtFloat if given.is_int() => Some(hint_numeric_message("<", "Int")),
+        BinOp::MultFloat if given.is_int() => Some(hint_numeric_message("*", "Int")),
+        BinOp::SubFloat if given.is_int() => Some(hint_numeric_message("-", "Int")),
+
+        BinOp::AddInt if given.is_string() => Some(hint_string_message()),
+        BinOp::AddFloat if given.is_string() => Some(hint_string_message()),
 
         _ => None,
     }
+}
+
+fn hint_numeric_message(alt: &str, type_: &str) -> String {
+    format!("the {} operator can be used with {}s\n", alt, type_)
+}
+
+fn hint_string_message() -> String {
+    "String can be concatted using `string.concat` from stdlib".to_string()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1704,5 +1704,6 @@ fn hint_numeric_message(alt: &str, type_: &str) -> String {
 
 fn hint_string_message() -> String {
     "Strings can be joined using the `append` or `concat` functions from
-the `gleam/string` module".to_string()
+the `gleam/string` module"
+        .to_string()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1703,5 +1703,6 @@ fn hint_numeric_message(alt: &str, type_: &str) -> String {
 }
 
 fn hint_string_message() -> String {
-    "String can be concatted using `string.concat` from stdlib".to_string()
+    "Strings can be joined using the `append` or `concat` functions from
+the `gleam/string` module".to_string()
 }

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -104,6 +104,13 @@ impl Type {
         }
     }
 
+    pub fn is_string(&self) -> bool {
+        match self {
+            Self::App { module, name, .. } => module.is_empty() && name == "String",
+            _ => false,
+        }
+    }
+
     /// Get the args for the type if the type is a specific `Type::App`.
     /// Returns None if the type is not a `Type::App` or is an incorrect `Type:App`
     ///


### PR DESCRIPTION
Related issue #985 

Produce hint when trying to use `+` and `+.` operator for string:
```
error: Type mismatch
  ┌─ /home/me/projects/gleam/experiments/test_str_concat/src/test_str_concat.gleam:4:9
  │
4 │   100 + "100"
  │         ^^^^^

The + operator expects arguments of this type:

    Int

But this argument has this type:

    String

Hint: String can be concatted using `string.concat` from stdlib


===> Unable to compile Gleam project
```