### PR TITLE
Fully-automate development setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+image:
+  file: .gitpod.Dockerfile
+
+# See: https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: cargo build && make
+    command: cargo watch -x run
+
+# See: https://www.gitpod.io/docs/prebuilds/#configure-the-github-app
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,6 @@ tasks:
 github:
   prebuilds:
     master: true
-    branches: true
     pullRequests: true
     pullRequestsFromForks: true
     addCheck: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,12 @@ Code changes to Gleam are welcomed via the process below.
 4. Once the changes have been approved the code will be rebased into the
    `main` branch.
 
+## Hacking on Gleam in Gitpod
+
+If you have a web browser, you can get a fully pre-configured Gleam development environment in one click:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gleam-lang/gleam)
+
 ## Local development
 
 To run the compiler tests.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/gleam-lang/gleam/releases"><img src="https://img.shields.io/github/release/gleam-lang/gleam" alt="GitHub release"></a>
   <a href="https://discord.gg/Fm8Pwmy"><img src="https://img.shields.io/discord/768594524158427167?color=blue" alt="Discord chat"></a>
   <a><img src="https://github.com/gleam-lang/gleam/workflows/ci/badge.svg?branch=main"></a>
+  <a href="https://gitpod.io/#https://github.com/gleam-lang/gleam"><img src="https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod"></a>
 </p>
 
 


### PR DESCRIPTION
Hi Gleam team! 👋

As discussed with @lpil , here is a PR that fully-automates the dev setup of Gleam with Gitpod, providing anyone with a pre-built, browser-based Gleam dev environment in one click:

![image](https://user-images.githubusercontent.com/127353/110269399-b2f5fa00-8017-11eb-8e6f-9ece9cc1d713.png)

**What it does**

- Comes with all Gleam dependencies pre-installed (including Rust)
- Runs cargo build && make ahead-of-time (so you don't need to wait)
- Gives anyone immediate access to the pre-compiled Gleam CLI, and allows to easily edit & rebuild the code

I hope this can make life easier for Gleam contributors, and for Gleam maintainers who need to review many PRs (hint: you can already [open this PR in Gitpod](https://gitpod.io/from-referrer/) to easily review & test it without messing up your local checkout). Gitpod is free for open-source use.

ps: you can save oodles of time when reviewing pull-requests by pre-compiling them if you enable the GitHub app. See https://www.gitpod.io/docs/prebuilds/
