### PR TITLE
Fix table alternative row colour in dark mode

### DIFF
--- a/templates/index.css
+++ b/templates/index.css
@@ -556,6 +556,7 @@ body.theme-dark {
   --accented-background: var(--bg-shade-1);
   --background: var(--bg);
   --code-background: var(--bg-shade-2);
+  --table-background: var(--bg-mono-1);
   --hard-black: var(--taupe-mono-1);
   --links: var(--pink);
   --text: var(--taupe-mono-1);


### PR DESCRIPTION
I don't know if this is the best colour choice but it seems better than
'pink-white' which is the colour at the moment.

We don't have many tables in the documentation so this might have been
missed on the initial introduction of dark mode.

Before:
![image](https://user-images.githubusercontent.com/5390/113475752-60212e00-946f-11eb-910a-212c683982d4.png)

After:
![image](https://user-images.githubusercontent.com/5390/113475854-9f4f7f00-946f-11eb-846e-cc7f134e567d.png)
