### PR TITLE
Add alternative `#(x, y, ...)` tuple syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   improved.
 - Fixed a bug where markdown tables in rendered HTML documentation would have
   the incorrect background colour on every other row.
+- Tuples now have a new, concise syntax variant: `#(x, y, ...)`
 
 ## v0.14.4 - 2021-03-27
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -361,7 +361,7 @@ where
                     label,
                 }
             }
-            Some((start, Tok::Tuple, _)) => {
+            Some((start, Tok::Tuple, _)) | Some((start, Tok::Hash, _)) => {
                 let _ = self.next_tok();
                 let _ = self.expect_one(&Tok::Lpar)?;
                 let elems = Parser::series_of(self, &Parser::parse_expression, Some(&Tok::Comma))?;

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -416,6 +416,9 @@ where
                     self.emit((tok_start, Tok::Dot, tok_end));
                 }
             }
+            '#' => {
+                self.eat_single_char(Tok::Hash);
+            }
             '\n' => {
                 let _ = self.next_char();
                 let tok_start = self.get_pos();

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -37,6 +37,7 @@ pub enum Tok {
     // Other Punctuation
     Colon,
     Comma,
+    Hash, // '#'
     Equal,
     EqualEqual, // '=='
     NotEqual,   // '!='
@@ -131,6 +132,7 @@ impl fmt::Display for Tok {
             Tok::GreaterEqualDot => ">=.",
             Tok::Colon => ":",
             Tok::Comma => ",",
+            Tok::Hash => "#",
             Tok::Equal => "=",
             Tok::EqualEqual => "==",
             Tok::NotEqual => "!=",

--- a/src/type_/pretty.rs
+++ b/src/type_/pretty.rs
@@ -66,9 +66,9 @@ impl Printer {
 
             Type::Var { type_: typ, .. } => self.type_var_doc(&*typ.borrow()),
 
-            Type::Tuple { elems, .. } => self
-                .args_to_gleam_doc(elems.as_slice())
-                .surround("tuple(", ")"),
+            Type::Tuple { elems, .. } => {
+                self.args_to_gleam_doc(elems.as_slice()).surround("#(", ")")
+            }
         }
     }
 
@@ -381,7 +381,7 @@ fn function_test() {
             float()
         )),
         "fn(
-  tuple(Float, Float, Float, Float, Float, Float),
+  #(Float, Float, Float, Float, Float, Float),
   Float,
   Float,
   Float,
@@ -407,10 +407,10 @@ fn function_test() {
                 tuple(vec![float(), float(), float(), float(), float(), float()]),
             ]),
         )),
-        "fn(tuple(Float, Float, Float, Float, Float, Float)) ->
-  tuple(
-    tuple(Float, Float, Float, Float, Float, Float),
-    tuple(Float, Float, Float, Float, Float, Float),
+        "fn(#(Float, Float, Float, Float, Float, Float)) ->
+  #(
+    #(Float, Float, Float, Float, Float, Float),
+    #(Float, Float, Float, Float, Float, Float),
   )"
     );
 }

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -295,13 +295,13 @@ fn let_() {
     assert_infer!("let x = 2 let y = x y", "Int");
     assert_infer!(
         "let tuple(tuple(_, _) as x, _) = tuple(tuple(0, 1.0), []) x",
-        "tuple(Int, Float)"
+        "#(Int, Float)"
     );
     assert_infer!("let x: String = \"\" x", "String");
-    assert_infer!("let x: tuple(Int, Int) = tuple(5, 5) x", "tuple(Int, Int)",);
+    assert_infer!("let x: tuple(Int, Int) = tuple(5, 5) x", "#(Int, Int)",);
     assert_infer!(
         "let x: tuple(Int, Float) = tuple(5, 5.0) x",
-        "tuple(Int, Float)",
+        "#(Int, Float)",
     );
     assert_infer!("let [1, 2, ..x]: List(Int) = [1,2,3] x", "List(Int)",);
     assert_infer!(
@@ -325,7 +325,7 @@ fn let_() {
     assert_infer!("let _x = 1 2.0", "Float");
     assert_infer!("let _ = 1 2.0", "Float");
     assert_infer!("let tuple(tag, x) = tuple(1.0, 1) x", "Int");
-    assert_infer!("fn(x) { let tuple(a, b) = x a }", "fn(tuple(a, b)) -> a");
+    assert_infer!("fn(x) { let tuple(a, b) = x a }", "fn(#(a, b)) -> a");
 
     // assert
     assert_infer!("assert [] = [] 1", "Int");
@@ -338,7 +338,7 @@ fn let_() {
     assert_infer!("assert _x = 1 2.0", "Float");
     assert_infer!("assert _ = 1 2.0", "Float");
     assert_infer!("assert tuple(tag, x) = tuple(1.0, 1) x", "Int");
-    assert_infer!("fn(x) { assert tuple(a, b) = x a }", "fn(tuple(a, b)) -> a");
+    assert_infer!("fn(x) { assert tuple(a, b) = x a }", "fn(#(a, b)) -> a");
     assert_infer!("assert 5: Int = 5 5", "Int");
 
     // try
@@ -381,18 +381,21 @@ fn lists() {
     assert_infer!("[fn(x) { x },..[]]", "List(fn(a) -> a)");
 
     assert_infer!("let f = fn(x) { x } [f, f]", "List(fn(a) -> a)");
-    assert_infer!("[tuple([], [])]", "List(tuple(List(a), List(b)))");
+    assert_infer!("[tuple([], [])]", "List(#(List(a), List(b)))");
 }
 
 #[test]
 fn tuples() {
-    assert_infer!("tuple(1)", "tuple(Int)");
-    assert_infer!("tuple(1, 2.0)", "tuple(Int, Float)");
-    assert_infer!("tuple(1, 2.0, 3)", "tuple(Int, Float, Int)");
-    assert_infer!(
-        "tuple(1, 2.0, tuple(1, 1))",
-        "tuple(Int, Float, tuple(Int, Int))",
-    );
+    assert_infer!("tuple(1)", "#(Int)");
+    assert_infer!("tuple(1, 2.0)", "#(Int, Float)");
+    assert_infer!("tuple(1, 2.0, 3)", "#(Int, Float, Int)");
+    assert_infer!("tuple(1, 2.0, tuple(1, 1))", "#(Int, Float, #(Int, Int))",);
+
+    // new syntax
+    assert_infer!("#(1)", "#(Int)");
+    assert_infer!("#(1, 2.0)", "#(Int, Float)");
+    assert_infer!("#(1, 2.0, 3)", "#(Int, Float, Int)");
+    assert_infer!("#(1, 2.0, #(1, 1))", "#(Int, Float, #(Int, Int))",);
 }
 
 #[test]
@@ -446,9 +449,9 @@ fn expr_fn() {
     );
 
     assert_infer!("let add = fn(x, y) { x + y } add(_, 2)", "fn(Int) -> Int");
-    assert_infer!("fn(x) { tuple(1, x) }", "fn(a) -> tuple(Int, a)");
-    assert_infer!("fn(x, y) { tuple(x, y) }", "fn(a, b) -> tuple(a, b)");
-    assert_infer!("fn(x) { tuple(x, x) }", "fn(a) -> tuple(a, a)");
+    assert_infer!("fn(x) { tuple(1, x) }", "fn(a) -> #(Int, a)");
+    assert_infer!("fn(x, y) { tuple(x, y) }", "fn(a, b) -> #(a, b)");
+    assert_infer!("fn(x) { tuple(x, x) }", "fn(a) -> #(a, a)");
     assert_infer!("fn(x) -> Int { x }", "fn(Int) -> Int");
     assert_infer!("fn(x) -> a { x }", "fn(a) -> a");
     assert_infer!("fn() -> Int { 2 }", "fn() -> Int");
@@ -1906,17 +1909,17 @@ fn infer_module_test() {
     // Anon structs
     assert_module_infer!(
         "pub fn ok(x) { tuple(1, x) }",
-        vec![("ok", "fn(a) -> tuple(Int, a)")],
+        vec![("ok", "fn(a) -> #(Int, a)")],
     );
 
     assert_module_infer!(
         "pub external fn ok(Int) -> tuple(Int, Int) = \"\" \"\"",
-        vec![("ok", "fn(Int) -> tuple(Int, Int)")],
+        vec![("ok", "fn(Int) -> #(Int, Int)")],
     );
 
     assert_module_infer!(
         "pub external fn go(tuple(a, c)) -> c = \"\" \"\"",
-        vec![("go", "fn(tuple(a, b)) -> b")],
+        vec![("go", "fn(#(a, b)) -> b")],
     );
 
     assert_module_infer!(
@@ -2932,7 +2935,7 @@ fn module_constants() {
             ("test_int5", "Int"),
             ("test_list", "List(Int)"),
             ("test_string", "String"),
-            ("test_tuple", "tuple(String, Int)"),
+            ("test_tuple", "#(String, Int)"),
         ],
     );
 }


### PR DESCRIPTION
Adds a new tuple syntax, as per #1005

Retains backwards compatibility for now (two possible syntax variants are accepted)