### PR TITLE
Add more refactoring

### DIFF
--- a/src/docs.rs
+++ b/src/docs.rs
@@ -242,7 +242,7 @@ fn markdown_documentation(doc: &Option<String>) -> String {
 
 fn render_markdown(text: &str) -> String {
     let mut s = String::with_capacity(text.len() * 3 / 2);
-    let p = pulldown_cmark::Parser::new_ext(&*text, pulldown_cmark::Options::all());
+    let p = pulldown_cmark::Parser::new_ext(text, pulldown_cmark::Options::all());
     pulldown_cmark::html::push_html(&mut s, p);
     s
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1466,9 +1466,9 @@ and try again.
                     ),
                     ParseErrorType::UnexpectedToken { expected } => {
                         let mut messages = expected.clone();
-                        let _ = messages
-                            .first_mut()
-                            .map(|s| *s = format!("Expected one of: {}", *s));
+                        if let Some(s) = messages.first_mut() {
+                            *s = format!("Expected one of: {}", s);
+                        }
 
                         ( "I was not expecting this.",
                           messages

--- a/src/format.rs
+++ b/src/format.rs
@@ -714,7 +714,7 @@ impl<'comments> Formatter<'comments> {
                 args.iter().map(|a| self.pattern_call_arg(a)),
             ))
         } else {
-            match &*args {
+            match args {
                 [arg] if is_breakable(&arg.value) => name
                     .append("(")
                     .append(self.pattern_call_arg(arg))

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, FileIoAction, FileKind, GleamExpect};
 use flate2::{write::GzEncoder, Compression};
+use ignore::DirEntry;
 use std::{
     ffi::OsStr,
     fmt::Debug,
@@ -276,7 +277,7 @@ pub fn gleam_files_excluding_gitignore(dir: &PathBuf) -> impl Iterator<Item = Pa
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
-        .map(|d| d.into_path())
+        .map(DirEntry::into_path)
         .filter(move |d| is_gleam_path(d, dir))
 }
 
@@ -445,7 +446,7 @@ pub mod test {
         pub fn into_contents(self) -> Result<Vec<u8>, ()> {
             Rc::try_unwrap(self.contents)
                 .map_err(|_| ())
-                .map(|cell| cell.into_inner())
+                .map(RefCell::into_inner)
         }
     }
 

--- a/src/metadata/module_decoder.rs
+++ b/src/metadata/module_decoder.rs
@@ -1,5 +1,7 @@
 #![allow(unused)]
 
+use itertools::Itertools;
+
 use crate::{
     ast::{
         BitStringSegment, BitStringSegmentOption, CallArg, Constant, TypedConstant,
@@ -382,8 +384,6 @@ impl ModuleDecoder {
 }
 
 fn name(module: &capnp::text_list::Reader<'_>) -> Result<Vec<String>> {
-    Ok(module
-        .iter()
-        .map(|s| s.map(String::from))
-        .collect::<Result<_, _>>()?)
+    let name = module.iter().map_ok(String::from).try_collect()?;
+    Ok(name)
 }

--- a/src/metadata/module_encoder.rs
+++ b/src/metadata/module_encoder.rs
@@ -327,7 +327,7 @@ impl<'a> ModuleEncoder<'a> {
             ),
 
             Type::Var { type_: typ } => match typ.borrow().deref() {
-                TypeVar::Link { type_: typ } => self.build_type(builder, &*typ),
+                TypeVar::Link { type_: typ } => self.build_type(builder, typ),
                 TypeVar::Generic { id } => self.build_type_var(builder.init_var(), *id),
                 TypeVar::Unbound { .. } => crate::error::fatal_compiler_bug(
                     "Unexpected unbound var when serialising module metadata",

--- a/src/type_/hydrator.rs
+++ b/src/type_/hydrator.rs
@@ -149,7 +149,7 @@ impl Hydrator {
                 elems
                     .iter()
                     .map(|t| self.type_from_ast(t, environment))
-                    .collect::<Result<_, _>>()?,
+                    .try_collect()?,
             )),
 
             TypeAst::Fn {
@@ -160,7 +160,7 @@ impl Hydrator {
                 let args = args
                     .iter()
                     .map(|t| self.type_from_ast(t, environment))
-                    .collect::<Result<_, _>>()?;
+                    .try_collect()?;
                 let retrn = self.type_from_ast(retrn, environment)?;
                 Ok(fn_(args, retrn))
             }


### PR DESCRIPTION
Highlights:

- Replace the `&*variable` deref pattern with verbose `.deref()` methods, or remove if unnecessary
- `erl::record()`: rewrite iterator adaptors to be more readable/simpler
- `Environment::increment_usage()`: simplify the cascading logic to use the `while let` loop
- use `Itertools`' convenience wrappers, `map_ok` and `try_collect`