### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,6 @@ dependencies = [
  "strsim 0.10.0",
  "structopt",
  "strum",
- "strum_macros",
  "tar",
  "termcolor",
  "tokio",
@@ -1525,6 +1524,9 @@ name = "strum"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ termcolor = "1.1.2"
 lazy_static = "1.4.0"
 # Data (de)serialisation
 serde = { version = "1.0.119", features = ["derive"] }
-serde_derive = "1.0.119"
 # toml config file parsing
 toml = "0.5.8"
 # Levenshtein string distance for typo suggestions
@@ -38,8 +37,7 @@ strsim = "0.10.0"
 ignore = "0.4.17"
 walkdir = "2.3.1"
 # Enum trait impl macros
-strum = "0.20.0"
-strum_macros = "0.20.1"
+strum = { version = "0.20.0", features = ["derive"] }
 # Doc rendering
 askama = "0.10.5"
 # Markdown in docs

--- a/src/new.rs
+++ b/src/new.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-use strum_macros::{Display, EnumString, EnumVariantNames};
+use strum::{Display, EnumString, EnumVariantNames};
 
 const GLEAM_STDLIB_VERSION: &str = "0.14.0";
 const GLEAM_OTP_VERSION: &str = "0.1.0";


### PR DESCRIPTION
Include `strum` and `serde` macros implicitly with the `derive` feature

