### PR TITLE
Add general refactoring

### DIFF
--- a/src/ast/typed.rs
+++ b/src/ast/typed.rs
@@ -143,10 +143,11 @@ impl TypedExpr {
         lazy_static! {
             static ref NON_ZERO: Regex = Regex::new(r"[1-9]").unwrap();
         }
-        match self {
-            Self::Int { value, .. } | Self::Float { value, .. } => NON_ZERO.is_match(value),
-            _ => false,
-        }
+
+        matches!(
+            self,
+            Self::Int{ value, .. } | Self::Float { value, .. } if NON_ZERO.is_match(value)
+        )
     }
 
     pub fn location(&self) -> SrcSpan {

--- a/src/build/dep_tree.rs
+++ b/src/build/dep_tree.rs
@@ -30,11 +30,9 @@ pub fn toposort_deps(inputs: Vec<(String, Vec<String>)>) -> Result<Vec<String>, 
     }
 
     for (value, deps) in inputs {
-        let from_index = indexes.get(&value).gleam_expect("Finding index for value");
-        for dep in deps {
-            if let Some(to_index) = indexes.get(&dep) {
-                graph.add_edge(*from_index, *to_index, ());
-            }
+        let &from_index = indexes.get(&value).gleam_expect("Finding index for value");
+        for &to_index in deps.into_iter().filter_map(|dep| indexes.get(&dep)) {
+            graph.add_edge(from_index, to_index, ());
         }
     }
 

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -234,10 +234,7 @@ fn function<'a>(
 }
 
 fn markdown_documentation(doc: &Option<String>) -> String {
-    match doc {
-        None => "".to_string(),
-        Some(d) => render_markdown(d),
-    }
+    doc.as_deref().map(render_markdown).unwrap_or_default()
 }
 
 fn render_markdown(text: &str) -> String {

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -1039,10 +1039,9 @@ fn optional_clause_guard<'a>(
     guard: Option<&'a TypedClauseGuard>,
     env: &mut Env<'a>,
 ) -> Document<'a> {
-    match guard {
-        Some(guard) => " when ".to_doc().append(bare_clause_guard(guard, env)),
-        None => nil(),
-    }
+    guard
+        .map(|guard| " when ".to_doc().append(bare_clause_guard(guard, env)))
+        .unwrap_or_else(nil)
 }
 
 fn bare_clause_guard<'a>(guard: &'a TypedClauseGuard, env: &mut Env<'a>) -> Document<'a> {
@@ -1317,10 +1316,9 @@ fn maybe_block_expr<'a>(expression: &'a TypedExpr, env: &mut Env<'a>) -> Documen
 }
 
 fn todo<'a>(message: &'a Option<String>, location: SrcSpan, env: &mut Env<'a>) -> Document<'a> {
-    let message = match message {
-        Some(message) => message,
-        None => "This has not yet been implemented",
-    };
+    let message = message
+        .as_deref()
+        .unwrap_or("This has not yet been implemented");
     erlang_error("todo", message, location, vec![], env)
 }
 
@@ -1549,11 +1547,11 @@ fn external_fun<'a>(
 }
 
 fn variable_name(name: &str) -> String {
-    let mut c = name.chars();
-    match c.next() {
-        None => String::new(),
-        Some(f) => f.to_uppercase().chain(c).collect(),
-    }
+    let mut chars = name.chars();
+    let first_char = chars.next();
+    let first_uppercased = first_char.into_iter().flat_map(char::to_uppercase);
+
+    first_uppercased.chain(chars).collect()
 }
 
 // When rendering a type variable to an erlang type spec we need all type variables with the

--- a/src/erl/pattern.rs
+++ b/src/erl/pattern.rs
@@ -108,9 +108,6 @@ fn pattern_list<'a>(
         elements.into_iter().map(|e| to_doc(e, vars, env)),
         break_(",", ", "),
     ));
-    let tail = match tail {
-        Some(tail) => Some(pattern(tail, env)),
-        None => None,
-    };
+    let tail = tail.map(|tail| pattern(tail, env));
     list(elements, tail)
 }

--- a/src/metadata/module_decoder.rs
+++ b/src/metadata/module_decoder.rs
@@ -116,7 +116,7 @@ impl ModuleDecoder {
     fn type_var(&mut self, reader: &schema::type_::var::Reader<'_>) -> Result<Arc<Type>> {
         let serialized_id = reader.get_id() as usize;
         let id = match self.type_var_id_map.get(&serialized_id) {
-            Some(id) => *id,
+            Some(&id) => id,
             None => {
                 let new_id = self.next_type_var_id;
                 self.next_type_var_id += 1;

--- a/src/metadata/module_encoder.rs
+++ b/src/metadata/module_encoder.rs
@@ -348,7 +348,7 @@ impl<'a> ModuleEncoder<'a> {
 
     fn build_type_var(&mut self, mut builder: schema::type_::var::Builder<'_>, id: usize) {
         let serialised_id = match self.type_var_id_map.get(&id) {
-            Some(id) => *id,
+            Some(&id) => id,
             None => {
                 let new_id = self.next_type_var_id;
                 self.next_type_var_id += 1;

--- a/src/new.rs
+++ b/src/new.rs
@@ -35,8 +35,8 @@ pub struct Creator {
 
 impl Creator {
     fn new(options: NewOptions, gleam_version: &'static str) -> Self {
-        let root = match options.project_root {
-            Some(ref root) => PathBuf::from(root),
+        let root = match &options.project_root {
+            Some(root) => PathBuf::from(root),
             None => PathBuf::from(&options.name),
         };
         let src = root.join("src");

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -84,10 +84,7 @@ impl<'a> Documentable<'a> for Vec<Document<'a>> {
 
 impl<'a, D: Documentable<'a>> Documentable<'a> for Option<D> {
     fn to_doc(self) -> Document<'a> {
-        match self {
-            Some(d) => d.to_doc(),
-            None => nil(),
-        }
+        self.map(Documentable::to_doc).unwrap_or_else(nil)
     }
 }
 

--- a/src/project/source_tree.rs
+++ b/src/project/source_tree.rs
@@ -80,15 +80,15 @@ impl SourceTree {
             let src = module.src.clone();
             let path = module.path.clone();
             let deps = module.module.dependencies();
-            let module_index = self.indexes.get(&module_name).gleam_expect(
+            let &module_index = self.indexes.get(&module_name).gleam_expect(
                 "SourceTree.calculate_dependencies(): Unable to find module index for name",
             );
-            let module = self.modules.get(module_index).gleam_expect(
+            let module = self.modules.get(&module_index).gleam_expect(
                 "SourceTree.calculate_dependencies(): Unable to find module for index",
             );
 
             for (dep, location) in deps {
-                let dep_index = self.indexes.get(&dep).ok_or_else(|| Error::UnknownImport {
+                let &dep_index = self.indexes.get(&dep).ok_or_else(|| Error::UnknownImport {
                     module: module_name.clone(),
                     import: dep.clone(),
                     src: src.clone(),
@@ -104,7 +104,7 @@ impl SourceTree {
                 if module.origin == ModuleOrigin::Src
                     && self
                         .modules
-                        .get(dep_index)
+                        .get(&dep_index)
                         .gleam_expect("SourceTree.calculate_dependencies(): Unable to find module for dep index")
                         .origin
                         == ModuleOrigin::Test
@@ -118,7 +118,7 @@ impl SourceTree {
                     });
                 }
 
-                let _ = self.graph.add_edge(*dep_index, *module_index, ());
+                let _ = self.graph.add_edge(dep_index, module_index, ());
             }
         }
         Ok(())

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -119,7 +119,7 @@ impl Type {
                 args,
                 ..
             } => {
-                if *module == m[..] && name == n && args.len() == arity {
+                if module == m && name == n && args.len() == arity {
                     Some(args.clone())
                 } else {
                     None
@@ -1524,6 +1524,8 @@ pub fn register_import(
 Missing modules should be detected prior to type checking",
                 );
 
+            let (_, imported_module) = module_info;
+
             // Determine local alias of imported module
             let module_name = as_name
                 .as_ref()
@@ -1542,13 +1544,10 @@ Missing modules should be detected prior to type checking",
                 let mut value_imported = false;
                 let mut variant = None;
 
-                let imported_name = match &as_name {
-                    None => name,
-                    Some(alias) => alias,
-                };
+                let imported_name = as_name.as_ref().unwrap_or(name);
 
                 // Register the unqualified import if it is a value
-                if let Some(value) = module_info.1.values.get(name) {
+                if let Some(value) = imported_module.values.get(name) {
                     environment.insert_variable(
                         imported_name.clone(),
                         value.variant.clone(),
@@ -1560,7 +1559,7 @@ Missing modules should be detected prior to type checking",
                 }
 
                 // Register the unqualified import if it is a type constructor
-                if let Some(typ) = module_info.1.types.get(name) {
+                if let Some(typ) = imported_module.types.get(name) {
                     let typ_info = TypeConstructor {
                         origin: *location,
                         ..typ.clone()
@@ -1604,14 +1603,12 @@ Missing modules should be detected prior to type checking",
                         location: *location,
                         name: name.clone(),
                         module_name: module.clone(),
-                        value_constructors: module_info
-                            .1
+                        value_constructors: imported_module
                             .values
                             .keys()
                             .map(|t| t.to_string())
                             .collect(),
-                        type_constructors: module_info
-                            .1
+                        type_constructors: imported_module
                             .types
                             .keys()
                             .map(|t| t.to_string())

--- a/src/type_/environment.rs
+++ b/src/type_/environment.rs
@@ -413,7 +413,7 @@ impl<'a, 'b> Environment<'a, 'b> {
             };
         }
 
-        if let Type::Var { .. } = *t2 {
+        if let Type::Var { .. } = t2.deref() {
             return self.unify(t2, t1).map_err(flip_unify_error);
         }
 

--- a/src/type_/expr.rs
+++ b/src/type_/expr.rs
@@ -1155,7 +1155,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         select_location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
         let (module_name, constructor) = {
-            let module_info = self
+            let (_, module) = self
                 .environment
                 .imported_modules
                 .get(module_alias)
@@ -1171,8 +1171,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                 })?;
 
             let constructor =
-                module_info
-                    .1
+                module
                     .values
                     .get(&label)
                     .ok_or_else(|| Error::UnknownModuleValue {
@@ -1181,16 +1180,11 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                             start: module_location.end,
                             end: select_location.end,
                         },
-                        module_name: module_info.1.name.clone(),
-                        value_constructors: module_info
-                            .1
-                            .values
-                            .keys()
-                            .map(|t| t.to_string())
-                            .collect(),
+                        module_name: module.name.clone(),
+                        value_constructors: module.values.keys().map(|t| t.to_string()).collect(),
                     })?;
 
-            (module_info.1.name.clone(), constructor.clone())
+            (module.name.clone(), constructor.clone())
         };
 
         Ok(TypedExpr::ModuleSelect {
@@ -1253,7 +1247,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                 .environment
                 .importable_modules
                 .get(&module.join("/"))
-                .and_then(|module| module.1.accessors.get(name)),
+                .and_then(|(_, module)| module.accessors.get(name)),
 
             _something_without_fields => return Err(unknown_field(vec![])),
         }

--- a/src/type_/fields.rs
+++ b/src/type_/fields.rs
@@ -70,7 +70,7 @@ impl FieldMap {
 
         let mut i = 0;
         while i < args.len() {
-            let (label, location) = match &args[i].label {
+            let (label, &location) = match &args[i].label {
                 // A labelled argument, we may need to reposition it in the array vector
                 Some(l) => (l, &args[i].location),
 
@@ -83,12 +83,12 @@ impl FieldMap {
 
             let position = match self.fields.get(label) {
                 None => {
-                    unknown_labels.push((label.clone(), *location));
+                    unknown_labels.push((label.clone(), location));
                     i += 1;
                     continue;
                 }
 
-                Some(p) => *p,
+                Some(&p) => p,
             };
 
             // If the argument is already in the right place
@@ -98,7 +98,7 @@ impl FieldMap {
             } else {
                 if seen_labels.contains(label) {
                     return Err(Error::DuplicateArgument {
-                        location: *location,
+                        location,
                         label: label.to_string(),
                     });
                 }

--- a/src/type_/pretty.rs
+++ b/src/type_/pretty.rs
@@ -111,20 +111,19 @@ impl Printer {
     }
 
     fn args_to_gleam_doc<'a>(&mut self, args: &[Arc<Type>]) -> Document<'a> {
-        match args.len() {
-            0 => nil(),
-            _ => {
-                let args = concat(Itertools::intersperse(
-                    args.iter().map(|t| self.print(t).group()),
-                    break_(",", ", "),
-                ));
-                break_("", "")
-                    .append(args)
-                    .nest(INDENT)
-                    .append(break_(",", ""))
-                    .group()
-            }
+        if args.is_empty() {
+            return nil();
         }
+
+        let args = concat(Itertools::intersperse(
+            args.iter().map(|t| self.print(t).group()),
+            break_(",", ", "),
+        ));
+        break_("", "")
+            .append(args)
+            .nest(INDENT)
+            .append(break_(",", ""))
+            .group()
     }
 }
 


### PR DESCRIPTION
Highlights:

- `erl::variable_name`: make the function a bit more readable
- `error::did_you_mean`: simplify the function and its signature
- `pretty::args_to_gleam_doc`: decrease code nesting for clarity
- general clean-up around matching, `Option`s etc.