### PR TITLE
New command doesn't create a new project if the target folder already exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Glean `new` command now checks if target folder exists, if so it returns
+  an error.
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,6 +155,10 @@ pub enum Error {
         reason: InvalidProjectNameReason,
     },
 
+    ProjectRootAlreadyExist {
+        path: String,
+    },
+    
     UnableToFindProjectRoot {
         path: String,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -158,7 +158,7 @@ pub enum Error {
     ProjectRootAlreadyExist {
         path: String,
     },
-    
+
     UnableToFindProjectRoot {
         path: String,
     },
@@ -325,7 +325,13 @@ numbers and underscores.",
                 };
                 write_project(buf, diagnostic);
             }
-
+            Error::ProjectRootAlreadyExist { path } => {
+                let diagnostic = ProjectErrorDiagnostic {
+                    title: "Project folder already exists".to_string(),
+                    label: format!("Project folder root:\n\n  {}", path),
+                };
+                write_project(buf, diagnostic);
+            }
             Error::UnableToFindProjectRoot { path } => {
                 let diagnostic = ProjectErrorDiagnostic {
                     title: "Invalid project root".to_string(),

--- a/src/new.rs
+++ b/src/new.rs
@@ -5,7 +5,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use strum::{Display, EnumString, EnumVariantNames};
 
 const GLEAM_STDLIB_VERSION: &str = "0.14.0";
@@ -528,6 +528,7 @@ pub fn hello_world_test() {{
 
 pub fn create(options: NewOptions, version: &'static str) -> Result<()> {
     validate_name(&options.name)?;
+    validate_root_folder(&options.name)?;
     let creator = Creator::new(options, version);
     creator.run()?;
 
@@ -567,6 +568,16 @@ fn write(path: PathBuf, contents: &str) -> Result<()> {
             err: Some(err.to_string()),
         })?;
     Ok(())
+}
+
+fn validate_root_folder(name: &str) -> Result<(), Error> {
+    if Path::new(name).exists() {
+        Err(Error::ProjectRootAlreadyExist {
+            path: name.to_string(),
+        })
+    } else {
+        Ok(())
+    }
 }
 
 fn validate_name(name: &str) -> Result<(), Error> {


### PR DESCRIPTION
This PR addresses #1076 

```
gleam new --template app myapp

error: Project folder already exists

Project folder root:

  myapp
```