### PR TITLE
Init command implementation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,9 @@ enum Command {
     #[structopt(name = "new", about = "Create a new project")]
     New(NewOptions),
 
+    #[structopt(name = "init", about = "Creates a project in an existing folder")]
+    Init(NewOptions),
+
     #[structopt(name = "format", about = "Format source code")]
     Format {
         #[structopt(help = "files to format", default_value = ".")]
@@ -306,7 +309,9 @@ fn main() {
             check,
         } => format::command::run(stdin, check, files),
 
-        Command::New(options) => new::create(options, VERSION),
+        Command::New(mut options) => new::create(&mut options, VERSION, false),
+
+        Command::Init(mut options) => new::create(&mut options, VERSION, true),
 
         Command::Shell { project_root } => shell::command(project_root),
 

--- a/src/new.rs
+++ b/src/new.rs
@@ -529,7 +529,9 @@ pub fn hello_world_test() {{
 pub fn create(options: &mut NewOptions, version: &'static str, init_mode: bool) -> Result<()> {
     if init_mode {
         print!("Enter a name for your project: ");
-        std::io::stdout().flush().expect("Error while flushing stdin");
+        std::io::stdout()
+            .flush()
+            .expect("Error while flushing stdin");
         options.project_root = Some(options.name.to_string());
         options.name = String::new();
         let _ = std::io::stdin()
@@ -574,7 +576,6 @@ The project can be compiled and tested by running these commands:
     );
     Ok(())
 }
-
 
 fn write(path: PathBuf, contents: &str) -> Result<()> {
     let mut f = File::create(&path).map_err(|err| Error::FileIo {

--- a/src/new.rs
+++ b/src/new.rs
@@ -568,7 +568,7 @@ The project can be compiled and tested by running these commands:
     {}
     {}
 ",
-        creator.root.to_str().expect("Unable to display path"),
+        options.name.to_string(),
         cd_folder,
         test_command,
     );

--- a/src/new.rs
+++ b/src/new.rs
@@ -553,13 +553,15 @@ pub fn create(options: &mut NewOptions, version: &'static str, init_mode: bool) 
     );
     creator.run()?;
 
-    let test_command = match &creator.options.template {
-        Template::Lib | Template::App | Template::Escript => "rebar3 eunit",
-        Template::GleamLib => "gleam eunit",
+    let cd_folder = if options.project_root.as_ref() == Some(&".".to_string()) {
+        "".to_string()
+    } else {
+        format!("\tcd {}\n", creator.options.name).to_string()
     };
-    let cd_folder = match init_mode {
-        true => "".to_string(),
-        _ => format!("cd {}", creator.options.name).to_string(),
+
+    let test_command = match &creator.options.template {
+        Template::Lib | Template::App | Template::Escript => "\trebar3 eunit",
+        Template::GleamLib => "gleam eunit",
     };
 
     println!(
@@ -567,8 +569,7 @@ pub fn create(options: &mut NewOptions, version: &'static str, init_mode: bool) 
 Your Gleam project {} has been successfully created.
 The project can be compiled and tested by running these commands:
 
-    {}
-    {}
+{}{}
 ",
         options.name.to_string(),
         cd_folder,


### PR DESCRIPTION
This PR implements an `init` command that takes as argument the root folder where the project files are going to be generated, it asks for the project name, which is going to be used in the gleam config files.

```
➜  hello git:(init-command) ✗ ./gleam init .
Enter a name for your project: my_project

Your Gleam project my_project has been successfully created.
The project can be compiled and tested by running these commands:


    rebar3 eunit

```


Therefore if you want to create a project called `my_super_project` in another folder, for instance in `my_projects/first_project` you just have to:

```
➜ gleam init my_projects/first_project
```

And you'll get all the required project files into  `my_projects/first_project` but you'r project internally will be called `my_super_project`

Related issue: https://github.com/gleam-lang/suggestions/issues/100