### PR TITLE
Add compiler error for duplicate module constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.
 - Projects without rebar3 can be generated using the `gleam-lib` template.
+- A compile time error is now raised when multiple module level constants with the same name are defined.
 
 ## v0.15.1 -2021-05-07
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -632,6 +632,32 @@ also be labelled.",
                     write_diagnostic(buf, diagnostic, Severity::Error);
                 }
 
+                TypeError::DuplicateConstName {
+                    location,
+                    name,
+                    previous_location,
+                    ..
+                } => {
+                    let diagnostic = MultiLineDiagnostic {
+                        title: format!("Duplicate const definition with name `{}`", name),
+                        file: path.to_str().unwrap().to_string(),
+                        src: src.to_string(),
+                        labels: vec![
+                            DiagnosticLabel {
+                                label: "redefined here".to_string(),
+                                location: *location,
+                                style: LabelStyle::Primary,
+                            },
+                            DiagnosticLabel {
+                                label: "previously defined here".to_string(),
+                                location: *previous_location,
+                                style: LabelStyle::Secondary,
+                            },
+                        ],
+                    };
+                    write_diagnostic(buf, diagnostic, Severity::Error);
+                }
+
                 TypeError::DuplicateTypeName {
                     name,
                     location,

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -490,6 +490,21 @@ fn assert_unique_type_name<'a>(
     }
 }
 
+fn assert_unique_const_name<'a>(
+    names: &mut HashMap<&'a str, &'a SrcSpan>,
+    name: &'a str,
+    location: &'a SrcSpan,
+) -> Result<(), Error> {
+    match names.insert(name, location) {
+        Some(previous_location) => Err(Error::DuplicateConstName {
+            name: name.to_string(),
+            previous_location: *previous_location,
+            location: *location,
+        }),
+        None => Ok(()),
+    }
+}
+
 fn register_values<'a>(
     s: &'a UntypedStatement,
     module_name: &[String],
@@ -720,6 +735,10 @@ fn register_values<'a>(
                     constructor.location,
                 );
             }
+        }
+
+        Statement::ModuleConstant { name, location, .. } => {
+            assert_unique_const_name(names, name, location)?;
         }
 
         _ => (),

--- a/src/type_/error.rs
+++ b/src/type_/error.rs
@@ -111,6 +111,12 @@ pub enum Error {
         name: String,
     },
 
+    DuplicateConstName {
+        location: SrcSpan,
+        previous_location: SrcSpan,
+        name: String,
+    },
+
     DuplicateArgument {
         location: SrcSpan,
         label: String,

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -2902,6 +2902,20 @@ fn duplicate_type_names() {
 }
 
 #[test]
+fn duplicate_const_names() {
+    // We cannot declare two const with the same name in a module
+    assert_module_error!(
+        "const duplicate = 1;
+         pub const duplicate = 1",
+        Error::DuplicateConstName {
+            location: SrcSpan { start: 40, end: 49 },
+            previous_location: SrcSpan { start: 6, end: 15 },
+            name: "duplicate".to_string(),
+        }
+    );
+}
+
+#[test]
 fn correct_pipe_arity_error_location() {
     // https://github.com/gleam-lang/gleam/issues/672
     assert_module_error!(


### PR DESCRIPTION
close #1100 

A naive solution to preventing duplicate module constants, using existing solutions for duplicate functions and types as a reference.

As mentioned in #1100, I was wondering if it would be better to consolidate the logic with the existing functions as they seem to be pretty similar?