### PR TITLE
use an always valid capture variable

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10,7 +10,7 @@ pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 use crate::type_::{self, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor};
 use std::sync::Arc;
 
-pub const CAPTURE_VARIABLE: &str = "gleam_capture_variable";
+pub const CAPTURE_VARIABLE: &str = "_gleam_capture";
 
 pub trait HasLocation {
     fn location(&self) -> SrcSpan;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10,7 +10,7 @@ pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 use crate::type_::{self, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor};
 use std::sync::Arc;
 
-pub const CAPTURE_VARIABLE: &str = "gleam@capture_variable";
+pub const CAPTURE_VARIABLE: &str = "gleam_capture_variable";
 
 pub trait HasLocation {
     fn location(&self) -> SrcSpan;


### PR DESCRIPTION
I started working on a solution to have a generic Gleam variable to pass around the ast.
something like
```rust
pub struct GleamVariable<'a>(&'a str);

pub const CAPTURE_VARIABLE: GleamVariable<'static> = GleamVariable("capture_variable");
```

This was actually introduced quite a lot of pain. i.e. https://github.com/gleam-lang/gleam/blob/main/src/parse.rs#L2736

Either the name of an arg needs to have a type that is an enum of String & GleamVariable. Doable but hits a lot of places.
Or, and I think even worse, the parse function needs to know if it's parsing for JS or erlang and generates a string variable name that is appropriate for each env.

In the end I realised that this simple fix would do everything we need, I can't imagine there are many programs with variables `gleam_something` although I will accept it's a possibility. and in the future maybe you would forbid variable names to start `gleam_`