### PR TITLE
Fix unexpected label when argument not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Projects without rebar3 can be generated using the `gleam-lib` template.
 - A compile time error is now raised when multiple module level constants with the same name are defined.
 - Fixed a bug where declaring a type constructor using reserved erlang keyword in its fields results in invalid erlang code being generated.
+- Fixed a bug where calling a function with discarded labelled arguments incorrectly results in a compile error.
 
 ## v0.15.1 -2021-05-07
 

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -530,7 +530,9 @@ fn register_values<'a>(
             // Create the field map so we can reorder labels for usage of this function
             let mut field_map = FieldMap::new(args.len());
             for (i, arg) in args.iter().enumerate() {
-                if let ArgNames::NamedLabelled { label, .. } = &arg.names {
+                if let ArgNames::NamedLabelled { label, .. }
+                | ArgNames::LabelledDiscard { label, .. } = &arg.names
+                {
                     field_map
                         .insert(label.clone(), i)
                         .map_err(|_| Error::DuplicateField {

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -3059,10 +3059,8 @@ fn x() {
     // https://github.com/gleam-lang/gleam/issues/1098
     // calling function with unused labelled argument should not emit warnings
     assert_no_warnings!(
-        r#"fn greet(name name: String, title _title: String) {
-            name
-         }
-         pub fn main() {greet(name: "Sam", title: "Mr")}"#,
+        r#"fn greet(name name: String, title _title: String) { name }
+           pub fn main() { greet(name: "Sam", title: "Mr") }"#,
     );
 }
 

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -3055,6 +3055,15 @@ fn x() {
             supplied: vec!["a".to_string()],
         })
     );
+
+    // https://github.com/gleam-lang/gleam/issues/1098
+    // calling function with unused labelled argument should not emit warnings
+    assert_no_warnings!(
+        r#"fn greet(name name: String, title _title: String) {
+            name
+         }
+         pub fn main() {greet(name: "Sam", title: "Mr")}"#,
+    );
 }
 
 #[test]


### PR DESCRIPTION
#1098

The issue for #1098 seems to be due to `field_map` not registering labelled function arguments with discarded argument.

This is a simple fix which includes discarded labelled arguments into `field_map`, so that it does not get classified as an `unknown_label` in `FieldMap::reorder`.

I am not sure if this is the right approach, and where would be an appropriate place to put a test for this, any advice would be appreciated