### PR TITLE
Escape Erlang keywords in Gleam type names

### DIFF
--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -2490,6 +2490,105 @@ fn build_in_erlang_type_escaping() {
 }
 
 #[test]
+fn escape_erlang_reserved_keywords_in_type_names() {
+    // list of all reserved words in erlang
+    // http://erlang.org/documentation/doc-5.8/doc/reference_manual/introduction.html
+    assert_erl!(
+        r#"pub type After { TestAfter }
+pub type And { TestAnd }
+pub type Andalso { TestAndAlso }
+pub type Band { TestBAnd }
+pub type Begin { TestBegin }
+pub type Bnot { TestBNot }
+pub type Bor { TestBOr }
+pub type Bsl { TestBsl }
+pub type Bsr { TestBsr }
+pub type Bxor { TestBXor }
+pub type Case { TestCase }
+pub type Catch { TestCatch }
+pub type Cond { TestCond }
+pub type Div { TestDiv }
+pub type End { TestEnd }
+pub type Fun { TestFun }
+pub type If { TestIf }
+pub type Let { TestLet }
+pub type Not { TestNot }
+pub type Of { TestOf }
+pub type Or { TestOr }
+pub type Orelse { TestOrElse }
+pub type Query { TestQuery }
+pub type Receive { TestReceive }
+pub type Rem { TestRem }
+pub type Try { TestTry }
+pub type When { TestWhen }
+pub type Xor { TestXor }"#,
+        r#"-module(the_app).
+-compile(no_auto_import).
+
+-export_type(['after'/0, 'and'/0, 'andalso'/0, 'band'/0, 'begin'/0, 'bnot'/0, 'bor'/0, 'bsl'/0, 'bsr'/0, 'bxor'/0, 'case'/0, 'catch'/0, 'cond'/0, 'div'/0, 'end'/0, 'fun'/0, 'if'/0, 'let'/0, 'not'/0, 'of'/0, 'or'/0, 'orelse'/0, 'query'/0, 'receive'/0, 'rem'/0, 'try'/0, 'when'/0, 'xor'/0]).
+
+-type 'after'() :: test_after.
+
+-type 'and'() :: test_and.
+
+-type 'andalso'() :: test_and_also.
+
+-type 'band'() :: test_b_and.
+
+-type 'begin'() :: test_begin.
+
+-type 'bnot'() :: test_b_not.
+
+-type 'bor'() :: test_b_or.
+
+-type 'bsl'() :: test_bsl.
+
+-type 'bsr'() :: test_bsr.
+
+-type 'bxor'() :: test_b_xor.
+
+-type 'case'() :: test_case.
+
+-type 'catch'() :: test_catch.
+
+-type 'cond'() :: test_cond.
+
+-type 'div'() :: test_div.
+
+-type 'end'() :: test_end.
+
+-type 'fun'() :: test_fun.
+
+-type 'if'() :: test_if.
+
+-type 'let'() :: test_let.
+
+-type 'not'() :: test_not.
+
+-type 'of'() :: test_of.
+
+-type 'or'() :: test_or.
+
+-type 'orelse'() :: test_or_else.
+
+-type 'query'() :: test_query.
+
+-type 'receive'() :: test_receive.
+
+-type 'rem'() :: test_rem.
+
+-type 'try'() :: test_try.
+
+-type 'when'() :: test_when.
+
+-type 'xor'() :: test_xor.
+
+
+"#
+    );
+}
+
+#[test]
 fn allowed_string_escapes() {
     assert_erl!(
         r#"fn a() { "\n" "\r" "\t" "\\" "\"" "\e" "\\^" }"#,


### PR DESCRIPTION
Hi!

In this PR, we refactor the `atom` function, separating the creation of a `Document::String` from the actual escape logic in a new function.
Using this new function, we can escape all reserved keywords when creating a type.
I also added to the reserved list some words based on the erlang [documentation](http://erlang.org/documentation/doc-5.8/doc/reference_manual/introduction.html) and created a test case using all of them.


This should fix  #1108 ;)