### PR TITLE
Do not use recursion in JS $equal

### DIFF
--- a/src/javascript.rs
+++ b/src/javascript.rs
@@ -11,27 +11,36 @@ const INDENT: isize = 2;
 const DEEP_EQUAL: &str = "
 
 function $equal(x, y) {
-  if ($isObject(x) && $isObject(y)) {
-    const kx = Object.keys(x);
-    const ky = Object.keys(x);
+  if (x === y) {
+      return true;
+  }
 
-    if (kx.length != ky.length) {
+  const nonEqualPairs = [x, y];
+
+  while (nonEqualPairs.length) {
+    const a = nonEqualPairs.pop();
+    const b = nonEqualPairs.pop();
+
+    if (!($isObject(a) && $isObject(b))) {
       return false;
     }
 
-    for (const k of kx) {
-      const a = x[k];
-      const b = y[k];
-      if !$equal(a, b) {
-        return false
-      }
+    const ka = Object.keys(a);
+    const kb = Object.keys(b);
+
+    if (ka.length != kb.length) {
+      return false;
     }
 
-    return true;
-
-  } else {
-    return x === y;
+    for (const k of ka) {
+      const ak = a[k];
+      const bk = b[k];
+      if (ak !== bk) {
+        nonEqualPairs.push(ak, bk);
+      }
+    }
   }
+  return true;
 }
 
 function $isObject(object) {

--- a/src/javascript/tests.rs
+++ b/src/javascript/tests.rs
@@ -87,27 +87,36 @@ function go() {
 }
 
 function $equal(x, y) {
-  if ($isObject(x) && $isObject(y)) {
-    const kx = Object.keys(x);
-    const ky = Object.keys(x);
+  if (x === y) {
+      return true;
+  }
 
-    if (kx.length != ky.length) {
+  const nonEqualPairs = [x, y];
+
+  while (nonEqualPairs.length) {
+    const a = nonEqualPairs.pop();
+    const b = nonEqualPairs.pop();
+
+    if (!($isObject(a) && $isObject(b))) {
       return false;
     }
 
-    for (const k of kx) {
-      const a = x[k];
-      const b = y[k];
-      if !$equal(a, b) {
-        return false
-      }
+    const ka = Object.keys(a);
+    const kb = Object.keys(b);
+
+    if (ka.length != kb.length) {
+      return false;
     }
 
-    return true;
-
-  } else {
-    return x === y;
+    for (const k of ka) {
+      const ak = a[k];
+      const bk = b[k];
+      if (ak !== bk) {
+        nonEqualPairs.push(ak, bk);
+      }
+    }
   }
+  return true;
 }
 
 function $isObject(object) {


### PR DESCRIPTION
Hello!
This is my first time contribution, I tried to give this issue a shot.
Some note: in order to avoid expensive operations (push/pop/loop on keys) for objects that are `===` (same pointer if object), they never make it to the array.

Closes #1113