### PR TITLE
Differentiate prelude constructor and custom type constructors

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -649,8 +649,7 @@ pub enum Pattern<Constructor, Type> {
         module: Option<String>,
         constructor: Constructor,
         with_spread: bool,
-        // TODO: https://github.com/gleam-lang/gleam/issues/1112
-        // type_: Type,
+        type_: Type,
     },
 
     Tuple {

--- a/src/javascript/pattern.rs
+++ b/src/javascript/pattern.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::type_::{FieldMap, PatternConstructor, Type};
+use crate::type_::{FieldMap, PatternConstructor};
 
 static ASSIGNMENT_VAR: &str = "$";
 
@@ -163,47 +163,62 @@ impl<'module, 'expression, 'a> Generator<'module, 'expression, 'a> {
 
             Pattern::Constructor {
                 type_,
+                constructor: PatternConstructor::Record { name, .. },
+                ..
+            } if type_.is_bool() && name == "True" => {
+                self.booly_check(true);
+                Ok(())
+            }
+
+            Pattern::Constructor {
+                type_,
+                constructor: PatternConstructor::Record { name, .. },
+                ..
+            } if type_.is_bool() && name == "False" => {
+                self.booly_check(false);
+                Ok(())
+            }
+
+            Pattern::Constructor {
+                type_,
+                constructor: PatternConstructor::Record { name, .. },
+                ..
+            } if type_.is_nil() && name == "Nil" => {
+                self.booly_check(false);
+                Ok(())
+            }
+
+            Pattern::Constructor {
                 constructor: PatternConstructor::Record { name, field_map },
                 arguments,
                 ..
-            } => match &**type_ {
-                Type::App { module, .. } if module.is_empty() && name == "True" => {
-                    self.booly_check(true);
-                    Ok(())
-                }
-                Type::App { module, .. }
-                    if module.is_empty() && (name == "False" || name == "Nil") =>
-                {
-                    self.booly_check(false);
-                    Ok(())
-                }
-                _ => {
-                    self.push_string("type");
-                    self.equality_check(expression::string(name));
-                    self.pop();
+            } => {
+                self.push_string("type");
+                self.equality_check(expression::string(name));
+                self.pop();
 
-                    for (index, arg) in arguments.iter().enumerate() {
-                        match field_map {
-                            None => self.push_int(index),
-                            Some(FieldMap { fields, .. }) => {
-                                let label = fields.iter().find_map(|(key, &val)| {
-                                    if val == index {
-                                        Some(key)
-                                    } else {
-                                        None
-                                    }
-                                });
-                                self.push_string(
-                                    label.gleam_expect("argument present in field map"),
+                for (index, arg) in arguments.iter().enumerate() {
+                    match field_map {
+                        None => self.push_int(index),
+                        Some(FieldMap { fields, .. }) => {
+                            let label =
+                                fields.iter().find_map(
+                                    |(key, &val)| {
+                                        if val == index {
+                                            Some(key)
+                                        } else {
+                                            None
+                                        }
+                                    },
                                 );
-                            }
+                            self.push_string(label.gleam_expect("argument present in field map"));
                         }
-                        self.traverse_pattern(&arg.value)?;
-                        self.pop_times(arguments.len());
                     }
-                    Ok(())
+                    self.traverse_pattern(&arg.value)?;
+                    self.pop_times(arguments.len());
                 }
-            },
+                Ok(())
+            }
 
             Pattern::VarUsage { .. } | Pattern::BitString { .. } => {
                 unsupported("BitString matching not supported in JS backend")

--- a/src/javascript/tests/bools.rs
+++ b/src/javascript/tests/bools.rs
@@ -83,31 +83,32 @@ function go(x, y) {
     );
 }
 
-// // TODO: FIXME: https://github.com/gleam-lang/gleam/issues/1112
-// #[test]
-// fn shadowed_bools_and_nil() {
-//     assert_js!(
-//         r#"
-// pub type Things { True False Nil }
-// fn go(x, y) {
-//     let True = x
-//     let False = x
-//     let Nil = y
-// }
-// "#,
-//         r#""use strict";
-//
-// function go(x, y) {
-//   if (x.type !== "True") throw new Error("Bad match");
-//
-//   if (x.type !== "False") throw new Error("Bad match");
-//
-//   if (x.type !== "Nil") throw new Error("Bad match");
-//   return y;
-// }
-// "#
-//     );
-// }
+// https://github.com/gleam-lang/gleam/issues/1112
+// differentiate between prelude constructors and custom type constructors
+#[test]
+fn shadowed_bools_and_nil() {
+    assert_js!(
+        r#"
+pub type True { True False Nil }
+fn go(x, y) {
+    let True = x
+    let False = x
+    let Nil = y
+}
+"#,
+        r#""use strict";
+
+function go(x, y) {
+  if (x.type !== "True") throw new Error("Bad match");
+  
+  if (x.type !== "False") throw new Error("Bad match");
+  
+  if (y.type !== "Nil") throw new Error("Bad match");
+  return y;
+}
+"#
+    );
+}
 
 #[test]
 fn equality() {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1040,6 +1040,7 @@ where
             name,
             with_spread,
             constructor: (),
+            type_: (),
         })
     }
 

--- a/src/type_/pattern.rs
+++ b/src/type_/pattern.rs
@@ -477,6 +477,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                                 arguments: pattern_args,
                                 constructor,
                                 with_spread,
+                                type_: instantiated_constructor_type,
                             })
                         } else {
                             Err(Error::IncorrectArity {
@@ -491,7 +492,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                     Type::App { .. } => {
                         if pattern_args.is_empty() {
                             self.environment
-                                .unify(typ, instantiated_constructor_type)
+                                .unify(typ, instantiated_constructor_type.clone())
                                 .map_err(|e| convert_unify_error(e, location))?;
                             Ok(Pattern::Constructor {
                                 location,
@@ -500,6 +501,7 @@ impl<'a, 'b, 'c> PatternTyper<'a, 'b, 'c> {
                                 arguments: vec![],
                                 constructor,
                                 with_spread,
+                                type_: instantiated_constructor_type,
                             })
                         } else {
                             Err(Error::IncorrectArity {


### PR DESCRIPTION
closes #1112 

Add `type_` field to `Pattern` constructor to allow js to differentiate between prelude constructor and custom type constructor