### PR TITLE
Draft for 'Typed records in erlang header files'

### DIFF
--- a/src/build/package_compilation_tests.rs
+++ b/src/build/package_compilation_tests.rs
@@ -653,7 +653,7 @@ call_thing() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Point.hrl"),
-                text: "-record(point, {x, y}).
+                text: "-record(point, {x :: integer(), y :: integer()}).
 "
                 .to_string(),
             },
@@ -1027,7 +1027,7 @@ funky() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Person.hrl"),
-                text: "-record(person, {name, age}).
+                text: "-record(person, {name :: binary(), age :: integer()}).
 "
                 .to_string(),
             },
@@ -1083,7 +1083,7 @@ get_name(Person) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Person.hrl"),
-                text: "-record(person, {name, age}).
+                text: "-record(person, {name :: binary(), age :: integer()}).
 "
                 .to_string(),
             },
@@ -1129,7 +1129,7 @@ get_name(Person) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Person.hrl"),
-                text: "-record(person, {name, age}).
+                text: "-record(person, {name :: binary(), age :: integer()}).
 "
                 .to_string(),
             },
@@ -1175,7 +1175,7 @@ get_name(Person) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_C.hrl"),
-                text: "-record(c, {a, b}).
+                text: "-record(c, {a :: integer(), b :: integer()}).
 "
                 .to_string(),
             },
@@ -1228,7 +1228,7 @@ id(X) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_X.hrl"),
-                text: "-record(x, {x}).
+                text: "-record(x, {x :: integer()}).
 "
                 .to_string(),
             },
@@ -1278,7 +1278,7 @@ make() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_C.hrl"),
-                text: "-record(c, {a, b}).
+                text: "-record(c, {a :: integer(), b :: integer()}).
 "
                 .to_string(),
             },
@@ -1431,7 +1431,7 @@ main() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/two_Two.hrl",),
-                text: "-record(two, {thing}).
+                text: "-record(two, {thing :: one:one(integer())}).
 "
                 .to_string(),
             },
@@ -1494,7 +1494,7 @@ to_int(P) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/power_Power.hrl",),
-                text: "-record(power, {value}).
+                text: "-record(power, {value :: integer()}).
 "
                 .to_string(),
             },

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -29,6 +29,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 const INDENT: isize = 4;
+const MAX_COLUMNS: isize = 80;
 
 pub fn generate_erlang(analysed: &[Analysed]) -> Vec<OutputFile> {
     let mut files = Vec::with_capacity(analysed.len() * 2);
@@ -146,15 +147,26 @@ pub fn records(module: &TypedModule) -> Vec<(&str, String)> {
             constructor
                 .arguments
                 .iter()
-                .map(|RecordConstructorArg { label, .. }| label.as_deref())
+                .map(
+                    |RecordConstructorArg {
+                         label,
+                         ast: _,
+                         location: _,
+                         type_,
+                     }| { label.as_deref().map(|label| (label, type_)) },
+                )
                 .collect::<Option<Vec<_>>>()
                 .map(|fields| (constructor.name.as_str(), fields))
         })
-        .map(|(name, fields)| (name, record_definition(name, &fields)))
+        .map(|(name, fields)| (name, record_definition(module, name, &fields)))
         .collect()
 }
 
-pub fn record_definition(name: &str, fields: &[&str]) -> String {
+pub fn record_definition(
+    module: &TypedModule,
+    name: &str,
+    fields: &[(&str, &Arc<Type>)],
+) -> String {
     let name = &name.to_snake_case();
     let escaped_name = if is_erlang_reserved_word(name) {
         format!("'{}'", name)
@@ -163,7 +175,20 @@ pub fn record_definition(name: &str, fields: &[&str]) -> String {
     };
     use std::fmt::Write;
     let mut buffer = format!("-record({}, {{", escaped_name);
-    for &field in Itertools::intersperse(fields.iter(), &", ") {
+    let type_printer = TypePrinter::new(&module.name);
+    let fields = fields
+        .iter()
+        .map(move |(field_name, field_type)| {
+            let escaped_field = if is_erlang_reserved_word(field_name) {
+                format!("'{}'", field_name)
+            } else {
+                (*field_name).to_string()
+            };
+            let type_name = type_printer.print(field_type).to_pretty_string(MAX_COLUMNS);
+            format!("{} :: {}", escaped_field, type_name)
+        })
+        .collect::<Vec<_>>();
+    for field in Itertools::intersperse(fields.iter(), &", ".to_string()) {
         let escaped_field = if is_erlang_reserved_word(field) {
             format!("'{}'", field)
         } else {
@@ -380,7 +405,7 @@ pub fn module(
         .append(type_defs)
         .append(statements)
         .append(line())
-        .pretty_print(80, writer)
+        .pretty_print(MAX_COLUMNS, writer)
 }
 
 fn statement<'a>(

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1,18 +1,48 @@
 use super::*;
-use crate::{build::Origin, type_::build_prelude};
+use crate::{build::Origin, type_, type_::build_prelude};
 use std::collections::HashMap;
 
 #[test]
 fn record_definition_test() {
+    let name = vec!["name".to_string()];
+    let documentation = vec![];
+    let type_info = type_::Module {
+        name: vec!["ok".to_string()],
+        types: HashMap::new(), // Core type constructors like String and Int are not included
+        values: HashMap::new(),
+        accessors: HashMap::new(),
+    };
+    let statements = vec![];
+    let module = TypedModule{
+        name,
+        documentation,
+        type_info,
+        statements
+    };
     assert_eq!(
-        record_definition("PetCat", &["name", "is_cute",]),
-        "-record(pet_cat, {name, is_cute}).\n".to_string()
+        record_definition(
+            &module,
+            "PetCat",
+            &[
+                ("name", &Arc::new(type_::Type::Tuple{elems: vec![]})),
+                ("is_cute", &Arc::new(type_::Type::Tuple{elems: vec![]}))
+            ]
+        ),
+        "-record(pet_cat, {name :: {}, is_cute :: {}}).\n".to_string()
     );
 
     // Reserved words are escaped in record names and fields
     assert_eq!(
-        record_definition("div", &["receive", "catch", "unreserved"]),
-        "-record(\'div\', {\'receive\', \'catch\', unreserved}).\n".to_string()
+        record_definition(
+            &module,
+            "div",
+            &[
+                ("receive", &Arc::new(type_::Type::Tuple{elems: vec![]})),
+                ("catch", &Arc::new(type_::Type::Tuple{elems: vec![]})),
+                ("unreserved", &Arc::new(type_::Type::Tuple{elems: vec![]}))
+            ]
+        ),
+        "-record(\'div\', {\'receive\' :: {}, \'catch\' :: {}, unreserved :: {}}).\n".to_string()
     );
 }
 

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -13,19 +13,19 @@ fn record_definition_test() {
         accessors: HashMap::new(),
     };
     let statements = vec![];
-    let module = TypedModule{
+    let module = TypedModule {
         name,
         documentation,
         type_info,
-        statements
+        statements,
     };
     assert_eq!(
         record_definition(
             &module,
             "PetCat",
             &[
-                ("name", &Arc::new(type_::Type::Tuple{elems: vec![]})),
-                ("is_cute", &Arc::new(type_::Type::Tuple{elems: vec![]}))
+                ("name", &Arc::new(type_::Type::Tuple { elems: vec![] })),
+                ("is_cute", &Arc::new(type_::Type::Tuple { elems: vec![] }))
             ]
         ),
         "-record(pet_cat, {name :: {}, is_cute :: {}}).\n".to_string()
@@ -37,9 +37,12 @@ fn record_definition_test() {
             &module,
             "div",
             &[
-                ("receive", &Arc::new(type_::Type::Tuple{elems: vec![]})),
-                ("catch", &Arc::new(type_::Type::Tuple{elems: vec![]})),
-                ("unreserved", &Arc::new(type_::Type::Tuple{elems: vec![]}))
+                ("receive", &Arc::new(type_::Type::Tuple { elems: vec![] })),
+                ("catch", &Arc::new(type_::Type::Tuple { elems: vec![] })),
+                (
+                    "unreserved",
+                    &Arc::new(type_::Type::Tuple { elems: vec![] })
+                )
             ]
         ),
         "-record(\'div\', {\'receive\' :: {}, \'catch\' :: {}, unreserved :: {}}).\n".to_string()

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -515,7 +515,7 @@ call_thing() ->
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Point.hrl"),
-                    text: "-record(point, {x, y}).\n".to_string(),
+                    text: "-record(point, {x :: integer(), y :: integer()}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -872,7 +872,7 @@ pub fn get_name(person: Person) { person.name }"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Person.hrl"),
-                    text: "-record(person, {name, age}).\n".to_string(),
+                    text: "-record(person, {name :: binary(), age :: integer()}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -926,7 +926,7 @@ type Two = one.Person"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Person.hrl"),
-                    text: "-record(person, {name, age}).\n".to_string(),
+                    text: "-record(person, {name :: binary(), age :: integer()}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -967,7 +967,7 @@ type Two = Person"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Person.hrl"),
-                    text: "-record(person, {name, age}).\n".to_string(),
+                    text: "-record(person, {name :: binary(), age :: integer()}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -1009,7 +1009,7 @@ fn main() { C }"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_C.hrl"),
-                    text: "-record(c, {a, b}).\n".to_string(),
+                    text: "-record(c, {a :: integer(), b :: integer()}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -1055,7 +1055,7 @@ main() ->
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_X.hrl"),
-                    text: "-record(x, {x}).\n".to_string(),
+                    text: "-record(x, {x :: integer()}).\n".to_string(),
 
                 },
                 OutputFile {
@@ -1107,7 +1107,7 @@ fn main() { one.C }"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_C.hrl"),
-                    text: "-record(c, {a, b}).\n".to_string(),
+                    text: "-record(c, {a :: integer(), b :: integer()}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -1343,7 +1343,7 @@ main(Arg1, Arg2, Arg3) ->
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/two_Two.hrl"),
-                    text: "-record(two, {thing}).\n"
+                    text: "-record(two, {thing :: one:one(integer())}).\n"
                         .to_string(),
                 },
                 OutputFile {


### PR DESCRIPTION
Allegedly closes [#1103](https://github.com/gleam-lang/gleam/issues/1103).

A couple of notes:

1. Running on fedora in `test/language`, `make` yields the following eventual error for this branch as well as for `main`. Reading between the lines in some other issues, it seems like `case` may just not be there in the JS target yet, in which case, apologies for the redundant report.
```
cargo run -- compile-package --name language --src src --out target-javascript --target javascript
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `/home/jclemer/gleam/target/debug/gleam compile-package --name language --src src --out target-javascript --target javascript`

error: Unsupported feature for compilation target

```
2. There's some regretable/verbose test set-up in src/erl/tests.rs