### PR TITLE
build node image

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -17,6 +17,9 @@ jobs:
           - elixir
           - elixir-slim
           - elixir-alpine
+          - node
+          - node-slim
+          - node-alpine
 
     steps: 
       - name: Checkout repository

--- a/containers/node-alpine.dockerfile
+++ b/containers/node-alpine.dockerfile
@@ -1,0 +1,3 @@
+FROM node:alpine
+COPY gleam /bin
+CMD ["gleam"]

--- a/containers/node-slim.dockerfile
+++ b/containers/node-slim.dockerfile
@@ -1,0 +1,3 @@
+FROM node:slim
+COPY gleam /bin
+CMD ["gleam"]

--- a/containers/node.dockerfile
+++ b/containers/node.dockerfile
@@ -1,0 +1,3 @@
+FROM node:latest
+COPY gleam /bin
+CMD ["gleam"]


### PR DESCRIPTION
Same as Elixir/erlang images.

node as far as I can see has the same convention for labelling slim/alpine images.