### PR TITLE
Remove nil name check

### DIFF
--- a/src/javascript/pattern.rs
+++ b/src/javascript/pattern.rs
@@ -181,7 +181,7 @@ impl<'module, 'expression, 'a> Generator<'module, 'expression, 'a> {
 
             Pattern::Constructor {
                 type_,
-                constructor: PatternConstructor::Record { name, .. },
+                constructor: PatternConstructor::Record { .. },
                 ..
             } if type_.is_nil() => {
                 self.booly_check(false);

--- a/src/javascript/pattern.rs
+++ b/src/javascript/pattern.rs
@@ -183,7 +183,7 @@ impl<'module, 'expression, 'a> Generator<'module, 'expression, 'a> {
                 type_,
                 constructor: PatternConstructor::Record { name, .. },
                 ..
-            } if type_.is_nil() && name == "Nil" => {
+            } if type_.is_nil() => {
                 self.booly_check(false);
                 Ok(())
             }


### PR DESCRIPTION
It will always be `Nil`, that's the only constructor for the `Nil` type.