### PR TITLE
Revert "Draft for 'Typed records in erlang header files'"

### DIFF
--- a/src/build/package_compilation_tests.rs
+++ b/src/build/package_compilation_tests.rs
@@ -653,7 +653,7 @@ call_thing() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Point.hrl"),
-                text: "-record(point, {x :: integer(), y :: integer()}).
+                text: "-record(point, {x, y}).
 "
                 .to_string(),
             },
@@ -1027,7 +1027,7 @@ funky() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Person.hrl"),
-                text: "-record(person, {name :: binary(), age :: integer()}).
+                text: "-record(person, {name, age}).
 "
                 .to_string(),
             },
@@ -1083,7 +1083,7 @@ get_name(Person) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Person.hrl"),
-                text: "-record(person, {name :: binary(), age :: integer()}).
+                text: "-record(person, {name, age}).
 "
                 .to_string(),
             },
@@ -1129,7 +1129,7 @@ get_name(Person) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_Person.hrl"),
-                text: "-record(person, {name :: binary(), age :: integer()}).
+                text: "-record(person, {name, age}).
 "
                 .to_string(),
             },
@@ -1175,7 +1175,7 @@ get_name(Person) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_C.hrl"),
-                text: "-record(c, {a :: integer(), b :: integer()}).
+                text: "-record(c, {a, b}).
 "
                 .to_string(),
             },
@@ -1228,7 +1228,7 @@ id(X) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_X.hrl"),
-                text: "-record(x, {x :: integer()}).
+                text: "-record(x, {x}).
 "
                 .to_string(),
             },
@@ -1278,7 +1278,7 @@ make() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/one_C.hrl"),
-                text: "-record(c, {a :: integer(), b :: integer()}).
+                text: "-record(c, {a, b}).
 "
                 .to_string(),
             },
@@ -1431,7 +1431,7 @@ main() ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/two_Two.hrl",),
-                text: "-record(two, {thing :: one:one(integer())}).
+                text: "-record(two, {thing}).
 "
                 .to_string(),
             },
@@ -1494,7 +1494,7 @@ to_int(P) ->
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/src/power_Power.hrl",),
-                text: "-record(power, {value :: integer()}).
+                text: "-record(power, {value}).
 "
                 .to_string(),
             },

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -13,19 +13,19 @@ fn record_definition_test() {
         accessors: HashMap::new(),
     };
     let statements = vec![];
-    let module = TypedModule {
+    let module = TypedModule{
         name,
         documentation,
         type_info,
-        statements,
+        statements
     };
     assert_eq!(
         record_definition(
             &module,
             "PetCat",
             &[
-                ("name", &Arc::new(type_::Type::Tuple { elems: vec![] })),
-                ("is_cute", &Arc::new(type_::Type::Tuple { elems: vec![] }))
+                ("name", &Arc::new(type_::Type::Tuple{elems: vec![]})),
+                ("is_cute", &Arc::new(type_::Type::Tuple{elems: vec![]}))
             ]
         ),
         "-record(pet_cat, {name :: {}, is_cute :: {}}).\n".to_string()
@@ -37,12 +37,9 @@ fn record_definition_test() {
             &module,
             "div",
             &[
-                ("receive", &Arc::new(type_::Type::Tuple { elems: vec![] })),
-                ("catch", &Arc::new(type_::Type::Tuple { elems: vec![] })),
-                (
-                    "unreserved",
-                    &Arc::new(type_::Type::Tuple { elems: vec![] })
-                )
+                ("receive", &Arc::new(type_::Type::Tuple{elems: vec![]})),
+                ("catch", &Arc::new(type_::Type::Tuple{elems: vec![]})),
+                ("unreserved", &Arc::new(type_::Type::Tuple{elems: vec![]}))
             ]
         ),
         "-record(\'div\', {\'receive\' :: {}, \'catch\' :: {}, unreserved :: {}}).\n".to_string()

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -1,48 +1,18 @@
 use super::*;
-use crate::{build::Origin, type_, type_::build_prelude};
+use crate::{build::Origin, type_::build_prelude};
 use std::collections::HashMap;
 
 #[test]
 fn record_definition_test() {
-    let name = vec!["name".to_string()];
-    let documentation = vec![];
-    let type_info = type_::Module {
-        name: vec!["ok".to_string()],
-        types: HashMap::new(), // Core type constructors like String and Int are not included
-        values: HashMap::new(),
-        accessors: HashMap::new(),
-    };
-    let statements = vec![];
-    let module = TypedModule{
-        name,
-        documentation,
-        type_info,
-        statements
-    };
     assert_eq!(
-        record_definition(
-            &module,
-            "PetCat",
-            &[
-                ("name", &Arc::new(type_::Type::Tuple{elems: vec![]})),
-                ("is_cute", &Arc::new(type_::Type::Tuple{elems: vec![]}))
-            ]
-        ),
-        "-record(pet_cat, {name :: {}, is_cute :: {}}).\n".to_string()
+        record_definition("PetCat", &["name", "is_cute",]),
+        "-record(pet_cat, {name, is_cute}).\n".to_string()
     );
 
     // Reserved words are escaped in record names and fields
     assert_eq!(
-        record_definition(
-            &module,
-            "div",
-            &[
-                ("receive", &Arc::new(type_::Type::Tuple{elems: vec![]})),
-                ("catch", &Arc::new(type_::Type::Tuple{elems: vec![]})),
-                ("unreserved", &Arc::new(type_::Type::Tuple{elems: vec![]}))
-            ]
-        ),
-        "-record(\'div\', {\'receive\' :: {}, \'catch\' :: {}, unreserved :: {}}).\n".to_string()
+        record_definition("div", &["receive", "catch", "unreserved"]),
+        "-record(\'div\', {\'receive\', \'catch\', unreserved}).\n".to_string()
     );
 }
 

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -515,7 +515,7 @@ call_thing() ->
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Point.hrl"),
-                    text: "-record(point, {x :: integer(), y :: integer()}).\n".to_string(),
+                    text: "-record(point, {x, y}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -872,7 +872,7 @@ pub fn get_name(person: Person) { person.name }"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Person.hrl"),
-                    text: "-record(person, {name :: binary(), age :: integer()}).\n".to_string(),
+                    text: "-record(person, {name, age}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -926,7 +926,7 @@ type Two = one.Person"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Person.hrl"),
-                    text: "-record(person, {name :: binary(), age :: integer()}).\n".to_string(),
+                    text: "-record(person, {name, age}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -967,7 +967,7 @@ type Two = Person"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_Person.hrl"),
-                    text: "-record(person, {name :: binary(), age :: integer()}).\n".to_string(),
+                    text: "-record(person, {name, age}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -1009,7 +1009,7 @@ fn main() { C }"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_C.hrl"),
-                    text: "-record(c, {a :: integer(), b :: integer()}).\n".to_string(),
+                    text: "-record(c, {a, b}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -1055,7 +1055,7 @@ main() ->
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_X.hrl"),
-                    text: "-record(x, {x :: integer()}).\n".to_string(),
+                    text: "-record(x, {x}).\n".to_string(),
 
                 },
                 OutputFile {
@@ -1107,7 +1107,7 @@ fn main() { one.C }"
             expected: Ok(vec![
                 OutputFile {
                     path: PathBuf::from("/gen/src/one_C.hrl"),
-                    text: "-record(c, {a :: integer(), b :: integer()}).\n".to_string(),
+                    text: "-record(c, {a, b}).\n".to_string(),
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/one.erl"),
@@ -1343,7 +1343,7 @@ main(Arg1, Arg2, Arg3) ->
                 },
                 OutputFile {
                     path: PathBuf::from("/gen/src/two_Two.hrl"),
-                    text: "-record(two, {thing :: one:one(integer())}).\n"
+                    text: "-record(two, {thing}).\n"
                         .to_string(),
                 },
                 OutputFile {


### PR DESCRIPTION
Reverts gleam-lang/gleam#1121

@lpil I just wanted to double-check a couple of things to make sure this didn't introduce a bug:
- one of the CI steps was failing (the app template step) and I wanted to check that that wasn't expected in non-main branches or something like that
- I also haven't updated the changelog yet
If all is well in the execution I'm happy to submit a follow-up for the changelog and close the revert-PR. I just didn't want to leave this merged if it shouldn't be for app-template-reasons. I was struggling with figuring out where that was going wrong, so if it's as simple as "it won't work but that's alright", then that's great.