### PR TITLE
check if unqualified import value was already imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Gleam compiler now is catching values which are being imported more than once 
+  in an unqualified fashion, this will raise a compile time error. 
 - Gleam can now compile Gleam projects without an external build tool.
 - Gleam can now run eunit without an external build tool.
 - Gleam can now run an Erlang shell without an external build tool.

--- a/generated/schema_capnp.rs
+++ b/generated/schema_capnp.rs
@@ -443,6 +443,13 @@ pub mod module {
     pub fn has_accessors(&self) -> bool {
       !self.reader.get_pointer_field(3).is_null()
     }
+    #[inline]
+    pub fn get_package(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
+    }
+    pub fn has_package(&self) -> bool {
+      !self.reader.get_pointer_field(4).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -553,6 +560,21 @@ pub mod module {
     pub fn has_accessors(&self) -> bool {
       !self.builder.get_pointer_field(3).is_null()
     }
+    #[inline]
+    pub fn get_package(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_package(&mut self, value: ::capnp::text::Reader<'_>)  {
+      self.builder.get_pointer_field(4).set_text(value);
+    }
+    #[inline]
+    pub fn init_package(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(4).init_text(size)
+    }
+    pub fn has_package(&self) -> bool {
+      !self.builder.get_pointer_field(4).is_null()
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -565,7 +587,7 @@ pub mod module {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 0, pointers: 4 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 0, pointers: 5 };
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
   }
 }

--- a/schema.capnp
+++ b/schema.capnp
@@ -24,6 +24,7 @@ struct Module {
   types @1 :List(Property(TypeConstructor));
   values @2 :List(Property(ValueConstructor));
   accessors @3 :List(Property(AccessorsMap));
+  package @4 :Text;
 }
 
 struct TypeConstructor {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -16,19 +16,19 @@ pub trait HasLocation {
     fn location(&self) -> SrcSpan;
 }
 
-pub type TypedModule = Module<Arc<Type>, TypedExpr, type_::Module, String>;
+pub type TypedModule = Module<Arc<Type>, TypedExpr, type_::Module, String, String>;
 
-pub type UntypedModule = Module<(), UntypedExpr, (), ()>;
+pub type UntypedModule = Module<(), UntypedExpr, (), (), ()>;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Module<T, Expr, Info, ConstantRecordTag> {
+pub struct Module<T, Expr, Info, ConstantRecordTag, PackageName> {
     pub name: Vec<String>,
     pub documentation: Vec<String>,
     pub type_info: Info,
-    pub statements: Vec<Statement<T, Expr, ConstantRecordTag>>,
+    pub statements: Vec<Statement<T, Expr, ConstantRecordTag, PackageName>>,
 }
 
-impl<A, B, C, D> Module<A, B, C, D> {
+impl<A, B, C, D, E> Module<A, B, C, D, E> {
     pub fn name_string(&self) -> String {
         self.name.join("/")
     }
@@ -179,11 +179,11 @@ impl TypeAst {
     }
 }
 
-pub type TypedStatement = Statement<Arc<Type>, TypedExpr, String>;
-pub type UntypedStatement = Statement<(), UntypedExpr, ()>;
+pub type TypedStatement = Statement<Arc<Type>, TypedExpr, String, String>;
+pub type UntypedStatement = Statement<(), UntypedExpr, (), ()>;
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Statement<T, Expr, ConstantRecordTag> {
+pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
     Fn {
         end_location: usize,
         location: SrcSpan,
@@ -242,6 +242,7 @@ pub enum Statement<T, Expr, ConstantRecordTag> {
         module: Vec<String>,
         as_name: Option<String>,
         unqualified: Vec<UnqualifiedImport>,
+        package: PackageName,
     },
 
     ModuleConstant {
@@ -255,7 +256,7 @@ pub enum Statement<T, Expr, ConstantRecordTag> {
     },
 }
 
-impl<A, B, C> Statement<A, B, C> {
+impl<A, B, C, E> Statement<A, B, C, E> {
     pub fn location(&self) -> &SrcSpan {
         match self {
             Statement::Import { location, .. }

--- a/src/build/compile_package.rs
+++ b/src/build/compile_package.rs
@@ -11,8 +11,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub type Manifests = HashMap<String, (Origin, Module)>;
-
 pub fn command(options: CompilePackage) -> Result<()> {
     let mut type_manifests = load_libraries(&options.libraries)?;
     let mut defined_modules = HashMap::new();
@@ -37,14 +35,14 @@ pub fn command(options: CompilePackage) -> Result<()> {
     Ok(())
 }
 
-fn load_libraries(libs: &[PathBuf]) -> Result<Manifests> {
+fn load_libraries(libs: &[PathBuf]) -> Result<HashMap<String, Module>> {
     tracing::info!("Reading precompiled module metadata files");
     let mut manifests = HashMap::with_capacity(libs.len() * 10);
     for lib in libs {
         for module in fs::gleam_modules_metadata_paths(lib)? {
             let reader = fs::buffered_reader(module)?;
             let module = metadata::ModuleDecoder::new().read(reader)?;
-            let _ = manifests.insert(module.name.join("/"), (Origin::Src, module));
+            let _ = manifests.insert(module.name.join("/"), module);
         }
     }
     Ok(manifests)

--- a/src/build/package_compiler.rs
+++ b/src/build/package_compiler.rs
@@ -61,15 +61,18 @@ impl<Writer: FileSystemWriter> PackageCompiler<Writer> {
     pub fn compile(
         mut self,
         warnings: &mut Vec<Warning>,
-        existing_modules: &mut HashMap<String, (Origin, type_::Module)>,
+        existing_modules: &mut HashMap<String, type_::Module>,
         already_defined_modules: &mut HashMap<String, PathBuf>,
     ) -> Result<Package, Error> {
         let span = tracing::info_span!("compile", package = self.options.name.as_str());
         let _enter = span.enter();
 
         tracing::info!("Parsing source code");
-        let parsed_modules =
-            parse_sources(std::mem::take(&mut self.sources), already_defined_modules)?;
+        let parsed_modules = parse_sources(
+            &self.options.name,
+            std::mem::take(&mut self.sources),
+            already_defined_modules,
+        )?;
 
         // Determine order in which modules are to be processed
         let sequence =
@@ -77,7 +80,13 @@ impl<Writer: FileSystemWriter> PackageCompiler<Writer> {
                 .map_err(convert_deps_tree_error)?;
 
         tracing::info!("Type checking modules");
-        let modules = type_check(sequence, parsed_modules, existing_modules, warnings)?;
+        let modules = type_check(
+            &self.options.name,
+            sequence,
+            parsed_modules,
+            existing_modules,
+            warnings,
+        )?;
 
         tracing::info!("Performing code generation");
         self.perform_codegen(&modules)?;
@@ -156,9 +165,10 @@ impl<Writer: FileSystemWriter> PackageCompiler<Writer> {
 }
 
 fn type_check(
+    package_name: &str,
     sequence: Vec<String>,
     mut parsed_modules: HashMap<String, Parsed>,
-    module_types: &mut HashMap<String, (Origin, type_::Module)>,
+    module_types: &mut HashMap<String, type_::Module>,
     warnings: &mut Vec<Warning>,
 ) -> Result<Vec<Module>, Error> {
     let mut modules = Vec::with_capacity(parsed_modules.len() + 1);
@@ -169,10 +179,7 @@ fn type_check(
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = module_types.insert(
-        "gleam".to_string(),
-        (Origin::Src, type_::build_prelude(&mut uid)),
-    );
+    let _ = module_types.insert("gleam".to_string(), type_::build_prelude(&mut uid));
 
     for name in sequence {
         let Parsed {
@@ -181,19 +188,26 @@ fn type_check(
             ast,
             path,
             origin,
+            package,
         } = parsed_modules
             .remove(&name)
             .gleam_expect("Getting parsed module for name");
 
         tracing::trace!(module = ?name, "Type checking");
         let mut type_warnings = Vec::new();
-        let ast = type_::infer_module(&mut uid, ast, module_types, &mut type_warnings).map_err(
-            |error| Error::Type {
-                path: path.clone(),
-                src: code.clone(),
-                error,
-            },
-        )?;
+        let ast = type_::infer_module(
+            &mut uid,
+            ast,
+            origin,
+            package_name,
+            module_types,
+            &mut type_warnings,
+        )
+        .map_err(|error| Error::Type {
+            path: path.clone(),
+            src: code.clone(),
+            error,
+        })?;
 
         // Register any warnings emitted as type warnings
         let type_warnings = type_warnings
@@ -203,7 +217,7 @@ fn type_check(
 
         // Register the types from this module so they can be imported into
         // other modules.
-        let _ = module_types.insert(name.clone(), (origin, ast.type_info.clone()));
+        let _ = module_types.insert(name.clone(), ast.type_info.clone());
 
         // Register the successfully type checked module data so that it can be
         // used for code generation
@@ -237,6 +251,7 @@ fn module_deps_for_graph(module: &Parsed) -> (String, Vec<String>) {
 }
 
 fn parse_sources(
+    package_name: &str,
     sources: Vec<Source>,
     already_defined_modules: &mut HashMap<String, PathBuf>,
 ) -> Result<HashMap<String, Parsed>, Error> {
@@ -258,6 +273,7 @@ fn parse_sources(
         ast.name = name.split("/").map(String::from).collect(); // TODO: store the module name as a string
 
         let module = Parsed {
+            package: package_name.to_string(),
             origin,
             path,
             name,
@@ -318,5 +334,6 @@ struct Parsed {
     name: String,
     code: String,
     origin: Origin,
+    package: String,
     ast: UntypedModule,
 }

--- a/src/build/project_compiler.rs
+++ b/src/build/project_compiler.rs
@@ -19,7 +19,7 @@ pub struct ProjectCompiler<'a> {
     root_config: PackageConfig,
     configs: HashMap<String, PackageConfig>,
     packages: HashMap<String, Package>,
-    type_manifests: HashMap<String, (Origin, type_::Module)>,
+    importable_modules: HashMap<String, type_::Module>,
     defined_modules: HashMap<String, PathBuf>,
     warnings: Vec<Warning>,
 }
@@ -37,7 +37,7 @@ impl<'a> ProjectCompiler<'a> {
         let estimated_number_of_modules = configs.len() * 5;
         Self {
             packages: HashMap::with_capacity(configs.len()),
-            type_manifests: HashMap::with_capacity(estimated_number_of_modules),
+            importable_modules: HashMap::with_capacity(estimated_number_of_modules),
             defined_modules: HashMap::with_capacity(estimated_number_of_modules),
             warnings: Vec::new(),
             root_config,
@@ -96,7 +96,7 @@ impl<'a> ProjectCompiler<'a> {
         // Compile project
         let compiled = compiler.compile(
             &mut self.warnings,
-            &mut self.type_manifests,
+            &mut self.importable_modules,
             &mut self.defined_modules,
         )?;
         ErlangApp::new(&out_path).render(&FileSystemAccessor::new(), &config, &compiled.modules)?;

--- a/src/erl/tests.rs
+++ b/src/erl/tests.rs
@@ -107,9 +107,16 @@ macro_rules! assert_erl {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
-        let ast = crate::type_::infer_module(&mut 0, ast, &modules, &mut vec![])
-            .expect("should successfully infer");
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
+        let ast = crate::type_::infer_module(
+            &mut 0,
+            ast,
+            Origin::Src,
+            "thepackage",
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
         let mut output = String::new();
         let line_numbers = LineNumbers::new($src);
         module(&ast, &line_numbers, &mut output).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -633,6 +633,32 @@ also be labelled.",
                     write_diagnostic(buf, diagnostic, Severity::Error);
                 }
 
+                TypeError::DuplicateImport {
+                    location,
+                    previous_location,
+                    name,
+                    ..
+                } => {
+                    let diagnostic = MultiLineDiagnostic {
+                        title: format!("Duplicate import with name `{}`", name),
+                        file: path.to_str().unwrap().to_string(),
+                        src: src.to_string(),
+                        labels: vec![
+                            DiagnosticLabel {
+                                label: "redefined here".to_string(),
+                                location: *location,
+                                style: LabelStyle::Primary,
+                            },
+                            DiagnosticLabel {
+                                label: "previously defined here".to_string(),
+                                location: *previous_location,
+                                style: LabelStyle::Secondary,
+                            },
+                        ],
+                    };
+                    write_diagnostic(buf, diagnostic, Severity::Error);
+                }
+
                 TypeError::DuplicateConstName {
                     location,
                     name,

--- a/src/javascript.rs
+++ b/src/javascript.rs
@@ -251,7 +251,7 @@ impl<'a> Generator<'a> {
         module: &'a str,
         fun: &'a str,
     ) -> Document<'a> {
-        if module == "" {
+        if module.is_empty() {
             self.global_external_function(public, name, arguments, fun)
         } else {
             self.imported_external_function(public, name, module, fun)
@@ -315,7 +315,7 @@ impl<'a> Generator<'a> {
     }
 }
 
-fn external_fn_args<'a, T>(arguments: &'a [ExternalFnArg<T>]) -> Document<'a> {
+fn external_fn_args<T>(arguments: &[ExternalFnArg<T>]) -> Document<'_> {
     wrap_args(arguments.iter().enumerate().map(|a| {
         match a {
             (index, ExternalFnArg { label, .. }) => label

--- a/src/javascript/tests.rs
+++ b/src/javascript/tests.rs
@@ -11,6 +11,8 @@ mod strings;
 mod try_;
 mod tuples;
 
+pub static CURRENT_PACKAGE: &str = "thepackage";
+
 #[macro_export]
 macro_rules! assert_js {
     ($src:expr, $erl:expr $(,)?) => {{
@@ -21,24 +23,26 @@ macro_rules! assert_js {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert(
-            "gleam".to_string(),
-            (
-                crate::build::Origin::Src,
-                crate::type_::build_prelude(&mut uid),
-            ),
-        );
+        let _ = modules.insert("gleam".to_string(), crate::type_::build_prelude(&mut uid));
+
         let (mut ast, _) = crate::parse::parse_module($src).expect("syntax error");
         ast.name = vec!["the_app".to_string()];
-        let ast = crate::type_::infer_module(&mut 0, ast, &modules, &mut vec![])
-            .expect("should successfully infer");
+        let ast = crate::type_::infer_module(
+            &mut 0,
+            ast,
+            crate::build::Origin::Src,
+            "thepackage",
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
         let mut output = String::new();
         let line_numbers = LineNumbers::new($src);
         module(&ast, &line_numbers, &mut output).unwrap();
         assert_eq!(($src, output), ($src, $erl.to_string()));
     }};
 
-    (($dep_name:expr, $dep_src:expr), $src:expr, $erl:expr $(,)?) => {{
+    (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr, $erl:expr $(,)?) => {{
         use crate::javascript::*;
         let mut modules = std::collections::HashMap::new();
         let mut uid = 0;
@@ -46,25 +50,30 @@ macro_rules! assert_js {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert(
-            "gleam".to_string(),
-            (
-                crate::build::Origin::Src,
-                crate::type_::build_prelude(&mut uid),
-            ),
-        );
+        let _ = modules.insert("gleam".to_string(), crate::type_::build_prelude(&mut uid));
         let (mut ast, _) = crate::parse::parse_module($dep_src).expect("dep syntax error");
         ast.name = $dep_name;
-        let dep = crate::type_::infer_module(&mut 0, ast, &modules, &mut vec![])
-            .expect("should successfully infer");
-        let _ = modules.insert(
-            $dep_name.join("/"),
-            (crate::build::Origin::Src, dep.type_info),
-        );
+        let dep = crate::type_::infer_module(
+            &mut 0,
+            ast,
+            crate::build::Origin::Src,
+            $dep_package,
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
+        let _ = modules.insert($dep_name.join("/"), dep.type_info);
         let (mut ast, _) = crate::parse::parse_module($src).expect("syntax error");
         ast.name = vec!["the_app".to_string()];
-        let ast = crate::type_::infer_module(&mut 0, ast, &modules, &mut vec![])
-            .expect("should successfully infer");
+        let ast = crate::type_::infer_module(
+            &mut 0,
+            ast,
+            crate::build::Origin::Src,
+            CURRENT_PACKAGE,
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
         let mut output = String::new();
         let line_numbers = LineNumbers::new($src);
         module(&ast, &line_numbers, &mut output).unwrap();

--- a/src/javascript/tests/custom_types.rs
+++ b/src/javascript/tests/custom_types.rs
@@ -1,4 +1,5 @@
 use crate::assert_js;
+use crate::javascript::tests::CURRENT_PACKAGE;
 
 #[test]
 fn zero_arity_literal() {
@@ -52,7 +53,11 @@ const that = {
 #[test]
 fn zero_arity_imported() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two }"#
+        ),
         r#"import other
 pub fn main() {
   other.Two
@@ -71,7 +76,11 @@ export function main() {
 #[test]
 fn zero_arity_imported_unqualified() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two }"#
+        ),
         r#"import other.{Two}
 pub fn main() {
   Two
@@ -91,7 +100,7 @@ export function main() {
 // #[test]
 // fn zero_arity_imported_unqualified_aliased() {
 //     assert_js!(
-//         (vec!["other".to_string()], r#"pub type One { Two }"#),
+//         ( CURRENT_PACKAGE, vec!["other".to_string()], r#"pub type One { Two }"#),
 //         r#"import other.{Two as Three}
 // pub fn main() {
 //   Three
@@ -111,7 +120,11 @@ export function main() {
 #[test]
 fn const_zero_arity_imported() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two }"#
+        ),
         r#"import other
 const x = other.Two
 "#,
@@ -127,7 +140,11 @@ import * as other from "./other.js";
 #[test]
 fn const_zero_arity_imported_unqualified() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two }"#
+        ),
         r#"import other.{Two}
 const a = Two
 "#,
@@ -144,7 +161,7 @@ import * as other from "./other.js";
 // #[test]
 // fn const_zero_arity_imported_unqualified_aliased() {
 //     assert_js!(
-//         (vec!["other".to_string()], r#"pub type One { Two }"#),
+//         ( CURRENT_PACKAGE, vec!["other".to_string()], r#"pub type One { Two }"#),
 //         r#"import other.{Two as Three}
 // const a = Three
 // "#,
@@ -371,7 +388,11 @@ function go(x) {
 #[test]
 fn imported_no_label() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two(Int) }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two(Int) }"#
+        ),
         r#"import other
 pub fn main() {
   other.Two(1)
@@ -391,6 +412,7 @@ export function main() {
 fn imported_ignoring_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -413,6 +435,7 @@ export function main() {
 fn imported_using_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -435,6 +458,7 @@ export function main() {
 fn imported_multiple_fields() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
         ),
@@ -456,7 +480,11 @@ export function main() {
 #[test]
 fn unqualified_imported_no_label() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two(Int) }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two(Int) }"#
+        ),
         r#"import other.{Two}
 pub fn main() {
   Two(1)
@@ -476,6 +504,7 @@ export function main() {
 fn unqualified_imported_ignoring_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -498,6 +527,7 @@ export function main() {
 fn unqualified_imported_using_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -520,6 +550,7 @@ export function main() {
 fn unqualified_imported_multiple_fields() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
         ),
@@ -542,6 +573,7 @@ export function main() {
 fn constructor_as_value() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
         ),
@@ -566,6 +598,7 @@ export function main() {
 fn unqualified_constructor_as_value() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
         ),
@@ -589,7 +622,11 @@ export function main() {
 #[test]
 fn const_imported_no_label() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two(Int) }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two(Int) }"#
+        ),
         r#"import other
 pub const main = other.Two(1)
 "#,
@@ -606,6 +643,7 @@ import * as other from "./other.js";
 fn const_imported_ignoring_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -625,6 +663,7 @@ import * as other from "./other.js";
 fn const_imported_using_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -644,6 +683,7 @@ import * as other from "./other.js";
 fn const_imported_multiple_fields() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
         ),
@@ -662,7 +702,11 @@ import * as other from "./other.js";
 #[test]
 fn const_unqualified_imported_no_label() {
     assert_js!(
-        (vec!["other".to_string()], r#"pub type One { Two(Int) }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two(Int) }"#
+        ),
         r#"import other.{Two}
 pub const main = Two(1)
 "#,
@@ -679,6 +723,7 @@ import * as other from "./other.js";
 fn const_unqualified_imported_ignoring_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -698,6 +743,7 @@ import * as other from "./other.js";
 fn const_unqualified_imported_using_label() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(field: Int) }"#
         ),
@@ -717,6 +763,7 @@ import * as other from "./other.js";
 fn const_unqualified_imported_multiple_fields() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
         ),
@@ -736,6 +783,7 @@ import * as other from "./other.js";
 fn imported_pattern() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["other".to_string()],
             r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
         ),

--- a/src/javascript/tests/modules.rs
+++ b/src/javascript/tests/modules.rs
@@ -1,9 +1,14 @@
 use crate::assert_js;
+use crate::javascript::tests::CURRENT_PACKAGE;
 
 #[test]
 fn unqualified_fn_call() {
     assert_js!(
-        (vec!["rocket_ship".to_string()], r#"pub fn launch() { 1 }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["rocket_ship".to_string()],
+            r#"pub fn launch() { 1 }"#
+        ),
         r#"import rocket_ship.{launch}
 pub fn go() { launch() }
 "#,
@@ -22,7 +27,11 @@ export function go() {
 #[test]
 fn aliased_unqualified_fn_call() {
     assert_js!(
-        (vec!["rocket_ship".to_string()], r#"pub fn launch() { 1 }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["rocket_ship".to_string()],
+            r#"pub fn launch() { 1 }"#
+        ),
         r#"import rocket_ship.{launch as boom_time}
 pub fn go() { boom_time() }
 "#,
@@ -42,6 +51,7 @@ export function go() {
 fn multiple_unqualified_fn_call() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["rocket_ship".to_string()],
             r#"
 pub fn a() { 1 }
@@ -65,7 +75,11 @@ export function go() {
 #[test]
 fn constant() {
     assert_js!(
-        (vec!["rocket_ship".to_string()], r#"pub const x = 1"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["rocket_ship".to_string()],
+            r#"pub const x = 1"#
+        ),
         r#"
 import rocket_ship
 pub fn go() { rocket_ship.x }
@@ -84,7 +98,11 @@ export function go() {
 #[test]
 fn alias_constant() {
     assert_js!(
-        (vec!["rocket_ship".to_string()], r#"pub const x = 1"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["rocket_ship".to_string()],
+            r#"pub const x = 1"#
+        ),
         r#"
 import rocket_ship as boop
 pub fn go() { boop.x }
@@ -103,7 +121,11 @@ export function go() {
 #[test]
 fn alias_fn_call() {
     assert_js!(
-        (vec!["rocket_ship".to_string()], r#"pub fn go() { 1 }"#),
+        (
+            CURRENT_PACKAGE,
+            vec!["rocket_ship".to_string()],
+            r#"pub fn go() { 1 }"#
+        ),
         r#"
 import rocket_ship as boop
 pub fn go() { boop.go() }
@@ -123,6 +145,7 @@ export function go() {
 fn nested_fn_call() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["one".to_string(), "two".to_string()],
             r#"pub fn go() { 1 }"#
         ),
@@ -143,6 +166,7 @@ export function go() {
 fn nested_nested_fn_call() {
     assert_js!(
         (
+            CURRENT_PACKAGE,
             vec!["one".to_string(), "two".to_string(), "three".to_string()],
             r#"pub fn go() { 1 }"#
         ),
@@ -154,6 +178,28 @@ import * as three from "./one/two/three.js";
 
 export function go() {
   return three.go();
+}
+"#
+    );
+}
+
+#[test]
+fn different_package_import() {
+    assert_js!(
+        (
+            "other_package",
+            vec!["one".to_string()],
+            r#"pub fn go() { 1 }"#
+        ),
+        r#"import one
+pub fn go() { one.go() }
+"#,
+        r#""use strict";
+
+import * as one from "other_package/one.js";
+
+export function go() {
+  return one.go();
 }
 "#
     );

--- a/src/metadata/module_encoder.rs
+++ b/src/metadata/module_encoder.rs
@@ -34,6 +34,7 @@ impl<'a> ModuleEncoder<'a> {
         self.set_module_types(&mut module);
         self.set_module_values(&mut module);
         self.set_module_accessors(&mut module);
+        module.set_package(self.data.package.as_str());
 
         let result = capnp::serialize_packed::write_message(&mut writer, &message);
         writer.convert_err(result)

--- a/src/metadata/tests.rs
+++ b/src/metadata/tests.rs
@@ -6,6 +6,7 @@ use crate::{
         BitStringSegment, BitStringSegmentOption, CallArg, Constant, TypedConstant,
         TypedConstantBitStringSegmentOption,
     },
+    build::Origin,
     fs::test::InMemoryFile,
     type_::{self, Module, Type, TypeConstructor, ValueConstructor, ValueConstructorVariant},
 };
@@ -22,6 +23,8 @@ fn roundtrip(input: &Module) -> Module {
 
 fn constant_module(constant: TypedConstant) -> Module {
     Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string()],
         types: HashMap::new(),
         accessors: HashMap::new(),
@@ -57,6 +60,8 @@ fn bit_string_segment_option_module(option: TypedConstantBitStringSegmentOption)
 #[test]
 fn empty_module() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["one".to_string(), "two".to_string()],
         types: HashMap::new(),
         values: HashMap::new(),
@@ -68,6 +73,8 @@ fn empty_module() {
 #[test]
 fn module_with_app_type() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string(), "b".to_string()],
         types: vec![(
             "ListIntType".to_string(),
@@ -90,6 +97,8 @@ fn module_with_app_type() {
 #[test]
 fn module_with_fn_type() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string(), "b".to_string()],
         types: vec![(
             "FnType".to_string(),
@@ -112,6 +121,8 @@ fn module_with_fn_type() {
 #[test]
 fn module_with_tuple_type() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string(), "b".to_string()],
         types: vec![(
             "TupleType".to_string(),
@@ -140,6 +151,8 @@ fn module_with_generic_type() {
 
     fn make(t1: Arc<Type>, t2: Arc<Type>) -> Module {
         Module {
+            package: "some_package".to_string(),
+            origin: Origin::Src,
             name: vec!["a".to_string(), "b".to_string()],
             types: vec![(
                 "TupleType".to_string(),
@@ -168,6 +181,8 @@ fn module_with_type_links() {
 
     fn make(type_: Arc<Type>) -> Module {
         Module {
+            package: "some_package".to_string(),
+            origin: Origin::Src,
             name: vec!["a".to_string()],
             types: vec![(
                 "SomeType".to_string(),
@@ -192,6 +207,8 @@ fn module_with_type_links() {
 #[test]
 fn module_fn_value() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string()],
         types: HashMap::new(),
         accessors: HashMap::new(),
@@ -219,6 +236,8 @@ fn module_fn_value() {
 #[test]
 fn module_fn_value_with_field_map() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string()],
         types: HashMap::new(),
         accessors: HashMap::new(),
@@ -251,6 +270,8 @@ fn module_fn_value_with_field_map() {
 #[test]
 fn record_value() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string()],
         types: HashMap::new(),
         accessors: HashMap::new(),
@@ -277,6 +298,8 @@ fn record_value() {
 #[test]
 fn record_value_with_field_map() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string()],
         types: HashMap::new(),
         accessors: HashMap::new(),
@@ -308,6 +331,8 @@ fn record_value_with_field_map() {
 #[test]
 fn accessors() {
     let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
         name: vec!["a".to_string()],
         types: HashMap::new(),
         values: HashMap::new(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1774,6 +1774,7 @@ where
             unqualified,
             module,
             as_name,
+            package: (),
         }))
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -166,10 +166,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules_type_infos.insert(
-        "gleam".to_string(),
-        (Origin::Src, type_::build_prelude(&mut uid)),
-    );
+    let _ = modules_type_infos.insert("gleam".to_string(), type_::build_prelude(&mut uid));
 
     struct Out {
         source_base_path: PathBuf,
@@ -198,8 +195,14 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
         println!("Compiling {}", name_string);
 
         let mut warnings = vec![];
-        let result =
-            crate::type_::infer_module(&mut uid, module, &modules_type_infos, &mut warnings);
+        let result = crate::type_::infer_module(
+            &mut uid,
+            module,
+            origin.to_origin(),
+            "old-build-system-doesnt-support-packages",
+            &modules_type_infos,
+            &mut warnings,
+        );
         let warnings = warnings
             .into_iter()
             .map(|warning| Warning::Type {
@@ -215,10 +218,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
             error,
         })?;
 
-        let _ = modules_type_infos.insert(
-            name_string.clone(),
-            (origin.to_origin(), ast.type_info.clone()),
-        );
+        let _ = modules_type_infos.insert(name_string.clone(), ast.type_info.clone());
 
         compiled_modules.push(Out {
             name,
@@ -256,8 +256,7 @@ pub fn analysed(inputs: Vec<Input>) -> Result<Vec<Analysed>, Error> {
                 origin,
                 type_info: modules_type_infos
                     .remove(&name_string)
-                    .gleam_expect("project::compile(): Merging module type info")
-                    .1,
+                    .gleam_expect("project::compile(): Merging module type info"),
                 warnings,
                 module_extra,
             }

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -1653,6 +1653,14 @@ Missing modules should be detected prior to type checking",
 
                 let imported_name = as_name.as_ref().unwrap_or(name);
 
+                // Check if value already was imported
+                if let Some(value) = environment.local_values.get(name) {
+                    return Err(Error::DuplicateImport {
+                        location: *location,
+                        previous_location: value.origin,
+                        name: name.to_string(),
+                    });
+                }
                 // Register the unqualified import if it is a value
                 if let Some(value) = imported_module.values.get(name) {
                     environment.insert_variable(

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -303,6 +303,8 @@ pub enum ModuleValueConstructor {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Module {
     pub name: Vec<String>,
+    pub origin: Origin,
+    pub package: String,
     pub types: HashMap<String, TypeConstructor>,
     pub values: HashMap<String, ValueConstructor>,
     pub accessors: HashMap<String, AccessorsMap>,
@@ -399,13 +401,16 @@ impl ValueConstructor {
     }
 }
 
+// TODO: This takes too many arguments.
 /// Crawl the AST, annotating each node with the inferred type or
 /// returning an error.
 ///
 pub fn infer_module(
     uid: &mut usize,
     module: UntypedModule,
-    modules: &HashMap<String, (Origin, Module)>,
+    origin: Origin,
+    package: &str,
+    modules: &HashMap<String, Module>,
     warnings: &mut Vec<Warning>,
 ) -> Result<TypedModule, Error> {
     let mut environment = Environment::new(uid, &module.name, modules, warnings);
@@ -510,6 +515,8 @@ pub fn infer_module(
             types,
             values,
             accessors,
+            origin,
+            package: package.to_string(),
         },
     })
 }
@@ -1141,12 +1148,24 @@ fn infer_statement(
             module,
             as_name,
             unqualified,
-        } => Ok(Statement::Import {
-            location,
-            module,
-            as_name,
-            unqualified,
-        }),
+            ..
+        } => {
+            // Find imported module
+            let module_info = environment
+                .importable_modules
+                .get(&module.join("/"))
+                .gleam_expect(
+                    "Typer could not find a module being imported during inference.
+Missing modules should be detected prior to type checking",
+                );
+            Ok(Statement::Import {
+                location,
+                module,
+                as_name,
+                unqualified,
+                package: module_info.package.clone(),
+            })
+        }
 
         Statement::ModuleConstant {
             doc,
@@ -1631,8 +1650,6 @@ pub fn register_import(
 Missing modules should be detected prior to type checking",
                 );
 
-            let (_, imported_module) = module_info;
-
             // Determine local alias of imported module
             let module_name = as_name
                 .as_ref()
@@ -1662,7 +1679,7 @@ Missing modules should be detected prior to type checking",
                     });
                 }
                 // Register the unqualified import if it is a value
-                if let Some(value) = imported_module.values.get(name) {
+                if let Some(value) = module_info.values.get(name) {
                     environment.insert_variable(
                         imported_name.clone(),
                         value.variant.clone(),
@@ -1674,7 +1691,7 @@ Missing modules should be detected prior to type checking",
                 }
 
                 // Register the unqualified import if it is a type constructor
-                if let Some(typ) = imported_module.types.get(name) {
+                if let Some(typ) = module_info.types.get(name) {
                     let typ_info = TypeConstructor {
                         origin: *location,
                         ..typ.clone()
@@ -1718,12 +1735,12 @@ Missing modules should be detected prior to type checking",
                         location: *location,
                         name: name.clone(),
                         module_name: module.clone(),
-                        value_constructors: imported_module
+                        value_constructors: module_info
                             .values
                             .keys()
                             .map(|t| t.to_string())
                             .collect(),
-                        type_constructors: imported_module
+                        type_constructors: module_info
                             .types
                             .keys()
                             .map(|t| t.to_string())

--- a/src/type_/environment.rs
+++ b/src/type_/environment.rs
@@ -6,8 +6,8 @@ pub struct Environment<'a, 'b> {
     pub current_module: &'a [String],
     pub uid: &'b mut usize,
     pub level: usize,
-    pub importable_modules: &'a HashMap<String, (Origin, Module)>,
-    pub imported_modules: HashMap<String, (Origin, Module)>,
+    pub importable_modules: &'a HashMap<String, Module>,
+    pub imported_modules: HashMap<String, Module>,
 
     // Values defined in the current function (or the prelude)
     pub local_values: im::HashMap<String, ValueConstructor>,
@@ -54,10 +54,10 @@ impl<'a, 'b> Environment<'a, 'b> {
     pub fn new(
         uid: &'b mut usize,
         current_module: &'a [String],
-        importable_modules: &'a HashMap<String, (Origin, Module)>,
+        importable_modules: &'a HashMap<String, Module>,
         warnings: &'a mut Vec<Warning>,
     ) -> Self {
-        let (_, prelude) = importable_modules
+        let prelude = importable_modules
             .get("gleam")
             .gleam_expect("Unable to find prelude in importable modules");
         Self {
@@ -224,7 +224,7 @@ impl<'a, 'b> Environment<'a, 'b> {
             }
 
             Some(m) => {
-                let (_, module) = self.imported_modules.get(m).ok_or_else(|| {
+                let module = self.imported_modules.get(m).ok_or_else(|| {
                     GetTypeConstructorError::UnknownModule {
                         name: name.to_string(),
                         imported_modules: self
@@ -262,7 +262,7 @@ impl<'a, 'b> Environment<'a, 'b> {
             }),
 
             Some(module) => {
-                let (_, module) = self.imported_modules.get(module).ok_or_else(|| {
+                let module = self.imported_modules.get(module).ok_or_else(|| {
                     GetValueConstructorError::UnknownModule {
                         name: name.to_string(),
                         imported_modules: self

--- a/src/type_/error.rs
+++ b/src/type_/error.rs
@@ -105,6 +105,12 @@ pub enum Error {
         name: String,
     },
 
+    DuplicateImport {
+        location: SrcSpan,
+        previous_location: SrcSpan,
+        name: String,
+    },
+
     DuplicateTypeName {
         location: SrcSpan,
         previous_location: SrcSpan,

--- a/src/type_/expr.rs
+++ b/src/type_/expr.rs
@@ -1211,7 +1211,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         select_location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
         let (module_name, constructor) = {
-            let (_, module) = self
+            let module = self
                 .environment
                 .imported_modules
                 .get(module_alias)
@@ -1304,7 +1304,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                 .environment
                 .importable_modules
                 .get(&module.join("/"))
-                .and_then(|(_, module)| module.accessors.get(name)),
+                .and_then(|module| module.accessors.get(name)),
 
             _something_without_fields => return Err(unknown_field(vec![])),
         }
@@ -1512,8 +1512,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                             .keys()
                             .map(|t| t.to_string())
                             .collect(),
-                    })?
-                    .1;
+                    })?;
                 module
                     .values
                     .get(name)
@@ -1650,7 +1649,6 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                             .imported_modules
                             .get(module_name)
                             .gleam_expect("Failed to find previously located module import")
-                            .1
                             .name
                             .clone(),
                         typ: constructor.type_.clone(),

--- a/src/type_/prelude.rs
+++ b/src/type_/prelude.rs
@@ -1,3 +1,5 @@
+use crate::build::Origin;
+
 use super::{Module, Type, TypeConstructor, TypeVar, ValueConstructor, ValueConstructorVariant};
 use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
@@ -125,6 +127,8 @@ pub fn build_prelude(uid: &mut usize) -> Module {
 
     let mut prelude = Module {
         name: vec!["gleam".to_string()],
+        package: "".to_string(),
+        origin: Origin::Src,
         types: HashMap::new(),
         values: HashMap::new(),
         accessors: HashMap::new(),

--- a/src/type_/test_helpers.rs
+++ b/src/type_/test_helpers.rs
@@ -15,7 +15,7 @@ pub fn env_types() -> Vec<String> {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
+    let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
     Environment::new(&mut 0, &[], &modules, &mut vec![])
         .module_types
         .keys()
@@ -38,7 +38,7 @@ pub fn env_vars() -> Vec<String> {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
+    let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
     Environment::new(&mut 0, &[], &modules, &mut vec![])
         .local_values
         .keys()

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -17,7 +17,7 @@ macro_rules! assert_infer {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
         let result = ExprTyper::new(&mut Environment::new(&mut uid, &[], &modules, &mut vec![]))
             .infer(ast)
             .expect("should successfully infer");
@@ -38,9 +38,16 @@ macro_rules! assert_module_error {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
-        let ast =
-            infer_module(&mut uid, ast, &modules, &mut vec![]).expect_err("should infer an error");
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
+        let ast = infer_module(
+            &mut uid,
+            ast,
+            Origin::Src,
+            "thepackage",
+            &modules,
+            &mut vec![],
+        )
+        .expect_err("should infer an error");
         assert_eq!(($src, sort_options($error)), ($src, sort_options(ast)));
     };
 
@@ -52,9 +59,16 @@ macro_rules! assert_module_error {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
-        let _ =
-            infer_module(&mut uid, ast, &modules, &mut vec![]).expect_err("should infer an error");
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
+        let _ = infer_module(
+            &mut uid,
+            ast,
+            Origin::Src,
+            "thepackage",
+            &modules,
+            &mut vec![],
+        )
+        .expect_err("should infer an error");
     };
 }
 
@@ -67,7 +81,7 @@ macro_rules! assert_error {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
         println!("new assert_error test: {}", modules.len());
         let result = ExprTyper::new(&mut Environment::new(
             &mut uid,
@@ -91,9 +105,16 @@ macro_rules! assert_module_infer {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
-        let ast =
-            infer_module(&mut uid, ast, &modules, &mut vec![]).expect("should successfully infer");
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
+        let ast = infer_module(
+            &mut uid,
+            ast,
+            Origin::Src,
+            "thepackage",
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
         let constructors: Vec<(_, _)> = ast
             .type_info
             .values
@@ -123,9 +144,16 @@ macro_rules! assert_warning {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
-        let _ = infer_module(&mut uid, ast, &modules, &mut warnings)
-            .expect("should successfully infer");
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
+        let _ = infer_module(
+            &mut uid,
+            ast,
+            Origin::Src,
+            "thepackage",
+            &modules,
+            &mut warnings,
+        )
+        .expect("should successfully infer");
 
         assert!(!warnings.is_empty());
         assert_eq!($warning, warnings[0]);
@@ -144,9 +172,16 @@ macro_rules! assert_no_warnings {
         // TODO: Currently we do this here and also in the tests. It would be better
         // to have one place where we create all this required state for use in each
         // place.
-        let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
-        let _ = infer_module(&mut uid, ast, &modules, &mut warnings)
-            .expect("should successfully infer");
+        let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
+        let _ = infer_module(
+            &mut uid,
+            ast,
+            Origin::Src,
+            "thepackage",
+            &modules,
+            &mut warnings,
+        )
+        .expect("should successfully infer");
 
         assert_eq!(expected, warnings);
     };
@@ -286,12 +321,22 @@ fn infer_module_type_retention_test() {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".to_string(), (Origin::Src, build_prelude(&mut uid)));
-    let module = infer_module(&mut uid, module, &modules, &mut vec![]).expect("Should infer OK");
+    let _ = modules.insert("gleam".to_string(), build_prelude(&mut uid));
+    let module = infer_module(
+        &mut uid,
+        module,
+        Origin::Src,
+        "thepackage",
+        &modules,
+        &mut vec![],
+    )
+    .expect("Should infer OK");
 
     assert_eq!(
         module.type_info,
         Module {
+            origin: Origin::Src,
+            package: "thepackage".to_string(),
             name: vec!["ok".to_string()],
             types: HashMap::new(), // Core type constructors like String and Int are not included
             values: HashMap::new(),

--- a/test/language/src/test.gleam
+++ b/test/language/src/test.gleam
@@ -23,17 +23,8 @@ pub opaque type Pass {
   Pass
 }
 
-external type Dynamic
-
-external fn erase(a) -> Dynamic =
-  "test" "identity"
-
-pub fn identity(a) {
-  a
-}
-
 pub opaque type Fail {
-  Fail(expected: Dynamic, got: Dynamic)
+  Fail
 }
 
 pub type Outcome =
@@ -46,7 +37,8 @@ pub fn pass() -> Outcome {
 pub fn assert_equal(expected: a, got: a) -> Outcome {
   case expected == got {
     True -> pass()
-    False -> Error(Fail(expected: erase(expected), got: erase(got)))
+    // TODO: print diff on failure
+    False -> Error(Fail)
   }
 }
 
@@ -131,21 +123,21 @@ fn run_single_test(name, proc, fns, stats, indentation) {
       fns.print("✨")
       Stats(..stats, passes: stats.passes + 1)
     }
-    Error(Fail(expected: expected, got: got)) -> {
+    Error(Fail) -> {
       fns.print("❌")
       fns.print("\n\n")
       print_indentation(fns, indentation)
       fns.print(name)
       fns.print(" test failed!")
       fns.print("\n")
-      print_indentation(fns, indentation)
-      fns.print("expected: ")
-      fns.print(fns.to_string(expected))
-      fns.print("\n")
-      print_indentation(fns, indentation)
-      fns.print("     got: ")
-      fns.print(fns.to_string(got))
-      fns.print("\n")
+      // print_indentation(fns, indentation)
+      // fns.print("expected: ")
+      // fns.print(fns.to_string(expected))
+      // fns.print("\n")
+      // print_indentation(fns, indentation)
+      // fns.print("     got: ")
+      // fns.print(fns.to_string(got))
+      // fns.print("\n")
       Stats(..stats, failures: stats.failures + 1)
     }
   }


### PR DESCRIPTION
Ref #1118 

Given some import:

```
import lib/http.{Request, my_val, my_val}
```
When compiling:
```
error: Duplicate import with name `my_val`
  ┌─ /Users/christian/myproyect/src/myproyect.gleam:1:35
  │
1 │ import lib/some.{Request, my_val, my_val}
  │                           ------  ^^^^^^ redefined here
  │                           │
  │                           previously defined here
```
