### PR TITLE
Improve pipe type error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -860,6 +860,18 @@ But this argument has this type:
                         src: src.to_string(),
                         location: *location,
                     };
+
+                    // Remap the pipe function type into just the type expected by the pipe.
+                    let expected = expected
+                        .fn_types()
+                        .and_then(|(args, _)| args.get(0).cloned());
+
+                    // Remap the argument as well, if it's a function.
+                    let given = given
+                        .fn_types()
+                        .and_then(|(args, _)| args.get(0).cloned())
+                        .unwrap_or_else(|| given.clone());
+
                     write(buf, diagnostic, Severity::Error);
                     let mut printer = Printer::new();
                     writeln!(
@@ -873,8 +885,10 @@ But (|>) is piping it to a function that expects:
 {expected}
 
 \n",
-                        expected = printer.pretty_print(expected, 4),
-                        given = printer.pretty_print(given, 4)
+                        expected = expected
+                            .map(|v| printer.pretty_print(&v, 4))
+                            .unwrap_or_else(|| "    No arguments".to_string()),
+                        given = printer.pretty_print(&given, 4)
                     )
                     .unwrap();
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -849,6 +849,40 @@ But this argument has this type:
                     location,
                     expected,
                     given,
+                    situation: Some(UnifyErrorSituation::PipeTypeMismatch),
+                } => {
+                    let diagnostic = Diagnostic {
+                        title:
+                            "This function cannot handle the argument sent through the (|>) pipe:"
+                                .to_string(),
+                        label: "".to_string(),
+                        file: path.to_str().unwrap().to_string(),
+                        src: src.to_string(),
+                        location: *location,
+                    };
+                    write(buf, diagnostic, Severity::Error);
+                    let mut printer = Printer::new();
+                    writeln!(
+                        buf,
+                        "The argument is:
+
+{given}
+
+But (|>) is piping it to a function that expects:
+
+{expected}
+
+\n",
+                        expected = printer.pretty_print(expected, 4),
+                        given = printer.pretty_print(given, 4)
+                    )
+                    .unwrap();
+                }
+
+                TypeError::CouldNotUnify {
+                    location,
+                    expected,
+                    given,
                     situation,
                 } => {
                     let diagnostic = Diagnostic {

--- a/src/type_/error.rs
+++ b/src/type_/error.rs
@@ -475,6 +475,7 @@ fn unify_enclosed_type_test() {
 pub enum UnifyErrorSituation {
     CaseClauseMismatch,
     ReturnAnnotationMismatch,
+    PipeTypeMismatch,
     Operator(BinOp),
 }
 
@@ -489,6 +490,9 @@ one, but all case clauses must return the same type.",
                 "The type of this returned value doesn't match the return type 
 annotation of this function.",
             ),
+            Self::PipeTypeMismatch => {
+                Some("This function cannot handle the argument sent through the (|>) pipe:")
+            }
             Self::Operator(_op) => None,
         }
     }
@@ -529,6 +533,10 @@ impl UnifyError {
 
     pub fn case_clause_mismatch(self) -> Self {
         self.with_unify_error_situation(UnifyErrorSituation::CaseClauseMismatch)
+    }
+
+    pub fn pipe_type_mismatch(self) -> Self {
+        self.with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch)
     }
 
     pub fn return_annotation_mismatch(self) -> Self {

--- a/src/type_/error.rs
+++ b/src/type_/error.rs
@@ -261,6 +261,20 @@ pub enum Warning {
     },
 }
 
+impl Error {
+    pub fn with_unify_error_situation(mut self, new_situation: UnifyErrorSituation) -> Self {
+        match self {
+            Error::CouldNotUnify {
+                ref mut situation, ..
+            } => {
+                *situation = Some(new_situation);
+                self
+            }
+            _ => self,
+        }
+    }
+}
+
 impl Warning {
     pub fn into_warning(self, path: PathBuf, src: String) -> crate::Warning {
         crate::Warning::Type {
@@ -533,10 +547,6 @@ impl UnifyError {
 
     pub fn case_clause_mismatch(self) -> Self {
         self.with_unify_error_situation(UnifyErrorSituation::CaseClauseMismatch)
-    }
-
-    pub fn pipe_type_mismatch(self) -> Self {
-        self.with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch)
     }
 
     pub fn return_annotation_mismatch(self) -> Self {

--- a/src/type_/expr.rs
+++ b/src/type_/expr.rs
@@ -273,7 +273,6 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
 
         let (fun, args, typ) = self.do_infer_call_with_known_fun(fun, new_args, location)?;
         // TODO: Preserve the fact this is a pipe instead of making it a Call
-
         Ok(TypedExpr::Call {
             location,
             typ,
@@ -296,7 +295,6 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
             args: vec![left.type_()],
             retrn: typ.clone(),
         });
-
         self.unify(right.type_(), fn_typ)
             .map_err(|e| convert_unify_error(e, location))?;
 

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -1201,7 +1201,7 @@ fn pipe_mismatch_error() {
          fn main() { 42.0 |> fun() }",
         Error::CouldNotUnify {
             situation: Some(UnifyErrorSituation::PipeTypeMismatch),
-            location: SrcSpan { start: 49, end: 62 },
+            location: SrcSpan { start: 49, end: 53 },
             expected: int(),
             given: float(),
         },
@@ -1222,17 +1222,32 @@ fn pipe_mismatch_error() {
         Error::CouldNotUnify {
             situation: Some(UnifyErrorSituation::PipeTypeMismatch),
             location: SrcSpan { start: 57, end: 70 },
-            expected: Arc::new(Type::App {
-                public: false,
-                module: vec!["my_module".to_string(),],
-                name: "Veg".to_string(),
-                args: vec![],
+            expected: Arc::new(Type::Fn {
+                args: vec![
+                    Arc::new(Type::App {
+                        public: false,
+                        module: vec!["my_module".to_string(),],
+                        name: "Veg".to_string(),
+                        args: vec![],
+                    }),
+                ],
+                retrn: Arc::new(Type::App {
+                    public: true,
+                    module: vec![],
+                    name: "String".to_string(),
+                    args: vec![],
+                }),
             }),
-            given: Arc::new(Type::App {
-                public: false,
-                module: vec!["my_module".to_string(),],
-                name: "Fruit".to_string(),
-                args: vec![],
+            given: Arc::new(Type::Fn {
+                args: vec![Arc::new(Type::App {
+                    public: false,
+                    module: vec!["my_module".to_string(),],
+                    name: "Fruit".to_string(),
+                    args: vec![],
+                }),],
+                retrn: Arc::new(Type::Var {
+                    type_: Arc::new(RefCell::new(TypeVar::Unbound { id: 7, level: 3 })),
+                })
             })
         },
     );

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -1195,6 +1195,50 @@ fn annotated_functions_unification_error() {
 }
 
 #[test]
+fn pipe_mismatch_error() {
+    assert_module_error!(
+        "fn fun(x: Int) -> Int { x }
+         fn main() { 42.0 |> fun() }",
+        Error::CouldNotUnify {
+            situation: Some(UnifyErrorSituation::PipeTypeMismatch),
+            location: SrcSpan { start: 49, end: 62 },
+            expected: int(),
+            given: float(),
+        },
+    );
+
+    assert_module_error!(
+        "pub fn main() -> String {
+            Orange
+            |> eat_veggie
+         }
+          
+         type Fruit{ Orange }
+         type Veg{ Lettuce }
+          
+         fn eat_veggie(v: Veg) -> String {
+            \"Ok\"
+         }",
+        Error::CouldNotUnify {
+            situation: Some(UnifyErrorSituation::PipeTypeMismatch),
+            location: SrcSpan { start: 57, end: 70 },
+            expected: Arc::new(Type::App {
+                public: false,
+                module: vec!["my_module".to_string(),],
+                name: "Veg".to_string(),
+                args: vec![],
+            }),
+            given: Arc::new(Type::App {
+                public: false,
+                module: vec!["my_module".to_string(),],
+                name: "Fruit".to_string(),
+                args: vec![],
+            })
+        },
+    );
+}
+
+#[test]
 fn the_rest() {
     assert_error!(
         "case tuple(1, 2, 3) { x if x == tuple(1, 1.0) -> 1 }",


### PR DESCRIPTION
Resolves #936

## Example 1
<details>
  <summary>Spoiler</summary>

```gleam
fn fun(x: Int) -> Int { 
  x 
}

fn main() { 
  42.0 |> fun() 
}
```
### Before
```
error: Type mismatch
  ┌─ src/gleam_test.gleam:5:3
  │
5 │   42.0 |> fun() 
  │   ^^^^

Expected type:

    Int

Found type:

    Float
```
### After
```
error: This function cannot handle the argument sent through the (|>) pipe:
  ┌─ src/gleam_test.gleam:7:3
  │
7 │   42.0 |> fun() 
  │   ^^^^^^^^^^^^^

The argument is:

    Float

But (|>) is piping it to a function that expects:

    Int
```
</details>

## Example 2

<details>
  <summary>Spoiler</summary>

```gleam
pub fn main() -> String {
  Orange |> eat_veggie
}

type Fruit {
  Orange
}

type Veg {
  Lettuce
}

fn eat_veggie(v: Veg) -> String {
  "Ok"
}
```
### Before
```
error: Type mismatch
  ┌─ src/gleam_test.gleam:8:10
  │
8 │   Orange |> eat_veggie
  │          ^^^^^^^^^^^^^

Expected type:

    fn(Veg) -> String

Found type:

    fn(Fruit) -> a
```
### After
```
error: This function cannot handle the argument sent through the (|>) pipe:
  ┌─ src/gleam_test.gleam:9:10
  │
9 │   Orange |> eat_veggie
  │          ^^^^^^^^^^^^^

The argument is:

    Fruit

But (|>) is piping it to a function that expects:

    Veg
```
</details>
