### PR TITLE
WIP: unify generic variables

### DIFF
--- a/src/type_.rs
+++ b/src/type_.rs
@@ -330,6 +330,10 @@ impl TypeVar {
         matches!(self, Self::Unbound { .. })
     }
 
+    pub fn is_generic(&self) -> bool {
+        matches!(self, Self::Generic { .. })
+    }
+
     pub fn is_nil(&self) -> bool {
         match self {
             Self::Link { type_ } => type_.is_nil(),

--- a/src/type_/environment.rs
+++ b/src/type_/environment.rs
@@ -388,7 +388,7 @@ impl<'a, 'b> Environment<'a, 'b> {
 
                 TypeVar::Generic { id } => {
                     if let Type::Var { type_: typ } = t2.deref() {
-                        if typ.borrow().is_unbound() {
+                        if typ.borrow().is_unbound() || typ.borrow().is_generic() {
                             *typ.borrow_mut() = TypeVar::Generic { id: *id };
                             return Ok(());
                         }

--- a/src/type_/tests.rs
+++ b/src/type_/tests.rs
@@ -2795,40 +2795,40 @@ fn main() {
     );
 
     // Type variables are shared between function annotations and let annotations within their body
-    assert_module_error!(
-        "
-        pub type Box(a) {
-            Box(value: a)
-        }
-        pub fn go(box1: Box(a), box2: Box(b)) {
-            let _: Box(a) = box2
-            let _: Box(b) = box1
-            5
-        }",
-        Error::CouldNotUnify {
-            situation: None,
-            location: SrcSpan {
-                start: 139,
-                end: 143
-            },
-            expected: Arc::new(Type::App {
-                public: true,
-                module: vec!["my_module".to_string()],
-                name: "Box".to_string(),
-                args: vec![Arc::new(Type::Var {
-                    type_: Arc::new(RefCell::new(TypeVar::Generic { id: 8 })),
-                })]
-            }),
-            given: Arc::new(Type::App {
-                public: true,
-                module: vec!["my_module".to_string()],
-                name: "Box".to_string(),
-                args: vec![Arc::new(Type::Var {
-                    type_: Arc::new(RefCell::new(TypeVar::Generic { id: 10 })),
-                })]
-            }),
-        },
-    );
+    // assert_module_error!(
+    //     "
+    //     pub type Box(a) {
+    //         Box(value: a)
+    //     }
+    //     pub fn go(box1: Box(a), box2: Box(b)) {
+    //         let _: Box(a) = box2
+    //         let _: Box(b) = box1
+    //         5
+    //     }",
+    //     Error::CouldNotUnify {
+    //         situation: None,
+    //         location: SrcSpan {
+    //             start: 139,
+    //             end: 143
+    //         },
+    //         expected: Arc::new(Type::App {
+    //             public: true,
+    //             module: vec!["my_module".to_string()],
+    //             name: "Box".to_string(),
+    //             args: vec![Arc::new(Type::Var {
+    //                 type_: Arc::new(RefCell::new(TypeVar::Generic { id: 8 })),
+    //             })]
+    //         }),
+    //         given: Arc::new(Type::App {
+    //             public: true,
+    //             module: vec!["my_module".to_string()],
+    //             name: "Box".to_string(),
+    //             args: vec![Arc::new(Type::Var {
+    //                 type_: Arc::new(RefCell::new(TypeVar::Generic { id: 10 })),
+    //             })]
+    //         }),
+    //     },
+    // );
 }
 
 #[test]
@@ -3276,28 +3276,28 @@ fn module_update() {
     );
 
     // A record update on polymorphic types with generic fields of the wrong type
-    assert_module_error!(
-        "
-        pub type Box(a) {
-            Box(value: a, i: Int)
-        };
-        pub fn update_box(box: Box(a), value: b) {
-            Box(..box, value: value)
-        };",
-        Error::CouldNotUnify {
-            situation: None,
-            location: SrcSpan {
-                start: 153,
-                end: 158,
-            },
-            expected: Arc::new(Type::Var {
-                type_: Arc::new(RefCell::new(TypeVar::Generic { id: 8 })),
-            }),
-            given: Arc::new(Type::Var {
-                type_: Arc::new(RefCell::new(TypeVar::Generic { id: 10 })),
-            }),
-        },
-    );
+    // assert_module_error!(
+    //     "
+    //     pub type Box(a) {
+    //         Box(value: a, i: Int)
+    //     };
+    //     pub fn update_box(box: Box(a), value: b) {
+    //         Box(..box, value: value)
+    //     };",
+    //     Error::CouldNotUnify {
+    //         situation: None,
+    //         location: SrcSpan {
+    //             start: 153,
+    //             end: 158,
+    //         },
+    //         expected: Arc::new(Type::Var {
+    //             type_: Arc::new(RefCell::new(TypeVar::Generic { id: 8 })),
+    //         }),
+    //         given: Arc::new(Type::Var {
+    //             type_: Arc::new(RefCell::new(TypeVar::Generic { id: 10 })),
+    //         }),
+    //     },
+    // );
 }
 
 #[test]


### PR DESCRIPTION
Attempt to close #1096

It seems like currently gleam does not attempt to unify unbound generic variables against each other, resulting in the compiler being unable to compile certain cases without explicit type annotation, see #1096 for more detail.

The attempted fix is to unify generic variables against each other, by assigning them to the same id.

This has caused some of the tests involving generics to break, but I believe they are false negatives. Instead of inferring `CouldNotUnify` for these tests, with this change the compiler only gives out actual type error only where the generics are instantiated with incompatible types.

Examples taken from the tests (I have commented out the tests for the time being):

<details>
<summary>Example 1</summary>
<p>
```gleam
pub type Box(a) {
  Box(value: a)
}

pub fn go(box1: Box(a), box2: Box(b)) {
  let _: Box(a) = box2
  let _: Box(b) = box1
  5
}

pub fn no_error() {
  go(Box(1), Box(2)) // a and b are of type Int, no error
}

pub fn error() {
  go(Box(1), Box("2") // Error: Expected type: Box(Int), Found type: Box(String)
}
```
</p>
</details>

<details>
<summary>Example 2</summary>
<p>
```gleam
pub type Box(a) {
  Box(value: a, i: Int)
}

pub fn update_box(box: Box(a), value: b) {
  Box(..box, value: value)
}

pub fn no_error() {
  update_box(Box(1.0, i: 1), 2.0) // a and b are of type Float, no error
}

pub fn error() {
  update_box(Box(1.0 i:1), 2) // Error: Expected type: Float, Found type: Int
}
```
</p>
</details>

If this approach is ok I would have to update and add new tests. I could be completely wrong any advice would be appreciated.
