### PR TITLE
Render custom type constructor argument docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Argument docs for custom type constructors is now rendered in the HTML documentation.
 - Gleam compiler now is catching values which are being imported more than once 
   in an unqualified fashion, this will raise a compile time error. 
 - Gleam can now compile Gleam projects without an external build tool.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -134,6 +134,13 @@ pub struct RecordConstructorArg<T> {
     pub ast: TypeAst,
     pub location: SrcSpan,
     pub type_: T,
+    pub doc: Option<String>,
+}
+
+impl<T> RecordConstructorArg<T> {
+    pub fn put_doc(&mut self, new_doc: String) {
+        self.doc = Some(new_doc);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -286,9 +286,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedStatement) -> Opti
                     arguments: constructor
                         .arguments
                         .iter()
-                        .filter_map(|arg| {
-                            arg.label.clone().map(|label| (arg, label))
-                        })
+                        .filter_map(|arg| arg.label.clone().map(|label| (arg, label)))
                         .map(|(argument, label)| TypeConstructorArg {
                             name: label.trim_end().to_string(),
                             doc: markdown_documentation(&argument.doc),

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -287,11 +287,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedStatement) -> Opti
                         .arguments
                         .iter()
                         .filter_map(|arg| {
-                            if let Some(label) = arg.label.clone() {
-                                Some((arg, label))
-                            } else {
-                                None
-                            }
+                            arg.label.clone().map(|label| (arg, label))
                         })
                         .map(|(argument, label)| TypeConstructorArg {
                             name: label.trim_end().to_string(),

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -198,6 +198,7 @@ fn function<'a>(
     statement: &'a TypedStatement,
 ) -> Option<Function<'a>> {
     let mut formatter = format::Formatter::new();
+
     match statement {
         Statement::ExternalFn {
             public: true,
@@ -246,6 +247,7 @@ fn render_markdown(text: &str) -> String {
 
 fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedStatement) -> Option<Type<'a>> {
     let mut formatter = format::Formatter::new();
+
     match statement {
         Statement::ExternalType {
             public: true,
@@ -281,6 +283,22 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedStatement) -> Opti
                 .map(|constructor| TypeConstructor {
                     definition: print(formatter.record_constructor(constructor)),
                     documentation: markdown_documentation(&constructor.documentation),
+                    arguments: constructor
+                        .arguments
+                        .iter()
+                        .filter_map(|arg| {
+                            if let Some(label) = arg.label.clone() {
+                                Some((arg, label))
+                            } else {
+                                None
+                            }
+                        })
+                        .map(|(argument, label)| TypeConstructorArg {
+                            name: label.trim_end().to_string(),
+                            doc: markdown_documentation(&argument.doc),
+                        })
+                        .filter(|arg| !arg.doc.is_empty())
+                        .collect(),
                 })
                 .collect(),
             source_url: source_links.url(location),
@@ -368,6 +386,13 @@ struct Function<'a> {
 struct TypeConstructor {
     definition: String,
     documentation: String,
+    arguments: Vec<TypeConstructorArg>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct TypeConstructorArg {
+    name: String,
+    doc: String,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]

--- a/src/erl.rs
+++ b/src/erl.rs
@@ -153,6 +153,7 @@ pub fn records(module: &TypedModule) -> Vec<(&str, String)> {
                          ast: _,
                          location: _,
                          type_,
+                         ..
                      }| {
                         label.as_deref().map(|label| (label, type_.clone()))
                     },

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1533,6 +1533,7 @@ where
                                 ast: type_ast,
                                 location: SrcSpan { start, end },
                                 type_: (),
+                                doc: None,
                             })),
                             None => {
                                 parse_error(ParseErrorType::ExpectedType, SrcSpan { start, end })
@@ -1550,6 +1551,7 @@ where
                                     ast: type_ast,
                                     location: type_location,
                                     type_: (),
+                                    doc: None,
                                 }))
                             }
                             None => Ok(None),

--- a/src/project.rs
+++ b/src/project.rs
@@ -66,6 +66,15 @@ impl Analysed {
                         let doc = docs.join("\n");
                         constructor.put_doc(doc);
                     }
+
+                    for argument in constructor.arguments.iter_mut() {
+                        let docs: Vec<&str> =
+                            comments_before(&mut doc_comments, argument.location.start, &self.src);
+                        if !docs.is_empty() {
+                            let doc = docs.join("\n");
+                            argument.put_doc(doc);
+                        }
+                    }
                 }
             }
         }

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -1083,6 +1083,7 @@ fn infer_statement(
                                             ast,
                                             location,
                                             type_: t.clone(),
+                                            doc: None,
                                         }
                                     },
                                 )

--- a/templates/documentation_module.html
+++ b/templates/documentation_module.html
@@ -67,9 +67,35 @@
       <ul class="constructor-list">
         {% for constructor in typ.constructors %}
         <li class="constructor-item">
-          <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-          <pre class="constructor-name"><code class="hljs gleam">{{ constructor.definition }}</code></pre>
-          {{ constructor.documentation|safe }}
+          <div class="constructor-row">
+            <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
+            <pre class="constructor-name"><code class="hljs gleam">{{ constructor.definition }}</code></pre>
+          </div>
+
+          <div class="constructor-item-docs">
+            {{ constructor.documentation|safe }}
+
+            {% if !constructor.arguments.is_empty() %}
+            <h4>
+              Arguments
+            </h4>
+
+            <ul class="constructor-argument-list">
+            {% for argument in constructor.arguments %}
+              <li>
+                <div class="constructor-argument-item">
+                  <p class="constructor-argument-label">
+                    <i>{{ argument.name }}</i>
+                  </p>
+                  <div class="constructor-argument-doc">
+                    {{ argument.doc|safe }}
+                  </div>
+                </div>
+              </li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+          </div>
         </li>
         {% endfor %}
       </ul>

--- a/templates/index.css
+++ b/templates/index.css
@@ -399,9 +399,34 @@ body.drawer-open .label-closed {
   padding: 0;
 }
 
-.constructor-item {
+.constructor-row {
   align-items: center;
   display: flex;
+}
+
+.constructor-item {
+  margin-bottom: var(--small-gap);
+}
+
+.constructor-argument-item {
+  display: flex;
+}
+
+.constructor-argument-label {
+  flex-shrink: 0;
+}
+
+.constructor-argument-doc {
+  margin-left: var(--gap);
+}
+
+.constructor-argument-list {
+  margin-bottom: var(--small-gap);
+}
+
+.constructor-item-docs {
+  margin-left: var(--large-gap);
+  margin-bottom: var(--gap);
 }
 
 .constructor-item .icon {


### PR DESCRIPTION
Resolves  #697

## Description
Renders custom type constructor argument docs as a bulleted list under an arguments header if at least one doc exists for the arguments that is not empty.

## Source
```
/// Thing comment
pub type Thing {
  /// Thing
  ///
  /// Lorem markdownum occupat maius [fugacibus](http://www.inplevi.io/nil.html).
  /// Tulit aperit vivacem, Seriphon gurgite, medio que Alba illi.
  WithAllDocs(
    /// One is the loneliest number
    one: Int,
    /// Two is better than one
    two: Int,
  )
  WithoutDocs(one: Int, two: Int)
  /// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur varius sem a nulla aliquet, nec lobortis libero venenatis. Donec nec lorem non leo euismod mollis. Nulla et blandit orci. Duis ex enim, viverra sed rhoncus id, iaculis sit amet dolor. Proin elementum nisl augue, eget aliquam metus posuere eget. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed non risus ligula. Nulla odio risus, sollicitudin id dapibus nec, euismod at metus. Fusce congue efficitur risus.
  OnlyOneArgDocumented(
    one: Int,
    /// Tulit aperit vivacem, Seriphon gurgite, medio que Alba illi.
    two: Int,
  )
}

```

## Output
![Screenshot](https://user-images.githubusercontent.com/3239951/121286324-a8b0f980-c8ad-11eb-965a-a469a668fc71.png)
