### PR TITLE
Refactor for new Rust version

### DIFF
--- a/src/bit_string.rs
+++ b/src/bit_string.rs
@@ -1,5 +1,4 @@
-use crate::ast::BitStringSegmentOption::{self, *};
-use crate::ast::SrcSpan;
+use crate::ast::{BitStringSegmentOption, SrcSpan};
 use crate::type_::Type;
 use std::sync::Arc;
 
@@ -40,6 +39,8 @@ impl<T> SegmentOptionCategories<'_, T> {
     }
 
     fn segment_type(&self) -> Arc<Type> {
+        use BitStringSegmentOption::*;
+
         match self.typ {
             Some(Int { .. }) => crate::type_::int(),
             Some(Float { .. }) => crate::type_::float(),
@@ -64,6 +65,8 @@ fn type_options<T>(
     value_mode: bool,
     must_have_size: bool,
 ) -> Result<Arc<Type>, Error> {
+    use BitStringSegmentOption::*;
+
     let mut categories = SegmentOptionCategories::new();
     // Basic category checking
     for option in input_options {
@@ -245,6 +248,8 @@ fn type_options<T>(
 }
 
 fn is_unicode<T>(opt: &BitStringSegmentOption<T>) -> bool {
+    use BitStringSegmentOption::*;
+
     matches!(
         opt,
         Utf8 { .. }

--- a/src/bit_string.rs
+++ b/src/bit_string.rs
@@ -1,4 +1,5 @@
-use crate::ast::{BitStringSegmentOption, SrcSpan};
+use crate::ast::BitStringSegmentOption::{self, *};
+use crate::ast::SrcSpan;
 use crate::type_::Type;
 use std::sync::Arc;
 
@@ -40,18 +41,18 @@ impl<T> SegmentOptionCategories<'_, T> {
 
     fn segment_type(&self) -> Arc<Type> {
         match self.typ {
-            Some(BitStringSegmentOption::Int { .. }) => crate::type_::int(),
-            Some(BitStringSegmentOption::Float { .. }) => crate::type_::float(),
-            Some(BitStringSegmentOption::Binary { .. }) => crate::type_::bit_string(),
-            Some(BitStringSegmentOption::BitString { .. }) => crate::type_::bit_string(),
-            Some(BitStringSegmentOption::Utf8 { .. }) => crate::type_::string(),
-            Some(BitStringSegmentOption::Utf16 { .. }) => crate::type_::string(),
-            Some(BitStringSegmentOption::Utf32 { .. }) => crate::type_::string(),
-            Some(BitStringSegmentOption::Utf8Codepoint { .. }) => crate::type_::utf_codepoint(),
-            Some(BitStringSegmentOption::Utf16Codepoint { .. }) => crate::type_::utf_codepoint(),
-            Some(BitStringSegmentOption::Utf32Codepoint { .. }) => crate::type_::utf_codepoint(),
+            Some(Int { .. }) => crate::type_::int(),
+            Some(Float { .. }) => crate::type_::float(),
+            Some(Binary { .. }) => crate::type_::bit_string(),
+            Some(BitString { .. }) => crate::type_::bit_string(),
+            Some(Utf8 { .. }) => crate::type_::string(),
+            Some(Utf16 { .. }) => crate::type_::string(),
+            Some(Utf32 { .. }) => crate::type_::string(),
+            Some(Utf8Codepoint { .. }) => crate::type_::utf_codepoint(),
+            Some(Utf16Codepoint { .. }) => crate::type_::utf_codepoint(),
+            Some(Utf32Codepoint { .. }) => crate::type_::utf_codepoint(),
             None => crate::type_::int(),
-            Some(_) => crate::error::fatal_compiler_bug(
+            _ => crate::error::fatal_compiler_bug(
                 "Tried to type a non type kind BitString segment option.",
             ),
         }
@@ -67,16 +68,16 @@ fn type_options<T>(
     // Basic category checking
     for option in input_options {
         match option {
-            BitStringSegmentOption::Binary { .. }
-            | BitStringSegmentOption::Int { .. }
-            | BitStringSegmentOption::Float { .. }
-            | BitStringSegmentOption::BitString { .. }
-            | BitStringSegmentOption::Utf8 { .. }
-            | BitStringSegmentOption::Utf16 { .. }
-            | BitStringSegmentOption::Utf32 { .. }
-            | BitStringSegmentOption::Utf8Codepoint { .. }
-            | BitStringSegmentOption::Utf16Codepoint { .. }
-            | BitStringSegmentOption::Utf32Codepoint { .. } => {
+            Binary { .. }
+            | Int { .. }
+            | Float { .. }
+            | BitString { .. }
+            | Utf8 { .. }
+            | Utf16 { .. }
+            | Utf32 { .. }
+            | Utf8Codepoint { .. }
+            | Utf16Codepoint { .. }
+            | Utf32Codepoint { .. } => {
                 if let Some(previous) = categories.typ {
                     return err(
                         ErrorType::ConflictingTypeOptions {
@@ -88,7 +89,8 @@ fn type_options<T>(
                     categories.typ = Some(option);
                 }
             }
-            BitStringSegmentOption::Signed { .. } | BitStringSegmentOption::Unsigned { .. } => {
+
+            Signed { .. } | Unsigned { .. } => {
                 if let Some(previous) = categories.signed {
                     return err(
                         ErrorType::ConflictingSignednessOptions {
@@ -100,9 +102,8 @@ fn type_options<T>(
                     categories.signed = Some(option);
                 }
             }
-            BitStringSegmentOption::Big { .. }
-            | BitStringSegmentOption::Little { .. }
-            | BitStringSegmentOption::Native { .. } => {
+
+            Big { .. } | Little { .. } | Native { .. } => {
                 if let Some(previous) = categories.endian {
                     return err(
                         ErrorType::ConflictingEndiannessOptions {
@@ -115,7 +116,7 @@ fn type_options<T>(
                 }
             }
 
-            BitStringSegmentOption::Size { .. } => {
+            Size { .. } => {
                 if categories.size.is_some() {
                     return err(ErrorType::ConflictingSizeOptions, option.location());
                 } else {
@@ -123,7 +124,7 @@ fn type_options<T>(
                 }
             }
 
-            BitStringSegmentOption::Unit { .. } => {
+            Unit { .. } => {
                 if categories.unit.is_some() {
                     return err(ErrorType::ConflictingUnitOptions, option.location());
                 } else {
@@ -135,58 +136,65 @@ fn type_options<T>(
 
     // Some options are not allowed in value mode
     if value_mode {
-        match categories {
-            SegmentOptionCategories {
-                signed: Some(opt), ..
-            }
-            | SegmentOptionCategories {
-                typ: Some(opt @ BitStringSegmentOption::Binary { .. }),
-                ..
-            } => return err(ErrorType::OptionNotAllowedInValue, opt.location()),
-
-            _ => {}
+        if let SegmentOptionCategories {
+            signed: Some(opt), ..
+        }
+        | SegmentOptionCategories {
+            typ: Some(opt @ Binary { .. }),
+            ..
+        } = categories
+        {
+            return err(ErrorType::OptionNotAllowedInValue, opt.location());
         }
     }
 
     // All but the last segment in a pattern must have an exact size
     if must_have_size {
-        match categories.typ {
-            Some(opt @ BitStringSegmentOption::Binary { .. })
-            | Some(opt @ BitStringSegmentOption::BitString { .. }) => {
-                if categories.size.is_none() {
-                    return err(ErrorType::SegmentMustHaveSize, opt.location());
-                }
-            }
-            _ => {}
+        if let SegmentOptionCategories {
+            typ: Some(opt @ (Binary { .. } | BitString { .. })),
+            size: None,
+            ..
+        } = categories
+        {
+            return err(ErrorType::SegmentMustHaveSize, opt.location());
         }
     }
 
     // Endianness is only valid for int, utf6, utf32 and float
-    if let Some(endian) = categories.endian {
-        match categories.typ {
-            None
-            | Some(BitStringSegmentOption::Int { .. })
-            | Some(BitStringSegmentOption::Utf16 { .. })
-            | Some(BitStringSegmentOption::Utf32 { .. })
-            | Some(BitStringSegmentOption::Float { .. }) => {}
+    match categories {
+        SegmentOptionCategories {
+            typ: None | Some(Int { .. } | Utf16 { .. } | Utf32 { .. } | Float { .. }),
+            ..
+        } => {}
 
-            _ => return err(ErrorType::InvalidEndianness, endian.location()),
-        }
-    };
+        SegmentOptionCategories {
+            endian: Some(endian),
+            ..
+        } => return err(ErrorType::InvalidEndianness, endian.location()),
+
+        _ => {}
+    }
 
     // signed and unsigned can only be used with int types
-    match categories.typ {
-        None | Some(BitStringSegmentOption::Int { .. }) => {}
+    match categories {
+        SegmentOptionCategories {
+            typ: None | Some(Int { .. }),
+            ..
+        } => {}
 
-        Some(opt) => {
-            if let Some(sign) = categories.signed {
-                return err(
-                    ErrorType::SignednessUsedOnNonInt { typ: opt.label() },
-                    sign.location(),
-                );
-            }
+        SegmentOptionCategories {
+            typ: Some(opt),
+            signed: Some(sign),
+            ..
+        } => {
+            return err(
+                ErrorType::SignednessUsedOnNonInt { typ: opt.label() },
+                sign.location(),
+            );
         }
-    };
+
+        _ => {}
+    }
 
     // utf8, utf16, utf32 exclude unit and size
     match categories {
@@ -194,40 +202,41 @@ fn type_options<T>(
             typ: Some(typ),
             unit: Some(_),
             ..
-        } => {
-            if is_unicode(typ) {
-                return err(
-                    ErrorType::TypeDoesNotAllowUnit { typ: typ.label() },
-                    typ.location(),
-                );
-            }
+        } if is_unicode(typ) => {
+            return err(
+                ErrorType::TypeDoesNotAllowUnit { typ: typ.label() },
+                typ.location(),
+            );
         }
+
         SegmentOptionCategories {
             typ: Some(typ),
             size: Some(_),
             ..
-        } => {
-            if is_unicode(typ) {
-                return err(
-                    ErrorType::TypeDoesNotAllowSize { typ: typ.label() },
-                    typ.location(),
-                );
-            }
+        } if is_unicode(typ) => {
+            return err(
+                ErrorType::TypeDoesNotAllowSize { typ: typ.label() },
+                typ.location(),
+            );
         }
+
         _ => {}
     }
 
     // if unit specified, size must be specified
-    if let Some(unit) = categories.unit {
-        if categories.size.is_none() {
-            return err(ErrorType::UnitMustHaveSize, unit.location());
-        };
-    };
+    if let SegmentOptionCategories {
+        unit: Some(unit),
+        size: None,
+        ..
+    } = categories
+    {
+        return err(ErrorType::UnitMustHaveSize, unit.location());
+    }
 
     // size cannot be used with float
     match categories {
         SegmentOptionCategories {
-            typ: Some(BitStringSegmentOption::Float { .. }),
+            typ: Some(Float { .. }),
             size: Some(opt),
             ..
         } => err(ErrorType::FloatWithSize, opt.location()),
@@ -238,12 +247,12 @@ fn type_options<T>(
 fn is_unicode<T>(opt: &BitStringSegmentOption<T>) -> bool {
     matches!(
         opt,
-        BitStringSegmentOption::Utf8 { .. }
-            | BitStringSegmentOption::Utf16 { .. }
-            | BitStringSegmentOption::Utf32 { .. }
-            | BitStringSegmentOption::Utf8Codepoint { .. }
-            | BitStringSegmentOption::Utf16Codepoint { .. }
-            | BitStringSegmentOption::Utf32Codepoint { .. }
+        Utf8 { .. }
+            | Utf16 { .. }
+            | Utf32 { .. }
+            | Utf8Codepoint { .. }
+            | Utf16Codepoint { .. }
+            | Utf32Codepoint { .. }
     )
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -338,8 +338,7 @@ where
                 }
             }
             // var lower_name and UpName
-            Some((start, Token::Name { name }, end))
-            | Some((start, Token::UpName { name }, end)) => {
+            Some((start, Token::Name { name } | Token::UpName { name }, end)) => {
                 let _ = self.next_tok();
                 UntypedExpr::Var {
                     location: SrcSpan { start, end },
@@ -360,7 +359,7 @@ where
                     label,
                 }
             }
-            Some((start, Token::Tuple, _)) | Some((start, Token::Hash, _)) => {
+            Some((start, Token::Tuple | Token::Hash, _)) => {
                 let _ = self.next_tok();
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elems =
@@ -753,7 +752,7 @@ where
                     value,
                 }
             }
-            Some((start, Token::Tuple, _)) | Some((start, Token::Hash, _)) => {
+            Some((start, Token::Tuple | Token::Hash, _)) => {
                 let _ = self.next_tok();
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elems = Parser::series_of(self, &Parser::parse_pattern, Some(&Token::Comma))?;
@@ -805,8 +804,7 @@ where
                 let (end, rsqb_e) = self.expect_one(&Token::RightSquare)?;
                 let tail = match tail {
                     // There is a tail and it has a Pattern::Var or Pattern::Discard
-                    Some(Some(pat @ Pattern::Var { .. }))
-                    | Some(Some(pat @ Pattern::Discard { .. })) => Some(pat),
+                    Some(Some(pat @ (Pattern::Var { .. } | Pattern::Discard { .. }))) => Some(pat),
                     // There is a tail and but it has no content, implicit discard
                     Some(Some(pat)) => {
                         return parse_error(ParseErrorType::InvalidTailPattern, pat.location())
@@ -1602,7 +1600,7 @@ where
             }
 
             // Tuple
-            Some((start, Token::Tuple, end)) | Some((start, Token::Hash, end)) => {
+            Some((start, Token::Tuple | Token::Hash, end)) => {
                 let _ = self.next_tok();
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elems = self.parse_types(for_const)?;
@@ -1784,8 +1782,7 @@ where
         loop {
             // parse imports
             match self.tok0.take() {
-                Some((start, Token::Name { name }, end))
-                | Some((start, Token::UpName { name }, end)) => {
+                Some((start, Token::Name { name } | Token::UpName { name }, end)) => {
                     let _ = self.next_tok();
                     let location = SrcSpan { start, end };
                     let mut import = UnqualifiedImport {
@@ -1881,7 +1878,7 @@ where
                 }))
             }
 
-            Some((start, Token::Tuple, _)) | Some((start, Token::Hash, _)) => {
+            Some((start, Token::Tuple | Token::Hash, _)) => {
                 let _ = self.next_tok();
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elements =

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -653,7 +653,7 @@ where
     // Test if a digit is of a certain radix.
     fn is_digit_of_radix(c: Option<char>, radix: u32) -> bool {
         match radix {
-            2 | 8 | 10 | 16 => matches!(c, Some(c) if c.is_digit(radix)),
+            2 | 8 | 10 | 16 => c.filter(|c| c.is_digit(radix)).is_some(),
             other => fatal_compiler_bug(&format!("Radix not implemented: {}", other)),
         }
     }

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -653,10 +653,7 @@ where
     // Test if a digit is of a certain radix.
     fn is_digit_of_radix(c: Option<char>, radix: u32) -> bool {
         match radix {
-            2 => matches!(c, Some('0'..='1')),
-            8 => matches!(c, Some('0'..='7')),
-            10 => matches!(c, Some('0'..='9')),
-            16 => matches!(c, Some('0'..='9') | Some('a'..='f') | Some('A'..='F')),
+            2 | 8 | 10 | 16 => matches!(c, Some(c) if c.is_digit(radix)),
             other => fatal_compiler_bug(&format!("Radix not implemented: {}", other)),
         }
     }

--- a/src/type_/environment.rs
+++ b/src/type_/environment.rs
@@ -485,6 +485,8 @@ impl<'a, 'b> Environment<'a, 'b> {
 
     /// Inserts an entity at the current scope for usage tracking.
     pub fn init_usage(&mut self, name: String, kind: EntityKind, location: SrcSpan) {
+        use EntityKind::*;
+
         match self
             .entity_usages
             .last_mut()
@@ -496,15 +498,15 @@ impl<'a, 'b> Environment<'a, 'b> {
             // TODO: Improve this so that we can tell if an imported overriden
             // type is actually used or not by tracking whether usages apply to
             // the value or type scope
-            Some((EntityKind::ImportedTypeAndConstructor, _, _))
-            | Some((EntityKind::ImportedType, _, _))
-            | Some((EntityKind::PrivateType, _, _)) => {}
+            Some((ImportedType | ImportedTypeAndConstructor | PrivateType, _, _)) => {}
+
             Some((kind, location, false)) => {
                 // an entity was overwritten in the top most scope without being used
                 let mut unused = HashMap::with_capacity(1);
                 let _ = unused.insert(name, (kind, location, false));
                 self.handle_unused(unused);
             }
+
             _ => {}
         }
     }


### PR DESCRIPTION
Highlights:

- nested or-patterns, yay! 😃
- import variants for selected enums that were too verbose to use as `LongEnumName::Variant`