### PR TITLE
Import aliased custom type constructors

### DIFF
--- a/src/build/package_compilation_tests.rs
+++ b/src/build/package_compilation_tests.rs
@@ -829,7 +829,7 @@ make() ->
                 origin: Origin::Src,
                 path: PathBuf::from("/src/two.gleam"),
                 name: "two".to_string(),
-                code: "import one.{Empty as e, id as i} fn make() { i(e) }".to_string(),
+                code: "import one.{Empty as E, id as i} fn make() { i(E) }".to_string(),
             },
         ],
         Ok(vec![
@@ -1208,7 +1208,7 @@ main() ->
                 origin: Origin::Src,
                 path: PathBuf::from("/src/two.gleam"),
                 name: "two".to_string(),
-                code: "import one.{X as e, id as i} fn make() { i(e) }".to_string(),
+                code: "import one.{X as E, id as i} fn make() { i(E) }".to_string(),
             },
         ],
         Ok(vec![

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1784,7 +1784,7 @@ where
         loop {
             // parse imports
             match self.tok0.take() {
-                Some((start, Token::Name { name } | Token::UpName { name }, end)) => {
+                Some((start, Token::Name { name }, end)) => {
                     let _ = self.next_tok();
                     let location = SrcSpan { start, end };
                     let mut import = UnqualifiedImport {
@@ -1794,7 +1794,21 @@ where
                     };
                     if self.maybe_one(&Token::As).is_some() {
                         let (_, as_name, _) = self.expect_name()?;
-                        import.as_name = Some(as_name)
+                        import.as_name = Some(as_name);
+                    }
+                    imports.push(import)
+                }
+                Some((start, Token::UpName { name }, end)) => {
+                    let _ = self.next_tok();
+                    let location = SrcSpan { start, end };
+                    let mut import = UnqualifiedImport {
+                        name,
+                        location,
+                        as_name: None,
+                    };
+                    if self.maybe_one(&Token::As).is_some() {
+                        let (_, as_name, _) = self.expect_upname()?;
+                        import.as_name = Some(as_name);
                     }
                     imports.push(import)
                 }

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -695,7 +695,7 @@ make() ->
                     origin: ModuleOrigin::Src,
                     path: PathBuf::from("/src/two.gleam"),
                     source_base_path: PathBuf::from("/src"),
-                    src: "import one.{Empty as e, id as i} fn make() { i(e) }".to_string(),
+                    src: "import one.{Empty as E, id as i} fn make() { i(E) }".to_string(),
                 },
             ],
             expected: Ok(vec![
@@ -1051,7 +1051,7 @@ main() ->
                     origin: ModuleOrigin::Src,
                     path: PathBuf::from("/src/two.gleam"),
                     source_base_path: PathBuf::from("/src"),
-                    src: "import one.{X as e, id as i} fn make() { i(e) }".to_string(),
+                    src: "import one.{X as E, id as i} fn make() { i(E) }".to_string(),
                 },
             ],
             expected: Ok(vec![


### PR DESCRIPTION
Hi! This should close #1126, allowing aliased imports of custom types :)

In this PR, we split the matching arms of `parse_unqualified_imports` into two branches:
    - the first, deals with patterns that start with a lowercase name, and should allow only lowercase aliases;
    - the second, deals with patterns that start with Uppercase names, here's is where we rely on the previous conditions to ensure that only types will be allowed to be imported with an uppercase name, as the definition is already previously verified.

The logic follows that a `Token::UpName` could be imported as, and only as, a `Token::UpName`; and that a `Token::Name` expects to be aliased as another `Token::Name`.

I added a test to ensure that this is working on the happy path, but I didn't figure out how to write a fail test (i.e. when a functional is imported with an uppercase name -- but I manually tested that this does not work).

> Also, note that this may be a breaking change, as some tests failed by types that were being imported with a lowercase name
