### PR TITLE
add a docker option to the new project command

### DIFF
--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -158,6 +158,13 @@ pub struct NewOptions {
         default_value = "lib"
     )]
     pub template: new::Template,
+
+    #[structopt(
+        long,
+        possible_values = &new::Docker::VARIANTS,
+        case_insensitive = true,
+    )]
+    pub docker: Option<Option<new::Docker>>,
 }
 
 #[derive(StructOpt, Debug)]

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -20,7 +20,8 @@
     clippy::inefficient_to_string,
     clippy::linkedlist,
     clippy::macro_use_imports,
-    clippy::option_option,
+    // Used for optional cli args that take optional values
+    // clippy::option_option,
     clippy::verbose_file_reads,
     clippy::unnested_or_patterns,
     rust_2018_idioms,


### PR DESCRIPTION
Maybe there's not much future in docker-compose.

However following perfection is the enemy of progress argument, this option is here now, and I will use it on my fork quite happily if not merged.
I don't have erlang rebar on my machines. I do have docker so I will now do the following.

```sh
gleam new foo --docker
cd foo
docker-compose run foo bash
rebar3 eunit.
```

I don't know the trade-offs but more people have docker than erlang. and installing erlang/rebar has seemed to be a blocker for some new gleam users.

