### PR TITLE
Recusive variables are not escaped.

### DIFF
--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -475,7 +475,7 @@ fn is_valid_js_identifier(word: &str) -> bool {
     )
 }
 
-fn maybe_escape_identifier(word: &str) -> Document<'_> {
+fn maybe_escape_identifier<'a>(word: &'a str) -> Document<'a> {
     if is_valid_js_identifier(word) {
         word.to_doc()
     } else {
@@ -483,6 +483,6 @@ fn maybe_escape_identifier(word: &str) -> Document<'_> {
     }
 }
 
-fn escape_identifier(word: &str) -> Document<'_> {
+fn escape_identifier<'a>(word: &'a str) -> Document<'a> {
     Document::String(format!("{}$", word))
 }

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -593,7 +593,10 @@ impl<'module> Generator<'module> {
                     }
                     // Create an assignment for each variable created by the function arguments
                     if let Some(name) = argument {
-                        docs.push(Document::String(format!("{} = ", name)));
+                        // TODO escape here
+                        // docs.push(Document::String(format!("{}!! = ", name)));
+                        docs.push(maybe_escape_identifier(name));
+                        docs.push(" = ".to_doc());
                     }
                     // Render the value given to the function. Even if it is not
                     // assigned we still render it because the expression may

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -465,3 +465,21 @@ export function main(_, _1, _2) {
 "#
     );
 }
+
+#[test]
+fn keyword_in_recursive_function() {
+    assert_js!(
+        r#"pub fn main(with: Int) -> Nil {
+  main(with - 1)
+}
+"#,
+        r#""use strict";
+
+export function main(with$) {
+  while (true) {
+    with$ = with$ - 1
+  }
+}
+"#
+    );
+}


### PR DESCRIPTION
I also had a look at changing things here https://github.com/gleam-lang/gleam/blob/a0aa0d1d65c3e186215f9c4558ad93e36efcb038/compiler-core/src/javascript/expression.rs#L61