### PR TITLE
Refactor iterator usage

### DIFF
--- a/compiler-cli/src/eunit.rs
+++ b/compiler-cli/src/eunit.rs
@@ -26,7 +26,7 @@ pub fn command(root_string: String) -> Result<(), Error> {
     // Build a list of test modules
     let test_modules = packages
         .into_iter()
-        .flat_map(|(_, p)| p.modules.into_iter())
+        .flat_map(|(_, p)| p.modules)
         .filter(|m| m.origin == Origin::Test)
         .map(|m| m.name.replace("/", "@"))
         .join(",");

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1404,9 +1404,9 @@ impl<'a> Documentable<'a> for &'a BinOp {
 
 pub fn wrap_args<'a, I>(args: I) -> Document<'a>
 where
-    I: Iterator<Item = Document<'a>>,
+    I: IntoIterator<Item = Document<'a>>,
 {
-    let mut args = args.peekable();
+    let mut args = args.into_iter().peekable();
     if args.peek().is_none() {
         return "()".to_doc();
     }
@@ -1419,9 +1419,9 @@ where
 
 pub fn wrap_args_with_spread<'a, I>(args: I) -> Document<'a>
 where
-    I: Iterator<Item = Document<'a>>,
+    I: IntoIterator<Item = Document<'a>>,
 {
-    let mut args = args.peekable();
+    let mut args = args.into_iter().peekable();
     if args.peek().is_none() {
         return "()".to_doc();
     }
@@ -1436,14 +1436,17 @@ where
         .group()
 }
 
-fn bit_string<'a>(segments: impl Iterator<Item = Document<'a>>, is_simple: bool) -> Document<'a> {
+fn bit_string<'a>(
+    segments: impl IntoIterator<Item = Document<'a>>,
+    is_simple: bool,
+) -> Document<'a> {
     let comma = if is_simple {
         break_(",", ", ").flex_break()
     } else {
         break_(",", ", ")
     };
     break_("<<", "<<")
-        .append(concat(Itertools::intersperse(segments, comma)))
+        .append(concat(Itertools::intersperse(segments.into_iter(), comma)))
         .nest(INDENT)
         .append(break_(",", ""))
         .append(">>")
@@ -1475,9 +1478,9 @@ fn list<'a>(elems: Document<'a>, tail: Option<Document<'a>>) -> Document<'a> {
 }
 
 fn printed_comments<'a, 'comments>(
-    comments: impl Iterator<Item = &'comments str>,
+    comments: impl IntoIterator<Item = &'comments str>,
 ) -> Option<Document<'a>> {
-    let mut comments = comments.peekable();
+    let mut comments = comments.into_iter().peekable();
     let _ = comments.peek()?;
     Some(concat(Itertools::intersperse(
         comments.map(|c| "//".to_doc().append(Document::String(c.to_string()))),
@@ -1487,7 +1490,7 @@ fn printed_comments<'a, 'comments>(
 
 fn commented<'a, 'comments>(
     doc: Document<'a>,
-    comments: impl Iterator<Item = &'comments str>,
+    comments: impl IntoIterator<Item = &'comments str>,
 ) -> Document<'a> {
     match printed_comments(comments) {
         Some(comments) => comments.append(force_break()).append(line()).append(doc),

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -389,10 +389,13 @@ fn fun_args(args: &'_ [TypedArg]) -> Document<'_> {
 
 fn wrap_args<'a, I>(args: I) -> Document<'a>
 where
-    I: Iterator<Item = Document<'a>>,
+    I: IntoIterator<Item = Document<'a>>,
 {
     break_("", "")
-        .append(concat(Itertools::intersperse(args, break_(",", ", "))))
+        .append(concat(Itertools::intersperse(
+            args.into_iter(),
+            break_(",", ", "),
+        )))
         .nest(INDENT)
         .append(break_("", ""))
         .surround("(", ")")
@@ -400,9 +403,9 @@ where
 }
 
 fn wrap_object<'a>(
-    items: impl Iterator<Item = (Document<'a>, Option<Document<'a>>)>,
+    items: impl IntoIterator<Item = (Document<'a>, Option<Document<'a>>)>,
 ) -> Document<'a> {
-    let fields = items.map(|(key, value)| match value {
+    let fields = items.into_iter().map(|(key, value)| match value {
         Some(value) => docvec![key, ": ", value,],
         None => key.to_doc(),
     });

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -90,8 +90,8 @@ impl<'a, D: Documentable<'a>> Documentable<'a> for Option<D> {
     }
 }
 
-pub fn concat<'a>(docs: impl Iterator<Item = Document<'a>>) -> Document<'a> {
-    Document::Vec(docs.collect())
+pub fn concat<'a>(docs: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
+    Document::Vec(docs.into_iter().collect())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -473,7 +473,7 @@ pub fn infer_module(
         }
     }
 
-    for statement in consts.into_iter().chain(not_consts.into_iter()) {
+    for statement in consts.into_iter().chain(not_consts) {
         let statement = infer_statement(statement, &name, &mut hydrators, &mut environment)?;
         statements.push(statement);
     }

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -39,7 +39,7 @@ impl<'a, 'b, 'c, 'd> PipeTyper<'a, 'b, 'c, 'd> {
 
     fn infer_expressions(
         mut self,
-        expressions: impl Iterator<Item = UntypedExpr>,
+        expressions: impl IntoIterator<Item = UntypedExpr>,
     ) -> Result<TypedExpr, Error> {
         let result = self.infer_each_expression(expressions);
 
@@ -61,9 +61,9 @@ impl<'a, 'b, 'c, 'd> PipeTyper<'a, 'b, 'c, 'd> {
 
     fn infer_each_expression(
         &mut self,
-        expressions: impl Iterator<Item = UntypedExpr>,
+        expressions: impl IntoIterator<Item = UntypedExpr>,
     ) -> Result<(), Error> {
-        for (i, call) in expressions.enumerate() {
+        for (i, call) in expressions.into_iter().enumerate() {
             let call = match call {
                 // left |> right(..args)
                 UntypedExpr::Call {


### PR DESCRIPTION
Highlights:

- Make functions accept `IntoIterator` where it makes sense
- Use arrays instead of chaining `std::iter::once`, or instead of temporary vecs
- Remove redundant `into_iter()` calls