### PR TITLE
Remove 'use strict' from generated js

### DIFF
--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -87,12 +87,11 @@ impl<'a> Generator<'a> {
     }
 
     pub fn compile(&mut self) -> Output<'a> {
-        let statements = std::iter::once(Ok(r#""use strict";"#.to_doc())).chain(
-            self.module
-                .statements
-                .iter()
-                .flat_map(|s| self.statement(s)),
-        );
+        let statements = self
+            .module
+            .statements
+            .iter()
+            .flat_map(|s| self.statement(s));
 
         // Two lines between each statement
         let mut statements: Vec<_> =

--- a/compiler-core/src/javascript/tests/assignments.rs
+++ b/compiler-core/src/javascript/tests/assignments.rs
@@ -8,9 +8,7 @@ fn go(x) {
   let #(1, 2) = x
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x[0] !== 1 || x[1] !== 2) throw new Error("Bad match");
   return x;
 }
@@ -22,9 +20,7 @@ function go(x) {
 fn assert() {
     assert_js!(
         r#"fn go(x) { assert 1 = x }"#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x !== 1) throw new Error("Bad match");
   return x;
 }
@@ -33,9 +29,7 @@ function go(x) {
 
     assert_js!(
         r#"fn go(x) { assert #(1, 2) = x }"#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x[0] !== 1 || x[1] !== 2) throw new Error("Bad match");
   return x;
 }
@@ -51,9 +45,7 @@ fn go(x) {
   let #(a, #(b, c, 2) as t, _, 1) = x
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x[1][2] !== 2 || x[3] !== 1) throw new Error("Bad match");
   let a = x[0];
   let t = x[1];
@@ -88,9 +80,7 @@ fn go(x, foo) {
   x
 }
 "#,
-        r#""use strict";
-
-function go(x, foo) {
+        r#"function go(x, foo) {
   let a = 1;
   foo(a);
   let a$1 = 2;
@@ -128,9 +118,7 @@ fn second() {
   a + 20
 }
 "#,
-        r#""use strict";
-
-const a = true;
+        r#"const a = true;
 
 function go() {
   a;
@@ -150,9 +138,7 @@ function second() {
 fn returning_literal_subject() {
     assert_js!(
         r#"fn go(x) { assert 1 = x + 1 }"#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   let $ = x + 1;
   if ($ !== 1) throw new Error("Bad match");
   return $;
@@ -169,9 +155,7 @@ fn rebound_argument() {
   x
 }
 "#,
-        r#""use strict";
-
-export function main(x) {
+        r#"export function main(x) {
   let x$1 = false;
   return x$1;
 }
@@ -191,9 +175,7 @@ pub fn main() {
   x
 }
 "#,
-        r#""use strict";
-
-export function x() {
+        r#"export function x() {
   return undefined;
 }
 
@@ -217,9 +199,7 @@ pub fn main(x) {
   x
 }
 "#,
-        r#""use strict";
-
-export function x() {
+        r#"export function x() {
   return undefined;
 }
 
@@ -239,9 +219,7 @@ fn variable_used_in_pattern_and_assignment() {
   x
 }
 "#,
-        r#""use strict";
-
-export function main(x) {
+        r#"export function main(x) {
   let $ = [x];
   let x$1 = $[0];
   return x$1;

--- a/compiler-core/src/javascript/tests/bit_strings.rs
+++ b/compiler-core/src/javascript/tests/bit_strings.rs
@@ -8,9 +8,7 @@ fn go() {
   <<>>
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return new Uint8Array();
 }
 "#
@@ -25,9 +23,7 @@ fn go() {
   <<256>>
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return $bit_string([256]);
 }
 
@@ -59,9 +55,7 @@ fn go() {
   <<256, 4>>
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return $bit_string([256, 4]);
 }
 
@@ -93,9 +87,7 @@ fn go(x) {
   <<256, 4, x>>
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   return $bit_string([256, 4, x]);
 }
 
@@ -127,9 +119,7 @@ fn go(x) {
   <<256, 4, x, "Gleam":utf8>>
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   return $bit_string([256, 4, x, new TextEncoder().encode("Gleam")]);
 }
 
@@ -161,9 +151,7 @@ fn go(x) {
   <<x:utf8_codepoint, "Gleam":utf8>>
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   return $bit_string([
     new TextEncoder().encode(x),
     new TextEncoder().encode("Gleam"),
@@ -198,9 +186,7 @@ fn go(x) {
   <<x:bit_string, "Gleam":utf8>>
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   return $bit_string([x, new TextEncoder().encode("Gleam")]);
 }
 

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -12,9 +12,7 @@ fn go() {
   x
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   let x = (() => {
     1;
     return 2;
@@ -35,9 +33,7 @@ fn go() {
   "three"
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   "one";
   "two";
   return "three";
@@ -57,9 +53,7 @@ fn go() {
   }
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return 1 === (() => {
     1;
     return 2;
@@ -80,9 +74,7 @@ fn go() {
   } == 1
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return (() => {
     1;
     return 2;

--- a/compiler-core/src/javascript/tests/bools.rs
+++ b/compiler-core/src/javascript/tests/bools.rs
@@ -10,9 +10,7 @@ fn go() {
     Nil
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   true;
   false;
   return undefined;
@@ -29,9 +27,7 @@ const a = True
 const b = False
 const c = Nil
 "#,
-        r#""use strict";
-
-const a = true;
+        r#"const a = true;
 
 const b = false;
 
@@ -49,9 +45,7 @@ fn go() {
     False || False
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   true && true;
   return false || false;
 }
@@ -69,9 +63,7 @@ fn go(x, y) {
   assert Nil = y
 }
 "#,
-        r#""use strict";
-
-function go(x, y) {
+        r#"function go(x, y) {
   if (!x) throw new Error("Bad match");
   if (x) throw new Error("Bad match");
   if (y) throw new Error("Bad match");
@@ -94,9 +86,7 @@ fn go(x, y) {
   let Nil = y
 }
 "#,
-        r#""use strict";
-
-function go(x, y) {
+        r#"function go(x, y) {
   if (x.type !== "True") throw new Error("Bad match");
   if (x.type !== "False") throw new Error("Bad match");
   if (y.type !== "Nil") throw new Error("Bad match");
@@ -122,9 +112,7 @@ fn go(a, b) {
   b == b
 }
 "#,
-        r#""use strict";
-
-function go(a, b) {
+        r#"function go(a, b) {
   a === true;
   a !== true;
   a === false;
@@ -150,9 +138,7 @@ fn go(a) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(a) {
+        r#"function go(a) {
   if (a) {
     return 1;
   } else if (!a) {
@@ -175,9 +161,7 @@ fn go(a) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(a) {
+        r#"function go(a) {
   if (!a) {
     return 0;
   } else {

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -11,9 +11,7 @@ fn go(x) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   return x;
 }
 "#
@@ -32,9 +30,7 @@ fn go(x) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x) {
     throw Object.assign(
       new Error("This has not yet been implemented"),
@@ -59,9 +55,7 @@ fn go(x, y) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(x, y) {
+        r#"function go(x, y) {
   if (x && y) {
     return 1;
   } else {
@@ -83,9 +77,7 @@ fn go(x, y) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(x, y) {
+        r#"function go(x, y) {
   if (x) {
     return 1;
   } else if (y) {
@@ -110,9 +102,7 @@ fn go(x, y) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(x, y) {
+        r#"function go(x, y) {
   if (x) {
     return 1;
   } else if (y) {
@@ -138,9 +128,7 @@ fn go() {
   }
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   let $ = true;
   let $1 = false;
   if ($ && $1) {
@@ -165,9 +153,7 @@ fn go(x) {
   y
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   let y = (() => {
     if (x) {
       return 1;
@@ -193,9 +179,7 @@ fn go(x) {
   y
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   let y = (() => {
     let $ = x();
     if ($) {

--- a/compiler-core/src/javascript/tests/case_clause_guards.rs
+++ b/compiler-core/src/javascript/tests/case_clause_guards.rs
@@ -10,9 +10,7 @@ fn guards_cause_badmatch_to_render() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(x, y) {
+        r#"export function main(x, y) {
   if (x === 1) {
     return 1;
   } else if (y) {
@@ -35,9 +33,7 @@ fn referencing_pattern_var() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs) {
+        r#"export function main(xs) {
   if (xs[0]) {
     let x = xs[0];
     return 1;
@@ -61,9 +57,7 @@ fn rebound_var() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main() {
+        r#"export function main() {
   let x = false;
   let x$1 = true;
   if (x$1) {
@@ -86,9 +80,7 @@ fn operator_wrapping_right() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs, y, z) {
+        r#"export function main(xs, y, z) {
   if (xs[0] === (y === z)) {
     let x = xs[0];
     return 1;
@@ -110,9 +102,7 @@ fn operator_wrapping_left() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs, y, z) {
+        r#"export function main(xs, y, z) {
   if ((xs[0] === y) === z) {
     let x = xs[0];
     return 1;
@@ -134,9 +124,7 @@ fn eq_scalar() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs, y) {
+        r#"export function main(xs, y) {
   if (xs[0] === y) {
     let x = xs[0];
     return 1;
@@ -158,9 +146,7 @@ fn not_eq_scalar() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs, y) {
+        r#"export function main(xs, y) {
   if (xs[0] !== y) {
     let x = xs[0];
     return 1;
@@ -182,9 +168,7 @@ fn tuple_index() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(x, xs) {
+        r#"export function main(x, xs) {
   if (xs[2]) {
     return 1;
   } else {
@@ -205,9 +189,7 @@ fn not_eq_complex() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs, y) {
+        r#"export function main(xs, y) {
   if (!$equal(xs, y)) {
     let x = xs[0];
     return x;
@@ -252,9 +234,7 @@ fn eq_complex() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs, y) {
+        r#"export function main(xs, y) {
   if ($equal(xs, y)) {
     let x = xs[0];
     return x;
@@ -299,9 +279,7 @@ fn constant() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs) {
+        r#"export function main(xs) {
   if (xs[0] === 1) {
     let x = xs[0];
     return x;
@@ -323,9 +301,7 @@ fn alternative_patterns() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs) {
+        r#"export function main(xs) {
   if (xs === 1) {
     return 0;
   } else if (xs === 2) {
@@ -348,9 +324,7 @@ fn alternative_patterns_list() {
   }
 }
 "#,
-        r#""use strict";
-
-export function main(xs) {
+        r#"export function main(xs) {
   if (xs?.[1]?.length === 0 && xs[0] === 1) {
     return 0;
   } else if (xs?.[1]?.[1]?.length === 0 && xs[0] === 1 && xs[1][0] === 2) {
@@ -373,9 +347,7 @@ fn alternative_patterns_assignment() {
   }
 }  
 "#,
-        r#""use strict";
-
-export function main(xs) {
+        r#"export function main(xs) {
   if (xs?.[1]?.length === 0) {
     let x = xs[0];
     return x;
@@ -400,9 +372,7 @@ fn alternative_patterns_guard() {
   }
 }   
 "#,
-        r#""use strict";
-
-export function main(xs) {
+        r#"export function main(xs) {
   if (xs?.[1]?.length === 0 && xs[0] === 1) {
     let x = xs[0];
     return x;

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -15,9 +15,7 @@ fn go() {
     ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   { type: "This" };
   return {
     type: "ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant"
@@ -39,9 +37,7 @@ type Mine {
 const this = This;
 const that = ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant;
 "#,
-        r#""use strict";
-
-const this$ = { type: "This" };
+        r#"const this$ = { type: "This" };
 
 const that = {
   type: "ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant"
@@ -62,9 +58,7 @@ fn zero_arity_imported() {
 pub fn main() {
   other.Two
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two" };
@@ -85,9 +79,7 @@ fn zero_arity_imported_unqualified() {
 pub fn main() {
   Two
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two" };
@@ -105,9 +97,7 @@ export function main() {
 // pub fn main() {
 //   Three
 // }"#,
-//         r#""use strict";
-//
-// import * as Other from "../other.js";
+//         r#"import * as Other from "../other.js";
 // const { Two as Three } = other;
 //
 // export function main() {
@@ -128,9 +118,7 @@ fn const_zero_arity_imported() {
         r#"import other
 const x = other.Two
 "#,
-        r#""use strict";
-
-const x = { type: "Two" };
+        r#"const x = { type: "Two" };
 
 import * as Other from "../other.js";
 "#
@@ -148,9 +136,7 @@ fn const_zero_arity_imported_unqualified() {
         r#"import other.{Two}
 const a = Two
 "#,
-        r#""use strict";
-
-const a = { type: "Two" };
+        r#"const a = { type: "Two" };
 
 import * as Other from "../other.js";
 "#
@@ -165,9 +151,7 @@ import * as Other from "../other.js";
 //         r#"import other.{Two as Three}
 // const a = Three
 // "#,
-//         r#""use strict";
-
-// const a = { type: "Two" };
+//         r#"// const a = { type: "Two" };
 
 // import * as Other from "../other.js";
 // const { Two as Three } = other;
@@ -186,9 +170,7 @@ type Mine {
 const labels = Mine(b: 2, a: 1)
 const no_labels = Mine(3, 4)
 "#,
-        r#""use strict";
-
-const labels = { type: "Mine", a: 1, b: 2 };
+        r#"const labels = { type: "Mine", a: 1, b: 2 };
 
 const no_labels = { type: "Mine", a: 3, b: 4 };
 "#
@@ -219,9 +201,7 @@ fn destructure(x) {
   raw
 }
 "#,
-        r#""use strict";
-
-const local = { type: "Ip", 0: "0.0.0.0" };
+        r#"const local = { type: "Ip", 0: "0.0.0.0" };
 
 function build(x) {
   return x("1.2.3.4");
@@ -251,9 +231,7 @@ fn go() {
   TypeWithALongNameAndSeveralArguments
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return (var0, var1, var2, var3, var4) => {
     return {
       type: "TypeWithALongNameAndSeveralArguments",
@@ -295,9 +273,7 @@ fn access(cat: Cat) {
   cat.cuteness
 }
 "#,
-        r#""use strict";
-
-const felix = { type: "Cat", name: "Felix", cuteness: 12 };
+        r#"const felix = { type: "Cat", name: "Felix", cuteness: 12 };
 
 const tom = { type: "Cat", name: "Tom", cuteness: 1 };
 
@@ -339,9 +315,7 @@ fn go(cat) {
 }
 
 "#,
-        r#""use strict";
-
-function go(cat) {
+        r#"function go(cat) {
   if (cat.type !== "Cat") throw new Error("Bad match");
   let x = cat.name;
   let y = cat.cuteness;
@@ -366,9 +340,7 @@ fn go(x) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x.type === "Box" && x.b.type === "Box") {
     let a = x.b.a;
     let b = x.b.b;
@@ -393,9 +365,7 @@ fn imported_no_label() {
 pub fn main() {
   other.Two(1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", 0: 1 };
@@ -416,9 +386,7 @@ fn imported_ignoring_label() {
 pub fn main() {
   other.Two(1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", field: 1 };
@@ -439,9 +407,7 @@ fn imported_using_label() {
 pub fn main() {
   other.Two(field: 1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", field: 1 };
@@ -462,9 +428,7 @@ fn imported_multiple_fields() {
 pub fn main() {
   other.Two(b: 2, c: 3, a: 1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", a: 1, b: 2, c: 3 };
@@ -485,9 +449,7 @@ fn unqualified_imported_no_label() {
 pub fn main() {
   Two(1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", 0: 1 };
@@ -508,9 +470,7 @@ fn unqualified_imported_ignoring_label() {
 pub fn main() {
   Two(1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", field: 1 };
@@ -531,9 +491,7 @@ fn unqualified_imported_using_label() {
 pub fn main() {
   Two(field: 1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", field: 1 };
@@ -554,9 +512,7 @@ fn unqualified_imported_multiple_fields() {
 pub fn main() {
   Two(b: 2, c: 3, a: 1)
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return { type: "Two", a: 1, b: 2, c: 3 };
@@ -577,9 +533,7 @@ fn constructor_as_value() {
 pub fn main() {
   other.Two
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return (var0, var1, var2) => {
@@ -602,9 +556,7 @@ fn unqualified_constructor_as_value() {
 pub fn main() {
   Two
 }"#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main() {
   return (var0, var1, var2) => {
@@ -626,9 +578,7 @@ fn const_imported_no_label() {
         r#"import other
 pub const main = other.Two(1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", 0: 1 };
+        r#"export const main = { type: "Two", 0: 1 };
 
 import * as Other from "../other.js";
 "#
@@ -646,9 +596,7 @@ fn const_imported_ignoring_label() {
         r#"import other
 pub const main = other.Two(1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", field: 1 };
+        r#"export const main = { type: "Two", field: 1 };
 
 import * as Other from "../other.js";
 "#
@@ -666,9 +614,7 @@ fn const_imported_using_label() {
         r#"import other
 pub const main = other.Two(field: 1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", field: 1 };
+        r#"export const main = { type: "Two", field: 1 };
 
 import * as Other from "../other.js";
 "#
@@ -686,9 +632,7 @@ fn const_imported_multiple_fields() {
         r#"import other
 pub const main = other.Two(b: 2, c: 3, a: 1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", a: 1, b: 2, c: 3 };
+        r#"export const main = { type: "Two", a: 1, b: 2, c: 3 };
 
 import * as Other from "../other.js";
 "#
@@ -706,9 +650,7 @@ fn const_unqualified_imported_no_label() {
         r#"import other.{Two}
 pub const main = Two(1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", 0: 1 };
+        r#"export const main = { type: "Two", 0: 1 };
 
 import * as Other from "../other.js";
 "#
@@ -726,9 +668,7 @@ fn const_unqualified_imported_ignoring_label() {
         r#"import other.{Two}
 pub const main = Two(1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", field: 1 };
+        r#"export const main = { type: "Two", field: 1 };
 
 import * as Other from "../other.js";
 "#
@@ -746,9 +686,7 @@ fn const_unqualified_imported_using_label() {
         r#"import other.{Two}
 pub const main = Two(field: 1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", field: 1 };
+        r#"export const main = { type: "Two", field: 1 };
 
 import * as Other from "../other.js";
 "#
@@ -766,9 +704,7 @@ fn const_unqualified_imported_multiple_fields() {
         r#"import other.{Two}
 pub const main = Two(b: 2, c: 3, a: 1)
 "#,
-        r#""use strict";
-
-export const main = { type: "Two", a: 1, b: 2, c: 3 };
+        r#"export const main = { type: "Two", a: 1, b: 2, c: 3 };
 
 import * as Other from "../other.js";
 "#
@@ -793,9 +729,7 @@ pub fn main(x) {
   }
 }
 "#,
-        r#""use strict";
-
-import * as Other from "../other.js";
+        r#"import * as Other from "../other.js";
 
 export function main(x) {
   if (x.type === "Two" && x.a === 1) {

--- a/compiler-core/src/javascript/tests/externals.rs
+++ b/compiler-core/src/javascript/tests/externals.rs
@@ -4,7 +4,7 @@ use crate::assert_js;
 fn type_() {
     assert_js!(
         r#"pub external type Thing"#,
-        r#""use strict";
+        r#"
 "#
     );
 }
@@ -13,9 +13,7 @@ fn type_() {
 fn module_fn() {
     assert_js!(
         r#"external fn show(anything) -> Nil = "utils" "inspect""#,
-        r#""use strict";
-
-import { inspect as show } from "utils";
+        r#"import { inspect as show } from "utils";
 "#
     );
 }
@@ -24,9 +22,7 @@ import { inspect as show } from "utils";
 fn pub_module_fn() {
     assert_js!(
         r#"pub external fn show(anything) -> Nil = "utils" "inspect""#,
-        r#""use strict";
-
-import { inspect as show } from "utils";
+        r#"import { inspect as show } from "utils";
 export { show };
 "#
     );
@@ -36,9 +32,7 @@ export { show };
 fn global_fn() {
     assert_js!(
         r#"external fn down(Float) -> Float = "" "Math.floor""#,
-        r#""use strict";
-
-function down(arg0) {
+        r#"function down(arg0) {
   return Math.floor(arg0)
 }
 "#
@@ -49,9 +43,7 @@ function down(arg0) {
 fn pub_global_fn() {
     assert_js!(
         r#"pub external fn down(Float) -> Float = "" "Math.floor""#,
-        r#""use strict";
-
-export function down(arg0) {
+        r#"export function down(arg0) {
   return Math.floor(arg0)
 }
 "#
@@ -62,9 +54,7 @@ export function down(arg0) {
 fn same_name_global_external() {
     assert_js!(
         r#"pub external fn fetch(Nil) -> Nil = "" "fetch""#,
-        r#""use strict";
-
-export function fetch(arg0) {
+        r#"export function fetch(arg0) {
   return globalThis.fetch(arg0)
 }
 "#

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -9,9 +9,7 @@ fn exported_functions() {
 pub fn add(x, y) {
     x + y
 }"#,
-        r#""use strict";
-
-export function add(x, y) {
+        r#"export function add(x, y) {
   return x + y;
 }
 "#
@@ -36,9 +34,7 @@ pub fn take_two(x: Int) -> Int {
     twice(fn(y) {y - 1}, x)
 }
 "#,
-        r#""use strict";
-
-export function twice(f, x) {
+        r#"export function twice(f, x) {
   return f(f(x));
 }
 
@@ -64,9 +60,7 @@ fn function_formatting() {
 pub fn add(the_first_variable_that_should_be_added, the_second_variable_that_should_be_added) {
   the_first_variable_that_should_be_added + the_second_variable_that_should_be_added
 }"#,
-        r#""use strict";
-
-export function add(
+        r#"export function add(
   the_first_variable_that_should_be_added,
   the_second_variable_that_should_be_added
 ) {
@@ -80,9 +74,7 @@ export function add(
 pub fn this_function_really_does_have_a_ludicrously_unfeasibly_long_name_for_a_function(x, y) {
 x + y
 }"#,
-        r#""use strict";
-
-export function this_function_really_does_have_a_ludicrously_unfeasibly_long_name_for_a_function(
+        r#"export function this_function_really_does_have_a_ludicrously_unfeasibly_long_name_for_a_function(
   x,
   y
 ) {
@@ -100,9 +92,7 @@ x + y
 pub fn long() {
   add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, add(1, 1)))))))))))))))
 }"#,
-        r#""use strict";
-
-export function add(x, y) {
+        r#"export function add(x, y) {
   return x + y;
 }
 
@@ -145,9 +135,7 @@ pub fn math(x, y) {
     2 * x
   }
 }"#,
-        r#""use strict";
-
-export function math(x, y) {
+        r#"export function math(x, y) {
   return () => {
     x + y;
     x - y;
@@ -169,9 +157,7 @@ pub fn count(xs, n) {
   }
 }
 "#,
-        r#""use strict";
-
-export function count(xs, n) {
+        r#"export function count(xs, n) {
   while (true) {
     if (xs?.length === 0) {
       return n;
@@ -199,9 +185,7 @@ pub fn loop(indentation) {
   }
 }
 "#,
-        r#""use strict";
-
-export function loop(indentation) {
+        r#"export function loop(indentation) {
   while (true) {
     let $ = indentation > 0;
     if ($) {
@@ -226,9 +210,7 @@ pub fn main() {
   |> id
 }
 "#,
-        r#""use strict";
-
-function id(x) {
+        r#"function id(x) {
   return x;
 }
 
@@ -247,9 +229,7 @@ fn calling_fn_literal() {
   fn(x) { x }(1)
 }
 "#,
-        r#""use strict";
-
-export function main() {
+        r#"export function main() {
   return ((x) => { return x; })(1);
 }
 "#
@@ -266,9 +246,7 @@ fn shadowing_current() {
   main()
 }
 "#,
-        r#""use strict";
-
-export function main() {
+        r#"export function main() {
   let main$1 = () => { return 0; };
   return main$1();
 }
@@ -284,9 +262,7 @@ fn recursion_with_discards() {
   main(f, 1)
 }
 "#,
-        r#""use strict";
-
-export function main(f, _) {
+        r#"export function main(f, _) {
   while (true) {
     f();
     f = f;
@@ -305,9 +281,7 @@ fn no_recur_in_anon_fn() {
   1
 }
 "#,
-        r#""use strict";
-
-export function main() {
+        r#"export function main() {
   () => { return main(); };
   return 1;
 }
@@ -325,9 +299,7 @@ fn case_in_call() {
   })
 }
 "#,
-        r#""use strict";
-
-export function main(f, x) {
+        r#"export function main(f, x) {
   return f(
     (() => {
       if (x === 1) {
@@ -349,9 +321,7 @@ fn reserved_word_fn() {
   Nil
 }
 "#,
-        r#""use strict";
-
-export function class$() {
+        r#"export function class$() {
   return undefined;
 }
 "#
@@ -372,9 +342,7 @@ pub fn export() {
   class()
 }
 "#,
-        r#""use strict";
-
-import * as For from "../for.js";
+        r#"import * as For from "../for.js";
 const { class$ } = For;
 
 export function export$() {
@@ -399,9 +367,7 @@ pub fn export() {
   while()
 }
 "#,
-        r#""use strict";
-
-import * as Function from "../for.js";
+        r#"import * as Function from "../for.js";
 const { class$: while$ } = Function;
 
 export function export$() {
@@ -421,9 +387,7 @@ pub fn export() {
   in
 }
 "#,
-        r#""use strict";
-
-const in$ = 1;
+        r#"const in$ = 1;
 
 export function export$() {
   return in$;
@@ -440,9 +404,7 @@ fn reserved_word_argument() {
   with
 }
 "#,
-        r#""use strict";
-
-export function main(with$) {
+        r#"export function main(with$) {
   return with$;
 }
 "#
@@ -457,9 +419,7 @@ fn multiple_discard() {
   1
 }
 "#,
-        r#""use strict";
-
-export function main(_, _1, _2) {
+        r#"export function main(_, _1, _2) {
   return 1;
 }
 "#
@@ -473,9 +433,7 @@ fn keyword_in_recursive_function() {
   main(with - 1)
 }
 "#,
-        r#""use strict";
-
-export function main(with$) {
+        r#"export function main(with$) {
   while (true) {
     with$ = with$ - 1;
   }
@@ -491,9 +449,7 @@ fn reserved_word_in_function_arguments() {
   #(arguments, eval)
 }
 "#,
-        r#""use strict";
-
-export function main(arguments$, eval$) {
+        r#"export function main(arguments$, eval$) {
   return [arguments$, eval$];
 }
 "#

--- a/compiler-core/src/javascript/tests/lists.rs
+++ b/compiler-core/src/javascript/tests/lists.rs
@@ -11,9 +11,7 @@ fn go(x) {
     [1, 2, ..x]
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   [];
   [1, []];
   [1, [2, []]];
@@ -32,9 +30,7 @@ fn go() {
   [11111111111111111111111111111111111111111111, 1111111111111111111111111111111111111111111]
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   [111111111111111111111111111111111111111111111111111111111111111111111111, []];
   return [
     11111111111111111111111111111111111111111111,
@@ -54,9 +50,7 @@ fn go(x) {
     [{True; 1}]
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   return [
     (() => {
       true;
@@ -76,9 +70,7 @@ fn list_constants() {
 const a = []
 const b = [1, 2, 3]
 "#,
-        r#""use strict";
-
-const a = [];
+        r#"const a = [];
 
 const b = [1, [2, [3, []]]];
 "#
@@ -97,9 +89,7 @@ fn go(x, y) {
   let [head, ..tail] = y
 }
 "#,
-        r#""use strict";
-
-function go(x, y) {
+        r#"function go(x, y) {
   if (x?.length !== 0) throw new Error("Bad match");
   if (x?.[1]?.length !== 0) throw new Error("Bad match");
   let a = x[0];
@@ -131,9 +121,7 @@ fn go() {
   [] != [1]
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   $equal([], [1, []]);
   return !$equal([], [1, []]);
 }
@@ -177,9 +165,7 @@ fn go(xs) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(xs) {
+        r#"function go(xs) {
   if (xs?.length === 0) {
     return 0;
   } else if (xs?.[1]?.length === 0) {

--- a/compiler-core/src/javascript/tests/modules.rs
+++ b/compiler-core/src/javascript/tests/modules.rs
@@ -12,9 +12,7 @@ fn unqualified_fn_call() {
         r#"import rocket_ship.{launch}
 pub fn go() { launch() }
 "#,
-        r#""use strict";
-
-import * as RocketShip from "../rocket_ship.js";
+        r#"import * as RocketShip from "../rocket_ship.js";
 const { launch } = RocketShip;
 
 export function go() {
@@ -35,9 +33,7 @@ fn aliased_unqualified_fn_call() {
         r#"import rocket_ship.{launch as boom_time}
 pub fn go() { boom_time() }
 "#,
-        r#""use strict";
-
-import * as RocketShip from "../rocket_ship.js";
+        r#"import * as RocketShip from "../rocket_ship.js";
 const { launch: boom_time } = RocketShip;
 
 export function go() {
@@ -60,9 +56,7 @@ pub fn b() { 2 }"#
         r#"import rocket_ship.{a,b as bb}
 pub fn go() { a() + bb() }
 "#,
-        r#""use strict";
-
-import * as RocketShip from "../rocket_ship.js";
+        r#"import * as RocketShip from "../rocket_ship.js";
 const { a, b: bb } = RocketShip;
 
 export function go() {
@@ -84,9 +78,7 @@ fn constant() {
 import rocket_ship
 pub fn go() { rocket_ship.x }
 "#,
-        r#""use strict";
-
-import * as RocketShip from "../rocket_ship.js";
+        r#"import * as RocketShip from "../rocket_ship.js";
 
 export function go() {
   return RocketShip.x;
@@ -107,9 +99,7 @@ fn alias_constant() {
 import rocket_ship as boop
 pub fn go() { boop.x }
 "#,
-        r#""use strict";
-
-import * as Boop from "../rocket_ship.js";
+        r#"import * as Boop from "../rocket_ship.js";
 
 export function go() {
   return Boop.x;
@@ -130,9 +120,7 @@ fn alias_fn_call() {
 import rocket_ship as boop
 pub fn go() { boop.go() }
 "#,
-        r#""use strict";
-
-import * as Boop from "../rocket_ship.js";
+        r#"import * as Boop from "../rocket_ship.js";
 
 export function go() {
   return Boop.go();
@@ -151,9 +139,7 @@ fn nested_fn_call() {
         ),
         r#"import one/two
 pub fn go() { two.go() }"#,
-        r#""use strict";
-
-import * as Two from "../one/two.js";
+        r#"import * as Two from "../one/two.js";
 
 export function go() {
   return Two.go();
@@ -172,9 +158,7 @@ fn nested_nested_fn_call() {
         ),
         r#"import one/two/three
 pub fn go() { three.go() }"#,
-        r#""use strict";
-
-import * as Three from "../one/two/three.js";
+        r#"import * as Three from "../one/two/three.js";
 
 export function go() {
   return Three.go();
@@ -194,9 +178,7 @@ fn different_package_import() {
         r#"import one
 pub fn go() { one.go() }
 "#,
-        r#""use strict";
-
-import * as One from "other_package/one.js";
+        r#"import * as One from "other_package/one.js";
 
 export function go() {
   return One.go();
@@ -216,9 +198,7 @@ fn nested_same_package() {
         r#"import one/two/three
 pub fn go() { three.go() }
 "#,
-        r#""use strict";
-
-import * as Three from "../one/two/three.js";
+        r#"import * as Three from "../one/two/three.js";
 
 export function go() {
   return Three.go();

--- a/compiler-core/src/javascript/tests/numbers.rs
+++ b/compiler-core/src/javascript/tests/numbers.rs
@@ -15,9 +15,7 @@ fn go() {
     1_000
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   1;
   2;
   -3;
@@ -42,9 +40,7 @@ fn go() {
     1.
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   1.5;
   2.0;
   -0.1;
@@ -70,9 +66,7 @@ fn go() {
     2 <= 1 // => False
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   1 + 1;
   5 - 1;
   5 / 2 | 0;
@@ -102,9 +96,7 @@ fn go() {
     2.0 <=. 1.0 // => False
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   1.0 + 1.4;
   5.0 - 1.5;
   $divide(5.0, 2.0);
@@ -128,9 +120,7 @@ fn go() {
   111111111111111111111111111111. /. 22222222222222222222222222222222222.
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return $divide(
     111111111111111111111111111111.,
     22222222222222222222222222222222222.
@@ -153,9 +143,7 @@ fn go(x) {
   let 4 = x
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x !== 4) throw new Error("Bad match");
   return x;
 }
@@ -172,9 +160,7 @@ fn go() {
   1 == 2
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   1 !== 2;
   return 1 === 2;
 }
@@ -188,9 +174,7 @@ fn go(y) {
   x == y
 }
 "#,
-        r#""use strict";
-
-function go(y) {
+        r#"function go(y) {
   let x = 1;
   return x === y;
 }
@@ -207,9 +191,7 @@ fn go() {
   1.0 == 2.0
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   1.0 !== 2.0;
   return 1.0 === 2.0;
 }
@@ -223,9 +205,7 @@ fn go(y) {
   x == y
 }
 "#,
-        r#""use strict";
-
-function go(y) {
+        r#"function go(y) {
   let x = 1.0;
   return x === y;
 }
@@ -241,9 +221,7 @@ fn go() {
   2.4 *. { 3.5 +. 6.0 }
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return 2.4 * (3.5 + 6.0);
 }
 "#

--- a/compiler-core/src/javascript/tests/prelude.rs
+++ b/compiler-core/src/javascript/tests/prelude.rs
@@ -6,9 +6,7 @@ fn qualified_ok() {
         r#"import gleam
 pub fn go() { gleam.Ok(1) }
 "#,
-        r#""use strict";
-
-export function go() {
+        r#"export function go() {
   return { type: "Ok", 0: 1 };
 }
 "#
@@ -21,9 +19,7 @@ fn qualified_error() {
         r#"import gleam
 pub fn go() { gleam.Error(1) }
 "#,
-        r#""use strict";
-
-export function go() {
+        r#"export function go() {
   return { type: "Error", 0: 1 };
 }
 "#
@@ -36,9 +32,7 @@ fn qualified_nil() {
         r#"import gleam
 pub fn go() { gleam.Nil }
 "#,
-        r#""use strict";
-
-export function go() {
+        r#"export function go() {
   return undefined;
 }
 "#

--- a/compiler-core/src/javascript/tests/strings.rs
+++ b/compiler-core/src/javascript/tests/strings.rs
@@ -8,9 +8,7 @@ fn go() {
   "Hello, Gleam!"
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return "Hello, Gleam!";
 }
 "#
@@ -25,9 +23,7 @@ fn go(x) {
   let "Hello" = x
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x !== "Hello") throw new Error("Bad match");
   return x;
 }
@@ -45,9 +41,7 @@ fn go(a) {
   a == a
 }
 "#,
-        r#""use strict";
-
-function go(a) {
+        r#"function go(a) {
   a === "ok";
   a !== "ok";
   return a === a;
@@ -69,9 +63,7 @@ fn go(a) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(a) {
+        r#"function go(a) {
   if (a === "") {
     return 0;
   } else if (a === "one") {

--- a/compiler-core/src/javascript/tests/todo.rs
+++ b/compiler-core/src/javascript/tests/todo.rs
@@ -8,9 +8,7 @@ fn go() {
     todo
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   throw Object.assign(
     new Error("This has not yet been implemented"),
     { gleam_error: "todo", module: "my/mod", function: "go", line: 3 }
@@ -28,9 +26,7 @@ fn go() {
     todo("I should do this");
 };
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   throw Object.assign(
     new Error("I should do this"),
     { gleam_error: "todo", module: "my/mod", function: "go", line: 3 }

--- a/compiler-core/src/javascript/tests/try_.rs
+++ b/compiler-core/src/javascript/tests/try_.rs
@@ -8,9 +8,7 @@ fn top() {
   try z = y
   Ok(z)
 }"#,
-        r#""use strict";
-
-export function main(x) {
+        r#"export function main(x) {
   if (x.type === "Error") return x;
   let y = x[0];
 
@@ -31,9 +29,7 @@ fn rebinding() {
   try x = x
   Ok(x)
 }"#,
-        r#""use strict";
-
-export function main(x) {
+        r#"export function main(x) {
   if (x.type === "Error") return x;
   let x$1 = x[0];
 
@@ -54,9 +50,7 @@ fn discard() {
   try _ = y
   x
 }"#,
-        r#""use strict";
-
-export function main(x, y) {
+        r#"export function main(x, y) {
   if (x.type === "Error") return x;
   if (y.type === "Error") return y;
   return x;
@@ -74,9 +68,7 @@ fn with_subpattern() {
   try #(a, 2) = Ok(#(1, 2))
   Ok(x)
 }"#,
-        r#""use strict";
-
-export function main(x) {
+        r#"export function main(x) {
   if (x.type === "Error") return x;
   let a = x[0][0];
   let b = x[0][1];
@@ -105,9 +97,7 @@ fn in_block() {
   }
   y
 }"#,
-        r#""use strict";
-
-export function main(x) {
+        r#"export function main(x) {
   let y = (() => {
     if (x.type === "Error") return x;
     let z = x[0];
@@ -130,9 +120,7 @@ fn assert_in_block() {
   }
   y
 }"#,
-        r#""use strict";
-
-export function main(x) {
+        r#"export function main(x) {
   let $ = (() => {
     if (x.type === "Error") return x;
     let z = x[0];

--- a/compiler-core/src/javascript/tests/tuples.rs
+++ b/compiler-core/src/javascript/tests/tuples.rs
@@ -8,9 +8,7 @@ fn go() {
   #("1", "2", "3")
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return ["1", "2", "3"];
 }
 "#
@@ -26,9 +24,7 @@ fn go() {
   )
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return [
     "1111111111111111111111111111111",
     ["1111111111111111111111111111111", "2", "3"],
@@ -47,9 +43,7 @@ fn go() {
   #(1, 2).0
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return [1, 2][0];
 }
 "#
@@ -70,9 +64,7 @@ fn go() {
   )
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return [
     "1",
     (() => {
@@ -94,9 +86,7 @@ fn go() {
   )
 }
 "#,
-        r#""use strict";
-
-function go() {
+        r#"function go() {
   return [
     "1111111111111111111111111111111",
     ["1111111111111111111111111111111", "2", "3"],
@@ -116,9 +106,7 @@ const b = 1;
 const c = 2.0;
 const e = #("bob", "dug")
         "#,
-        r#""use strict";
-
-const a = "Hello";
+        r#"const a = "Hello";
 
 const b = 1;
 
@@ -135,9 +123,7 @@ const e = #(
   "loooooooooooooong", "loooooooooooong", "loooooooooooooong",
 )
         "#,
-        r#""use strict";
-
-const e = [
+        r#"const e = [
   "loooooooooooooong",
   "loooooooooooong",
   "loooooooooooooong",
@@ -161,9 +147,7 @@ fn go(a) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(a) {
+        r#"function go(a) {
   if (a[0] === 2) {
     let a$1 = a[1];
     return a$1;
@@ -190,9 +174,7 @@ fn go(x) {
   }
 }
 "#,
-        r#""use strict";
-
-function go(x) {
+        r#"function go(x) {
   if (x[0] === 2) {
     let a = x[1][0];
     let b = x[1][1];


### PR DESCRIPTION
As noted in #1225, it is not required as ES modules are always strict.

Tests updated with something like:

    grep -R -l 'use strict' . | xargs sed -i -z 's/"use strict";\n\n//g'

And some manual adjustments.

Apparently '-z' causes sed to more or less treat the whole file as one
line so you can use it to work across new lines.

Closes #1225 