### PR TITLE
🐛 Fixed bug where `equal` was far too optimistic.

### DIFF
--- a/compiler-core/templates/prelude.js
+++ b/compiler-core/templates/prelude.js
@@ -174,7 +174,7 @@ function dateEqual(a, b) {
 }
 
 function typedArrayEqual(a, b) {
-  return a.length === b.length && a.every((n, i) => n === b[i]);
+  return a.byteLength === b.byteLength && a.every((n, i) => n === b[i]);
 }
 
 console.log("");


### PR DESCRIPTION
Things we can now handle properly:
- Structural equality for object-like things (objects, arrays, classes).
- Value equality for idiots that do `new Number(10)` somehow.
- Structural equality for all `TypedArray`s.
- Fancy `Date` equality that we stole from ReScript.

---

> 🚨 **Note**: This is using `Object.prototype.constructor` and **not** `Object.prototype.constructor.name`. This means equality will break if the prelude is included in every Gleam module individually. I can change it back to `.name` if that's the case.