### PR TITLE
Add support for map equality check

### DIFF
--- a/compiler-core/templates/prelude.js
+++ b/compiler-core/templates/prelude.js
@@ -235,11 +235,19 @@ export function isEqual(x, y) {
       !structurallyCompatibleObjects(a, b) ||
       unequalDates(a, b) ||
       unequalBuffers(a, b) ||
-      unequalArrays(a, b);
+      unequalArrays(a, b) ||
+      unequalMaps(a, b);
     if (unequal) return false;
 
     for (const k of Object.keys(a)) {
       values.push(a[k], b[k]);
+    }
+
+    if (a instanceof Map) {
+      for (const k of a.keys()) {
+        values.push(a.get(k));
+        values.push(b.get(k));
+      }
     }
   }
 
@@ -262,6 +270,10 @@ function unequalArrays(a, b) {
   return Array.isArray(a) && a.length !== b.length;
 }
 
+function unequalMaps(a, b) {
+  return a instanceof Map && a.size !== b.size;
+}
+
 function isObject(a) {
   return typeof a === "object" && a !== null;
 }
@@ -270,7 +282,7 @@ function structurallyCompatibleObjects(a, b) {
   if (typeof a !== "object" && typeof b !== "object" && (!a || !b))
     return false;
 
-  let nonstructural = [Promise, Set, Map, WeakSet, WeakMap];
+  let nonstructural = [Promise, Set, WeakSet, WeakMap];
   if (nonstructural.some((c) => a instanceof c)) return false;
 
   return (

--- a/compiler-core/templates/prelude.js
+++ b/compiler-core/templates/prelude.js
@@ -236,7 +236,8 @@ export function isEqual(x, y) {
       unequalDates(a, b) ||
       unequalBuffers(a, b) ||
       unequalArrays(a, b) ||
-      unequalMaps(a, b);
+      unequalMaps(a, b) ||
+      unequalSets(a, b);
     if (unequal) return false;
 
     for (const k of Object.keys(a)) {
@@ -274,6 +275,12 @@ function unequalMaps(a, b) {
   return a instanceof Map && a.size !== b.size;
 }
 
+function unequalSets(a, b) {
+  return a instanceof Set && (
+    a.size != b.size || [...a].some(e => !b.has(e))
+  )
+}
+
 function isObject(a) {
   return typeof a === "object" && a !== null;
 }
@@ -282,7 +289,7 @@ function structurallyCompatibleObjects(a, b) {
   if (typeof a !== "object" && typeof b !== "object" && (!a || !b))
     return false;
 
-  let nonstructural = [Promise, Set, WeakSet, WeakMap];
+  let nonstructural = [Promise, WeakSet, WeakMap];
   if (nonstructural.some((c) => a instanceof c)) return false;
 
   return (

--- a/test/javascript_prelude/main.js
+++ b/test/javascript_prelude/main.js
@@ -199,15 +199,21 @@ assertNotEqual(
   () => 1
 );
 
-// Maps are not equal unless they have reference equality
+// Maps are compared structurally
 let map = new Map([["a", 1]]);
 assertEqual(map, map);
-assertNotEqual(new Map([["a", 1]]), new Map([["a", 1]]));
+assertEqual(new Map([["a", 1]]), new Map([["a", 1]]));
+assertNotEqual(new Map([["a", 1], ["b", 2]]), new Map([["a", 1]]));
+assertNotEqual(new Map([["a", 1]]), new Map([["a", 1], ["b", 2]]));
+assertNotEqual(new Map([["a", 1]]), new Map([["b", 1]]));
 
-// Sets are not equal unless they have reference equality
+// Sets are compared structurally
 let set = new Set(["a", 1]);
 assertEqual(set, set);
-assertNotEqual(new Set(["a", 1]), new Set(["a", 1]));
+assertEqual(new Set(["a", 1]), new Set(["a", 1]));
+assertNotEqual(new Set(["a", 1]), new Set(["b", 1]));
+assertNotEqual(new Set(["a", 1, "b"]), new Set(["a", 1]));
+assertNotEqual(new Set(["a", 1]), new Set(["a", 1, "b"]));
 
 // WeakMaps are not equal unless they have reference equality
 let weak_map = new WeakMap([[map, 1]]);


### PR DESCRIPTION
Currently, map comparisons do not work properly. This change is necessary for the tests in gleam-lang/stdlib#232 to pass.
I'm not at all familiar with how the compiler works so this may not be the best way to do it, please let me know if there are any changes needed :)