### PR TITLE
Problem: unused code warning in javascript.rs

### DIFF
--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -615,5 +615,4 @@ pub(crate) struct UsageTracker {
     pub bit_string_literal_used: bool,
     pub string_bit_string_segment_used: bool,
     pub codepoint_bit_string_segment_used: bool,
-    pub utfcodepoint_bit_string_segment_used: bool,
 }


### PR DESCRIPTION
Analysis:

- 1891c159339a7c4ddf25596f3038cf5d1c136086 adds tracker
- tracker is simply a way to reduce the amount of fields of JS code generator
- there are three modes of operation for [bit_string](https://gleam.run/book/tour/bit-strings.html) generation:
    - string_bit_string_segment
    - codepoint_bit_string_segment
    - utfcodepoint_bit_string_segment
- seems like utfcodepoint_bit_string_segment and codepoint_bit_string_segment is a legacy aberration

Indeed, when we look at `gleam_core__javascript__tests__bit_strings__utf8_codepoint.snap` test, we see that `codepointBits` corresponds with the capability of encoding Unicode code points into a 1-4 bytes, as per UTF-8 representation.

Soluiton:

- Remove utfcodepoint_bit_string_segment, leaving only more reasonably-named codepoint_bit_string_segment

Open questions:

- Gleam provides facilities of specifying that a codepoint supplied should be [encoded in UTF-16 or UTF-32 forms](https://gleam.run/book/tour/bit-strings.html#options-in-patterns).

Thus, a question raises of whether or not we should be more dilligent in testing that [the underlying JS semantics](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint) matches ours.