### PR TITLE
Add deps list command

### DIFF
--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -25,8 +25,10 @@ use crate::{
 };
 
 pub fn list() -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
+
     let config = crate::config::root_config()?;
-    let manifest = read_manifest_from_disc()?;
+    let (_, manifest) = get_manifest(runtime.handle().clone(), Mode::Dev, &config)?;
     list_manifest_packages(std::io::stdout(), config.name, manifest)
 }
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -24,6 +24,26 @@ use crate::{
     http::HttpClient,
 };
 
+pub fn list() -> Result<()> {
+    let config = crate::config::root_config()?;
+
+    println!(
+        "{} deps (from {}):\n",
+        config.name,
+        paths::root_config().display().to_string(),
+    );
+
+    for (name, version) in config.dependencies {
+        println!("    * {} ({})", name, version);
+    }
+
+    for (name, version) in config.dev_dependencies {
+        println!("    * {} ({}) (dev)", name, version);
+    }
+
+    Ok(())
+}
+
 pub fn download(new_package: Option<(&str, bool)>) -> Result<Manifest> {
     let span = tracing::info_span!("download_deps");
     let _enter = span.enter();

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -54,7 +54,52 @@ fn list_manifest_packages<W: std::io::Write>(
 
 #[test]
 fn list_manifest_format() {
-    assert_eq!("Hello", "there")
+    let mut buffer = vec![];
+    let manifest = Manifest {
+        requirements: HashMap::new(),
+        packages: vec![
+            ManifestPackage {
+                name: "root".to_string(),
+                version: Version::parse("1.0.0").unwrap(),
+                build_tools: ["gleam".into()].into(),
+                otp_app: None,
+                requirements: vec![],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![1, 2, 3, 4]),
+                },
+            },
+            ManifestPackage {
+                name: "aaa".to_string(),
+                version: Version::new(0, 4, 2),
+                build_tools: ["rebar3".into(), "make".into()].into(),
+                otp_app: Some("aaa_app".into()),
+                requirements: vec!["zzz".into(), "gleam_stdlib".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+            ManifestPackage {
+                name: "zzz".to_string(),
+                version: Version::new(0, 4, 0),
+                build_tools: ["mix".into()].into(),
+                otp_app: None,
+                requirements: vec![],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+        ],
+    };
+    list_manifest_packages(&mut buffer, "test_project".to_string(), manifest).unwrap();
+    assert_eq!(
+        std::str::from_utf8(&buffer).unwrap(),
+        r#"test_project deps (from manifest.toml):
+
+    * root (1.0.0)
+    * aaa (0.4.2)
+    * zzz (0.4.0)
+"#
+    )
 }
 
 pub fn download(new_package: Option<(&str, bool)>) -> Result<Manifest> {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -52,6 +52,11 @@ fn list_manifest_packages<W: std::io::Write>(
     })
 }
 
+#[test]
+fn list_manifest_format() {
+    assert_eq!("Hello", "there")
+}
+
 pub fn download(new_package: Option<(&str, bool)>) -> Result<Manifest> {
     let span = tracing::info_span!("download_deps");
     let _enter = span.enter();

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -292,7 +292,7 @@ fn main() {
             check,
         } => format::run(stdin, check, files),
 
-        Command::Deps(Dependencies::List) => dependencies::list(std::io::stdout()),
+        Command::Deps(Dependencies::List) => dependencies::list(),
 
         Command::Deps(Dependencies::Download) => dependencies::download(None).map(|_| ()),
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -227,6 +227,9 @@ impl CompilePackage {
 
 #[derive(StructOpt, Debug)]
 enum Dependencies {
+    /// List packages from the root config
+    List,
+
     /// Download packages to the local cache
     Download,
 }
@@ -288,6 +291,8 @@ fn main() {
             files,
             check,
         } => format::run(stdin, check, files),
+
+        Command::Deps(Dependencies::List) => dependencies::list(),
 
         Command::Deps(Dependencies::Download) => dependencies::download(None).map(|_| ()),
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -292,7 +292,7 @@ fn main() {
             check,
         } => format::run(stdin, check, files),
 
-        Command::Deps(Dependencies::List) => dependencies::list(),
+        Command::Deps(Dependencies::List) => dependencies::list(std::io::stdout()),
 
         Command::Deps(Dependencies::Download) => dependencies::download(None).map(|_| ()),
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -266,12 +266,14 @@ pub enum InvalidProjectNameReason {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum StandardIoAction {
     Read,
+    Write,
 }
 
 impl StandardIoAction {
     fn text(&self) -> &'static str {
         match self {
             StandardIoAction::Read => "read from",
+            StandardIoAction::Write => "write to",
         }
     }
 }


### PR DESCRIPTION
Hi there! This is my first pass at fixing #1346 😄 

Based on our conversation in the issue, I was targeting this format:

```
From gleam.toml:

    *  gleam_stdlib (~> 0.18)                                    
    *  gleam_otp (~> 0.3)
```

While implementing it, I ran into a couple of questions

- Should we distinguish between development dependencies?
- Should we show the version range specified in the config, or the concrete version in the manifest?

I wasn't sure what the best answer to these questions were, but I decided to start with a label for development dependencies and version ranges. When running `gleam deps list` from the test project, here's the current output:

```
project deps (from gleam.toml):

    * gleam_stdlib (~> 0.18)
    * gleam_otp (~> 0.3)
    * first_gleam_publish_package (> 0.0.0) (dev)
    * accept (~> 0.3) (dev)
    * gleeunit (~> 0.1) (dev)
```

I'm totally happy to make any changes you think would be best, though! 😄 Thank you so much for your time!