### PR TITLE
[pretty] Simplify fits

### DIFF
--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -1,5 +1,4 @@
 use super::Document::*;
-use super::Mode::*;
 use super::*;
 
 use im::vector;
@@ -14,131 +13,68 @@ fn fits_test() {
     assert!(fits(0, vector![]));
 
     // ForceBreak never fits
-    assert!(!fits(100, vector![(0, Unbroken, ForceBreak)]));
-    assert!(!fits(100, vector![(0, Broken, ForceBreak)]));
+    assert!(!fits(100, vector![ForceBreak]));
 
     // Break in Broken fits always
     assert!(fits(
         1,
-        vector![(
-            0,
-            Broken,
-            Break {
-                broken: "12",
-                unbroken: "",
-            }
-        )]
+        vector![Break {
+            broken: "12",
+            unbroken: "",
+        }]
     ));
 
     // Break in Unbroken mode fits if `unbroken` fits
     assert!(fits(
         3,
-        vector![(
-            0,
-            Unbroken,
-            Break {
-                broken: "",
-                unbroken: "123",
-            }
-        )]
+        vector![Break {
+            broken: "",
+            unbroken: "123",
+        }]
     ));
     assert!(!fits(
         2,
-        vector![(
-            0,
-            Unbroken,
-            Break {
-                broken: "",
-                unbroken: "123",
-            }
-        )]
+        vector![Break {
+            broken: "",
+            unbroken: "123",
+        }]
     ));
 
     // Line always fits
-    assert!(fits(0, vector![(0, Broken, Line(100))]));
-    assert!(fits(0, vector![(0, Unbroken, Line(100))]));
+    assert!(fits(0, vector![Line(100)]));
 
     // String fits if smaller than limit
-    assert!(fits(5, vector![(0, Broken, String("Hello".to_string()))]));
-    assert!(fits(5, vector![(0, Unbroken, String("Hello".to_string()))]));
-    assert!(!fits(4, vector![(0, Broken, String("Hello".to_string()))]));
-    assert!(!fits(
-        4,
-        vector![(0, Unbroken, String("Hello".to_string()))]
-    ));
+    assert!(fits(5, vector![String("Hello".to_string())]));
+    assert!(!fits(4, vector![String("Hello".to_string())]));
 
     // Cons fits if combined smaller than limit
     assert!(fits(
         2,
-        vector![(
-            0,
-            Broken,
-            String("1".to_string()).append(String("2".to_string()))
-        )]
-    ));
-    assert!(fits(
-        2,
-        vector![(
-            0,
-            Unbroken,
-            String("1".to_string()).append(String("2".to_string()))
-        )]
+        vector![String("1".to_string()).append(String("2".to_string()))]
     ));
     assert!(!fits(
         1,
-        vector![(
-            0,
-            Broken,
-            String("1".to_string()).append(String("2".to_string()))
-        )]
-    ));
-    assert!(!fits(
-        1,
-        vector![(
-            0,
-            Unbroken,
-            String("1".to_string()).append(String("2".to_string()))
-        )]
+        vector![String("1".to_string()).append(String("2".to_string()))]
     ));
 
     // Nest fits if combined smaller than limit
     assert!(fits(
         2,
-        vector![(0, Broken, Nest(1, Box::new(String("12".to_string())),))]
-    ));
-    assert!(fits(
-        2,
-        vector![(0, Unbroken, Nest(1, Box::new(String("12".to_string())),))]
+        vector![Nest(1, Box::new(String("12".to_string())),)]
     ));
     assert!(!fits(
         1,
-        vector![(0, Broken, Nest(1, Box::new(String("12".to_string())),))]
-    ));
-    assert!(!fits(
-        1,
-        vector![(0, Unbroken, Nest(1, Box::new(String("12".to_string()))))]
+        vector![Nest(1, Box::new(String("12".to_string())))]
     ));
 
     // Nest fits if combined smaller than limit
     assert!(fits(
         2,
-        vector![(0, Broken, NestCurrent(Box::new(String("12".to_string())),))]
-    ));
-    assert!(fits(
-        2,
-        vector![(
-            0,
-            Unbroken,
-            NestCurrent(Box::new(String("12".to_string())),)
-        )]
+        vector![NestCurrent(Box::new(String("12".to_string())),)]
     ));
     assert!(!fits(
         1,
-        vector![(0, Broken, NestCurrent(Box::new(String("12".to_string())),))]
-    ));
-    assert!(!fits(
-        1,
-        vector![(0, Unbroken, NestCurrent(Box::new(String("12".to_string()))))]
+        vector![NestCurrent(Box::new(String("12".to_string())))]
     ));
 }
 


### PR DESCRIPTION
This PR simplifies the `fits` function. The reference implementation in _Strictly Pretty_ (which this mirrors) is actually overly complex: `indent` and `mode` are unused and can be removed without changing behavior.

**I know this PR is both out of the blue and unimportant -- totally understand if it's not something you want to spend time reviewing.**

### Why `indent` is Unused
`indent` is tracked and passed around, but is never used in a position which can affect the return value of `fits`.
### Why `mode` is Unused
`fits` is only called with `Mode::Unbroken` (and there's no point in calling it with `Mode::Broken` -- at that point you've already decided to split the rest of the line) and can only ever stay the same or transition to `Mode::Unbroken`. I.e. `mode` will _always_ be `Mode::Unbroken`.
