### PR TITLE
Apple Silicon support in releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [macos, windows-64bit]
+        build: [macos, macos-arm, windows-64bit]
         toolchain: [stable]
         include:
           - build: macos
             os: macos-latest
             target: x86_64-apple-darwin
-          - build: macos
+          - build: macos-arm
             os: macos-latest
             target: aarch64-apple-darwin
           - build: windows-64bit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           - build: macos
             os: macos-latest
             target: x86_64-apple-darwin
-          - build: macos-arm
+          - build: macos-arm64
             os: macos-latest
             target: aarch64-apple-darwin
           - build: windows-64bit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,9 @@ jobs:
           - build: macos
             os: macos-latest
             target: x86_64-apple-darwin
+          - build: macos
+            os: macos-latest
+            target: aarch64-apple-darwin
           - build: windows-64bit
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [macos, macos-arm, windows-64bit]
+        build: [macos, macos-arm64, windows-64bit]
         toolchain: [stable]
         include:
           - build: macos


### PR DESCRIPTION
I added a target for the `aarch64-apple-darwin` toolchain, to cross compile an Apple Silicon version on the default macOS runner, since currently there aren't no Apple Silicon runners on GitHub.

I tested the release build in my fork (https://github.com/moogle19/gleam/releases/tag/untagged-c219bd7e74291f9abbcb) and the binary locally on my M1 Mac and it seems to work just fine.