### PR TITLE
Fix arm64 builds for macOS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
           - build: macos-arm64
-            os: macos-latest
+            os: macos-11
             target: aarch64-apple-darwin
           - build: windows-64bit
             os: windows-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,16 +28,16 @@ jobs:
       matrix:
         build: 
           - macos
-          # - macos-arm64
+          - macos-arm64
           - windows-64bit
         toolchain: [stable]
         include:
           - build: macos
             os: macos-latest
             target: x86_64-apple-darwin
-          # - build: macos-arm64
-          #   os: macos-latest
-          #   target: aarch64-apple-darwin
+          - build: macos-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
           - build: windows-64bit
             os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Fixes #1387.

I changed the macOS version to `macos-11` for the arm64 builds.

For whatever reason my test builds used macOS 11 although `macos-latest` was defined as version, which should default to macOS 10.15. The cross compilation only works in macOS >= 11.