### PR TITLE
feature(cli): New `clean` subcommand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- You can now remove build artifacts using the new `gleam clean` command.
 - The `compile-package` can now generate `package.app` files and compile source
   modules to `.beam` bytecode files.
 - The flags that `compile-package` accepts have changed.

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -159,6 +159,9 @@ enum Command {
         #[structopt(long)]
         dev: bool,
     },
+
+    /// Clean build artifacts
+    Clean,
 }
 
 #[derive(StructOpt, Debug, Clone)]
@@ -301,6 +304,8 @@ fn main() {
         }
 
         Command::Add { package, dev } => add::command(package, dev),
+
+        Command::Clean => clean(),
     };
 
     match result {
@@ -378,6 +383,10 @@ fn print_config() -> Result<()> {
     let config = root_config()?;
     println!("{:#?}", config);
     Ok(())
+}
+
+fn clean() -> Result<()> {
+    crate::fs::delete_dir(gleam_core::paths::build().as_path())
 }
 
 fn initialise_logger() {


### PR DESCRIPTION
`gleam clean` will simply remove the `build` directory.

Is there any other directory outside of `build` that we should also remove?

Closes #1389 