### PR TITLE
Dont allow lowercase boolean variables in patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `true` and `false` can no longer be used as pattern matching variables.
+  A syntax error will hint about using Gleam's `True` and `False` values instead.
 - You can now remove build artifacts using the new `gleam clean` command.
 - The `compile-package` can now generate `package.app` files and compile source
   modules to `.beam` bytecode files.

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1698,6 +1698,10 @@ Try a different name for this module.",
                         "This is a reserved word.",
                         vec!["Hint: I was expecting to see a name here.".to_string(), "See: https://gleam.run/book/tour/reserved-words".to_string()]
                     ),
+                    ParseErrorType::LowcaseBooleanPattern => (
+                        "Did you want a Bool instead of a variable?",
+                        vec!["Hint: In Gleam boolean literals are True and False".to_string(), "See: https://gleam.run/book/tour/bools.html".to_string()]
+                    ),
                     ParseErrorType::UnexpectedToken { expected } => {
                         let mut messages = expected.clone();
                         if let Some(s) = messages.first_mut() {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -763,9 +763,17 @@ where
                 if self.maybe_one(&Token::Dot).is_some() {
                     self.expect_constructor_pattern(Some((start, name, end)))?
                 } else {
-                    Pattern::Var {
-                        location: SrcSpan { start, end },
-                        name,
+                    match name.as_str() {
+                        "true" | "false" => {
+                            return parse_error(
+                                ParseErrorType::LowcaseBooleanPattern,
+                                SrcSpan { start, end },
+                            )
+                        }
+                        _ => Pattern::Var {
+                            location: SrcSpan { start, end },
+                            name,
+                        },
                     }
                 }
             }

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -55,6 +55,7 @@ pub enum ParseErrorType {
     OpaqueTypeAlias, // Type aliases cannot be opaque
     TooManyArgHoles, // a function call can have at most 1 arg hole
     ListSpreadWithoutElements, // Pointless spread: `[..xs]`
+    LowcaseBooleanPattern, // most likely user meant True or False in patterns
     UnexpectedEof,
     UnexpectedReservedWord, // reserved word used when a name was expected
     UnexpectedToken { expected: Vec<String> },

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -185,3 +185,15 @@ fn pointless_spread() {
         }
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/1358
+#[test]
+fn lowcase_bool_in_pattern() {
+    assert_error!(
+        "case 42 > 42 { true -> 1; false -> 2; }",
+        ParseError {
+            error: ParseErrorType::LowcaseBooleanPattern,
+            location: SrcSpan { start: 15, end: 19 },
+        }
+    );
+}

--- a/test/language/src/main.gleam
+++ b/test/language/src/main.gleam
@@ -338,9 +338,9 @@ fn make_error(reason) {
 // same result
 fn clause_guard_tests() -> List(Test) {
   // Testing that the name reuse is valid
-  let true = true()
+  let true_ = true()
   // Testing that the name reuse is valid
-  let false = false()
+  let false_ = false()
   let int_zero = make_int_zero()
   let int_one = make_int_zero() + 1
   let float_zero = make_float_zero()
@@ -355,7 +355,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         0,
         case Nil {
-          _ if true -> 0
+          _ if true_ -> 0
           _ -> 1
         },
       )
@@ -365,7 +365,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         1,
         case Nil {
-          _ if false -> 0
+          _ if false_ -> 0
           _ -> 1
         },
       )
@@ -455,7 +455,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         0,
         case Nil {
-          _ if true && true -> 0
+          _ if true_ && true_ -> 0
           _ -> 1
         },
       )
@@ -465,7 +465,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         1,
         case Nil {
-          _ if true && false -> 0
+          _ if true_ && false_ -> 0
           _ -> 1
         },
       )
@@ -475,7 +475,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         1,
         case Nil {
-          _ if false && true -> 0
+          _ if false_ && true_ -> 0
           _ -> 1
         },
       )
@@ -485,7 +485,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         1,
         case Nil {
-          _ if false && false -> 0
+          _ if false_ && false_ -> 0
           _ -> 1
         },
       )
@@ -495,7 +495,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         0,
         case Nil {
-          _ if true || true -> 0
+          _ if true_ || true_ -> 0
           _ -> 1
         },
       )
@@ -505,7 +505,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         0,
         case Nil {
-          _ if true || false -> 0
+          _ if true_ || false_ -> 0
           _ -> 1
         },
       )
@@ -515,7 +515,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         0,
         case Nil {
-          _ if false || true -> 0
+          _ if false_ || true_ -> 0
           _ -> 1
         },
       )
@@ -525,7 +525,7 @@ fn clause_guard_tests() -> List(Test) {
       assert_equal(
         1,
         case Nil {
-          _ if false || false -> 0
+          _ if false_ || false_ -> 0
           _ -> 1
         },
       )


### PR DESCRIPTION
Inside patterns, when people use `true` and `false` variables
they probaly meant to use Gleam's `True` and `False`.


```gleam
case 42 > 42 {
     true -> "Nop"
     false -> "Yes"
}
```

The previous code generates an error like:

![Screen Shot 2021-12-19 at 12 23 09](https://user-images.githubusercontent.com/331/146686591-cd2dcd9a-eb23-4829-9d15-adb87aadacf0.png)


Closes #1358