### PR TITLE
Allow expression for record in record update syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Fixed a bug where tail recursion could sometimes generated incorrect
   JavaScript code.
 - Performance of code generators has been slightly improved.
+- Allow the record in a record expansion to be an expression that returns a
+  record.
 
 ## v0.18.2 - 2021-12-12
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -518,7 +518,7 @@ pub struct CallArg<A> {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct RecordUpdateSpread {
-    pub name: String,
+    pub base: Box<UntypedExpr>,
     pub location: SrcSpan,
 }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -819,7 +819,7 @@ impl<'comments> Formatter<'comments> {
     ) -> Document<'a> {
         use std::iter::once;
         let constructor_doc = self.expr(constructor);
-        let spread_doc = "..".to_doc().append(spread.name.to_doc());
+        let spread_doc = "..".to_doc().append(self.expr(&spread.base));
         let arg_docs = args.iter().map(|a| self.record_update_arg(a));
         let all_arg_docs = once(spread_doc).chain(arg_docs);
         constructor_doc.append(wrap_args(all_arg_docs)).group()

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -189,6 +189,10 @@ type Cat {
   Cat(name: String, cuteness: Int)
 }
 
+type Box {
+  Box(occupant: Cat)
+}
+
 const felix = Cat("Felix", 12)
 const tom = Cat(cuteness: 1, name: "Tom")
 
@@ -201,10 +205,17 @@ fn go() {
 fn update(cat) {
   Cat(..cat, name: "Sid")
   Cat(..cat, name: "Bartholemew Wonder Puss the Fourth !!!!!!!!!!!!!!!!")
+  Cat(..new_cat(), name: "Molly")
+  let box = Box(occupant: cat)
+  Cat(..box.occupant, cuteness: box.occupant.cuteness + 1)
 }
 
 fn access(cat: Cat) {
   cat.cuteness
+}
+
+fn new_cat() {
+  Cat(name: "Beau", cuteness: 11)
 }
 "#,
     );

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__custom_type_with_named_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__custom_type_with_named_fields.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
-expression: "\ntype Cat {\n  Cat(name: String, cuteness: Int)\n}\n\nconst felix = Cat(\"Felix\", 12)\nconst tom = Cat(cuteness: 1, name: \"Tom\")\n\nfn go() {\n  Cat(\"Nubi\", 1)\n  Cat(2, name: \"Nubi\")\n  Cat(cuteness: 3, name: \"Nubi\")\n}\n\nfn update(cat) {\n  Cat(..cat, name: \"Sid\")\n  Cat(..cat, name: \"Bartholemew Wonder Puss the Fourth !!!!!!!!!!!!!!!!\")\n}\n\nfn access(cat: Cat) {\n  cat.cuteness\n}\n"
+expression: "\ntype Cat {\n  Cat(name: String, cuteness: Int)\n}\n\ntype Box {\n  Box(occupant: Cat)\n}\n\nconst felix = Cat(\"Felix\", 12)\nconst tom = Cat(cuteness: 1, name: \"Tom\")\n\nfn go() {\n  Cat(\"Nubi\", 1)\n  Cat(2, name: \"Nubi\")\n  Cat(cuteness: 3, name: \"Nubi\")\n}\n\nfn update(cat) {\n  Cat(..cat, name: \"Sid\")\n  Cat(..cat, name: \"Bartholemew Wonder Puss the Fourth !!!!!!!!!!!!!!!!\")\n  Cat(..new_cat(), name: \"Molly\")\n  let box = Box(occupant: cat)\n  Cat(..box.occupant, cuteness: box.occupant.cuteness + 1)\n}\n\nfn access(cat: Cat) {\n  cat.cuteness\n}\n\nfn new_cat() {\n  Cat(name: \"Beau\", cuteness: 11)\n}\n"
 
 ---
 import { CustomType } from "../gleam.mjs";
@@ -17,6 +17,13 @@ class Cat extends CustomType {
   }
 }
 
+class Box extends CustomType {
+  constructor(occupant) {
+    super();
+    this.occupant = occupant;
+  }
+}
+
 function go() {
   new Cat("Nubi", 1);
   new Cat("Nubi", 2);
@@ -25,12 +32,17 @@ function go() {
 
 function update(cat) {
   cat.withFields({ name: "Sid" });
-  return cat.withFields({
-    name: "Bartholemew Wonder Puss the Fourth !!!!!!!!!!!!!!!!"
-  });
+  cat.withFields({ name: "Bartholemew Wonder Puss the Fourth !!!!!!!!!!!!!!!!" });
+  new_cat().withFields({ name: "Molly" });
+  let box = new Box(cat);
+  return box.occupant.withFields({ cuteness: box.occupant.cuteness + 1 });
 }
 
 function access(cat) {
   return cat.cuteness;
+}
+
+function new_cat() {
+  return new Cat("Beau", 11);
 }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -593,12 +593,13 @@ where
                 let start = expr.location().start;
                 if let Some((dot_s, _)) = self.maybe_one(&Token::DotDot) {
                     // Record update
-                    let (_, name, name_e) = self.expect_name()?;
+                    let base = self.expect_expression()?;
+                    let base_e = base.location().end;
                     let spread = RecordUpdateSpread {
-                        name,
+                        base: Box::new(base),
                         location: SrcSpan {
                             start: dot_s,
-                            end: name_e,
+                            end: base_e,
                         },
                     };
                     let mut args = vec![];

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1255,7 +1255,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
         } = value_constructor
         {
             if let Type::Fn { retrn, .. } = value_constructor.type_.as_ref() {
-                let spread = self.infer_var(spread.name, spread.location)?;
+                let spread = self.infer(*spread.base)?;
                 let return_type = self.instantiate(retrn.clone(), &mut hashmap![]);
 
                 // Check that the spread variable unifies with the return type of the constructor

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_update.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_update.snap
@@ -4,10 +4,10 @@ expression: "\npub type Person {\n  Person(name: String, age: Int)\n};\npub fn u
 
 ---
 error: Unknown variable
-  ┌─ /src/one/two.gleam:6:10
+  ┌─ /src/one/two.gleam:6:12
   │
 6 │   Person(..person)
-  │          ^^^^^^^^ did you mean `Person`?
+  │            ^^^^^^ did you mean `Person`?
 
 The name `person` is not in scope here.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__wrong_type_update.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__wrong_type_update.snap
@@ -4,10 +4,10 @@ expression: "\n pub type Person {\n   Person(name: String, age: Int)\n };\n pub 
 
 ---
 error: Type mismatch
-  ┌─ /src/one/two.gleam:9:11
+  ┌─ /src/one/two.gleam:9:13
   │
 9 │    Person(..box)
-  │           ^^^^^
+  │             ^^^
 
 Expected type:
 


### PR DESCRIPTION
Fixes #1411 

Overall the change is very small. The updated parser now expects the item after the spread operator to be any expression instead of only `Name`. This `base` expression had to be wrapped in a `Box` when put into the `RecordUpdateSpread` struct in order to prevent a cyclic dependency; let me know if there's a better way to do this :sweat_smile: 

Added a few spot-checking tests for both Erlang and JavaScript; specifically for the record being a function call and for the record being a field access (as referenced in #1411). Let me know if there's any more you'd like me to add!