### PR TITLE
Provide sha256 and sha512 checksums for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: 
+        build:
           - macos
           - macos-arm64
           - windows-64bit
@@ -68,13 +68,15 @@ jobs:
             ARCHIVE="gleam-$VERSION-${{ matrix.build }}.zip"
             cp "target/${{ matrix.target }}/release/gleam.exe" "gleam.exe"
             7z a "$ARCHIVE" "gleam.exe"
-            echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
           else
             ARCHIVE="gleam-$VERSION-${{ matrix.build }}.tar.gz"
             cp "target/${{ matrix.target }}/release/gleam" "gleam"
             tar -czvf "$ARCHIVE" "gleam"
-            echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
           fi
+
+          openssl dgst -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
+          openssl dgst -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
+          echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive
         uses: actions/upload-release-asset@v1
@@ -85,6 +87,26 @@ jobs:
           asset_path: ${{ env.ASSET }}
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/gzip
+
+      - name: Upload sha256 checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET }}.sha256
+          asset_name: ${{ env.ASSET }}.sha256
+          asset_content_type: text/plain
+
+      - name: Upload sha512 checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET }}.sha512
+          asset_name: ${{ env.ASSET }}.sha512
+          asset_content_type: text/plain
 
   build-release-musl:
     needs: create-release
@@ -110,6 +132,8 @@ jobs:
           ARCHIVE="gleam-$VERSION-linux-amd64.tar.gz"
           cp "target/x86_64-unknown-linux-musl/release/gleam" "gleam"
           tar -czvf "$ARCHIVE" "gleam"
+          openssl dgst -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
+          openssl dgst -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive
@@ -121,3 +145,23 @@ jobs:
           asset_path: ${{ env.ASSET }}
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/gzip
+
+      - name: Upload sha256 checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET }}.sha256
+          asset_name: ${{ env.ASSET }}.sha256
+          asset_content_type: text/plain
+
+      - name: Upload sha512 checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET }}.sha512
+          asset_name: ${{ env.ASSET }}.sha512
+          asset_content_type: text/plain

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,8 +57,8 @@ jobs:
             tar -czvf "$ARCHIVE" "gleam"
           fi
 
-          openssl dgst -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
-          openssl dgst -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
+          openssl dgst -r -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
+          openssl dgst -r -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive
@@ -98,8 +98,8 @@ jobs:
           ARCHIVE="gleam-$VERSION-linux-amd64.tar.gz"
           cp "target/x86_64-unknown-linux-musl/release/gleam" "gleam"
           tar -czvf "$ARCHIVE" "gleam"
-          openssl dgst -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
-          openssl dgst -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
+          openssl dgst -r -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
+          openssl dgst -r -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,8 +57,8 @@ jobs:
             tar -czvf "$ARCHIVE" "gleam"
           fi
 
-          openssl dgst -r -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
-          openssl dgst -r -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
+          openssl dgst -r -sha256 -out "$ARCHIVE".sha256 "$ARCHIVE"
+          openssl dgst -r -sha512 -out "$ARCHIVE".sha512 "$ARCHIVE"
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive
@@ -98,8 +98,8 @@ jobs:
           ARCHIVE="gleam-$VERSION-linux-amd64.tar.gz"
           cp "target/x86_64-unknown-linux-musl/release/gleam" "gleam"
           tar -czvf "$ARCHIVE" "gleam"
-          openssl dgst -r -sha256 "$ARCHIVE" > "$ARCHIVE".sha256
-          openssl dgst -r -sha512 "$ARCHIVE" > "$ARCHIVE".sha512
+          openssl dgst -r -sha256 -out "$ARCHIVE".sha256 "$ARCHIVE"
+          openssl dgst -r -sha512 -out "$ARCHIVE".sha512 "$ARCHIVE"
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,25 +4,8 @@ on:
     tags:
       - "v*"
 jobs:
-  create-release:
-    name: create-release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.release.outputs.upload_url }}
-    steps:
-      - name: Create GitHub release
-        id: release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: true
-
   build-release:
     name: build-release
-    needs: create-release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -79,37 +62,20 @@ jobs:
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/gzip
-
-      - name: Upload sha256 checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}.sha256
-          asset_name: ${{ env.ASSET }}.sha256
-          asset_content_type: text/plain
-
-      - name: Upload sha512 checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}.sha512
-          asset_name: ${{ env.ASSET }}.sha512
-          asset_content_type: text/plain
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.ref }}
+          name: ${{ github.ref }}
+          draft: true
+          prelease: false
+          fail_on_unmatched_files: true
+          files: |
+            "$ASSET"
+            "$ASSET".sha256
+            "$ASSET".sha512
 
   build-release-musl:
-    needs: create-release
     runs-on: ubuntu-latest
     container: clux/muslrust:stable
     steps:
@@ -137,31 +103,15 @@ jobs:
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/gzip
-
-      - name: Upload sha256 checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}.sha256
-          asset_name: ${{ env.ASSET }}.sha256
-          asset_content_type: text/plain
-
-      - name: Upload sha512 checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}.sha512
-          asset_name: ${{ env.ASSET }}.sha512
-          asset_content_type: text/plain
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.ref }}
+          name: ${{ github.ref }}
+          draft: true
+          prelease: false
+          fail_on_unmatched_files: true
+          files: |
+            "$ASSET"
+            "$ASSET".sha256
+            "$ASSET".sha512


### PR DESCRIPTION
We may have an additional happy accident here @lpil from https://github.com/gleam-lang/gleam/pull/1419#issuecomment-1002348110

> RE release creation, I'm happy to have the draft be created even if it fails. I can delete the draft release no problem, and it's less work than fixing the build which I would have to do anyway.

To merge 3 artifact upload statements into 1, I changed the action. The new action supports glob updating but doesn't allow passing in a URI of an existing release. Releases with the same name(s) will be used if found - this needs verification.

/cc @jinyus