### PR TITLE
Update `parse_custom_type` examples

### DIFF
--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1474,8 +1474,8 @@ where
     // examples:
     //   type A { A }
     //   type A { A(String) }
-    //   type A(a) { A(a: b) }
-    //   type A(a) { A(String, a: b) }
+    //   type Box(inner_type) { Box(inner: inner_type) }
+    //   type NamedBox(inner_type) { Box(String, inner: inner_type) }
     fn parse_custom_type(
         &mut self,
         start: usize,


### PR DESCRIPTION
These examples, e.g.
```gleam
type A(a) { A(String, a: b) }
```
seem to indicate that the type parameter `a` declares a field that must exist in all records/constructors. This may have been true at one point, but this is not how type parameters are used today. I replaced these examples with examples from [the "Generics" section of the Language Tour](https://gleam.run/book/tour/custom-types.html#generics).