### PR TITLE
Enhance type mismatch errors in the presence of try

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - New projects include Hex badges and a link to Hexdocs.
+- Enhance type mismatch errors in the presence of try.
 
 ## v0.19.0 - 2022-01-12
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -608,7 +608,7 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
                 .type_from_ast(ann)
                 .map(|t| self.instantiate(t, &mut hashmap![]))?;
             self.unify(ann_typ, value_typ)
-                .map_err(|e| convert_unify_error(e, value.location()))?;
+                .map_err(|e| convert_unify_error(e, value.type_defining_location()))?;
         }
 
         Ok(TypedExpr::Assignment {
@@ -1760,10 +1760,12 @@ impl<'a, 'b, 'c> ExprTyper<'a, 'b, 'c> {
             body_typer.infer(body)
         })?;
 
-        // Check that any return type type is accurate.
+        // Check that any return type is accurate.
         if let Some(return_type) = return_type {
-            self.unify(return_type, body.type_())
-                .map_err(|e| e.return_annotation_mismatch().into_error(body.location()))?;
+            self.unify(return_type, body.type_()).map_err(|e| {
+                e.return_annotation_mismatch()
+                    .into_error(body.type_defining_location())
+            })?;
         }
 
         Ok((args, body))

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -395,6 +395,54 @@ fn function_arg_and_return_annotation() {
 }
 
 #[test]
+fn function_return_annotation_mismatch_with_try() {
+    assert_error!(
+        "fn() -> Result(Nil, Nil) {
+            let a = 1
+            try _ = Error(1)
+            // comments
+            // comments
+            // comments
+            // comments
+            // comments
+            // comments
+            // comments
+            // comments
+            // comments
+            // comments
+            Ok(Nil)
+        }"
+    );
+}
+
+#[test]
+fn function_return_annotation_mismatch_with_try_nested() {
+    assert_error!(
+        "fn() -> Result(Nil, Nil) {
+          try _ = {
+            try _ = {
+                try _ = Error(1)
+                Ok(Nil)
+            }
+            Ok(Nil)
+          }
+          Ok(Nil)
+        }"
+    );
+}
+
+#[test]
+fn variable_annotation_with_try() {
+    assert_error!(
+        "let x: Result(Nil, Nil) = {
+            let a_var = 1
+            try _ = Error(1)
+            Ok(Nil)
+        }"
+    );
+}
+
+#[test]
 fn pipe_mismatch_error() {
     assert_module_error!(
         "pub fn main() -> String {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__function_return_annotation_mismatch_with_try.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__function_return_annotation_mismatch_with_try.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "fn() -> Result(Nil, Nil) {\n            let a = 1\n            try _ = Error(1)\n            // comments\n            // comments\n            // comments\n            // comments\n            // comments\n            // comments\n            // comments\n            // comments\n            // comments\n            // comments\n            Ok(Nil)\n        }"
+
+---
+error: Type mismatch
+   ┌─ /src/one/two.gleam:3:13
+   │  
+ 3 │ ╭             try _ = Error(1)
+ 4 │ │             // comments
+ 5 │ │             // comments
+ 6 │ │             // comments
+   · │
+13 │ │             // comments
+14 │ │             Ok(Nil)
+   │ ╰───────────────────^
+
+The type of this returned value doesn't match the return type 
+annotation of this function.
+
+Expected type:
+
+    Result(Nil, Nil)
+
+Found type:
+
+    Result(Nil, Int)
+
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__function_return_annotation_mismatch_with_try_nested.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__function_return_annotation_mismatch_with_try_nested.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "fn() -> Result(Nil, Nil) {\n          try _ = {\n            try _ = {\n                try _ = Error(1)\n                Ok(Nil)\n            }\n            Ok(Nil)\n          }\n          Ok(Nil)\n        }"
+
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:2:11
+  │  
+2 │ ╭           try _ = {
+3 │ │             try _ = {
+4 │ │                 try _ = Error(1)
+5 │ │                 Ok(Nil)
+  · │
+8 │ │           }
+9 │ │           Ok(Nil)
+  │ ╰─────────────────^
+
+The type of this returned value doesn't match the return type 
+annotation of this function.
+
+Expected type:
+
+    Result(Nil, Nil)
+
+Found type:
+
+    Result(Nil, Int)
+
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__variable_annotation_with_try.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__variable_annotation_with_try.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "let x: Result(Nil, Nil) = {\n            let a_var = 1\n            try _ = Error(1)\n            Ok(Nil)\n        }"
+
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:13
+  │  
+3 │ ╭             try _ = Error(1)
+4 │ │             Ok(Nil)
+  │ ╰───────────────────^
+
+Expected type:
+
+    Result(Nil, Nil)
+
+Found type:
+
+    Result(Nil, Int)
+
+


### PR DESCRIPTION
Fixes issue https://github.com/gleam-lang/gleam/issues/1403

When a type mismatch occurs in the presence of a try, the whole code from the try expression to the block return value is reported. The display library already handles the trimming when there are many lines.