### PR TITLE
Add rust-cache GitHub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,12 @@ jobs:
           target: ${{ matrix.target }}
           profile: minimal
           override: true
+          default: true
+
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.target }}
 
       - name: Build binary
         uses: actions-rs/cargo@v1
@@ -72,6 +78,11 @@ jobs:
         run: |
           ln -s /root/.cargo $HOME/.cargo
           ln -s /root/.rustup $HOME/.rustup
+
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: linux-musl
 
       - name: Build binary
         run: cargo build --release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,12 @@ jobs:
           target: ${{ matrix.target }}
           profile: minimal
           override: true
+          default: true
+
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.target }}
 
       - name: Build release binary
         uses: actions-rs/cargo@v1
@@ -100,6 +106,11 @@ jobs:
         run: |
           ln -s /root/.cargo $HOME/.cargo
           ln -s /root/.rustup $HOME/.rustup
+
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: linux-musl
 
       - name: Build release binary
         run: cargo build --release


### PR DESCRIPTION
Add [rust-cache](https://github.com/Swatinem/rust-cache) GitHub action for caching Rust dependencies.
Cache is separate for different target platforms, and different kinds of jobs (test/release).

To avoid [issues with cross compilation](https://github.com/Swatinem/rust-cache/issues/33),
set the toolchain as default in actions-rs/toolchain.

[Example test run that leveraged the cache](https://github.com/michallepicki/gleam/actions/runs/1651524456)

[Example release run that should leverage the cache](https://github.com/michallepicki/gleam/actions/runs/1651549344) (at the time of writing it's still going but I'm pretty sure it will work)

edit: The release builds didn't hit the cache even though [previous release run](https://github.com/michallepicki/gleam/actions/runs/1651489871) shows the same cache keys... I think it's either just GitHub cache not being super reliable, or the caches are taking too much space. Sill, the workflow ran successfully :)

edit2: Tried again, same result. Test build cache works, release build cache doesn't work. No idea why.