### PR TITLE
Build dependency packages managed with Mix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Introduce a limited form of exhaustiveness checking for pattern matching
   of custom types, which only checks that all constructor tags are covered
   at the top level of patterns.
+- Gleam can now build dependency packages that are managed using Mix.
+
 
 ## v0.19.0 - 2022-01-12
 

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -28,6 +28,14 @@ pub fn command() -> Result<(), Error> {
         let _ = command.arg("-pa").arg(entry.path().join("ebin"));
     }
 
+    // Start applications
+    //let config = crate::config::root_config()?;
+    //let package = paths::build_package(Mode::Dev, Target::Erlang, &config.name);
+    //let app_file = format!("{}.app", &config.name);
+    //let _ = command.arg("-s").arg(package.join("ebin").join(app_file));
+    //let _ = command.arg("-s").arg(&config.name);
+    //let _ = command.arg("-s").arg("application").arg("ensure_all_started").arg(&config.name).arg("temporary");
+
     crate::cli::print_running("Erlang shell");
 
     // Run the shell

--- a/test/project_erlang/gleam.toml
+++ b/test/project_erlang/gleam.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 [dependencies]
 gleam_stdlib = "~> 0.18"
 certifi = "~> 2.8" # This is a rebar3 dep that uses files in ./priv
+countries = "~> 1.6" # This is a mix dep that uses files in ./priv
 gleam_erlang = "~> 0.5"
 
 [dev-dependencies]


### PR DESCRIPTION
This is an initial effort to get Mix-managed dependencies compiling for projects using the Gleam build tool.

Presently, some dependencies compile and run (Nx, Jason, Earmark), but other dependencies—I suspect those that depend on running applications in particular—fail to compile (Phoenix, Timex, Countries [added to the test project because it uses the `priv` dir]).

Even for Nx, the application must be started explicitly—`application:ensure_all_started(nx)`—e.g. after launching `gleam shell`. While this results in an error, it does indeed allow the module to be used afterward (contrary to what I would understand from the docs: "If an error occurs, the applications started by the function are stopped to bring the set of running applications back to its initial state." [[ensure_all_started-1]](https://www.erlang.org/doc/man/application.html#ensure_all_started-1)); unfortunately, the error precludes it from being launched via command-line flags in my testing thus far (commented code remains in `shell.rs` for reference).

Some further reference material: https://github.com/Supersonido/rebar_mix

One thought is that it might be cleaner to add the detected Elixir lib to the `ebins` path, rather than copying it into the project's `build` dir.

Addresses #1408.