### PR TITLE
fix: make `gleam add` support multiple arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Log messages controlled with `GLEAM_LOG` now print to standard error.
 - Log message colours can be disabled by setting the `GLEAM_LOG_NOCOLOUR`
   environment variable.
+- You can now specify multiple packages when using `gleam add`
 
 ## v0.20.1 - 2022-02-24
 

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -7,26 +7,12 @@ use gleam_core::{
 
 use crate::{cli, fs};
 
-pub fn command(to_add: String, dev: bool) -> Result<()> {
-    // Insert the new package into the manifest and perform dependency
-    // resolution to determine a suitable version
-    let manifest = crate::dependencies::download(Some((&to_add, dev)))?;
+pub fn command(packages: Vec<String>, dev: bool) -> Result<()> {
+    // Insert the new packages into the manifest and perform dependency
+    // resolution to determine suitable versions
+    let manifest = crate::dependencies::download(Some((packages.to_vec(), dev)))?;
 
-    // Pull the selected version out of the new manifest so we know what it is
-    let version = manifest
-        .packages
-        .into_iter()
-        .find(|package| package.name == to_add)
-        .expect("Added package not found in resolved manifest")
-        .version;
-
-    tracing::info!(version=%version, "new_package_version_resolved");
-
-    // Produce a version requirement locked to the major version.
-    // i.e. if 1.2.3 is selected we want ~> 1.2
-    let range = format!("~> {}.{}", version.major, version.minor);
-
-    // Read gleam.toml so we can insert the new dep into it
+    // Read gleam.toml so we can insert new deps into it
     let mut toml = fs::read("gleam.toml")?
         .parse::<toml_edit::Document>()
         .map_err(|e| Error::FileIo {
@@ -36,18 +22,34 @@ pub fn command(to_add: String, dev: bool) -> Result<()> {
             err: Some(e.to_string()),
         })?;
 
-    // Insert the new dep
-    #[allow(clippy::indexing_slicing)]
-    if dev {
-        toml["dev-dependencies"][&to_add] = toml_edit::value(range);
-    } else {
-        toml["dependencies"][&to_add] = toml_edit::value(range);
-    };
+    // Insert the new deps
+    for package_to_add in packages {
+        // Pull the selected version out of the new manifest so we know what it is
+        let version = &manifest
+            .packages
+            .iter()
+            .find(|package| package.name == *package_to_add)
+            .expect("Added package not found in resolved manifest")
+            .version;
+
+        tracing::info!(version=%version, "new_package_version_resolved");
+
+        // Produce a version requirement locked to the major version.
+        // i.e. if 1.2.3 is selected we want ~> 1.2
+        let range = format!("~> {}.{}", version.major, version.minor);
+
+        #[allow(clippy::indexing_slicing)]
+        if dev {
+            toml["dev-dependencies"][&package_to_add] = toml_edit::value(range);
+        } else {
+            toml["dependencies"][&package_to_add] = toml_edit::value(range);
+        };
+
+        cli::print_added(&format!("{} v{}", package_to_add, version));
+    }
 
     // Write the updated config
     fs::write(Path::new("gleam.toml"), &toml.to_string())?;
-
-    cli::print_added(&format!("{} v{}", to_add, version));
 
     Ok(())
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -91,7 +91,7 @@ zzz 0.4.0
     )
 }
 
-pub fn download(new_package: Option<(&str, bool)>) -> Result<Manifest> {
+pub fn download(new_package: Option<(Vec<String>, bool)>) -> Result<Manifest> {
     let span = tracing::info_span!("download_deps");
     let _enter = span.enter();
     let mode = Mode::Dev;
@@ -104,14 +104,16 @@ pub fn download(new_package: Option<(&str, bool)>) -> Result<Manifest> {
     let mut config = crate::config::root_config()?;
     let project_name = config.name.clone();
 
-    // Insert the new package to add, if it exists
-    if let Some((package, dev)) = new_package {
-        let version = hexpm::version::Range::new(">= 0.0.0".into());
-        let _ = if dev {
-            config.dev_dependencies.insert(package.to_string(), version)
-        } else {
-            config.dependencies.insert(package.to_string(), version)
-        };
+    // Insert the new packages to add, if it exists
+    if let Some((packages, dev)) = new_package {
+        for package in packages {
+            let version = hexpm::version::Range::new(">= 0.0.0".into());
+            let _ = if dev {
+                config.dev_dependencies.insert(package.to_string(), version)
+            } else {
+                config.dependencies.insert(package.to_string(), version)
+            };
+        }
     }
 
     // Start event loop so we can run async functions to call the Hex API

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -175,11 +175,11 @@ enum Command {
     #[clap(setting = AppSettings::Hidden)]
     PrintConfig,
 
-    /// Add a new project dependency
+    /// Add new project dependencies
     Add {
-        package: String,
+        packages: Vec<String>,
 
-        /// Add the package as a dev-only dependency
+        /// Add the packages as dev-only dependencies
         #[clap(long)]
         dev: bool,
     },
@@ -338,7 +338,7 @@ fn main() {
             hex::UnretireCommand::new(package, version).run()
         }
 
-        Command::Add { package, dev } => add::command(package, dev),
+        Command::Add { packages, dev } => add::command(packages, dev),
 
         Command::Clean => clean(),
 


### PR DESCRIPTION
Please note I am not very familiar with rust, let me know if this change could be improved.

Enabling "Hide whitespace" should make this change more readable, since a lot of the code was just moved one indent deeper to put it in a loop