### PR TITLE
fix: do not print warnings as errors

### DIFF
--- a/compiler-core/src/diagnostic.rs
+++ b/compiler-core/src/diagnostic.rs
@@ -64,7 +64,13 @@ impl Diagnostic {
                 }
             })
             .collect();
-        let diagnostic = codespan_reporting::diagnostic::Diagnostic::new(Severity::Error)
+
+        let severity = match self.level {
+            Level::Error => Severity::Error,
+            Level::Warning => Severity::Warning,
+        };
+
+        let diagnostic = codespan_reporting::diagnostic::Diagnostic::new(severity)
             .with_message(&self.title)
             .with_labels(labels);
         let config = codespan_reporting::term::Config::default();


### PR DESCRIPTION
Closes #1533

Before:

![image](https://user-images.githubusercontent.com/42675056/156663860-e9811d42-7067-4531-a9cc-1fe74f0a0398.png)

After:

![image](https://user-images.githubusercontent.com/42675056/156663890-2b7f065d-a3a9-4b61-8db4-dd42c8747d35.png)
