### PR TITLE
Clear build directory if compiler version changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Log message colours can be disabled by setting the `GLEAM_LOG_NOCOLOUR`
   environment variable.
 - You can now specify multiple packages when using `gleam add`
+- If the compiler version changes we now rebuild the project from scratch on
+  next build command (#1547)
 
 ## v0.20.1 - 2022-02-24
 

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -5,11 +5,13 @@ use crate::{
     },
     codegen::{self, ErlangApp},
     config::PackageConfig,
+    error::{FileIoAction, FileKind},
     io::{CommandExecutor, FileSystemIO, FileSystemWriter},
     metadata, paths,
     project::ManifestPackage,
     type_,
     uid::UniqueIdGenerator,
+    version::COMPILER_VERSION,
     warning, Error, Result, Warning,
 };
 use std::{
@@ -106,6 +108,7 @@ where
 
     /// Returns the compiled information from the root package
     pub fn compile(&mut self) -> Result<Package> {
+        self.check_gleam_version()?;
         self.compile_dependencies()?;
 
         if self.options.perform_codegen {
@@ -128,6 +131,37 @@ where
         let modules = self.compile_gleam_package(&config, true, paths::root())?;
 
         Ok(Package { config, modules })
+    }
+
+    /// Checks that version file found in the build directory matches the
+    /// current version of gleam. If not, we will clear the build directory
+    /// before continuing. This will ensure that upgrading gleam will not leave
+    /// one with confusing or hard to debug states.
+    pub fn check_gleam_version(&self) -> Result<(), Error> {
+        let build_path = paths::build();
+        let version_path = paths::build_gleam_version();
+        if self.io.is_file(&version_path) {
+            let version = self.io.read(&version_path)?;
+            if version == COMPILER_VERSION {
+                return Ok(());
+            }
+        }
+
+        // Either file is missing our the versions do not match. Time to rebuild
+        tracing::info!("removing_build_state_from_different_gleam_version");
+        self.io.delete(&build_path)?;
+
+        // Recreate build directory with new updated version file
+        self.io.mkdir(&build_path)?;
+        let mut writer = self.io.writer(&version_path)?;
+        writer
+            .write_str(COMPILER_VERSION)
+            .map_err(|e| Error::FileIo {
+                action: FileIoAction::WriteTo,
+                kind: FileKind::File,
+                path: version_path,
+                err: Some(e.to_string()),
+            })
     }
 
     pub fn compile_dependencies(&mut self) -> Result<(), Error> {

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -71,6 +71,7 @@ pub mod pretty;
 pub mod project;
 pub mod type_;
 pub mod uid;
+pub mod version;
 pub mod warning;
 
 pub use error::{Error, Result};

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -45,6 +45,13 @@ pub fn build_deps_package_test(package: &str) -> PathBuf {
     build_deps_package(package).join("test")
 }
 
+/// A path to a special file that contains the version of gleam that last built
+/// the artifacts. If this file does not match the current version of gleam we
+/// will rebuild from scratch
+pub fn build_gleam_version() -> PathBuf {
+    build().join("gleam_version")
+}
+
 pub fn packages() -> PathBuf {
     build().join("packages")
 }

--- a/compiler-core/src/version.rs
+++ b/compiler-core/src/version.rs
@@ -1,0 +1,4 @@
+/// The current version of the gleam compiler. If this does not match what is
+/// already in the build folder we will not reuse any cached artifacts and
+/// instead build from scratch
+pub const COMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
This updates the project compiler to first look at a `build/gleam_version` file to know what version the artifacts were last built with. If the version has changed (or if the file doesn't yet exist) then we first delete the `build` directory and create a new `gleam_version` file with the updated version. This should ensure that we don't reuse any artifacts from the last version.

This is my first contribution to this project (and to a non-toy rust codebase) so I'm sure I may not have followed all the right conventions. Happy to make any and all modifications!

Fixes https://github.com/gleam-lang/gleam/issues/1477