### PR TITLE
feat(error): Update unknown label formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - You can now specify multiple packages when using `gleam add`
 - If the compiler version changes we now rebuild the project from scratch on
   next build command (#1547)
+- Updated the "Unknown label" error message to match other error messages
+  (#1548)
 
 ## v0.20.1 - 2022-02-24
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -714,10 +714,12 @@ Second: {}",
 constructor accepts."
                             .into()
                     } else {
-                        wrap_format!(
-                            "The other labelled arguments that this constructor accepts are `{}`.",
-                            other_labels.iter().join("`, `")
-                        )
+                        let mut label_text = String::from("It accepts these labels:\n");
+                        for label in other_labels.iter().sorted() {
+                            label_text.push_str("\n    ");
+                            label_text.push_str(label);
+                        }
+                        label_text
                     };
                     Diagnostic {
                         title,

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_label.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_label.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1172
 expression: "type X { X(a: Int, b: Float) }\nfn x() {\n  let x = X(a: 1, c: 2.0)\n  x\n}"
-
 ---
 error: Unknown label
   ┌─ /src/one/two.gleam:3:19
@@ -10,5 +8,7 @@ error: Unknown label
 3 │   let x = X(a: 1, c: 2.0)
   │                   ^^^^^^ Did you mean `b`?
 
-The other labelled arguments that this constructor accepts are `b`.
+It accepts these labels:
+
+    b
 


### PR DESCRIPTION
Instead of listing the labels on one (wrapped) line we instead put each label on its own line. This both matches other errors like "Unknown record field" as well as allows room for metadata to be shown in the future. I.E. The types of these labels

Fixes https://github.com/gleam-lang/gleam/issues/1539

I tried going doing the second part to show what type each label has, but it doesn't look like that information is available?
 In `type_/fields.rs` it seems the only thing we have is a `HashMap<String, usize>`. Is there a canonical way to get from the index / string to the corresponding types? If we could do that then we can add the type information to the `UnknownLabels` struct.