### PR TITLE
 fix(build): Do not destroy downloaded packages

### DIFF
--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -138,8 +138,8 @@ where
     /// before continuing. This will ensure that upgrading gleam will not leave
     /// one with confusing or hard to debug states.
     pub fn check_gleam_version(&self) -> Result<(), Error> {
-        let build_path = paths::build();
-        let version_path = paths::build_gleam_version();
+        let build_path = paths::build_packages(self.mode(), self.target());
+        let version_path = paths::build_gleam_version(self.mode(), self.target());
         if self.io.is_file(&version_path) {
             let version = self.io.read(&version_path)?;
             if version == COMPILER_VERSION {

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -45,13 +45,6 @@ pub fn build_deps_package_test(package: &str) -> PathBuf {
     build_deps_package(package).join("test")
 }
 
-/// A path to a special file that contains the version of gleam that last built
-/// the artifacts. If this file does not match the current version of gleam we
-/// will rebuild from scratch
-pub fn build_gleam_version() -> PathBuf {
-    build().join("gleam_version")
-}
-
 pub fn packages() -> PathBuf {
     build().join("packages")
 }
@@ -110,6 +103,13 @@ pub fn build_docs(package: &str) -> PathBuf {
 
 pub fn build_package(mode: Mode, target: Target, package: &str) -> PathBuf {
     build_packages(mode, target).join(package)
+}
+
+/// A path to a special file that contains the version of gleam that last built
+/// the artifacts. If this file does not match the current version of gleam we
+/// will rebuild from scratch
+pub fn build_gleam_version(mode: Mode, target: Target) -> PathBuf {
+    build_packages(mode, target).join("gleam_version")
 }
 
 #[test]


### PR DESCRIPTION
This patch corrects which directory we delete when we detect that the compiler version has changed. Before we were deleting the top level `build` directory. But that was also deleting our downloaded `packages` and never re-downloading them.

This fixes that by leaving the dependencies alone and instead _only_ deleting/recompiling the build targets instead.

Fixes https://github.com/gleam-lang/gleam/issues/1549