### PR TITLE
Report unused module imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Updated the "Unknown label" error message to match other error messages
   (#1548)
 - Permit type holes in function arguments and return annotations (#1519)
+- Report unused module imports (#1553)
 
 ## v0.20.1 - 2022-02-24
 

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1777,6 +1777,14 @@ pub fn register_import(
                 }
             }
 
+            if unqualified.is_empty() {
+                // When the module has no unqualified imports, we track its usage
+                // so we can warn if not used by the end of the type checking
+                let _ = environment
+                    .unused_modules
+                    .insert(module_name.clone(), *location);
+            }
+
             // Insert imported module into scope
             // TODO: use a refernce to the module to avoid copying
             let _ = environment

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -316,8 +316,8 @@ impl<'a> Environment<'a> {
                     })
             }
 
-            Some(module) => {
-                let module = self.imported_modules.get(module).ok_or_else(|| {
+            Some(m) => {
+                let module = self.imported_modules.get(m).ok_or_else(|| {
                     UnknownValueConstructorError::Module {
                         name: name.to_string(),
                         imported_modules: self

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -13,6 +13,7 @@ pub struct Environment<'a> {
     pub imported_names: HashMap<String, SrcSpan>,
     pub importable_modules: &'a im::HashMap<String, Module>,
     pub imported_modules: HashMap<String, Module>,
+    pub unused_modules: HashMap<String, SrcSpan>,
     pub imported_types: HashSet<String>,
 
     /// Values defined in the current function (or the prelude)
@@ -78,6 +79,7 @@ impl<'a> Environment<'a> {
             module_types_constructors: prelude.types_constructors.clone(),
             module_values: HashMap::new(),
             imported_modules: HashMap::new(),
+            unused_modules: HashMap::new(),
             imported_names: HashMap::new(),
             accessors: prelude.accessors.clone(),
             local_values: prelude.values.clone().into(),

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -41,6 +41,7 @@ pub struct Environment<'a> {
     /// entity_usages is a stack of scopes. When an entity is created it is
     /// added to the top scope. When an entity is used we crawl down the scope
     /// stack for an entity with that name and mark it as used.
+    /// NOTE: The bool in the tuple here tracks if the entity has been used
     pub entity_usages: Vec<HashMap<String, (EntityKind, SrcSpan, bool)>>,
 }
 

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -259,6 +259,11 @@ pub enum Warning {
         name: String,
     },
 
+    UnusedImportedModule {
+        location: SrcSpan,
+        name: String,
+    },
+
     UnusedPrivateModuleConstant {
         location: SrcSpan,
         name: String,

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -167,6 +167,21 @@ your program.",
                     }
                 }
 
+                type_::Warning::UnusedImportedModule { location, .. } => Diagnostic {
+                    title: "Unused imported module".into(),
+                    text: "Hint: You can safely remove it.".into(),
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        src: src.to_string(),
+                        path: path.to_path_buf(),
+                        label: diagnostic::Label {
+                            text: Some("This imported module is never used.".into()),
+                            span: *location,
+                        },
+                        extra_labels: Vec::new(),
+                    }),
+                },
+
                 type_::Warning::UnusedImportedValue { location, .. } => Diagnostic {
                     title: "Unused imported value".into(),
                     text: "Hint: You can safely remove it.".into(),


### PR DESCRIPTION
With this patch we will not track the usages of imported modules if they have no unqualified imports (aka are naked). When a module is imported but then never used we will report a warning at the end.

Things not yet known:
- [x] Does this cover modules aliases? (I.E. `import gleam/http as fetch`)
- [ ] Did I cover every usage of module? This I'm very unsure of

Things not covered in this PR:
- [ ] unused named unqualified imports (I.E. `import foo.{Foo as Foobar} as foobar`)
- [ ] distinguish variables from imports of the same name

Related to: https://github.com/gleam-lang/gleam/issues/1516