### PR TITLE
feat(parse): Add hint for multi line clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   (#1548)
 - Permit type holes in function arguments and return annotations (#1519)
 - Report unused module imports (#1553)
+- Add parse error hint for multi line clauses without curly braces (#1555)
 
 ## v0.20.1 - 2022-02-24
 

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -163,10 +163,14 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                     "See: https://gleam.run/book/tour/bools.html".to_string(),
                 ],
             ),
-            ParseErrorType::UnexpectedToken { expected } => {
+            ParseErrorType::UnexpectedToken { expected, hint } => {
                 let mut messages = expected.clone();
                 if let Some(s) = messages.first_mut() {
                     *s = format!("Expected one of: {}", s);
+                }
+
+                if let Some(hint_text) = hint {
+                    messages.push(format!("Hint: {}", hint_text));
                 }
 
                 ("I was not expecting this.", messages)
@@ -192,7 +196,9 @@ pub enum ParseErrorType {
     InvalidBitStringUnit,    // in <<1:unit(x)>> x must be 1 <= x <= 256
     InvalidTailPattern,      // only name and _name are allowed after ".." in list pattern
     InvalidTupleAccess,      // only positive int literals for tuple access
-    LexError { error: LexicalError },
+    LexError {
+        error: LexicalError,
+    },
     NestedBitStringPattern,    // <<<<1>>, 2>>, <<1>> is not allowed in there
     NoConstructors,            // A type "A {}" must have at least one constructor
     NoCaseClause,              // a case with no claueses
@@ -206,7 +212,10 @@ pub enum ParseErrorType {
     LowcaseBooleanPattern, // most likely user meant True or False in patterns
     UnexpectedEof,
     UnexpectedReservedWord, // reserved word used when a name was expected
-    UnexpectedToken { expected: Vec<String> },
+    UnexpectedToken {
+        expected: Vec<String>,
+        hint: Option<String>,
+    },
 }
 
 impl LexicalError {

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -197,3 +197,24 @@ fn lowcase_bool_in_pattern() {
         }
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/1404
+#[test]
+fn clause_mutiple_expressions() {
+    assert_error!(
+        "case True {
+True ->
+  let a = 1
+  a + 1
+False -> 0
+}
+",
+        ParseError {
+            location: SrcSpan { start: 36, end: 37 },
+            error: ParseErrorType::UnexpectedToken {
+                expected: vec!["\"->\"".to_string()],
+                hint: Some("Did you mean to wrap a multi line clause in curly braces?".to_string())
+            },
+        }
+    );
+}


### PR DESCRIPTION
When we expect a `RArrow` token inside a clause but don't see one, it
may be due to the developer forgetting to wrap their multiple
expressions with curly braces. Currently the developer is left on their
own to figure that out.

This patch adds a `hint` field to the `UnexpectedToken` parse error and
hints that a developer may want to add curly braces if they were trying
to do a multiple expressions in a clause.

This also allows gleam to add future hints to other `UnexpectedToken`
errors in subsequent patches.

Fixes #1404 