### PR TITLE
gleam tasks

### DIFF
--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -188,6 +188,9 @@ enum Command {
     /// Run the language server, to be used by editors
     #[clap(name = "lsp", hide = true)]
     LanguageServer,
+
+    #[clap(external_subcommand)]
+    Task(Vec<String>),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -341,6 +344,8 @@ fn main() {
         Command::Clean => clean(),
 
         Command::LanguageServer => lsp::main(),
+
+        Command::Task(arguments) => run::command(arguments, None, run::Which::Task),
     };
 
     match result {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -115,6 +115,9 @@ pub enum Error {
     #[error("shell program `{program}` not found")]
     ShellProgramNotFound { program: String },
 
+    #[error("task `{task}` not found")]
+    TaskNotFound { task: String },
+
     #[error("shell program `{program}` failed")]
     ShellCommand {
         program: String,
@@ -442,6 +445,17 @@ https://gleam.run/getting-started/",
 
                 Diagnostic {
                     title: "Program not found".into(),
+                    text,
+                    level: Level::Error,
+                    location: None,
+                }
+            }
+
+            Error::TaskNotFound { task } => {
+                let text = format!("The task `{}` was not found", task);
+
+                Diagnostic {
+                    title: "Task not found".into(),
                     text,
                     level: Level::Error,
                     location: None,


### PR DESCRIPTION
Enable the gleam build tool to run user defined tasks.
The user can create gleam files inside `src/tasks` and run them using the gleam build tool. For example if there is a file `src/tasks/welcome.gleam`, the command `gleam welcome` will run that file.
It's possible to divide the tasks into different directories like `src/tasks/hello/world.gleam` and `src/tasks/bye/world.gleam` and run them with `gleam hello world` and `gleam bye world`.
Of course if gleam can't find a task, it will return an error.
I think this can be really helpful and hope you find it helpful too.