### PR TITLE
added ability to specify branch/tag/commit for repo

### DIFF
--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -429,25 +429,45 @@ pub struct ErlangConfig {
 #[derive(Deserialize, Debug, PartialEq, Clone)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Repository {
-    GitHub { user: String, repo: String },
-    GitLab { user: String, repo: String },
-    BitBucket { user: String, repo: String },
-    Custom { url: String },
+    GitHub {
+        user: String,
+        repo: String,
+        refer: Option<String>,
+    },
+    GitLab {
+        user: String,
+        repo: String,
+        refer: Option<String>,
+    },
+    BitBucket {
+        user: String,
+        repo: String,
+        refer: Option<String>,
+    },
+    Custom {
+        url: String,
+    },
     None,
 }
 
 impl Repository {
     pub fn url(&self) -> Option<String> {
         match self {
-            Repository::GitHub { repo, user } => {
-                Some(format!("https://github.com/{}/{}", user, repo))
-            }
-            Repository::GitLab { repo, user } => {
-                Some(format!("https://gitlab.com/{}/{}", user, repo))
-            }
-            Repository::BitBucket { repo, user } => {
-                Some(format!("https://bitbucket.com/{}/{}", user, repo))
-            }
+            Repository::GitHub {
+                repo,
+                user,
+                refer: _,
+            } => Some(format!("https://github.com/{}/{}", user, repo)),
+            Repository::GitLab {
+                repo,
+                user,
+                refer: _,
+            } => Some(format!("https://gitlab.com/{}/{}", user, repo)),
+            Repository::BitBucket {
+                repo,
+                user,
+                refer: _,
+            } => Some(format!("https://bitbucket.com/{}/{}", user, repo)),
             Repository::Custom { url } => Some(url.clone()),
             Repository::None => None,
         }

--- a/compiler-core/src/docs/source_links.rs
+++ b/compiler-core/src/docs/source_links.rs
@@ -17,27 +17,54 @@ impl SourceLinker {
         let path_in_repo = get_path_in_repo(&module.name);
 
         let url_pattern = match &project_config.repository {
-            Repository::GitHub { user, repo } => Some((
-                format!(
-                    "https://github.com/{}/{}/blob/v{}/{}#L",
-                    user, repo, project_config.version, path_in_repo
-                ),
-                "-L".to_string(),
-            )),
-            Repository::GitLab { user, repo } => Some((
-                format!(
-                    "https://gitlab.com/{}/{}/-/blob/v{}/{}#L",
-                    user, repo, project_config.version, path_in_repo
-                ),
-                "-".to_string(),
-            )),
-            Repository::BitBucket { user, repo } => Some((
-                format!(
-                    "https://bitbucket.com/{}/{}/src/v{}/{}#lines-",
-                    user, repo, project_config.version, path_in_repo
-                ),
-                ":".to_string(),
-            )),
+            Repository::GitHub { user, repo, refer } => match refer {
+                Some(refer) => Some((
+                    format!(
+                        "https://github.com/{}/{}/blob/{}/{}#L",
+                        user, repo, refer, path_in_repo
+                    ),
+                    "-L".to_string(),
+                )),
+                None => Some((
+                    format!(
+                        "https://github.com/{}/{}/blob/v{}/{}#L",
+                        user, repo, project_config.version, path_in_repo
+                    ),
+                    "-L".to_string(),
+                )),
+            },
+            Repository::GitLab { user, repo, refer } => match refer {
+                Some(refer) => Some((
+                    format!(
+                        "https://gitlab.com/{}/{}/-/blob/{}/{}#L",
+                        user, repo, refer, path_in_repo
+                    ),
+                    "-".to_string(),
+                )),
+                None => Some((
+                    format!(
+                        "https://gitlab.com/{}/{}/-/blob/v{}/{}#L",
+                        user, repo, project_config.version, path_in_repo
+                    ),
+                    "-".to_string(),
+                )),
+            },
+            Repository::BitBucket { user, repo, refer } => match refer {
+                Some(refer) => Some((
+                    format!(
+                        "https://bitbucket.com/{}/{}/src/{}/{}#lines-",
+                        user, repo, refer, path_in_repo
+                    ),
+                    ":".to_string(),
+                )),
+                None => Some((
+                    format!(
+                        "https://bitbucket.com/{}/{}/src/v{}/{}#lines-",
+                        user, repo, project_config.version, path_in_repo
+                    ),
+                    ":".to_string(),
+                )),
+            },
             Repository::Custom { .. } | Repository::None => None,
         };
 


### PR DESCRIPTION
not all repositories have version tags which means for those repositories, the links in the gleam documentation for functions, types,... won't work. So I think it would help if the developer has the ability to specify a branch,tag or commit for their repo.

P.S.
I wanted to use `ref` but it's a keyword in rust and I didn't know how to tell `serde` to rename it.