### PR TITLE
docs: Add module docs for statements and types

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -280,6 +280,16 @@ pub type UntypedStatement = Statement<(), UntypedExpr, (), ()>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
+    /// A function definition
+    ///
+    /// # Example(s)
+    ///
+    /// ```gleam
+    /// // Public function
+    /// pub fn bar() -> String { ... }
+    /// // Private function
+    /// fn foo(x: Int) -> Int { ... }
+    /// ```
     Fn {
         end_location: usize,
         location: SrcSpan,
@@ -292,6 +302,14 @@ pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
         doc: Option<String>,
     },
 
+    /// A new name for an existing type
+    ///
+    /// # Example(s)
+    ///
+    /// ```gleam
+    /// pub type Headers =
+    ///   List(#(String, String))
+    /// ```
     TypeAlias {
         location: SrcSpan,
         alias: String,
@@ -302,6 +320,21 @@ pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
         doc: Option<String>,
     },
 
+    /// A newly defined type with one or more constructors.
+    /// Each variant of the custom type can contain different types, so the type is
+    /// the product of the types contained by each variant.
+    ///
+    /// This might be called an algebraic data type (ADT) or tagged union in other
+    /// languages and type systems.
+    ///
+    ///
+    /// # Example(s)
+    ///
+    /// ```gleam
+    /// pub type Cat {
+    ///   Cat(name: String, cuteness: Int)
+    /// }
+    /// ```
     CustomType {
         location: SrcSpan,
         name: String,
@@ -313,6 +346,16 @@ pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
         typed_parameters: Vec<T>,
     },
 
+    /// Import a function defined outside of Gleam code.
+    /// When compiling to Erlang the function could be implemented in Erlang
+    /// or Elixir, when compiling to JavaScript it might be implemented in
+    /// JavaScript or TypeScript.
+    ///
+    /// # Example(s)
+    ///
+    /// ```gleam
+    /// pub external fn random_float() -> Float = "rand" "uniform"
+    /// ```
     ExternalFn {
         location: SrcSpan,
         public: bool,
@@ -325,6 +368,15 @@ pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
         doc: Option<String>,
     },
 
+    /// Import a type defined in another language.
+    /// Nothing is known about the runtime characteristics of the type, we only
+    /// know that it exists and that we have given it this name.
+    ///
+    /// # Example(s)
+    ///
+    /// ```gleam
+    /// pub external type Queue(a)
+    /// ```
     ExternalType {
         location: SrcSpan,
         public: bool,
@@ -333,6 +385,16 @@ pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
         doc: Option<String>,
     },
 
+    /// Import another Gleam module so the current module can use the types and
+    /// values it defines.
+    ///
+    /// # Example(s)
+    ///
+    /// ```gleam
+    /// import unix/cat
+    /// // Import with alias
+    /// import animal/cat as kitty
+    /// ```
     Import {
         location: SrcSpan,
         module: Vec<String>,
@@ -341,6 +403,14 @@ pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
         package: PackageName,
     },
 
+    /// A certain fixed value that can be used in multiple places
+    ///
+    /// # Example(s)
+    ///
+    /// ```gleam
+    /// pub const start_year = 2101
+    /// pub const end_year = 2111
+    /// ```
     ModuleConstant {
         doc: Option<String>,
         location: SrcSpan,

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -46,6 +46,14 @@ pub trait HasType {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
+    /// A nominal (named) type such as `Int`, `Float`, or a programmer defined
+    /// custom type such as `Person`. The type can take other types as
+    /// arguments (aka "generics" or "parametric polymorphism").
+    ///
+    /// If the type is defined in the Gleam prelude the `module` field will be
+    /// empty, otherwise it will contain the name of the module that
+    /// defines the type.
+    ///
     App {
         public: bool,
         module: Vec<String>,
@@ -53,18 +61,22 @@ pub enum Type {
         args: Vec<Arc<Type>>,
     },
 
+    /// The type of a function. It takes arguments and returns a value.
+    ///
     Fn {
         args: Vec<Arc<Type>>,
         retrn: Arc<Type>,
     },
 
-    Var {
-        type_: Arc<RefCell<TypeVar>>,
-    },
+    /// A type variable. See the contained `TypeVar` enum for more information.
+    ///
+    Var { type_: Arc<RefCell<TypeVar>> },
 
-    Tuple {
-        elems: Vec<Arc<Type>>,
-    },
+    /// A tuple is an ordered collection of 0 or more values, each of which
+    /// can have a different type, so the `tuple` type is the sum of all the
+    /// contained types.
+    ///
+    Tuple { elems: Vec<Arc<Type>> },
 }
 
 impl Type {
@@ -337,8 +349,29 @@ pub enum PatternConstructor {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeVar {
+    /// Unbound is an unbound variable. It is one specific type but we don't
+    /// know what yet in the inference process. It has a unique id which can be used to
+    /// identify if two unbound variable Rust values are the same Gleam type variable
+    /// instance or not.
+    ///
+    ///
     Unbound { id: u64 },
+    /// Link is type variable where it was an unbound variable but we worked out
+    /// that it is some other type and now we point to that one.
+    ///
     Link { type_: Arc<Type> },
+    /// A Generic variable stands in for any possible type and cannot be
+    /// specialised to any one type
+    ///
+    /// # Example
+    ///
+    /// ```gleam
+    /// type Cat(a) {
+    ///   Cat(name: a)
+    /// }
+    /// // a is TypeVar::Generic
+    /// ```
+    ///
     Generic { id: u64 },
 }
 


### PR DESCRIPTION
Figured after I learned this myself I would add comments so that future developers don't have to code splunk themselves as much to gain an understanding.

I may have gotten some of these wrong! Please correct me where I may have misunderstood what was happening.