### PR TITLE
feat(javascript): Output Typescript declaration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   evaluates to could generate invalid JavaScript.
 - Fixed a bug where running a project on the Erlang target when the default
   project target is set to JavaScript.
+- The compiler can now generate TypeScript declaration files when targeting
+  JavaScript (#1563)
 
 ## v0.21.0 - 2022-04-24
 

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -2648,9 +2648,9 @@ export class A extends CustomType {}\n"
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/dist/one/two.d.ts"),
-                text: r#"import * as $Gleam from "../gleam.d.ts";
+                text: r#"import * as _ from "../gleam.d.ts";
 
-export class A extends $Gleam.CustomType {}
+export class A extends _.CustomType {}
 
 export type A$ = A;
 "#

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -2626,6 +2626,10 @@ const x = two.A"#
                 text: javascript::PRELUDE.to_string(),
             },
             OutputFile {
+                path: PathBuf::from("_build/default/lib/the_package/dist/gleam.d.ts"),
+                text: javascript::PRELUDE_TS_DEF.to_string(),
+            },
+            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/dist/one/two.mjs"),
                 text: "import { CustomType } from \"../gleam.mjs\";
 

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         Origin, Target,
     },
     codegen,
-    config::{Docs, ErlangConfig, PackageConfig, Repository},
+    config::{Docs, ErlangConfig, JavascriptConfig, PackageConfig, Repository},
     erlang,
     io::test::FilesChannel,
     javascript, type_,
@@ -33,6 +33,9 @@ macro_rules! assert_erlang_compile {
             erlang: ErlangConfig {
                 application_start_module: None,
                 extra_applications: vec![],
+            },
+            javascript: JavascriptConfig {
+                typescript_declarations: false,
             },
             target: Target::Erlang,
         };
@@ -90,6 +93,9 @@ macro_rules! assert_javascript_compile {
                 application_start_module: None,
                 extra_applications: vec![],
             },
+            javascript: JavascriptConfig {
+                typescript_declarations: true,
+            },
             target: Target::JavaScript,
         };
         let (file_writer, file_receiver) = FilesChannel::new();
@@ -145,6 +151,9 @@ macro_rules! assert_no_warnings {
             erlang: ErlangConfig {
                 application_start_module: None,
                 extra_applications: vec![],
+            },
+            javascript: JavascriptConfig {
+                typescript_declarations: false,
             },
             target: Target::Erlang,
         };
@@ -2357,6 +2366,7 @@ fn config_compilation_test() {
             documentation: Default::default(),
             licences: Default::default(),
             erlang: Default::default(),
+            javascript: Default::default(),
             links: vec![],
             target: Target::Erlang,
         }

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -2637,13 +2637,27 @@ export class A extends CustomType {}\n"
                     .to_string(),
             },
             OutputFile {
+                path: PathBuf::from("_build/default/lib/the_package/dist/one/two.d.ts"),
+                text: r#"import * as $Gleam from "../gleam.d.ts";
+
+export class A extends $Gleam.CustomType {}
+
+export type A$ = A;
+"#
+                .to_string(),
+            },
+            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/dist/two.mjs"),
                 text: r#"import * as $two from "./one/two.mjs";
 
 const x = new $two.A();
 "#
                 .to_string(),
-            }
+            },
+            OutputFile {
+                path: PathBuf::from("_build/default/lib/the_package/dist/two.d.ts"),
+                text: "import * as $OneTwo from \"./one/two.d.ts\";\n".to_string(),
+            },
         ]),
     );
 }

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -2666,7 +2666,7 @@ const x = new $two.A();
             },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/dist/two.d.ts"),
-                text: "import * as $OneTwo from \"./one/two.d.ts\";\n".to_string(),
+                text: "import * as two from \"./one/two.d.ts\";\n".to_string(),
             },
         ]),
     );

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -334,7 +334,7 @@ where
         let mut written = HashSet::new();
         let artifact_dir = self.out.join("dist");
 
-        JavaScript::new(&artifact_dir).render(&self.io, modules)?;
+        JavaScript::new(&artifact_dir, &self.config.javascript).render(&self.io, modules)?;
 
         if self.copy_native_files {
             self.copy_project_native_files(&artifact_dir, &mut written)?;

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -158,10 +158,14 @@ impl<'a> JavaScript<'a> {
     }
 
     fn write_prelude(&self, writer: &impl FileSystemWriter) -> Result<()> {
-        tracing::debug!("Generated js prelude");
         writer
             .writer(&self.output_directory.join("gleam.mjs"))?
             .str_write(javascript::PRELUDE)?;
+        tracing::debug!("Generated js prelude");
+        writer
+            .writer(&self.output_directory.join("gleam.d.ts"))?
+            .str_write(javascript::PRELUDE_TS_DEF)?;
+        tracing::debug!("Generated TS prelude");
         Ok(())
     }
 

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -80,6 +80,8 @@ pub struct PackageConfig {
     pub links: Vec<Link>,
     #[serde(default)]
     pub erlang: ErlangConfig,
+    #[serde(default)]
+    pub javascript: JavascriptConfig,
     #[serde(default = "erlang_target")]
     pub target: Target,
 }
@@ -409,6 +411,7 @@ impl Default for PackageConfig {
             documentation: Default::default(),
             dependencies: Default::default(),
             erlang: Default::default(),
+            javascript: Default::default(),
             repository: Default::default(),
             dev_dependencies: Default::default(),
             licences: Default::default(),
@@ -424,6 +427,12 @@ pub struct ErlangConfig {
     pub application_start_module: Option<String>,
     #[serde(default)]
     pub extra_applications: Vec<String>,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Default, Clone, Copy)]
+pub struct JavascriptConfig {
+    #[serde(default)]
+    pub typescript_declarations: bool,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -3,6 +3,7 @@ mod import;
 mod pattern;
 #[cfg(test)]
 mod tests;
+mod typescript;
 
 use std::path::Path;
 
@@ -447,6 +448,22 @@ pub fn module(
     writer: &mut impl Utf8Writer,
 ) -> Result<(), crate::Error> {
     Generator::new(line_numbers, module)
+        .compile()
+        .map_err(|error| crate::Error::JavaScript {
+            path: path.to_path_buf(),
+            src: src.to_string(),
+            error,
+        })?
+        .pretty_print(80, writer)
+}
+
+pub fn ts_declaration(
+    module: &TypedModule,
+    path: &Path,
+    src: &str,
+    writer: &mut impl Utf8Writer,
+) -> Result<(), crate::Error> {
+    typescript::TypeScriptGenerator::new(module)
         .compile()
         .map_err(|error| crate::Error::JavaScript {
             path: path.to_path_buf(),

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -14,6 +14,7 @@ use self::import::{Imports, Member};
 const INDENT: isize = 2;
 
 pub const PRELUDE: &str = include_str!("../templates/prelude.js");
+pub const PRELUDE_TS_DEF: &str = include_str!("../templates/prelude.d.ts");
 
 pub type Output<'a> = Result<Document<'a>, Error>;
 

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -7,6 +7,7 @@ mod case_clause_guards;
 mod custom_types;
 mod externals;
 mod functions;
+mod generics;
 mod lists;
 mod modules;
 mod numbers;
@@ -17,6 +18,7 @@ mod strings;
 mod todo;
 mod try_;
 mod tuples;
+mod type_alias;
 
 pub static CURRENT_PACKAGE: &str = "thepackage";
 
@@ -158,6 +160,144 @@ macro_rules! assert_js {
         let mut output = String::new();
         let line_numbers = LineNumbers::new($src);
         module(&ast, &line_numbers, Path::new(""), "", &mut output).unwrap();
+        assert_eq!(($src, output), ($src, $erl.to_string()));
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_ts_def {
+    (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr $(,)?) => {{
+        use crate::{javascript::*, uid::UniqueIdGenerator};
+        use std::path::Path;
+        let mut modules = im::HashMap::new();
+        let ids = UniqueIdGenerator::new();
+        // DUPE: preludeinsertion
+        // TODO: Currently we do this here and also in the tests. It would be better
+        // to have one place where we create all this required state for use in each
+        // place.
+        let _ = modules.insert("gleam".to_string(), crate::type_::build_prelude(&ids));
+        let (mut ast, _) = crate::parse::parse_module($dep_src).expect("dep syntax error");
+        ast.name = $dep_name;
+        let dep = crate::type_::infer_module(
+            crate::build::Target::JavaScript,
+            &ids,
+            ast,
+            crate::build::Origin::Src,
+            $dep_package,
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
+        let _ = modules.insert($dep_name.join("/"), dep.type_info);
+        let (mut ast, _) = crate::parse::parse_module($src).expect("syntax error");
+        ast.name = vec!["my".to_string(), "mod".to_string()];
+        let ast = crate::type_::infer_module(
+            crate::build::Target::JavaScript,
+            &ids,
+            ast,
+            crate::build::Origin::Src,
+            CURRENT_PACKAGE,
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
+        let mut output = String::new();
+        ts_declaration(&ast, Path::new(""), "", &mut output).unwrap();
+        insta::assert_snapshot!(insta::internals::AutoName, output, $src);
+    }};
+
+    (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr, $erl:expr $(,)?) => {{
+        use std::path::Path;
+        let mut modules = im::HashMap::new();
+        let ids = UniqueIdGenerator::new();
+        // DUPE: preludeinsertion
+        // TODO: Currently we do this here and also in the tests. It would be better
+        // to have one place where we create all this required state for use in each
+        // place.
+        let _ = modules.insert("gleam".to_string(), crate::type_::build_prelude(&ids));
+        let (mut ast, _) = crate::parse::parse_module($dep_src).expect("dep syntax error");
+        ast.name = $dep_name;
+        let dep = crate::type_::infer_module(
+            crate::build::Target::JavaScript,
+            &ids,
+            ast,
+            crate::build::Origin::Src,
+            $dep_package,
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
+        let _ = modules.insert($dep_name.join("/"), dep.type_info);
+        let (mut ast, _) = crate::parse::parse_module($src).expect("syntax error");
+        ast.name = vec!["my".to_string(), "mod".to_string()];
+        let ast = crate::type_::infer_module(
+            crate::build::Target::JavaScript,
+            &ids,
+            ast,
+            crate::build::Origin::Src,
+            CURRENT_PACKAGE,
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
+        let mut output = String::new();
+        ts_declaration(&ast, Path::new(""), "", &mut output).unwrap();
+        assert_eq!(($src, output), ($src, $erl.to_string()));
+    }};
+
+    ($src:expr $(,)?) => {{
+        use crate::{javascript::*, uid::UniqueIdGenerator};
+        use std::path::Path;
+        let mut modules = im::HashMap::new();
+        let ids = UniqueIdGenerator::new();
+        // DUPE: preludeinsertion
+        // TODO: Currently we do this here and also in the tests. It would be better
+        // to have one place where we create all this required state for use in each
+        // place.
+        let _ = modules.insert("gleam".to_string(), crate::type_::build_prelude(&ids));
+
+        let (mut ast, _) = crate::parse::parse_module($src).expect("syntax error");
+        ast.name = vec!["my".to_string(), "mod".to_string()];
+        let ast = crate::type_::infer_module(
+            crate::build::Target::JavaScript,
+            &ids,
+            ast,
+            crate::build::Origin::Src,
+            "thepackage",
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
+        let mut output = String::new();
+        ts_declaration(&ast, Path::new(""), "", &mut output).unwrap();
+        insta::assert_snapshot!(insta::internals::AutoName, output, $src);
+    }};
+
+    ($src:expr, $erl:expr $(,)?) => {{
+        use crate::{javascript::*, uid::UniqueIdGenerator};
+        use std::path::Path;
+        let mut modules = im::HashMap::new();
+        let ids = UniqueIdGenerator::new();
+        // DUPE: preludeinsertion
+        // TODO: Currently we do this here and also in the tests. It would be better
+        // to have one place where we create all this required state for use in each
+        // place.
+        let _ = modules.insert("gleam".to_string(), crate::type_::build_prelude(&ids));
+
+        let (mut ast, _) = crate::parse::parse_module($src).expect("syntax error");
+        ast.name = vec!["my".to_string(), "mod".to_string()];
+        let ast = crate::type_::infer_module(
+            crate::build::Target::JavaScript,
+            &ids,
+            ast,
+            crate::build::Origin::Src,
+            "thepackage",
+            &modules,
+            &mut vec![],
+        )
+        .expect("should successfully infer");
+        let mut output = String::new();
+        ts_declaration(&ast, Path::new(""), "", &mut output).unwrap();
         assert_eq!(($src, output), ($src, $erl.to_string()));
     }};
 }

--- a/compiler-core/src/javascript/tests/bit_strings.rs
+++ b/compiler-core/src/javascript/tests/bit_strings.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn empty() {
@@ -122,10 +122,32 @@ fn go(x) {
 }
 
 #[test]
+fn utf8_codepoint_typescript() {
+    assert_ts_def!(
+        r#"
+pub fn go(x) {
+  <<x:utf8_codepoint, "Gleam":utf8>>
+}
+"#,
+    );
+}
+
+#[test]
 fn bit_string() {
     assert_js!(
         r#"
 fn go(x) {
+  <<x:bit_string, "Gleam":utf8>>
+}
+"#,
+    );
+}
+
+#[test]
+fn bit_string_typescript() {
+    assert_ts_def!(
+        r#"
+pub fn go(x) {
   <<x:bit_string, "Gleam":utf8>>
 }
 "#,

--- a/compiler-core/src/javascript/tests/bools.rs
+++ b/compiler-core/src/javascript/tests/bools.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn expressions() {
@@ -20,6 +20,17 @@ fn constants() {
 const a = True
 const b = False
 const c = Nil
+"#,
+    );
+}
+
+#[test]
+fn constants_typescript() {
+    assert_ts_def!(
+        r#"
+pub const a = True
+pub const b = False
+pub const c = Nil
 "#,
     );
 }
@@ -57,6 +68,20 @@ fn shadowed_bools_and_nil() {
         r#"
 pub type True { True False Nil }
 fn go(x, y) {
+  assert True = x
+  assert False = x
+  assert Nil = y
+}
+"#,
+    );
+}
+
+#[test]
+fn shadowed_bools_and_nil_typescript() {
+    assert_ts_def!(
+        r#"
+pub type True { True False Nil }
+pub fn go(x, y) {
   assert True = x
   assert False = x
   assert Nil = y

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -1,7 +1,7 @@
 // TODO: snapshots for tests that use another module
 
-use crate::assert_js;
 use crate::javascript::tests::CURRENT_PACKAGE;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn zero_arity_literal() {
@@ -51,6 +51,21 @@ pub fn main() {
 }
 
 #[test]
+fn zero_arity_imported_typscript() {
+    assert_ts_def!(
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two }"#
+        ),
+        r#"import other
+pub fn main() {
+  other.Two
+}"#,
+    );
+}
+
+#[test]
 fn zero_arity_imported_unqualified() {
     assert_js!(
         (
@@ -66,8 +81,38 @@ pub fn main() {
 }
 
 #[test]
+fn zero_arity_imported_unqualified_typescript() {
+    assert_ts_def!(
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two }"#
+        ),
+        r#"import other.{Two}
+pub fn main() {
+  Two
+}"#,
+    );
+}
+
+#[test]
 fn zero_arity_imported_unqualified_aliased() {
     assert_js!(
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two }"#
+        ),
+        r#"import other.{Two as Three}
+pub fn main() {
+  Three
+}"#
+    );
+}
+
+#[test]
+fn zero_arity_imported_unqualified_aliased_typescript() {
+    assert_ts_def!(
         (
             CURRENT_PACKAGE,
             vec!["other".to_string()],
@@ -134,6 +179,20 @@ type Mine {
 
 const labels = Mine(b: 2, a: 1)
 const no_labels = Mine(3, 4)
+"#,
+    );
+}
+
+#[test]
+fn const_with_fields_typescript() {
+    assert_ts_def!(
+        r#"
+pub type Mine {
+  Mine(a: Int, b: Int)
+}
+
+pub const labels = Mine(b: 2, a: 1)
+pub const no_labels = Mine(3, 4)
 "#,
     );
 }
@@ -317,6 +376,21 @@ pub fn main() {
 #[test]
 fn unqualified_imported_no_label() {
     assert_js!(
+        (
+            CURRENT_PACKAGE,
+            vec!["other".to_string()],
+            r#"pub type One { Two(Int) }"#
+        ),
+        r#"import other.{Two}
+pub fn main() {
+  Two(1)
+}"#,
+    );
+}
+
+#[test]
+fn unqualified_imported_no_label_typescript() {
+    assert_ts_def!(
         (
             CURRENT_PACKAGE,
             vec!["other".to_string()],
@@ -561,5 +635,28 @@ pub fn main() {
   other.One
 }
 "#,
+    );
+}
+
+#[test]
+fn unapplied_record_constructors_typescript() {
+    assert_ts_def!(
+        r#"pub type Cat { Cat(name: String) }
+
+pub fn return_unapplied_cat() {
+  Cat
+}
+"#
+    );
+}
+
+#[test]
+fn opaque_types_typescript() {
+    assert_ts_def!(
+        r#"pub opaque type Animal {
+  Cat(goes_outside: Bool)
+  Dog(plays_fetch: Bool)
+}
+"#
     );
 }

--- a/compiler-core/src/javascript/tests/externals.rs
+++ b/compiler-core/src/javascript/tests/externals.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn type_() {
@@ -16,6 +16,11 @@ fn pub_module_fn() {
 }
 
 #[test]
+fn pub_module_fn_typescript() {
+    assert_ts_def!(r#"pub external fn show(anything) -> Nil = "utils" "inspect""#,);
+}
+
+#[test]
 fn global_fn() {
     assert_js!(r#"external fn down(Float) -> Float = "" "Math.floor""#,);
 }
@@ -23,6 +28,11 @@ fn global_fn() {
 #[test]
 fn pub_global_fn() {
     assert_js!(r#"pub external fn down(Float) -> Float = "" "Math.floor""#,);
+}
+
+#[test]
+fn pub_global_fn_typescript() {
+    assert_ts_def!(r#"pub external fn down(Float) -> Float = "" "Math.floor""#,);
 }
 
 #[test]
@@ -52,6 +62,15 @@ pub external fn two() -> Nil = "./the/module.mjs" "dup"
 fn name_to_escape() {
     assert_js!(
         r#"pub external fn class() -> Nil = "./the/module.mjs" "one"
+"#,
+    );
+}
+
+#[test]
+fn external_type_typescript() {
+    assert_ts_def!(
+        r#"pub external type Queue(a)
+pub external fn new() -> Queue(a) = "queue" "new"
 "#,
     );
 }

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 use super::CURRENT_PACKAGE;
 
@@ -68,6 +68,23 @@ pub fn math(x, y) {
     x - y
     2 * x
   }
+}"#,
+    );
+}
+
+#[test]
+fn function_formatting_typescript() {
+    assert_ts_def!(
+        r#"
+pub fn add(the_first_variable_that_should_be_added, the_second_variable_that_should_be_added) {
+  the_first_variable_that_should_be_added + the_second_variable_that_should_be_added
+}"#,
+    );
+
+    assert_ts_def!(
+        r#"
+pub fn this_function_really_does_have_a_ludicrously_unfeasibly_long_name_for_a_function(x, y) {
+x + y
 }"#,
     );
 }
@@ -284,6 +301,17 @@ fn assert_last() {
     assert_js!(
         r#"pub fn main() {
   assert x = 1
+}
+"#,
+    );
+}
+
+#[test]
+fn fn_return_fn_typescript() {
+    assert_ts_def!(
+        r#"pub fn main(f: fn(Int) -> Int) {
+  let func = fn(x, y) { f(x) + f(y) }
+  func
 }
 "#,
     );

--- a/compiler-core/src/javascript/tests/generics.rs
+++ b/compiler-core/src/javascript/tests/generics.rs
@@ -1,0 +1,50 @@
+use crate::assert_ts_def;
+
+#[test]
+fn fn_generics_typescript() {
+    assert_ts_def!(
+        r#"pub fn indentity(a) -> a {
+  a
+}
+"#,
+    );
+}
+
+#[test]
+fn record_generics_typescript() {
+    assert_ts_def!(
+        r#"pub type Animal(t) {
+  Cat(type_: t)
+  Dog(type_: t)
+}
+
+pub fn main() {
+  Cat(type_: 6)
+}
+"#,
+    );
+}
+
+#[test]
+fn tuple_generics_typescript() {
+    assert_ts_def!(
+        r#"pub fn make_tuple(x: t) -> #(Int, t, Int) {
+  #(0, x, 1)
+}
+"#,
+    );
+}
+
+#[test]
+fn externals_generics_typescript() {
+    assert_ts_def!(
+        r#"pub external type Queue(a)
+
+pub external fn new() -> Queue(a) = "queue" "new"
+
+pub external fn length(Queue(a)) -> Int = "queue" "len"
+
+pub external fn push(Queue(a), a) -> Queue(a) = "queue" "in"
+"#,
+    );
+}

--- a/compiler-core/src/javascript/tests/lists.rs
+++ b/compiler-core/src/javascript/tests/lists.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn list_literals() {
@@ -43,6 +43,16 @@ fn list_constants() {
         r#"
 const a = []
 const b = [1, 2, 3]
+"#,
+    );
+}
+
+#[test]
+fn list_constants_typescript() {
+    assert_ts_def!(
+        r#"
+pub const a = []
+pub const b = [1, 2, 3]
 "#,
     );
 }

--- a/compiler-core/src/javascript/tests/modules.rs
+++ b/compiler-core/src/javascript/tests/modules.rs
@@ -1,5 +1,5 @@
-use crate::assert_js;
 use crate::javascript::tests::CURRENT_PACKAGE;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn empty_module() {
@@ -184,6 +184,21 @@ pub fn go() { 1 }
 #[test]
 fn imported_custom_types_dont_get_rendered() {
     assert_js!(
+        (
+            CURRENT_PACKAGE,
+            vec!["one".to_string(), "two".to_string(), "three".to_string()],
+            r#"pub type Custom { One Two }"#
+        ),
+        r#"import one/two/three.{Custom, One, Two}
+
+pub fn go() -> List(Custom) { [One, Two] }
+"#,
+    );
+}
+
+#[test]
+fn imported_custom_types_do_get_rendered_in_typescript() {
+    assert_ts_def!(
         (
             CURRENT_PACKAGE,
             vec!["one".to_string(), "two".to_string(), "three".to_string()],

--- a/compiler-core/src/javascript/tests/prelude.rs
+++ b/compiler-core/src/javascript/tests/prelude.rs
@@ -1,8 +1,17 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn qualified_ok() {
     assert_js!(
+        r#"import gleam
+pub fn go() { gleam.Ok(1) }
+"#,
+    );
+}
+
+#[test]
+fn qualified_ok_typescript() {
+    assert_ts_def!(
         r#"import gleam
 pub fn go() { gleam.Ok(1) }
 "#,
@@ -21,6 +30,15 @@ pub fn go() { gleam.Error(1) }
 #[test]
 fn qualified_nil() {
     assert_js!(
+        r#"import gleam
+pub fn go() { gleam.Nil }
+"#,
+    );
+}
+
+#[test]
+fn qualified_nil_typescript() {
+    assert_ts_def!(
         r#"import gleam
 pub fn go() { gleam.Nil }
 "#,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__bit_string_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__bit_string_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/bit_strings.rs
+expression: "\npub fn go(x) {\n  <<x:bit_string, \"Gleam\":utf8>>\n}\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export function go(x: $Gleam.BitString): $Gleam.BitString;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__bit_string_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__bit_string_typescript.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/bit_strings.rs
+assertion_line: 148
 expression: "\npub fn go(x) {\n  <<x:bit_string, \"Gleam\":utf8>>\n}\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export function go(x: $Gleam.BitString): $Gleam.BitString;
+export function go(x: _.BitString): _.BitString;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__utf8_codepoint_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__utf8_codepoint_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/bit_strings.rs
+expression: "\npub fn go(x) {\n  <<x:utf8_codepoint, \"Gleam\":utf8>>\n}\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export function go(x: $Gleam.UtfCodepoint): $Gleam.BitString;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__utf8_codepoint_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__utf8_codepoint_typescript.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/bit_strings.rs
+assertion_line: 126
 expression: "\npub fn go(x) {\n  <<x:utf8_codepoint, \"Gleam\":utf8>>\n}\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export function go(x: $Gleam.UtfCodepoint): $Gleam.BitString;
+export function go(x: _.UtfCodepoint): _.BitString;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__constants_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__constants_typescript.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/javascript/tests/bools.rs
+expression: "\npub const a = True\npub const b = False\npub const c = Nil\n"
+---
+export const a: boolean;
+
+export const b: boolean;
+
+export const c: null;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
@@ -1,14 +1,15 @@
 ---
 source: compiler-core/src/javascript/tests/bools.rs
+assertion_line: 81
 expression: "\npub type True { True False Nil }\npub fn go(x, y) {\n  assert True = x\n  assert False = x\n  assert Nil = y\n}\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export class True extends $Gleam.CustomType {}
+export class True extends _.CustomType {}
 
-export class False extends $Gleam.CustomType {}
+export class False extends _.CustomType {}
 
-export class Nil extends $Gleam.CustomType {}
+export class Nil extends _.CustomType {}
 
 export type True$ = True | False | Nil;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/javascript/tests/bools.rs
+expression: "\npub type True { True False Nil }\npub fn go(x, y) {\n  assert True = x\n  assert False = x\n  assert Nil = y\n}\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export class True extends $Gleam.CustomType {}
+
+export class False extends $Gleam.CustomType {}
+
+export class Nil extends $Gleam.CustomType {}
+
+export type True$ = True | False | Nil;
+
+export function go(x: True$, y: True$): True$;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
@@ -1,14 +1,15 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
+assertion_line: 188
 expression: "\npub type Mine {\n  Mine(a: Int, b: Int)\n}\n\npub const labels = Mine(b: 2, a: 1)\npub const no_labels = Mine(3, 4)\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
 export const labels: Mine$;
 
 export const no_labels: Mine$;
 
-export class Mine extends $Gleam.CustomType {
+export class Mine extends _.CustomType {
   constructor(a: number, b: number);
   
   a: number;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Mine {\n  Mine(a: Int, b: Int)\n}\n\npub const labels = Mine(b: 2, a: 1)\npub const no_labels = Mine(3, 4)\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export const labels: Mine$;
+
+export const no_labels: Mine$;
+
+export class Mine extends $Gleam.CustomType {
+  constructor(a: number, b: number);
+  
+  a: number;
+  b: number;
+}
+
+export type Mine$ = Mine;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "pub opaque type Animal {\n  Cat(goes_outside: Bool)\n  Dog(plays_fetch: Bool)\n}\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+class Cat extends $Gleam.CustomType {
+  constructor(goes_outside: boolean);
+  
+  goes_outside: boolean;
+}
+
+class Dog extends $Gleam.CustomType {
+  constructor(plays_fetch: boolean);
+  
+  plays_fetch: boolean;
+}
+
+export type Animal$ = Cat | Dog;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
@@ -1,16 +1,17 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
+assertion_line: 655
 expression: "pub opaque type Animal {\n  Cat(goes_outside: Bool)\n  Dog(plays_fetch: Bool)\n}\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-class Cat extends $Gleam.CustomType {
+class Cat extends _.CustomType {
   constructor(goes_outside: boolean);
   
   goes_outside: boolean;
 }
 
-class Dog extends $Gleam.CustomType {
+class Dog extends _.CustomType {
   constructor(plays_fetch: boolean);
   
   plays_fetch: boolean;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
+assertion_line: 643
 expression: "pub type Cat { Cat(name: String) }\n\npub fn return_unapplied_cat() {\n  Cat\n}\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export class Cat extends $Gleam.CustomType {
+export class Cat extends _.CustomType {
   constructor(name: string);
   
   name: string;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "pub type Cat { Cat(name: String) }\n\npub fn return_unapplied_cat() {\n  Cat\n}\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export class Cat extends $Gleam.CustomType {
+  constructor(name: string);
+  
+  name: string;
+}
+
+export type Cat$ = Cat;
+
+export function return_unapplied_cat(): (x0: string) => Cat$;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "import other.{Two}\npub fn main() {\n  Two(1)\n}"
+---
+import * as $Other from "../other.d.ts";
+
+export function main(): $Other.One$;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
+assertion_line: 393
 expression: "import other.{Two}\npub fn main() {\n  Two(1)\n}"
 ---
-import * as $Other from "../other.d.ts";
+import * as other from "../other.d.ts";
 
-export function main(): $Other.One$;
+export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "import other\npub fn main() {\n  other.Two\n}"
+---
+import * as $Other from "../other.d.ts";
+
+export function main(): $Other.One$;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
+assertion_line: 55
 expression: "import other\npub fn main() {\n  other.Two\n}"
 ---
-import * as $Other from "../other.d.ts";
+import * as other from "../other.d.ts";
 
-export function main(): $Other.One$;
+export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
+assertion_line: 115
 expression: "import other.{Two as Three}\npub fn main() {\n  Three\n}"
 ---
-import * as $Other from "../other.d.ts";
+import * as other from "../other.d.ts";
 
-export function main(): $Other.One$;
+export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "import other.{Two as Three}\npub fn main() {\n  Three\n}"
+---
+import * as $Other from "../other.d.ts";
+
+export function main(): $Other.One$;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "import other.{Two}\npub fn main() {\n  Two\n}"
+---
+import * as $Other from "../other.d.ts";
+
+export function main(): $Other.One$;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
+assertion_line: 85
 expression: "import other.{Two}\npub fn main() {\n  Two\n}"
 ---
-import * as $Other from "../other.d.ts";
+import * as other from "../other.d.ts";
 
-export function main(): $Other.One$;
+export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__external_type_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__external_type_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/externals.rs
+expression: "pub external type Queue(a)\npub external fn new() -> Queue(a) = \"queue\" \"new\"\n"
+---
+export type Queue$<A> = any;
+
+export function new$(): Queue$<any>;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__pub_global_fn_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__pub_global_fn_typescript.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/javascript/tests/externals.rs
+expression: "pub external fn down(Float) -> Float = \"\" \"Math.floor\""
+---
+export function down(x0: number): number;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__pub_module_fn_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__pub_module_fn_typescript.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/javascript/tests/externals.rs
+expression: "pub external fn show(anything) -> Nil = \"utils\" \"inspect\""
+---
+export function show(x0: any): null;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__fn_return_fn_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__fn_return_fn_typescript.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "pub fn main(f: fn(Int) -> Int) {\n  let func = fn(x, y) { f(x) + f(y) }\n  func\n}\n"
+---
+export function main(f: (x0: number) => number): (x0: number, x1: number) => number;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__function_formatting_typescript-2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__function_formatting_typescript-2.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\npub fn this_function_really_does_have_a_ludicrously_unfeasibly_long_name_for_a_function(x, y) {\nx + y\n}"
+---
+export function this_function_really_does_have_a_ludicrously_unfeasibly_long_name_for_a_function(
+  x: number,
+  y: number
+): number;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__function_formatting_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__function_formatting_typescript.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\npub fn add(the_first_variable_that_should_be_added, the_second_variable_that_should_be_added) {\n  the_first_variable_that_should_be_added + the_second_variable_that_should_be_added\n}"
+---
+export function add(
+  the_first_variable_that_should_be_added: number,
+  the_second_variable_that_should_be_added: number
+): number;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__externals_generics_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__externals_generics_typescript.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/javascript/tests/generics.rs
+expression: "pub external type Queue(a)\n\npub external fn new() -> Queue(a) = \"queue\" \"new\"\n\npub external fn length(Queue(a)) -> Int = \"queue\" \"len\"\n\npub external fn push(Queue(a), a) -> Queue(a) = \"queue\" \"in\"\n"
+---
+export type Queue$<A> = any;
+
+export function new$(): Queue$<any>;
+
+export function length(x0: Queue$<any>): number;
+
+export function push<N>(x0: Queue$<N>, x1: N): Queue$<N>;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__fn_generics_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__fn_generics_typescript.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/javascript/tests/generics.rs
+expression: "pub fn indentity(a) -> a {\n  a\n}\n"
+---
+export function indentity<J>(a: J): J;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
@@ -1,16 +1,17 @@
 ---
 source: compiler-core/src/javascript/tests/generics.rs
+assertion_line: 15
 expression: "pub type Animal(t) {\n  Cat(type_: t)\n  Dog(type_: t)\n}\n\npub fn main() {\n  Cat(type_: 6)\n}\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export class Cat<I> extends $Gleam.CustomType {
+export class Cat<I> extends _.CustomType {
   constructor(type_: I);
   
   type_: I;
 }
 
-export class Dog<I> extends $Gleam.CustomType {
+export class Dog<I> extends _.CustomType {
   constructor(type_: I);
   
   type_: I;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/javascript/tests/generics.rs
+expression: "pub type Animal(t) {\n  Cat(type_: t)\n  Dog(type_: t)\n}\n\npub fn main() {\n  Cat(type_: 6)\n}\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export class Cat<I> extends $Gleam.CustomType {
+  constructor(type_: I);
+  
+  type_: I;
+}
+
+export class Dog<I> extends $Gleam.CustomType {
+  constructor(type_: I);
+  
+  type_: I;
+}
+
+export type Animal$<I> = Cat<I> | Dog<I>;
+
+export function main(): Animal$<number>;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__tuple_generics_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__tuple_generics_typescript.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/javascript/tests/generics.rs
+expression: "pub fn make_tuple(x: t) -> #(Int, t, Int) {\n  #(0, x, 1)\n}\n"
+---
+export function make_tuple<I>(x: I): [number, I, number];
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants_typescript.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/lists.rs
+assertion_line: 52
 expression: "\npub const a = []\npub const b = [1, 2, 3]\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export const a: $Gleam.List<any>;
+export const a: _.List<any>;
 
-export const b: $Gleam.List<number>;
+export const b: _.List<number>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants_typescript.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/javascript/tests/lists.rs
+expression: "\npub const a = []\npub const b = [1, 2, 3]\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export const a: $Gleam.List<any>;
+
+export const b: $Gleam.List<number>;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler-core/src/javascript/tests/modules.rs
+assertion_line: 201
 expression: "import one/two/three.{Custom, One, Two}\n\npub fn go() -> List(Custom) { [One, Two] }\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 import * as $OneTwoThree from "../one/two/three.d.ts";
 
-export function go(): $Gleam.List<$OneTwoThree.Custom$>;
+export function go(): _.List<$OneTwoThree.Custom$>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/modules.rs
+expression: "import one/two/three.{Custom, One, Two}\n\npub fn go() -> List(Custom) { [One, Two] }\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+import * as $OneTwoThree from "../one/two/three.d.ts";
+
+export function go(): $Gleam.List<$OneTwoThree.Custom$>;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
@@ -4,7 +4,7 @@ assertion_line: 201
 expression: "import one/two/three.{Custom, One, Two}\n\npub fn go() -> List(Custom) { [One, Two] }\n"
 ---
 import * as _ from "../gleam.d.ts";
-import * as $OneTwoThree from "../one/two/three.d.ts";
+import * as three from "../one/two/three.d.ts";
 
-export function go(): _.List<$OneTwoThree.Custom$>;
+export function go(): _.List<three.Custom$>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/prelude.rs
+expression: "import gleam\npub fn go() { gleam.Nil }\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export function go(): null;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/prelude.rs
+assertion_line: 41
 expression: "import gleam\npub fn go() { gleam.Nil }\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as gleam from "../gleam.d.ts";
 
 export function go(): null;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
@@ -1,8 +1,10 @@
 ---
 source: compiler-core/src/javascript/tests/prelude.rs
+assertion_line: 14
 expression: "import gleam\npub fn go() { gleam.Ok(1) }\n"
 ---
 import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export function go(): $Gleam.Result<number, any>;
+export function go(): _.Result<number, any>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/prelude.rs
+expression: "import gleam\npub fn go() { gleam.Ok(1) }\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export function go(): $Gleam.Result<number, any>;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
@@ -3,8 +3,8 @@ source: compiler-core/src/javascript/tests/prelude.rs
 assertion_line: 14
 expression: "import gleam\npub fn go() { gleam.Ok(1) }\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
 import * as _ from "../gleam.d.ts";
+import * as gleam from "../gleam.d.ts";
 
 export function go(): _.Result<number, any>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__todo__without_message_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__todo__without_message_typescript.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/javascript/tests/todo.rs
+expression: "\npub fn go() {\n    todo\n}\n"
+---
+export function go(): any;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__tuples__tuple_formating_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__tuples__tuple_formating_typescript.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/javascript/tests/tuples.rs
+expression: "\npub const e = #(\n  \"a\", \"a\", \"a\", \"a\", \"a\", \"a\", \"a\",\n  \"a\", \"a\", \"a\", \"a\", \"a\", \"a\", \"a\",\n  \"a\", \"a\", \"a\", \"a\", \"a\", \"a\", \"a\",\n)\n"
+---
+export const e: [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string
+];
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__tuples__tuple_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__tuples__tuple_typescript.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/javascript/tests/tuples.rs
+expression: "\npub fn go() {\n  #(\"1\", \"2\", \"3\")\n}\n"
+---
+export function go(): [string, string, string];
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__type_alias.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__type_alias.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/type_alias.rs
+expression: "\npub type Headers = List(#(String, String))\n"
+---
+import * as $Gleam from "../gleam.d.ts";
+
+export type Headers = $Gleam.List<[string, string]>;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__type_alias.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__type_alias.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/type_alias.rs
+assertion_line: 5
 expression: "\npub type Headers = List(#(String, String))\n"
 ---
-import * as $Gleam from "../gleam.d.ts";
+import * as _ from "../gleam.d.ts";
 
-export type Headers = $Gleam.List<[string, string]>;
+export type Headers = _.List<[string, string]>;
 

--- a/compiler-core/src/javascript/tests/todo.rs
+++ b/compiler-core/src/javascript/tests/todo.rs
@@ -1,10 +1,21 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn without_message() {
     assert_js!(
         r#"
 fn go() {
+    todo
+}
+"#,
+    );
+}
+
+#[test]
+fn without_message_typescript() {
+    assert_ts_def!(
+        r#"
+pub fn go() {
     todo
 }
 "#,

--- a/compiler-core/src/javascript/tests/tuples.rs
+++ b/compiler-core/src/javascript/tests/tuples.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn tuple() {
@@ -18,6 +18,17 @@ fn go() {
     #("1111111111111111111111111111111", "2", "3"),
     "3",
   )
+}
+"#,
+    );
+}
+
+#[test]
+fn tuple_typescript() {
+    assert_ts_def!(
+        r#"
+pub fn go() {
+  #("1", "2", "3")
 }
 "#,
     );
@@ -79,6 +90,19 @@ const e = #("bob", "dug")
 const e = #(
   "loooooooooooooong", "loooooooooooong", "loooooooooooooong",
   "loooooooooooooong", "loooooooooooong", "loooooooooooooong",
+)
+"#
+    );
+}
+
+#[test]
+fn tuple_formating_typescript() {
+    assert_ts_def!(
+        r#"
+pub const e = #(
+  "a", "a", "a", "a", "a", "a", "a",
+  "a", "a", "a", "a", "a", "a", "a",
+  "a", "a", "a", "a", "a", "a", "a",
 )
 "#
     );

--- a/compiler-core/src/javascript/tests/type_alias.rs
+++ b/compiler-core/src/javascript/tests/type_alias.rs
@@ -1,0 +1,10 @@
+use crate::assert_ts_def;
+
+#[test]
+fn type_alias() {
+    assert_ts_def!(
+        r#"
+pub type Headers = List(#(String, String))
+"#,
+    );
+}

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -1,0 +1,774 @@
+//! This module is responsible for generating TypeScript type declaration files.
+//! This code is run during the code generation phase along side the normal
+//! Javascript code emission. Here we walk through the typed AST and translate
+//! the Gleam statements into their TypeScript equivalent. Unlike the Javascript
+//! code generation, the TypeScript generation only needs to look at the module
+//! statements and not the expressions that may be _inside_ those statements.
+//! This is due to the TypeScript declarations only caring about inputs and outputs
+//! rather than _how_ those outputs are generated.
+//!
+//! ## Links
+//! <https://www.typescriptlang.org/>
+//! <https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html>
+
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
+use heck::ToUpperCamelCase;
+use itertools::Itertools;
+
+use crate::{
+    ast::{
+        Statement, TypedArg, TypedConstant, TypedExternalFnArg, TypedModule,
+        TypedRecordConstructor, TypedStatement,
+    },
+    docvec,
+    pretty::{break_, Document, Documentable},
+    type_::{Type, TypeVar},
+};
+
+use super::{concat, import::Imports, line, lines, wrap_args, Output, INDENT};
+
+/// The `TypePrinter` contains the logic of how to convert Gleam's type system
+/// into the equivalent TypeScript type strings.
+///
+#[derive(Debug)]
+struct TypePrinter<'a> {
+    tracker: UsageTracker,
+    current_module: &'a [String],
+}
+
+impl<'a> TypePrinter<'a> {
+    fn new(current_module: &'a [String]) -> Self {
+        Self {
+            current_module,
+            tracker: UsageTracker::default(),
+        }
+    }
+
+    /// Converts a Gleam type into a TypeScript type string
+    ///
+    pub fn print(&mut self, type_: &Type) -> Document<'static> {
+        self.do_print(type_, None)
+    }
+
+    /// Helper function for genering a TypeScript type string after collecting
+    /// all of the generics used in a statement
+    ///
+    pub fn print_with_generic_usages(
+        &mut self,
+        type_: &Type,
+        generic_usages: &HashMap<u64, u64>,
+    ) -> Document<'static> {
+        self.do_print(type_, Some(generic_usages))
+    }
+
+    fn do_print(
+        &mut self,
+        type_: &Type,
+        generic_usages: Option<&HashMap<u64, u64>>,
+    ) -> Document<'static> {
+        match type_ {
+            Type::Var { type_: typ } => self.print_var(&typ.borrow(), generic_usages),
+
+            Type::App {
+                name, module, args, ..
+            } if module.is_empty() => self.print_prelude_type(name, args, generic_usages),
+
+            Type::App {
+                name, args, module, ..
+            } => self.print_type_app(name, args, module, generic_usages),
+
+            Type::Fn { args, retrn } => self.print_fn(args, retrn, generic_usages),
+
+            Type::Tuple { elems } => tuple(elems.iter().map(|e| self.do_print(e, generic_usages))),
+        }
+    }
+
+    fn print_var(
+        &mut self,
+        type_: &TypeVar,
+        generic_usages: Option<&HashMap<u64, u64>>,
+    ) -> Document<'static> {
+        match type_ {
+            TypeVar::Generic { id } => match &generic_usages {
+                Some(usages) => match usages.get(id) {
+                    Some(&0) => super::nil(),
+                    Some(&1) => "any".to_doc(),
+                    _ => id_to_type_var(*id),
+                },
+                None => id_to_type_var(*id),
+            },
+            // Shouldn't get here unless something went wrong
+            TypeVar::Unbound { .. } => "any".to_doc(),
+            TypeVar::Link { type_: typ } => self.do_print(typ, generic_usages),
+        }
+    }
+
+    /// Prints a type coming from the Gleam prelude module. These are often the
+    /// low level types the rest of the type system are built up from. If there
+    /// is no built-in TypeScript equivalent, the type is prefixed with "$Gleam."
+    /// and the Gleam prelude namespace will be imported during the code emission.
+    ///
+    fn print_prelude_type(
+        &mut self,
+        name: &str,
+        args: &[Arc<Type>],
+        generic_usages: Option<&HashMap<u64, u64>>,
+    ) -> Document<'static> {
+        match name {
+            "Nil" => "null".to_doc(),
+            "Int" | "Float" => "number".to_doc(),
+            "UtfCodepoint" => {
+                self.tracker.prelude_used = true;
+                "$Gleam.UtfCodepoint".to_doc()
+            }
+            "String" => "string".to_doc(),
+            "Bool" => "boolean".to_doc(),
+            "BitString" => {
+                self.tracker.prelude_used = true;
+                "$Gleam.BitString".to_doc()
+            }
+            "List" => {
+                self.tracker.prelude_used = true;
+                docvec![
+                    "$Gleam.List",
+                    wrap_generic_args(args.iter().map(|x| self.do_print(x, generic_usages)))
+                ]
+            }
+            "Result" => {
+                self.tracker.prelude_used = true;
+                docvec![
+                    "$Gleam.Result",
+                    wrap_generic_args(args.iter().map(|x| self.do_print(x, generic_usages)))
+                ]
+            }
+            // Getting here sholud mean we either forgot a built-in type or there is a
+            // compiler error
+            name => panic!("{} is not a built-in type.", name),
+        }
+    }
+
+    /// Prints a "named" programmer-defined Gleam type into the TypeScript
+    /// equivalent.
+    ///
+    fn print_type_app(
+        &mut self,
+        name: &str,
+        args: &[Arc<Type>],
+        module: &[String],
+        generic_usages: Option<&HashMap<u64, u64>>,
+    ) -> Document<'static> {
+        let name = format!("{}$", ts_safe_type_name(name.to_upper_camel_case()));
+        let name = match module == self.current_module {
+            true => Document::String(name),
+            false => {
+                // If type comes from a seperate module, use that module's nam
+                // as a TypeScript namespace prefix
+                docvec![
+                    Document::String(format!("${}", module_name(module))),
+                    ".",
+                    Document::String(name),
+                ]
+            }
+        };
+        if args.is_empty() {
+            return name;
+        }
+
+        // If the App type takes arguments, pass them in as TypeScript generics
+        docvec![
+            name,
+            wrap_generic_args(args.iter().map(|a| self.do_print(a, generic_usages)))
+        ]
+    }
+
+    /// Prints the TypeScript type for an anonymous function (aka lambda)
+    ///
+    fn print_fn(
+        &mut self,
+        args: &[Arc<Type>],
+        retrn: &Type,
+        generic_usages: Option<&HashMap<u64, u64>>,
+    ) -> Document<'static> {
+        docvec![
+            wrap_args(args.iter().enumerate().map(|(idx, a)| docvec![
+                "x",
+                idx,
+                ": ",
+                self.do_print(a, generic_usages)
+            ])),
+            " => ",
+            self.do_print(retrn, generic_usages)
+        ]
+    }
+
+    /// Allows an outside module to mark the Gleam prelude as "used"
+    ///
+    pub fn set_prelude_used(&mut self) {
+        self.tracker.prelude_used = true
+    }
+
+    /// Returns if the Gleam prelude has been used at all during the process
+    /// of printing the TypeScript types
+    ///
+    pub fn prelude_used(&self) -> bool {
+        self.tracker.prelude_used
+    }
+}
+
+// When rendering a type variable to an TypeScript type spec we need all type
+// variables with the same id to end up with the same name in the generated
+// TypeScript. This function converts a usize into base 26 A-Z for this purpose.
+fn id_to_type_var(id: u64) -> Document<'static> {
+    if id < 26 {
+        let mut name = "".to_string();
+        name.push(std::char::from_u32((id % 26 + 65) as u32).expect("id_to_type_var 0"));
+        return Document::String(name);
+    }
+    let mut name = vec![];
+    let mut last_char = id;
+    while last_char >= 26 {
+        name.push(std::char::from_u32((last_char % 26 + 65) as u32).expect("id_to_type_var 1"));
+        last_char /= 26;
+    }
+    name.push(std::char::from_u32((last_char % 26 + 64) as u32).expect("id_to_type_var 2"));
+    name.reverse();
+    Document::String(name.into_iter().collect())
+}
+
+fn name_with_generics<'a>(
+    name: Document<'a>,
+    types: impl IntoIterator<Item = &'a Arc<Type>>,
+) -> Document<'a> {
+    let generic_usages = collect_generic_usages(HashMap::new(), types);
+    let generic_names: Vec<Document<'_>> = generic_usages
+        .iter()
+        .map(|(id, _use_count)| id_to_type_var(*id))
+        .collect();
+
+    docvec![
+        name,
+        if generic_names.is_empty() {
+            super::nil()
+        } else {
+            wrap_generic_args(generic_names)
+        },
+    ]
+}
+
+// A generic can either be rendered as an actual type variable such as `A` or `B`,
+// or it can be rendered as `any` depending on how many usages it has. If it
+// has only 1 usage it is an `any` type. If it has more than 1 usage it is a
+// TS generic. This function gathers usages for this determination.
+//
+//   Examples:
+//     fn(a) -> String       // `a` is `any`
+//     fn() -> Result(a, b)  // `a` and `b` are `any`
+//     fn(a) -> a            // `a` is a generic
+fn collect_generic_usages<'a>(
+    mut ids: HashMap<u64, u64>,
+    types: impl IntoIterator<Item = &'a Arc<Type>>,
+) -> HashMap<u64, u64> {
+    for typ in types {
+        generic_ids(typ, &mut ids);
+    }
+    ids
+}
+
+fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
+    match type_ {
+        Type::Var { type_: typ } => match typ.borrow().deref() {
+            TypeVar::Generic { id, .. } => {
+                let count = ids.entry(*id).or_insert(0);
+                *count += 1;
+            }
+            TypeVar::Unbound { .. } => (),
+            TypeVar::Link { type_: typ } => generic_ids(typ, ids),
+        },
+        Type::App { args, .. } => {
+            for arg in args {
+                generic_ids(arg, ids)
+            }
+        }
+        Type::Fn { args, retrn } => {
+            for arg in args {
+                generic_ids(arg, ids)
+            }
+            generic_ids(retrn, ids);
+        }
+        Type::Tuple { elems } => {
+            for elem in elems {
+                generic_ids(elem, ids)
+            }
+        }
+    }
+}
+
+/// Prints a Gleam tuple in the TypeScript equivalent syntax
+///
+fn tuple<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
+    break_("", "")
+        .append(concat(Itertools::intersperse(
+            elems.into_iter(),
+            break_(",", ", "),
+        )))
+        .nest(INDENT)
+        .append(break_("", ""))
+        .surround("[", "]")
+        .group()
+}
+
+fn wrap_generic_args<'a, I>(args: I) -> Document<'a>
+where
+    I: IntoIterator<Item = Document<'a>>,
+{
+    break_("", "")
+        .append(concat(Itertools::intersperse(
+            args.into_iter(),
+            break_(",", ", "),
+        )))
+        .nest(INDENT)
+        .append(break_("", ""))
+        .surround("<", ">")
+        .group()
+}
+
+/// Returns a name that can be used as a TypeScript type name. If there is a
+/// naming clash a '_' will be appended.
+///
+fn ts_safe_type_name(mut name: String) -> String {
+    if matches!(
+        name.as_str(),
+        "any"
+            | "boolean"
+            | "constructor"
+            | "declare"
+            | "get"
+            | "module"
+            | "require"
+            | "number"
+            | "set"
+            | "string"
+            | "symbol"
+            | "type"
+            | "from"
+            | "of"
+    ) {
+        name.push('_');
+        name
+    } else {
+        super::maybe_escape_identifier_string(&name)
+    }
+}
+
+/// The `TypeScriptGenerator` contains the logic of how to convert Gleam's typed
+/// AST into the equivalent TypeScript type declaration file.
+///
+#[derive(Debug)]
+pub struct TypeScriptGenerator<'a> {
+    module: &'a TypedModule,
+    type_printer: TypePrinter<'a>,
+}
+
+/// Joins the parts of the import into a single `UpperCamelCase` string
+///
+fn module_name(parts: &[String]) -> String {
+    parts.iter().map(|x| x.to_upper_camel_case()).join("")
+}
+
+impl<'a> TypeScriptGenerator<'a> {
+    pub fn new(module: &'a TypedModule) -> Self {
+        Self {
+            module,
+            type_printer: TypePrinter::new(&module.name),
+        }
+    }
+
+    pub fn compile(&mut self) -> Output<'a> {
+        let mut imports = self.collect_imports();
+        let statements = self
+            .module
+            .statements
+            .iter()
+            .flat_map(|s| self.statement(s));
+
+        // Two lines between each statement
+        let mut statements: Vec<_> =
+            Itertools::intersperse(statements, Ok(lines(2))).try_collect()?;
+
+        // Put it all together
+
+        if self.type_printer.prelude_used() {
+            let path = self.import_path(&self.module.type_info.package, &["gleam".to_string()]);
+            imports.register_module(path, ["$Gleam".to_string()], []);
+        }
+
+        if imports.is_empty() && statements.is_empty() {
+            Ok(docvec!("export {}", line()))
+        } else if imports.is_empty() {
+            statements.push(line());
+            Ok(statements.to_doc())
+        } else if statements.is_empty() {
+            Ok(imports.into_doc())
+        } else {
+            Ok(docvec![imports.into_doc(), line(), statements, line()])
+        }
+    }
+
+    fn collect_imports(&mut self) -> Imports<'a> {
+        let mut imports = Imports::new();
+
+        for statement in &self.module.statements {
+            match statement {
+                Statement::Fn { .. }
+                | Statement::TypeAlias { .. }
+                | Statement::CustomType { .. }
+                | Statement::ExternalType { .. }
+                | Statement::ExternalFn { .. }
+                | Statement::ModuleConstant { .. } => (),
+
+                Statement::Import {
+                    module, package, ..
+                } => {
+                    self.register_import(&mut imports, package, module);
+                }
+            }
+        }
+
+        imports
+    }
+
+    /// Registers an import of an external module so that it can be added to
+    /// the top of the generated Document. The module names are prefixed with a
+    /// "$" symbol to prevent any clashes with other Gleam names that may be
+    /// used in this module.
+    ///
+    fn register_import(
+        &mut self,
+        imports: &mut Imports<'a>,
+        package: &'a str,
+        module: &'a [String],
+    ) {
+        let path = self.import_path(package, module);
+        imports.register_module(path, [format!("${}", module_name(module))], []);
+    }
+
+    /// Calculates the path of where to import an external module from
+    ///
+    fn import_path(&self, package: &'a str, module: &'a [String]) -> String {
+        let path = module.join("/");
+
+        // TODO: strip shared prefixed between current module and imported
+        // module to avoid decending and climbing back out again
+        if package == self.module.type_info.package || package.is_empty() {
+            // Same package
+            match self.module.name.len() {
+                1 => format!("./{}.d.ts", path),
+                _ => {
+                    let prefix = "../".repeat(self.module.name.len() - 1);
+                    format!("{}{}.d.ts", prefix, path)
+                }
+            }
+        } else {
+            // Different package
+            let prefix = "../".repeat(self.module.name.len() + 1);
+            format!("{}{}/dist/{}.d.ts", prefix, package, path)
+        }
+    }
+
+    fn statement(&mut self, statement: &'a TypedStatement) -> Vec<Output<'a>> {
+        match statement {
+            Statement::TypeAlias {
+                alias,
+                public,
+                type_,
+                ..
+            } if *public => vec![self.type_alias(alias, type_)],
+            Statement::TypeAlias { .. } => vec![],
+
+            Statement::ExternalType {
+                public,
+                name,
+                arguments,
+                ..
+            } if *public => vec![self.external_type(name, arguments)],
+            Statement::ExternalType { .. } => vec![],
+
+            Statement::Import { .. } => vec![],
+
+            Statement::CustomType {
+                public,
+                constructors,
+                opaque,
+                name,
+                typed_parameters,
+                ..
+            } if *public => {
+                self.custom_type_definition(name, typed_parameters, constructors, *opaque)
+            }
+            Statement::CustomType { .. } => vec![],
+
+            Statement::ModuleConstant {
+                public,
+                name,
+                value,
+                ..
+            } if *public => vec![self.module_constant(name, value)],
+            Statement::ModuleConstant { .. } => vec![],
+
+            Statement::Fn {
+                arguments,
+                name,
+                public,
+                return_type,
+                ..
+            } if *public => vec![self.module_function(name, arguments, return_type)],
+            Statement::Fn { .. } => vec![],
+
+            Statement::ExternalFn {
+                public,
+                name,
+                arguments,
+                return_type,
+                ..
+            } if *public => vec![self.external_function(name, arguments, return_type)],
+            Statement::ExternalFn { .. } => vec![],
+        }
+    }
+
+    fn external_type(&self, name: &str, args: &'a [String]) -> Output<'a> {
+        let doc_name = Document::String(format!("{}$", ts_safe_type_name(name.to_string())));
+        if args.is_empty() {
+            Ok(docvec!["export type ", doc_name, " = any;"])
+        } else {
+            Ok(docvec![
+                "export type ",
+                doc_name,
+                wrap_generic_args(
+                    args.iter()
+                        .map(|x| Document::String(x.to_upper_camel_case()))
+                ),
+                " = any;",
+            ])
+        }
+    }
+
+    fn type_alias(&mut self, alias: &str, type_: &Type) -> Output<'a> {
+        Ok(docvec![
+            "export type ",
+            Document::String(ts_safe_type_name(alias.to_string())),
+            " = ",
+            self.type_printer.print(type_),
+            ";"
+        ])
+    }
+
+    /// Converts a Gleam custom type definition into the TypeScript equivalent.
+    /// In Gleam, all custom types have one to many concrete constructors. This
+    /// function first converts the constructors into TypeScript then finally
+    /// emits a union type to represent the TypeScript type itself. Because in
+    /// Gleam constructors can have the same name as the custom type, here we
+    /// append a "$" symbol to the emited TypeScript type to prevent those
+    /// naming clases.
+    ///
+    fn custom_type_definition(
+        &mut self,
+        name: &'a str,
+        typed_parameters: &'a [Arc<Type>],
+        constructors: &'a [TypedRecordConstructor],
+        opaque: bool,
+    ) -> Vec<Output<'a>> {
+        let mut definitions: Vec<Output<'_>> = constructors
+            .iter()
+            .map(|constructor| Ok(self.record_definition(constructor, opaque)))
+            .collect();
+
+        definitions.push(Ok(docvec![
+            "export type ",
+            name_with_generics(Document::String(format!("{}$", name)), typed_parameters),
+            " = ",
+            concat(Itertools::intersperse(
+                constructors.iter().map(|x| name_with_generics(
+                    super::maybe_escape_identifier_doc(&x.name),
+                    x.arguments.iter().map(|a| &a.type_)
+                )),
+                break_("| ", " | "),
+            )),
+            ";",
+        ]));
+
+        definitions
+    }
+
+    fn record_definition(
+        &mut self,
+        constructor: &'a TypedRecordConstructor,
+        opaque: bool,
+    ) -> Document<'a> {
+        self.type_printer.set_prelude_used();
+        let head = docvec![
+            // opaque type constructors are not exposed to JS
+            if opaque {
+                super::nil()
+            } else {
+                "export ".to_doc()
+            },
+            "class ",
+            name_with_generics(
+                super::maybe_escape_identifier_doc(&constructor.name),
+                constructor.arguments.iter().map(|a| &a.type_)
+            ),
+            " extends $Gleam.CustomType {"
+        ];
+
+        if constructor.arguments.is_empty() {
+            return head.append("}");
+        };
+
+        let class_body = docvec![
+            line(),
+            // First add the constructor
+            "constructor",
+            wrap_args(constructor.arguments.iter().enumerate().map(|(i, arg)| {
+                let name = arg
+                    .label
+                    .as_ref()
+                    .map(|s| super::maybe_escape_identifier_doc(s))
+                    .unwrap_or_else(|| Document::String(format!("{}", i)));
+                docvec![name, ": ", self.type_printer.print(&arg.type_)]
+            })),
+            ";",
+            line(),
+            line(),
+            // Then add each field to the class
+            concat(Itertools::intersperse(
+                constructor.arguments.iter().enumerate().map(|(i, arg)| {
+                    let name = arg
+                        .label
+                        .as_ref()
+                        .map(|s| super::maybe_escape_identifier_doc(s))
+                        .unwrap_or_else(|| Document::String(format!("x{}", i)));
+                    docvec![name, ": ", self.type_printer.print(&arg.type_), ";"]
+                }),
+                line(),
+            )),
+        ]
+        .nest(INDENT);
+
+        docvec![head, class_body, line(), "}"]
+    }
+
+    fn module_constant(&mut self, name: &'a str, value: &'a TypedConstant) -> Output<'a> {
+        Ok(docvec![
+            "export const ",
+            super::maybe_escape_identifier_doc(name),
+            ": ",
+            self.type_printer.print(&value.type_()),
+            ";",
+        ])
+    }
+
+    fn module_function(
+        &mut self,
+        name: &'a str,
+        args: &'a [TypedArg],
+        return_type: &'a Arc<Type>,
+    ) -> Output<'a> {
+        let generic_usages = collect_generic_usages(
+            HashMap::new(),
+            std::iter::once(return_type).chain(args.iter().map(|a| &a.type_)),
+        );
+        let generic_names: Vec<Document<'_>> = generic_usages
+            .iter()
+            .filter(|(_id, use_count)| **use_count > 1)
+            .map(|(id, _use_count)| id_to_type_var(*id))
+            .collect();
+
+        Ok(docvec![
+            "export function ",
+            super::maybe_escape_identifier_doc(name),
+            if generic_names.is_empty() {
+                super::nil()
+            } else {
+                wrap_generic_args(generic_names)
+            },
+            wrap_args(
+                args.iter()
+                    .enumerate()
+                    .map(|(i, a)| match a.get_variable_name() {
+                        None => {
+                            docvec![
+                                "x",
+                                i,
+                                ": ",
+                                self.type_printer
+                                    .print_with_generic_usages(&a.type_, &generic_usages)
+                            ]
+                        }
+                        Some(name) => docvec![
+                            super::maybe_escape_identifier_doc(name),
+                            ": ",
+                            self.type_printer
+                                .print_with_generic_usages(&a.type_, &generic_usages)
+                        ],
+                    }),
+            ),
+            ": ",
+            self.type_printer
+                .print_with_generic_usages(return_type, &generic_usages),
+            ";",
+        ])
+    }
+
+    fn external_function(
+        &mut self,
+        name: &'a str,
+        args: &'a [TypedExternalFnArg],
+        return_type: &'a Arc<Type>,
+    ) -> Output<'a> {
+        let generic_usages = collect_generic_usages(
+            HashMap::new(),
+            std::iter::once(return_type).chain(args.iter().map(|a| &a.type_)),
+        );
+        let generic_names: Vec<Document<'_>> = generic_usages
+            .iter()
+            .filter(|(_id, use_count)| **use_count > 1)
+            .map(|(id, _use_count)| id_to_type_var(*id))
+            .collect();
+
+        Ok(docvec![
+            "export function ",
+            super::maybe_escape_identifier_doc(name),
+            if generic_names.is_empty() {
+                super::nil()
+            } else {
+                wrap_generic_args(generic_names)
+            },
+            wrap_args(args.iter().enumerate().map(|(i, a)| match &a.label {
+                None => {
+                    docvec![
+                        "x",
+                        i,
+                        ": ",
+                        self.type_printer
+                            .print_with_generic_usages(&a.type_, &generic_usages)
+                    ]
+                }
+                Some(name) => docvec![
+                    super::maybe_escape_identifier_doc(name),
+                    ": ",
+                    self.type_printer.print_with_generic_usages(&a.type_, &generic_usages)
+                ],
+            })),
+            ": ",
+            self.type_printer
+                .print_with_generic_usages(return_type, &generic_usages),
+            ";",
+        ])
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct UsageTracker {
+    pub prelude_used: bool,
+}

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -242,7 +242,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     ..
                 } => {
                     if let Some(alias) = as_name {
-                        let _ = self.aliased_module_names.insert(module, &alias);
+                        let _ = self.aliased_module_names.insert(module, alias);
                     }
                     self.register_import(&mut imports, package, module);
                 }
@@ -603,7 +603,7 @@ impl<'a> TypeScriptGenerator<'a> {
         }
 
         match self.aliased_module_names.get(parts) {
-            Some(name) => name.to_string(),
+            Some(name) => (*name).to_string(),
             None => parts.last().expect("Non empty module path").clone(),
         }
     }

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -106,7 +106,7 @@ impl<'a> TypePrinter<'a> {
 
     /// Prints a type coming from the Gleam prelude module. These are often the
     /// low level types the rest of the type system are built up from. If there
-    /// is no built-in TypeScript equivalent, the type is prefixed with "$Gleam."
+    /// is no built-in TypeScript equivalent, the type is prefixed with "_."
     /// and the Gleam prelude namespace will be imported during the code emission.
     ///
     fn print_prelude_type(
@@ -120,25 +120,25 @@ impl<'a> TypePrinter<'a> {
             "Int" | "Float" => "number".to_doc(),
             "UtfCodepoint" => {
                 self.tracker.prelude_used = true;
-                "$Gleam.UtfCodepoint".to_doc()
+                "_.UtfCodepoint".to_doc()
             }
             "String" => "string".to_doc(),
             "Bool" => "boolean".to_doc(),
             "BitString" => {
                 self.tracker.prelude_used = true;
-                "$Gleam.BitString".to_doc()
+                "_.BitString".to_doc()
             }
             "List" => {
                 self.tracker.prelude_used = true;
                 docvec![
-                    "$Gleam.List",
+                    "_.List",
                     wrap_generic_args(args.iter().map(|x| self.do_print(x, generic_usages)))
                 ]
             }
             "Result" => {
                 self.tracker.prelude_used = true;
                 docvec![
-                    "$Gleam.Result",
+                    "_.Result",
                     wrap_generic_args(args.iter().map(|x| self.do_print(x, generic_usages)))
                 ]
             }
@@ -399,8 +399,8 @@ impl<'a> TypeScriptGenerator<'a> {
         // Put it all together
 
         if self.type_printer.prelude_used() {
-            let path = self.import_path(&self.module.type_info.package, &["gleam".to_string()]);
-            imports.register_module(path, ["$Gleam".to_string()], []);
+            let path = self.import_path(&self.module.type_info.package, &["gleam".into()]);
+            imports.register_module(path, ["_".into()], []);
         }
 
         if imports.is_empty() && statements.is_empty() {
@@ -618,7 +618,7 @@ impl<'a> TypeScriptGenerator<'a> {
                 super::maybe_escape_identifier_doc(&constructor.name),
                 constructor.arguments.iter().map(|a| &a.type_)
             ),
-            " extends $Gleam.CustomType {"
+            " extends _.CustomType {"
         ];
 
         if constructor.arguments.is_empty() {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -396,7 +396,6 @@ pub enum TypeVar {
     /// identify if two unbound variable Rust values are the same Gleam type variable
     /// instance or not.
     ///
-    ///
     Unbound { id: u64 },
     /// Link is type variable where it was an unbound variable but we worked out
     /// that it is some other type and now we point to that one.

--- a/compiler-core/templates/prelude.d.ts
+++ b/compiler-core/templates/prelude.d.ts
@@ -1,3 +1,8 @@
+export class CustomType {
+  inspect(): string;
+  withFields<K extends keyof this>(fields: { [P in K]: this[P] }): this;
+}
+
 export interface ListStatic {
   fromArray<T>(array: Array<T>): List<T>;
   isList(value: unknown): boolean;


### PR DESCRIPTION
This modifies the Javascript codegen to _also_ emit Typescript type declaration files alongside the existing `.mjs` files. This allows the generated Gleam code to be better used in Typescript environments without losing type safety.

~~@lpil I tried to make sure to copy over from the Javascript tests and tests that looked relevant. But I'm still not sure I'm covering every edge case. Is there a way in Gleam to mark a feature as "experimental" and have a user opt into using it?~~ I've added a commit to allow the Typescript code generation to be toggled on/off via the project TOML file. It defaults to off.

Features I'm unsure about:
- [x] Generics - Didn't see any existing tests for these in JS
- [x] Opaque types - Not sure how to models these in TS. Typescript doesn't have any equivalent unfortunately.

Closes #1269

As an aside, I wanted to record myself building this to possibly get more people interested in Gleam (not saying I succeeded haha). Here are the video links for any future code spelunkers:
Part 1:  https://youtu.be/bEcCyiO1b4k
Part 2: https://youtu.be/t472JiJ1Lnk
Part 3: https://youtu.be/WxHlU8thAMY