### PR TITLE
Bump `heck` and `strum` dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
  "os_str_bytes",
  "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -717,7 +717,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
- "heck 0.3.3",
+ "heck",
  "hexpm",
  "http",
  "im",
@@ -735,7 +735,7 @@ dependencies = [
  "strum",
  "tar",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap",
  "thiserror",
  "toml",
  "tracing",
@@ -795,15 +795,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -1869,20 +1860,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
- "heck 0.3.3",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1958,21 +1949,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
  "smawk",
  "terminal_size",
  "unicode-linebreak",
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -2202,12 +2187,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -31,7 +31,7 @@ toml = "0.5.8"
 ignore = "0.4.18"
 walkdir = "2.3.2"
 # Enum trait impl macros
-strum = { version = "0.23.0", features = ["derive"] }
+strum = { version = "0.24.0", features = ["derive"] }
 # Check for tty
 atty = "0.2.14"
 # Hex package manager client

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1.29"
 # Extra iter methods
 itertools = "0.10.1"
 # String case conversion
-heck = "0.3.3"
+heck = "0.4.0"
 # Parsing
 regex = "1.5.4"
 # Graph data structures
@@ -30,7 +30,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 # Cap'n Proto binary format runtime
 capnp = "0.14.3"
 # Enum trait impl macros
-strum = { version = "0.23.0", features = ["derive"] }
+strum = { version = "0.24.0", features = ["derive"] }
 # Template rendering
 askama = "0.10.5"
 # Markdown parsing
@@ -58,7 +58,7 @@ tar = "0.4.37"
 # gzip compression
 flate2 = "1.0.22"
 # Helper for wrapping text onto lines based upon width
-textwrap = { version = "0.14.2", features = ["terminal_size"] }
+textwrap = { version = "0.15.0", features = ["terminal_size"] }
 # base encoding
 base16 = "0.2.1"
 # toml config file parsing

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     Result,
 };
-use heck::SnakeCase;
+use heck::ToSnakeCase;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use pattern::pattern;

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -1,7 +1,6 @@
 use crate::ast::SrcSpan;
 use crate::error::wrap;
-use heck::CamelCase;
-use heck::SnakeCase;
+use heck::{ToSnakeCase, ToUpperCamelCase};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct LexicalError {
@@ -263,7 +262,7 @@ impl LexicalError {
                 vec![
                     "Hint: Upnames start with an uppercase letter and contain".to_string(),
                     "only lowercase letters, numbers, and uppercase letters.".to_string(),
-                    format!("Try: {}", name.to_camel_case()),
+                    format!("Try: {}", name.to_upper_camel_case()),
                 ],
             ),
         }


### PR DESCRIPTION
Quick bump of `heck` and `strum` to reduce duplicated transitive dependencies.

There is one dupe left, `base64 v0.12.3` and `base64 v0.13.0`, but that one can't be removed as it is introduced by `hexpm` and its dependencies.