### PR TITLE
feat(codegen): Skip dev-dependencies in `.app` if not root project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@
 - Fixed a bug where `gleam format` would output an unwanted newline at the top
   of documents that only contain simple `//` comments.
 - No longer add `dev-dependencies` to generated `.app` Erlang files unless
-  we're compiling the root project (#1569). When using the package-compiler API
-  this behaviour is configurable.
+  we're compiling the root project (#1569).
+- The `gleam compile-package` command no longer generates a `.app` file. This
+  should now be done by the build tool that calls this command as it is
+  responsible for handling dependencies.
 
 ## v0.21.0 - 2022-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@
 - Fixed a bug where `gleam format` would output an unwanted newline at the top
   of documents that only contain simple `//` comments.
 - No longer add `dev-dependencies` to generated `.app` Erlang files unless
-  we're compiling the root project (#1569)
+  we're compiling the root project (#1569). When using the package-compiler API
+  this behaviour is configurable.
 
 ## v0.21.0 - 2022-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   comments, as well as between comments and any following expression
 - Fixed a bug where `gleam format` would output an unwanted newline at the top
   of documents that only contain simple `//` comments.
+- No longer add `dev-dependencies` to generated `.app` Erlang files unless
+  we're compiling the root project (#1569)
 
 ## v0.21.0 - 2022-04-24
 

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -18,9 +18,9 @@ pub fn command(options: CompilePackage) -> Result<()> {
     let mut defined_modules = im::HashMap::new();
     let mut warnings = Vec::new();
     let config = config::read(options.package_directory.join("gleam.toml"))?;
-    let target= match options.target {
+    let target = match options.target {
         Target::Erlang => TargetCodegenConfiguration::Erlang { app_file: None },
-        Target::JavaScript => TargetCodegenConfiguration::JavaScript
+        Target::JavaScript => TargetCodegenConfiguration::JavaScript,
     };
 
     tracing::info!("Compiling package");

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -4,7 +4,7 @@ use crate::{
     CompilePackage,
 };
 use gleam_core::{
-    build::{Mode, PackageCompiler},
+    build::{package_compiler::DependencyMode, Mode, PackageCompiler},
     metadata,
     type_::Module,
     uid::UniqueIdGenerator,
@@ -28,6 +28,7 @@ pub fn command(options: CompilePackage) -> Result<()> {
         &options.libraries_directory,
         options.target,
         ids,
+        DependencyMode::ProdOnly,
         ProjectIO::new(),
         None,
     );

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -4,7 +4,7 @@ use crate::{
     CompilePackage,
 };
 use gleam_core::{
-    build::{package_compiler::DependencyMode, Mode, PackageCompiler},
+    build::{Mode, PackageCompiler, Target, TargetCodegenConfiguration},
     metadata,
     type_::Module,
     uid::UniqueIdGenerator,
@@ -18,6 +18,10 @@ pub fn command(options: CompilePackage) -> Result<()> {
     let mut defined_modules = im::HashMap::new();
     let mut warnings = Vec::new();
     let config = config::read(options.package_directory.join("gleam.toml"))?;
+    let target= match options.target {
+        Target::Erlang => TargetCodegenConfiguration::Erlang { app_file: None },
+        Target::JavaScript => TargetCodegenConfiguration::JavaScript
+    };
 
     tracing::info!("Compiling package");
 
@@ -26,9 +30,8 @@ pub fn command(options: CompilePackage) -> Result<()> {
         &options.package_directory,
         &options.output_directory,
         &options.libraries_directory,
-        options.target,
+        &target,
         ids,
-        DependencyMode::ProdOnly,
         ProjectIO::new(),
         None,
     );

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -50,24 +50,23 @@ impl Target {
 pub enum TargetCodegenConfiguration {
     JavaScript,
     Erlang {
-        app_file: Option<ErlangAppCodegenConfiguration>
-    }
+        app_file: Option<ErlangAppCodegenConfiguration>,
+    },
 }
 
 impl TargetCodegenConfiguration {
     pub fn target(&self) -> Target {
         match self {
             Self::JavaScript => Target::JavaScript,
-            Self::Erlang { .. } => Target::Erlang
+            Self::Erlang { .. } => Target::Erlang,
         }
     }
 }
 
 #[derive(Debug)]
 pub struct ErlangAppCodegenConfiguration {
-    include_dev_deps: bool
+    include_dev_deps: bool,
 }
-
 
 #[derive(
     Debug, Serialize, Deserialize, Display, EnumString, EnumVariantNames, Clone, Copy, PartialEq,

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -46,6 +46,29 @@ impl Target {
     }
 }
 
+#[derive(Debug)]
+pub enum TargetCodegenConfiguration {
+    JavaScript,
+    Erlang {
+        app_file: Option<ErlangAppCodegenConfiguration>
+    }
+}
+
+impl TargetCodegenConfiguration {
+    pub fn target(&self) -> Target {
+        match self {
+            Self::JavaScript => Target::JavaScript,
+            Self::Erlang { .. } => Target::Erlang
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ErlangAppCodegenConfiguration {
+    include_dev_deps: bool
+}
+
+
 #[derive(
     Debug, Serialize, Deserialize, Display, EnumString, EnumVariantNames, Clone, Copy, PartialEq,
 )]

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{
     ast::SrcSpan,
     build::{
-        package_compiler::{DependencyMode, PackageCompiler, Source},
+        package_compiler::{PackageCompiler, Source},
         Origin, Target,
     },
     codegen,
@@ -49,9 +49,10 @@ macro_rules! assert_erlang_compile {
             &root,
             &out,
             &lib,
-            Target::Erlang,
+            &TargetCodegenConfiguration::Erlang {
+                app_file: None,
+            },
             ids,
-            DependencyMode::IncludeDev,
             file_writer,
             Some(&mut build_journal),
         );
@@ -109,9 +110,8 @@ macro_rules! assert_javascript_compile {
             &root,
             &out,
             &lib,
-            Target::JavaScript,
+            &TargetCodegenConfiguration::JavaScript,
             ids,
-            DependencyMode::IncludeDev,
             file_writer,
             Some(&mut build_journal),
         );
@@ -170,9 +170,12 @@ macro_rules! assert_no_warnings {
             &root,
             &out,
             &lib,
-            Target::Erlang,
+            &TargetCodegenConfiguration::Erlang {
+                app_file: Some(ErlangAppCodegenConfiguration {
+                    include_dev_deps: true
+                })
+            },
             ids,
-            DependencyMode::IncludeDev,
             file_writer,
             Some(&mut build_journal),
         );
@@ -192,18 +195,7 @@ macro_rules! assert_no_warnings {
 fn package_compiler_test() {
     assert_erlang_compile!(
         vec![],
-        Ok(vec![OutputFile {
-            path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-            text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, []},
-    {registered, []}
-]}.
-"
-            .into(),
-        },])
+        Ok(vec![])
     );
 
     assert_erlang_compile!(
@@ -214,18 +206,6 @@ fn package_compiler_test() {
             origin: Origin::Src,
         }],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 text: "-module(one).\n".to_string(),
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
@@ -250,19 +230,6 @@ fn package_compiler_test() {
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 text: "-module(one).\n".to_string(),
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
             },
@@ -281,18 +248,6 @@ fn package_compiler_test() {
             code: "".to_string(),
         }],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).\n".to_string(),
@@ -343,19 +298,6 @@ fn package_compiler_test() {
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).\n".to_string(),
             },
@@ -383,19 +325,6 @@ fn package_compiler_test() {
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).\n".to_string(),
             },
@@ -422,19 +351,6 @@ fn package_compiler_test() {
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -482,19 +398,6 @@ unbox(X) ->
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -532,18 +435,6 @@ box(X) ->
         }],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one@two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one@two.erl"),
                 text: "-module(one@two).
 -compile(no_auto_import).
@@ -575,19 +466,6 @@ box(X) ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -633,19 +511,6 @@ box() ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -694,19 +559,6 @@ pub fn go(x) { let one.Box(y) = x y }"
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [nested@one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/nested@one.erl"),
                 text: "-module(nested@one).
 -compile(no_auto_import).
@@ -754,19 +606,6 @@ pub fn go(x) { let thingy.Box(y) = x y }"
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [nested@one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/nested@one.erl"),
                 text: "-module(nested@one).
@@ -818,19 +657,6 @@ go(X) ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [nested@one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/nested@one.erl"),
                 text: "-module(nested@one).
@@ -913,19 +739,6 @@ pub fn x(p) { let one.Point(x, _) = p x }"
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -985,19 +798,6 @@ x(P) ->
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -1050,19 +850,6 @@ pub fn make() { one.Empty }"
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -1107,19 +894,6 @@ make() ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -1170,19 +944,6 @@ make() ->
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -1231,19 +992,6 @@ make() ->
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -1288,19 +1036,6 @@ funky() ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -1347,19 +1082,6 @@ funky() ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -1410,19 +1132,6 @@ funky() ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -1480,19 +1189,6 @@ get_name(Person) ->
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -1536,19 +1232,6 @@ get_name(Person) ->
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -1589,19 +1272,6 @@ get_name(Person) ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -1652,19 +1322,6 @@ main() ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -1721,18 +1378,6 @@ make() ->
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-".into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).\n"
                 .to_string(),
@@ -1770,19 +1415,6 @@ make_list() ->
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -1929,19 +1561,6 @@ fn bug_752() {
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl",),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -2001,19 +1620,6 @@ pub fn main(power: Power) { power.to_int(power) }"
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [main,
-               power]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/main.erl",),
                 text: "-module(main).
@@ -2075,19 +1681,6 @@ pub fn x() { test }"
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
 -compile(no_auto_import).
@@ -2135,19 +1728,6 @@ pub fn x() { test }"
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -2233,19 +1813,6 @@ pub fn x() { one.A }"
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).
@@ -2339,9 +1906,12 @@ fn config_compilation_test() {
                 &root,
                 &out,
                 &lib,
-                Target::Erlang,
+                &TargetCodegenConfiguration::Erlang {
+                    app_file: Some(ErlangAppCodegenConfiguration {
+                        include_dev_deps: true
+                    })
+                },
                 ids,
-                DependencyMode::IncludeDev,
                 file_writer,
                 Some(&mut build_journal),
             );
@@ -2582,19 +2152,6 @@ const x = two.A"#
         ],
         Ok(vec![
             OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one@two,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
-            OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one@two.erl"),
                 text: "-module(one@two).
 -compile(no_auto_import).
@@ -2695,19 +2252,6 @@ fn import_error() {
             },
         ],
         Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/ebin/the_package.app"),
-                text: "{application, the_package, [
-    {vsn, \"1.0.0\"},
-    {applications, []},
-    {description, \"The description\"},
-    {modules, [one,
-               two]},
-    {registered, []}
-]}.
-"
-                .into(),
-            },
             OutputFile {
                 path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
                 text: "-module(one).

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{
     ast::SrcSpan,
     build::{
-        package_compiler::{PackageCompiler, Source},
+        package_compiler::{DependencyMode, PackageCompiler, Source},
         Origin, Target,
     },
     codegen,
@@ -51,6 +51,7 @@ macro_rules! assert_erlang_compile {
             &lib,
             Target::Erlang,
             ids,
+            DependencyMode::IncludeDev,
             file_writer,
             Some(&mut build_journal),
         );
@@ -110,6 +111,7 @@ macro_rules! assert_javascript_compile {
             &lib,
             Target::JavaScript,
             ids,
+            DependencyMode::IncludeDev,
             file_writer,
             Some(&mut build_journal),
         );
@@ -170,6 +172,7 @@ macro_rules! assert_no_warnings {
             &lib,
             Target::Erlang,
             ids,
+            DependencyMode::IncludeDev,
             file_writer,
             Some(&mut build_journal),
         );
@@ -2338,6 +2341,7 @@ fn config_compilation_test() {
                 &lib,
                 Target::Erlang,
                 ids,
+                DependencyMode::IncludeDev,
                 file_writer,
                 Some(&mut build_journal),
             );

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -49,9 +49,7 @@ macro_rules! assert_erlang_compile {
             &root,
             &out,
             &lib,
-            &TargetCodegenConfiguration::Erlang {
-                app_file: None,
-            },
+            &TargetCodegenConfiguration::Erlang { app_file: None },
             ids,
             file_writer,
             Some(&mut build_journal),
@@ -172,8 +170,8 @@ macro_rules! assert_no_warnings {
             &lib,
             &TargetCodegenConfiguration::Erlang {
                 app_file: Some(ErlangAppCodegenConfiguration {
-                    include_dev_deps: true
-                })
+                    include_dev_deps: true,
+                }),
             },
             ids,
             file_writer,
@@ -193,10 +191,7 @@ macro_rules! assert_no_warnings {
 
 #[test]
 fn package_compiler_test() {
-    assert_erlang_compile!(
-        vec![],
-        Ok(vec![])
-    );
+    assert_erlang_compile!(vec![], Ok(vec![]));
 
     assert_erlang_compile!(
         vec![Source {
@@ -205,12 +200,10 @@ fn package_compiler_test() {
             code: "".to_string(),
             origin: Origin::Src,
         }],
-        Ok(vec![
-            OutputFile {
-                text: "-module(one).\n".to_string(),
-                path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
-            },
-        ])
+        Ok(vec![OutputFile {
+            text: "-module(one).\n".to_string(),
+            path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
+        },])
     );
 
     assert_erlang_compile!(
@@ -247,12 +240,10 @@ fn package_compiler_test() {
             path: PathBuf::from("src/one.gleam"),
             code: "".to_string(),
         }],
-        Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
-                text: "-module(one).\n".to_string(),
-            },
-        ]),
+        Ok(vec![OutputFile {
+            path: PathBuf::from("_build/default/lib/the_package/build/one.erl"),
+            text: "-module(one).\n".to_string(),
+        },]),
     );
 
     // TODO: src modules cannot be allowed to import test modules
@@ -433,10 +424,9 @@ box(X) ->
             name: "one/two".to_string(),
             code: "pub type Box { Box }".to_string(),
         }],
-        Ok(vec![
-            OutputFile {
-                path: PathBuf::from("_build/default/lib/the_package/build/one@two.erl"),
-                text: "-module(one@two).
+        Ok(vec![OutputFile {
+            path: PathBuf::from("_build/default/lib/the_package/build/one@two.erl"),
+            text: "-module(one@two).
 -compile(no_auto_import).
 
 -export_type([box/0]).
@@ -445,9 +435,8 @@ box(X) ->
 
 
 "
-                .to_string(),
-            }
-        ]),
+            .to_string(),
+        }]),
     );
 
     assert_erlang_compile!(
@@ -1908,8 +1897,8 @@ fn config_compilation_test() {
                 &lib,
                 &TargetCodegenConfiguration::Erlang {
                     app_file: Some(ErlangAppCodegenConfiguration {
-                        include_dev_deps: true
-                    })
+                        include_dev_deps: true,
+                    }),
                 },
                 ids,
                 file_writer,

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -99,7 +99,7 @@ where
         let sequence = dep_tree::toposort_deps(
             parsed_modules
                 .values()
-                .map(|m| module_deps_for_graph(self.target, m))
+                .map(|m| module_deps_for_graph(self.target.target(), m))
                 .collect(),
         )
         .map_err(convert_deps_tree_error)?;
@@ -454,13 +454,13 @@ fn convert_deps_tree_error(e: dep_tree::Error) -> Error {
 }
 
 fn module_deps_for_graph(
-    target: &TargetCodegenConfiguration,
+    target: Target,
     module: &Parsed,
 ) -> (String, Vec<String>) {
     let name = module.name.clone();
     let deps: Vec<_> = module
         .ast
-        .dependencies(target.target())
+        .dependencies(target)
         .into_iter()
         .map(|(dep, _span)| dep)
         .collect();

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -453,10 +453,7 @@ fn convert_deps_tree_error(e: dep_tree::Error) -> Error {
     }
 }
 
-fn module_deps_for_graph(
-    target: Target,
-    module: &Parsed,
-) -> (String, Vec<String>) {
+fn module_deps_for_graph(target: Target, module: &Parsed) -> (String, Vec<String>) {
     let name = module.name.clone();
     let deps: Vec<_> = module
         .ast

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -23,7 +23,8 @@ use std::{
     time::Instant,
 };
 
-use super::package_compiler::DependencyMode;
+use super::ErlangAppCodegenConfiguration;
+
 
 // On Windows we have to call rebar3 via a little wrapper script.
 //
@@ -361,18 +362,19 @@ where
         let lib_path = paths::build_packages(self.mode(), self.target());
         let artifact_path = out_path.join("build");
         let mode = self.mode();
+        let target = match self.target() {
+            Target::Erlang => super::TargetCodegenConfiguration::Erlang { app_file: Some(ErlangAppCodegenConfiguration {
+                include_dev_deps: is_root
+            }) },
+            Target::JavaScript => super::TargetCodegenConfiguration::JavaScript
+        };
         let mut compiler = PackageCompiler::new(
             config,
             &root_path,
             &out_path,
             &lib_path,
-            self.target(),
+            &target,
             self.ids.clone(),
-            if is_root {
-                DependencyMode::ProdOnly
-            } else {
-                DependencyMode::IncludeDev
-            },
             self.io.clone(),
             if (is_root) {
                 Some(&mut self.build_journal)

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -25,7 +25,6 @@ use std::{
 
 use super::ErlangAppCodegenConfiguration;
 
-
 // On Windows we have to call rebar3 via a little wrapper script.
 //
 #[cfg(not(target_os = "windows"))]
@@ -363,10 +362,12 @@ where
         let artifact_path = out_path.join("build");
         let mode = self.mode();
         let target = match self.target() {
-            Target::Erlang => super::TargetCodegenConfiguration::Erlang { app_file: Some(ErlangAppCodegenConfiguration {
-                include_dev_deps: is_root
-            }) },
-            Target::JavaScript => super::TargetCodegenConfiguration::JavaScript
+            Target::Erlang => super::TargetCodegenConfiguration::Erlang {
+                app_file: Some(ErlangAppCodegenConfiguration {
+                    include_dev_deps: is_root,
+                }),
+            },
+            Target::JavaScript => super::TargetCodegenConfiguration::JavaScript,
         };
         let mut compiler = PackageCompiler::new(
             config,

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -23,6 +23,8 @@ use std::{
     time::Instant,
 };
 
+use super::package_compiler::DependencyMode;
+
 // On Windows we have to call rebar3 via a little wrapper script.
 //
 #[cfg(not(target_os = "windows"))]
@@ -366,6 +368,11 @@ where
             &lib_path,
             self.target(),
             self.ids.clone(),
+            if is_root {
+                DependencyMode::ProdOnly
+            } else {
+                DependencyMode::IncludeDev
+            },
             self.io.clone(),
             if (is_root) {
                 Some(&mut self.build_journal)

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -1,5 +1,5 @@
 use crate::{
-    build::{package_compiler::DependencyMode, Module},
+    build::Module,
     config::{JavaScriptConfig, PackageConfig},
     erlang,
     io::{FileSystemWriter, Utf8Writer},
@@ -75,14 +75,14 @@ impl<'a> Erlang<'a> {
 #[derive(Debug)]
 pub struct ErlangApp<'a> {
     output_directory: &'a Path,
-    dependency_mode: DependencyMode,
+    include_dev_deps: bool,
 }
 
 impl<'a> ErlangApp<'a> {
-    pub fn new(output_directory: &'a Path, dependency_mode: DependencyMode) -> Self {
+    pub fn new(output_directory: &'a Path, include_dev_deps: bool) -> Self {
         Self {
             output_directory,
-            dependency_mode,
+            include_dev_deps,
         }
     }
 
@@ -120,7 +120,7 @@ impl<'a> ErlangApp<'a> {
                 config
                     .dev_dependencies
                     .keys()
-                    .take_while(|_| self.dependency_mode == DependencyMode::IncludeDev),
+                    .take_while(|_| self.include_dev_deps),
             )
             .chain(config.erlang.extra_applications.iter())
             .sorted()


### PR DESCRIPTION
Currently we add all dependencies to the generated `.app` folder even if
they are `dev_dependencies` and we're not currently compiling the root
project. This can cause errors as Gleam will be expecting certain Erlang
applications that may not be present.