### PR TITLE
fix(lsp): uri to module name fails on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "walkdir",
 ]
 
@@ -2226,6 +2227,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "valuable"

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -76,6 +76,8 @@ lsp-server = "0.5"
 lsp-types = "0.92"
 # File locking
 fslock = "0.2.1"
+# File URl decoding
+urlencoding = "2.1.0"
 
 [dev-dependencies]
 # Test assertion errors with diffs

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -76,6 +76,8 @@ lsp-server = "0.5"
 lsp-types = "0.92"
 # File locking
 fslock = "0.2.1"
+
+[target.'cfg(target_os = "windows")'.dependencies]
 # File URl decoding
 urlencoding = "2.1.0"
 

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -716,7 +716,7 @@ impl LanguageServer {
 }
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
-    let path = uri.to_file_path().expect("uri to pathbuf");
+    let path = PathBuf::from(uri.path());
     let components = path
         .strip_prefix(&root)
         .ok()?

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -717,9 +717,14 @@ impl LanguageServer {
 }
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
-    let mut uri_path = decode(&*uri.path().replace("/", "\\")).expect("Invalid formatting").to_string();
+    let mut uri_path = decode(&*uri.path().replace("/", "\\"))
+        .expect("Invalid formatting")
+        .to_string();
     if uri_path.starts_with("/") {
-        uri_path = uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix").to_string();
+        uri_path = uri_path
+            .strip_prefix("/")
+            .expect("Failed to remove \"/\" prefix")
+            .to_string();
     }
     let path = PathBuf::from(uri_path);
     let components = path

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -27,6 +27,7 @@ use lsp_types::{
     HoverContents, HoverProviderCapability, InitializeParams, MarkedString, Position,
     PublishDiagnosticsParams, Range, TextEdit, Url,
 };
+use urlencoding::decode;
 
 const COMPILING_PROGRESS_TOKEN: &str = "compiling-gleam";
 const CREATE_COMPILING_PROGRESS_TOKEN: &str = "create-compiling-progress-token";
@@ -717,6 +718,11 @@ impl LanguageServer {
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
     let path = PathBuf::from(uri.path());
+    let mut uri_path = decode(&*uri.path().replace("/", "\\")).expect("Invalid formatting").to_string();
+    if cfg!(target_os = "windows") {
+        uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix")
+    }
+    let path = PathBuf::from(uri_path);
     let components = path
         .strip_prefix(&root)
         .ok()?

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -720,7 +720,7 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
     let mut uri_path = decode(&*uri.path().replace('/', "\\"))
         .expect("Invalid formatting")
         .to_string();
-    if uri_path.starts_with('/') {
+    if uri_path.starts_with('/') && cfg!(target_os = "windows") {
         uri_path = uri_path
             .strip_prefix('/')
             .expect("Failed to remove \"/\" prefix")

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -723,7 +723,6 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
         .expect("Invalid formatting")
         .to_string();
     if uri_path.starts_with("\\") {
-        uri_path = uri_path.strip_prefix("\\").expect("Failed to remove \"\\\" prefix").to_string();
         uri_path = uri_path
             .strip_prefix("\\")
             .expect("Failed to remove \"\\\" prefix")

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -691,7 +691,10 @@ impl LanguageServer {
     }
 
     fn module_for_uri(&self, uri: &Url) -> Option<&Module> {
+        tracing::info!("File URI: {}", uri.to_string());
+        tracing::info!("Project Root: {}", self.project_root.to_str()?);
         let module_name = uri_to_module_name(uri, &self.project_root).expect("uri to module name");
+        tracing::info!("Module: {}", module_name);
         self.compiler.modules.get(&module_name)
     }
 
@@ -725,6 +728,10 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
         uri_path = uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix").to_string();
     }
     let path = PathBuf::from(uri_path);
+    tracing::info!("(uri_to_module_name) URI: {}", uri.path());
+    tracing::info!("(uri_to_module_name) PathBuf: {}", path.to_str()?);
+    tracing::info!("(uri_to_module_name) root: {}", root.to_str()?);
+    tracing::info!("(uri_to_module_name) root_with_edits: {}", root.to_path_buf().to_str()?);
     let components = path
         .strip_prefix(&root)
         .ok()?
@@ -735,6 +742,7 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
         .collect::<String>()
         .strip_suffix(".gleam")?
         .to_string();
+    tracing::info!("(uri_to_module_name) module_name: {}", module_name);
     Some(module_name)
 }
 

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -723,6 +723,10 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
         .to_string();
     if uri_path.starts_with("\\") {
         uri_path = uri_path.strip_prefix("\\").expect("Failed to remove \"\\\" prefix").to_string();
+        uri_path = uri_path
+            .strip_prefix("\\")
+            .expect("Failed to remove \"\\\" prefix")
+            .to_string();
     }
     let path = PathBuf::from(uri_path);
     let components = path

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -154,7 +154,7 @@ pub struct LanguageServer {
 impl LanguageServer {
     pub fn new(initialise_params: InitializeParams) -> Result<Self> {
         let compiler = LspProjectCompiler::new(ProjectIO::new())?;
-        let project_root = PathBuf::from("./").canonicalize().expect("Absolute root");
+        let project_root = std::env::current_dir().expect("Project root");
         Ok(Self {
             initialise_params,
             edited: HashMap::new(),

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -753,6 +753,14 @@ fn uri_to_module_name_test() {
     let root = PathBuf::from("/projects/app");
     let uri = Url::parse("file:///projects/app/src/one/two/three.rs").unwrap();
     assert_eq!(uri_to_module_name(&uri, &root), None);
+
+    let root = PathBuf::from("/projects/app");
+    let uri = Url::parse("file:///b%3A/projects/app/src/one/two/three.rs").unwrap();
+    assert_eq!(uri_to_module_name(&uri, &root), None);
+
+    let root = PathBuf::from("/projects/app");
+    let uri = Url::parse("file:///c%3A/projects/app/src/one/two/three.rs").unwrap();
+    assert_eq!(uri_to_module_name(&uri, &root), None);
 }
 
 fn cast_request<R>(request: lsp_server::Request) -> Result<R::Params, lsp_server::Request>

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -717,12 +717,12 @@ impl LanguageServer {
 }
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
-    let mut uri_path = decode(&*uri.path().replace("/", "\\"))
+    let mut uri_path = decode(&*uri.path().replace('/', "\\"))
         .expect("Invalid formatting")
         .to_string();
-    if uri_path.starts_with("/") {
+    if uri_path.starts_with('/') {
         uri_path = uri_path
-            .strip_prefix("/")
+            .strip_prefix('/')
             .expect("Failed to remove \"/\" prefix")
             .to_string();
     }

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -721,6 +721,7 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
     let mut uri_path = decode(&*uri.path().replace("/", "\\")).expect("Invalid formatting").to_string();
     if cfg!(target_os = "windows") {
         uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix")
+        uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix");
     }
     let path = PathBuf::from(uri_path);
     let components = path

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -717,14 +717,19 @@ impl LanguageServer {
 }
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
-    let mut uri_path = decode(&*uri.path().replace('/', "\\"))
-        .expect("Invalid formatting")
-        .to_string();
-    if uri_path.starts_with('/') && cfg!(target_os = "windows") {
-        uri_path = uri_path
-            .strip_prefix('/')
-            .expect("Failed to remove \"/\" prefix")
+    let mut uri_path: String;
+    if cfg!(target_os = "windows") {
+        uri_path = decode(&*uri.path().replace('/', "\\"))
+            .expect("Invalid formatting")
             .to_string();
+        if uri_path.starts_with('/') {
+            uri_path = uri_path
+                .strip_prefix('/')
+                .expect("Failed to remove \"/\" prefix")
+                .to_string();
+        }
+    } else {
+        uri_path = uri.path().to_string();
     }
     let path = PathBuf::from(uri_path);
     let components = path

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -27,6 +27,7 @@ use lsp_types::{
     HoverContents, HoverProviderCapability, InitializeParams, MarkedString, Position,
     PublishDiagnosticsParams, Range, TextEdit, Url,
 };
+#[cfg(target_os = "windows")]
 use urlencoding::decode;
 
 const COMPILING_PROGRESS_TOKEN: &str = "compiling-gleam";

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -691,10 +691,7 @@ impl LanguageServer {
     }
 
     fn module_for_uri(&self, uri: &Url) -> Option<&Module> {
-        tracing::info!("File URI: {}", uri.to_string());
-        tracing::info!("Project Root: {}", self.project_root.to_str()?);
         let module_name = uri_to_module_name(uri, &self.project_root).expect("uri to module name");
-        tracing::info!("Module: {}", module_name);
         self.compiler.modules.get(&module_name)
     }
 

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -720,18 +720,11 @@ impl LanguageServer {
 }
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
-    let path = PathBuf::from(uri.path());
     let mut uri_path = decode(&*uri.path().replace("/", "\\")).expect("Invalid formatting").to_string();
-    if cfg!(target_os = "windows") {
-        uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix")
-        uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix");
+    if uri_path[0] == "/" {
         uri_path = uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix").to_string();
     }
     let path = PathBuf::from(uri_path);
-    tracing::info!("(uri_to_module_name) URI: {}", uri.path());
-    tracing::info!("(uri_to_module_name) PathBuf: {}", path.to_str()?);
-    tracing::info!("(uri_to_module_name) root: {}", root.to_str()?);
-    tracing::info!("(uri_to_module_name) root_with_edits: {}", root.to_path_buf().to_str()?);
     let components = path
         .strip_prefix(&root)
         .ok()?
@@ -742,7 +735,6 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
         .collect::<String>()
         .strip_suffix(".gleam")?
         .to_string();
-    tracing::info!("(uri_to_module_name) module_name: {}", module_name);
     Some(module_name)
 }
 

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -721,7 +721,7 @@ impl LanguageServer {
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
     let mut uri_path = decode(&*uri.path().replace("/", "\\")).expect("Invalid formatting").to_string();
-    if uri_path[0] == "/" {
+    if uri_path.starts_with("/") {
         uri_path = uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix").to_string();
     }
     let path = PathBuf::from(uri_path);

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -716,7 +716,7 @@ impl LanguageServer {
 }
 
 fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
-    let path = PathBuf::from(uri.path());
+    let path = uri.to_file_path().expect("uri to pathbuf");
     let components = path
         .strip_prefix(&root)
         .ok()?

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -722,6 +722,7 @@ fn uri_to_module_name(uri: &Url, root: &Path) -> Option<String> {
     if cfg!(target_os = "windows") {
         uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix")
         uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix");
+        uri_path = uri_path.strip_prefix("/").expect("Failed to remove \"/\" prefix").to_string();
     }
     let path = PathBuf::from(uri_path);
     let components = path


### PR DESCRIPTION
Fixes #1595 by using a built in method on `Uri` to convert it to a `PathBuf`