### PR TITLE
fix(ci): Nightly builds broken

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -9,8 +9,26 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  nightly-last-run:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: print latest_commit
+        run: echo ${{ github.sha }}
+
+      - id: should_run
+        continue-on-error: true
+        name: check latest commit is less than a day
+        if: ${{ github.event_name == 'schedule' }}
+        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+
   build-nightly-clean:
     runs-on: ubuntu-latest
+    needs: [ nightly-last-run ]
+    if: ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
     steps:
       - name: Delete old release assets
         uses: mknejp/delete-release-assets@v1

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -17,6 +17,8 @@ jobs:
         with:
           token: ${{ github.token }}
           tag: nightly
+          fail-if-no-assets: false
+          fail-if-no-release: false
           assets: |
             *.zip
             *.tar.gz


### PR DESCRIPTION
Nightly builds were broken as the delete assets action couldn't find any assets due to first run, this PR also adds a check to make sure it only runs when there have been changes within the past 24hrs