### PR TITLE
feat: Named accessors with multiple variants

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -283,6 +283,12 @@ impl TypeAst {
         }
     }
 
+    pub fn compare_without_location(&self, other: TypeAst) -> bool {
+        // TODO write this
+        false
+    }
+
+    // TODO delete this
     pub fn clear_location(&self) -> TypeAst {
         match self {
             TypeAst::Constructor {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -282,6 +282,41 @@ impl TypeAst {
             | TypeAst::Constructor { location, .. } => *location,
         }
     }
+
+    pub fn clear_location(&self) -> TypeAst {
+        match self {
+            TypeAst::Constructor {
+                module,
+                name,
+                arguments,
+                ..
+            } => TypeAst::Constructor {
+                module: module.clone(),
+                name: name.clone(),
+                arguments: arguments.clone(),
+                location: SrcSpan { start: 0, end: 0 },
+            },
+            TypeAst::Fn {
+                arguments, return_, ..
+            } => TypeAst::Fn {
+                arguments: arguments.clone(),
+                return_: return_.clone(),
+                location: SrcSpan { start: 0, end: 0 },
+            },
+            TypeAst::Var { name, .. } => TypeAst::Var {
+                name: name.clone(),
+                location: SrcSpan { start: 0, end: 0 },
+            },
+            TypeAst::Tuple { elems, .. } => TypeAst::Tuple {
+                elems: elems.clone(),
+                location: SrcSpan { start: 0, end: 0 },
+            },
+            TypeAst::Hole { name, .. } => TypeAst::Hole {
+                name: name.clone(),
+                location: SrcSpan { start: 0, end: 0 },
+            },
+        }
+    }
 }
 
 pub type TypedStatement = Statement<Arc<Type>, TypedExpr, String, String>;

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -296,36 +296,47 @@ impl TypeAst {
                 module,
                 name,
                 arguments,
-                ..
+                location: _,
             } => match other {
                 TypeAst::Constructor {
                     module: o_module,
                     name: o_name,
                     arguments: o_arguments,
-                    ..
+                    location: _,
                 } => module == o_module && name == o_name && arguments == o_arguments,
                 _ => false,
             },
             TypeAst::Fn {
-                arguments, return_, ..
+                arguments,
+                return_,
+                location: _,
             } => match other {
                 TypeAst::Fn {
                     arguments: o_arguments,
                     return_: o_return_,
-                    ..
+                    location: _,
                 } => arguments == o_arguments && return_ == o_return_,
                 _ => false,
             },
-            TypeAst::Var { name, .. } => match other {
-                TypeAst::Var { name: o_name, .. } => name == o_name,
+            TypeAst::Var { name, location: _ } => match other {
+                TypeAst::Var {
+                    name: o_name,
+                    location: _,
+                } => name == o_name,
                 _ => false,
             },
-            TypeAst::Tuple { elems, .. } => match other {
-                TypeAst::Tuple { elems: o_elems, .. } => elems == o_elems,
+            TypeAst::Tuple { elems, location: _ } => match other {
+                TypeAst::Tuple {
+                    elems: o_elems,
+                    location: _,
+                } => elems == o_elems,
                 _ => false,
             },
-            TypeAst::Hole { name, .. } => match other {
-                TypeAst::Hole { name: o_name, .. } => name == o_name,
+            TypeAst::Hole { name, location: _ } => match other {
+                TypeAst::Hole {
+                    name: o_name,
+                    location: _,
+                } => name == o_name,
                 _ => false,
             },
         }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -235,9 +235,16 @@ pub struct RecordConstructorArg<T> {
     pub doc: Option<String>,
 }
 
-impl<T> RecordConstructorArg<T> {
+impl<T: PartialEq> RecordConstructorArg<T> {
     pub fn put_doc(&mut self, new_doc: String) {
         self.doc = Some(new_doc);
+    }
+
+    pub fn compare_without_location(&self, other: &RecordConstructorArg<T>) -> bool {
+        self.type_ == other.type_
+            && self.label == other.label
+            && self.doc == other.doc
+            && self.ast.compare_without_location(&other.ast)
     }
 }
 
@@ -283,43 +290,43 @@ impl TypeAst {
         }
     }
 
-    pub fn compare_without_location(&self, other: TypeAst) -> bool {
-        // TODO write this
-        false
-    }
-
-    // TODO delete this
-    pub fn clear_location(&self) -> TypeAst {
+    pub fn compare_without_location(&self, other: &TypeAst) -> bool {
         match self {
             TypeAst::Constructor {
                 module,
                 name,
                 arguments,
                 ..
-            } => TypeAst::Constructor {
-                module: module.clone(),
-                name: name.clone(),
-                arguments: arguments.clone(),
-                location: SrcSpan { start: 0, end: 0 },
+            } => match other {
+                TypeAst::Constructor {
+                    module: o_module,
+                    name: o_name,
+                    arguments: o_arguments,
+                    ..
+                } => module == o_module && name == o_name && arguments == o_arguments,
+                _ => false,
             },
             TypeAst::Fn {
                 arguments, return_, ..
-            } => TypeAst::Fn {
-                arguments: arguments.clone(),
-                return_: return_.clone(),
-                location: SrcSpan { start: 0, end: 0 },
+            } => match other {
+                TypeAst::Fn {
+                    arguments: o_arguments,
+                    return_: o_return_,
+                    ..
+                } => arguments == o_arguments && return_ == o_return_,
+                _ => false,
             },
-            TypeAst::Var { name, .. } => TypeAst::Var {
-                name: name.clone(),
-                location: SrcSpan { start: 0, end: 0 },
+            TypeAst::Var { name, .. } => match other {
+                TypeAst::Var { name: o_name, .. } => name == o_name,
+                _ => false,
             },
-            TypeAst::Tuple { elems, .. } => TypeAst::Tuple {
-                elems: elems.clone(),
-                location: SrcSpan { start: 0, end: 0 },
+            TypeAst::Tuple { elems, .. } => match other {
+                TypeAst::Tuple { elems: o_elems, .. } => elems == o_elems,
+                _ => false,
             },
-            TypeAst::Hole { name, .. } => TypeAst::Hole {
-                name: name.clone(),
-                location: SrcSpan { start: 0, end: 0 },
+            TypeAst::Hole { name, .. } => match other {
+                TypeAst::Hole { name: o_name, .. } => name == o_name,
+                _ => false,
             },
         }
     }

--- a/compiler-core/src/erlang/tests/records.rs
+++ b/compiler-core/src/erlang/tests/records.rs
@@ -107,33 +107,6 @@ pub fn get_name(person: Person) { person.name }"
 }
 
 #[test]
-fn record_accessor_multiple_variants_multiple_positions() {
-    // We can access fields on custom types with multiple variants
-    // Where they are in different positions e.g. 2nd and 3rd
-    assert_erl!(
-        "
-pub type Person {
-    Teacher(name: String, title: String, age: Int)
-    Student(name: String, age: Int)
-}
-pub fn get_name(person: Person) { person.name }
-pub fn get_age(person: Person) { person.age }"
-    );
-
-    // We can access fields on custom types with multiple variants
-    // Where they are in different positions e.g. 1st and 3rd
-    assert_erl!(
-        "
-pub type Person {
-    Teacher(title: String, age: Int, name: String)
-    Student(name: String, age: Int)
-}
-pub fn get_name(person: Person) { person.name }
-pub fn get_age(person: Person) { person.age }"
-    );
-}
-
-#[test]
 fn record_accessor_multiple_variants_positions_other_than_first() {
     // We can access fields on custom types with multiple variants
     // In positions other than the 1st field

--- a/compiler-core/src/erlang/tests/records.rs
+++ b/compiler-core/src/erlang/tests/records.rs
@@ -122,6 +122,20 @@ pub fn get_age(person: Person) { person.age }"
 }
 
 #[test]
+fn record_accessor_multiple_with_first_position_different_types() {
+    // We can access fields on custom types with multiple variants
+    // In positions other than the 1st field
+    assert_erl!(
+        "
+pub type Person {
+    Teacher(name: Nil, age: Int)
+    Student(name: String, age: Int)
+}
+pub fn get_age(person: Person) { person.age }"
+    );
+}
+
+#[test]
 fn record_spread() {
     // Test binding to a record field with the spread operator
     assert_erl!(

--- a/compiler-core/src/erlang/tests/records.rs
+++ b/compiler-core/src/erlang/tests/records.rs
@@ -94,6 +94,61 @@ pub fn get_name(person: Person) { person.name }
 }
 
 #[test]
+fn record_accessor_multiple_variants() {
+    // We can access fields on custom types with multiple variants
+    assert_erl!(
+        "
+pub type Person {
+    Teacher(name: String, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }"
+    );
+}
+
+#[test]
+fn record_accessor_multiple_variants_multiple_positions() {
+    // We can access fields on custom types with multiple variants
+    // Where they are in different positions e.g. 2nd and 3rd
+    assert_erl!(
+        "
+pub type Person {
+    Teacher(name: String, title: String, age: Int)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
+    );
+
+    // We can access fields on custom types with multiple variants
+    // Where they are in different positions e.g. 1st and 3rd
+    assert_erl!(
+        "
+pub type Person {
+    Teacher(title: String, age: Int, name: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
+    );
+}
+
+#[test]
+fn record_accessor_multiple_variants_positions_other_than_first() {
+    // We can access fields on custom types with multiple variants
+    // In positions other than the 1st field
+    assert_erl!(
+        "
+pub type Person {
+    Teacher(name: String, age: Int, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
+    );
+}
+
+#[test]
 fn record_spread() {
     // Test binding to a record field with the spread operator
     assert_erl!(

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/erlang/tests/records.rs
+expression: "\npub type Person {\n    Teacher(name: String, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }"
+---
+-module(the_app).
+-compile(no_auto_import).
+
+-export([get_name/1]).
+-export_type([person/0]).
+
+-type person() :: {teacher, binary(), binary()} | {student, binary(), integer()}.
+
+-spec get_name(person()) -> binary().
+get_name(Person) ->
+    erlang:element(2, Person).
+

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants_positions_other_than_first.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants_positions_other_than_first.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests/records.rs
+expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+---
+-module(the_app).
+-compile(no_auto_import).
+
+-export([get_name/1, get_age/1]).
+-export_type([person/0]).
+
+-type person() :: {teacher, binary(), integer(), binary()} |
+    {student, binary(), integer()}.
+
+-spec get_name(person()) -> binary().
+get_name(Person) ->
+    erlang:element(2, Person).
+
+-spec get_age(person()) -> integer().
+get_age(Person) ->
+    erlang:element(3, Person).
+

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_with_first_position_different_types.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_with_first_position_different_types.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/erlang/tests/records.rs
+assertion_line: 128
+expression: "\npub type Person {\n    Teacher(name: Nil, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_age(person: Person) { person.age }"
+---
+-module(the_app).
+-compile(no_auto_import).
+
+-export([get_age/1]).
+-export_type([person/0]).
+
+-type person() :: {teacher, nil, integer()} | {student, binary(), integer()}.
+
+-spec get_age(person()) -> integer().
+get_age(Person) ->
+    erlang:element(3, Person).
+

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -11,6 +11,7 @@ mod lists;
 mod modules;
 mod numbers;
 mod prelude;
+mod records;
 mod results;
 mod strings;
 mod todo;

--- a/compiler-core/src/javascript/tests/records.rs
+++ b/compiler-core/src/javascript/tests/records.rs
@@ -26,33 +26,6 @@ pub fn get_name(person: Person) { person.name }"
 }
 
 #[test]
-fn record_accessor_multiple_variants_multiple_positions() {
-    // We can access fields on custom types with multiple variants
-    // Where they are in different positions e.g. 2nd and 3rd
-    assert_js!(
-        "
-pub type Person {
-    Teacher(name: String, title: String, age: Int)
-    Student(name: String, age: Int)
-}
-pub fn get_name(person: Person) { person.name }
-pub fn get_age(person: Person) { person.age }"
-    );
-
-    // We can access fields on custom types with multiple variants
-    // Where they are in different positions e.g. 1st and 3rd
-    assert_js!(
-        "
-pub type Person {
-    Teacher(title: String, age: Int, name: String)
-    Student(name: String, age: Int)
-}
-pub fn get_name(person: Person) { person.name }
-pub fn get_age(person: Person) { person.age }"
-    );
-}
-
-#[test]
 fn record_accessor_multiple_variants_positions_other_than_first() {
     // We can access fields on custom types with multiple variants
     // In positions other than the 1st field

--- a/compiler-core/src/javascript/tests/records.rs
+++ b/compiler-core/src/javascript/tests/records.rs
@@ -1,0 +1,68 @@
+use crate::assert_js;
+
+#[test]
+fn record_accessors() {
+    // We can use record accessors for types with only one constructor
+    assert_js!(
+        r#"
+pub type Person { Person(name: String, age: Int) }
+pub fn get_age(person: Person) { person.age }
+pub fn get_name(person: Person) { person.name }
+"#
+    );
+}
+
+#[test]
+fn record_accessor_multiple_variants() {
+    // We can access fields on custom types with multiple variants
+    assert_js!(
+        "
+pub type Person {
+    Teacher(name: String, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }"
+    );
+}
+
+#[test]
+fn record_accessor_multiple_variants_multiple_positions() {
+    // We can access fields on custom types with multiple variants
+    // Where they are in different positions e.g. 2nd and 3rd
+    assert_js!(
+        "
+pub type Person {
+    Teacher(name: String, title: String, age: Int)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
+    );
+
+    // We can access fields on custom types with multiple variants
+    // Where they are in different positions e.g. 1st and 3rd
+    assert_js!(
+        "
+pub type Person {
+    Teacher(title: String, age: Int, name: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
+    );
+}
+
+#[test]
+fn record_accessor_multiple_variants_positions_other_than_first() {
+    // We can access fields on custom types with multiple variants
+    // In positions other than the 1st field
+    assert_js!(
+        "
+pub type Person {
+    Teacher(name: String, age: Int, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
+    );
+}

--- a/compiler-core/src/javascript/tests/records.rs
+++ b/compiler-core/src/javascript/tests/records.rs
@@ -39,3 +39,17 @@ pub fn get_name(person: Person) { person.name }
 pub fn get_age(person: Person) { person.age }"
     );
 }
+
+#[test]
+fn record_accessor_multiple_with_first_position_different_types() {
+    // We can access fields on custom types with multiple variants
+    // In positions other than the 1st field
+    assert_js!(
+        "
+pub type Person {
+    Teacher(name: Nil, age: Int)
+    Student(name: String, age: Int)
+}
+pub fn get_age(person: Person) { person.age }"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+expression: "\npub type Person {\n    Teacher(name: String, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }"
+---
+import { CustomType } from "../gleam.mjs";
+
+export class Teacher extends CustomType {
+  constructor(name, title) {
+    super();
+    this.name = name;
+    this.title = title;
+  }
+}
+
+export class Student extends CustomType {
+  constructor(name, age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+}
+
+export function get_name(person) {
+  return person.name;
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants_multiple_positions-2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants_multiple_positions-2.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+expression: "\npub type Person {\n    Teacher(title: String, age: Int, name: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+---
+import { CustomType } from "../gleam.mjs";
+
+export class Teacher extends CustomType {
+  constructor(title, age, name) {
+    super();
+    this.title = title;
+    this.age = age;
+    this.name = name;
+  }
+}
+
+export class Student extends CustomType {
+  constructor(name, age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+}
+
+export function get_name(person) {
+  return person.name;
+}
+
+export function get_age(person) {
+  return person.age;
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants_multiple_positions.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants_multiple_positions.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+expression: "\npub type Person {\n    Teacher(name: String, title: String, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+---
+import { CustomType } from "../gleam.mjs";
+
+export class Teacher extends CustomType {
+  constructor(name, title, age) {
+    super();
+    this.name = name;
+    this.title = title;
+    this.age = age;
+  }
+}
+
+export class Student extends CustomType {
+  constructor(name, age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+}
+
+export function get_name(person) {
+  return person.name;
+}
+
+export function get_age(person) {
+  return person.age;
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants_positions_other_than_first.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_variants_positions_other_than_first.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+---
+import { CustomType } from "../gleam.mjs";
+
+export class Teacher extends CustomType {
+  constructor(name, age, title) {
+    super();
+    this.name = name;
+    this.age = age;
+    this.title = title;
+  }
+}
+
+export class Student extends CustomType {
+  constructor(name, age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+}
+
+export function get_name(person) {
+  return person.name;
+}
+
+export function get_age(person) {
+  return person.age;
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_with_first_position_different_types.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessor_multiple_with_first_position_different_types.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+assertion_line: 47
+expression: "\npub type Person {\n    Teacher(name: Nil, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_age(person: Person) { person.age }"
+---
+import { CustomType } from "../gleam.mjs";
+
+export class Teacher extends CustomType {
+  constructor(name, age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+}
+
+export class Student extends CustomType {
+  constructor(name, age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+}
+
+export function get_age(person) {
+  return person.age;
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessors.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_accessors.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+expression: "\npub type Person { Person(name: String, age: Int) }\npub fn get_age(person: Person) { person.age }\npub fn get_name(person: Person) { person.name }\n"
+---
+import { CustomType } from "../gleam.mjs";
+
+export class Person extends CustomType {
+  constructor(name, age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+}
+
+export function get_age(person) {
+  return person.age;
+}
+
+export function get_name(person) {
+  return person.name;
+}
+

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1598,13 +1598,13 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
         .expect("No constructs with args");
     let args = first_constructor_arg
         .iter()
-        .filter(|data_type|
-            constructor_args
-                .iter()
-                .all(|set| set
-                    .iter()
-                    .map(|item| { (item.label.clone(), item.type_.clone()) })
-                    .contains(&(data_type.label.clone(), data_type.type_.clone()))))
+        .filter(|data_type| {
+            constructor_args.iter().all(|set| {
+                set.iter()
+                    .map(|item| (item.label.clone(), item.type_.clone()))
+                    .contains(&(data_type.label.clone(), data_type.type_.clone()))
+            })
+        })
         .collect::<Vec<_>>();
 
     let mut fields = HashMap::with_capacity(args.len());

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1600,12 +1600,22 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
     let args = first_constructor_arg
         .iter()
         .filter(|data_type| {
+            let mut clear_data_type = data_type.clone().clone();
+            clear_data_type.location = SrcSpan { start: 0, end: 0 };
+            let clear_data_type_ast = clear_data_type.ast.clone();
+            clear_data_type.ast = clear_data_type_ast.clear_location();
             constructor_args.iter().all(|arg| {
                 !arg.iter()
-                    .map(|item| (item.label.as_ref(), item.type_.clone()))
+                    .map(|item| {
+                        let mut new_item = item.clone();
+                        new_item.location = SrcSpan { start: 0, end: 0 };
+                        let new_item_ast = new_item.ast.clone();
+                        new_item.ast = new_item_ast.clear_location();
+                        new_item
+                    })
                     .filter(|item| {
                         // TODO type comparison
-                        item.0 == data_type.label.as_ref()
+                        item == &clear_data_type
                     })
                     .collect_vec()
                     .is_empty()

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1579,6 +1579,7 @@ fn make_type_vars(
         .try_collect()
 }
 
+#[allow(unused_qualifications)]
 fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
     constructors: &[RecordConstructor<A>],
     hydrator: &mut Hydrator,

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1608,7 +1608,8 @@ fn custom_type_accessors<A: Clone + PartialEq>(
             let clear_data_type_ast = clear_data_type.ast.clone();
             clear_data_type.ast = clear_data_type_ast.clear_location();
             let res = constructor_args.iter().all(|arg| {
-                let res_inner = !arg.iter()
+                let res_inner = !arg
+                    .iter()
                     .map(|item| {
                         let mut new_item = item.clone();
                         new_item.location = SrcSpan { start: 0, end: 0 };

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1602,8 +1602,8 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
         .filter(|data_type| {
             constructor_args.iter().all(|arg| {
                 arg.iter()
-                    .map(|item| (item.label.clone(), item.type_.clone()))
-                    .contains(&(data_type.label.clone(), data_type.type_.clone()))
+                    .map(|item| (item.label.as_ref(), item.type_.clone()))
+                    .contains(&(data_type.label.as_ref(), data_type.type_.clone()))
             })
         })
         .collect::<Vec<_>>();

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1600,8 +1600,8 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
     let args = first_constructor_arg
         .iter()
         .filter(|data_type| {
-            constructor_args.iter().all(|set| {
-                set.iter()
+            constructor_args.iter().all(|arg| {
+                arg.iter()
                     .map(|item| (item.label.clone(), item.type_.clone()))
                     .contains(&(data_type.label.clone(), data_type.type_.clone()))
             })

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1601,9 +1601,14 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
         .iter()
         .filter(|data_type| {
             constructor_args.iter().all(|arg| {
-                arg.iter()
+                !arg.iter()
                     .map(|item| (item.label.as_ref(), item.type_.clone()))
-                    .contains(&(data_type.label.as_ref(), data_type.type_.clone()))
+                    .filter(|item| {
+                        // TODO type comparison
+                        item.0 == data_type.label.as_ref()
+                    })
+                    .collect_vec()
+                    .is_empty()
             })
         })
         .collect::<Vec<_>>();

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1616,7 +1616,7 @@ fn custom_type_accessors<A: Clone + PartialEq>(
 
     let mut fields = HashMap::with_capacity(args.len());
     hydrator.disallow_new_type_variables();
-    for (_, (index, RecordConstructorArg { label, ast, .. })) in args.iter().enumerate() {
+    for (index, RecordConstructorArg { label, ast, .. }) in args.iter() {
         if let Some(label) = label {
             let typ = hydrator.type_from_ast(ast, environment)?;
             let _ = fields.insert(

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1588,33 +1588,16 @@ fn custom_type_accessors<A: std::cmp::PartialEq>(
         return Ok(None);
     }
 
-    let mut args: Vec<&RecordConstructorArg<A>> = vec![];
-
-    let constructor_args = constructors
+    let constructor_args_data = constructors
         .iter()
         .map(|constructor| constructor.arguments.as_slice())
         .collect_vec();
 
-    let first_constructor = *constructor_args.first().expect("First constructor");
-
-    for arg in first_constructor {
-        let mut should_insert = true;
-        for constructor_arg_group in &constructor_args {
-            if !constructor_arg_group
-                .iter()
-                .filter(|a| a.type_ == arg.type_ && a.label == arg.label)
-                .collect_vec()
-                .is_empty()
-            {
-                should_insert = false;
-                break;
-            }
-        }
-
-        if should_insert {
-            args.push(arg)
-        }
-    }
+    let (first_constructor_arg, constructor_args) = constructor_args_data.split_first().expect("No constructs with args");
+    let args = first_constructor_arg
+        .iter()
+        .filter(|data_type| constructor_args.iter().all(|set| set.contains(data_type)))
+            .collect::<Vec<_>>();
 
     let mut fields = HashMap::with_capacity(args.len());
     hydrator.disallow_new_type_variables();

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1593,11 +1593,13 @@ fn custom_type_accessors<A: std::cmp::PartialEq>(
         .map(|constructor| constructor.arguments.as_slice())
         .collect_vec();
 
-    let (first_constructor_arg, constructor_args) = constructor_args_data.split_first().expect("No constructs with args");
+    let (first_constructor_arg, constructor_args) = constructor_args_data
+        .split_first()
+        .expect("No constructs with args");
     let args = first_constructor_arg
         .iter()
         .filter(|data_type| constructor_args.iter().all(|set| set.contains(data_type)))
-            .collect::<Vec<_>>();
+        .collect::<Vec<_>>();
 
     let mut fields = HashMap::with_capacity(args.len());
     hydrator.disallow_new_type_variables();

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1579,8 +1579,7 @@ fn make_type_vars(
         .try_collect()
 }
 
-#[allow(unused_qualifications)]
-fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
+fn custom_type_accessors<A: Clone + PartialEq>(
     constructors: &[RecordConstructor<A>],
     hydrator: &mut Hydrator,
     environment: &mut Environment<'_>,

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1597,6 +1597,10 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
     let (first_constructor_arg, constructor_args) = constructor_args_data
         .split_first()
         .expect("No constructs with args");
+
+    let mut x = 0;
+    let mut y = 0;
+
     let args = first_constructor_arg
         .iter()
         .filter(|data_type| {
@@ -1604,8 +1608,8 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
             clear_data_type.location = SrcSpan { start: 0, end: 0 };
             let clear_data_type_ast = clear_data_type.ast.clone();
             clear_data_type.ast = clear_data_type_ast.clear_location();
-            constructor_args.iter().all(|arg| {
-                !arg.iter()
+            let res = constructor_args.iter().all(|arg| {
+                let res_inner = !arg.iter()
                     .map(|item| {
                         let mut new_item = item.clone();
                         new_item.location = SrcSpan { start: 0, end: 0 };
@@ -1615,11 +1619,15 @@ fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
                     })
                     .filter(|item| {
                         // TODO type comparison
-                        item == &clear_data_type
+                        item == &clear_data_type && x == y
                     })
                     .collect_vec()
-                    .is_empty()
-            })
+                    .is_empty();
+                y = y + 1;
+                res_inner
+            });
+            x = x + 1;
+            res
         })
         .collect::<Vec<_>>();
 

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1603,6 +1603,7 @@ fn custom_type_accessors<A: Clone + PartialEq>(
     let args = first_constructor_arg
         .iter()
         .filter(|data_type| {
+            // TODO delete this section
             let mut clear_data_type = data_type.clone().clone();
             clear_data_type.location = SrcSpan { start: 0, end: 0 };
             let clear_data_type_ast = clear_data_type.ast.clone();
@@ -1618,7 +1619,7 @@ fn custom_type_accessors<A: Clone + PartialEq>(
                         new_item
                     })
                     .filter(|item| {
-                        // TODO type comparison
+                        // TODO type comparison using `.compare_without_location(data_type)`
                         item == &clear_data_type && x == y
                     })
                     .collect_vec()

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1579,7 +1579,7 @@ fn make_type_vars(
         .try_collect()
 }
 
-fn custom_type_accessors<A: std::cmp::PartialEq>(
+fn custom_type_accessors<A: Clone + std::cmp::PartialEq>(
     constructors: &[RecordConstructor<A>],
     hydrator: &mut Hydrator,
     environment: &mut Environment<'_>,
@@ -1598,7 +1598,13 @@ fn custom_type_accessors<A: std::cmp::PartialEq>(
         .expect("No constructs with args");
     let args = first_constructor_arg
         .iter()
-        .filter(|data_type| constructor_args.iter().all(|set| set.contains(data_type)))
+        .filter(|data_type|
+            constructor_args
+                .iter()
+                .all(|set| set
+                    .iter()
+                    .map(|item| { (item.label.clone(), item.type_.clone()) })
+                    .contains(&(data_type.label.clone(), data_type.type_.clone()))))
         .collect::<Vec<_>>();
 
     let mut fields = HashMap::with_capacity(args.len());

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1105,7 +1105,8 @@ pub type Person {
 }
 pub fn get_name(person: Person) { person.name }",
         vec![
-            ("Person", "fn(String, Int) -> Person"),
+            ("Student", "fn(String, Int) -> Person"),
+            ("Teacher", "fn(String, String) -> Person"),
             ("get_name", "fn(Person) -> String"),
         ]
     );

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1113,45 +1113,6 @@ pub fn get_name(person: Person) { person.name }",
 }
 
 #[test]
-fn accessor_multiple_variants_multiple_positions() {
-    // We can access fields on custom types with multiple variants
-    // Where they are in different positions e.g. 2nd and 3rd
-    assert_module_infer!(
-        "
-pub type Person {
-    Teacher(name: String, title: String, age: Int)
-    Student(name: String, age: Int)
-}
-pub fn get_name(person: Person) { person.name }
-pub fn get_age(person: Person) { person.age }",
-        vec![
-            ("Student", "fn(String, Int) -> Person"),
-            ("Teacher", "fn(String, String, Int) -> Person"),
-            ("get_age", "fn(Person) -> Int"),
-            ("get_name", "fn(Person) -> String"),
-        ]
-    );
-
-    // We can access fields on custom types with multiple variants
-    // Where they are in different positions e.g. 1st and 3rd
-    assert_module_infer!(
-        "
-pub type Person {
-    Teacher(title: String, age: Int, name: String)
-    Student(name: String, age: Int)
-}
-pub fn get_name(person: Person) { person.name }
-pub fn get_age(person: Person) { person.age }",
-        vec![
-            ("Student", "fn(String, Int) -> Person"),
-            ("Teacher", "fn(String, Int, String) -> Person"),
-            ("get_age", "fn(Person) -> Int"),
-            ("get_name", "fn(Person) -> String"),
-        ]
-    );
-}
-
-#[test]
 fn accessor_multiple_variants_positions_other_than_first() {
     // We can access fields on custom types with multiple variants
     // In positions other than the 1st field

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1095,6 +1095,23 @@ fn fn_annotation_reused() {
 }
 
 #[test]
+fn accessor_multiple_variants() {
+    // We can access fields on custom types with multiple variants
+    assert_module_infer!(
+        "
+pub type Person {
+    Teacher(name: String, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }",
+        vec![
+            ("Person", "fn(String, Int) -> Person"),
+            ("get_name", "fn(Person) -> String"),
+        ]
+    );
+}
+
+#[test]
 fn box_record() {
     assert_module_infer!(
         "

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1110,25 +1110,10 @@ pub fn get_name(person: Person) { person.name }",
             ("get_name", "fn(Person) -> String"),
         ]
     );
-
-    // We can access fields on custom types with multiple variants
-    // In positions other than the 1st field
-    assert_module_infer!(
-        "
-pub type Person {
-    Teacher(name: String, age: Int, title: String)
-    Student(name: String, age: Int)
 }
-pub fn get_name(person: Person) { person.name }
-pub fn get_age(person: Person) { person.age }",
-        vec![
-            ("Student", "fn(String, Int) -> Person"),
-            ("Teacher", "fn(String, Int, String) -> Person"),
-            ("get_age", "fn(Person) -> Int"),
-            ("get_name", "fn(Person) -> String"),
-        ]
-    );
 
+#[test]
+fn accessor_multiple_variants_multiple_positions() {
     // We can access fields on custom types with multiple variants
     // Where they are in different positions e.g. 2nd and 3rd
     assert_module_infer!(
@@ -1153,6 +1138,27 @@ pub fn get_age(person: Person) { person.age }",
         "
 pub type Person {
     Teacher(title: String, age: Int, name: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }",
+        vec![
+            ("Student", "fn(String, Int) -> Person"),
+            ("Teacher", "fn(String, Int, String) -> Person"),
+            ("get_age", "fn(Person) -> Int"),
+            ("get_name", "fn(Person) -> String"),
+        ]
+    );
+}
+
+#[test]
+fn accessor_multiple_variants_positions_other_than_first() {
+    // We can access fields on custom types with multiple variants
+    // In positions other than the 1st field
+    assert_module_infer!(
+        "
+pub type Person {
+    Teacher(name: String, age: Int, title: String)
     Student(name: String, age: Int)
 }
 pub fn get_name(person: Person) { person.name }

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1110,6 +1110,60 @@ pub fn get_name(person: Person) { person.name }",
             ("get_name", "fn(Person) -> String"),
         ]
     );
+
+    // We can access fields on custom types with multiple variants
+    // In positions other than the 1st field
+    assert_module_infer!(
+        "
+pub type Person {
+    Teacher(name: String, age: Int, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }",
+        vec![
+            ("Student", "fn(String, Int) -> Person"),
+            ("Teacher", "fn(String, Int, String) -> Person"),
+            ("get_age", "fn(Person) -> Int"),
+            ("get_name", "fn(Person) -> String"),
+        ]
+    );
+
+    // We can access fields on custom types with multiple variants
+    // Where they are in different positions e.g. 2nd and 3rd
+    assert_module_infer!(
+        "
+pub type Person {
+    Teacher(name: String, title: String, age: Int)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }",
+        vec![
+            ("Student", "fn(String, Int) -> Person"),
+            ("Teacher", "fn(String, String, Int) -> Person"),
+            ("get_age", "fn(Person) -> Int"),
+            ("get_name", "fn(Person) -> String"),
+        ]
+    );
+
+    // We can access fields on custom types with multiple variants
+    // Where they are in different positions e.g. 1st and 3rd
+    assert_module_infer!(
+        "
+pub type Person {
+    Teacher(title: String, age: Int, name: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }",
+        vec![
+            ("Student", "fn(String, Int) -> Person"),
+            ("Teacher", "fn(String, Int, String) -> Person"),
+            ("get_age", "fn(Person) -> Int"),
+            ("get_name", "fn(Person) -> String"),
+        ]
+    );
 }
 
 #[test]

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -25,7 +25,6 @@ macro_rules! assert_module_error {
     };
 
     ($src:expr) => {
-        use std::path::PathBuf;
         let (ast, _) = crate::parse::parse_module($src).expect("syntax error");
         let mut modules = im::HashMap::new();
         let ids = UniqueIdGenerator::new();
@@ -779,6 +778,31 @@ pub type Shape {
 }
 pub fn get_x(shape: Shape) { shape.x }
 pub fn get_y(shape: Shape) { shape.y }"
+    );
+}
+
+#[test]
+fn accessor_multiple_variants_multiple_positions() {
+    // We cannot access fields on custom types with multiple variants where they are in different positions e.g. 2nd and 3rd
+    assert_module_error!(
+        "
+pub type Person {
+    Teacher(name: String, title: String, age: Int)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
+    );
+
+    // We cannot access fields on custom types with multiple variants where they are in different positions e.g. 1st and 3rd
+    assert_module_error!(
+        "
+pub type Person {
+    Teacher(title: String, age: Int, name: String)
+    Student(name: String, age: Int)
+}
+pub fn get_name(person: Person) { person.name }
+pub fn get_age(person: Person) { person.age }"
     );
 }
 

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -770,6 +770,19 @@ pub fn get_height(person: Person) { person.height }"
 }
 
 #[test]
+fn field_type_different_between_variants() {
+    assert_module_error!(
+        "
+pub type Shape {
+    Square(x: Int, y: Int)
+    Rectangle(x: String, y: String)
+}
+pub fn get_x(shape: Shape) { shape.x }
+pub fn get_y(shape: Shape) { shape.y }"
+    );
+}
+
+#[test]
 fn module_could_not_unify() {
     assert_module_error!("fn go() { 1 + 2.0 }");
 }

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -746,6 +746,30 @@ fn inconsistent_try_5() {
 }
 
 #[test]
+fn field_not_in_all_variants() {
+    assert_module_error!(
+        "
+pub type Person {
+    Teacher(name: String, age: Int, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_title(person: Person) { person.title }"
+    );
+}
+
+#[test]
+fn field_not_in_any_variant() {
+    assert_module_error!(
+        "
+pub type Person {
+    Teacher(name: String, age: Int, title: String)
+    Student(name: String, age: Int)
+}
+pub fn get_height(person: Person) { person.height }"
+    );
+}
+
+#[test]
 fn module_could_not_unify() {
     assert_module_error!("fn go() { 1 + 2.0 }");
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions-2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions-2.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Person {\n    Teacher(title: String, age: Int, name: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+---
+error: Unknown record field
+  ┌─ /src/one/two.gleam:6:35
+  │
+6 │ pub fn get_name(person: Person) { person.name }
+  │                                   ^^^^^^^^^^^ Did you mean `age`?
+
+The value being accessed has this type:
+
+    Person
+
+It has these fields:
+
+    .age
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Person {\n    Teacher(name: String, title: String, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+---
+error: Unknown record field
+  ┌─ /src/one/two.gleam:7:34
+  │
+7 │ pub fn get_age(person: Person) { person.age }
+  │                                  ^^^^^^^^^^ Did you mean `name`?
+
+The value being accessed has this type:
+
+    Person
+
+It has these fields:
+
+    .name
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_title(person: Person) { person.title }"
+---
+error: Unknown record field
+  ┌─ /src/one/two.gleam:6:36
+  │
+6 │ pub fn get_title(person: Person) { person.title }
+  │                                    ^^^^^^^^^^^^ Did you mean `age`?
+
+The value being accessed has this type:
+
+    Person
+
+It has these fields:
+
+    .age
+    .name
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_any_variant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_any_variant.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_height(person: Person) { person.height }"
+---
+error: Unknown record field
+  ┌─ /src/one/two.gleam:6:37
+  │
+6 │ pub fn get_height(person: Person) { person.height }
+  │                                     ^^^^^^^^^^^^^ Did you mean `age`?
+
+The value being accessed has this type:
+
+    Person
+
+It has these fields:
+
+    .age
+    .name
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Shape {\n    Square(x: Int, y: Int)\n    Rectangle(x: String, y: String)\n}\npub fn get_x(shape: Shape) { shape.x }\npub fn get_y(shape: Shape) { shape.y }"
+---
+error: Unknown record field
+  ┌─ /src/one/two.gleam:6:30
+  │
+6 │ pub fn get_x(shape: Shape) { shape.x }
+  │                              ^^^^^^^ This field does not exist
+
+The value being accessed has this type:
+
+    Shape
+
+It does not have any fields.
+


### PR DESCRIPTION
Fixes #935 

## Tests Needed
- [x] Accessor cannot be used if type is different
- [x] Accessor cannot be used if label is different
- [x] Accessor can be used in position other than 1st field
- [x] Accessor can be used in position other than 1st field when 1st field of each variant is different
- [x] Test showing Erlang code generator
- [x] Test showing JavaScript code generation