### PR TITLE
feat(tooling): env vars for hexpm auth & `--yes/-y` flag for gleam publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added the ability to replace a release up to one hour after it is published using `gleam publish --replace`
+- All commands that authenticate using the `ApiKeyCommand` trait (currently `gleam publish`, `gleam docs pulish`, `gleam docs remove`, `gleam hex retire`, and `gleam hex unretire`) and now have access to environment variables for username (default key `HEXPM_USER`) and password (default key `HEXPM_PASS`)
+- The `gleam publish` command gains the `-y/--yes` flag to disable the "are you sure" prompt
+
 ## v0.21.0 - 2022-04-24
 
 - New projects are created with `gleam_stdlib` v0.21.

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -10,36 +10,47 @@ use gleam_core::{
     paths, Result,
 };
 
-static TOKEN_NAME: &str = concat!(env!("CARGO_PKG_NAME"), " (", env!("CARGO_PKG_VERSION"), ")");
+pub fn remove(package: String, version: String) -> Result<()> {
+    RemoveCommand::new(package, version).run()
+}
 
-pub fn remove(package: String, version: String) -> Result<(), Error> {
-    let config = hexpm::Config::new();
-    let http = HttpClient::new();
+struct RemoveCommand {
+    package: String,
+    version: String,
+}
 
-    // Start event loop so we can run async functions to call the Hex API
-    let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
+impl RemoveCommand {
+    pub fn new(package: String, version: String) -> Self {
+        Self {
+            package: package,
+            version: version,
+        }
+    }
+}
 
-    // Get login creds from user
-    let username = cli::ask("https://hex.pm username")?;
-    let password = cli::ask_password("https://hex.pm password")?;
+impl ApiKeyCommand for RemoveCommand {
+    fn with_api_key(
+        &mut self,
+        handle: &tokio::runtime::Handle,
+        hex_config: &hexpm::Config,
+        api_key: &str,
+    ) -> Result<()> {
+        let http = HttpClient::new();
 
-    // Authenticate with API
-    let request = hexpm::create_api_key_request(&username, &password, TOKEN_NAME, &config);
-    let response = runtime.block_on(http.send(request))?;
-    let token = hexpm::create_api_key_response(response).map_err(Error::hex)?;
+        // Remove docs from API
+        let request =
+            hexpm::remove_docs_request(&self.package, &self.version, &api_key, &hex_config)
+                .map_err(Error::hex)?;
+        let response = handle.block_on(http.send(request))?;
+        hexpm::remove_docs_response(response).map_err(Error::hex)?;
 
-    // Remove docs from API
-    let request =
-        hexpm::remove_docs_request(&package, &version, &token, &config).map_err(Error::hex)?;
-    let response = runtime.block_on(http.send(request))?;
-    hexpm::remove_docs_response(response).map_err(Error::hex)?;
-
-    // Done!
-    println!(
-        "The docs for {} {} have been removed from HexDocs",
-        package, version
-    );
-    Ok(())
+        // Done!
+        println!(
+            "The docs for {} {} have been removed from HexDocs",
+            self.package, self.version
+        );
+        Ok(())
+    }
 }
 
 pub fn build() -> Result<()> {
@@ -82,9 +93,13 @@ pub(crate) fn build_documentation(
     Ok(outputs)
 }
 
-pub struct PublishCommand {
+struct PublishCommand {
     config: PackageConfig,
     archive: Vec<u8>,
+}
+
+pub fn publish() -> Result<()> {
+    PublishCommand::new()?.run()
 }
 
 impl PublishCommand {
@@ -98,10 +113,6 @@ impl PublishCommand {
         let outputs = build_documentation(&config, &mut compiled)?;
         let archive = crate::fs::create_tar_archive(outputs)?;
         Ok(Self { config, archive })
-    }
-
-    pub fn publish() -> Result<()> {
-        Self::new()?.run()
     }
 }
 

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -21,10 +21,7 @@ struct RemoveCommand {
 
 impl RemoveCommand {
     pub fn new(package: String, version: String) -> Self {
-        Self {
-            package: package,
-            version: version,
-        }
+        Self { package, version }
     }
 }
 
@@ -38,9 +35,8 @@ impl ApiKeyCommand for RemoveCommand {
         let http = HttpClient::new();
 
         // Remove docs from API
-        let request =
-            hexpm::remove_docs_request(&self.package, &self.version, &api_key, &hex_config)
-                .map_err(Error::hex)?;
+        let request = hexpm::remove_docs_request(&self.package, &self.version, api_key, hex_config)
+            .map_err(Error::hex)?;
         let response = handle.block_on(http.send(request))?;
         hexpm::remove_docs_response(response).map_err(Error::hex)?;
 

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -7,6 +7,12 @@ use crate::{cli, http::HttpClient};
 
 /// A helper trait that handles the provisioning and destruction of a Hex API key.
 pub trait ApiKeyCommand {
+    const USER_PROMPT: &'static str = "https://hex.pm username";
+    const USER_KEY: &'static str = "HEXPM_USER";
+
+    const PASS_PROMPT: &'static str = "https://hex.pm password";
+    const PASS_KEY: &'static str = "HEXPM_PASS";
+
     fn with_api_key(
         &mut self,
         runtime: &tokio::runtime::Handle,
@@ -21,8 +27,10 @@ pub trait ApiKeyCommand {
         let http = HttpClient::new();
 
         // Get login creds from user
-        let username = cli::ask("https://hex.pm username")?;
-        let password = cli::ask_password("https://hex.pm password")?;
+
+        let username = std::env::var(Self::USER_KEY).or_else(|_| cli::ask(Self::USER_PROMPT))?;
+        let password =
+            std::env::var(Self::PASS_KEY).or_else(|_| cli::ask_password(Self::PASS_PROMPT))?;
 
         // Get API key
         let api_key = runtime.block_on(gleam_core::hex::create_api_key(

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -113,6 +113,8 @@ enum Command {
     Publish {
         #[clap(long)]
         replace: bool,
+        #[clap(long)]
+        yes: bool,
     },
 
     /// Render HTML documentation
@@ -328,7 +330,7 @@ fn main() {
 
         Command::CompilePackage(opts) => compile_package::command(opts),
 
-        Command::Publish { replace } => publish::command(replace),
+        Command::Publish { replace, yes } => publish::command(replace, yes),
 
         Command::PrintConfig => print_config(),
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -113,7 +113,7 @@ enum Command {
     Publish {
         #[clap(long)]
         replace: bool,
-        #[clap(long)]
+        #[clap(short, long)]
         yes: bool,
     },
 
@@ -304,7 +304,7 @@ fn main() {
 
         Command::Docs(Docs::Build) => docs::build(),
 
-        Command::Docs(Docs::Publish) => docs::PublishCommand::publish(),
+        Command::Docs(Docs::Publish) => docs::publish(),
 
         Command::Docs(Docs::Remove { package, version }) => docs::remove(package, version),
 

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -16,8 +16,8 @@ use sha2::Digest;
 
 use crate::{build, cli, docs, fs, hex::ApiKeyCommand, http::HttpClient};
 
-pub fn command(replace: bool) -> Result<()> {
-    PublishCommand::setup(replace)?.run()
+pub fn command(replace: bool, yes: bool) -> Result<()> {
+    PublishCommand::setup(replace, yes)?.run()
 }
 
 pub struct PublishCommand {
@@ -28,7 +28,7 @@ pub struct PublishCommand {
 }
 
 impl PublishCommand {
-    pub fn setup(replace: bool) -> Result<Self> {
+    pub fn setup(replace: bool, yes: bool) -> Result<Self> {
         // Reset the build directory so we know the state of the project
         fs::delete_dir(&paths::build_packages(Mode::Prod, Target::Erlang))?;
 
@@ -74,7 +74,7 @@ impl PublishCommand {
         println!("\nName: {}", config.name);
         println!("Version: {}", config.version);
 
-        if cli::ask("\nDo you wish to publish this package? [y/n]")? != "y" {
+        if !yes && cli::ask("\nDo you wish to publish this package? [y/n]")? != "y" {
             println!("Not publishing.");
             std::process::exit(0);
         }

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -28,7 +28,7 @@ pub struct PublishCommand {
 }
 
 impl PublishCommand {
-    pub fn setup(replace: bool, yes: bool) -> Result<Self> {
+    pub fn setup(replace: bool, i_am_sure: bool) -> Result<Self> {
         // Reset the build directory so we know the state of the project
         fs::delete_dir(&paths::build_packages(Mode::Prod, Target::Erlang))?;
 
@@ -74,7 +74,7 @@ impl PublishCommand {
         println!("\nName: {}", config.name);
         println!("Version: {}", config.version);
 
-        if !yes && cli::ask("\nDo you wish to publish this package? [y/n]")? != "y" {
+        if !i_am_sure && cli::ask("\nDo you wish to publish this package? [y/n]")? != "y" {
             println!("Not publishing.");
             std::process::exit(0);
         }


### PR DESCRIPTION
Starting work on addressing #1583

Current course of action:
- Add env vars check to `ApiKeyCommand` trait default implementation (This will allow other commands that use this behaviour to get the benefit of this work for free)
- Add a `yes` flag to `gleam publish` to avoid the "are you sure" prompt (i'm open to changing the name of the flag and associated variables)

I noticed `gleam docs remove` doesn't use the `ApiKeyCommand` workflow (yet) and has its own auth setup that is basically identical, might be suitable for a refactor later on or as part of this if I have time :smile: 