### PR TITLE
Proof of concept: Use Deno as a JavaScript runtime

### DIFF
--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -150,9 +150,14 @@ where
             let beam_path = self.out.join("ebin").join(module).with_extension("beam");
             self.add_build_journal(beam_path);
         }
-        let status = self
-            .io
-            .exec("escript", &args, &[], None, self.silence_subprocess_stdout)?;
+        let status = self.io.exec(
+            "escript",
+            None,
+            &args,
+            &[],
+            None,
+            self.silence_subprocess_stdout,
+        )?;
 
         if status == 0 {
             Ok(())

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -307,6 +307,7 @@ where
         ];
         let status = self.io.exec(
             REBAR_EXECUTABLE,
+            None,
             &args,
             &env,
             Some(&project_dir),

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -158,7 +158,7 @@ impl<'a> JavaScript<'a> {
     }
 
     fn write_prelude(&self, writer: &impl FileSystemWriter) -> Result<()> {
-        tracing::debug!("Generated js prelude");
+        tracing::debug!("Generating js prelude");
         writer
             .writer(&self.output_directory.join("gleam.mjs"))?
             .str_write(javascript::PRELUDE)?;

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -133,6 +133,7 @@ pub trait CommandExecutor {
     fn exec(
         &self,
         program: &str,
+        stdin: Option<&[u8]>,
         args: &[String],
         env: &[(&str, String)],
         cwd: Option<&Path>,
@@ -285,6 +286,7 @@ pub mod test {
         fn exec(
             &self,
             _program: &str,
+            _stdin: Option<&[u8]>,
             _args: &[String],
             _env: &[(&str, String)],
             _cwd: Option<&Path>,

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -24,6 +24,7 @@ impl CommandExecutor for WasmFileSystem {
     fn exec(
         &self,
         _program: &str,
+        _stdin: Option<&[u8]>,
         _args: &[String],
         _env: &[(&str, String)],
         _cwd: Option<&Path>,


### PR DESCRIPTION
Not really mergable as is, but is a nice PoC and gives us a spot for discussion

- We probably want a way to specify runtime (semi-independent of build target)
- Deno runs in a strict sandbox by default, which I'm disabling here by passing `-A`. This sandboxing is one of Deno's best features imo, so it'd be great to find a way to preserve it.

A theoretical gleam.toml could look like...

```
target = "javascript"
runtime = "deno"
runtime_options = ["--allow-read=."]
```