### PR TITLE
style-changelog-nitpickery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,8 @@
 - Clear outdated files from the build directory after compilation.
 - Fixed a bug where immediately calling the value that a case expression
   evaluates to could generate invalid JavaScript.
-- Fixed a bug where running a project on target Erlang when the default
-  project target is set to JavaScript.
-- Fixed a bug where running a project would run on target Erlang while the
-  default project target is set to JavaScript.
+- Fixed a bug where the default project target is set to JavaScript,
+  but the project would run on target Erlang instead.
 - The compiler is now able to generate TypeScript declaration files on target
   JavaScript (#1563). To enable this edit `gleam.toml` like so:
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   evaluates to could generate invalid JavaScript.
 - Fixed a bug where running a project on target Erlang when the default
   project target is set to JavaScript.
+- Fixed a bug where running a project would run on target Erlang while the
+  default project target is set to JavaScript.
 - The compiler is now able to generate TypeScript declaration files on target
   JavaScript (#1563). To enable this edit `gleam.toml` like so:
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,20 @@
 ## Unreleased
 
 - Added the ability to replace a release up to one hour after it is published
-  using `gleam publish --replace`
+  using `gleam publish --replace`.
 - All commands that authenticate using the `ApiKeyCommand` trait (currently
   `gleam publish`, `gleam docs publish`, `gleam docs remove`, `gleam hex retire`,
   and `gleam hex unretire`) and now have access to environment variables for
-  username (default key `HEXPM_USER`) and password (default key `HEXPM_PASS`)
+  username (default key `HEXPM_USER`) and password (default key `HEXPM_PASS`).
 - The `gleam publish` command gains the `-y/--yes` flag to disable the "are you
-  sure" prompt
+  sure" prompt.
 - Clear outdated files from the build directory after compilation.
 - Fixed a bug where immediately calling the value that a case expression
   evaluates to could generate invalid JavaScript.
 - Fixed a bug where running a project on the Erlang target when the default
   project target is set to JavaScript.
-- The compiler can now generate TypeScript declaration files when targeting
-  JavaScript (#1563)
+- The compiler now generates TypeScript declaration files when targeting
+  JavaScript (#1563).
 
 ## v0.21.0 - 2022-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   
   ```toml
   [javascript]
-  typescript_declarations: true
+  typescript_declarations = true
   ```
   
 - Fixed a bug where argument labels were allowed for anonymous functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@
   project target is set to JavaScript.
 - The compiler is now able to generate TypeScript declaration files when targeting
   JavaScript (#1563). To enable this edit `gleam.toml` like so:
+  
   ```toml
   [javascript]
   typescript_declarations: true
   ```
+  
 - Fixed a bug where argument labels were allowed for anonymous functions.
 - Generated HTML docs easter egg updated.
 - `gleam export erlang-shipment` can be used to create a directory of compiled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@
 - Clear outdated files from the build directory after compilation.
 - Fixed a bug where immediately calling the value that a case expression
   evaluates to could generate invalid JavaScript.
-- Fixed a bug where running a project on the Erlang target when the default
+- Fixed a bug where running a project on target Erlang when the default
   project target is set to JavaScript.
-- The compiler is now able to generate TypeScript declaration files when targeting
+- The compiler is now able to generate TypeScript declaration files on target
   JavaScript (#1563). To enable this edit `gleam.toml` like so:
   
   ```toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -628,7 +628,7 @@ Dedicated to the memory of Muhammad Shaheer, a good and caring man.
   both definitions.
 - Fix compiler bug where labelled arguments were being reordered incorrectly.
 
-# v0.10.0 - 2020-07-01
+## v0.10.0 - 2020-07-01
 
 [Release Blog Post](https://lpil.uk/blog/gleam-v0.10-released/)
 
@@ -636,12 +636,12 @@ Dedicated to the memory of Muhammad Shaheer, a good and caring man.
 - Fixed a bug where discards inside bit string patterns generated invalid
   code.
 
-# v0.10.0-rc2 - 2020-06-30
+## v0.10.0-rc2 - 2020-06-30
 
 - Fixed a bug where variables names would be incorrectly generated when using
   alternative patterns.
 
-# v0.10.0-rc1 - 2020-06-29
+## v0.10.0-rc1 - 2020-06-29
 
 - Single letter module names are now permitted.
 - Added support for bit string syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 - Added the ability to replace a release up to one hour after it is published
   using `gleam publish --replace`.
-- All commands that authenticate using the `ApiKeyCommand` trait (currently
-  `gleam publish`, `gleam docs publish`, `gleam docs remove`, `gleam hex retire`,
-  and `gleam hex unretire`) and now have access to environment variables for
-  username (default key `HEXPM_USER`) and password (default key `HEXPM_PASS`).
-  using `gleam publish --replace`
 - `gleam publish`, `gleam docs publish`, `gleam docs remove`, `gleam hex retire`,
   and `gleam hex unretire` now have access to environment variables for
   username (default key `HEXPM_USER`) and password (default key `HEXPM_PASS`)

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         Origin, Target,
     },
     codegen,
-    config::{Docs, ErlangConfig, JavascriptConfig, PackageConfig, Repository},
+    config::{Docs, ErlangConfig, JavaScriptConfig, PackageConfig, Repository},
     erlang,
     io::test::FilesChannel,
     javascript, type_,
@@ -34,7 +34,7 @@ macro_rules! assert_erlang_compile {
                 application_start_module: None,
                 extra_applications: vec![],
             },
-            javascript: JavascriptConfig {
+            javascript: JavaScriptConfig {
                 typescript_declarations: false,
             },
             target: Target::Erlang,
@@ -93,7 +93,7 @@ macro_rules! assert_javascript_compile {
                 application_start_module: None,
                 extra_applications: vec![],
             },
-            javascript: JavascriptConfig {
+            javascript: JavaScriptConfig {
                 typescript_declarations: true,
             },
             target: Target::JavaScript,
@@ -152,7 +152,7 @@ macro_rules! assert_no_warnings {
                 application_start_module: None,
                 extra_applications: vec![],
             },
-            javascript: JavascriptConfig {
+            javascript: JavaScriptConfig {
                 typescript_declarations: false,
             },
             target: Target::Erlang,

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -1,6 +1,6 @@
 use crate::{
     build::Module,
-    config::{JavascriptConfig, PackageConfig},
+    config::{JavaScriptConfig, PackageConfig},
     erlang,
     io::{FileSystemWriter, Utf8Writer},
     javascript,
@@ -141,11 +141,11 @@ impl<'a> ErlangApp<'a> {
 #[derive(Debug)]
 pub struct JavaScript<'a> {
     output_directory: &'a Path,
-    config: &'a JavascriptConfig,
+    config: &'a JavaScriptConfig,
 }
 
 impl<'a> JavaScript<'a> {
-    pub fn new(output_directory: &'a Path, config: &'a JavascriptConfig) -> Self {
+    pub fn new(output_directory: &'a Path, config: &'a JavaScriptConfig) -> Self {
         Self {
             output_directory,
             config,
@@ -168,7 +168,7 @@ impl<'a> JavaScript<'a> {
         writer
             .writer(&self.output_directory.join("gleam.mjs"))?
             .str_write(javascript::PRELUDE)?;
-        tracing::debug!("Generated js prelude");
+        tracing::debug!("Generated JS prelude");
         if self.config.typescript_declarations {
             writer
                 .writer(&self.output_directory.join("gleam.d.ts"))?

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -81,7 +81,7 @@ pub struct PackageConfig {
     #[serde(default)]
     pub erlang: ErlangConfig,
     #[serde(default)]
-    pub javascript: JavascriptConfig,
+    pub javascript: JavaScriptConfig,
     #[serde(default = "erlang_target")]
     pub target: Target,
 }
@@ -430,7 +430,7 @@ pub struct ErlangConfig {
 }
 
 #[derive(Deserialize, Debug, PartialEq, Default, Clone, Copy)]
-pub struct JavascriptConfig {
+pub struct JavaScriptConfig {
     #[serde(default)]
     pub typescript_declarations: bool,
 }


### PR DESCRIPTION
* renamed Javascript to JavaScript to be consistent with the usage in gleam rust source in other places.
* unified debug messages.
* fixed full stop dots at end of sentence.
* ~~corrected changelog to say that the compiler **_will_** instead of **_may_** output ts def file.~~