### PR TITLE
feat: preserve empty lines between comments when formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - `gleam export erlang-shipment` can be used to create a directory of compiled
   Erlang bytecode that can be used as a deployment artefact to get your
   application live.
+- `gleam format` will now preserve (up to one) empty lines between consecutive
+  comments, as well as between comments and any following expression
 
 ## v0.21.0 - 2022-04-24
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -397,8 +397,7 @@ impl<'comments> Formatter<'comments> {
             Some(_) => concat(Itertools::intersperse(
                 comments.map(|c| match c {
                     Some(c) => "///".to_doc().append(Document::String(c.to_string())),
-                    // empty lines have been dropped by pop_doc_comments
-                    None => unreachable!(),
+                    None => unreachable!("empty lines dropped by pop_doc_comments"),
                 }),
                 line(),
             ))

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3335,3 +3335,74 @@ fn negation_block() {
 "
     );
 }
+
+#[test]
+fn single_empty_line_between_comments() {
+    // empty line isn't added if it's not already present
+    assert_format!(
+        "pub fn foo() {
+  // foo
+  // bar
+  123
+}
+"
+    );
+
+    // single empty line between comments/statement preserved
+    assert_format!(
+        "pub fn foo() {
+  // foo
+
+  // bar
+
+  123
+}
+"
+    );
+
+    // multiple consecutive empty lines condensed into one
+    assert_format_rewrite!(
+        "pub fn foo() {
+  // foo
+
+
+  // bar
+
+
+  123
+}
+",
+        "pub fn foo() {
+  // foo
+
+  // bar
+
+  123
+}
+"
+    );
+
+    // freestanding comments keep empty lines
+    assert_format!(
+        "
+// foo
+
+// bar
+"
+    );
+
+    // freestanding comments condense consecutive empty lines
+    assert_format_rewrite!(
+        "
+// foo
+
+
+// bar
+",
+        "
+// foo
+
+// bar
+",
+    );
+}


### PR DESCRIPTION
This PR modifies the formatter to keep (at most) one empty line between standard `//` comments. This allows "commenting out" expressions to be idempotent, i.e. comment, format, uncomment will leave the source meaningfully unchanged. For example:

```gleam
value
|> io.debug

value
```

when commented/formatted becomes

```gleam
// value
// |> io.debug

// value
```

and reverts to the original when uncommented/formatted.

Closes #1621.