### PR TITLE
fix: don't output newline at top of docs that only contain comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   application live.
 - `gleam format` will now preserve (up to one) empty lines between consecutive
   comments, as well as between comments and any following expression
+- Fixed a bug where `gleam format` would output an unwanted newline at the top
+  of documents that only contain simple `//` comments.
 
 ## v0.21.0 - 2022-04-24
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3384,8 +3384,7 @@ fn single_empty_line_between_comments() {
 
     // freestanding comments keep empty lines
     assert_format!(
-        "
-// foo
+        "// foo
 
 // bar
 "
@@ -3393,14 +3392,12 @@ fn single_empty_line_between_comments() {
 
     // freestanding comments condense consecutive empty lines
     assert_format_rewrite!(
-        "
-// foo
+        "// foo
 
 
 // bar
 ",
-        "
-// foo
+        "// foo
 
 // bar
 ",

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3406,3 +3406,13 @@ fn single_empty_line_between_comments() {
 ",
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/1640
+#[test]
+fn no_newline_before_comments() {
+    assert_format!(
+        "// foo
+// bar
+"
+    );
+}

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -132,3 +132,39 @@ fn let_left_side_fits_test() {
 
     assert_eq!("[1] = [1]", doc.clone().to_pretty_string(16));
 }
+
+#[test]
+fn empty_documents() {
+    // nil
+    assert!(nil().is_empty());
+
+    // lines
+    assert!(lines(0).is_empty());
+    assert!(!line().is_empty());
+
+    // force break
+    assert!(force_break().is_empty());
+
+    // strings
+    assert!("".to_doc().is_empty());
+    assert!(!"foo".to_doc().is_empty());
+    assert!(!" ".to_doc().is_empty());
+    assert!(!"\n".to_doc().is_empty());
+
+    // containers
+    assert!("".to_doc().nest(2).is_empty());
+    assert!(!"foo".to_doc().nest(2).is_empty());
+    assert!("".to_doc().nest_current().is_empty());
+    assert!(!"foo".to_doc().nest_current().is_empty());
+    assert!("".to_doc().group().is_empty());
+    assert!(!"foo".to_doc().group().is_empty());
+    assert!("".to_doc().flex_break().is_empty());
+    assert!(!"foo".to_doc().flex_break().is_empty());
+    assert!(break_("", "").is_empty());
+    assert!(!break_("foo", "foo").is_empty());
+    assert!(!break_("foo\nbar", "foo bar").is_empty());
+    assert!(!"foo".to_doc().flex_break().is_empty());
+    assert!("".to_doc().append("".to_doc()).is_empty());
+    assert!(!"foo".to_doc().append("".to_doc()).is_empty());
+    assert!(!"".to_doc().append("foo".to_doc()).is_empty());
+}


### PR DESCRIPTION
This fixes an issue where the formatter would introduce an unwanted newline at the top of documents that only contained simple `//` comments. For example:

```gleam
// foo
// bar
```

This will no longer have a newline added at the top.

This PR introduces two new functions, `Document::is_empty` and `join`. `is_empty` recursively checks all members of a document and returns true when they contain no printable characters; this is used to determine whether or not newlines should be appended/prepended when joining formatted module sections together. `join` is a simple wrapper for `concat(Itertools::intersperse(..), separator`, an idiom I noticed was used pretty frequently around the formatter. I introduced it in a separate commit, so it can be reverted if it's undesirable 😇

Closes #1640.