### PR TITLE
Sort statements before generating docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed a bug where doc comments would dissociate from their statements when
+  generating html documentation.
 - You are now allowed to use named accessors on types with multiple constructors if the 
   accessor's name, position and type match (among the constructors). (#1610)
 - Added the ability to replace a release up to one hour after it is published

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -145,9 +145,13 @@ impl Module {
             })
             .collect();
 
+        // Order statements to avoid dissociating doc comments from them
+        let mut statements: Vec<_> = self.ast.statements.iter_mut().collect();
+        statements.sort_by(|a, b| a.location().start.cmp(&b.location().start));
+
         // Doc Comments
         let mut doc_comments = self.extra.doc_comments.iter().peekable();
-        for statement in &mut self.ast.statements {
+        for statement in &mut statements {
             let docs: Vec<&str> =
                 comments_before(&mut doc_comments, statement.location().start, &self.code);
             if !docs.is_empty() {

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -453,10 +453,7 @@ fn convert_deps_tree_error(e: dep_tree::Error) -> Error {
     }
 }
 
-fn module_deps_for_graph(
-    target: Target,
-    module: &Parsed,
-) -> (String, Vec<String>) {
+fn module_deps_for_graph(target: Target, module: &Parsed) -> (String, Vec<String>) {
     let name = module.name.clone();
     let deps: Vec<_> = module
         .ast


### PR DESCRIPTION
Fixes cases where doc comments are separated from their associated statements.

This bug can be reproduced most notably with type alias documentation.

Possibly addresses #1633.