### PR TITLE
Fix missing maybe-expr around list tail (fixes #1655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@
   but the project would run on target Erlang instead.
 - The compiler is now able to generate TypeScript declaration files on target
   JavaScript (#1563). To enable this edit `gleam.toml` like so:
+
   ```toml
   [javascript]
   typescript_declarations = true
   ```
+
 - Fixed a bug where argument labels were allowed for anonymous functions.
 - Fixed a bug where JavaScript code could be invalid if a variable is defined
   inside an anonymous function with a parameter with the same name as the
@@ -47,6 +49,7 @@
 - The `gleam compile-package` command no longer generates a `.app` file. This
   should now be done by the build tool that calls this command as it is
   responsible for handling dependencies.
+- Fixed a bug where piping a list tail would create invalid Erlang code (#1656).
 
 ## v0.21.0 - 2022-04-24
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -909,7 +909,7 @@ fn expr_list<'a>(
         elements.iter().map(|e| maybe_block_expr(e, env)),
         break_(",", ", "),
     ));
-    list(elements, tail.as_ref().map(|e| expr(e, env)))
+    list(elements, tail.as_ref().map(|e| maybe_block_expr(e, env)))
 }
 
 fn list<'a>(elems: Document<'a>, tail: Option<Document<'a>>) -> Document<'a> {

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr.snap
@@ -1,6 +1,0 @@
----
-source: compiler-core/src/erlang/tests.rs
-expression: "fn a() {\n  let a = [99]\n  let fake_tap = fn(x) { x }\n  let b = [\n    1,\n    2,\n    ..a\n    |> fake_tap\n  ]\n  b\n}\n"
----
--module(the_app).
-

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/erlang/tests.rs
+expression: "fn a() {\n  let a = [99]\n  let fake_tap = fn(x) { x }\n  let b = [\n    1,\n    2,\n    ..a\n    |> fake_tap\n  ]\n  b\n}\n"
+---
+-module(the_app).
+

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr_block.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr_block.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-expression: "pub fn a() {\n  let a = [99]\n  let fake_tap = fn(x) { x }\n  let b = [\n    1,\n    2,\n    ..a\n    |> fake_tap\n  ]\n  b\n}\n"
+expression: "pub fn a() {\n  let fake_tap = fn(x) { x }\n  let b = [99]\n  [\n    1,\n    2,\n    ..b\n    |> fake_tap\n  ]\n}\n"
 ---
 -module(the_app).
 -compile(no_auto_import).
@@ -9,13 +9,12 @@ expression: "pub fn a() {\n  let a = [99]\n  let fake_tap = fn(x) { x }\n  let b
 
 -spec a() -> list(integer()).
 a() ->
-    A = [99],
     Fake_tap = fun(X) -> X end,
-    B = [1,
-         2 |
-         begin
-             _pipe = A,
-             Fake_tap(_pipe)
-         end],
-    B.
+    B = [99],
+    [1,
+     2 |
+     begin
+         _pipe = B,
+         Fake_tap(_pipe)
+     end].
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr_block.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr_block.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests.rs
+expression: "pub fn a() {\n  let a = [99]\n  let fake_tap = fn(x) { x }\n  let b = [\n    1,\n    2,\n    ..a\n    |> fake_tap\n  ]\n  b\n}\n"
+---
+-module(the_app).
+-compile(no_auto_import).
+
+-export([a/0]).
+
+-spec a() -> list(integer()).
+a() ->
+    A = [99],
+    Fake_tap = fun(X) -> X end,
+    B = [1,
+         2 |
+         begin
+             _pipe = A,
+             Fake_tap(_pipe)
+         end],
+    B.
+

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -435,7 +435,7 @@ fn negation_block() {
 #[test]
 fn tail_maybe_expr_block() {
     assert_erl!(
-"pub fn a() {
+        "pub fn a() {
   let a = [99]
   let fake_tap = fn(x) { x }
   let b = [
@@ -445,7 +445,6 @@ fn tail_maybe_expr_block() {
     |> fake_tap
   ]
   b
-}
-"
+}"
     );
 }

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -430,3 +430,22 @@ fn negation_block() {
 }"
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/1655
+#[test]
+fn tail_maybe_expr_block() {
+    assert_erl!(
+"pub fn a() {
+  let a = [99]
+  let fake_tap = fn(x) { x }
+  let b = [
+    1,
+    2,
+    ..a
+    |> fake_tap
+  ]
+  b
+}
+"
+    );
+}

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -436,15 +436,15 @@ fn negation_block() {
 fn tail_maybe_expr_block() {
     assert_erl!(
         "pub fn a() {
-  let a = [99]
   let fake_tap = fn(x) { x }
-  let b = [
+  let b = [99]
+  [
     1,
     2,
-    ..a
+    ..b
     |> fake_tap
   ]
-  b
-}"
+}
+"
     );
 }


### PR DESCRIPTION
Fixes issue #1655 in local tests:

```
cargo build
cd target/debug
./gleam new area51
code src/area51.gleam
```

```gleam
import gleam/io

pub fn main() {
  io.println("Hello from area51!")
  let a = [99]

  let b = [
    1,
    2,
    ..a
    |> io.debug
  ]

  let c = [
    3,
    4
    |> io.debug,
    5,
  ]

  #(a, b, c)
}
```

```
../gleam run
```