### PR TITLE
 feature request: allow functions as arguments in constant literals #1632 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@
   after the case expresson could render incorrect Erlang.
 - Fixed a bug where formatter would strip curly braces around case guards even
   when they are required to specify boolean precedence.
-- In JavaScript, if an object has defined an `equals` method in it's prototype, Gleam will now use this method when checking for equality.
+- In JavaScript, if an object has defined an `equals` method in it's prototype,
+  Gleam will now use this method when checking for equality.
+- Functions can now be defined and referenced in constant expressions.
 
 ## v0.22.1 - 2022-06-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,12 +204,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
+ "js-sys",
  "num-integer",
  "num-traits",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -3317,7 +3317,7 @@ pub mod field_map {
 }
 
 pub mod constant {
-  pub use self::Which::{Int,Float,String,Tuple,List,Record,BitString};
+  pub use self::Which::{Int,Float,String,Tuple,List,Record,BitString,Var};
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
@@ -3420,6 +3420,11 @@ pub mod constant {
         6 => {
           ::core::result::Result::Ok(BitString(
             ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+          ))
+        }
+        7 => {
+          ::core::result::Result::Ok(Var(
+            ::capnp::traits::FromStructReader::new(self.reader)
           ))
         }
         x => ::core::result::Result::Err(::capnp::NotInSchema(x))
@@ -3561,6 +3566,15 @@ pub mod constant {
       !self.builder.get_pointer_field(0).is_null()
     }
     #[inline]
+    pub fn init_var(self, ) -> crate::schema_capnp::constant::var::Builder<'a> {
+      self.builder.set_data_field::<u16>(0, 7);
+      self.builder.get_pointer_field(0).clear();
+      self.builder.get_pointer_field(1).clear();
+      self.builder.get_pointer_field(2).clear();
+      self.builder.get_pointer_field(3).clear();
+      ::capnp::traits::FromStructBuilder::new(self.builder)
+    }
+    #[inline]
     pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
       match self.builder.get_data_field::<u16>(0) {
         0 => {
@@ -3598,6 +3612,11 @@ pub mod constant {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
           ))
         }
+        7 => {
+          ::core::result::Result::Ok(Var(
+            ::capnp::traits::FromStructBuilder::new(self.builder)
+          ))
+        }
         x => ::core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
@@ -3613,10 +3632,10 @@ pub mod constant {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 3 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 4 };
     pub const TYPE_ID: u64 = 0xe6ea_dc6f_e66d_526a;
   }
-  pub enum Which<A0,A1,A2,A3,A4,A5,A6> {
+  pub enum Which<A0,A1,A2,A3,A4,A5,A6,A7> {
     Int(A0),
     Float(A1),
     String(A2),
@@ -3624,9 +3643,10 @@ pub mod constant {
     List(A4),
     Record(A5),
     BitString(A6),
+    Var(A7),
   }
-  pub type WhichReader<'a,> = Which<::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::constant::Owned>>,crate::schema_capnp::constant::list::Reader<'a>,crate::schema_capnp::constant::record::Reader<'a>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::bit_string_segment::Owned>>>;
-  pub type WhichBuilder<'a,> = Which<::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::constant::Owned>>,crate::schema_capnp::constant::list::Builder<'a>,crate::schema_capnp::constant::record::Builder<'a>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::bit_string_segment::Owned>>>;
+  pub type WhichReader<'a,> = Which<::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::constant::Owned>>,crate::schema_capnp::constant::list::Reader<'a>,crate::schema_capnp::constant::record::Reader<'a>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::bit_string_segment::Owned>>,crate::schema_capnp::constant::var::Reader<'a>>;
+  pub type WhichBuilder<'a,> = Which<::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::constant::Owned>>,crate::schema_capnp::constant::list::Builder<'a>,crate::schema_capnp::constant::record::Builder<'a>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::bit_string_segment::Owned>>,crate::schema_capnp::constant::var::Builder<'a>>;
 
   pub mod list {
     #[derive(Copy, Clone)]
@@ -3783,7 +3803,7 @@ pub mod constant {
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 3 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 4 };
       pub const TYPE_ID: u64 = 0xe8fe_3c65_95aa_1abb;
     }
   }
@@ -3965,8 +3985,215 @@ pub mod constant {
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 3 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 4 };
       pub const TYPE_ID: u64 = 0xe6b5_727b_a6fc_9f1c;
+    }
+  }
+
+  pub mod var {
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+    impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+    #[derive(Clone, Copy)]
+    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+
+    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+      #[inline]
+      fn type_id() -> u64 { _private::TYPE_ID }
+    }
+    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+        Reader { reader,  }
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
+        ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+        self.reader
+      }
+    }
+
+    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+      }
+    }
+
+    impl <'a,> Reader<'a,>  {
+      pub fn reborrow(&self) -> Reader<'_,> {
+        Reader { .. *self }
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.reader.total_size()
+      }
+      #[inline]
+      pub fn get_module(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      }
+      pub fn has_module(&self) -> bool {
+        !self.reader.get_pointer_field(0).is_null()
+      }
+      #[inline]
+      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+      }
+      pub fn has_name(&self) -> bool {
+        !self.reader.get_pointer_field(1).is_null()
+      }
+      #[inline]
+      pub fn get_typ(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+      }
+      pub fn has_typ(&self) -> bool {
+        !self.reader.get_pointer_field(2).is_null()
+      }
+      #[inline]
+      pub fn get_constructor(self) -> ::capnp::Result<crate::schema_capnp::value_constructor::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+      }
+      pub fn has_constructor(&self) -> bool {
+        !self.reader.get_pointer_field(3).is_null()
+      }
+    }
+
+    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
+      #[inline]
+      fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
+    }
+    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+      #[inline]
+      fn type_id() -> u64 { _private::TYPE_ID }
+    }
+    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+        Builder { builder,  }
+      }
+    }
+
+    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+        ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+      }
+      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
+        ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
+      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    }
+
+    impl <'a,> Builder<'a,>  {
+      pub fn into_reader(self) -> Reader<'a,> {
+        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      }
+      pub fn reborrow(&mut self) -> Builder<'_,> {
+        Builder { .. *self }
+      }
+      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.builder.into_reader().total_size()
+      }
+      #[inline]
+      pub fn get_module(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_module(&mut self, value: ::capnp::text::Reader<'_>)  {
+        self.builder.get_pointer_field(0).set_text(value);
+      }
+      #[inline]
+      pub fn init_module(self, size: u32) -> ::capnp::text::Builder<'a> {
+        self.builder.get_pointer_field(0).init_text(size)
+      }
+      pub fn has_module(&self) -> bool {
+        !self.builder.get_pointer_field(0).is_null()
+      }
+      #[inline]
+      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
+        self.builder.get_pointer_field(1).set_text(value);
+      }
+      #[inline]
+      pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+        self.builder.get_pointer_field(1).init_text(size)
+      }
+      pub fn has_name(&self) -> bool {
+        !self.builder.get_pointer_field(1).is_null()
+      }
+      #[inline]
+      pub fn get_typ(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_typ(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+      }
+      #[inline]
+      pub fn init_typ(self, ) -> crate::schema_capnp::type_::Builder<'a> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
+      }
+      pub fn has_typ(&self) -> bool {
+        !self.builder.get_pointer_field(2).is_null()
+      }
+      #[inline]
+      pub fn get_constructor(self) -> ::capnp::Result<crate::schema_capnp::value_constructor::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_constructor(&mut self, value: crate::schema_capnp::value_constructor::Reader<'_>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
+      }
+      #[inline]
+      pub fn init_constructor(self, ) -> crate::schema_capnp::value_constructor::Builder<'a> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
+      }
+      pub fn has_constructor(&self) -> bool {
+        !self.builder.get_pointer_field(3).is_null()
+      }
+    }
+
+    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+        Pipeline { _typeless: typeless,  }
+      }
+    }
+    impl Pipeline  {
+      pub fn get_typ(&self) -> crate::schema_capnp::type_::Pipeline {
+        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+      }
+      pub fn get_constructor(&self) -> crate::schema_capnp::value_constructor::Pipeline {
+        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
+      }
+    }
+    mod _private {
+      use capnp::private::layout;
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 4 };
+      pub const TYPE_ID: u64 = 0xcb0a_e954_2cff_02a7;
     }
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -136,6 +136,13 @@ struct Constant {
     }
 
     bitString @9 :List(BitStringSegment);
+
+    var :group {
+      module @10 :Text;
+      name @11 :Text;
+      typ @12 :Type;
+      constructor @13 :ValueConstructor;
+    }
   }
 }
 

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -49,6 +49,7 @@ pub enum Constant<T, RecordTag> {
 
     Var {
         location: SrcSpan,
+        module: Option<String>,
         name: String,
         typ: T,
     },

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -46,6 +46,12 @@ pub enum Constant<T, RecordTag> {
         location: SrcSpan,
         segments: Vec<BitStringSegment<Self, T>>,
     },
+
+    Var {
+        location: SrcSpan,
+        name: String,
+        typ: T,
+    },
 }
 
 impl TypedConstant {
@@ -54,12 +60,13 @@ impl TypedConstant {
             Constant::Int { .. } => crate::type_::int(),
             Constant::Float { .. } => crate::type_::float(),
             Constant::String { .. } => crate::type_::string(),
-            Constant::List { typ, .. } => typ.clone(),
-            Constant::Record { typ, .. } => typ.clone(),
             Constant::BitString { .. } => crate::type_::bit_string(),
             Constant::Tuple { elements, .. } => {
                 crate::type_::tuple(elements.iter().map(|e| e.type_()).collect())
             }
+            Constant::List { typ, .. }
+            | Constant::Record { typ, .. }
+            | Constant::Var { typ, .. } => typ.clone(),
         }
     }
 }
@@ -79,7 +86,8 @@ impl<A, B> Constant<A, B> {
             | Constant::Tuple { location, .. }
             | Constant::String { location, .. }
             | Constant::Record { location, .. }
-            | Constant::BitString { location, .. } => *location,
+            | Constant::BitString { location, .. }
+            | Constant::Var { location, .. } => *location,
         }
     }
 

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -51,7 +51,7 @@ pub enum Constant<T, RecordTag> {
         location: SrcSpan,
         module: Option<String>,
         name: String,
-        constructor: Option<Arc<ValueConstructor>>,
+        constructor: Option<Box<ValueConstructor>>,
         typ: T,
     },
 }

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -51,6 +51,7 @@ pub enum Constant<T, RecordTag> {
         location: SrcSpan,
         module: Option<String>,
         name: String,
+        constructor: Option<Arc<ValueConstructor>>,
         typ: T,
     },
 }

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1245,7 +1245,7 @@ fn docs_args_call<'a>(
             ..
         } if constructor.variant.is_module_fn() => {
             if let ValueConstructorVariant::ModuleFn { module, name, .. } = &constructor.variant {
-                module_fn_with_args(&module, &name, args, env)
+                module_fn_with_args(module, name, args, env)
             } else {
                 unreachable!("The above clause guard ensures that this is a module fn")
             }

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -969,6 +969,9 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
                 tuple(std::iter::once(tag).chain(args))
             }
         }
+
+        // TODO: Implement erlang output for Constant::Var
+        Constant::Var { .. } => unimplemented!(),
     }
 }
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -970,8 +970,15 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
             }
         }
 
-        // TODO: Implement erlang output for Constant::Var
-        Constant::Var { .. } => unimplemented!(),
+        Constant::Var {
+            name, constructor, ..
+        } => var(
+            name,
+            constructor
+                .as_ref()
+                .expect("This is guaranteed to hold a value."),
+            env,
+        ),
     }
 }
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__module_const_vars.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__module_const_vars.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/erlang/tests/variables.rs
+expression: "const int = 42\nconst int_alias = int\npub fn use_int_alias() { int_alias }\n\nfn int_identity(i: Int) { i }\nconst int_identity_alias: fn(Int) -> Int = int_identity\npub fn use_int_identity_alias() { int_identity_alias(42) }\n\nconst compound: #(Int, fn(Int) -> Int, fn(Int) -> Int) = #(int, int_identity, int_identity_alias)\npub fn use_compound() { compound.1(compound.0) }\n"
+---
+-module(the_app).
+-compile(no_auto_import).
+
+-export([use_int_alias/0, use_int_identity_alias/0, use_compound/0]).
+
+-spec use_int_alias() -> integer().
+use_int_alias() ->
+    42.
+
+-spec int_identity(integer()) -> integer().
+int_identity(I) ->
+    I.
+
+-spec use_int_identity_alias() -> integer().
+use_int_identity_alias() ->
+    fun int_identity/1(42).
+
+-spec use_compound() -> integer().
+use_compound() ->
+    (erlang:element(2, {42, fun int_identity/1, fun int_identity/1}))(
+        erlang:element(1, {42, fun int_identity/1, fun int_identity/1})
+    ).
+

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__module_const_vars.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__module_const_vars.snap
@@ -17,7 +17,7 @@ int_identity(I) ->
 
 -spec use_int_identity_alias() -> integer().
 use_int_identity_alias() ->
-    fun int_identity/1(42).
+    int_identity(42).
 
 -spec use_compound() -> integer().
 use_compound() ->

--- a/compiler-core/src/erlang/tests/variables.rs
+++ b/compiler-core/src/erlang/tests/variables.rs
@@ -75,3 +75,20 @@ pub fn main() {
 }"#
     );
 }
+
+#[test]
+fn module_const_vars() {
+    assert_erl!(
+        "const int = 42
+const int_alias = int
+pub fn use_int_alias() { int_alias }
+
+fn int_identity(i: Int) { i }
+const int_identity_alias: fn(Int) -> Int = int_identity
+pub fn use_int_identity_alias() { int_identity_alias(42) }
+
+const compound: #(Int, fn(Int) -> Int, fn(Int) -> Int) = #(int, int_identity, int_identity_alias)
+pub fn use_compound() { compound.1(compound.0) }
+"
+    )
+}

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -368,6 +368,11 @@ impl<'comments> Formatter<'comments> {
                 .append(name.as_str())
                 .append(wrap_args(args.iter().map(|a| self.constant_call_arg(a))))
                 .group(),
+
+            Constant::Var {
+                name,
+                ..
+            } => name.to_doc(),
         }
     }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -369,10 +369,7 @@ impl<'comments> Formatter<'comments> {
                 .append(wrap_args(args.iter().map(|a| self.constant_call_arg(a))))
                 .group(),
 
-            Constant::Var {
-                name,
-                ..
-            } => name.to_doc(),
+            Constant::Var { name, .. } => name.to_doc(),
         }
     }
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3146,11 +3146,14 @@ fn var_constant() {
     assert_format!(
         r#"const x = 1
 
-        const xAlias = x
+const x_alias = x
 
-        fn int_identity(i: Int) -> { i }
+fn f(i: Int) -> Int {
+  i
+}
 
-        const intIdentityAlias: fn(Int) -> Int = int_identity"#
+const f_alias: fn(Int) -> Int = f
+"#
     );
 }
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3142,6 +3142,19 @@ fn tuple_constant() {
 }
 
 #[test]
+fn var_constant() {
+    assert_format!(
+        r#"const x = 1
+
+        const xAlias = x
+
+        fn int_identity(i: Int) -> { i }
+
+        const intIdentityAlias: fn(Int) -> Int = int_identity"#
+    );
+}
+
+#[test]
 fn let_as_expression() {
     assert_format!(
         "pub fn main() {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1124,6 +1124,8 @@ pub(crate) fn constant_expression<'a>(
             feature: "Bit string syntax".to_string(),
             location: *location,
         }),
+        // TODO: Emit javascript for Constant::Var variant.
+        Constant::Var { .. } => unimplemented!(),
     }
 }
 

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1124,8 +1124,7 @@ pub(crate) fn constant_expression<'a>(
             feature: "Bit string syntax".to_string(),
             location: *location,
         }),
-        // TODO: Emit javascript for Constant::Var variant.
-        Constant::Var { .. } => unimplemented!(),
+        Constant::Var { name, .. } => Ok(name.to_doc()),
     }
 }
 

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -36,7 +36,7 @@ macro_rules! assert_js {
         let _ = modules.insert("gleam".to_string(), $crate::type_::build_prelude(&ids));
         let (mut ast, _) = $crate::parse::parse_module($dep_src).expect("dep syntax error");
         ast.name = $dep_name;
-        let dep = crate::type_::infer_module(
+        let dep = $crate::type_::infer_module(
             crate::build::Target::JavaScript,
             &ids,
             ast,
@@ -178,7 +178,7 @@ macro_rules! assert_ts_def {
         let _ = modules.insert("gleam".to_string(), $crate::type_::build_prelude(&ids));
         let (mut ast, _) = $crate::parse::parse_module($dep_src).expect("dep syntax error");
         ast.name = $dep_name;
-        let dep = crate::type_::infer_module(
+        let dep = $crate::type_::infer_module(
             crate::build::Target::JavaScript,
             &ids,
             ast,

--- a/compiler-core/src/javascript/tests/assignments.rs
+++ b/compiler-core/src/javascript/tests/assignments.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn tuple_matching() {
@@ -142,5 +142,26 @@ pub fn debug(x) {
   fn(x) { x + 1 }
 }
 "#,
+    );
+}
+
+#[test]
+fn module_const_var() {
+    assert_js!(
+        r#"
+pub const int = 42
+pub const int_alias = int 
+pub fn use_int_alias() { int_alias }
+
+pub const compound: #(Int, Int) = #(int, int_alias)
+pub fn use_compound() { compound.0 + compound.1 }
+"#
+    );
+    assert_ts_def!(
+        r#"
+pub const int = 42
+pub const int_alias = int 
+pub const compound: #(Int, Int) = #(int, int_alias)
+"#
     );
 }

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -379,5 +379,26 @@ fn pipe_shadow_import() {
             |> println
           println
         }"#
+    );
+}
+
+#[test]
+fn module_const_fn() {
+    assert_js!(
+        r#"
+pub fn int_identity(i: Int) -> Int { i }
+pub const int_identity_alias: fn(Int) -> Int = int_identity
+pub fn use_int_identity_alias() { int_identity_alias(42) }
+
+pub const compound: #(fn(Int) -> Int, fn(Int) -> Int) = #(int_identity, int_identity_alias)
+pub fn use_compound() { compound.0(compound.1(42)) }"#
+    );
+
+    assert_ts_def!(
+        r#"
+pub fn int_identity(i: Int) -> Int { i }
+pub const int_identity_alias: fn(Int) -> Int = int_identity
+pub const compound: #(fn(Int) -> Int, fn(Int) -> Int) = 
+    #(int_identity, int_identity_alias)"#
     )
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__module_const_var-2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__module_const_var-2.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/javascript/tests/assignments.rs
+expression: "\npub const int = 42\npub const int_alias = int \npub const compound: #(Int, Int) = #(int, int_alias)\n"
+---
+export const int: number;
+
+export const int_alias: number;
+
+export const compound: [number, number];
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__module_const_var.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__module_const_var.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/javascript/tests/assignments.rs
+expression: "\npub const int = 42\npub const int_alias = int \npub fn use_int_alias() { int_alias }\n\npub const compound: #(Int, Int) = #(int, int_alias)\npub fn use_compound() { compound.0 + compound.1 }\n"
+---
+export const int = 42;
+
+export const int_alias = int;
+
+export const compound = [int, int_alias];
+
+export function use_int_alias() {
+  return int_alias;
+}
+
+export function use_compound() {
+  return compound[0] + compound[1];
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__module_const_fn-2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__module_const_fn-2.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\npub fn int_identity(i: Int) -> Int { i }\npub const int_identity_alias: fn(Int) -> Int = int_identity\npub const compound: #(fn(Int) -> Int, fn(Int) -> Int) = \n    #(int_identity, int_identity_alias)"
+---
+export const int_identity_alias: (x0: number) => number;
+
+export const compound: [(x0: number) => number, (x0: number) => number];
+
+export function int_identity(i: number): number;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__module_const_fn.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__module_const_fn.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\npub fn int_identity(i: Int) -> Int { i }\npub const int_identity_alias: fn(Int) -> Int = int_identity\npub fn use_int_identity_alias() { int_identity_alias(42) }\n\npub const compound: #(fn(Int) -> Int, fn(Int) -> Int) = #(int_identity, int_identity_alias)\npub fn use_compound() { compound.0(compound.1(42)) }"
+---
+export const int_identity_alias = int_identity;
+
+export const compound = [int_identity, int_identity_alias];
+
+export function int_identity(i) {
+  return i;
+}
+
+export function use_int_identity_alias() {
+  return int_identity_alias(42);
+}
+
+export function use_compound() {
+  return compound[0](compound[1](42));
+}
+

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -166,6 +166,7 @@ impl ModuleDecoder {
             Which::List(reader) => self.constant_list(&reader),
             Which::Record(reader) => self.constant_record(&reader),
             Which::BitString(reader) => self.constant_bit_string(&reader?),
+            Which::Var(reader) => self.constant_var(&reader),
         }
     }
 
@@ -242,6 +243,23 @@ impl ModuleDecoder {
         Ok(Constant::BitString {
             location: Default::default(),
             segments: read_vec!(reader, self, bit_string_segment),
+        })
+    }
+
+    fn constant_var(&mut self, reader: &constant::var::Reader<'_>) -> Result<TypedConstant> {
+        let type_ = self.type_(&reader.get_typ()?)?;
+        let module = match reader.get_module()? {
+            "" => None,
+            module_str => Some(module_str),
+        };
+        let name = reader.get_name()?;
+        let constructor = self.value_constructor(&reader.get_constructor()?)?;
+        Ok(Constant::Var {
+            location: Default::default(),
+            module: module.map(String::from),
+            name: String::from(name),
+            constructor: Some(Arc::from(constructor)),
+            typ: type_,
         })
     }
 

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -258,7 +258,7 @@ impl ModuleDecoder {
             location: Default::default(),
             module: module.map(String::from),
             name: String::from(name),
-            constructor: Some(Arc::from(constructor)),
+            constructor: Some(Box::from(constructor)),
             typ: type_,
         })
     }

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -289,9 +289,28 @@ impl<'a> ModuleEncoder<'a> {
                 builder.reborrow().set_tag(tag);
                 self.build_type(builder.reborrow().init_typ(), typ);
             }
-            
-            // TODO: ask about the expected behavior here.
-            Constant::Var { .. } => unimplemented!(),
+
+            Constant::Var {
+                module,
+                name,
+                typ,
+                constructor,
+                ..
+            } => {
+                let mut builder = builder.init_var();
+                match module {
+                    Some(name) => builder.set_module(name),
+                    None => builder.set_module(""),
+                };
+                builder.set_name(name);
+                self.build_type(builder.reborrow().init_typ(), typ);
+                self.build_value_constructor(
+                    builder.reborrow().init_constructor(),
+                    constructor
+                        .as_ref()
+                        .expect("This is guaranteed to hold a value."),
+                );
+            }
         }
     }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -289,6 +289,9 @@ impl<'a> ModuleEncoder<'a> {
                 builder.reborrow().set_tag(tag);
                 self.build_type(builder.reborrow().init_typ(), typ);
             }
+            
+            // TODO: ask about the expected behavior here.
+            Constant::Var { .. } => unimplemented!(),
         }
     }
 

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -569,6 +569,7 @@ fn constant_record() {
 fn constant_var() {
     let module = constant_module(Constant::Var {
         location: Default::default(),
+        module: None,
         name: "otherVar".to_string(),
         typ: type_::int(),
     });

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -566,6 +566,17 @@ fn constant_record() {
 }
 
 #[test]
+fn constant_var() {
+    let module = constant_module(Constant::Var {
+        location: Default::default(),
+        name: "otherVar".to_string(),
+        typ: type_::int(),
+    });
+
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
 fn constant_bit_string() {
     let module = constant_module(Constant::BitString {
         location: Default::default(),

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -567,13 +567,62 @@ fn constant_record() {
 
 #[test]
 fn constant_var() {
-    let module = constant_module(Constant::Var {
+    let one_original = Constant::Int {
+        location: Default::default(),
+        value: "1".to_string(),
+    };
+
+    let one = Constant::Var {
         location: Default::default(),
         module: None,
-        name: "otherVar".to_string(),
+        name: "one_original".to_string(),
         typ: type_::int(),
-        constructor: None,
-    });
+        constructor: Some(Arc::from(ValueConstructor {
+            public: true,
+            type_: type_::int(),
+            variant: ValueConstructorVariant::ModuleConstant {
+                literal: one_original.clone(),
+                location: SrcSpan::default(),
+                module: "one/two".into(),
+            },
+        })),
+    };
+
+    let module = Module {
+        package: "some_package".to_string(),
+        origin: Origin::Src,
+        name: vec!["a".to_string()],
+        types: HashMap::new(),
+        types_constructors: HashMap::new(),
+        accessors: HashMap::new(),
+        values: [
+            (
+                "one".to_string(),
+                ValueConstructor {
+                    public: true,
+                    type_: type_::int(),
+                    variant: ValueConstructorVariant::ModuleConstant {
+                        literal: one,
+                        location: SrcSpan::default(),
+                        module: "one/two".into(),
+                    },
+                },
+            ),
+            (
+                "one_original".to_string(),
+                ValueConstructor {
+                    public: true,
+                    type_: type_::int(),
+                    variant: ValueConstructorVariant::ModuleConstant {
+                        literal: one_original,
+                        location: SrcSpan::default(),
+                        module: "one/two".into(),
+                    },
+                },
+            ),
+        ]
+        .into(),
+    };
 
     assert_eq!(roundtrip(&module), module);
 }

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -577,7 +577,7 @@ fn constant_var() {
         module: None,
         name: "one_original".to_string(),
         typ: type_::int(),
-        constructor: Some(Arc::from(ValueConstructor {
+        constructor: Some(Box::from(ValueConstructor {
             public: true,
             type_: type_::int(),
             variant: ValueConstructorVariant::ModuleConstant {

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -572,6 +572,7 @@ fn constant_var() {
         module: None,
         name: "otherVar".to_string(),
         typ: type_::int(),
+        constructor: None,
     });
 
     assert_eq!(roundtrip(&module), module);

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2082,7 +2082,7 @@ where
 
             Some((start, Token::Name { name }, end)) => {
                 let _ = self.next_tok();
-                if self.expect_one(&Token::Dot).is_ok() {
+                if self.maybe_one(&Token::Dot).is_some() {
                     match self.tok0.take() {
                         Some((_, Token::UpName { name: upname }, end)) => {
                             let _ = self.next_tok();

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2092,6 +2092,7 @@ where
                             location: SrcSpan { start, end },
                             module: Some(name),
                             name: end_name,
+                            constructor: None,
                             typ: (),
                         })),
                         Some((start, _, end)) => parse_error(
@@ -2110,6 +2111,7 @@ where
                         location: SrcSpan { start, end },
                         module: None,
                         name,
+                        constructor: None,
                         typ: (),
                     }))
                 }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -338,6 +338,14 @@ impl ValueConstructorVariant {
     pub fn is_local_variable(&self) -> bool {
         matches!(self, Self::LocalVariable { .. })
     }
+
+    /// Returns `true` if the value constructor variant is [`ModuleFn`].
+    ///
+    /// [`ModuleFn`]: ValueConstructorVariant::ModuleFn
+    #[must_use]
+    pub fn is_module_fn(&self) -> bool {
+        matches!(self, Self::ModuleFn { .. })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1658,6 +1658,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     field_map,
                 })
             }
+            // TODO: Implement type inference/checking for Constant::Var
+            Constant::Var { .. } => unimplemented!(),
         }?;
 
         // Check type annotation is accurate.

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1672,7 +1672,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         module,
                         name,
                         typ: Arc::clone(&constructor.type_),
-                        constructor: Some(Arc::from(constructor)),
+                        constructor: Some(Box::from(constructor)),
                     }),
                     // constructor.variant cannot be a LocalVariable because module constants can
                     // only be defined at module scope. It also cannot be a Record because then

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1297,7 +1297,9 @@ fn module_constants() {
     pub const test_float: Float = 4.2
     pub const test_string = \"hey!\"
     pub const test_list = [1,2,3]
-    pub const test_tuple = #(\"yes!\", 42)",
+    pub const test_tuple = #(\"yes!\", 42)
+    pub const test_var1 = test_int1
+    pub const test_var2: Int = test_int1",
         vec![
             ("test_float", "Float"),
             ("test_int1", "Int"),
@@ -1308,6 +1310,8 @@ fn module_constants() {
             ("test_list", "List(Int)"),
             ("test_string", "String"),
             ("test_tuple", "#(String, Int)"),
+            ("test_var1", "Int"),
+            ("test_var2", "Int")
         ],
     );
 }
@@ -1318,6 +1322,22 @@ fn custom_type_module_constants() {
         "pub type Test { A }
         pub const test = A",
         vec![("A", "Test"), ("test", "Test")],
+    );
+}
+
+#[test]
+fn module_constant_functions() {
+    assert_module_infer!(
+        "pub fn int_identity(i: Int) -> Int { i }
+        pub const int_identity_alias1 = int_identity
+        pub const int_identity_alias2 = int_identity_alias1
+        pub const int_identity_alias3: fn(Int) -> Int = int_identity_alias2",
+        vec![
+            ("int_identity", "fn(Int) -> Int"),
+            ("int_identity_alias1", "fn(Int) -> Int"),
+            ("int_identity_alias2", "fn(Int) -> Int"),
+            ("int_identity_alias3", "fn(Int) -> Int"),
+        ]
     );
 }
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -43,7 +43,7 @@ macro_rules! assert_module_infer {
         // place.
         let _ = modules.insert("gleam".to_string(), build_prelude(&ids));
         let ast = infer_module(
-            crate::build::Target::Erlang,
+            $crate::build::Target::Erlang,
             &ids,
             ast,
             crate::build::Origin::Src,


### PR DESCRIPTION
This is an implementation for feature request #1632. The changes can be summarized as follows:
- Add variant Constant::Name (in compiler-core/src/ast/constant.rs)
- Parse identifiers into Constant::Name (in compiler-core/src/parse.rs)
- Parse function types for module constants (also in compiler-core/src/parse.rs)
- Typecheck/infer types for Constant::Name (in compiler-core/src/type_/expression.rs)
- Add metadata encoding/decoding for Constant::Var. This involves changing `schema.capnp` and `metadata/module_{encoder/decoder}.rs`
- Update how module constant statements are codegen'd in JS to properly output Constant::Name definition statements   (in `compiler-core/src/javascript/expression.rs`)
- Update how module constant usages are codegen'd in Elixir to properly output Constant::Name usages (in compiler-core/src/erlang.rs)
- Add tests for formatting, metadata encoding/decoding, and type checking. 

Should a language integration test be added for this as well? If so, how can I go about doing that?