### PR TITLE
fix:  Formatter: case guards loses curley braces even if required for manual precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   empty lines in a row.
 - Fixed a bug alternative patterns with a clause containing a pipe with a pipe
   after the case expresson could render incorrect Erlang.
+- Fixed a bug where formatter would strip curly braces around case guards due 
+to lack of precedence.
 
 ## v0.22.1 - 2022-06-27
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -873,6 +873,28 @@ impl<A, B> ClauseGuard<A, B> {
             | ClauseGuard::LtEqFloat { location, .. } => *location,
         }
     }
+
+    pub fn precedence(&self) -> u8 {
+        match self {
+            ClauseGuard::Or { .. } => 1,
+            ClauseGuard::And { .. } => 2,
+
+            ClauseGuard::Equals { .. } | ClauseGuard::NotEquals { .. } => 3,
+
+            ClauseGuard::GtInt { .. }
+            | ClauseGuard::GtEqInt { .. }
+            | ClauseGuard::LtInt { .. }
+            | ClauseGuard::LtEqInt { .. }
+            | ClauseGuard::GtFloat { .. }
+            | ClauseGuard::GtEqFloat { .. }
+            | ClauseGuard::LtFloat { .. }
+            | ClauseGuard::LtEqFloat { .. } => 4,
+
+            ClauseGuard::Constant(_) | ClauseGuard::Var { .. } | ClauseGuard::TupleIndex { .. } => {
+                6
+            }
+        }
+    }
 }
 
 impl TypedClauseGuard {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -891,7 +891,7 @@ impl<A, B> ClauseGuard<A, B> {
             | ClauseGuard::LtEqFloat { .. } => 4,
 
             ClauseGuard::Constant(_) | ClauseGuard::Var { .. } | ClauseGuard::TupleIndex { .. } => {
-                6
+                5
             }
         }
     }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1277,67 +1277,63 @@ impl<'comments> Formatter<'comments> {
             .append(self.pattern(&arg.value))
     }
 
+    pub fn clause_guard_bin_op<'a>(
+        &mut self,
+        name: &'a str,
+        name_precedence: u8,
+        left: &'a UntypedClauseGuard,
+        right: &'a UntypedClauseGuard,
+    ) -> Document<'a> {
+        let left_precedence = left.precedence();
+        let right_precedence = right.precedence();
+        let left = self.clause_guard(left);
+        let right = self.clause_guard(right);
+        self.operator_side(left, name_precedence, left_precedence)
+            .append(name)
+            .append(self.operator_side(right, name_precedence, right_precedence - 1))
+    }
+
     fn clause_guard<'a>(&mut self, clause_guard: &'a UntypedClauseGuard) -> Document<'a> {
         match clause_guard {
-            ClauseGuard::And { left, right, .. } => self
-                .clause_guard(left)
-                .append(" && ")
-                .append(self.clause_guard(right)),
+            ClauseGuard::And { left, right, .. } => {
+                self.clause_guard_bin_op(" && ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::Or { left, right, .. } => {
+                self.clause_guard_bin_op(" || ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::Equals { left, right, .. } => {
+                self.clause_guard_bin_op(" == ", clause_guard.precedence(), left, right)
+            }
 
-            ClauseGuard::Or { left, right, .. } => self
-                .clause_guard(left)
-                .append(" || ")
-                .append(self.clause_guard(right)),
+            ClauseGuard::NotEquals { left, right, .. } => {
+                self.clause_guard_bin_op(" != ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::GtInt { left, right, .. } => {
+                self.clause_guard_bin_op(" > ", clause_guard.precedence(), left, right)
+            }
 
-            ClauseGuard::Equals { left, right, .. } => self
-                .clause_guard(left)
-                .append(" == ")
-                .append(self.clause_guard(right)),
+            ClauseGuard::GtEqInt { left, right, .. } => {
+                self.clause_guard_bin_op(" >= ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::LtInt { left, right, .. } => {
+                self.clause_guard_bin_op(" < ", clause_guard.precedence(), left, right)
+            }
 
-            ClauseGuard::NotEquals { left, right, .. } => self
-                .clause_guard(left)
-                .append(" != ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::GtInt { left, right, .. } => self
-                .clause_guard(left)
-                .append(" > ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::GtEqInt { left, right, .. } => self
-                .clause_guard(left)
-                .append(" >= ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::LtInt { left, right, .. } => self
-                .clause_guard(left)
-                .append(" < ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::LtEqInt { left, right, .. } => self
-                .clause_guard(left)
-                .append(" <= ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::GtFloat { left, right, .. } => self
-                .clause_guard(left)
-                .append(" >. ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::GtEqFloat { left, right, .. } => self
-                .clause_guard(left)
-                .append(" >=. ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::LtFloat { left, right, .. } => self
-                .clause_guard(left)
-                .append(" <. ")
-                .append(self.clause_guard(right)),
-
-            ClauseGuard::LtEqFloat { left, right, .. } => self
-                .clause_guard(left)
-                .append(" <=. ")
-                .append(self.clause_guard(right)),
+            ClauseGuard::LtEqInt { left, right, .. } => {
+                self.clause_guard_bin_op(" <= ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::GtFloat { left, right, .. } => {
+                self.clause_guard_bin_op(" >. ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::GtEqFloat { left, right, .. } => {
+                self.clause_guard_bin_op(" >=. ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::LtFloat { left, right, .. } => {
+                self.clause_guard_bin_op(" <. ", clause_guard.precedence(), left, right)
+            }
+            ClauseGuard::LtEqFloat { left, right, .. } => {
+                self.clause_guard_bin_op(" <=. ", clause_guard.precedence(), left, right)
+            }
 
             ClauseGuard::Var { name, .. } => name.to_doc(),
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3491,3 +3491,43 @@ const x = 1
 "#
     );
 }
+
+#[test]
+fn do_not_remove_required_braces_case_guard() {
+    assert_format!(
+        "fn main() {
+  let is_enabled = False
+  let is_confirmed = False
+  let is_admin = True
+  case is_enabled, is_confirmed, is_admin {
+    // `{` and `}` will be stripped on save for me, changing the logic
+    is_enabled, is_confirmed, is_admin if True && { False || True } ->
+      // enabled andalso (admin andor confirmed) - does not allow disabled admins
+      Nil
+    _, _, _ -> Nil
+  }
+}
+"
+    );
+
+    assert_format!(
+      "fn main() {
+        let foo = True;
+        case foo {
+          foo if True != { 1 == 2 } -> Nil
+          _ -> Nil  
+        }        
+      }"
+    );
+
+    assert_format!(
+      "fn main() {
+        let foo = True;
+        let bar = False;
+        case foo {
+          foo if True != { 1 == { bar == foo } } -> Nil,
+          _ -> Nil  
+        }        
+      }"
+    );
+}

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3500,10 +3500,9 @@ fn do_not_remove_required_braces_case_guard() {
   let is_confirmed = False
   let is_admin = True
   case is_enabled, is_confirmed, is_admin {
-    // `{` and `}` will be stripped on save for me, changing the logic
-    is_enabled, is_confirmed, is_admin if True && { False || True } ->
-      // enabled andalso (admin andor confirmed) - does not allow disabled admins
-      Nil
+    is_enabled, is_confirmed, is_admin if is_enabled && {
+      is_confirmed || is_admin
+    } -> Nil
     _, _, _ -> Nil
   }
 }
@@ -3511,23 +3510,83 @@ fn do_not_remove_required_braces_case_guard() {
     );
 
     assert_format!(
-      "fn main() {
-        let foo = True;
-        case foo {
-          foo if True != { 1 == 2 } -> Nil
-          _ -> Nil  
-        }        
-      }"
+        "fn main() {
+  let foo = True
+  case foo {
+    foo if True != { 1 == 2 } -> Nil
+    _ -> Nil
+  }
+}
+"
     );
 
     assert_format!(
-      "fn main() {
-        let foo = True;
-        let bar = False;
-        case foo {
-          foo if True != { 1 == { bar == foo } } -> Nil,
-          _ -> Nil  
-        }        
-      }"
+        "fn main() {
+  let foo = True
+  let bar = False
+  case foo {
+    foo if True != { 1 == { bar == foo } } -> Nil
+    _ -> Nil
+  }
+}
+"
+    );
+
+    assert_format!(
+        "fn main() {
+  let foo = #(10, [0])
+  case foo {
+    foo if True && { foo.0 == 10 || foo.0 == 1 } -> Nil
+    _ -> Nil
+  }
+}
+"
+    );
+}
+
+#[test]
+fn remove_braces_case_guard() {
+    assert_format_rewrite!(
+        "fn main() {
+  let is_enabled = False
+  let is_confirmed = False
+  let is_admin = True
+  case is_enabled, is_confirmed, is_admin {
+    is_enabled, is_confirmed, is_admin if { is_enabled && is_confirmed } || is_admin ->
+      Nil
+    _, _, _ -> Nil
+  }
+}
+",
+        "fn main() {
+  let is_enabled = False
+  let is_confirmed = False
+  let is_admin = True
+  case is_enabled, is_confirmed, is_admin {
+    is_enabled, is_confirmed, is_admin if is_enabled && is_confirmed || is_admin ->
+      Nil
+    _, _, _ -> Nil
+  }
+}
+"
+    );
+
+    assert_format_rewrite!(
+        "fn main() {
+  let foo = #(10, [0])
+  case foo {
+    foo if True && { foo.0 == 10 } -> Nil
+    _ -> Nil
+  }
+}
+",
+        "fn main() {
+  let foo = #(10, [0])
+  case foo {
+    foo if True && foo.0 == 10 -> Nil
+    _ -> Nil
+  }
+}
+"
     );
 }


### PR DESCRIPTION
- Closes #1671 


### Bug Description
For let binding such as: 
```
let test1 = is_enabled && { is_confirmed || is_admin }
```
The formatter calls `binop` function, which compare the precedence of each sub-expression. Therefore, it doesn't strip braces in the case above.

For case guard 
```
...
case is_enabled, is_admin, is_confirmed {
    is_enabled, is_admin, is_confirmed if is_enabled && { is_confirmed || is_admin } -> ...
```
The formatter calls `clause_guard` function. But the function doesn't compare precedence of each sub-expression. Therefore, it strips braces away.

### Fix

My fix is to add an implementation of `precedence` for `ClauseGuard` struct. Then in `clause_guard` function, we can rely on `operator_side` function, which compares precedence and handles the braces accordingly.

Thank you @inoas for the test cases! Super helpful and clear to understand the bug. 