### PR TITLE
support 'equals' method in JS for object equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   after the case expresson could render incorrect Erlang.
 - Fixed a bug where formatter would strip curly braces around case guards even
   when they are required to specify boolean precedence.
+- In JavaScript, if an object has defined an `equals` method in it's prototype, Gleam will now use this method when checking for equality.
 
 ## v0.22.1 - 2022-06-27
 

--- a/compiler-core/templates/prelude.js
+++ b/compiler-core/templates/prelude.js
@@ -316,8 +316,11 @@ export function isEqual(x, y) {
       unequalSets(a, b);
     if (unequal) return false;
 
-    if (typeof a.equals === "function" && a.equals(b)) {
-      continue;
+    const proto = Object.getPrototypeOf(a)
+    if (proto !== null && typeof proto.equals === "function") {
+      try {
+        if (a.equals(b)) continue; else return false;
+      } catch {}
     }
 
     let [keys, get] = getters(a);

--- a/compiler-core/templates/prelude.js
+++ b/compiler-core/templates/prelude.js
@@ -316,6 +316,10 @@ export function isEqual(x, y) {
       unequalSets(a, b);
     if (unequal) return false;
 
+    if (typeof a.equals === "function" && a.equals(b)) {
+      continue;
+    }
+
     let [keys, get] = getters(a);
     for (const k of keys(a)) {
       values.push(get(a, k), get(b, k));

--- a/test/javascript_prelude/main.mjs
+++ b/test/javascript_prelude/main.mjs
@@ -262,6 +262,58 @@ assertEqual(new ExampleB(1), new ExampleB(1));
 assertNotEqual(new ExampleA(1), new ExampleA(2));
 assertNotEqual(new ExampleA(1), new ExampleB(1));
 
+// Custom .equals() method
+class NoCustomEquals {
+  constructor(id, notImportant) {
+    this.id = id;
+    this.notImportant = notImportant;
+  }
+}
+class HasCustomEqualsThatThrows {
+  constructor(id, notImportant) {
+    this.id = id;
+    this.notImportant = notImportant;
+  }
+  equals() {
+    throw "not today";
+  }
+}
+class HasCustomEquals {
+  constructor(id, notImportant) {
+    this.id = id;
+    this.notImportant = notImportant;
+  }
+  equals(o) {
+    return this.id === o.id;
+  }
+}
+function testCustomEquals(o) {
+  this.id === o.id;
+}
+const hasEqualsField = {
+  id: 1,
+  notImportant: 2,
+  equals: testCustomEquals,
+};
+const hasEqualsField2 = {
+  id: 1,
+  notImportant: 3,
+  equals: testCustomEquals,
+};
+// no custom equals, use structural equality
+assertEqual(new NoCustomEquals(1, 1), new NoCustomEquals(1, 1));
+assertNotEqual(new NoCustomEquals(1, 1), new NoCustomEquals(1, 2));
+// custom equals throws, fallback to structural equality
+assertEqual(new HasCustomEqualsThatThrows(1, 1), new HasCustomEqualsThatThrows(1, 1));
+assertNotEqual(new HasCustomEqualsThatThrows(1, 1), new HasCustomEqualsThatThrows(1, 2));
+// custom equals works, use it
+assertEqual(new HasCustomEquals(1, 1), new HasCustomEquals(1, 1));
+assertEqual(new HasCustomEquals(1, 1), new HasCustomEquals(1, 2));
+assertNotEqual(new HasCustomEquals(1, 1), new HasCustomEquals(2, 1));
+// custom equals defined on object instead of prototype, don't use it
+assertEqual(hasEqualsField, { ...hasEqualsField });
+assertNotEqual(hasEqualsField, hasEqualsField2);
+
 // Equality between Gleam prelude types from different packages
 //
 // The prelude is not global, each package gets one to fit into the JavaScript


### PR DESCRIPTION
If the object has a .equals method, use that to determine equality.
See discussion in gleam-lang/stdlib/pull/328