### PR TITLE
fix: surround erlang:error with parenthesis when piping to todo function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fixed a bug where piping to `todo` would generate invalid code.
+- Fixed a bug where piping to `todo` would generate invalid Erlang code.
 - The `gleam update` command can now be used to update dependency packages to
   their latest versions.
 - Module functions with empty bodies are no longer syntax errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fixed a bug where piping to `todo` would generate invalid code
+- Fixed a bug where piping to `todo` would generate invalid code.
 - The `gleam update` command can now be used to update dependency packages to
   their latest versions.
 - Module functions with empty bodies are no longer syntax errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Fixed a bug where piping to `todo` would generate invalid code
 - The `gleam update` command can now be used to update dependency packages to
   their latest versions.
 - Module functions with empty bodies are no longer syntax errors.

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1249,6 +1249,7 @@ fn docs_args_call<'a>(
 
         TypedExpr::Call { .. }
         | TypedExpr::Fn { .. }
+        | TypedExpr::Todo { .. }
         | TypedExpr::RecordAccess { .. }
         | TypedExpr::TupleIndex { .. } => {
             let args = wrap_args(args);

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__piped.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__piped.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/erlang/tests/todo.rs
+expression: "\n     pub fn main(){\n      \"lets\"\n      |> todo(\"pipe\")\n      |> todo(\"other todo\")\n    }\n    "
+---
+-module(the_app).
+-compile(no_auto_import).
+
+-export([main/0]).
+
+-spec main() -> any().
+main() ->
+    _pipe = <<"lets"/utf8>>,
+    _pipe@1 = (erlang:error(#{gleam_error => todo,
+                              message => <<"pipe"/utf8>>,
+                              module => <<"the_app"/utf8>>,
+                              function => <<"main"/utf8>>,
+                              line => 4}))(_pipe),
+    (erlang:error(#{gleam_error => todo,
+                    message => <<"other todo"/utf8>>,
+                    module => <<"the_app"/utf8>>,
+                    function => <<"main"/utf8>>,
+                    line => 5}))(_pipe@1).
+

--- a/compiler-core/src/erlang/tests/todo.rs
+++ b/compiler-core/src/erlang/tests/todo.rs
@@ -21,3 +21,16 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn piped(){
+  assert_erl!(
+    r#"
+     pub fn main(){
+      "lets"
+      |> todo("pipe")
+      |> todo("other todo")
+    }
+    "#
+  );
+}

--- a/compiler-core/src/erlang/tests/todo.rs
+++ b/compiler-core/src/erlang/tests/todo.rs
@@ -23,14 +23,14 @@ pub fn main() {
 }
 
 #[test]
-fn piped(){
-  assert_erl!(
-    r#"
+fn piped() {
+    assert_erl!(
+        r#"
      pub fn main(){
       "lets"
       |> todo("pipe")
       |> todo("other todo")
     }
     "#
-  );
+    );
 }


### PR DESCRIPTION
surround `erlang:error` function call with parenthesis when piping to `todo` function, making the generated code valid.

fixes #1700