### PR TITLE
Fix root_folder validation

### DIFF
--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -215,15 +215,16 @@ pub fn hello_world_test() {
 }
 
 pub fn create(options: NewOptions, version: &'static str) -> Result<()> {
+    let root_folder = get_foldername(&options.project_root)?;
     let name = if let Some(name) = options.name.clone() {
         name
     } else {
-        get_foldername(&options.project_root)?
+        root_folder.clone()
     }
     .trim()
     .to_string();
     validate_name(&name)?;
-    validate_root_folder(&name)?;
+    validate_root_folder(&root_folder)?;
     let creator = Creator::new(options.clone(), name, version);
 
     creator.run()?;

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -215,16 +215,15 @@ pub fn hello_world_test() {
 }
 
 pub fn create(options: NewOptions, version: &'static str) -> Result<()> {
-    let root_folder = get_foldername(&options.project_root)?;
     let name = if let Some(name) = options.name.clone() {
         name
     } else {
-        root_folder.clone()
+        get_foldername(&options.project_root)?
     }
     .trim()
     .to_string();
     validate_name(&name)?;
-    validate_root_folder(&root_folder)?;
+    validate_root_folder(&options.project_root)?;
     let creator = Creator::new(options.clone(), name, version);
 
     creator.run()?;


### PR DESCRIPTION
If given a `--name`, `gleam new` would validate the name as `PROJECT_ROOT` and not the actual root, 
e.g. `gleam new --name foo bar`, wouldn't work when a folder `foo` is present in the current directory.

This should fix the validation.