### PR TITLE
Serialize build modules & Expose function to get serialized modules in wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,9 @@ name = "vec1"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc1631c774f0f9570797191e01247cbefde789eebfbf128074cb934115a6133"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "version_check"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4.0"
 # Levenshtein string distance for typo suggestions
 strsim = "0.10.0"
 # Data (de)serialisation
-serde = { version = "1.0.130", features = ["derive"] }
+serde = { version = "1.0.130", features = ["derive", "rc"] }
 # Cap'n Proto binary format runtime
 capnp = "0.14.3"
 # Enum trait impl macros
@@ -36,7 +36,7 @@ askama = "0.10.5"
 # Markdown parsing
 pulldown-cmark = { version = "0.8.0", default-features = false }
 # Non-empty vectors
-vec1 = "1.8.0"
+vec1 = { version = "1.8.0", features = ["serde"] }
 # Hex package manager client
 hexpm = "2.0.0"
 # XDG directory locations

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -4,8 +4,8 @@ use crate::type_::{FieldMap, HasType};
 pub type TypedConstant = Constant<Arc<Type>, String>;
 pub type UntypedConstant = Constant<(), ()>;
 
-#[derive(Debug, PartialEq, Clone)]
-pub enum Constant<T, RecordTag> {
+#[derive(Serialize, Debug, PartialEq, Clone)]
+pub enum Constant<T: Serialize, RecordTag: Serialize> {
     Int {
         location: SrcSpan,
         value: String,
@@ -79,7 +79,7 @@ impl HasType for TypedConstant {
     }
 }
 
-impl<A, B> Constant<A, B> {
+impl<A: Serialize, B: Serialize> Constant<A, B> {
     pub fn location(&self) -> SrcSpan {
         match self {
             Constant::Int { location, .. }
@@ -101,7 +101,7 @@ impl<A, B> Constant<A, B> {
     }
 }
 
-impl<A, B> HasLocation for Constant<A, B> {
+impl<A: Serialize, B: Serialize> HasLocation for Constant<A, B> {
     fn location(&self) -> SrcSpan {
         self.location()
     }

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -2,8 +2,9 @@ use super::*;
 use crate::type_::{bool, HasType, Type};
 
 use lazy_static::lazy_static;
+use serde::Serialize;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 pub enum TypedExpr {
     Int {
         location: SrcSpan,

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -2,7 +2,7 @@ use vec1::Vec1;
 
 use super::*;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 pub enum UntypedExpr {
     Int {
         location: SrcSpan,

--- a/compiler-core/src/bit_string.rs
+++ b/compiler-core/src/bit_string.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use crate::ast::{BitStringSegmentOption, SrcSpan};
 use crate::type_::Type;
 use std::sync::Arc;
@@ -6,20 +8,20 @@ use std::sync::Arc;
 //  Public Interface
 //
 
-pub fn type_options_for_value<T>(
+pub fn type_options_for_value<T: Serialize>(
     input_options: &[BitStringSegmentOption<T>],
 ) -> Result<Arc<Type>, Error> {
     type_options(input_options, true, false)
 }
 
-pub fn type_options_for_pattern<T>(
+pub fn type_options_for_pattern<T: Serialize>(
     input_options: &[BitStringSegmentOption<T>],
     must_have_size: bool,
 ) -> Result<Arc<Type>, Error> {
     type_options(input_options, false, must_have_size)
 }
 
-struct SegmentOptionCategories<'a, T> {
+struct SegmentOptionCategories<'a, T: Serialize> {
     typ: Option<&'a BitStringSegmentOption<T>>,
     signed: Option<&'a BitStringSegmentOption<T>>,
     endian: Option<&'a BitStringSegmentOption<T>>,
@@ -27,7 +29,7 @@ struct SegmentOptionCategories<'a, T> {
     size: Option<&'a BitStringSegmentOption<T>>,
 }
 
-impl<T> SegmentOptionCategories<'_, T> {
+impl<T: Serialize> SegmentOptionCategories<'_, T> {
     fn new() -> Self {
         SegmentOptionCategories {
             typ: None,
@@ -58,7 +60,7 @@ impl<T> SegmentOptionCategories<'_, T> {
     }
 }
 
-fn type_options<T>(
+fn type_options<T: Serialize>(
     input_options: &[BitStringSegmentOption<T>],
     value_mode: bool,
     must_have_size: bool,
@@ -245,7 +247,7 @@ fn type_options<T>(
     }
 }
 
-fn is_unicode<T>(opt: &BitStringSegmentOption<T>) -> bool {
+fn is_unicode<T: Serialize>(opt: &BitStringSegmentOption<T>) -> bool {
     use BitStringSegmentOption::*;
 
     matches!(

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -107,7 +107,7 @@ impl Package {
     }
 }
 
-#[derive(Debug)]
+#[derive(Serialize, Debug)]
 pub struct Module {
     pub name: String,
     pub code: String,
@@ -204,7 +204,7 @@ impl<'a> Located<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Debug, Clone, Copy, PartialEq)]
 pub enum Origin {
     Src,
     Test,

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -22,6 +22,7 @@ use heck::ToSnakeCase;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use pattern::pattern;
+use serde::Serialize;
 use std::{char, collections::HashMap, ops::Deref, str::FromStr, sync::Arc};
 
 const INDENT: isize = 4;
@@ -619,7 +620,7 @@ fn expr_segment<'a>(
     )
 }
 
-fn bit_string_segment<'a, Value: 'a, SizeToDoc, UnitToDoc>(
+fn bit_string_segment<'a, Value: 'a + Serialize, SizeToDoc, UnitToDoc>(
     mut document: Document<'a>,
     options: &'a [BitStringSegmentOption<Value>],
     mut size_to_doc: SizeToDoc,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -11,6 +11,7 @@ use crate::{
     Error, Result,
 };
 use itertools::Itertools;
+use serde::Serialize;
 use std::{path::Path, sync::Arc};
 use vec1::Vec1;
 
@@ -305,7 +306,10 @@ impl<'comments> Formatter<'comments> {
         }
     }
 
-    fn const_expr<'a, A, B>(&mut self, value: &'a Constant<A, B>) -> Document<'a> {
+    fn const_expr<'a, A: Serialize, B: Serialize>(
+        &mut self,
+        value: &'a Constant<A, B>,
+    ) -> Document<'a> {
         match value {
             Constant::Int { value, .. } | Constant::Float { value, .. } => value.to_doc(),
 
@@ -529,7 +533,7 @@ impl<'comments> Formatter<'comments> {
             .append("}")
     }
 
-    pub fn external_fn_signature<'a, A>(
+    pub fn external_fn_signature<'a, A: Serialize>(
         &mut self,
         public: bool,
         name: &'a str,
@@ -961,7 +965,7 @@ impl<'comments> Formatter<'comments> {
         }
     }
 
-    pub fn record_constructor<'a, A>(
+    pub fn record_constructor<'a, A: Serialize>(
         &mut self,
         constructor: &'a RecordConstructor<A>,
     ) -> Document<'a> {
@@ -999,7 +1003,7 @@ impl<'comments> Formatter<'comments> {
         commented(doc_comments.append(doc).group(), comments)
     }
 
-    pub fn custom_type<'a, A>(
+    pub fn custom_type<'a, A: Serialize>(
         &mut self,
         public: bool,
         opaque: bool,
@@ -1084,13 +1088,13 @@ impl<'comments> Formatter<'comments> {
         }))
     }
 
-    fn external_fn_arg<'a, A>(&mut self, arg: &'a ExternalFnArg<A>) -> Document<'a> {
+    fn external_fn_arg<'a, A: Serialize>(&mut self, arg: &'a ExternalFnArg<A>) -> Document<'a> {
         let comments = self.pop_comments(arg.location.start);
         let doc = label(&arg.label).append(self.type_ast(&arg.annotation));
         commented(doc.group(), comments)
     }
 
-    fn external_fn_args<'a, A>(&mut self, args: &'a [ExternalFnArg<A>]) -> Document<'a> {
+    fn external_fn_args<'a, A: Serialize>(&mut self, args: &'a [ExternalFnArg<A>]) -> Document<'a> {
         wrap_args(args.iter().map(|e| self.external_fn_arg(e)))
     }
 
@@ -1356,7 +1360,10 @@ impl<'comments> Formatter<'comments> {
         }
     }
 
-    fn constant_call_arg<'a, A, B>(&mut self, arg: &'a CallArg<Constant<A, B>>) -> Document<'a> {
+    fn constant_call_arg<'a, A: Serialize, B: Serialize>(
+        &mut self,
+        arg: &'a CallArg<Constant<A, B>>,
+    ) -> Document<'a> {
         match &arg.label {
             None => self.const_expr(&arg.value),
             Some(s) => s.to_doc().append(": ").append(self.const_expr(&arg.value)),
@@ -1565,7 +1572,7 @@ fn commented<'a, 'comments>(
     }
 }
 
-fn bit_string_segment<Value, Type, ToDoc>(
+fn bit_string_segment<Value: Serialize, Type: Serialize, ToDoc>(
     segment: &BitStringSegment<Value, Type>,
     mut to_doc: ToDoc,
 ) -> Document<'_>
@@ -1582,7 +1589,7 @@ where
     }
 }
 
-fn segment_option<ToDoc, Value>(
+fn segment_option<ToDoc, Value: Serialize>(
     option: &BitStringSegmentOption<Value>,
     mut to_doc: ToDoc,
 ) -> Document<'_>

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use crate::{ast::*, docvec, io::Utf8Writer, line_numbers::LineNumbers, pretty::*};
 use itertools::Itertools;
+use serde::Serialize;
 
 use self::import::{Imports, Member};
 
@@ -432,7 +433,7 @@ impl<'a> Generator<'a> {
         ])
     }
 
-    fn global_external_function<T>(
+    fn global_external_function<T: Serialize>(
         &mut self,
         public: bool,
         name: &'a str,
@@ -473,7 +474,7 @@ impl<'a> Generator<'a> {
     }
 }
 
-fn external_fn_args<T>(arguments: &[ExternalFnArg<T>]) -> Document<'_> {
+fn external_fn_args<T: Serialize>(arguments: &[ExternalFnArg<T>]) -> Document<'_> {
     wrap_args(
         arguments
             .iter()

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -66,6 +66,7 @@ use crate::build::Target;
 use crate::parse::extra::ModuleExtra;
 use error::{LexicalError, ParseError, ParseErrorType};
 use lexer::{LexResult, Spanned};
+use serde::Serialize;
 use std::cmp::Ordering;
 use std::str::FromStr;
 use token::Token;
@@ -2217,7 +2218,7 @@ where
     // thats why these functions take functions
     //
     // patern (: option)?
-    fn parse_bit_string_segment<A>(
+    fn parse_bit_string_segment<A: Serialize>(
         &mut self,
         value_parser: &impl Fn(&mut Self) -> Result<Option<A>, ParseError>,
         arg_parser: &impl Fn(&mut Self) -> Result<A, ParseError>,
@@ -2259,7 +2260,7 @@ where
     //   size(1)
     //   size(five)
     //   utf8
-    fn parse_bit_string_segment_option<A>(
+    fn parse_bit_string_segment_option<A: Serialize>(
         &mut self,
         arg_parser: &impl Fn(&mut Self) -> Result<A, ParseError>,
         to_int_segment: &impl Fn(String, usize, usize) -> A,
@@ -2829,7 +2830,7 @@ fn bit_string_const_int(value: String, start: usize, end: usize) -> UntypedConst
     }
 }
 
-fn str_to_bit_string_segment_option<A>(
+fn str_to_bit_string_segment_option<A: Serialize>(
     lit: &str,
     location: SrcSpan,
 ) -> Option<BitStringSegmentOption<A>> {

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 use crate::ast::SrcSpan;
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Serialize, Debug, PartialEq, Default)]
 pub struct ModuleExtra {
     pub module_comments: Vec<SrcSpan>,
     pub doc_comments: Vec<SrcSpan>,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -529,7 +529,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Ok(Constant::BitString { location, segments })
     }
 
-    fn infer_bit_segment<UntypedValue, TypedValue, InferFn>(
+    fn infer_bit_segment<UntypedValue: Serialize, TypedValue: Serialize, InferFn>(
         &mut self,
         value: UntypedValue,
         options: Vec<BitStringSegmentOption<UntypedValue>>,

--- a/compiler-core/src/type_/fields.rs
+++ b/compiler-core/src/type_/fields.rs
@@ -1,9 +1,10 @@
 use super::Error;
 use crate::ast::{CallArg, SrcSpan};
 use itertools::Itertools;
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct FieldMap {
     pub arity: usize,
     pub fields: HashMap<String, usize>,
@@ -38,7 +39,11 @@ impl FieldMap {
     /// Reorder an argument list so that labelled fields supplied out-of-order are
     /// in the correct order.
     ///
-    pub fn reorder<A>(&self, args: &mut [CallArg<A>], location: SrcSpan) -> Result<(), Error> {
+    pub fn reorder<A: Serialize>(
+        &self,
+        args: &mut [CallArg<A>],
+        location: SrcSpan,
+    ) -> Result<(), Error> {
         let mut labelled_arguments_given = false;
         let mut seen_labels = std::collections::HashSet::new();
         let mut unknown_labels = Vec::new();
@@ -126,7 +131,7 @@ impl FieldMap {
         }
     }
 
-    pub fn incorrect_arity_labels<A>(&self, args: &[CallArg<A>]) -> Vec<String> {
+    pub fn incorrect_arity_labels<A: Serialize>(&self, args: &[CallArg<A>]) -> Vec<String> {
         let given: HashSet<_> = args.iter().filter_map(|arg| arg.label.as_ref()).collect();
 
         self.fields


### PR DESCRIPTION
After building with `wasm-pack build --target no-modules`

This page can console.log the full build ast.

```html
<html>
  <head>
    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
  </head>
  <body>
    <script src="./gleam_wasm.js"></script>

    <script>
      const initialSource = `
pub fn main() {
  42
}`;
      const { init, get_modules, compile } = wasm_bindgen;

      async function run() {
        await wasm_bindgen("./gleam_wasm_bg.wasm");

        const result = init();
        console.log(result);

        const args = {
          target: "javascript",
          sourceFiles: {
            "./src/main.gleam": initialSource,
          },
          dependencies: [],
          mode: "Prod",
        };
        console.error(compile(args));
        console.error(get_modules(args));
      }

      run();
    </script>
  </body>
</html>
``` 

![image](https://user-images.githubusercontent.com/12750442/183782759-6a857511-a497-43f9-bda4-e0270b1e41b2.png)

I'd like to have a tool like this to help with compiler development https://ts-ast-viewer.com/