### PR TITLE
LSP: Don't find node on function call, do find node on assignment, find node when de-structuring

### DIFF
--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -724,7 +724,7 @@ impl LanguageServer {
     fn node_at_position(
         &self,
         params: &lsp::TextDocumentPositionParams,
-    ) -> Option<(LineNumbers, Located<'_>)> {
+    ) -> Option<(LineNumbers, Located)> {
         let module = self.module_for_uri(&params.text_document.uri)?;
         let line_numbers = LineNumbers::new(&module.code);
         let byte_index = line_numbers.byte_index(params.position.line, params.position.character);

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -703,7 +703,7 @@ impl CallArg<TypedExpr> {
 }
 
 impl CallArg<Pattern<PatternConstructor, Arc<Type>>> {
-    pub fn find_node(&self, byte_index: usize, typ: &Type) -> Option<Located<'_>> {
+    pub fn find_node<'a>(&'a self, byte_index: usize, typ: &'a Type) -> Option<Located<'a>> {
         self.value.find_node(byte_index, typ)
     }
 }
@@ -1061,7 +1061,7 @@ impl<A, B> Pattern<A, B> {
 }
 
 impl Pattern<PatternConstructor, Arc<Type>> {
-    pub fn find_node(&self, byte_index: usize, typ: &Type) -> Option<Located<'_>> {
+    pub fn find_node<'a>(&'a self, byte_index: usize, typ: &'a Type) -> Option<Located<'a>> {
         if !self.location().contains(byte_index) {
             return None;
         }
@@ -1070,8 +1070,7 @@ impl Pattern<PatternConstructor, Arc<Type>> {
             Pattern::Int { .. }
             | Pattern::Float { .. }
             | Pattern::String { .. }
-            // TODO: How not to clone the type?
-            | Pattern::Var { .. } => Some(Located::Pattern(self, typ.clone())),
+            | Pattern::Var { .. } => Some(Located::Pattern(self, typ)),
 
             Pattern::Tuple { elems, .. } => match typ {
                 Type::Tuple {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1099,10 +1099,6 @@ impl Pattern<PatternConstructor, Arc<Type>> {
             | Pattern::BitString { .. } => None,
         }
     }
-
-    pub fn definition_location(&self) -> Option<DefinitionLocation<'_>> {
-        todo!("definition_location");
-    }
 }
 
 impl<A, B> HasLocation for Pattern<A, B> {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -44,7 +44,7 @@ impl TypedModule {
 
         for statement in &self.statements {
             if let Some(node) = statement.find_node(byte_index) {
-                return Some(Located::Expression(node));
+                return Some(node);
             }
             in_any_statement = in_any_statement || statement.location().contains(byte_index)
         }
@@ -518,7 +518,7 @@ pub enum Statement<T, Expr, ConstantRecordTag, PackageName> {
 }
 
 impl TypedStatement {
-    pub fn find_node(&self, byte_index: usize) -> Option<&TypedExpr> {
+    pub fn find_node(&self, byte_index: usize) -> Option<Located<'_>> {
         match self {
             Statement::Fn { body, .. } => body.find_node(byte_index),
 
@@ -697,7 +697,7 @@ pub struct CallArg<A> {
 }
 
 impl CallArg<TypedExpr> {
-    pub fn find_node(&self, byte_index: usize) -> Option<&TypedExpr> {
+    pub fn find_node(&self, byte_index: usize) -> Option<Located<'_>> {
         self.value.find_node(byte_index)
     }
 }
@@ -733,7 +733,7 @@ pub struct TypedRecordUpdateArg {
 }
 
 impl TypedRecordUpdateArg {
-    pub fn find_node(&self, byte_index: usize) -> Option<&TypedExpr> {
+    pub fn find_node(&self, byte_index: usize) -> Option<Located<'_>> {
         self.value.find_node(byte_index)
     }
 }
@@ -768,7 +768,7 @@ impl TypedClause {
         }
     }
 
-    pub fn find_node(&self, byte_index: usize) -> Option<&TypedExpr> {
+    pub fn find_node(&self, byte_index: usize) -> Option<Located<'_>> {
         self.then.find_node(byte_index)
     }
 }
@@ -1085,7 +1085,7 @@ pub struct BitStringSegment<Value, Type> {
 }
 
 impl TypedExprBitStringSegment {
-    pub fn find_node(&self, byte_index: usize) -> Option<&TypedExpr> {
+    pub fn find_node(&self, byte_index: usize) -> Option<Located<'_>> {
         self.value.find_node(byte_index)
     }
 }

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    ast::{SrcSpan, TypedExpr},
+    ast::{AssignmentKind, Pattern, SrcSpan, TypedExpr},
     build::Located,
     type_::{
         self, AccessorsMap, Environment, ExprTyper, FieldMap, ModuleValueConstructor,
@@ -334,11 +334,60 @@ fn find_node_call() {
     };
 
     assert_eq!(expr.find_node(11), Some(&retrn));
-    assert_eq!(expr.find_node(14), Some(&expr));
+    assert_eq!(expr.find_node(14), None);
     assert_eq!(expr.find_node(15), Some(&arg1));
-    assert_eq!(expr.find_node(16), Some(&expr));
+    assert_eq!(expr.find_node(16), None);
     assert_eq!(expr.find_node(18), Some(&arg2));
-    assert_eq!(expr.find_node(19), Some(&expr));
+    assert_eq!(expr.find_node(19), None);
+}
+
+#[test]
+fn find_node_assignment() {
+    let expr = compile_expression("let a = 123");
+
+    let assignment = TypedExpr::Assignment {
+        location: SrcSpan { start: 0, end: 11 },
+        typ: Arc::new(Type::App {
+            public: true,
+            module: vec![],
+            name: "Int".to_string(),
+            args: vec![],
+        }),
+        value: Box::new(TypedExpr::Int {
+            location: SrcSpan { start: 8, end: 11 },
+            typ: Arc::new(Type::App {
+                public: true,
+                module: vec![],
+                name: "Int".to_string(),
+                args: vec![],
+            }),
+            value: "123".to_string(),
+        }),
+        pattern: Pattern::Var {
+            location: SrcSpan { start: 4, end: 5 },
+            name: "a".to_string(),
+        },
+        kind: AssignmentKind::Let,
+    };
+
+    let val = TypedExpr::Int {
+        location: SrcSpan { start: 8, end: 11 },
+        value: "123".into(),
+        typ: type_::int(),
+    };
+
+    assert_eq!(expr.find_node(0), Some(&assignment));
+    assert_eq!(expr.find_node(1), Some(&assignment));
+    assert_eq!(expr.find_node(2), Some(&assignment));
+    assert_eq!(expr.find_node(3), Some(&assignment));
+    assert_eq!(expr.find_node(4), Some(&assignment));
+    assert_eq!(expr.find_node(5), Some(&assignment));
+    assert_eq!(expr.find_node(5), Some(&assignment));
+    assert_eq!(expr.find_node(6), Some(&assignment));
+    assert_eq!(expr.find_node(7), Some(&assignment));
+    assert_eq!(expr.find_node(8), Some(&val));
+    assert_eq!(expr.find_node(9), Some(&val));
+    assert_eq!(expr.find_node(10), Some(&val));
 }
 
 #[test]

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    ast::{AssignmentKind, Pattern, SrcSpan, TypedExpr},
+    ast::{SrcSpan, TypedExpr},
     build::Located,
     type_::{
         self, AccessorsMap, Environment, ExprTyper, FieldMap, ModuleValueConstructor,
@@ -105,8 +105,8 @@ fn compile_expression(src: &str) -> TypedExpr {
 fn find_node_todo() {
     let expr = compile_expression(r#" todo "#);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(&expr));
-    assert_eq!(expr.find_node(4), Some(&expr));
+    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(4), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(5), None);
 }
 
@@ -114,8 +114,8 @@ fn find_node_todo() {
 fn find_node_todo_with_string() {
     let expr = compile_expression(r#" todo("ok") "#);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(&expr));
-    assert_eq!(expr.find_node(10), Some(&expr));
+    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(10), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(11), None);
 }
 
@@ -123,8 +123,8 @@ fn find_node_todo_with_string() {
 fn find_node_string() {
     let expr = compile_expression(r#" "ok" "#);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(&expr));
-    assert_eq!(expr.find_node(4), Some(&expr));
+    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(4), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(5), None);
 }
 
@@ -132,8 +132,8 @@ fn find_node_string() {
 fn find_node_float() {
     let expr = compile_expression(r#" 1.02 "#);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(&expr));
-    assert_eq!(expr.find_node(4), Some(&expr));
+    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(4), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(5), None);
 }
 
@@ -141,8 +141,8 @@ fn find_node_float() {
 fn find_node_int() {
     let expr = compile_expression(r#" 1302 "#);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(&expr));
-    assert_eq!(expr.find_node(4), Some(&expr));
+    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(4), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(5), None);
 }
 
@@ -166,8 +166,8 @@ wibble"#,
     };
 
     assert_eq!(expr.find_node(14), None);
-    assert_eq!(expr.find_node(15), Some(&var));
-    assert_eq!(expr.find_node(20), Some(&var));
+    assert_eq!(expr.find_node(15), Some(Located::Expression(&var)));
+    assert_eq!(expr.find_node(20), Some(Located::Expression(&var)));
     assert_eq!(expr.find_node(21), None);
 }
 
@@ -202,15 +202,15 @@ fn find_node_list() {
         value: "3".into(),
     };
 
-    assert_eq!(list.find_node(0), Some(&list));
-    assert_eq!(list.find_node(1), Some(&int1));
-    assert_eq!(list.find_node(2), Some(&list));
-    assert_eq!(list.find_node(3), Some(&list));
-    assert_eq!(list.find_node(4), Some(&int2));
-    assert_eq!(list.find_node(5), Some(&list));
-    assert_eq!(list.find_node(6), Some(&list));
-    assert_eq!(list.find_node(7), Some(&int3));
-    assert_eq!(list.find_node(8), Some(&list));
+    assert_eq!(list.find_node(0), Some(Located::Expression(&list)));
+    assert_eq!(list.find_node(1), Some(Located::Expression(&int1)));
+    assert_eq!(list.find_node(2), Some(Located::Expression(&list)));
+    assert_eq!(list.find_node(3), Some(Located::Expression(&list)));
+    assert_eq!(list.find_node(4), Some(Located::Expression(&int2)));
+    assert_eq!(list.find_node(5), Some(Located::Expression(&list)));
+    assert_eq!(list.find_node(6), Some(Located::Expression(&list)));
+    assert_eq!(list.find_node(7), Some(Located::Expression(&int3)));
+    assert_eq!(list.find_node(8), Some(Located::Expression(&list)));
     assert_eq!(list.find_node(9), None);
 }
 
@@ -234,16 +234,16 @@ fn find_node_tuple() {
         value: "3".into(),
     };
 
-    assert_eq!(tuple.find_node(0), Some(&tuple));
-    assert_eq!(tuple.find_node(1), Some(&tuple));
-    assert_eq!(tuple.find_node(2), Some(&int1));
-    assert_eq!(tuple.find_node(3), Some(&tuple));
-    assert_eq!(tuple.find_node(4), Some(&tuple));
-    assert_eq!(tuple.find_node(5), Some(&int2));
-    assert_eq!(tuple.find_node(6), Some(&tuple));
-    assert_eq!(tuple.find_node(7), Some(&tuple));
-    assert_eq!(tuple.find_node(8), Some(&int3));
-    assert_eq!(tuple.find_node(9), Some(&tuple));
+    assert_eq!(tuple.find_node(0), Some(Located::Expression(&tuple)));
+    assert_eq!(tuple.find_node(1), Some(Located::Expression(&tuple)));
+    assert_eq!(tuple.find_node(2), Some(Located::Expression(&int1)));
+    assert_eq!(tuple.find_node(3), Some(Located::Expression(&tuple)));
+    assert_eq!(tuple.find_node(4), Some(Located::Expression(&tuple)));
+    assert_eq!(tuple.find_node(5), Some(Located::Expression(&int2)));
+    assert_eq!(tuple.find_node(6), Some(Located::Expression(&tuple)));
+    assert_eq!(tuple.find_node(7), Some(Located::Expression(&tuple)));
+    assert_eq!(tuple.find_node(8), Some(Located::Expression(&int3)));
+    assert_eq!(tuple.find_node(9), Some(Located::Expression(&tuple)));
     assert_eq!(tuple.find_node(10), None);
 }
 
@@ -268,9 +268,9 @@ fn find_node_tuple_index() {
         typ: type_::int(),
     };
 
-    assert_eq!(expr.find_node(2), Some(&int));
-    assert_eq!(expr.find_node(4), Some(&expr));
-    assert_eq!(expr.find_node(5), Some(&expr));
+    assert_eq!(expr.find_node(2), Some(Located::Expression(&int)));
+    assert_eq!(expr.find_node(4), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(5), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(6), None);
 }
 
@@ -288,8 +288,8 @@ fn find_node_module_select() {
     };
 
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(&expr));
-    assert_eq!(expr.find_node(2), Some(&expr));
+    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(2), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(3), None);
 }
 
@@ -303,11 +303,11 @@ fn find_node_fn() {
         typ: type_::int(),
     };
 
-    assert_eq!(expr.find_node(0), Some(&expr));
-    assert_eq!(expr.find_node(6), Some(&expr));
-    assert_eq!(expr.find_node(7), Some(&int));
-    assert_eq!(expr.find_node(8), Some(&expr));
-    assert_eq!(expr.find_node(9), Some(&expr));
+    assert_eq!(expr.find_node(0), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(6), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(7), Some(Located::Expression(&int)));
+    assert_eq!(expr.find_node(8), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(9), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(10), None);
 }
 
@@ -333,11 +333,11 @@ fn find_node_call() {
         typ: type_::int(),
     };
 
-    assert_eq!(expr.find_node(11), Some(&retrn));
+    assert_eq!(expr.find_node(11), Some(Located::Expression(&retrn)));
     assert_eq!(expr.find_node(14), None);
-    assert_eq!(expr.find_node(15), Some(&arg1));
+    assert_eq!(expr.find_node(15), Some(Located::Expression(&arg1)));
     assert_eq!(expr.find_node(16), None);
-    assert_eq!(expr.find_node(18), Some(&arg2));
+    assert_eq!(expr.find_node(18), Some(Located::Expression(&arg2)));
     assert_eq!(expr.find_node(19), None);
 }
 
@@ -345,49 +345,24 @@ fn find_node_call() {
 fn find_node_assignment() {
     let expr = compile_expression("let a = 123");
 
-    let assignment = TypedExpr::Assignment {
-        location: SrcSpan { start: 0, end: 11 },
-        typ: Arc::new(Type::App {
-            public: true,
-            module: vec![],
-            name: "Int".to_string(),
-            args: vec![],
-        }),
-        value: Box::new(TypedExpr::Int {
-            location: SrcSpan { start: 8, end: 11 },
-            typ: Arc::new(Type::App {
-                public: true,
-                module: vec![],
-                name: "Int".to_string(),
-                args: vec![],
-            }),
-            value: "123".to_string(),
-        }),
-        pattern: Pattern::Var {
-            location: SrcSpan { start: 4, end: 5 },
-            name: "a".to_string(),
-        },
-        kind: AssignmentKind::Let,
-    };
-
     let val = TypedExpr::Int {
         location: SrcSpan { start: 8, end: 11 },
         value: "123".into(),
         typ: type_::int(),
     };
 
-    assert_eq!(expr.find_node(0), Some(&assignment));
-    assert_eq!(expr.find_node(1), Some(&assignment));
-    assert_eq!(expr.find_node(2), Some(&assignment));
-    assert_eq!(expr.find_node(3), Some(&assignment));
-    assert_eq!(expr.find_node(4), Some(&assignment));
-    assert_eq!(expr.find_node(5), Some(&assignment));
-    assert_eq!(expr.find_node(5), Some(&assignment));
-    assert_eq!(expr.find_node(6), Some(&assignment));
-    assert_eq!(expr.find_node(7), Some(&assignment));
-    assert_eq!(expr.find_node(8), Some(&val));
-    assert_eq!(expr.find_node(9), Some(&val));
-    assert_eq!(expr.find_node(10), Some(&val));
+    assert_eq!(expr.find_node(0), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(2), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(3), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(4), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(5), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(5), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(6), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(7), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(8), Some(Located::Expression(&val)));
+    assert_eq!(expr.find_node(9), Some(Located::Expression(&val)));
+    assert_eq!(expr.find_node(10), Some(Located::Expression(&val)));
 }
 
 #[test]
@@ -406,11 +381,11 @@ fn find_node_record_access() {
         typ: type_::int(),
     };
 
-    assert_eq!(access.find_node(4), Some(&string));
-    assert_eq!(access.find_node(9), Some(&string));
-    assert_eq!(access.find_node(12), Some(&int));
-    assert_eq!(access.find_node(14), Some(&access));
-    assert_eq!(access.find_node(18), Some(&access));
+    assert_eq!(access.find_node(4), Some(Located::Expression(&string)));
+    assert_eq!(access.find_node(9), Some(Located::Expression(&string)));
+    assert_eq!(access.find_node(12), Some(Located::Expression(&int)));
+    assert_eq!(access.find_node(14), Some(Located::Expression(&access)));
+    assert_eq!(access.find_node(18), Some(Located::Expression(&access)));
     assert_eq!(access.find_node(19), None);
 }
 
@@ -424,10 +399,10 @@ fn find_node_record_update() {
         typ: type_::int(),
     };
 
-    assert_eq!(update.find_node(0), Some(&update));
-    assert_eq!(update.find_node(3), Some(&update));
-    assert_eq!(update.find_node(27), Some(&int));
-    assert_eq!(update.find_node(28), Some(&update));
+    assert_eq!(update.find_node(0), Some(Located::Expression(&update)));
+    assert_eq!(update.find_node(3), Some(Located::Expression(&update)));
+    assert_eq!(update.find_node(27), Some(Located::Expression(&int)));
+    assert_eq!(update.find_node(28), Some(Located::Expression(&update)));
     assert_eq!(update.find_node(29), None);
 }
 
@@ -447,9 +422,9 @@ fn find_node_try() {
         typ: type_::int(),
     };
 
-    assert_eq!(try_.find_node(0), Some(&try_));
-    assert_eq!(try_.find_node(11), Some(&int1));
-    assert_eq!(try_.find_node(17), Some(&int2));
+    assert_eq!(try_.find_node(0), Some(Located::Expression(&try_)));
+    assert_eq!(try_.find_node(11), Some(Located::Expression(&int1)));
+    assert_eq!(try_.find_node(17), Some(Located::Expression(&int2)));
     assert_eq!(try_.find_node(19), None);
 }
 
@@ -481,11 +456,11 @@ case 1, 2 {
         typ: type_::int(),
     };
 
-    assert_eq!(case.find_node(1), Some(&case));
-    assert_eq!(case.find_node(6), Some(&int1));
-    assert_eq!(case.find_node(9), Some(&int2));
-    assert_eq!(case.find_node(23), Some(&int3));
-    assert_eq!(case.find_node(25), Some(&case));
+    assert_eq!(case.find_node(1), Some(Located::Expression(&case)));
+    assert_eq!(case.find_node(6), Some(Located::Expression(&int1)));
+    assert_eq!(case.find_node(9), Some(Located::Expression(&int2)));
+    assert_eq!(case.find_node(23), Some(Located::Expression(&int3)));
+    assert_eq!(case.find_node(25), Some(Located::Expression(&case)));
     assert_eq!(case.find_node(26), None);
 }
 
@@ -509,11 +484,11 @@ fn find_node_bool() {
         name: "True".into(),
     };
 
-    assert_eq!(negate.find_node(0), Some(&negate));
-    assert_eq!(negate.find_node(1), Some(&bool));
-    assert_eq!(negate.find_node(2), Some(&bool));
-    assert_eq!(negate.find_node(3), Some(&bool));
-    assert_eq!(negate.find_node(4), Some(&bool));
+    assert_eq!(negate.find_node(0), Some(Located::Expression(&negate)));
+    assert_eq!(negate.find_node(1), Some(Located::Expression(&bool)));
+    assert_eq!(negate.find_node(2), Some(Located::Expression(&bool)));
+    assert_eq!(negate.find_node(3), Some(Located::Expression(&bool)));
+    assert_eq!(negate.find_node(4), Some(Located::Expression(&bool)));
     assert_eq!(negate.find_node(5), None);
 }
 

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -365,7 +365,7 @@ fn find_node_assignment() {
     assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(2), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(3), Some(Located::Expression(&expr)));
-    assert_eq!(expr.find_node(4), Some(Located::Pattern(&ptn, typ)));
+    assert_eq!(expr.find_node(4), Some(Located::Pattern(&ptn, &typ)));
     assert_eq!(expr.find_node(5), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(5), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(6), Some(Located::Expression(&expr)));
@@ -389,7 +389,7 @@ fn find_node_tuple_constructor_assignment() {
         name: "Int".to_string(),
         args: vec![],
     };
-    assert_eq!(module.find_node(54), Some(Located::Pattern(&ptn, typ)));
+    assert_eq!(module.find_node(54), Some(Located::Pattern(&ptn, &typ)));
 }
 
 #[test]
@@ -412,7 +412,7 @@ fn find_node_tuple_assignment() {
     assert_eq!(expr.find_node(4), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(5), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(5), Some(Located::Expression(&expr)));
-    assert_eq!(expr.find_node(6), Some(Located::Pattern(&ptn, typ)));
+    assert_eq!(expr.find_node(6), Some(Located::Pattern(&ptn, &typ)));
 }
 
 #[test]

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -191,14 +191,13 @@ impl TypedExpr {
             Self::Call { fun, args, .. } => args
                 .iter()
                 .find_map(|arg| arg.find_node(byte_index))
-                .or_else(|| fun.find_node(byte_index))
-                .or(Some(self)),
+                .or_else(|| fun.find_node(byte_index)),
 
             Self::BinOp { left, right, .. } => left
                 .find_node(byte_index)
                 .or_else(|| right.find_node(byte_index)),
 
-            Self::Assignment { value, .. } => value.find_node(byte_index),
+            Self::Assignment { value, .. } => value.find_node(byte_index).or(Some(self)),
 
             Self::Try { value, then, .. } => value
                 .find_node(byte_index)

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -186,7 +186,7 @@ impl Module {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Located<'a> {
     Expression(&'a TypedExpr),
-    Pattern(&'a TypedPattern, Type),
+    Pattern(&'a TypedPattern, &'a Type),
 
     /// This variant is returned when the focused location is not within any
     /// statements, in which case let's assume it's going to be an import and

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -202,7 +202,7 @@ impl<'a> Located<'a> {
         match self {
             Self::Expression(expression) => expression.definition_location(),
             Self::OutsideAnyStatement => None,
-            Self::Pattern(pattern, _type) => pattern.definition_location(),
+            Self::Pattern(pattern, _type) => None,
         }
     }
 }

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -12,7 +12,8 @@ pub use self::package_compiler::PackageCompiler;
 pub use self::project_compiler::{Options, ProjectCompiler};
 pub use self::telemetry::Telemetry;
 
-use crate::ast::{DefinitionLocation, TypedExpr, TypedStatement};
+use crate::ast::{DefinitionLocation, TypedExpr, TypedPattern, TypedStatement};
+use crate::type_::Type;
 use crate::{
     ast::{SrcSpan, Statement, TypedModule},
     config::{self, PackageConfig},
@@ -185,6 +186,7 @@ impl Module {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Located<'a> {
     Expression(&'a TypedExpr),
+    Pattern(&'a TypedPattern, Type),
 
     /// This variant is returned when the focused location is not within any
     /// statements, in which case let's assume it's going to be an import and
@@ -200,6 +202,7 @@ impl<'a> Located<'a> {
         match self {
             Self::Expression(expression) => expression.definition_location(),
             Self::OutsideAnyStatement => None,
+            Self::Pattern(pattern, _type) => pattern.definition_location(),
         }
     }
 }

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -129,7 +129,7 @@ impl Module {
         self.origin == Origin::Test
     }
 
-    pub fn find_node(&self, byte_index: usize) -> Option<Located<'_>> {
+    pub fn find_node(&self, byte_index: usize) -> Option<Located> {
         self.ast.find_node(byte_index)
     }
 
@@ -184,9 +184,9 @@ impl Module {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Located<'a> {
-    Expression(&'a TypedExpr),
-    Pattern(&'a TypedPattern, &'a Type),
+pub enum Located {
+    Expression(TypedExpr),
+    Pattern(TypedPattern, Type),
 
     /// This variant is returned when the focused location is not within any
     /// statements, in which case let's assume it's going to be an import and
@@ -197,7 +197,7 @@ pub enum Located<'a> {
     OutsideAnyStatement,
 }
 
-impl<'a> Located<'a> {
+impl Located {
     pub fn definition_location(&self) -> Option<DefinitionLocation<'_>> {
         match self {
             Self::Expression(expression) => expression.definition_location(),

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -726,7 +726,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             let ann_typ = self
                 .type_from_ast(ann)
                 .map(|t| self.instantiate(t, &mut hashmap![]))?;
-            self.unify(ann_typ, value_type)
+            self.unify(ann_typ, value_type.clone())
                 .map_err(|e| convert_unify_error(e, value.type_defining_location()))?;
         }
 
@@ -734,6 +734,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             location,
             typ,
             pattern,
+            pattern_type: value_type,
             value: Box::new(value),
             then: Box::new(then),
         })


### PR DESCRIPTION
It's more what the Rust LSP does...

I constantly mis-hover a function argument, and the LSP shows the call.
I constantly try to create a variable and hover it to inspect the type, but the assignment does not has hover.

This MR fixes both.


Is `find_node` used for important stuff or can it be changed to please the LSP UX?