### PR TITLE
Fix lint warnings from Clippy 1.63.0

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -30,7 +30,7 @@ pub type TypedModule = Module<type_::Module, TypedStatement>;
 
 pub type UntypedModule = Module<(), TargetGroup>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Module<Info, Statements> {
     pub name: Vec<String>,
     pub documentation: Vec<String>,
@@ -204,7 +204,7 @@ impl<A> ExternalFnArg<A> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArgNames {
     Discard { name: String },
     LabelledDiscard { label: String, name: String },
@@ -560,7 +560,7 @@ impl<A, B, C, E> Statement<A, B, C, E> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnqualifiedImport {
     pub location: SrcSpan,
     pub name: String,
@@ -578,7 +578,7 @@ impl UnqualifiedImport {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum Layer {
     Value,
     Type,
@@ -689,7 +689,7 @@ impl BinOp {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CallArg<A> {
     pub label: Option<String>,
     pub location: SrcSpan,
@@ -933,7 +933,7 @@ impl TypedClauseGuard {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub struct SrcSpan {
     pub start: usize,
     pub end: usize,
@@ -945,7 +945,7 @@ impl SrcSpan {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DefinitionLocation<'module> {
     pub module: Option<&'module str>,
     pub span: SrcSpan,
@@ -1059,7 +1059,7 @@ impl<A, B> HasLocation for Pattern<A, B> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssignmentKind {
     Let,
     Assert,
@@ -1076,7 +1076,7 @@ pub type TypedConstantBitStringSegment = BitStringSegment<TypedConstant, Arc<Typ
 pub type UntypedPatternBitStringSegment = BitStringSegment<UntypedPattern, ()>;
 pub type TypedPatternBitStringSegment = BitStringSegment<TypedPattern, Arc<Type>>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BitStringSegment<Value, Type> {
     pub location: SrcSpan,
     pub value: Box<Value>,
@@ -1092,7 +1092,7 @@ impl TypedExprBitStringSegment {
 
 pub type TypedConstantBitStringSegmentOption = BitStringSegmentOption<TypedConstant>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BitStringSegmentOption<Value> {
     Binary {
         location: SrcSpan,

--- a/compiler-core/src/bit_string.rs
+++ b/compiler-core/src/bit_string.rs
@@ -269,7 +269,7 @@ pub struct Error {
     pub error: ErrorType,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ErrorType {
     ConflictingEndiannessOptions { existing_endianness: String },
     ConflictingSignednessOptions { existing_signed: String },

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -23,7 +23,7 @@ fn erlang_target() -> Target {
 
 pub type Dependencies = HashMap<String, Range>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SpdxLicense {
     pub licence: String,
 }
@@ -421,7 +421,7 @@ impl Default for PackageConfig {
     }
 }
 
-#[derive(Deserialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Default, Clone)]
 pub struct ErlangConfig {
     #[serde(default)]
     pub application_start_module: Option<String>,
@@ -429,13 +429,13 @@ pub struct ErlangConfig {
     pub extra_applications: Vec<String>,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Default, Clone, Copy)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub struct JavaScriptConfig {
     #[serde(default)]
     pub typescript_declarations: bool,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Repository {
     GitHub { user: String, repo: String },
@@ -469,20 +469,20 @@ impl Default for Repository {
     }
 }
 
-#[derive(Deserialize, Default, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Default, Debug, PartialEq, Eq, Clone)]
 pub struct Docs {
     #[serde(default)]
     pub pages: Vec<DocsPage>,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct DocsPage {
     pub title: String,
     pub path: String,
     pub source: PathBuf,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Link {
     pub title: String,
     #[serde(with = "uri_serde")]

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -259,7 +259,7 @@ impl From<capnp::NotInSchema> for Error {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InvalidProjectNameReason {
     Format,
     GleamPrefix,
@@ -269,7 +269,7 @@ pub enum InvalidProjectNameReason {
     GleamReservedModule,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum StandardIoAction {
     Read,
     Write,
@@ -284,7 +284,7 @@ impl StandardIoAction {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum FileIoAction {
     Link,
     Open,
@@ -319,7 +319,7 @@ impl FileIoAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileKind {
     File,
     Directory,
@@ -2317,7 +2317,7 @@ fn hint_string_message() -> String {
     wrap("Strings can be joined using the `append` or `concat` functions from the `gleam/string` module")
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Unformatted {
     pub source: PathBuf,
     pub destination: PathBuf,

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -59,7 +59,7 @@ pub async fn publish_package<Http: HttpClient>(
     hexpm::publish_package_response(response).map_err(Error::hex)
 }
 
-#[derive(Debug, strum::EnumString, strum::EnumVariantNames, Clone, Copy, PartialEq)]
+#[derive(Debug, strum::EnumString, strum::EnumVariantNames, Clone, Copy, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
 pub enum RetirementReason {
     Other,

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -50,7 +50,7 @@ pub trait Writer: std::io::Write + Utf8Writer {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct OutputFile {
     pub text: String,
     pub path: PathBuf,

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -14,7 +14,7 @@ use std::{cell::RefCell, collections::HashMap, ffi::OsStr, rc::Rc};
 // Only supports absolute paths. For now. In future we could have a explicit
 // current directory, or say that the current directory is always the root.
 //
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct InMemoryFileSystem {
     files: Rc<RefCell<HashMap<PathBuf, InMemoryFile>>>,
 }
@@ -148,7 +148,7 @@ impl FileSystemReader for InMemoryFileSystem {
 //
 // Not thread safe. The compiler is single threaded, so that's OK.
 //
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct InMemoryFile {
     buffer: Rc<RefCell<Vec<u8>>>,
 }

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -520,7 +520,7 @@ pub fn ts_declaration(
         .pretty_print(80, writer)
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     Unsupported { feature: String, location: SrcSpan },
 }

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -2,13 +2,13 @@ use crate::ast::SrcSpan;
 use crate::error::wrap;
 use heck::{ToSnakeCase, ToUpperCamelCase};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LexicalError {
     pub error: LexicalErrorType,
     pub location: SrcSpan,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LexicalErrorType {
     BadStringEscape,       // string contains an unescaped slash
     DigitOutOfRadix,       // 0x012 , 2 is out of radix
@@ -21,7 +21,7 @@ pub enum LexicalErrorType {
     BadUpname { name: String },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ParseError {
     pub error: ParseErrorType,
     pub location: SrcSpan,
@@ -195,7 +195,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ParseErrorType {
     ExpectedEqual,           // expect "="
     ExpectedExpr,            // after "->" in a case clause

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -1,6 +1,6 @@
 use crate::ast::SrcSpan;
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct ModuleExtra {
     pub module_comments: Vec<SrcSpan>,
     pub doc_comments: Vec<SrcSpan>,
@@ -14,7 +14,7 @@ impl ModuleExtra {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Comment<'a> {
     pub start: usize,
     pub content: &'a str,

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Token {
     Name { name: String },
     UpName { name: String },

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -389,7 +389,7 @@ pub struct Module {
     pub accessors: HashMap<String, AccessorsMap>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PatternConstructor {
     Record {
         name: String,

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -47,7 +47,7 @@ pub struct Environment<'a> {
 }
 
 /// For Keeping track of entity usages and knowing which error to display.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EntityKind {
     PrivateConstant,
     // String here is the type constructor's type name

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -318,7 +318,7 @@ impl Warning {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum UnknownValueConstructorError {
     Variable {
         name: String,
@@ -370,7 +370,7 @@ pub fn convert_get_value_constructor_error(
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum UnknownTypeConstructorError {
     Type {
         name: String,

--- a/compiler-core/src/type_/fields.rs
+++ b/compiler-core/src/type_/fields.rs
@@ -3,7 +3,7 @@ use crate::ast::{CallArg, SrcSpan};
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldMap {
     pub arity: usize,
     pub fields: HashMap<String, usize>,


### PR DESCRIPTION
Fixes this rule https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

It was added today, and the CI job uses the latest version.

That's why https://github.com/gleam-lang/gleam/pull/1725 is red.