### PR TITLE
Build dependency packages managed with Mix (take 2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,7 +199,8 @@ jobs:
       - name: Install Erlang
         uses: erlef/setup-beam@v1.9.0
         with:
-          otp-version: 23.2
+          otp-version: "23.2"
+          elixir-version: "1.13.4"
 
       - name: Download Gleam binary from previous job
         uses: actions/download-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Gleam can now build dependency packages that are managed using Mix.
 - The `gleam publish` command now adds the `priv` directory and any `NOTICE`
   file to the tarball.
 - The `gleam update` command can now be used to update dependency packages to

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -80,6 +80,15 @@ impl gleam_core::io::FileSystemReader for ProjectIO {
                 .collect()
         })
     }
+
+    fn current_dir(&self) -> Result<PathBuf, Error> {
+        std::env::current_dir().map_err(|e| Error::FileIo {
+            action: FileIoAction::Read,
+            kind: FileKind::Directory,
+            path: PathBuf::from("."),
+            err: Some(e.to_string()),
+        })
+    }
 }
 
 impl FileSystemWriter for ProjectIO {

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -124,6 +124,7 @@ pub trait FileSystemReader {
     fn reader(&self, path: &Path) -> Result<WrappedReader, Error>;
     fn is_file(&self, path: &Path) -> bool;
     fn is_directory(&self, path: &Path) -> bool;
+    fn current_dir(&self) -> Result<PathBuf, Error>;
 }
 
 pub trait FileSystemIO: FileSystemWriter + FileSystemReader {}
@@ -356,6 +357,10 @@ pub mod test {
         }
 
         fn read_dir(&self, _path: &Path) -> Result<ReadDir> {
+            unimplemented!()
+        }
+
+        fn current_dir(&self) -> Result<PathBuf, Error> {
             unimplemented!()
         }
     }

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -137,6 +137,10 @@ impl FileSystemReader for InMemoryFileSystem {
 
         Ok(read_dir)
     }
+
+    fn current_dir(&self) -> Result<PathBuf, Error> {
+        Ok(PathBuf::from("/"))
+    }
 }
 
 // An in memory sharable that can be used in place of a real file. It is a

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -106,4 +106,8 @@ impl FileSystemReader for WasmFileSystem {
         tracing::trace!("read_dir {:?}", path);
         self.imfs.read_dir(path)
     }
+
+    fn current_dir(&self) -> Result<PathBuf, Error> {
+        self.imfs.current_dir()
+    }
 }

--- a/test/project_erlang/gleam.toml
+++ b/test/project_erlang/gleam.toml
@@ -6,6 +6,7 @@ gleam_stdlib = "~> 0.18"
 gleam_erlang = "~> 0.5"
 certifi = "~> 2.8" # This is a rebar3 dep that uses files in ./priv
 cowboy = "~> 2.9" # This is a rebar3 dep that uses files in ./ebin
+countries = "~> 1.6" # This is a mix dep that uses files in ./priv
 
 [dev-dependencies]
 first_gleam_publish_package = "> 0.0.0"


### PR DESCRIPTION
Closes #1408 and #1738.

Updated from previous PR to use the method shown in https://github.com/Supersonido/rebar_mix/issues/29 for compiling mix packages (thanks @tsloughter).

Includes an improved and more efficient method of loading core Elixir libraries.