### PR TITLE
Fix CHANGELOG typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 - Gleam can now build dependency packages that are managed using Mix.
 - Compiler performance has been improved by buffering disc writing and by lazily
-  loading TLS certs.
+  loading TLS certs. In testing this doubles performance when compiling the
+  standard library.
 - The `gleam publish` command now adds the `priv` directory and any `NOTICE`
   file to the tarball.
 - The `gleam update` command can now be used to update dependency packages to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Gleam can now build dependency packages that are managed using Mix.
 - Compiler performance has been improved by buffering disc writing and by lazily
   loading TLS certs.
-  compiling the standard library.
 - The `gleam publish` command now adds the `priv` directory and any `NOTICE`
   file to the tarball.
 - The `gleam update` command can now be used to update dependency packages to
@@ -26,7 +25,7 @@
   keyword or a value.
 - Qualifiers are now used when multiple types have the same name in an error
   message.
-- In JavaScript, if an object has defined an `equals` method in it's prototype,
+- In JavaScript, if an object has defined an `equals` method in its prototype,
   Gleam will now use this method when checking for equality.
 - Functions can now be defined and referenced in constant expressions.
 - An error is now raised if the record update syntax is used with a custom type
@@ -47,7 +46,7 @@
   after the case expresson could render incorrect Erlang.
 - Fixed a bug where formatter would strip curly braces around case guards even
   when they are required to specify boolean precedence.
-- Fixed a bug where `gleam new` would not in some situations not validate the
+- Fixed a bug where `gleam new` would in some situations not validate the
   target directory correctly.
 - Fixed a bug where pipes inside record update subjects could generate invalid
   Erlang.


### PR DESCRIPTION
I don't know where `compiling the standard library` comes from ... maybe here half a changelog entry was cut off/out?