### PR TITLE
Fix width of images in gleam docs, so the image scales correctly 

### DIFF
--- a/compiler-core/templates/index.css
+++ b/compiler-core/templates/index.css
@@ -164,6 +164,10 @@ p code {
   max-width: var(--content-width);
 }
 
+.content img {
+  max-width: 100vw;
+}
+
 /* Page header */
 
 .page-header {

--- a/compiler-core/templates/index.css
+++ b/compiler-core/templates/index.css
@@ -165,7 +165,7 @@ p code {
 }
 
 .content img {
-  max-width: 100vw;
+  max-width: 100%;
 }
 
 /* Page header */


### PR DESCRIPTION
From discord:

>  we need to add a max-width or something to doc content 

> 11:33 PM]tynanbe: I think the best you can do might be using regular html for the img and adding something like a width="630" attribute.
[11:34 PM]lilac: that'll mess with how it's displayed on Github. this needs to be fixed at the doc generator level.

>  but max-width: 100% actually looks fine

I ended up implementing the the `max-width:100%` because `max-width:100vw` makes the image not respect the bounds of the parent container

Here's some test screenshots with an example image:
![Screen Shot 2022-10-04 at 8 41 53 PM](https://user-images.githubusercontent.com/4021935/193957706-4eb0ae0a-3b51-4dad-b942-42d21d73a9f6.png)

![Screen Shot 2022-10-04 at 9 04 44 PM](https://user-images.githubusercontent.com/4021935/193957783-ecebf04a-b246-4672-97bd-b57443c19c76.png)

![Screen Shot 2022-10-04 at 9 05 01 PM](https://user-images.githubusercontent.com/4021935/193957804-53e82375-d73d-4416-9f66-093dbf18e8ed.png)


