### PR TITLE
Rename modulo to remainder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
   custom type constructor fields could be formatted incorrectly.
 - Fixed a bug where tail call optimisation could be incorrectly applied when
   compiling to JavaScript in some situations.
-- Fixed a bug where the modulo operator would return NaN results when the right
-  hand side was zero when compiling to JavaScript.
+- Fixed a bug where the remainder operator would return NaN results when the
+  right hand side was zero when compiling to JavaScript.
 - Fixed a bug where images added to HTML documentation via documentation
   comments would not have a max width.
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -627,7 +627,7 @@ pub enum BinOp {
     MultFloat,
     DivInt,
     DivFloat,
-    ModuloInt,
+    RemainderInt,
 
     // Strings
     Concatenate,
@@ -657,7 +657,11 @@ impl BinOp {
             // Pipe is 6
             Self::AddInt | Self::AddFloat | Self::SubInt | Self::SubFloat => 7,
 
-            Self::MultInt | Self::MultFloat | Self::DivInt | Self::DivFloat | Self::ModuloInt => 8,
+            Self::MultInt
+            | Self::MultFloat
+            | Self::DivInt
+            | Self::DivFloat
+            | Self::RemainderInt => 8,
         }
     }
 
@@ -683,7 +687,7 @@ impl BinOp {
             Self::MultFloat => "*.",
             Self::DivInt => "/",
             Self::DivFloat => "/.",
-            Self::ModuloInt => "%",
+            Self::RemainderInt => "%",
             Self::Concatenate => "<>",
         }
     }

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -732,7 +732,7 @@ fn bin_op<'a>(
     env: &mut Env<'a>,
 ) -> Document<'a> {
     let div_zero = match name {
-        BinOp::DivInt | BinOp::ModuloInt => Some("0"),
+        BinOp::DivInt | BinOp::RemainderInt => Some("0"),
         BinOp::DivFloat => Some("0.0"),
         _ => None,
     };
@@ -753,7 +753,7 @@ fn bin_op<'a>(
         BinOp::MultFloat => "*",
         BinOp::DivInt => "div",
         BinOp::DivFloat => "/",
-        BinOp::ModuloInt => "rem",
+        BinOp::RemainderInt => "rem",
         BinOp::Concatenate => return string_concatenate(left, right, env),
     };
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_6.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_6.snap
@@ -1,12 +1,11 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 128
-expression: "pub fn and(x, y) { x && y }\npub fn or(x, y) { x || y }\npub fn modulo(x, y) { x % y }\npub fn fdiv(x, y) { x /. y }\n            "
+expression: "pub fn and(x, y) { x && y }\npub fn or(x, y) { x || y }\npub fn remainder(x, y) { x % y }\npub fn fdiv(x, y) { x /. y }\n            "
 ---
 -module(the_app).
 -compile(no_auto_import).
 
--export(['and'/2, 'or'/2, modulo/2, fdiv/2]).
+-export(['and'/2, 'or'/2, remainder/2, fdiv/2]).
 
 -spec 'and'(boolean(), boolean()) -> boolean().
 'and'(X, Y) ->
@@ -16,8 +15,8 @@ expression: "pub fn and(x, y) { x && y }\npub fn or(x, y) { x || y }\npub fn mod
 'or'(X, Y) ->
     X orelse Y.
 
--spec modulo(integer(), integer()) -> integer().
-modulo(X, Y) ->
+-spec remainder(integer(), integer()) -> integer().
+remainder(X, Y) ->
     case Y of
         0 -> 0;
         Gleam@denominator -> X rem Gleam@denominator

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -165,7 +165,7 @@ fn integration_test1_6() {
     assert_erl!(
         r#"pub fn and(x, y) { x && y }
 pub fn or(x, y) { x || y }
-pub fn modulo(x, y) { x % y }
+pub fn remainder(x, y) { x % y }
 pub fn fdiv(x, y) { x /. y }
             "#
     );

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1451,7 +1451,7 @@ impl<'a> Documentable<'a> for &'a BinOp {
             BinOp::MultFloat => " *. ",
             BinOp::DivInt => " / ",
             BinOp::DivFloat => " /. ",
-            BinOp::ModuloInt => " % ",
+            BinOp::RemainderInt => " % ",
             BinOp::Concatenate => " <> ",
         }
         .to_doc()

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -80,8 +80,8 @@ impl<'a> Generator<'a> {
             self.register_prelude_usage(&mut imports, "throwError", None);
         };
 
-        if self.tracker.int_modulo_used {
-            self.register_prelude_usage(&mut imports, "moduloInt", None);
+        if self.tracker.int_remainder_used {
+            self.register_prelude_usage(&mut imports, "remainderInt", None);
         };
 
         if self.tracker.float_division_used {
@@ -695,7 +695,7 @@ pub(crate) struct UsageTracker {
     pub ok_used: bool,
     pub list_used: bool,
     pub error_used: bool,
-    pub int_modulo_used: bool,
+    pub int_remainder_used: bool,
     pub throw_error_used: bool,
     pub custom_type_used: bool,
     pub int_division_used: bool,

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -855,7 +855,7 @@ impl<'module> Generator<'module> {
             BinOp::SubInt | BinOp::SubFloat => self.print_bin_op(left, right, "-"),
             BinOp::MultInt => self.mult_int(left, right),
             BinOp::MultFloat => self.print_bin_op(left, right, "*"),
-            BinOp::ModuloInt => self.modulo_int(left, right),
+            BinOp::ModuloInt => self.remainder_int(left, right),
             BinOp::DivInt => self.div_int(left, right),
             BinOp::DivFloat => self.div_float(left, right),
         }
@@ -874,11 +874,11 @@ impl<'module> Generator<'module> {
         Ok(docvec!("divideInt", wrap_args([left, right])))
     }
 
-    fn modulo_int<'a>(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
+    fn remainder_int<'a>(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
         let left = self.not_in_tail_position(|gen| gen.expression(left))?;
         let right = self.not_in_tail_position(|gen| gen.expression(right))?;
-        self.tracker.int_modulo_used = true;
-        Ok(docvec!("moduloInt", wrap_args([left, right])))
+        self.tracker.int_remainder_used = true;
+        Ok(docvec!("remainderInt", wrap_args([left, right])))
     }
 
     fn div_float<'a>(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -855,7 +855,7 @@ impl<'module> Generator<'module> {
             BinOp::SubInt | BinOp::SubFloat => self.print_bin_op(left, right, "-"),
             BinOp::MultInt => self.mult_int(left, right),
             BinOp::MultFloat => self.print_bin_op(left, right, "*"),
-            BinOp::ModuloInt => self.remainder_int(left, right),
+            BinOp::RemainderInt => self.remainder_int(left, right),
             BinOp::DivInt => self.div_int(left, right),
             BinOp::DivFloat => self.div_float(left, right),
         }
@@ -1265,7 +1265,7 @@ impl BinOp {
             | BinOp::MultFloat
             | BinOp::DivInt
             | BinOp::DivFloat
-            | BinOp::ModuloInt
+            | BinOp::RemainderInt
             | BinOp::Concatenate => true,
             BinOp::MultInt => false,
         }

--- a/compiler-core/src/javascript/tests/numbers.rs
+++ b/compiler-core/src/javascript/tests/numbers.rs
@@ -146,7 +146,7 @@ fn go() {
 }
 
 #[test]
-fn modulo() {
+fn remainder() {
     assert_js!(
         r#"
 fn go() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__int_operators.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__int_operators.snap
@@ -1,16 +1,15 @@
 ---
 source: compiler-core/src/javascript/tests/numbers.rs
-assertion_line: 37
 expression: "\nfn go() {\n    1 + 1 // => 2\n    5 - 1 // => 4\n    5 / 2 // => 2\n    3 * 3 // => 9\n    5 % 2 // => 1\n    2 > 1  // => True\n    2 < 1  // => False\n    2 >= 1 // => True\n    2 <= 1 // => False\n}\n"
 ---
-import { moduloInt, divideInt } from "../gleam.mjs";
+import { remainderInt, divideInt } from "../gleam.mjs";
 
 function go() {
   1 + 1;
   5 - 1;
   divideInt(5, 2);
   Math.imul(3, 3);
-  moduloInt(5, 2);
+  remainderInt(5, 2);
   2 > 1;
   2 < 1;
   2 >= 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__remainder.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__remainder.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/javascript/tests/numbers.rs
+expression: "\nfn go() {\n  5 % 0 // => 0\n}\n"
+---
+import { remainderInt } from "../gleam.mjs";
+
+function go() {
+  return remainderInt(5, 0);
+}
+

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2727,7 +2727,7 @@ fn tok_to_binop(t: &Token) -> Option<BinOp> {
         Token::Minus => Some(BinOp::SubInt),
         Token::PlusDot => Some(BinOp::AddFloat),
         Token::MinusDot => Some(BinOp::SubFloat),
-        Token::Percent => Some(BinOp::ModuloInt),
+        Token::Percent => Some(BinOp::RemainderInt),
         Token::Star => Some(BinOp::MultInt),
         Token::StarDot => Some(BinOp::MultFloat),
         Token::Slash => Some(BinOp::DivInt),

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -613,7 +613,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             BinOp::MultFloat => (float(), float()),
             BinOp::DivInt => (int(), int()),
             BinOp::DivFloat => (float(), float()),
-            BinOp::ModuloInt => (int(), int()),
+            BinOp::RemainderInt => (int(), int()),
             BinOp::Concatenate => (string(), string()),
         };
 

--- a/compiler-core/templates/prelude.d.ts
+++ b/compiler-core/templates/prelude.d.ts
@@ -72,7 +72,7 @@ export function inspect(value: any): string;
 
 export function isEqual(a: any, b: any): boolean;
 
-export function moduloInt(a: number, b: number): number;
+export function remainderInt(a: number, b: number): number;
 
 export function divideInt(a: number, b: number): number;
 

--- a/compiler-core/templates/prelude.js
+++ b/compiler-core/templates/prelude.js
@@ -386,7 +386,7 @@ function structurallyCompatibleObjects(a, b) {
   );
 }
 
-export function moduloInt(a, b) {
+export function remainderInt(a, b) {
   if (b === 0) {
     return 0;
   } else {

--- a/test/language/src/main.gleam
+++ b/test/language/src/main.gleam
@@ -1172,7 +1172,7 @@ fn remainder_tests() -> List(Test) {
     "13 % -3"
     |> example(fn() { assert_equal(1, 13 % -3) }),
     "-13 % -3"
-    |> example(fn() { assert_equal(-1, 13 % -3) }),
+    |> example(fn() { assert_equal(-1, -13 % -3) }),
   ]
 }
 

--- a/test/language/src/main.gleam
+++ b/test/language/src/main.gleam
@@ -33,7 +33,7 @@ pub fn main() -> Int {
       suite("call returned function", call_returned_function_tests()),
       suite("floats", floats_tests()),
       suite("ints", ints_tests()),
-      suite("modulo", modulo_tests()),
+      suite("remainder", remainder_tests()),
       suite("mod with numbers", mod_with_numbers_tests()),
       suite("record update", record_update_tests()),
       suite("record access", record_access_tests()),
@@ -1152,7 +1152,7 @@ fn ints_tests() -> List(Test) {
   ]
 }
 
-fn modulo_tests() -> List(Test) {
+fn remainder_tests() -> List(Test) {
   [
     "1 % 1"
     |> example(fn() { assert_equal(0, 1 % 1) }),
@@ -1166,6 +1166,13 @@ fn modulo_tests() -> List(Test) {
     |> example(fn() { assert_equal(1, 3 % -2) }),
     "3 % -0"
     |> example(fn() { assert_equal(0, 3 % -0) }),
+
+    "-13 % 3"
+    |> example(fn() { assert_equal(-1, -13 % 3) }),
+    "13 % -3"
+    |> example(fn() { assert_equal(1, 13 % -3) }),
+    "-13 % -3"
+    |> example(fn() { assert_equal(-1, 13 % -3) }),
   ]
 }
 


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/gleam/commit/7d1ebf20a7f96f36d63c5f182a9cfd2be1d47336#commitcomment-86422710

How would I run these gleam tests locally: https://github.com/gleam-lang/gleam/compare/main...inoas:gleam-src:rename-modulo-to-remainder?expand=1#diff-9d3bd960f2c78cd4cc676f5d6d004518bef3e64b47c22cc012db04608140ca3aR1171-R1175

Edit: I was told `make test` :)

