### PR TITLE
Fix minor typo

### DIFF
--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -13,7 +13,7 @@ use std::{
 use tar::{Archive, Entry};
 
 pub trait Reader: std::io::Read {
-    /// A wrapper around `std::io::Write` that has Gleam's error handling.
+    /// A wrapper around `std::io::Read` that has Gleam's error handling.
     fn read_bytes(&mut self, buffer: &mut [u8]) -> Result<usize> {
         self.read(buffer).map_err(|e| self.convert_err(e))
     }


### PR DESCRIPTION
Just a minor thing I noticed while reading the source code.

The text ` /// A wrapper around std::io::Write that has Gleam's error handling.` 
should be `/// A wrapper around std::io::Read that has Gleam's error handling.`