### PR TITLE
Correctly record public information

### DIFF
--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -64,7 +64,7 @@ fn compile_expression(src: &str) -> TypedExpr {
         }),
         module: "mymod".into(),
     };
-    environment.insert_module_variable(
+    environment.insert_variable(
         "Cat".into(),
         variant,
         type_::fn_(vec![type_::string(), type_::int()], cat_type.clone()),

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -64,10 +64,11 @@ fn compile_expression(src: &str) -> TypedExpr {
         }),
         module: "mymod".into(),
     };
-    environment.insert_variable(
+    environment.insert_module_variable(
         "Cat".into(),
         variant,
         type_::fn_(vec![type_::string(), type_::int()], cat_type.clone()),
+        true
     );
 
     environment.insert_accessors(

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -68,7 +68,7 @@ fn compile_expression(src: &str) -> TypedExpr {
         "Cat".into(),
         variant,
         type_::fn_(vec![type_::string(), type_::int()], cat_type.clone()),
-        true
+        true,
     );
 
     environment.insert_accessors(

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -785,7 +785,7 @@ fn register_values<'a>(
             let _ = hydrators.insert(name.clone(), hydrator);
 
             // Insert the function into the environment
-            environment.insert_variable(
+            environment.insert_module_variable(
                 name.clone(),
                 ValueConstructorVariant::ModuleFn {
                     name: name.clone(),
@@ -795,6 +795,7 @@ fn register_values<'a>(
                     location: *location,
                 },
                 typ,
+                *public,
             );
             if !public {
                 environment.init_usage(name.clone(), EntityKind::PrivateFunction, *location);
@@ -854,7 +855,7 @@ fn register_values<'a>(
             );
 
             // Insert function into module's internal scope
-            environment.insert_variable(
+            environment.insert_module_variable(
                 name.clone(),
                 ValueConstructorVariant::ModuleFn {
                     name: fun.clone(),
@@ -864,6 +865,7 @@ fn register_values<'a>(
                     location: *location,
                 },
                 typ,
+                *public,
             );
             if !public {
                 environment.init_usage(name.clone(), EntityKind::PrivateFunction, *location);
@@ -959,7 +961,7 @@ fn register_values<'a>(
                     );
                 }
 
-                environment.insert_variable(constructor.name.clone(), constructor_info, typ);
+                environment.insert_module_variable(constructor.name.clone(), constructor_info, typ, *public);
             }
         }
 
@@ -1098,7 +1100,7 @@ fn infer_statement(
             let typ = if safe_to_generalise {
                 let _ = environment.ungeneralised_functions.remove(&name);
                 let typ = generalise(typ, 0);
-                environment.insert_variable(
+                environment.insert_module_variable(
                     name.clone(),
                     ValueConstructorVariant::ModuleFn {
                         name: name.clone(),
@@ -1108,6 +1110,7 @@ fn infer_statement(
                         location,
                     },
                     typ.clone(),
+                    public,
                 );
                 typ
             } else {
@@ -1350,7 +1353,7 @@ fn infer_statement(
                 type_: type_.clone(),
             };
 
-            environment.insert_variable(name.clone(), variant.variant.clone(), type_.clone());
+            environment.insert_module_variable(name.clone(), variant.variant.clone(), type_.clone(), public);
             environment.insert_module_value(&name, variant);
 
             if !public {
@@ -1873,10 +1876,11 @@ pub fn register_import(
 
                 // Register the unqualified import if it is a value
                 if let Some(value) = module_info.values.get(name) {
-                    environment.insert_variable(
+                    environment.insert_module_variable(
                         imported_name.clone(),
                         value.variant.clone(),
                         value.type_.clone(),
+                        true,
                     );
                     variant = Some(&value.variant);
                     value_imported = true;

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -961,7 +961,12 @@ fn register_values<'a>(
                     );
                 }
 
-                environment.insert_variable(constructor.name.clone(), constructor_info, typ, *public);
+                environment.insert_variable(
+                    constructor.name.clone(),
+                    constructor_info,
+                    typ,
+                    *public,
+                );
             }
         }
 
@@ -1353,7 +1358,12 @@ fn infer_statement(
                 type_: type_.clone(),
             };
 
-            environment.insert_variable(name.clone(), variant.variant.clone(), type_.clone(), public);
+            environment.insert_variable(
+                name.clone(),
+                variant.variant.clone(),
+                type_.clone(),
+                public,
+            );
             environment.insert_module_value(&name, variant);
 
             if !public {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -785,7 +785,7 @@ fn register_values<'a>(
             let _ = hydrators.insert(name.clone(), hydrator);
 
             // Insert the function into the environment
-            environment.insert_module_variable(
+            environment.insert_variable(
                 name.clone(),
                 ValueConstructorVariant::ModuleFn {
                     name: name.clone(),
@@ -855,7 +855,7 @@ fn register_values<'a>(
             );
 
             // Insert function into module's internal scope
-            environment.insert_module_variable(
+            environment.insert_variable(
                 name.clone(),
                 ValueConstructorVariant::ModuleFn {
                     name: fun.clone(),
@@ -961,7 +961,7 @@ fn register_values<'a>(
                     );
                 }
 
-                environment.insert_module_variable(constructor.name.clone(), constructor_info, typ, *public);
+                environment.insert_variable(constructor.name.clone(), constructor_info, typ, *public);
             }
         }
 
@@ -1100,7 +1100,7 @@ fn infer_statement(
             let typ = if safe_to_generalise {
                 let _ = environment.ungeneralised_functions.remove(&name);
                 let typ = generalise(typ, 0);
-                environment.insert_module_variable(
+                environment.insert_variable(
                     name.clone(),
                     ValueConstructorVariant::ModuleFn {
                         name: name.clone(),
@@ -1353,7 +1353,7 @@ fn infer_statement(
                 type_: type_.clone(),
             };
 
-            environment.insert_module_variable(name.clone(), variant.variant.clone(), type_.clone(), public);
+            environment.insert_variable(name.clone(), variant.variant.clone(), type_.clone(), public);
             environment.insert_module_value(&name, variant);
 
             if !public {
@@ -1876,7 +1876,7 @@ pub fn register_import(
 
                 // Register the unqualified import if it is a value
                 if let Some(value) = module_info.values.get(name) {
-                    environment.insert_module_variable(
+                    environment.insert_variable(
                         imported_name.clone(),
                         value.variant.clone(),
                         value.type_.clone(),

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -170,6 +170,25 @@ impl<'a> Environment<'a> {
         );
     }
 
+    /// Insert a variable in the current scope.
+    ///
+    pub fn insert_module_variable(
+        &mut self,
+        name: String,
+        variant: ValueConstructorVariant,
+        typ: Arc<Type>,
+        public: bool
+    ) {
+        let _ = self.scope.insert(
+            name,
+            ValueConstructor {
+                public,
+                variant,
+                type_: typ,
+            },
+        );
+    }
+
     /// Insert a value into the current module.
     /// Errors if the module already has a value with that name.
     ///

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -154,12 +154,7 @@ impl<'a> Environment<'a> {
 
     /// Insert a variable in the current scope.
     ///
-    pub fn insert_local_variable(
-        &mut self,
-        name: String,
-        location: SrcSpan,
-        typ: Arc<Type>,
-    ) {
+    pub fn insert_local_variable(&mut self, name: String, location: SrcSpan, typ: Arc<Type>) {
         let _ = self.scope.insert(
             name,
             ValueConstructor {
@@ -177,7 +172,7 @@ impl<'a> Environment<'a> {
         name: String,
         variant: ValueConstructorVariant,
         typ: Arc<Type>,
-        public: bool
+        public: bool,
     ) {
         let _ = self.scope.insert(
             name,

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -154,17 +154,17 @@ impl<'a> Environment<'a> {
 
     /// Insert a variable in the current scope.
     ///
-    pub fn insert_variable(
+    pub fn insert_local_variable(
         &mut self,
         name: String,
-        variant: ValueConstructorVariant,
+        location: SrcSpan,
         typ: Arc<Type>,
     ) {
         let _ = self.scope.insert(
             name,
             ValueConstructor {
                 public: false,
-                variant,
+                variant: ValueConstructorVariant::LocalVariable { location },
                 type_: typ,
             },
         );
@@ -172,7 +172,7 @@ impl<'a> Environment<'a> {
 
     /// Insert a variable in the current scope.
     ///
-    pub fn insert_module_variable(
+    pub fn insert_variable(
         &mut self,
         name: String,
         variant: ValueConstructorVariant,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1948,11 +1948,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             for (arg, t) in args.iter().zip(args.iter().map(|arg| arg.type_.clone())) {
                 match &arg.names {
                     ArgNames::Named { name } | ArgNames::NamedLabelled { name, .. } => {
-                        body_typer.environment.insert_variable(
+                        body_typer.environment.insert_local_variable(
                             name.to_string(),
-                            ValueConstructorVariant::LocalVariable {
-                                location: arg.location,
-                            },
+                            arg.location,
                             t,
                         );
                         body_typer.environment.init_usage(

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -53,9 +53,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 let _ = self.initial_pattern_vars.insert(name.to_string());
                 // And now insert the variable for use in the code that comes
                 // after the pattern.
-                self.environment.insert_variable(
+                self.environment.insert_local_variable(
                     name.to_string(),
-                    ValueConstructorVariant::LocalVariable { location },
+                    location,
                     typ,
                 );
                 Ok(())

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -53,11 +53,8 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 let _ = self.initial_pattern_vars.insert(name.to_string());
                 // And now insert the variable for use in the code that comes
                 // after the pattern.
-                self.environment.insert_local_variable(
-                    name.to_string(),
-                    location,
-                    typ,
-                );
+                self.environment
+                    .insert_local_variable(name.to_string(), location, typ);
                 Ok(())
             }
 

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -153,9 +153,9 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
     fn push_assignment_no_update(&mut self, expression: TypedExpr) {
         let location = expression.location();
         // Insert the variable for use in type checking the rest of the pipeline
-        self.expr_typer.environment.insert_variable(
+        self.expr_typer.environment.insert_local_variable(
             PIPE_VARIABLE.to_string(),
-            ValueConstructorVariant::LocalVariable { location },
+            location,
             expression.type_(),
         );
         // Add the assignment to the AST


### PR DESCRIPTION
Module level variables were being recorded as false unconditionally, which is not true. This fixes the issue by introducing a new `insert_module_variable` function that allows specifying if the variable is public/private and using that in the correct places. 
