### PR TITLE
feat: Only run CI when rust code changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: ci
 on:
   pull_request:
+    paths:
+      - "./compiler-cli/**"
+      - "./compiler-core/**"
+      - "./compiler-wasm/**"
+      - "./test/**"
+      - "Cargo.toml"
   push:
     branches:
       - main
@@ -113,7 +119,7 @@ jobs:
           ./build/erlang-shipment/entrypoint.sh run
         working-directory: ./test/project_erlang
         # erlang-shipment does not support Windows
-        if: ${{ matrix.os != 'windows-latest' && matrix.run-integration-tests }} 
+        if: ${{ matrix.os != 'windows-latest' && matrix.run-integration-tests }}
 
       - name: test/project_javascript
         run: |
@@ -305,4 +311,3 @@ jobs:
       - name: Test JavaScript prelude
         run: make
         working-directory: ./test/javascript_prelude
-


### PR DESCRIPTION
Only run the Compiler CI when the compiler code has been changed. Saves on CI minutes and means that PRs that don't affect the compiler don't have to wait for the compiler tests.