### PR TITLE
bitstring allow float sizes

### DIFF
--- a/compiler-core/src/bit_string.rs
+++ b/compiler-core/src/bit_string.rs
@@ -234,15 +234,7 @@ fn type_options<T>(
         return err(ErrorType::UnitMustHaveSize, unit.location());
     }
 
-    // size cannot be used with float
-    match categories {
-        SegmentOptionCategories {
-            typ: Some(Float { .. }),
-            size: Some(opt),
-            ..
-        } => err(ErrorType::FloatWithSize, opt.location()),
-        _ => Ok(categories.segment_type()),
-    }
+    Ok(categories.segment_type())
 }
 
 fn is_unicode<T>(opt: &BitStringSegmentOption<T>) -> bool {

--- a/compiler-core/src/erlang/tests/bit_strings.rs
+++ b/compiler-core/src/erlang/tests/bit_strings.rs
@@ -9,7 +9,8 @@ fn bit_strings() {
   let complex = <<4:int-big, 5.0:little-float, 6:native-int>>
   let <<7:2, 8:size(3), b:binary-size(4)>> = <<1>>
   let <<c:8-unit(1), d:binary-size(2)-unit(2)>> = <<1>>
-
+  let floats = <<1.0:16-float, 5.0:float-16, 6.0:float-64-little>>
+ 
   simple
 }
 "#

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_strings__bit_strings.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_strings__bit_strings.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler-core/src/erlang/tests/bit_strings.rs
 assertion_line: 5
-expression: "pub fn main() {\n  let a = 1\n  let simple = <<1, a>>\n  let complex = <<4:int-big, 5.0:little-float, 6:native-int>>\n  let <<7:2, 8:size(3), b:binary-size(4)>> = <<1>>\n  let <<c:8-unit(1), d:binary-size(2)-unit(2)>> = <<1>>\n\n  simple\n}\n"
+expression: "pub fn main() {\n  let a = 1\n  let simple = <<1, a>>\n  let complex = <<4:int-big, 5.0:little-float, 6:native-int>>\n  let <<7:2, 8:size(3), b:binary-size(4)>> = <<1>>\n  let <<c:8-unit(1), d:binary-size(2)-unit(2)>> = <<1>>\n  let floats = <<1.0:16-float, 5.0:float-16, 6.0:float-64-little>>\n \n  simple\n}\n"
 ---
 -module(the_app).
 -compile(no_auto_import).
@@ -15,5 +15,6 @@ main() ->
     Complex = <<4/integer-big, 5.0/little-float, 6/native-integer>>,
     <<7:2, 8:3, B:4/binary>> = <<1>>,
     <<C:8/unit:1, D:2/binary-unit:2>> = <<1>>,
+    Floats = <<1.0:16/float, 5.0:16/float, 6.0:64/float-little>>,
     Simple.
 

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -184,12 +184,6 @@ fn bit_string_size_not_int_variable() {
 }
 
 #[test]
-fn bit_string_float_size() {
-    // float given size
-    assert_error!("let x = <<1:8-float>> x");
-}
-
-#[test]
 fn bit_string_binary_option_in_value() {
     // using binary in value
     assert_error!("let x = <<<<1:1>>:binary>> x");


### PR DESCRIPTION
change the test, add 16/32/64 so it always work, dynamic size(from variable) is also allowed on erlang