### PR TITLE
Update nightly-build action and BEAM setup action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           profile: minimal
 
       - name: Install Erlang (non-macos)
-        uses: erlef/setup-beam@v1.13.0
+        uses: erlef/setup-beam@v1.14.0
         with:
           otp-version: "25.1"
           elixir-version: "1.14.1"
@@ -282,7 +282,7 @@ jobs:
         uses: actions/checkout@v3.0.0
 
       - name: Install Erlang
-        uses: erlef/setup-beam@v1.13.0
+        uses: erlef/setup-beam@v1.14.0
         with:
           otp-version: "25.1"
           elixir-version: "1.14.1"

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -23,7 +23,7 @@ jobs:
         continue-on-error: true
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "should_run=false" >> $GITHUB_OUTPUT
 
   build-nightly-clean:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Generated HTML documentation now includes all static assets (but the web
   fonts), so that it can be accessed offline or in far future once CDNs would
   404.
+- Updated the deprecated actions on nightly builds action and updated the BEAM
+  setup action on CI to erlef/setup-beam@v1.14.0.
+- New Gleam projects are created using GitHub actions erlef/setup-beam@v1.14.0
 
 ## 0.24.0 - 2022-10-25
 

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.0
-      - uses: erlef/setup-beam@v1.13.0
+      - uses: erlef/setup-beam@v1.14.0
         with:
           otp-version: "{}"
           gleam-version: "{}"


### PR DESCRIPTION
Upgraded the `set-ouput` deprecated command to use instead the env files as described on the GHA update guide [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). I'm not sure on the best way to test this but I've tested a similar action with the env file on a personal private repo to be sure it worked.

Also upgraded the BEAM setup action to the latest one which also gets rid of this warning on the action (as can be seen [here](https://github.com/erlef/setup-beam/releases/tag/v1.14.0)).

This work is related to #1847 