### PR TITLE
Update use of set-output on release-containers workflow

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -50,10 +50,10 @@ jobs:
           # Build container tag
           TAG=ghcr.io/${{ github.repository }}:$PLATFORM_VERSION
 
-          echo "::set-output name=v_version::$V_VERSION"
-          echo "::set-output name=bare_version::$BARE_VERSION"
-          echo "::set-output name=platform_version::$PLATFORM_VERSION"
-          echo "::set-output name=container_tag::$TAG"
+          echo "v_version=$V_VERSION" >> $GITHUB_OUTPUT
+          echo "bare_version=$BARE_VERSION" >> $GITHUB_OUTPUT
+          echo "platform_version=$PLATFORM_VERSION" >> $GITHUB_OUTPUT
+          echo "container_tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Download Gleam archive from GitHub release
         run: |


### PR DESCRIPTION
`set-output` is also used on the release containers flow. Maybe this could be merged tomorrow after seeing the nightly build works as expected with the new format.

Related to #1847 