### PR TITLE
Add a zero to floats ending with . when formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   fonts), so that it can be accessed offline or in far future once CDNs would
   404.
 - New Gleam projects are created using GitHub actions erlef/setup-beam@v1.14.0
+- The formatter now adds a 0 to floats ending with `.` (ie 1. => 1.0).
 
 ## 0.24.0 - 2022-10-25
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -653,7 +653,7 @@ impl<'comments> Formatter<'comments> {
 
             UntypedExpr::Int { value, .. } => value.to_doc(),
 
-            UntypedExpr::Float { value, .. } => value.to_doc(),
+            UntypedExpr::Float { value, .. } => self.float(value),
 
             UntypedExpr::String { value, .. } => self.string(value),
 
@@ -749,6 +749,16 @@ impl<'comments> Formatter<'comments> {
         let doc = string.to_doc().surround("\"", "\"");
         if string.contains('\n') {
             doc.force_break()
+        } else {
+            doc
+        }
+    }
+
+    fn float<'a>(&self, value: &'a String) -> Document<'a> {
+        let doc = value.to_doc();
+        if value.ends_with('.') {
+            let suffix = "0".to_doc();
+            doc.append(suffix)
         } else {
             doc
         }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -1063,6 +1063,17 @@ fn expr_int() {
 
 #[test]
 fn expr_float() {
+    assert_format_rewrite!(
+        r#"fn main() {
+  1.
+}
+"#,
+        r#"fn main() {
+  1.0
+}
+"#
+    );
+
     assert_format!(
         r#"fn main() {
   1.0


### PR DESCRIPTION
Added a new `float` fn to the formatter which adds a `0` if the float ends with `.`.

Should close #1843 