### PR TITLE
0.25 RC Docs gen: BugFix highlightJS for Elixir and further langs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
   the entire project rather than just the top level package.
 - The formatter now adds a 0 to floats ending with `.` (ie 1. => 1.0).
 - New projects require `gleam_stdlib` v0.25.
-- Fixed a regression where Elixir and Erlang markdown code blocks in generated
+- Fixed a regression where Elixir and Erlang Markdown code blocks in generated
   docs would not be highlighted.
 
 ## 0.24.0 - 2022-10-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.25.0-rc2 - unreleased
+
+- Fixed a regression where Elixir and Erlang Markdown code blocks in generated
+  documentation would not be highlighted.
+
 ## v0.25.0-rc1 - 2022-11-19
 
 - Generated HTML documentation now includes the `theme-color` HTML meta tag.
@@ -26,8 +31,6 @@
   the entire project rather than just the top level package.
 - The formatter now adds a 0 to floats ending with `.` (ie 1. => 1.0).
 - New projects require `gleam_stdlib` v0.25.
-- Fixed a regression where Elixir and Erlang Markdown code blocks in generated
-  documentation would not be highlighted.
 
 ## 0.24.0 - 2022-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - The formatter now adds a 0 to floats ending with `.` (ie 1. => 1.0).
 - New projects require `gleam_stdlib` v0.25.
 - Fixed a regression where Elixir and Erlang Markdown code blocks in generated
-  docs would not be highlighted.
+  documentation would not be highlighted.
 
 ## 0.24.0 - 2022-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   the entire project rather than just the top level package.
 - The formatter now adds a 0 to floats ending with `.` (ie 1. => 1.0).
 - New projects require `gleam_stdlib` v0.25.
+- Fixed a regression where Elixir and Erlang markdown code blocks in generated
+  docs would not be highlighted.
 
 ## 0.24.0 - 2022-10-25
 

--- a/compiler-core/templates/docs-js/highlightjs-gleam.js
+++ b/compiler-core/templates/docs-js/highlightjs-gleam.js
@@ -101,9 +101,3 @@ hljs.registerLanguage("gleam", function (hljs) {
     ],
   };
 });
-document.querySelectorAll("pre code").forEach((block) => {
-  if (block.className === "") {
-    block.classList.add("gleam");
-  }
-  hljs.highlightBlock(block);
-});

--- a/compiler-core/templates/docs-js/index.js
+++ b/compiler-core/templates/docs-js/index.js
@@ -607,3 +607,5 @@ window.Gleam = (function () {
 
   return self;
 })();
+
+hljs.highlightAll();

--- a/compiler-core/templates/docs-js/index.js
+++ b/compiler-core/templates/docs-js/index.js
@@ -607,5 +607,3 @@ window.Gleam = (function () {
 
   return self;
 })();
-
-hljs.highlightAll();

--- a/compiler-core/templates/documentation_layout.html
+++ b/compiler-core/templates/documentation_layout.html
@@ -291,6 +291,7 @@
     <script src="{{ unnest }}/js/highlightjs-erlang.min.js?v={{ gleam_version }}"></script>
     <script src="{{ unnest }}/js/highlightjs-elixir.min.js?v={{ gleam_version }}"></script>
     <script src="{{ unnest }}/js/highlightjs-javascript.min.js?v={{ gleam_version }}"></script>
+    <script>hljs.highlightAll();</script>
     <script src="{{ unnest }}/js/lunr.min.js?v={{ gleam_version }}"></script>    
     <script src="{{ unnest }}/js/index.js?v={{ rendering_timestamp }}"></script>
 

--- a/compiler-core/templates/documentation_layout.html
+++ b/compiler-core/templates/documentation_layout.html
@@ -291,7 +291,14 @@
     <script src="{{ unnest }}/js/highlightjs-erlang.min.js?v={{ gleam_version }}"></script>
     <script src="{{ unnest }}/js/highlightjs-elixir.min.js?v={{ gleam_version }}"></script>
     <script src="{{ unnest }}/js/highlightjs-javascript.min.js?v={{ gleam_version }}"></script>
-    <script>hljs.highlightAll();</script>
+    <script>
+      document.querySelectorAll("pre code").forEach((elem) => {
+        if (elem.className === "") {
+          elem.classList.add("gleam");
+        }
+      });
+      hljs.highlightAll();
+    </script>
     <script src="{{ unnest }}/js/lunr.min.js?v={{ gleam_version }}"></script>    
     <script src="{{ unnest }}/js/index.js?v={{ rendering_timestamp }}"></script>
 


### PR DESCRIPTION
Before this PR:
- Erlang, Elixir etc would not be highlighted correctly.
- Additional modules would throw warnings as `highlightBlock` is called with unsupported elements if the gleam highlight js file gets loaded before the erlang and elixir ones.

Followup/fix for https://github.com/gleam-lang/gleam/pull/1819

Changes:
- `highlightBlock()` is deprecated in favour of `highlightElement`.
- Calling `hljs.highlightAll();` applies hljs to all languages loaded at that moment, so we don't need to do it specifically for the gleam highlighter.