### PR TITLE
0.25 docs-gen highlightjs-gleam: add `use` to keyword list

### DIFF
--- a/compiler-core/templates/docs-js/highlightjs-gleam.js
+++ b/compiler-core/templates/docs-js/highlightjs-gleam.js
@@ -1,7 +1,7 @@
 hljs.registerLanguage("gleam", function (hljs) {
   const KEYWORDS =
     "as assert case const external fn if import let " +
-    "opaque pub todo try tuple type";
+    "use opaque pub todo try tuple type";
   const STRING = {
     className: "string",
     variants: [{ begin: /"/, end: /"/ }],


### PR DESCRIPTION
Same as https://github.com/gleam-lang/website/pull/199/files#diff-b26437457572304127311c50540cfaaf95f4c959263be430b89c1dbfdc3f14fe