### PR TITLE
Make the typechecker recover from errors and fill the typed AST

### DIFF
--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -2,12 +2,12 @@ use std::time::Instant;
 
 use gleam_core::{
     build::{Options, Package, ProjectCompiler},
-    Result,
+    WResult,
 };
 
 use crate::{build_lock::BuildLock, cli, dependencies::UseManifest, fs};
 
-pub fn main(options: Options) -> Result<Package> {
+pub fn main(options: Options) -> WResult<Package> {
     let lock = BuildLock::new()?;
     let manifest = crate::dependencies::download(cli::Reporter::new(), None, UseManifest::Yes)?;
 

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -8,11 +8,11 @@ use gleam_core::{
     metadata, paths,
     type_::Module,
     uid::UniqueIdGenerator,
-    Result,
+    Result, WResult,
 };
 use std::path::Path;
 
-pub fn command(options: CompilePackage) -> Result<()> {
+pub fn command(options: CompilePackage) -> WResult<()> {
     let ids = UniqueIdGenerator::new();
     let mut type_manifests = load_libraries(&ids, &options.libraries_directory)?;
     let mut defined_modules = im::HashMap::new();

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -7,7 +7,7 @@ use gleam_core::{
     error::Error,
     hex,
     io::HttpClient as _,
-    paths, Result,
+    paths, Result, WResult,
 };
 
 pub fn remove(package: String, version: String) -> Result<()> {
@@ -49,7 +49,7 @@ impl ApiKeyCommand for RemoveCommand {
     }
 }
 
-pub fn build() -> Result<()> {
+pub fn build() -> WResult<()> {
     let config = crate::config::root_config()?;
     let out = paths::build_docs(&config.name);
     let mut compiled = crate::build::main(Options {
@@ -94,12 +94,12 @@ struct PublishCommand {
     archive: Vec<u8>,
 }
 
-pub fn publish() -> Result<()> {
-    PublishCommand::new()?.run()
+pub fn publish() -> WResult<()> {
+    PublishCommand::new()?.run().map_err(Into::into)
 }
 
 impl PublishCommand {
-    pub fn new() -> Result<Self> {
+    pub fn new() -> WResult<Self> {
         let config = crate::config::root_config()?;
         let mut compiled = crate::build::main(Options {
             perform_codegen: true,

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -1,6 +1,6 @@
 use gleam_core::{
     build::{Mode, Options, Target},
-    paths, Result,
+    paths, Result, WResult,
 };
 
 // TODO: start in embedded mode
@@ -14,7 +14,7 @@ use gleam_core::{
 /// - ebin
 /// - include
 /// - priv
-pub(crate) fn erlang_shipment() -> Result<()> {
+pub(crate) fn erlang_shipment() -> WResult<()> {
     let target = Target::Erlang;
     let mode = Mode::Prod;
     let build = paths::build_packages(mode, target);

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -8,7 +8,7 @@ use flate2::{write::GzEncoder, Compression};
 use gleam_core::{
     build::{Mode, Options, Package, Target},
     config::{PackageConfig, SpdxLicense},
-    hex, paths, Error, Result,
+    hex, paths, Error, Result, WResult,
 };
 use hexpm::version::{Range, Version};
 use itertools::Itertools;
@@ -16,8 +16,9 @@ use sha2::Digest;
 
 use crate::{build, cli, docs, fs, hex::ApiKeyCommand, http::HttpClient};
 
-pub fn command(replace: bool, yes: bool) -> Result<()> {
-    PublishCommand::setup(replace, yes)?.run()
+pub fn command(replace: bool, yes: bool) -> WResult<()> {
+    PublishCommand::setup(replace, yes)?.run()?;
+    Ok(())
 }
 
 pub struct PublishCommand {
@@ -28,7 +29,7 @@ pub struct PublishCommand {
 }
 
 impl PublishCommand {
-    pub fn setup(replace: bool, i_am_sure: bool) -> Result<Self> {
+    pub fn setup(replace: bool, i_am_sure: bool) -> WResult<Self> {
         // Reset the build directory so we know the state of the project
         fs::delete_dir(&paths::build_packages(Mode::Prod, Target::Erlang))?;
 
@@ -46,7 +47,7 @@ impl PublishCommand {
             return Err(Error::MissingHexPublishFields {
                 description_missing: config.description.is_empty(),
                 licence_missing: config.licences.is_empty(),
-            });
+            }.into());
         }
 
         // Build the package release tarball

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -3,7 +3,7 @@ use gleam_core::{
     config::PackageConfig,
     error::Error,
     io::{CommandExecutor, Stdio},
-    paths,
+    paths, WResult,
 };
 
 use crate::fs::ProjectIO;
@@ -14,7 +14,7 @@ pub enum Which {
     Test,
 }
 
-pub fn command(arguments: Vec<String>, target: Option<Target>, which: Which) -> Result<(), Error> {
+pub fn command(arguments: Vec<String>, target: Option<Target>, which: Which) -> WResult<()> {
     let config = crate::config::root_config()?;
 
     // Determine which module to run

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -1,11 +1,11 @@
 use gleam_core::{
     build::{Mode, Options, Target},
     error::Error,
-    paths,
+    paths, WResult,
 };
 use std::process::Command;
 
-pub fn command() -> Result<(), Error> {
+pub fn command() -> WResult<()> {
     // Build project
     let _ = crate::build::main(Options {
         perform_codegen: true,

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -99,6 +99,7 @@ fn compile_expression(src: &str) -> TypedExpr {
     );
     ExprTyper::new(&mut environment)
         .infer(ast)
+        .collapse_into_result()
         .expect("should successfully infer")
 }
 

--- a/compiler-core/src/build/package_compilation_tests.rs
+++ b/compiler-core/src/build/package_compilation_tests.rs
@@ -67,11 +67,13 @@ macro_rules! assert_erlang_compile {
                 outputs.sort_by(|a, b| a.path.partial_cmp(&b.path).unwrap());
                 outputs
             })
-            .map_err(|e| normalise_error(e));
-        let expected = $expected_output.map(|mut outputs: Vec<OutputFile>| {
-            outputs.sort_by(|a, b| a.path.partial_cmp(&b.path).unwrap());
-            outputs
-        });
+            .map_err(|e| e.into_iter().map(normalise_error).collect::<Vec<_>>());
+        let expected = $expected_output
+            .map(|mut outputs: Vec<OutputFile>| {
+                outputs.sort_by(|a, b| a.path.partial_cmp(&b.path).unwrap());
+                outputs
+            })
+            .map_err(|e| vec![e]);
         assert_eq!(expected, outputs);
     };
 }
@@ -128,11 +130,13 @@ macro_rules! assert_javascript_compile {
                 outputs.sort_by(|a, b| a.path.partial_cmp(&b.path).unwrap());
                 outputs
             })
-            .map_err(|e| normalise_error(e));
-        let expected = $expected_output.map(|mut outputs: Vec<OutputFile>| {
-            outputs.sort_by(|a, b| a.path.partial_cmp(&b.path).unwrap());
-            outputs
-        });
+            .map_err(|e| e.into_iter().map(normalise_error).collect::<Vec<_>>());
+        let expected = $expected_output
+            .map(|mut outputs: Vec<OutputFile>| {
+                outputs.sort_by(|a, b| a.path.partial_cmp(&b.path).unwrap());
+                outputs
+            })
+            .map_err(|e| vec![e]);
         assert_eq!(expected, outputs);
     };
 }

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -11,7 +11,7 @@ use crate::{
     metadata, paths, type_,
     uid::UniqueIdGenerator,
     version::COMPILER_VERSION,
-    warning, Error, Result, Warning,
+    warning, Error, Result, Warning, WResult,
 };
 use itertools::Itertools;
 use std::{
@@ -133,8 +133,8 @@ where
     }
 
     /// Returns the compiled information from the root package
-    pub fn compile(&mut self) -> Result<Package, Vec<Error>> {
-        self.check_gleam_version().map_err(|e| vec![e])?;
+    pub fn compile(&mut self) -> WResult<Package> {
+        self.check_gleam_version()?;
         self.compile_dependencies()?;
 
         if self.options.perform_codegen {
@@ -144,7 +144,7 @@ where
         }
         let result = self.compile_root_package();
 
-        self.check_build_journal().map_err(|e| vec![e])?;
+        self.check_build_journal()?;
 
         // Print warnings
         for warning in &self.warnings {
@@ -154,7 +154,7 @@ where
         result
     }
 
-    pub fn compile_root_package(&mut self) -> Result<Package, Vec<Error>> {
+    pub fn compile_root_package(&mut self) -> WResult<Package> {
         let config = self.config.clone();
         let modules = self.compile_gleam_package(&config, true, paths::root())?;
 

--- a/compiler-core/src/filled_result.rs
+++ b/compiler-core/src/filled_result.rs
@@ -1,0 +1,130 @@
+/// A wrapper structure that contains an error with some form of data.
+/// This will be useful to transmit errors through the pipeline while also providing
+/// with some data, e.g for LSP implementations.
+///
+/// Since most of the time the compiler will want to report multiple errors instead of just one,
+/// it uses a Vec to store the errors.
+#[derive(Debug)]
+pub struct FilledResult<T, E> {
+    data: T,
+    errors: Vec<E>,
+}
+impl<T, E> FilledResult<T, E> {
+    pub const fn ok(data: T) -> Self {
+        Self {
+            data,
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn err(error: E, data: T) -> Self {
+        Self {
+            data,
+            errors: vec![error],
+        }
+    }
+
+    pub fn with_check(mut self, res: Result<(), E>) -> Self {
+        if let Err(e) = res {
+            self.errors.push(e);
+        }
+        self
+    }
+
+    pub fn map<U>(self, map_fn: impl FnOnce(T) -> U) -> FilledResult<U, E> {
+        FilledResult {
+            data: map_fn(self.data),
+            errors: self.errors,
+        }
+    }
+
+    pub fn collapse_into_result(self) -> Result<T, Vec<E>> {
+        if self.errors.is_empty() {
+            Ok(self.data)
+        } else {
+            Err(self.errors)
+        }
+    }
+
+    /// Useful function for retrieving a context from this result that already has the errors from
+    /// this result loaded.
+    pub fn into_context(self) -> (FilledResultContext<E>, T) {
+        let ctx = FilledResultContext {
+            errors: self.errors,
+        };
+        (ctx, self.data)
+    }
+
+    /// A bind-like operator for chaining operations directly with FilledResults. This method is
+    /// meant to be used sparsely, the 'imperative' methods with `FilledResultContext` are preferred.
+    pub fn join_with<U>(self, f: impl FnOnce(T) -> FilledResult<U, E>) -> FilledResult<U, E> {
+        let mut res = f(self.data);
+        // make sure that errors are forwarded in the correct order.
+        let errors = self
+            .errors
+            .into_iter()
+            .chain(std::mem::take(&mut res.errors))
+            .collect();
+        res.errors = errors;
+        res
+    }
+}
+
+/// The context to manage `FilledResult`s. It can convert to and from them, and absorb their
+/// errors.
+#[derive(Debug)]
+pub struct FilledResultContext<E> {
+    errors: Vec<E>,
+}
+
+impl<E> FilledResultContext<E> {
+    pub const fn new() -> Self {
+        Self { errors: Vec::new() }
+    }
+
+    /// Absorbs the errors from another `FilledResult`.
+    pub fn slurp_filled<U>(&mut self, res: FilledResult<U, E>) -> U {
+        self.errors.extend(res.errors);
+        res.data
+    }
+
+    /// Absorbs the errors from another `FilledResult`, using the mapping function to convert
+    /// between iterators.
+    pub fn slurp_filled_with<U, E2, F, I>(&mut self, res: FilledResult<U, E2>, iterator_fn: F) -> U
+    where
+        I: IntoIterator<Item = E>,
+        F: FnOnce(<Vec<E2> as IntoIterator>::IntoIter) -> I,
+    {
+        self.errors.extend(iterator_fn(res.errors.into_iter()));
+        res.data
+    }
+
+    /// Absorbs the error from a `Result`, while ignoring the value
+    pub fn just_slurp_result(&mut self, res: Result<(), E>) {
+        if let Err(e) = res {
+            self.errors.push(e);
+        }
+    }
+
+    /// Absorbs the error from a Result, turning it into an Option.
+    pub fn slurp_result<U>(&mut self, res: Result<U, E>) -> Option<U> {
+        match res {
+            Ok(v) => Some(v),
+            Err(e) => {
+                self.errors.push(e);
+                None
+            }
+        }
+    }
+
+    pub fn register_error(&mut self, error: E) {
+        self.errors.push(error);
+    }
+
+    pub fn finish<T>(self, data: T) -> FilledResult<T, E> {
+        FilledResult {
+            data,
+            errors: self.errors,
+        }
+    }
+}

--- a/compiler-core/src/filled_result.rs
+++ b/compiler-core/src/filled_result.rs
@@ -1,3 +1,5 @@
+use vec1::Vec1;
+
 /// A wrapper structure that contains an error with some form of data.
 /// This will be useful to transmit errors through the pipeline while also providing
 /// with some data, e.g for LSP implementations.
@@ -50,11 +52,11 @@ impl<T, E> FilledResult<T, E> {
         }
     }
 
-    pub fn collapse_into_result(self) -> Result<T, Vec<E>> {
+    pub fn collapse_into_result(self) -> Result<T, Vec1<E>> {
         if self.errors.is_empty() {
             Ok(self.data)
         } else {
-            Err(self.errors)
+            Err(Vec1::try_from_vec(self.errors).unwrap())
         }
     }
 

--- a/compiler-core/src/filled_result.rs
+++ b/compiler-core/src/filled_result.rs
@@ -160,3 +160,14 @@ impl<E> FilledResultContext<E> {
         }
     }
 }
+
+impl<U, A, E> FromIterator<FilledResult<U, E>> for FilledResult<A, E>
+where
+    A: FromIterator<U>,
+{
+    fn from_iter<T: IntoIterator<Item = FilledResult<U, E>>>(iter: T) -> Self {
+        let mut ctx = FilledResultContext::new();
+        let collected = ctx.slurp_filled_collect(iter);
+        ctx.finish(collected)
+    }
+}

--- a/compiler-core/src/filled_result.rs
+++ b/compiler-core/src/filled_result.rs
@@ -17,6 +17,11 @@ impl<T, E> FilledResult<T, E> {
         }
     }
 
+    pub fn no_errors(self) -> T {
+        debug_assert!(self.errors.is_empty(), "Error list should have been empty!");
+        self.data
+    }
+
     pub fn err(error: E, data: T) -> Self {
         Self {
             data,
@@ -119,6 +124,16 @@ impl<E> FilledResultContext<E> {
 
     pub fn register_error(&mut self, error: E) {
         self.errors.push(error);
+    }
+
+    pub fn slurp_filled_collect<T, C>(
+        &mut self,
+        results: impl IntoIterator<Item = FilledResult<T, E>>,
+    ) -> C
+    where
+        C: FromIterator<T>,
+    {
+        results.into_iter().map(|r| self.slurp_filled(r)).collect()
     }
 
     pub fn finish<T>(self, data: T) -> FilledResult<T, E> {

--- a/compiler-core/src/filled_result.rs
+++ b/compiler-core/src/filled_result.rs
@@ -17,6 +17,10 @@ impl<T, E> FilledResult<T, E> {
         }
     }
 
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
     pub fn no_errors(self) -> T {
         debug_assert!(self.errors.is_empty(), "Error list should have been empty!");
         self.data
@@ -85,6 +89,19 @@ pub struct FilledResultContext<E> {
 impl<E> FilledResultContext<E> {
     pub const fn new() -> Self {
         Self { errors: Vec::new() }
+    }
+
+    pub const fn from_errors(errors: Vec<E>) -> Self {
+        Self { errors }
+    }
+
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Clears the errors collected up until now.
+    pub fn clear(&mut self) {
+        self.errors.clear()
     }
 
     /// Absorbs the errors from another `FilledResult`.

--- a/compiler-core/src/filled_result.rs
+++ b/compiler-core/src/filled_result.rs
@@ -10,6 +10,9 @@ pub struct FilledResult<T, E> {
     errors: Vec<E>,
 }
 impl<T, E> FilledResult<T, E> {
+    pub const fn new(data: T, errors: Vec<E>) -> Self {
+        Self { data, errors }
+    }
     pub const fn ok(data: T) -> Self {
         Self {
             data,

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -73,6 +73,7 @@ pub mod type_;
 pub mod uid;
 pub mod version;
 pub mod warning;
+pub mod filled_result;
 
 pub use error::{Error, Result};
 pub use warning::Warning;

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod version;
 pub mod warning;
 pub mod filled_result;
 
-pub use error::{Error, Result};
+pub use error::{Error, Result, WResult};
 pub use warning::Warning;
 
 mod schema_capnp {

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -43,7 +43,7 @@ impl<'a> ModuleEncoder<'a> {
         self.set_module_types_constructors(&mut module);
 
         let result = capnp::serialize_packed::write_message(&mut writer, &message);
-        result.map_err(|e| writer.convert_err(e))
+        result.map_err(|e| writer.convert_err(e).into())
     }
 
     fn set_module_accessors(&mut self, module: &mut module::Builder<'_>) {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -27,6 +27,7 @@ use crate::{
     },
     bit_string,
     build::{Origin, Target},
+    filled_result::{FilledResult, FilledResultContext},
     uid::UniqueIdGenerator,
 };
 
@@ -1392,9 +1393,9 @@ fn infer_statement(
 fn infer_bit_string_segment_option<UntypedValue, TypedValue, Typer>(
     segment_option: BitStringSegmentOption<UntypedValue>,
     mut type_check: Typer,
-) -> Result<BitStringSegmentOption<TypedValue>, Error>
+) -> FilledResult<BitStringSegmentOption<TypedValue>, Error>
 where
-    Typer: FnMut(UntypedValue, Arc<Type>) -> Result<TypedValue, Error>,
+    Typer: FnMut(UntypedValue, Arc<Type>) -> FilledResult<TypedValue, Error>,
 {
     match segment_option {
         BitStringSegmentOption::Size {
@@ -1402,57 +1403,60 @@ where
             location,
             short_form,
             ..
-        } => {
-            let value = type_check(*value, int())?;
-            Ok(BitStringSegmentOption::Size {
-                location,
-                short_form,
-                value: Box::new(value),
-            })
-        }
+        } => type_check(*value, int()).map(|value| BitStringSegmentOption::Size {
+            location,
+            short_form,
+            value: Box::new(value),
+        }),
 
         BitStringSegmentOption::Unit { location, value } => {
-            Ok(BitStringSegmentOption::Unit { location, value })
+            FilledResult::ok(BitStringSegmentOption::Unit { location, value })
         }
 
         BitStringSegmentOption::Binary { location } => {
-            Ok(BitStringSegmentOption::Binary { location })
+            FilledResult::ok(BitStringSegmentOption::Binary { location })
         }
-        BitStringSegmentOption::Int { location } => Ok(BitStringSegmentOption::Int { location }),
+        BitStringSegmentOption::Int { location } => {
+            FilledResult::ok(BitStringSegmentOption::Int { location })
+        }
         BitStringSegmentOption::Float { location } => {
-            Ok(BitStringSegmentOption::Float { location })
+            FilledResult::ok(BitStringSegmentOption::Float { location })
         }
         BitStringSegmentOption::BitString { location } => {
-            Ok(BitStringSegmentOption::BitString { location })
+            FilledResult::ok(BitStringSegmentOption::BitString { location })
         }
-        BitStringSegmentOption::Utf8 { location } => Ok(BitStringSegmentOption::Utf8 { location }),
+        BitStringSegmentOption::Utf8 { location } => {
+            FilledResult::ok(BitStringSegmentOption::Utf8 { location })
+        }
         BitStringSegmentOption::Utf16 { location } => {
-            Ok(BitStringSegmentOption::Utf16 { location })
+            FilledResult::ok(BitStringSegmentOption::Utf16 { location })
         }
         BitStringSegmentOption::Utf32 { location } => {
-            Ok(BitStringSegmentOption::Utf32 { location })
+            FilledResult::ok(BitStringSegmentOption::Utf32 { location })
         }
         BitStringSegmentOption::Utf8Codepoint { location } => {
-            Ok(BitStringSegmentOption::Utf8Codepoint { location })
+            FilledResult::ok(BitStringSegmentOption::Utf8Codepoint { location })
         }
         BitStringSegmentOption::Utf16Codepoint { location } => {
-            Ok(BitStringSegmentOption::Utf16Codepoint { location })
+            FilledResult::ok(BitStringSegmentOption::Utf16Codepoint { location })
         }
         BitStringSegmentOption::Utf32Codepoint { location } => {
-            Ok(BitStringSegmentOption::Utf32Codepoint { location })
+            FilledResult::ok(BitStringSegmentOption::Utf32Codepoint { location })
         }
         BitStringSegmentOption::Signed { location } => {
-            Ok(BitStringSegmentOption::Signed { location })
+            FilledResult::ok(BitStringSegmentOption::Signed { location })
         }
         BitStringSegmentOption::Unsigned { location } => {
-            Ok(BitStringSegmentOption::Unsigned { location })
+            FilledResult::ok(BitStringSegmentOption::Unsigned { location })
         }
-        BitStringSegmentOption::Big { location } => Ok(BitStringSegmentOption::Big { location }),
+        BitStringSegmentOption::Big { location } => {
+            FilledResult::ok(BitStringSegmentOption::Big { location })
+        }
         BitStringSegmentOption::Little { location } => {
-            Ok(BitStringSegmentOption::Little { location })
+            FilledResult::ok(BitStringSegmentOption::Little { location })
         }
         BitStringSegmentOption::Native { location } => {
-            Ok(BitStringSegmentOption::Native { location })
+            FilledResult::ok(BitStringSegmentOption::Native { location })
         }
     }
 }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1648,14 +1648,14 @@ fn make_type_vars(
     location: &SrcSpan,
     hydrator: &mut Hydrator,
     environment: &mut Environment<'_>,
-) -> Result<Vec<Arc<Type>>, Error> {
+) -> FilledResult<Vec<Arc<Type>>, Error> {
     args.iter()
         .map(|arg| TypeAst::Var {
             location: *location,
             name: arg.to_string(),
         })
         .map(|ast| hydrator.type_from_ast(&ast, environment))
-        .try_collect()
+        .collect()
 }
 
 fn custom_type_accessors<A>(

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -15,6 +15,7 @@ pub use error::{Error, UnifyErrorSituation, Warning};
 pub(crate) use expression::ExprTyper;
 pub use fields::FieldMap;
 pub use prelude::*;
+use vec1::Vec1;
 
 use crate::{
     ast::{
@@ -577,7 +578,7 @@ pub fn infer_module(
     package: &str,
     modules: &im::HashMap<String, Module>,
     warnings: &mut Vec<Warning>,
-) -> Result<TypedModule, Vec<Error>> {
+) -> Result<TypedModule, Vec1<Error>> {
     let mut ctx = FilledResultContext::new();
     let name = module.name.clone();
     let documentation = std::mem::take(&mut module.documentation);

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2350,16 +2350,17 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let return_type = return_annotation.map(|ann| ctx.slurp_filled(self.type_from_ast(&ann)));
 
-        self.infer_fn_with_known_types(ctx, args, body, return_type)
+        ctx.finish(())
+            .join_with(|_| self.infer_fn_with_known_types(args, body, return_type))
     }
 
     pub fn infer_fn_with_known_types(
         &mut self,
-        ctx: FilledResultContext<Error>,
         args: Vec<TypedArg>,
         body: UntypedExpr,
         return_type: Option<Arc<Type>>,
     ) -> FilledResult<(Vec<TypedArg>, TypedExpr), Error> {
+        let mut ctx = FilledResultContext::new();
         let (body_rigid_names, body_infer) = self.in_new_scope(|body_typer| {
             for (arg, t) in args.iter().zip(args.iter().map(|arg| arg.type_.clone())) {
                 match &arg.names {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -428,10 +428,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // function being type checked, resulting in better type errors and the
         // record field access syntax working.
         if let Some(expected) = expected {
-            unify(expected, typ.clone()).map_err(|e| convert_unify_error(e, location))?;
+            let _ = ctx.slurp_result(
+                unify(expected, typ.clone()).map_err(|e| convert_unify_error(e, location)),
+            );
         }
 
-        Ok(Arg {
+        ctx.finish(Arg {
             names,
             location,
             annotation,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -389,18 +389,20 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         is_capture: bool,
         return_annotation: Option<TypeAst>,
         location: SrcSpan,
-    ) -> Result<TypedExpr, Error> {
-        let (args, body) = self.do_infer_fn(args, expected_args, body, &return_annotation)?;
-        let args_types = args.iter().map(|a| a.type_.clone()).collect();
-        let typ = fn_(args_types, body.type_());
-        Ok(TypedExpr::Fn {
-            location,
-            typ,
-            is_capture,
-            args,
-            body: Box::new(body),
-            return_annotation,
-        })
+    ) -> FilledResult<TypedExpr, Error> {
+        self.do_infer_fn(args, expected_args, body, &return_annotation)
+            .map(|(args, body)| {
+                let arg_types = args.iter().map(|a| a.type_.clone()).collect();
+                let typ = fn_(arg_types, body.type_());
+                TypedExpr::Fn {
+                    location,
+                    typ,
+                    is_capture,
+                    args,
+                    body: Box::new(body),
+                    return_annotation,
+                }
+            })
     }
 
     fn infer_arg(

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use vec1::Vec1;
 
 use super::{pipe::PipeTyper, *};

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -415,15 +415,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             location,
             ..
         } = arg;
-        let typ = ctx
-            .slurp_result(
-                annotation
-                    .clone()
-                    .map(|t| self.type_from_ast(&t))
-                    .transpose(),
-            )
-            .flatten()
-            .unwrap_or_else(|| self.new_unbound_var());
+        let typ = annotation
+            .map(|t| ctx.slurp_filled(self.type_from_ast(&t)))
+            .unwrap_or_else(|| self.environment.new_unbound_var());
 
         // If we know the expected type of the argument from its contextual
         // usage then unify the newly constructed type with the expected type.

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2,13 +2,16 @@ use itertools::Itertools;
 use vec1::Vec1;
 
 use super::{pipe::PipeTyper, *};
-use crate::ast::{
-    Arg, AssignName, AssignmentKind, BinOp, BitStringSegment, BitStringSegmentOption, CallArg,
-    Clause, ClauseGuard, Constant, HasLocation, RecordUpdateSpread, SrcSpan, TodoKind, TypeAst,
-    TypedArg, TypedClause, TypedClauseGuard, TypedConstant, TypedExpr, TypedMultiPattern,
-    UntypedArg, UntypedClause, UntypedClauseGuard, UntypedConstant,
-    UntypedConstantBitStringSegment, UntypedExpr, UntypedExprBitStringSegment, UntypedMultiPattern,
-    UntypedPattern, Use,
+use crate::{
+    ast::{
+        Arg, AssignName, AssignmentKind, BinOp, BitStringSegment, BitStringSegmentOption, CallArg,
+        Clause, ClauseGuard, Constant, HasLocation, RecordUpdateSpread, SrcSpan, TodoKind, TypeAst,
+        TypedArg, TypedClause, TypedClauseGuard, TypedConstant, TypedExpr, TypedMultiPattern,
+        UntypedArg, UntypedClause, UntypedClauseGuard, UntypedConstant,
+        UntypedConstantBitStringSegment, UntypedExpr, UntypedExprBitStringSegment,
+        UntypedMultiPattern, UntypedPattern, Use,
+    },
+    filled_result::{FilledResult, FilledResultContext},
 };
 
 use im::hashmap;
@@ -66,20 +69,20 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     /// Crawl the AST, annotating each node with the inferred type or
     /// returning an error.
     ///
-    pub fn infer(&mut self, expr: UntypedExpr) -> Result<TypedExpr, Error> {
+    pub fn infer(&mut self, expr: UntypedExpr) -> FilledResult<TypedExpr, Error> {
         match expr {
             UntypedExpr::Todo {
                 location,
                 label,
                 kind,
                 ..
-            } => Ok(self.infer_todo(location, kind, label)),
+            } => FilledResult::ok(self.infer_todo(location, kind, label)),
 
             UntypedExpr::Var { location, name, .. } => self.infer_var(name, location),
 
             UntypedExpr::Int {
                 location, value, ..
-            } => Ok(self.infer_int(value, location)),
+            } => FilledResult::ok(self.infer_int(value, location)),
 
             UntypedExpr::Sequence {
                 expressions,
@@ -92,11 +95,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             UntypedExpr::Float {
                 location, value, ..
-            } => Ok(self.infer_float(value, location)),
+            } => FilledResult::ok(self.infer_float(value, location)),
 
             UntypedExpr::String {
                 location, value, ..
-            } => Ok(self.infer_string(value, location)),
+            } => FilledResult::ok(self.infer_string(value, location)),
 
             UntypedExpr::PipeLine { expressions } => self.infer_pipeline(expressions),
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2136,15 +2136,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         untyped_elements: Vec<UntypedConstant>,
         location: SrcSpan,
-    ) -> Result<TypedConstant, Error> {
-        let mut elements = Vec::with_capacity(untyped_elements.len());
+    ) -> FilledResult<TypedConstant, Error> {
+        let mut ctx = FilledResultContext::new();
 
-        for element in untyped_elements {
-            let element = self.infer_const(&None, element)?;
-            elements.push(element);
-        }
+        let elements = ctx.slurp_filled_collect(
+            untyped_elements
+                .into_iter()
+                .map(|elem| self.infer_const(&None, elem)),
+        );
 
-        Ok(Constant::Tuple { elements, location })
+        ctx.finish(Constant::Tuple { elements, location })
     }
 
     fn infer_const_list(

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -499,10 +499,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         elems: Vec<UntypedExpr>,
         location: SrcSpan,
-    ) -> Result<TypedExpr, Error> {
-        let elems: Vec<_> = elems.into_iter().map(|e| self.infer(e)).try_collect()?;
+    ) -> FilledResult<TypedExpr, Error> {
+        let mut ctx = FilledResultContext::new();
+        let elems: Vec<_> = elems
+            .into_iter()
+            .map(|e| ctx.slurp_filled(self.infer(e)))
+            .collect();
         let typ = tuple(elems.iter().map(HasType::type_).collect());
-        Ok(TypedExpr::Tuple {
+        ctx.finish(TypedExpr::Tuple {
             location,
             elems,
             typ,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -445,14 +445,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         fun: UntypedExpr,
         args: Vec<CallArg<UntypedExpr>>,
         location: SrcSpan,
-    ) -> Result<TypedExpr, Error> {
-        let (fun, args, typ) = self.do_infer_call(fun, args, location)?;
-        Ok(TypedExpr::Call {
-            location,
-            typ,
-            args,
-            fun: Box::new(fun),
-        })
+    ) -> FilledResult<TypedExpr, Error> {
+        self.do_infer_call(fun, args, location)
+            .map(|(fun, args, typ)| TypedExpr::Call {
+                location,
+                typ,
+                args,
+                fun: Box::new(fun),
+            })
     }
 
     fn infer_list(

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2272,7 +2272,7 @@ struct UseCall {
     arguments: Vec<CallArg<UntypedExpr>>,
 }
 
-fn get_use_expression_call(call: UntypedExpr) -> Result<UseCall, Error> {
+fn get_use_expression_call(call: UntypedExpr) -> UseCall {
     // Ensure that the use's call is of the right structure. i.e. it is a
     // call to a function.
     match call {
@@ -2280,17 +2280,17 @@ fn get_use_expression_call(call: UntypedExpr) -> Result<UseCall, Error> {
             location,
             fun: function,
             arguments,
-        } => Ok(UseCall {
+        } => UseCall {
             location,
             arguments,
             function,
-        }),
+        },
 
-        other => Ok(UseCall {
+        other => UseCall {
             location: other.location(),
             function: Box::new(other),
             arguments: vec![],
-        }),
+        },
     }
 }
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -30,6 +30,7 @@ macro_rules! assert_infer {
             &mut vec![],
         ))
         .infer(ast)
+        .collapse_into_result()
         .expect("should successfully infer");
         assert_eq!(
             ($src, printer.pretty_print(result.type_().as_ref(), 0),),
@@ -178,12 +179,16 @@ macro_rules! assert_module_error {
             &mut vec![],
         )
         .expect_err("should infer an error");
-        let error = $crate::error::Error::Type {
-            src: $src.to_string(),
-            path: std::path::PathBuf::from("/src/one/two.gleam"),
-            error,
-        };
-        let output = error.pretty_string();
+        let error = error
+            .into_iter()
+            .map(|error| $crate::error::Error::Type {
+                src: $src.to_string(),
+                path: std::path::PathBuf::from("/src/one/two.gleam"),
+                error,
+            })
+            .collect::<Vec<_>>();
+        let output = error.into_iter().map(|e| e.pretty_string()).join("\n");
+
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }
@@ -246,13 +251,21 @@ macro_rules! assert_error {
             &mut vec![],
         ))
         .infer(ast)
+        .collapse_into_result()
         .expect_err("should infer an error");
-        let error = $crate::error::Error::Type {
-            src: $src.to_string(),
-            path: PathBuf::from("/src/one/two.gleam"),
-            error,
-        };
-        let output = error.pretty_string();
+        let error = error
+            .into_iter()
+            .map(|error| $crate::error::Error::Type {
+                src: $src.to_string(),
+                path: PathBuf::from("/src/one/two.gleam"),
+                error,
+            })
+            .collect::<Vec<_>>();
+        use itertools::Itertools;
+        let output = error
+            .into_iter()
+            .map(|error| error.pretty_string())
+            .join("\n");
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }
@@ -295,12 +308,18 @@ macro_rules! assert_with_module_error {
             &mut vec![],
         )
         .expect_err("should infer an error");
-        let error = $crate::error::Error::Type {
-            src: $src.to_string(),
-            path: PathBuf::from("/src/one/two.gleam"),
-            error,
-        };
-        let output = error.pretty_string();
+        let error = error
+            .into_iter()
+            .map(|error| $crate::error::Error::Type {
+                src: $src.to_string(),
+                path: PathBuf::from("/src/one/two.gleam"),
+                error,
+            })
+            .collect::<Vec<_>>();
+        let output = error
+            .into_iter()
+            .map(|error| error.pretty_string())
+            .join("\n");
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 
@@ -354,12 +373,18 @@ macro_rules! assert_with_module_error {
             &mut vec![],
         )
         .expect_err("should infer an error");
-        let error = crate::error::Error::Type {
-            src: $src.to_string(),
-            path: PathBuf::from("/src/one/two.gleam"),
-            error,
-        };
-        let output = error.pretty_string();
+        let error = error
+            .into_iter()
+            .map(|error| crate::error::Error::Type {
+                src: $src.to_string(),
+                path: PathBuf::from("/src/one/two.gleam"),
+                error,
+            })
+            .collect::<Vec<_>>();
+        let output = error
+            .into_iter()
+            .map(|error| error.pretty_string())
+            .join("\n");
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }


### PR DESCRIPTION
This PR focuses making sure errors can be propagated while also having
available data for the LSP:

- [x] Introduces a new `Result`-like structure that always has data, `FilledResult`, to the pipeline, which interacts almost seamlessly with `Result`s and is able to gather multiple errors.

- [x] Uses the new `FilledResult` and `FilledResultContext` helper structures to recover missing data (e.g unknown types from bad lookups) while propagating any errors that happened.

- [ ] Passes tests (current status: they don't pass due to error duplication happening *somewhere* in the code)

- [ ] Uses the data returned by `FilledResult` in LSP to be able to provide information even when the types are missing.