### PR TITLE
feat: add ts file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug where returning an anonymous function from a pipeline and calling
   it immediately without assigning it to a variable would produce invalid Erlang
   code.
+- Added support for top level TypeScript file inclusion in builds.
 
 ## v0.25.0 - 2022-11-24
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -354,7 +354,7 @@ pub fn native_files(dir: &Path) -> Result<impl Iterator<Item = PathBuf> + '_> {
                 .unwrap_or_default()
                 .to_str()
                 .unwrap_or_default();
-            matches!(extension, "erl" | "hrl" | "ex" | "js" | "mjs")
+            matches!(extension, "erl" | "hrl" | "ex" | "js" | "mjs" | "ts")
         }))
 }
 

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -235,7 +235,7 @@ where
                 .to_path_buf();
 
             match extension {
-                "mjs" | "js" | "hrl" => (),
+                "mjs" | "js" | "ts" | "hrl" => (),
                 "erl" => {
                     let _ = to_compile_modules.insert(relative_path.clone());
                 }

--- a/test/language/src/ffi.gleam
+++ b/test/language/src/ffi.gleam
@@ -10,6 +10,9 @@ if javascript {
 
   pub external fn ansi_green(String) -> String =
     "./ffi_javascript.mjs" "ansi_green"
+
+  pub external fn file_exists(String) -> Bool =
+    "./ffi_javascript.mjs" "fileExists"
 }
 
 if erlang {
@@ -24,4 +27,7 @@ if erlang {
 
   pub external fn ansi_green(String) -> String =
     "ffi_erlang" "ansi_green"
+
+  pub external fn file_exists(String) -> Bool =
+    "ffi_erlang" "file_exists"
 }

--- a/test/language/src/ffi_erlang.erl
+++ b/test/language/src/ffi_erlang.erl
@@ -1,6 +1,6 @@
 -module(ffi_erlang).
 
--export([to_string/1, append/2, print/1, ansi_green/1]).
+-export([to_string/1, append/2, print/1, ansi_green/1, file_exists/1]).
 
 append(A, B) ->
     <<A/binary, B/binary>>.
@@ -15,3 +15,6 @@ to_string(Term) ->
 
 ansi_green(String) ->
     <<"\e[32m", String/binary, "\e[0m">>.
+
+file_exists(Path) ->
+    filelib:is_regular(Path).

--- a/test/language/src/ffi_javascript.mjs
+++ b/test/language/src/ffi_javascript.mjs
@@ -1,3 +1,5 @@
+import fs from "fs";
+
 export function append(a, b) {
   return a + b;
 }
@@ -18,4 +20,8 @@ export function toString(a) {
 
 export function ansi_green(string) {
   return `\u001b[32m${string}\u001b[0m`;
+}
+
+export function fileExists(path) {
+  return fs.existsSync(path);
 }

--- a/test/language/src/ffi_typescript.ts
+++ b/test/language/src/ffi_typescript.ts
@@ -1,0 +1,3 @@
+export function append(a: string, b: string) {
+  return a + b;
+}

--- a/test/language/src/main.gleam
+++ b/test/language/src/main.gleam
@@ -6,6 +6,7 @@ import importable.{NoFields}
 import mod_with_numbers_0123456789
 import record_update
 import shadowed_module.{ShadowPerson}
+import ffi.{file_exists}
 import gleam
 
 pub fn main() -> Int {
@@ -43,6 +44,7 @@ pub fn main() -> Int {
       suite("bit string match", bit_string_match_tests()),
       suite("anonymous functions", anonymous_function_tests()),
       suite("string pattern matching", string_pattern_matching_tests()),
+      suite("typescript file inclusion", typescript_file_included_tests()),
     ])
 
   case stats.failures {
@@ -84,18 +86,18 @@ fn float_tests() -> List(Test) {
   let basic_subtraction = operator_test("-.", fn(a, b) { a -. b })
   let basic_multiplication = operator_test("*.", fn(a, b) { a *. b })
   [
-    basic_addition(0., 0., 0.),
-    basic_addition(1., 1., 2.),
-    basic_addition(5., 1., 6.),
-    basic_addition(1., 3., 4.),
-    basic_addition(1., -3., -2.),
-    basic_subtraction(0., 0., 0.),
-    basic_subtraction(1., 1., 0.),
-    basic_subtraction(5., 1., 4.),
-    basic_subtraction(1., 3., -2.),
-    basic_subtraction(1., -3., 4.),
-    basic_subtraction(0.5, 0., 0.5),
-    basic_subtraction(1., 4.5, -3.5),
+    basic_addition(0.0, 0.0, 0.0),
+    basic_addition(1.0, 1.0, 2.0),
+    basic_addition(5.0, 1.0, 6.0),
+    basic_addition(1.0, 3.0, 4.0),
+    basic_addition(1.0, -3.0, -2.0),
+    basic_subtraction(0.0, 0.0, 0.0),
+    basic_subtraction(1.0, 1.0, 0.0),
+    basic_subtraction(5.0, 1.0, 4.0),
+    basic_subtraction(1.0, 3.0, -2.0),
+    basic_subtraction(1.0, -3.0, 4.0),
+    basic_subtraction(0.5, 0.0, 0.5),
+    basic_subtraction(1.0, 4.5, -3.5),
     basic_multiplication(0.0, 0.0, 0.0),
     basic_multiplication(1.0, 1.0, 1.0),
     basic_multiplication(2.0, 2.0, 4.0),
@@ -1033,31 +1035,28 @@ fn bit_string_tests() -> List(Test) {
     "<<63, 240, 0, 0, 0, 0, 0, 0>> == <<1.0:float>>"
     |> example(fn() {
       assert_equal(True, <<63, 240, 0, 0, 0, 0, 0, 0>> == <<1.0:float>>)
-    })
+    }),
   ]
 }
 
 if erlang {
   fn bit_string_float_erlang() -> List(Test) {
     [
-       "<<60,0>> == <<1.0:float-size(16)>>"
-        |> example(fn() {
-          assert_equal(True, <<60,0>> == <<1.0:float-16>>)
-        }),
-         "<<63,128,0,0>> == <<1.0:float-32>>"
-        |> example(fn() {
-          assert_equal(True, <<63,128,0,0>> == <<1.0:float-32>>)
-        })
+      "<<60,0>> == <<1.0:float-size(16)>>"
+      |> example(fn() { assert_equal(True, <<60, 0>> == <<1.0:float-16>>) }),
+      "<<63,128,0,0>> == <<1.0:float-32>>"
+      |> example(fn() {
+        assert_equal(True, <<63, 128, 0, 0>> == <<1.0:float-32>>)
+      }),
     ]
   }
 }
+
 if javascript {
   fn bit_string_float_erlang() -> List(Test) {
-    [
-     ]
+    []
   }
 }
-
 
 fn sized_bit_string_tests() -> List(Test) {
   [
@@ -1416,4 +1415,29 @@ fn string_pattern_matching_tests() {
       )
     }),
   ]
+}
+
+if javascript {
+  fn typescript_file_included_tests() {
+    [
+      "./target-javascript/ffi_typescript.ts"
+      |> example(fn() {
+        assert_equal(file_exists("./target-javascript/ffi_typescript.ts"), True)
+      }),
+    ]
+  }
+}
+
+if erlang {
+  fn typescript_file_included_tests() {
+    [
+      "./target-erlang/_gleam_artefacts/ffi_typescript.ts"
+      |> example(fn() {
+        assert_equal(
+          file_exists("./target-erlang/_gleam_artefacts/ffi_typescript.ts"),
+          True,
+        )
+      }),
+    ]
+  }
 }


### PR DESCRIPTION
Closes #1835 

These changes successfully allow you to have top level `.ts` files in your src directory that are copied over to the build. 

At the moment the only test for this is the fact that running `make javascript` in `test/language` does indeed copy the file over because using the file in a Gleam project would require either a Node build step or Deno support. Is this enough for the feature or should some build step be included?