### PR TITLE
Changelog: add a few missing links to blogposts for 0.25, 0.22, 0.21, 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,9 +160,9 @@
 
 ## v0.22.0 - 2022-06-12
 
-- New projects are created with `gleam_stdlib` v0.22.
-
 [Release Blog Post](https://gleam.run/news/gleam-v0.22-released/)
+
+- New projects are created with `gleam_stdlib` v0.22.
 
 ## v0.22.0-rc1 - 2022-06-12
 
@@ -225,9 +225,9 @@
 
 ## v0.21.0 - 2022-04-24
 
-- New projects are created with `gleam_stdlib` v0.21.
-
 [Release Blog Post](https://gleam.run/news/v0.21-introducing-the-gleam-language-server/)
+
+- New projects are created with `gleam_stdlib` v0.21.
 
 ## v0.21.0-rc2 - 2022-04-20
 
@@ -283,9 +283,9 @@
 
 ## v0.20.0 - 2022-02-23
 
-- New projects are created with `gleam_stdlib` v0.20.
-
 [Release Blog Post](https://gleam.run/news/gleam-v0.20-released/)
+
+- New projects are created with `gleam_stdlib` v0.20.
 
 ## v0.20.0-rc1 - 2022-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,8 @@
 
 - New projects are created with `gleam_stdlib` v0.22.
 
+[Release Blog Post](https://gleam.run/news/gleam-v0.22-released/)
+
 ## v0.22.0-rc1 - 2022-06-12
 
 - Fixed a bug where doc comments would dissociate from their statements when
@@ -225,6 +227,8 @@
 
 - New projects are created with `gleam_stdlib` v0.21.
 
+[Release Blog Post](https://gleam.run/news/v0.21-introducing-the-gleam-language-server/)
+
 ## v0.21.0-rc2 - 2022-04-20
 
 - Added the ability to replace a release up to one hour after it is published
@@ -280,6 +284,8 @@
 ## v0.20.0 - 2022-02-23
 
 - New projects are created with `gleam_stdlib` v0.20.
+
+[Release Blog Post](https://gleam.run/news/gleam-v0.20-released/)
 
 ## v0.20.0-rc1 - 2022-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ## v0.25.0 - 2022-11-24
 
+[Release blog post](https://gleam.run/news/v0.25-introducing-use-expressions/)
+
 ## v0.25.0-rc2 - 2022-11-23
 
 - Fixed a bug where Gleam dependency packages with a `priv` directory could fail


### PR DESCRIPTION
For 0.25, make the blog post about `use` easier to discover for people.

Edit: Found a few more missing links, added them so we have all links from 0.25 down to 0.3 (and one more to 0.1) which should help discover gleam things via the changelog :)