### PR TITLE
add `gleam new` flags to control git init and .github content creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 - 4 digit integers are now always formatted without underscores.
 - Running `gleam new` will skip `git init` if the new project directory is
   already part of a git work tree.
-- The `gleam new` command gains the `--skip-git` flag to skip initialization
-  of both git and .github content.
-- The `gleam new` command gains the `--skip-github` flag to skip initialization
-  of .github content.
+- The `gleam new` command gains the `--skip-git` flag to skip creation of
+  `.git/*`, `.gitignore` and `.github/*` files.
+- The `gleam new` command gains the `--skip-github` flag to skip creation of
+  `.github/*` files.
+
 
 ## v0.25.3 - 2022-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - 4 digit integers are now always formatted without underscores.
 - Running `gleam new` will skip `git init` if the new project directory is
   already part of a git work tree.
+- The `gleam new` command gains the `--git-init` and `--github-init` flags
+  to initialize git and .github (respectively). Unless these flags are
+  specified, new projects default to skipping initialization of both git
+  and .github content.
 
 ## v0.25.3 - 2022-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 - 4 digit integers are now always formatted without underscores.
 - Running `gleam new` will skip `git init` if the new project directory is
   already part of a git work tree.
-- The `gleam new` command gains the `--git-init` and `--github-init` flags
-  to initialize git and .github (respectively). Unless these flags are
-  specified, new projects default to skipping initialization of both git
-  and .github content.
+- The `gleam new` command gains the `--skip-git` flag to skip initialization
+  of both git and .github content.
+- The `gleam new` command gains the `--skip-github` flag to skip initialization
+  of .github content.
 
 ## v0.25.3 - 2022-12-16
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -236,11 +236,11 @@ pub struct NewOptions {
     )]
     pub template: new::Template,
 
-    /// Skip git initialization and creation of .github content
+    /// Skip git initialization and creation of .gitignore, .git/* and .github/* files
     #[clap(long)]
     pub skip_git: bool,
 
-    /// Skip creation of .github content
+    /// Skip creation of .github/* files
     #[clap(long)]
     pub skip_github: bool,
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -235,6 +235,14 @@ pub struct NewOptions {
         default_value = "lib"
     )]
     pub template: new::Template,
+
+    /// Run `git init` in new project directory
+    #[clap(long)]
+    pub git_init: bool,
+
+    /// Create .github in new project directory
+    #[clap(long)]
+    pub github_init: bool,
 }
 
 #[derive(Args, Debug)]

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -236,13 +236,13 @@ pub struct NewOptions {
     )]
     pub template: new::Template,
 
-    /// Run `git init` in new project directory
+    /// Skip git initialization and creation of .github content
     #[clap(long)]
-    pub git_init: bool,
+    pub skip_git: bool,
 
-    /// Create .github in new project directory
+    /// Skip creation of .github content
     #[clap(long)]
-    pub github_init: bool,
+    pub skip_github: bool,
 }
 
 #[derive(Args, Debug)]

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -72,14 +72,22 @@ impl Creator {
         crate::fs::mkdir(&self.root)?;
         crate::fs::mkdir(&self.src)?;
         crate::fs::mkdir(&self.test)?;
-        crate::fs::mkdir(&self.github)?;
-        crate::fs::mkdir(&self.workflows)?;
-        crate::fs::git_init(&self.root)?;
+        if self.options.github_init {
+            crate::fs::mkdir(&self.github)?;
+            crate::fs::mkdir(&self.workflows)?;
+        }
+        if self.options.git_init {
+            crate::fs::git_init(&self.root)?;
+        }
 
         match self.options.template {
             Template::Lib => {
-                self.gitignore()?;
-                self.github_ci()?;
+                if self.options.git_init {
+                    self.gitignore()?;
+                }
+                if self.options.github_init {
+                    self.github_ci()?;
+                }
                 self.readme()?;
                 self.gleam_toml()?;
                 self.src_module()?;

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -72,20 +72,23 @@ impl Creator {
         crate::fs::mkdir(&self.root)?;
         crate::fs::mkdir(&self.src)?;
         crate::fs::mkdir(&self.test)?;
-        if self.options.github_init {
+
+        if !self.options.skip_git && !self.options.skip_github {
             crate::fs::mkdir(&self.github)?;
             crate::fs::mkdir(&self.workflows)?;
         }
-        if self.options.git_init {
+
+        if !self.options.skip_git {
             crate::fs::git_init(&self.root)?;
         }
 
         match self.options.template {
             Template::Lib => {
-                if self.options.git_init {
+                if !self.options.skip_git {
                     self.gitignore()?;
                 }
-                if self.options.github_init {
+
+                if !self.options.skip_git && !self.options.skip_github {
                     self.github_ci()?;
                 }
                 self.readme()?;

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -9,8 +9,8 @@ fn new() {
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
-            git_init: false,
-            github_init: false,
+            skip_git: false,
+            skip_github: false,
         },
         "1.0.0-gleam",
     )
@@ -18,12 +18,12 @@ fn new() {
 
     creator.run().unwrap();
 
-    assert!(!path.join(".git").exists());
+    assert!(path.join(".git").exists());
     assert!(path.join("README.md").exists());
     assert!(path.join("gleam.toml").exists());
     assert!(path.join("src/my_project.gleam").exists());
     assert!(path.join("test/my_project_test.gleam").exists());
-    assert!(!path.join(".github/workflows/test.yml").exists());
+    assert!(path.join(".github/workflows/test.yml").exists());
 
     let toml = crate::fs::read(&path.join("gleam.toml")).unwrap();
     assert!(toml.contains("name = \"my_project\""));
@@ -31,7 +31,7 @@ fn new() {
 }
 
 #[test]
-fn new_with_git_init() {
+fn new_with_skip_git() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("my_project");
 
@@ -41,19 +41,19 @@ fn new_with_git_init() {
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
-            git_init: true,
-            github_init: false,
+            skip_git: true,
+            skip_github: false,
         },
         "1.0.0-gleam",
     )
     .unwrap();
     creator.run().unwrap();
-    assert!(path.join(".git").exists());
+    assert!(!path.join(".git").exists());
     assert!(!path.join(".github").exists());
 }
 
 #[test]
-fn new_with_github_init() {
+fn new_with_skip_github() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("my_project");
 
@@ -63,16 +63,43 @@ fn new_with_github_init() {
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
-            git_init: false,
-            github_init: true,
+            skip_git: false,
+            skip_github: true,
         },
         "1.0.0-gleam",
     )
     .unwrap();
     creator.run().unwrap();
-    assert!(path.join(".github").exists());
+
+    assert!(path.join(".git").exists());
+
+    assert!(!path.join(".github").exists());
+    assert!(!path.join(".github/workflows/test.yml").exists());
+}
+
+#[test]
+fn new_with_skip_git_and_github() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("my_project");
+
+    let creator = super::Creator::new(
+        super::NewOptions {
+            project_root: path.to_str().unwrap().to_string(),
+            template: super::Template::Lib,
+            name: None,
+            description: "Wibble wobble".into(),
+            skip_git: true,
+            skip_github: true,
+        },
+        "1.0.0-gleam",
+    )
+    .unwrap();
+    creator.run().unwrap();
+
     assert!(!path.join(".git").exists());
-    assert!(path.join(".github/workflows/test.yml").exists());
+
+    assert!(!path.join(".github").exists());
+    assert!(!path.join(".github/workflows/test.yml").exists());
 }
 
 #[test]
@@ -86,8 +113,8 @@ fn invalid_path() {
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
-            git_init: false,
-            github_init: false,
+            skip_git: false,
+            skip_github: false,
         },
         "1.0.0-gleam",
     )
@@ -105,8 +132,8 @@ fn invalid_name() {
             template: super::Template::Lib,
             name: Some("-".into()),
             description: "Wibble wobble".into(),
-            git_init: false,
-            github_init: false,
+            skip_git: false,
+            skip_github: false,
         },
         "1.0.0-gleam",
     )

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -9,6 +9,8 @@ fn new() {
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
+            git_init: false,
+            github_init: false,
         },
         "1.0.0-gleam",
     )
@@ -16,16 +18,61 @@ fn new() {
 
     creator.run().unwrap();
 
-    assert!(path.join(".git").exists());
+    assert!(!path.join(".git").exists());
     assert!(path.join("README.md").exists());
     assert!(path.join("gleam.toml").exists());
     assert!(path.join("src/my_project.gleam").exists());
     assert!(path.join("test/my_project_test.gleam").exists());
-    assert!(path.join(".github/workflows/test.yml").exists());
+    assert!(!path.join(".github/workflows/test.yml").exists());
 
     let toml = crate::fs::read(&path.join("gleam.toml")).unwrap();
     assert!(toml.contains("name = \"my_project\""));
     assert!(toml.contains("description = \"Wibble wobble\""));
+}
+
+#[test]
+fn new_with_git_init() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("my_project");
+
+    let creator = super::Creator::new(
+        super::NewOptions {
+            project_root: path.to_str().unwrap().to_string(),
+            template: super::Template::Lib,
+            name: None,
+            description: "Wibble wobble".into(),
+            git_init: true,
+            github_init: false,
+        },
+        "1.0.0-gleam",
+    )
+    .unwrap();
+    creator.run().unwrap();
+    assert!(path.join(".git").exists());
+    assert!(!path.join(".github").exists());
+}
+
+#[test]
+fn new_with_github_init() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("my_project");
+
+    let creator = super::Creator::new(
+        super::NewOptions {
+            project_root: path.to_str().unwrap().to_string(),
+            template: super::Template::Lib,
+            name: None,
+            description: "Wibble wobble".into(),
+            git_init: false,
+            github_init: true,
+        },
+        "1.0.0-gleam",
+    )
+    .unwrap();
+    creator.run().unwrap();
+    assert!(path.join(".github").exists());
+    assert!(!path.join(".git").exists());
+    assert!(path.join(".github/workflows/test.yml").exists());
 }
 
 #[test]
@@ -39,6 +86,8 @@ fn invalid_path() {
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
+            git_init: false,
+            github_init: false,
         },
         "1.0.0-gleam",
     )
@@ -56,6 +105,8 @@ fn invalid_name() {
             template: super::Template::Lib,
             name: Some("-".into()),
             description: "Wibble wobble".into(),
+            git_init: false,
+            github_init: false,
         },
         "1.0.0-gleam",
     )


### PR DESCRIPTION
Addresses the cli feature request from #1875.