### PR TITLE
Adjust constructor-name css

### DIFF
--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -568,7 +568,9 @@ body.drawer-open .label-closed {
   margin: 0;
 }
 
-.constructor-name > code {
+/* .hljs included to have higher specificity than
+   matching classes in atom-one themes */
+.constructor-name > code.hljs {
   padding: var(--small-gap);
 }
 


### PR DESCRIPTION
This css is meant to be applied but it currently isn't due to classes in the atom-one theme overriding the padding on `pre code.hljs` blocks.

We add the extra class here to up the specificity of this rule and have it win against the atom-one classes.

We should either have this or consider removing the rule entirely as it currently isn't being applied.