### PR TITLE
Do not remove new lines in expression blocks within case branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fixed `int` and `float` formatting in `const`s and patterns.
 - Fixed a bug where piping into a function capture expression with a pipe as one
   of the arguments would produce invalid Erlang code.
+- Formatter no longer removes new lines in expression blocks within case branches
 
 ## v0.25.3 - 2022-12-16
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1245,7 +1245,6 @@ impl<'comments> Formatter<'comments> {
 
     fn clause<'a>(&mut self, clause: &'a UntypedClause, index: u32) -> Document<'a> {
         let space_before = self.pop_empty_lines(clause.location.start);
-        let after_position = clause.location.end;
         let clause_doc = join(
             std::iter::once(&clause.pattern)
                 .chain(&clause.alternative_patterns)
@@ -1256,9 +1255,6 @@ impl<'comments> Formatter<'comments> {
             None => clause_doc,
             Some(guard) => clause_doc.append(" if ").append(self.clause_guard(guard)),
         };
-
-        // Remove any unused empty lines within the clause
-        let _ = self.pop_empty_lines(after_position);
 
         if index == 0 {
             clause_doc

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -2750,6 +2750,24 @@ fn expr_case() {
 }
 "
     );
+
+    assert_format!(
+        r#"fn main() {
+  case bool {
+    True -> {
+      "Foo"
+      |> io.println
+
+      "Bar"
+      |> io.println
+
+      Nil
+    }
+    False -> Nil
+  }
+}
+"#
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1919 

Seems a bit too good to be true but didn't break any tests...

