### PR TITLE
Upgrade the version of docker/build-push-action to v3

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -66,7 +66,7 @@ jobs:
         run: tar xf gleam.tar.gz
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: containers/${{ matrix.base-image }}.dockerfile


### PR DESCRIPTION
Should fix #1955 . The warnings were not about code on our actual workflows but rather the ones on this action used from docker. The new version seems to not use any more the commands that are causing the warnings.