### PR TITLE
Fix import of constant var dropping module prefix in JS code generation.

### DIFF
--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1218,7 +1218,13 @@ pub(crate) fn constant_expression<'a>(
             feature: "Bit string syntax".into(),
             location: *location,
         }),
-        Constant::Var { name, .. } => Ok(name.to_doc()),
+
+        Constant::Var { name, module, .. } => Ok({
+            match module {
+                None => name.to_doc(),
+                Some(module) => docvec!["$", module, ".", name],
+            }
+        }),
     }
 }
 

--- a/compiler-core/src/javascript/tests/modules.rs
+++ b/compiler-core/src/javascript/tests/modules.rs
@@ -70,6 +70,21 @@ const z = y
 }
 
 #[test]
+fn renamed_module() {
+    assert_js!(
+        (
+            CURRENT_PACKAGE,
+            vec!["x".to_string()],
+            r#"pub const v = 1"#
+        ),
+        r#"
+import x as y
+const z = y.v
+"#,
+    );
+}
+
+#[test]
 fn nested_module_constant() {
     assert_js!(
         (

--- a/compiler-core/src/javascript/tests/modules.rs
+++ b/compiler-core/src/javascript/tests/modules.rs
@@ -59,7 +59,7 @@ fn alias_aliased_constant() {
     assert_js!(
         (
             CURRENT_PACKAGE,
-            vec!["rocket_ship".to_string()],
+            "rocket_ship",
             r#"pub const x = 1"#
         ),
         r#"
@@ -74,7 +74,7 @@ fn renamed_module() {
     assert_js!(
         (
             CURRENT_PACKAGE,
-            vec!["x".to_string()],
+            "x",
             r#"pub const v = 1"#
         ),
         r#"
@@ -89,7 +89,7 @@ fn nested_module_constant() {
     assert_js!(
         (
             CURRENT_PACKAGE,
-            vec!["rocket_ship".to_string(), "launcher".to_string()],
+            "rocket_ship/launcher",
             r#"pub const x = 1"#
         ),
         r#"

--- a/compiler-core/src/javascript/tests/modules.rs
+++ b/compiler-core/src/javascript/tests/modules.rs
@@ -55,6 +55,36 @@ pub fn go() { rocket_ship.x }
 }
 
 #[test]
+fn alias_aliased_constant() {
+    assert_js!(
+        (
+            CURRENT_PACKAGE,
+            vec!["rocket_ship".to_string()],
+            r#"pub const x = 1"#
+        ),
+        r#"
+import rocket_ship.{ x as y }
+const z = y
+"#,
+    );
+}
+
+#[test]
+fn nested_module_constant() {
+    assert_js!(
+        (
+            CURRENT_PACKAGE,
+            vec!["rocket_ship".to_string(), "launcher".to_string()],
+            r#"pub const x = 1"#
+        ),
+        r#"
+import rocket_ship/launcher
+pub fn go() { launcher.x }
+"#,
+    );
+}
+
+#[test]
 fn alias_constant() {
     assert_js!(
         (CURRENT_PACKAGE, "rocket_ship", r#"pub const x = 1"#),

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_aliased_constant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_aliased_constant.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/modules.rs
+expression: "\nimport rocket_ship.{ x as y }\nconst z = y\n"
+---
+import * as $rocket_ship from "../rocket_ship.mjs";
+import { x as y } from "../rocket_ship.mjs";
+
+const z = y;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_module_constant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_module_constant.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/javascript/tests/modules.rs
+expression: "\nimport rocket_ship/launcher\npub fn go() { launcher.x }\n"
+---
+import * as $launcher from "../rocket_ship/launcher.mjs";
+
+export function go() {
+  return $launcher.x;
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__renamed_module.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__renamed_module.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/modules.rs
+expression: "\nimport x as y\nconst z = y.v\n"
+---
+import * as $y from "../x.mjs";
+
+const z = $y.v;
+


### PR DESCRIPTION
As detailed in #1963, importing constants from another module would not be qualified properly in the output `.mjs` file.

Therefore, when emitting code for a `Constant Var` expression in the Javascript backend, we check to see if that constant variable is defined in some module. If so, we prefix the constant variable with the qualified name of the module.

# Note for the reviewer
To test the code change, I created a small sample project as the bug reporter did in #1963. What I would like to do is to adhere to your principle of snapshot testing, but I am a bit unsure where I would place the gleam source files (module with constant + importing file) in this case :)