### PR TITLE
Update rust-cache GHA to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }} # setup-beam does not support macOS
 
       - name: Handle Rust dependencies caching
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: v1-${{ matrix.target }}
 
@@ -266,7 +266,7 @@ jobs:
           components: clippy
 
       - name: Handle Rust dependencies caching
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: v1-linux-gnu
 

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -100,7 +100,7 @@ jobs:
           profile: minimal
 
       - name: Handle Rust dependencies caching
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: v1-${{ matrix.target }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
           profile: minimal
 
       - name: Handle Rust dependencies caching
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: v1-${{ matrix.target }}
 


### PR DESCRIPTION
Saw that the release of v0.26 still throws warnings on the GitHub Actions. Looking more closely, it seems the action `rust-cache` also needs an update.

<img width="1057" alt="Screen Shot 2023-01-19 at 21 43 06" src="https://user-images.githubusercontent.com/24900688/213614286-eda71f37-601d-45c4-aa1f-76afa40822f7.png">
