### PR TITLE
Format long | pattern with sensible breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed a bug where arguments would be passed incorrectly to Deno.
 - Fixed a bug where defining variables that shadow external functions could
   generate invalid JavaScript.
+- Format long | patterns with sensible breaks.
 
 ## v0.26.0 - 2023-01-19
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1252,8 +1252,10 @@ impl<'comments> Formatter<'comments> {
             std::iter::once(&clause.pattern)
                 .chain(&clause.alternative_patterns)
                 .map(|p| join(p.iter().map(|p| self.pattern(p)), ", ".to_doc())),
-            " | ".to_doc(),
-        );
+            break_(" |", " | "),
+        )
+        .group();
+
         let clause_doc = match &clause.guard {
             None => clause_doc,
             Some(guard) => clause_doc.append(" if ").append(self.clause_guard(guard)),

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1252,7 +1252,7 @@ impl<'comments> Formatter<'comments> {
             std::iter::once(&clause.pattern)
                 .chain(&clause.alternative_patterns)
                 .map(|p| join(p.iter().map(|p| self.pattern(p)), ", ".to_doc())),
-            break_(" |", " | "),
+            break_("", " ").append("| "),
         )
         .group();
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -2870,6 +2870,17 @@ fn expr_case_alternative_patterns() {
 }
 "#
     );
+
+    assert_format!(
+        r#"fn main() {
+  case pat {
+    pat.Typeof("Boolean", pat) |
+    pat.Typeof("Number", pat) |
+    pat.Typeof("String", pat) -> Nil
+  }
+}
+"#
+    );
 }
 
 #[test]

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -2874,9 +2874,9 @@ fn expr_case_alternative_patterns() {
     assert_format!(
         r#"fn main() {
   case pat {
-    pat.Typeof("Boolean", pat) |
-    pat.Typeof("Number", pat) |
-    pat.Typeof("String", pat) -> Nil
+    pat.Typeof("Boolean", pat)
+    | pat.Typeof("Number", pat)
+    | pat.Typeof("String", pat) -> Nil
   }
 }
 "#


### PR DESCRIPTION
Fixes the formatter issue in #1960 🚀 