### PR TITLE
Reintroduce warnings_as_errors build flag

### DIFF
--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -48,9 +48,6 @@ pub fn command(options: CompilePackage) -> Result<()> {
         crate::print_warning(&warning);
     }
 
-    // TODO: Support --warnings-as-errors
-    // TODO: Create a Warnings struct to wrap up this functionality
-
     Ok(())
 }
 

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use crate::{cli, hex::ApiKeyCommand, http::HttpClient};
 use gleam_core::{
-    build::{Mode, Options, Package},
+    build::{Mode, Options, Package, WarningLevel},
     config::{DocsPage, PackageConfig},
     error::Error,
     hex,
@@ -60,7 +60,7 @@ pub fn build() -> Result<()> {
         mode: Mode::Prod,
         perform_codegen: true,
         target: None,
-        warnings_as_errors: false,
+        warnings_as_errors: WarningLevel::Warn,
     })?;
     let outputs = build_documentation(&config, &mut compiled)?;
 
@@ -114,7 +114,7 @@ impl PublishCommand {
             mode: Mode::Prod,
             perform_codegen: true,
             target: None,
-            warnings_as_errors: false,
+            warnings_as_errors: WarningLevel::Warn,
         })?;
         let outputs = build_documentation(&config, &mut compiled)?;
         let archive = crate::fs::create_tar_archive(outputs)?;

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -58,8 +58,9 @@ pub fn build() -> Result<()> {
     let out = paths::build_docs(&config.name);
     let mut compiled = crate::build::main(Options {
         mode: Mode::Prod,
-        target: None,
         perform_codegen: true,
+        target: None,
+        warnings_as_errors: false,
     })?;
     let outputs = build_documentation(&config, &mut compiled)?;
 
@@ -110,9 +111,10 @@ impl PublishCommand {
         crate::fs::delete_dir(&paths::build_packages(Mode::Prod, config.target))?;
 
         let mut compiled = crate::build::main(Options {
-            perform_codegen: true,
             mode: Mode::Prod,
+            perform_codegen: true,
             target: None,
+            warnings_as_errors: false,
         })?;
         let outputs = build_documentation(&config, &mut compiled)?;
         let archive = crate::fs::create_tar_archive(outputs)?;

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -28,9 +28,10 @@ pub(crate) fn erlang_shipment() -> Result<()> {
 
     // Build project in production mode
     let package = crate::build::main(Options {
-        perform_codegen: true,
         mode,
+        perform_codegen: true,
         target: Some(target),
+        warnings_as_errors: true,
     })?;
 
     for entry in crate::fs::read_dir(&build)?

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -1,5 +1,5 @@
 use gleam_core::{
-    build::{Mode, Options, Target},
+    build::{Mode, Options, Target, WarningLevel},
     paths, Result,
 };
 
@@ -31,7 +31,7 @@ pub(crate) fn erlang_shipment() -> Result<()> {
         mode,
         perform_codegen: true,
         target: Some(target),
-        warnings_as_errors: true,
+        warnings_as_errors: WarningLevel::Error,
     })?;
 
     for entry in crate::fs::read_dir(&build)?

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -31,7 +31,7 @@ pub(crate) fn erlang_shipment() -> Result<()> {
         mode,
         perform_codegen: true,
         target: Some(target),
-        warnings_as_errors: WarningLevel::Error,
+        warnings_as_errors: WarningLevel::Warn,
     })?;
 
     for entry in crate::fs::read_dir(&build)?

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -1010,8 +1010,9 @@ where
 
         let options = build::Options {
             mode: build::Mode::Lsp,
-            target: None,
             perform_codegen: false,
+            target: None,
+            warnings_as_errors: false,
         };
         let mut project_compiler =
             ProjectCompiler::new(config, options, manifest.packages, Box::new(telemetry), io);

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -13,7 +13,10 @@ use crate::{
     fs::{self, ProjectIO},
     telemetry::NullTelemetry,
 };
-use gleam_core::{ast::Import, build::Mode};
+use gleam_core::{
+    ast::Import,
+    build::{Mode, WarningLevel},
+};
 use gleam_core::{
     ast::{SrcSpan, Statement},
     build::{self, Located, Module, ProjectCompiler},
@@ -1012,7 +1015,7 @@ where
             mode: build::Mode::Lsp,
             perform_codegen: false,
             target: None,
-            warnings_as_errors: false,
+            warnings_as_errors: WarningLevel::Warn,
         };
         let mut project_compiler =
             ProjectCompiler::new(config, options, manifest.packages, Box::new(telemetry), io);

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -79,7 +79,7 @@ pub use gleam_core::{
 };
 
 use gleam_core::{
-    build::{Mode, Options, Runtime, Target},
+    build::{Mode, Options, Runtime, Target, WarningLevel},
     hex::RetirementReason,
 };
 use hex::ApiKeyCommand as _;
@@ -357,7 +357,14 @@ fn main() {
         Command::Build {
             target,
             warnings_as_errors,
-        } => command_build(target, warnings_as_errors),
+        } => command_build(
+            target,
+            if warnings_as_errors {
+                WarningLevel::Error
+            } else {
+                WarningLevel::Warn
+            },
+        ),
 
         Command::Check => command_check(),
 
@@ -444,17 +451,17 @@ fn command_check() -> Result<(), Error> {
         perform_codegen: false,
         mode: Mode::Dev,
         target: None,
-        warnings_as_errors: false,
+        warnings_as_errors: WarningLevel::Error,
     })?;
     Ok(())
 }
 
-fn command_build(target: Option<Target>, warnings_as_errors: bool) -> Result<(), Error> {
+fn command_build(target: Option<Target>, warning_level: WarningLevel) -> Result<(), Error> {
     let _ = build::main(Options {
         mode: Mode::Dev,
         perform_codegen: true,
         target,
-        warnings_as_errors,
+        warnings_as_errors: warning_level,
     })?;
     Ok(())
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -451,7 +451,7 @@ fn command_check() -> Result<(), Error> {
         perform_codegen: false,
         mode: Mode::Dev,
         target: None,
-        warnings_as_errors: WarningLevel::Error,
+        warnings_as_errors: WarningLevel::Warn,
     })?;
     Ok(())
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -356,8 +356,8 @@ fn main() {
     let result = match Command::parse() {
         Command::Build {
             target,
-            warnings_as_errors: _,
-        } => command_build(target),
+            warnings_as_errors,
+        } => command_build(target, warnings_as_errors),
 
         Command::Check => command_check(),
 
@@ -444,15 +444,17 @@ fn command_check() -> Result<(), Error> {
         perform_codegen: false,
         mode: Mode::Dev,
         target: None,
+        warnings_as_errors: false,
     })?;
     Ok(())
 }
 
-fn command_build(target: Option<Target>) -> Result<(), Error> {
+fn command_build(target: Option<Target>, warnings_as_errors: bool) -> Result<(), Error> {
     let _ = build::main(Options {
-        perform_codegen: true,
         mode: Mode::Dev,
+        perform_codegen: true,
         target,
+        warnings_as_errors,
     })?;
     Ok(())
 }

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -6,7 +6,7 @@ use std::{
 
 use flate2::{write::GzEncoder, Compression};
 use gleam_core::{
-    build::{Mode, Options, Package, Target},
+    build::{Mode, Options, Package, Target, WarningLevel},
     config::{PackageConfig, SpdxLicense},
     hex, paths, Error, Result,
 };
@@ -39,7 +39,7 @@ impl PublishCommand {
             mode: Mode::Prod,
             perform_codegen: true,
             target: Some(Target::Erlang),
-            warnings_as_errors: true,
+            warnings_as_errors: WarningLevel::Error,
         })?;
 
         // These fields are required to publish a Hex package. Hex will reject

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -37,8 +37,9 @@ impl PublishCommand {
         // Build the project to check that it is valid
         let mut compiled = build::main(Options {
             mode: Mode::Prod,
-            target: Some(Target::Erlang),
             perform_codegen: true,
+            target: Some(Target::Erlang),
+            warnings_as_errors: true,
         })?;
 
         // These fields are required to publish a Hex package. Hex will reject

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -39,7 +39,7 @@ impl PublishCommand {
             mode: Mode::Prod,
             perform_codegen: true,
             target: Some(Target::Erlang),
-            warnings_as_errors: WarningLevel::Error,
+            warnings_as_errors: WarningLevel::Warn,
         })?;
 
         // These fields are required to publish a Hex package. Hex will reject

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use gleam_core::{
-    build::{Mode, Options, Runtime, Target},
+    build::{Mode, Options, Runtime, Target, WarningLevel},
     config::{DenoFlag, PackageConfig},
     error::Error,
     io::{CommandExecutor, Stdio},
@@ -36,7 +36,7 @@ pub fn command(
         mode: Mode::Dev,
         perform_codegen: true,
         target,
-        warnings_as_errors: false,
+        warnings_as_errors: WarningLevel::Warn,
     })?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -33,9 +33,10 @@ pub fn command(
 
     // Build project so we have bytecode to run
     let _ = crate::build::main(Options {
-        perform_codegen: true,
         mode: Mode::Dev,
+        perform_codegen: true,
         target,
+        warnings_as_errors: false,
     })?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -8,9 +8,10 @@ use std::process::Command;
 pub fn command() -> Result<(), Error> {
     // Build project
     let _ = crate::build::main(Options {
-        perform_codegen: true,
         mode: Mode::Dev,
+        perform_codegen: true,
         target: Some(Target::Erlang),
+        warnings_as_errors: false,
     })?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -1,5 +1,5 @@
 use gleam_core::{
-    build::{Mode, Options, Target},
+    build::{Mode, Options, Target, WarningLevel},
     error::Error,
     paths,
 };
@@ -11,7 +11,7 @@ pub fn command() -> Result<(), Error> {
         mode: Mode::Dev,
         perform_codegen: true,
         target: Some(Target::Erlang),
-        warnings_as_errors: false,
+        warnings_as_errors: WarningLevel::Warn,
     })?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -34,6 +34,12 @@ use std::{
 };
 use strum::{Display, EnumIter, EnumString, EnumVariantNames, VariantNames};
 
+#[derive(Debug)]
+pub enum WarningLevel {
+    Warn,
+    Error,
+}
+
 #[derive(
     Debug,
     Serialize,

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -41,6 +41,7 @@ const ELIXIR_EXECUTABLE: &str = "elixir.bat";
 pub struct Options {
     pub mode: Mode,
     pub target: Option<Target>,
+    pub warnings_as_errors: bool,
     /// Whether to perform codegen for the root project. Dependencies always
     /// have codegen run. Use for the `gleam check` command.
     /// If future when we have per-module incremental builds we will need to
@@ -144,6 +145,14 @@ where
         // Print warnings
         for warning in &self.warnings {
             self.telemetry.warning(warning);
+        }
+
+        // Exit if warnings_as_errors and warnings
+        let warning_count = &self.warnings.len();
+        if self.options.warnings_as_errors && warning_count > &0 {
+            return Err(Error::ForbiddenWarnings {
+                count: *warning_count,
+            });
         }
 
         result

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ffi::OsStr, path::Path};
 
 use gleam_core::{
-    build::{Mode, Options, Package, ProjectCompiler, Target},
+    build::{Mode, Options, Package, ProjectCompiler, Target, WarningLevel},
     config::PackageConfig,
     io::{FileSystemReader, FileSystemWriter},
     manifest::{Base16Checksum, ManifestPackage, ManifestPackageSource},
@@ -96,7 +96,7 @@ fn compile_project(
         mode: Mode::Dev,
         perform_codegen: true,
         target: Some(target),
-        warnings_as_errors: false,
+        warnings_as_errors: WarningLevel::Warn,
     };
 
     let mut pcompiler = ProjectCompiler::new(

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -94,8 +94,9 @@ fn compile_project(
 
     let options = Options {
         mode: Mode::Dev,
-        target: Some(target),
         perform_codegen: true,
+        target: Some(target),
+        warnings_as_errors: false,
     };
 
     let mut pcompiler = ProjectCompiler::new(


### PR DESCRIPTION
Potential fix for #1292, looking for feedback for the approach since it doesn't feel optimal to having to pass it into various build cmds throughout the project (mostly with `false`, but some might actually profit from the `true`, e.g. the publish cmd)