### PR TITLE
Allow JS constructor patterns with mixed labelled and unlabelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Fixed a bug where pattern matches on custom types with mixed labelled and 
+  unlabelled arguments could not be compiled with target=javascript
+
 ## v0.26.2 - 2023-02-03
 
 - The formatter now wraps long `|` patterns in case clauses over multiple lines.

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -405,7 +405,10 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                                 }
                             };
                             let label = fields.iter().find_map(find);
-                            self.push_string(label.expect("argument present in field map"));
+                            match label {
+                                Some(label) => self.push_string(label),
+                                None => self.push_int(index)
+                            }
                         }
                     }
                     self.traverse_pattern(subject, &arg.value)?;

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -407,7 +407,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                             let label = fields.iter().find_map(find);
                             match label {
                                 Some(label) => self.push_string(label),
-                                None => self.push_int(index)
+                                None => self.push_int(index),
                             }
                         }
                     }

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -266,6 +266,44 @@ fn go(cat) {
 }
 
 #[test]
+fn destructure_custom_type_with_mixed_fields_first_unlabelled() {
+    assert_js!(
+        r#"
+type Cat {
+  Cat(String, cuteness: Int)
+}
+
+fn go(cat) {
+  let Cat(x, y) = cat
+  let Cat(cuteness: y, ..) = cat
+  let Cat(x, cuteness: y) = cat
+  x
+}
+
+"#,
+    )
+}
+
+#[test]
+fn destructure_custom_type_with_mixed_fields_second_unlabelled() {
+    assert_js!(
+        r#"
+type Cat {
+  Cat(name: String, Int)
+}
+
+fn go(cat) {
+  let Cat(x, y) = cat
+  let Cat(name: x, ..) = cat
+  let Cat(y, name: x) = cat
+  x
+}
+
+"#,
+    )
+}
+
+#[test]
 fn nested_pattern_with_labels() {
     assert_js!(
         r#"pub type Box(x) { Box(a: Int, b: x) }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_mixed_fields_first_unlabelled.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_mixed_fields_first_unlabelled.snap
@@ -1,0 +1,53 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\ntype Cat {\n  Cat(String, cuteness: Int)\n}\n\nfn go(cat) {\n  let Cat(x, y) = cat\n  let Cat(cuteness: y, ..) = cat\n  let Cat(x, cuteness: y) = cat\n  x\n}\n\n"
+---
+import { CustomType as $CustomType, throwError } from "../gleam.mjs";
+
+class Cat extends $CustomType {
+  constructor(x0, cuteness) {
+    super();
+    this[0] = x0;
+    this.cuteness = cuteness;
+  }
+}
+
+function go(cat) {
+  if (!(cat instanceof Cat)) {
+    throwError(
+      "assignment_no_match",
+      "my/mod",
+      7,
+      "go",
+      "Assignment pattern did not match",
+      { value: cat }
+    );
+  }
+  let x = cat[0];
+  let y = cat.cuteness;
+  if (!(cat instanceof Cat)) {
+    throwError(
+      "assignment_no_match",
+      "my/mod",
+      8,
+      "go",
+      "Assignment pattern did not match",
+      { value: cat }
+    );
+  }
+  let y$1 = cat.cuteness;
+  if (!(cat instanceof Cat)) {
+    throwError(
+      "assignment_no_match",
+      "my/mod",
+      9,
+      "go",
+      "Assignment pattern did not match",
+      { value: cat }
+    );
+  }
+  let x$1 = cat[0];
+  let y$2 = cat.cuteness;
+  return x$1;
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_mixed_fields_second_unlabelled.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_mixed_fields_second_unlabelled.snap
@@ -1,0 +1,53 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\ntype Cat {\n  Cat(name: String, Int)\n}\n\nfn go(cat) {\n  let Cat(x, y) = cat\n  let Cat(name: x, ..) = cat\n  let Cat(y, name: x) = cat\n  x\n}\n\n"
+---
+import { CustomType as $CustomType, throwError } from "../gleam.mjs";
+
+class Cat extends $CustomType {
+  constructor(name, x1) {
+    super();
+    this.name = name;
+    this[1] = x1;
+  }
+}
+
+function go(cat) {
+  if (!(cat instanceof Cat)) {
+    throwError(
+      "assignment_no_match",
+      "my/mod",
+      7,
+      "go",
+      "Assignment pattern did not match",
+      { value: cat }
+    );
+  }
+  let x = cat.name;
+  let y = cat[1];
+  if (!(cat instanceof Cat)) {
+    throwError(
+      "assignment_no_match",
+      "my/mod",
+      8,
+      "go",
+      "Assignment pattern did not match",
+      { value: cat }
+    );
+  }
+  let x$1 = cat.name;
+  if (!(cat instanceof Cat)) {
+    throwError(
+      "assignment_no_match",
+      "my/mod",
+      9,
+      "go",
+      "Assignment pattern did not match",
+      { value: cat }
+    );
+  }
+  let x$2 = cat.name;
+  let y$1 = cat[1];
+  return x$2;
+}
+

--- a/test/language/src/main.gleam
+++ b/test/language/src/main.gleam
@@ -45,6 +45,7 @@ pub fn main() -> Int {
       suite("anonymous functions", anonymous_function_tests()),
       suite("string pattern matching", string_pattern_matching_tests()),
       suite("typescript file inclusion", typescript_file_included_tests()),
+      suite("custom types mixed args match", mixed_arg_match_tests()),
     ])
 
   case stats.failures {
@@ -1479,4 +1480,52 @@ if erlang {
       }),
     ]
   }
+}
+
+type Cat {
+  Cat(String, cuteness: Int)
+}
+
+type NestedCat {
+  NestedCat(Cat, String, cuteness: Int)
+}
+
+type InverseCat {
+  InverseCat(cuteness: Int, String)
+}
+
+fn mixed_arg_match_tests() {
+  [
+    "matching second labelled arg as first"
+    |> example(fn() {
+      let Cat(cuteness: y, ..) = Cat("fluffy", 10)
+      assert_equal(y, 10)
+    }),
+    "matching both args on position"
+    |> example(fn() {
+      let Cat(x, y) = Cat("fluffy", 10)
+      assert_equal(#(x, y), #("fluffy", 10))
+    }),
+    "matching second labelled arg as second"
+    |> example(fn() {
+      let Cat(x, cuteness: y) = Cat("fluffy", 10)
+      assert_equal(#(x, y), #("fluffy", 10))
+    }),
+    "nested custom types"
+    |> example(fn() {
+      let NestedCat(Cat(x, cuteness: y), cuteness: y2, ..) =
+        NestedCat(Cat("fluffy", 10), "gleamy", 100)
+      assert_equal(#(x, y, y2), #("fluffy", 10, 100))
+    }),
+    "matching first labelled arg as first"
+    |> example(fn() {
+      let InverseCat(cuteness: y, ..) = InverseCat(10, "fluffy")
+      assert_equal(y, 10)
+    }),
+    "matching first labelled arg as second"
+    |> example(fn() {
+      let InverseCat(x, cuteness: y) = InverseCat(10, "fluffy")
+      assert_equal(#(x, y), #("fluffy", 10))
+    }),
+  ]
 }


### PR DESCRIPTION
Potential fix for #1982 

I thought this one seemed to be a nice issue for a first contribution (specially since I reported it so I already had an idea of the problem description).

The change ended up being quite small. Just using indexed access as a fallback when not finding the label in case of mixed arguments. I added two snapshot tests and accepted the snapshots that were created. Please have a look if they seem to be ok (I reviewed them and thought it looked as if they were doing the right thing).

Unsure if there are some more tests that should be added to verify the functionality on a higher level?