### PR TITLE
Fix/1998

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - The argument `--runtime` now accepts `nodejs` as the name for that runtime.
   The previous name `node` is still accepted.
 - Fixed a bug where typescript type definitions for types with unlabelled
-  arguments where generated with an invalid identifier.
+  arguments where generated with an invalid identifier and unlabelled fields
+  were generated with a name that didn't match the javascript implementation.
 - Fixed a bug in the type inferrer were unannotated functions that were
   used before they were defined in a module could in rare cased be inferred with
   a more general type than is correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 - The unused private type and constructor detection has been improved.
 - The argument `--runtime` now accepts `nodejs` as the name for that runtime.
   The previous name `node` is still accepted.
+- Fixed a bug where typescript type definitions for types with unlabelled
+  arguments where generated with an invalid identifier.
 - Fixed a bug in the type inferrer were unannotated functions that were
   used before they were defined in a module could in rare cased be inferred with
   a more general type than is correct.
-- Fixed a bug where pattern matches on custom types with mixed labelled and 
+- Fixed a bug where pattern matches on custom types with mixed labelled and
   unlabelled arguments could not be compiled when targeting JavaScript.
 
 ## v0.26.2 - 2023-02-03
@@ -45,7 +47,6 @@
 ## v0.26.0 - 2023-01-19
 
 [Release blog post](https://gleam.run/news/v0.26-incremental-compilation-and-deno/)
-
 
 - New projects require `gleam_stdlib` v0.26 and `gleeunit` v0.9.
 - Fixed a bug where JavaScript default projects would fail to publish to Hex.
@@ -150,8 +151,7 @@
 - Fixed a bug where `try` expressions inside blocks could generate incorrect
   JavaScript.
 - Generated HTML documentation now includes all static assets (but the web
-  fonts), so that it can be accessed offline or in far future once CDNs would
-  404.
+  fonts), so that it can be accessed offline or in far future once CDNs would 404.
 - New Gleam projects are created using GitHub actions erlef/setup-beam@v1.14.0
 - The `javascript.typescript_declarations` field in `gleam.toml` now applies to
   the entire project rather than just the top level package.

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -191,6 +191,20 @@ fn destructure(x) {
 }
 
 #[test]
+fn unnamed_fields_typescript() {
+    assert_ts_def!(
+        r#"
+pub type Ip{
+    Ip(String)
+}
+
+pub const local = Ip("0.0.0.0")
+
+"#,
+    );
+}
+
+#[test]
 fn long_name_variant_without_labels() {
     assert_js!(
         r#"
@@ -202,6 +216,19 @@ type TypeWithALongNameAndSeveralArguments{
 fn go() {
   TypeWithALongNameAndSeveralArguments
 }
+"#,
+    );
+}
+
+#[test]
+fn long_name_variant_mixed_labels_typescript() {
+    assert_ts_def!(
+        r#"
+pub type TypeWithALongNameAndSeveralArguments{
+  TypeWithALongNameAndSeveralArguments(String, String, String, a: String, b: String)
+}
+
+pub const local = TypeWithALongNameAndSeveralArguments("one", "two", "three", "four", "five")
 "#,
     );
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type TypeWithALongNameAndSeveralArguments{\n  TypeWithALongNameAndSeveralArguments(String, String, String, a: String, b: String)\n}\n\npub const local = TypeWithALongNameAndSeveralArguments(\"one\", \"two\", \"three\", \"four\", \"five\")\n"
+---
+import * as _ from "../gleam.d.ts";
+
+export const local: TypeWithALongNameAndSeveralArguments$;
+
+export class TypeWithALongNameAndSeveralArguments extends _.CustomType {
+  constructor(
+    argument$0: string,
+    argument$1: string,
+    argument$2: string,
+    a: string,
+    b: string
+  );
+  
+  x0: string;
+  x1: string;
+  x2: string;
+  a: string;
+  b: string;
+}
+
+export type TypeWithALongNameAndSeveralArguments$ = TypeWithALongNameAndSeveralArguments;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
@@ -15,9 +15,9 @@ export class TypeWithALongNameAndSeveralArguments extends _.CustomType {
     b: string
   );
   
-  x0: string;
-  x1: string;
-  x2: string;
+  0: string;
+  1: string;
+  2: string;
   a: string;
   b: string;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
@@ -4,8 +4,6 @@ expression: "\npub type TypeWithALongNameAndSeveralArguments{\n  TypeWithALongNa
 ---
 import * as _ from "../gleam.d.ts";
 
-export const local: TypeWithALongNameAndSeveralArguments$;
-
 export class TypeWithALongNameAndSeveralArguments extends _.CustomType {
   constructor(
     argument$0: string,
@@ -23,4 +21,6 @@ export class TypeWithALongNameAndSeveralArguments extends _.CustomType {
 }
 
 export type TypeWithALongNameAndSeveralArguments$ = TypeWithALongNameAndSeveralArguments;
+
+export const local: TypeWithALongNameAndSeveralArguments$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Ip{\n    Ip(String)\n}\n\npub const local = Ip(\"0.0.0.0\")\n\n"
+---
+import * as _ from "../gleam.d.ts";
+
+export const local: Ip$;
+
+export class Ip extends _.CustomType {
+  constructor(argument$0: string);
+  
+  x0: string;
+}
+
+export type Ip$ = Ip;
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
@@ -9,7 +9,7 @@ export const local: Ip$;
 export class Ip extends _.CustomType {
   constructor(argument$0: string);
   
-  x0: string;
+  0: string;
 }
 
 export type Ip$ = Ip;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
@@ -4,8 +4,6 @@ expression: "\npub type Ip{\n    Ip(String)\n}\n\npub const local = Ip(\"0.0.0.0
 ---
 import * as _ from "../gleam.d.ts";
 
-export const local: Ip$;
-
 export class Ip extends _.CustomType {
   constructor(argument$0: string);
   
@@ -13,4 +11,6 @@ export class Ip extends _.CustomType {
 }
 
 export type Ip$ = Ip;
+
+export const local: Ip$;
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -448,7 +448,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     .label
                     .as_ref()
                     .map(|s| super::maybe_escape_identifier_doc(s))
-                    .unwrap_or_else(|| Document::String(format!("{i}")));
+                    .unwrap_or_else(|| Document::String(format!("argument${i}")));
                 docvec![name, ": ", self.do_print_force_generic_param(&arg.type_)]
             })),
             ";",

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -461,7 +461,7 @@ impl<'a> TypeScriptGenerator<'a> {
                         .label
                         .as_ref()
                         .map(|s| super::maybe_escape_identifier_doc(s))
-                        .unwrap_or_else(|| Document::String(format!("x{i}")));
+                        .unwrap_or_else(|| Document::String(format!("{i}")));
                     docvec![
                         name,
                         ": ",


### PR DESCRIPTION
Fixing #1998 according to the discussion in the issue.

Added two snapshot asserting type definitions with unlabelled arguments. Unsure why the constant is part of the
type definition file, but this is consistent with theFixing #1998 according to the discussion in the issue.

Added two snapshot asserting type definitions with unlabelled arguments. Unsure why the constant is part of the
type definition file, but this is consistent with the output from already existing tests. output from already existing tests.