### PR TITLE
Use UTF-16 char count for calculating js slice for concat match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - The unused private type and constructor detection has been improved.
 - The argument `--runtime` now accepts `nodejs` as the name for that runtime.
   The previous name `node` is still accepted.
+- Fixed a bug where string concatenation patterns could generate javascript
+  code with wrong slice index due to ut8/ut16 length mismatch.
 - Fixed a bug where typescript type definitions for types with unlabelled
   arguments where generated with an invalid identifier and unlabelled fields
   were generated with a name that didn't match the javascript implementation.

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -364,7 +364,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 ..
             } => {
                 self.push_string_prefix_check(subject.clone(), left_side_string);
-                self.push_string_prefix_slice(left_side_string.len());
+                self.push_string_prefix_slice(left_side_string.encode_utf16().count());
                 if let AssignName::Variable(right) = right_side_assignment {
                     self.push_assignment(subject.clone(), right);
                 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
@@ -1,0 +1,51 @@
+---
+source: compiler-core/src/javascript/tests/strings.rs
+expression: "\npub fn go(x) {\n  case \"Θ foo bar\" {\n    \"Θ\" <> rest -> rest\n  }\n  case \"🫥 is neutral dotted\" {\n    \"🫥\" <> rest -> rest\n  }\n  case \"🇺🇸 is a cluster\" {\n    \"🇺🇸\" <> rest -> rest\n  }\n}\n"
+---
+import { throwError } from "../gleam.mjs";
+
+export function go(x) {
+  let $ = "Θ foo bar";
+  if ($.startsWith("Θ")) {
+    let rest = $.slice(1);
+    rest
+  } else {
+    throwError(
+      "case_no_match",
+      "my/mod",
+      3,
+      "go",
+      "No case clause matched",
+      { values: [$] }
+    );
+  }
+  let $1 = "🫥 is neutral dotted";
+  if ($1.startsWith("🫥")) {
+    let rest = $1.slice(2);
+    rest
+  } else {
+    throwError(
+      "case_no_match",
+      "my/mod",
+      6,
+      "go",
+      "No case clause matched",
+      { values: [$1] }
+    );
+  }
+  let $2 = "🇺🇸 is a cluster";
+  if ($2.startsWith("🇺🇸")) {
+    let rest = $2.slice(4);
+    return rest;
+  } else {
+    throwError(
+      "case_no_match",
+      "my/mod",
+      9,
+      "go",
+      "No case clause matched",
+      { values: [$2] }
+    );
+  }
+}
+

--- a/compiler-core/src/javascript/tests/strings.rs
+++ b/compiler-core/src/javascript/tests/strings.rs
@@ -77,6 +77,25 @@ pub fn go(x) {
 }
 
 #[test]
+fn string_prefix_utf16() {
+    assert_js!(
+        r#"
+pub fn go(x) {
+  case "Θ foo bar" {
+    "Θ" <> rest -> rest
+  }
+  case "🫥 is neutral dotted" {
+    "🫥" <> rest -> rest
+  }
+  case "🇺🇸 is a cluster" {
+    "🇺🇸" <> rest -> rest
+  }
+}
+"#,
+    );
+}
+
+#[test]
 fn discard_concat_rest_pattern() {
     // We can discard the right hand side, it parses and type checks ok
     assert_js!(

--- a/test/language/src/main.gleam
+++ b/test/language/src/main.gleam
@@ -1451,6 +1451,33 @@ fn string_pattern_matching_tests() {
         },
       )
     }),
+    "match 🫥 test"
+    |> example(fn() {
+      assert_equal(
+        " is neutral dotted",
+        case "🫥 is neutral dotted" {
+          "🫥" <> rest -> rest
+        },
+      )
+    }),
+    "match Θ test"
+    |> example(fn() {
+      assert_equal(
+        " foo bar",
+        case "Θ foo bar" {
+          "Θ" <> rest -> rest
+        },
+      )
+    }),
+    "match 🇺🇸 test"
+    |> example(fn() {
+      assert_equal(
+        " is a cluster",
+        case "🇺🇸 is a cluster" {
+          "🇺🇸" <> rest -> rest
+        },
+      )
+    }),
   ]
 }
 


### PR DESCRIPTION
Fix for issue #2001

The `SmolStr` is encoded as UTF-16 and the number of chars is used to calculate the slice-index.

I added some snapshot tests and also language test to verify and as far as I can see this strategy seem to produce correct results.