### PR TITLE
Insert todo in empty anonymous functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   unlabelled arguments could not be compiled when targeting JavaScript.
 - Fixed a bug where local variables in case guard constant expressions caused
   the compiler to panic.
+- Insert todo in empty anonymous functions.
 
 ## v0.26.2 - 2023-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
   unlabelled arguments could not be compiled when targeting JavaScript.
 - Fixed a bug where local variables in case guard constant expressions caused
   the compiler to panic.
-- Insert todo in empty anonymous functions.
+- To be consistent with named functions the formatter now inserts a `todo` into
+  empty anonymous functions.
 
 ## v0.26.2 - 2023-02-03
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3029,6 +3029,17 @@ fn expr_todo() {
 }
 "#
     );
+
+    assert_format_rewrite!(
+        r#"fn main() {
+  fn() {}
+}
+"#,
+        r#"fn main() {
+  fn() { todo }
+}
+"#
+    );
 }
 
 #[test]

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1362,9 +1362,6 @@ where
             .map(|l| l.location().end)
             .unwrap_or_else(|| if is_anon { rbr_e } else { rpar_e });
         let body = match some_body {
-            None if is_anon => {
-                return self.next_tok_unexpected(vec!["The body of a function".into()]);
-            }
             None => UntypedExpr::Todo {
                 kind: TodoKind::EmptyFunction,
                 location: SrcSpan { start, end },

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -239,20 +239,6 @@ fn anonymous_function_labeled_arguments() {
 }
 
 #[test]
-fn anon_function_no_body() {
-    assert_error!(
-        "let x = fn() {} x()",
-        ParseError {
-            error: ParseErrorType::UnexpectedToken {
-                expected: vec!["The body of a function".into()],
-                hint: None
-            },
-            location: SrcSpan { start: 16, end: 17 },
-        }
-    );
-}
-
-#[test]
 fn no_let_binding() {
     assert_error!(
         "foo = 32",


### PR DESCRIPTION
Closes #2008 

```gleam
fn main() {
  fn() { todo }
}
```