### PR TITLE
Add lexer error for semicolons

### DIFF
--- a/compiler-core/src/erlang/tests/try_.rs
+++ b/compiler-core/src/erlang/tests/try_.rs
@@ -29,7 +29,7 @@ fn in_block() {
     assert_erl!(
         "pub fn main() {
   {
-    try b = Error(Nil);
+    try b = Error(Nil)
     b
   }
   Ok(1)

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -27,8 +27,8 @@ type Mine {
     ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant
 }
 
-const this = This;
-const that = ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant;
+const this = This
+const that = ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant
 "#,
     );
 }

--- a/compiler-core/src/javascript/tests/lists.rs
+++ b/compiler-core/src/javascript/tests/lists.rs
@@ -31,7 +31,7 @@ fn multi_line_list_literals() {
     assert_js!(
         r#"
 fn go(x) {
-    [{True; 1}]
+    [{True 1}]
 }
 "#,
     );

--- a/compiler-core/src/javascript/tests/panic.rs
+++ b/compiler-core/src/javascript/tests/panic.rs
@@ -29,7 +29,7 @@ fn as_expression() {
 fn go(f) {
   let boop = panic
   f(panic)
-};
+}
 "#,
     );
 }
@@ -40,7 +40,7 @@ fn pipe() {
         r#"
 fn go(f) {
   f |> panic
-};
+}
 "#,
     );
 }
@@ -52,7 +52,7 @@ fn sequence() {
 fn go(at_the_disco) {
   panic
   at_the_disco
-};
+}
 "#,
     );
 }
@@ -65,7 +65,7 @@ fn go(x) {
   case x {
     _ -> panic
   }
-};
+}
 "#,
     );
 }

--- a/compiler-core/src/javascript/tests/todo.rs
+++ b/compiler-core/src/javascript/tests/todo.rs
@@ -28,7 +28,7 @@ fn with_message() {
         r#"
 fn go() {
   todo("I should do this")
-};
+}
 "#,
     );
 }
@@ -41,7 +41,7 @@ fn as_expression() {
 fn go(f) {
   let boop = todo("I should do this")
   f(todo("Boom"))
-};
+}
 "#,
     );
 }

--- a/compiler-core/src/javascript/tests/try_.rs
+++ b/compiler-core/src/javascript/tests/try_.rs
@@ -77,7 +77,7 @@ fn in_block_not_assigned() {
     assert_js!(
         "pub fn main() {
   {
-    try b = Error(Nil);
+    try b = Error(Nil)
     b
   }
   Ok(1)

--- a/compiler-core/src/javascript/tests/tuples.rs
+++ b/compiler-core/src/javascript/tests/tuples.rs
@@ -79,8 +79,8 @@ fn constant_tuples() {
     assert_js!(
         r#"
 const a = "Hello"
-const b = 1;
-const c = 2.0;
+const b = 1
+const c = 2.0
 const e = #("bob", "dug")
         "#,
     );

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -276,6 +276,10 @@ impl LexicalError {
             LexicalErrorType::UnexpectedStringEnd => {
                 ("The string starting here was left open.", vec![])
             }
+            LexicalErrorType::UnrecognizedToken { tok } if *tok == ';' => (
+                "Semicolons used to be white space, but are no longer allowed.",
+                vec!["Hint: You can safely delete them.".into()],
+            ),
             LexicalErrorType::UnrecognizedToken { .. } => (
                 "I can't figure out what to do with this character.",
                 vec!["Hint: Is it a typo?".into()],

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -437,8 +437,8 @@ where
                     }
                 }
             }
-            ' ' | '\t' | '\x0C' | ';' => {
-                // Skip whitespaces and semicolons
+            ' ' | '\t' | '\x0C' => {
+                // Skip whitespaces
                 let _ = self.next_char();
             }
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__semicolons.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__semicolons.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "{ 2 + 3; - -5; }"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:8
+  │
+1 │ { 2 + 3; - -5; }
+  │        ^ Semicolons used to be white space, but are no longer allowed.
+
+Hint: You can safely delete them.
+

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -347,3 +347,9 @@ fn assign_left_hand_side_of_concat_pattern() {
 fn valueless_list_spread_expression() {
     assert_error!(r#"let x = [1, 2, 3, ..]"#);
 }
+
+// https://github.com/gleam-lang/gleam/issues/2035
+#[test]
+fn semicolons() {
+    assert_error!(r#"{ 2 + 3; - -5; }"#);
+}

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1369,7 +1369,7 @@ fn fn_annotation_reused() {
         "
         pub type Box(a) {
             Box(value: a)
-        };
+        }
         pub fn go(box1: Box(a)) {
             fn(box2: Box(a)) { box1.value == box2.value }
         }",
@@ -1384,7 +1384,7 @@ fn fn_annotation_reused() {
         "
         pub type Box(a) {
             Box(value: a)
-        };
+        }
         pub fn go(box1: Box(a)) {
             let x: Box(a) = box1
             fn(box2: Box(a)) { x.value == box2.value }
@@ -1481,7 +1481,7 @@ fn record_update_no_fields() {
         "
         pub type Person {
             Person(name: String, age: Int)
-        };
+        }
         pub fn identity(person: Person) {
             Person(..person)
         }",
@@ -1499,7 +1499,7 @@ fn record_update() {
         "
         pub type Person {
             Person(name: String, age: Int)
-        };
+        }
         pub fn update_name(person: Person, name: String) {
             Person(..person, name: name)
         }",
@@ -1517,7 +1517,7 @@ fn record_update_all_fields() {
         "
         pub type Person {
             Person(name: String, age: Int)
-        };
+        }
         pub fn update_person(person: Person, name: String, age: Int) {
             Person(..person, name: name, age: age, )
         }",
@@ -1535,7 +1535,7 @@ fn record_update_out_of_order() {
         "
         pub type Person {
             Person(name: String, age: Int)
-        };
+        }
         pub fn update_person(person: Person, name: String, age: Int) {
             Person(..person, age: age, name: name)
         }",
@@ -1553,7 +1553,7 @@ fn record_update_generic() {
         "
         pub type Box(a, b) {
             Box(left: a, right: b)
-        };
+        }
 
         pub fn combine_boxes(a: Box(Int, Bool), b: Box(Bool, Int)) {
             Box(..a, left: a.left + b.right, right: b.left)
@@ -1575,7 +1575,7 @@ fn record_update_generic_unannotated() {
         "
         pub type Box(a, b) {
             Box(left: a, right: b)
-        };
+        }
 
         pub fn combine_boxes(a: Box(t1, t2), b: Box(t2, t1)) {
             Box(..a, left: b.right, right: b.left)

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1082,7 +1082,7 @@ fn duplicate_custom_type_names() {
 fn duplicate_const_names() {
     // We cannot declare two const with the same name in a module
     assert_module_error!(
-        "const duplicate = 1;
+        "const duplicate = 1
 pub const duplicate = 1"
     );
 }
@@ -1189,10 +1189,10 @@ fn wrong_type_update() {
         "
  pub type Person {
    Person(name: String, age: Int)
- };
+ }
  pub type Box(a) {
    Box(a)
- };
+ }
  pub fn update_person(person: Person, box: Box(a)) {
    Person(..box)
  }"
@@ -1206,7 +1206,7 @@ fn unknown_variable_update() {
         "
 pub type Person {
   Person(name: String, age: Int)
-};
+}
 pub fn update_person() {
   Person(..person)
 }"
@@ -1220,7 +1220,7 @@ fn unknown_field_update() {
         "
  pub type Person {
    Person(name: String)
- };
+ }
  pub fn update_person(person: Person) {
    Person(..person, one: 5)
  }"
@@ -1234,7 +1234,7 @@ fn unknown_field_update2() {
         "
  pub type Person {
    Person(name: String, age: Int, size: Int)
- };
+ }
  pub fn update_person(person: Person) {
    Person(..person, size: 66, one: 5, age: 3)
  }"
@@ -1248,7 +1248,7 @@ fn unknown_constructor_update() {
         "
 pub type Person {
    Person(name: String, age: Int)
-};
+}
 pub fn update_person(person: Person) {
    NotAPerson(..person)
 }"
@@ -1262,7 +1262,7 @@ fn not_a_constructor_update() {
         "
 pub type Person {
   Person(name: String, age: Int)
-};
+}
 pub fn identity(a) { a }
 pub fn update_person(person: Person) {
   identity(..person)
@@ -1277,7 +1277,7 @@ fn expression_constructor_update() {
         "
 pub type Person {
   Person(name: String, age: Int)
-};
+}
 pub fn update_person(person: Person) {
   let constructor = Person
   constructor(..person)
@@ -1292,10 +1292,10 @@ fn generic_record_update1() {
         "
 pub type Box(a) {
   Box(value: a, i: Int)
-};
+}
 pub fn update_box(box: Box(Int), value: String) {
   Box(..box, value: value)
-};"
+}"
     );
 }
 
@@ -1306,10 +1306,10 @@ fn generic_record_update2() {
         "
 pub type Box(a) {
   Box(value: a, i: Int)
-};
+}
 pub fn update_box(box: Box(a), value: b) {
   Box(..box, value: value)
-};"
+}"
     );
 }
 
@@ -1317,7 +1317,7 @@ pub fn update_box(box: Box(a), value: b) {
 fn type_vars_must_be_declared() {
     // https://github.com/gleam-lang/gleam/issues/734
     assert_module_error!(
-        r#"type A(a) { A };
+        r#"type A(a) { A }
 type B = a"#
     );
 }
@@ -1325,7 +1325,7 @@ type B = a"#
 #[test]
 fn type_holes1() {
     // Type holes cannot be used when decaring types or external functions
-    assert_module_error!(r#"type A { A(_) };"#);
+    assert_module_error!(r#"type A { A(_) }"#);
 }
 
 #[test]
@@ -1555,9 +1555,9 @@ fn negate_string() {
 fn ambiguous_type_error() {
     assert_with_module_error!(
         ("foo", "pub type Thing { Thing }"),
-        "import foo; pub type Thing { Thing }; 
-        pub fn main() { 
-            [Thing] == [foo.Thing]; 
+        "import foo pub type Thing { Thing }
+        pub fn main() {
+            [Thing] == [foo.Thing]
         }",
     );
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_type_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_type_error.snap
@@ -1,12 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1758
-expression: "import foo; pub type Thing { Thing }; \n        pub fn main() { \n            [Thing] == [foo.Thing]; \n        }"
+expression: "import foo pub type Thing { Thing }\n        pub fn main() {\n            [Thing] == [foo.Thing]\n        }"
 ---
 error: Type mismatch
   ┌─ /src/one/two.gleam:3:24
   │
-3 │             [Thing] == [foo.Thing]; 
+3 │             [Thing] == [foo.Thing]
   │                        ^^^^^^^^^^^
 
 Expected type:

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_names.snap
@@ -1,12 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1286
-expression: "const duplicate = 1;\npub const duplicate = 1"
+expression: "const duplicate = 1\npub const duplicate = 1"
 ---
 error: Duplicate constant definition
   ┌─ /src/one/two.gleam:1:7
   │
-1 │ const duplicate = 1;
+1 │ const duplicate = 1
   │       ^^^^^^^^^ First defined here
 2 │ pub const duplicate = 1
   │           ^^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_holes1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_holes1.snap
@@ -1,12 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1530
-expression: "type A { A(_) };"
+expression: "type A { A(_) }"
 ---
 error: Unexpected type hole
   ┌─ /src/one/two.gleam:1:12
   │
-1 │ type A { A(_) };
+1 │ type A { A(_) }
   │            ^ I need to know what this is
 
 We need to know the exact type here so type holes cannot be used.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -81,9 +81,12 @@ fn result_discard_warning_test() {
     assert_warning!(
         "
 fn foo() { Ok(5) }
-fn main() { foo(); 5 }",
+fn main() {
+		foo()
+		5
+}",
         Warning::ImplicitlyDiscardedResult {
-            location: SrcSpan { start: 32, end: 37 }
+            location: SrcSpan { start: 34, end: 39 }
         }
     );
 }
@@ -94,14 +97,14 @@ fn result_discard_warning_test2() {
     assert_no_warnings!(
         "
 pub fn foo() { Ok(5) }
-pub fn main() { let _ = foo(); 5 }",
+pub fn main() { let _ = foo() 5 }",
     );
 }
 
 #[test]
 fn unused_int() {
     assert_warning!(
-        "fn main() { 1; 2 }",
+        "fn main() { 1 2 }",
         Warning::UnusedLiteral {
             location: SrcSpan { start: 12, end: 13 }
         }
@@ -111,7 +114,7 @@ fn unused_int() {
 #[test]
 fn unused_float() {
     assert_warning!(
-        "fn main() { 1.0; 2 }",
+        "fn main() { 1.0 2 }",
         Warning::UnusedLiteral {
             location: SrcSpan { start: 12, end: 15 }
         }
@@ -122,11 +125,12 @@ fn unused_float() {
 fn unused_string() {
     assert_warning!(
         "
-    fn main() { 
-        \"1\"; 2 
+    fn main() {
+        \"1\"
+				2
     }",
         Warning::UnusedLiteral {
-            location: SrcSpan { start: 26, end: 29 }
+            location: SrcSpan { start: 25, end: 28 }
         }
     );
 }
@@ -135,11 +139,12 @@ fn unused_string() {
 fn unused_bit_string() {
     assert_warning!(
         "
-    fn main() { 
-        <<3>>; 2 
+    fn main() {
+        <<3>>
+				2
     }",
         Warning::UnusedLiteral {
-            location: SrcSpan { start: 26, end: 31 }
+            location: SrcSpan { start: 25, end: 30 }
         }
     );
 }
@@ -148,11 +153,12 @@ fn unused_bit_string() {
 fn unused_tuple() {
     assert_warning!(
         "
-    fn main() { 
-        #(1.0, \"Hello world\"); 2
+    fn main() {
+        #(1.0, \"Hello world\")
+				2
     }",
         Warning::UnusedLiteral {
-            location: SrcSpan { start: 26, end: 47 }
+            location: SrcSpan { start: 25, end: 46 }
         }
     );
 }
@@ -161,11 +167,12 @@ fn unused_tuple() {
 fn unused_list() {
     assert_warning!(
         "
-    fn main() { 
-        [1, 2, 3]; 2 
+    fn main() {
+        [1, 2, 3]
+				2
     }",
         Warning::UnusedLiteral {
-            location: SrcSpan { start: 26, end: 35 }
+            location: SrcSpan { start: 25, end: 34 }
         }
     );
 }
@@ -177,7 +184,7 @@ fn record_update_warnings_test() {
         "
         pub type Person {
             Person(name: String, age: Int)
-        };
+        }
         pub fn update_person() {
             let past = Person(\"Quinn\", 27)
             let present = Person(..past, name: \"Santi\")
@@ -193,7 +200,7 @@ fn record_update_warnings_test2() {
         "
         pub type Person {
             Person(name: String, age: Int)
-        };
+        }
         pub fn update_person() {
             let past = Person(\"Quinn\", 27)
             let present = Person(..past)
@@ -201,8 +208,8 @@ fn record_update_warnings_test2() {
         }",
         Warning::NoFieldsRecordUpdate {
             location: SrcSpan {
-                start: 183,
-                end: 197
+                start: 182,
+                end: 196
             }
         }
     );
@@ -215,7 +222,7 @@ fn record_update_warnings_test3() {
         "
         pub type Person {
             Person(name: String, age: Int)
-        };
+        }
         pub fn update_person() {
             let past = Person(\"Quinn\", 27)
             let present = Person(..past, name: \"Quinn\", age: 28)
@@ -223,8 +230,8 @@ fn record_update_warnings_test3() {
         }",
         Warning::AllFieldsRecordUpdate {
             location: SrcSpan {
-                start: 183,
-                end: 221
+                start: 182,
+                end: 220
             }
         }
     );
@@ -431,7 +438,7 @@ fn unused_imported_module_with_alias_warnings_test() {
 fn unused_imported_module_no_warning_on_used_function_test() {
     assert_no_warnings!(
         ("gleam/foo", "pub fn bar() { 1 }"),
-        "import gleam/foo; pub fn baz() { foo.bar() }",
+        "import gleam/foo pub fn baz() { foo.bar() }",
     );
 }
 
@@ -439,7 +446,7 @@ fn unused_imported_module_no_warning_on_used_function_test() {
 fn unused_imported_module_no_warning_on_used_type_test() {
     assert_no_warnings!(
         ("gleam/foo", "pub type Foo = Int"),
-        "import gleam/foo; pub fn baz(a: foo.Foo) { a }",
+        "import gleam/foo pub fn baz(a: foo.Foo) { a }",
     );
 }
 
@@ -447,7 +454,7 @@ fn unused_imported_module_no_warning_on_used_type_test() {
 fn unused_imported_module_no_warning_on_used_unqualified_function_test() {
     assert_no_warnings!(
         ("gleam/foo", "pub fn bar() { 1 }"),
-        "import gleam/foo.{bar}; pub fn baz() { bar() }",
+        "import gleam/foo.{bar} pub fn baz() { bar() }",
     );
 }
 
@@ -455,7 +462,7 @@ fn unused_imported_module_no_warning_on_used_unqualified_function_test() {
 fn unused_imported_module_no_warning_on_used_unqualified_type_test() {
     assert_no_warnings!(
         ("gleam/foo", "pub type Foo = Int"),
-        "import gleam/foo.{Foo}; pub fn baz(a: Foo) { a }",
+        "import gleam/foo.{Foo} pub fn baz(a: Foo) { a }",
     );
 }
 


### PR DESCRIPTION
New error message: `Semicolons used to be white space, but are no longer allowed.`
Hint: `You can safely delete them.`

Issue: #2035 