### PR TITLE
Filtering escape characters when calculating slice index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Semicolons are no longer whitespace. An error will be emitted if one is
   encountered.
+- Fixed a bug where string concatenation patterns on strings with escape
+  characters would generate javascript code with wrong slice index.
 
 ## v0.27.0 - 2023-03-01
 

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -368,7 +368,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 ..
             } => {
                 self.push_string_prefix_check(subject.clone(), left_side_string);
-                self.push_string_prefix_slice(left_side_string.encode_utf16().count());
+                self.push_string_prefix_slice(utf16_no_escape_len(left_side_string));
                 if let AssignName::Variable(right) = right_side_assignment {
                     self.push_assignment(subject.clone(), right);
                 }
@@ -769,4 +769,20 @@ pub(crate) fn assign_subjects<'a>(
         out.push(assign_subject(expression_generator, subject))
     }
     out
+}
+// Helper function to calculate length of str as utf16 without escape characters
+fn utf16_no_escape_len(str: &SmolStr) -> usize {
+    let mut filtered_str = String::new();
+    let mut str_iter = str.chars();
+    loop {
+        match str_iter.next() {
+            Some('\\') => match str_iter.next() {
+                Some(c) => filtered_str.push_str(c.to_string().as_str()),
+                None => break,
+            },
+            Some(c) => filtered_str.push_str(c.to_string().as_str()),
+            None => break,
+        }
+    }
+    return filtered_str.encode_utf16().count();
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/strings.rs
-expression: "\npub fn go(x) {\n  case \"Θ foo bar\" {\n    \"Θ\" <> rest -> rest\n  }\n  case \"🫥 is neutral dotted\" {\n    \"🫥\" <> rest -> rest\n  }\n  case \"🇺🇸 is a cluster\" {\n    \"🇺🇸\" <> rest -> rest\n  }\n}\n"
+expression: "\npub fn go(x) {\n  case \"Θ foo bar\" {\n    \"Θ\" <> rest -> rest\n  }\n  case \"🫥 is neutral dotted\" {\n    \"🫥\" <> rest -> rest\n  }\n  case \"🇺🇸 is a cluster\" {\n    \"🇺🇸\" <> rest -> rest\n  }\n  case \"\\\" is a an escaped quote\" {\n    \"\\\"\" <> rest -> rest\n  }\n  case \"\\\\ is a an escaped backslash\" {\n    \"\\\\\" <> rest -> rest\n  }\n}\n"
 ---
 import { makeError } from "../gleam.mjs";
 
@@ -36,7 +36,7 @@ export function go(x) {
   let $2 = "🇺🇸 is a cluster";
   if ($2.startsWith("🇺🇸")) {
     let rest = $2.slice(4);
-    return rest;
+    rest
   } else {
     throw makeError(
       "case_no_match",
@@ -45,6 +45,34 @@ export function go(x) {
       "go",
       "No case clause matched",
       { values: [$2] }
+    )
+  }
+  let $3 = "\" is a an escaped quote";
+  if ($3.startsWith("\"")) {
+    let rest = $3.slice(1);
+    rest
+  } else {
+    throw makeError(
+      "case_no_match",
+      "my/mod",
+      12,
+      "go",
+      "No case clause matched",
+      { values: [$3] }
+    )
+  }
+  let $4 = "\\ is a an escaped backslash";
+  if ($4.startsWith("\\")) {
+    let rest = $4.slice(1);
+    return rest;
+  } else {
+    throw makeError(
+      "case_no_match",
+      "my/mod",
+      15,
+      "go",
+      "No case clause matched",
+      { values: [$4] }
     )
   }
 }

--- a/compiler-core/src/javascript/tests/strings.rs
+++ b/compiler-core/src/javascript/tests/strings.rs
@@ -90,6 +90,12 @@ pub fn go(x) {
   case "🇺🇸 is a cluster" {
     "🇺🇸" <> rest -> rest
   }
+  case "\" is a an escaped quote" {
+    "\"" <> rest -> rest
+  }
+  case "\\ is a an escaped backslash" {
+    "\\" <> rest -> rest
+  }
 }
 "#,
     );

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -1506,6 +1506,15 @@ fn string_pattern_matching_tests() {
         },
       )
     }),
+    "match newline test"
+    |> example(fn() {
+      assert_equal(
+        " is a newline that escaped",
+        case "\\n is a newline that escaped" {
+          "\\n" <> rest -> rest
+        },
+      )
+    }),
   ]
 }
 

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -1488,6 +1488,24 @@ fn string_pattern_matching_tests() {
         },
       )
     }),
+    "match backslash test"
+    |> example(fn() {
+      assert_equal(
+        " is a backslash",
+        case "\" is a backslash" {
+          "\"" <> rest -> rest
+        },
+      )
+    }),
+    "match newline test"
+    |> example(fn() {
+      assert_equal(
+        " is a newline",
+        case "\n is a newline" {
+          "\n" <> rest -> rest
+        },
+      )
+    }),
   ]
 }
 


### PR DESCRIPTION
Follow up fix for #2001 

Added a helper for the calculation. Not sure if this fits into the general structure. Happy to move it around if you have some opinion on where that code should live.