### PR TITLE
Set end.line to #lines instead of u32::MAX in text_edit_replace

### DIFF
--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -4,6 +4,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    convert::TryFrom,
     path::{Path, PathBuf},
 };
 
@@ -858,6 +859,7 @@ where
 }
 
 fn text_edit_replace(new_text: String) -> TextEdit {
+    let numlines = u32::try_from(new_text.lines().count()).unwrap();
     TextEdit {
         range: Range {
             start: Position {
@@ -865,7 +867,7 @@ fn text_edit_replace(new_text: String) -> TextEdit {
                 character: 0,
             },
             end: Position {
-                line: u32::MAX,
+                line: numlines,
                 character: 0,
             },
         },


### PR DESCRIPTION
Always returning u32::MAX as the last line in text_edit_replace relies on the LSP client exhibiting a behavior that is not covered by the LSP specification.

See related discussion in [helix-editor/helix](https://github.com/helix-editor/helix/issues/6022) and [microsoft/vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node/issues/1199#issuecomment-1449544173)

The proposed change works for me, but since I'm not really familiar with Rust, might not be a very idiomatic solution.