### PR TITLE
Check source hashes when loading from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   server which was incompatible with Helix.
 - Fixed a bug where string concatenation patterns on strings with escape
   characters would generate javascript code with wrong slice index.
+- Cache loader now checks the file hashes in addition to modification times before loading cached entry.
 
 ## v0.27.0 - 2023-03-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2",
  "smol_str",
  "spdx",
  "strsim",

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -72,6 +72,8 @@ bincode = "1.3.3"
 globset = { version = "0.4.9", features = ["serde1"] }
 # Compact and cheap to clone immutable string type
 smol_str = { version = "0.1", features = ["serde"] }
+# Checksums
+sha2 = "0.9.8"
 
 [build-dependencies]
 # Data (de)serialisation

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -26,7 +26,8 @@ use crate::{
     type_,
 };
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{digest::Output, Digest, Sha256};
 use smol_str::SmolStr;
 use std::time::SystemTime;
 use std::{
@@ -178,6 +179,34 @@ impl Package {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub(crate) struct SourceDigest(Output<Sha256>);
+
+impl TryFrom<String> for SourceDigest {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let raw_digest = base16::decode(value.as_bytes())
+            .map_err(|e| Error::InvalidSourceDigest(e.to_string()))?;
+        let digest = Output::<Sha256>::from_exact_iter(raw_digest.into_iter())
+            .ok_or_else(|| Error::InvalidSourceDigest("unexpected length for sha256".into()))?;
+        Ok(SourceDigest(digest))
+    }
+}
+
+impl From<SourceDigest> for String {
+    fn from(digest: SourceDigest) -> Self {
+        base16::encode_upper(&digest.0)
+    }
+}
+
+pub(crate) fn source_digest(source: &SmolStr) -> SourceDigest {
+    let mut hasher = Sha256::new();
+    hasher.update(source.as_bytes());
+    SourceDigest(hasher.finalize())
+}
+
 #[derive(Debug)]
 pub struct Module {
     pub name: SmolStr,
@@ -255,6 +284,10 @@ impl Module {
             .iter()
             .map(|(name, _)| name.clone())
             .collect()
+    }
+
+    pub(crate) fn digest(&self) -> SourceDigest {
+        source_digest(&self.code)
     }
 }
 

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    build::source_digest,
+    build::module_loader::SourceDigest,
     io::{memory::InMemoryFileSystem, FileSystemWriter},
 };
 use std::time::Duration;
@@ -126,7 +126,7 @@ fn write_cache(fs: &InMemoryFileSystem, path: &str, seconds: u64, codegen_perfor
         mtime: SystemTime::UNIX_EPOCH + Duration::from_secs(seconds),
         codegen_performed,
         dependencies: vec![],
-        digest: source_digest(&path.into()),
+        digest: SourceDigest::new(""),
     };
     let path = Path::new(path);
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -32,8 +32,8 @@ fn cache_present_and_fresh() {
     let loader = make_loader(&name, &fs, src, artefact);
 
     // The mtime of the source is older than that of the cache
-    write_src(&fs, "/src/main.gleam", 0);
-    write_cache(&fs, "/artefact/main.cache_meta", 1, false);
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 0);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
         .load(Path::new("/src/main.gleam").to_path_buf())
@@ -51,14 +51,33 @@ fn cache_present_and_stale() {
     let loader = make_loader(&name, &fs, src, artefact);
 
     // The mtime of the source is newer than that of the cache
-    write_src(&fs, "/src/main.gleam", 2);
-    write_cache(&fs, "/artefact/main.cache_meta", 1, false);
+    write_src(&fs, TEST_SOURCE_2, "/src/main.gleam", 2);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
         .load(Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_new());
+}
+
+#[test]
+fn cache_present_and_stale_but_source_is_the_same() {
+    let name = "package".into();
+    let src = Path::new("/src");
+    let artefact = Path::new("/artefact");
+    let fs = InMemoryFileSystem::new();
+    let loader = make_loader(&name, &fs, src, artefact);
+
+    // The mtime of the source is newer than that of the cache
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 2);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
+
+    let result = loader
+        .load(Path::new("/src/main.gleam").to_path_buf())
+        .unwrap();
+
+    assert!(result.is_cached());
 }
 
 #[test]
@@ -71,8 +90,8 @@ fn cache_present_without_codegen_when_required() {
     loader.codegen = CodegenRequired::Yes;
 
     // The mtime of the cache is newer than that of the source
-    write_src(&fs, "/src/main.gleam", 0);
-    write_cache(&fs, "/artefact/main.cache_meta", 1, false);
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 0);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
         .load(Path::new("/src/main.gleam").to_path_buf())
@@ -91,8 +110,8 @@ fn cache_present_with_codegen_when_required() {
     loader.codegen = CodegenRequired::Yes;
 
     // The mtime of the cache is newer than that of the source
-    write_src(&fs, "/src/main.gleam", 0);
-    write_cache(&fs, "/artefact/main.cache_meta", 1, true);
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 0);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, true);
 
     let result = loader
         .load(Path::new("/src/main.gleam").to_path_buf())
@@ -111,8 +130,8 @@ fn cache_present_without_codegen_when_not_required() {
     loader.codegen = CodegenRequired::No;
 
     // The mtime of the cache is newer than that of the source
-    write_src(&fs, "/src/main.gleam", 0);
-    write_cache(&fs, "/artefact/main.cache_meta", 1, false);
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 0);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
         .load(Path::new("/src/main.gleam").to_path_buf())
@@ -121,20 +140,29 @@ fn cache_present_without_codegen_when_not_required() {
     assert!(result.is_cached());
 }
 
-fn write_cache(fs: &InMemoryFileSystem, path: &str, seconds: u64, codegen_performed: bool) {
+const TEST_SOURCE_1: &'static str = "const x = 1";
+const TEST_SOURCE_2: &'static str = "const x = 2";
+
+fn write_cache(
+    fs: &InMemoryFileSystem,
+    source: &str,
+    path: &str,
+    seconds: u64,
+    codegen_performed: bool,
+) {
     let cache_metadata = CacheMetadata {
         mtime: SystemTime::UNIX_EPOCH + Duration::from_secs(seconds),
         codegen_performed,
         dependencies: vec![],
-        digest: SourceDigest::new(""),
+        digest: SourceDigest::new(source),
     };
     let path = Path::new(path);
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();
 }
 
-fn write_src(fs: &InMemoryFileSystem, path: &str, seconds: u64) {
+fn write_src(fs: &InMemoryFileSystem, source: &str, path: &str, seconds: u64) {
     let path = Path::new(path);
-    fs.write(&path, "const x = 1").unwrap();
+    fs.write(&path, source).unwrap();
     fs.set_modification_time(&path, SystemTime::UNIX_EPOCH + Duration::from_secs(seconds));
 }
 

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::io::{memory::InMemoryFileSystem, FileSystemWriter};
+use crate::{
+    build::source_digest,
+    io::{memory::InMemoryFileSystem, FileSystemWriter},
+};
 use std::time::Duration;
 
 #[test]
@@ -119,12 +122,13 @@ fn cache_present_without_codegen_when_not_required() {
 }
 
 fn write_cache(fs: &InMemoryFileSystem, path: &str, seconds: u64, codegen_performed: bool) {
-    let path = Path::new(path);
     let cache_metadata = CacheMetadata {
         mtime: SystemTime::UNIX_EPOCH + Duration::from_secs(seconds),
         codegen_performed,
         dependencies: vec![],
+        digest: source_digest(&path.into()),
     };
+    let path = Path::new(path);
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();
 }
 

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -4,7 +4,7 @@ use crate::{
         dep_tree,
         native_file_copier::NativeFileCopier,
         package_loader::{CodegenRequired, PackageLoader},
-        Mode, Module, Origin, Package, Target,
+        source_digest, Mode, Module, Origin, Package, SourceDigest, Target,
     },
     codegen::{Erlang, ErlangApp, JavaScript, TypeScriptDeclarations},
     config::PackageConfig,
@@ -239,6 +239,7 @@ where
                 mtime: module.mtime,
                 codegen_performed: self.perform_codegen,
                 dependencies: module.dependencies_list(),
+                digest: module.digest(),
             };
             self.io.write_bytes(&path, &info.to_binary())?;
         }
@@ -591,6 +592,7 @@ pub(crate) struct CacheMetadata {
     pub mtime: SystemTime,
     pub codegen_performed: bool,
     pub dependencies: Vec<SmolStr>,
+    pub digest: SourceDigest,
 }
 
 impl CacheMetadata {

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -2,9 +2,10 @@ use crate::{
     ast::{SrcSpan, TypedModule, UntypedModule},
     build::{
         dep_tree,
+        module_loader::SourceDigest,
         native_file_copier::NativeFileCopier,
         package_loader::{CodegenRequired, PackageLoader},
-        source_digest, Mode, Module, Origin, Package, SourceDigest, Target,
+        Mode, Module, Origin, Package, Target,
     },
     codegen::{Erlang, ErlangApp, JavaScript, TypeScriptDeclarations},
     config::PackageConfig,
@@ -239,7 +240,7 @@ where
                 mtime: module.mtime,
                 codegen_performed: self.perform_codegen,
                 dependencies: module.dependencies_list(),
-                digest: module.digest(),
+                digest: SourceDigest::new(&module.code),
             };
             self.io.write_bytes(&path, &info.to_binary())?;
         }

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -2,7 +2,7 @@ use smol_str::SmolStr;
 
 use super::*;
 use crate::{
-    build::source_digest,
+    build::module_loader::SourceDigest,
     io::{memory::InMemoryFileSystem, FileSystemWriter},
     parse::extra::ModuleExtra,
 };
@@ -26,7 +26,7 @@ fn write_cache(fs: &InMemoryFileSystem, name: &str, seconds: u64, deps: Vec<Smol
         mtime,
         codegen_performed: true,
         dependencies: deps,
-        digest: source_digest(&name.into()),
+        digest: SourceDigest::new(""),
     };
     let path = Path::new("/artefact").join(format!("{name}.cache_meta"));
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -2,6 +2,7 @@ use smol_str::SmolStr;
 
 use super::*;
 use crate::{
+    build::source_digest,
     io::{memory::InMemoryFileSystem, FileSystemWriter},
     parse::extra::ModuleExtra,
 };
@@ -25,6 +26,7 @@ fn write_cache(fs: &InMemoryFileSystem, name: &str, seconds: u64, deps: Vec<Smol
         mtime,
         codegen_performed: true,
         dependencies: deps,
+        digest: source_digest(&name.into()),
     };
     let path = Path::new("/artefact").join(format!("{name}.cache_meta"));
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -185,9 +185,6 @@ pub enum Error {
         package: String,
         build_tools: Vec<String>,
     },
-
-    #[error("Invalid source digest: {0}")]
-    InvalidSourceDigest(String),
 }
 
 impl Error {
@@ -449,14 +446,6 @@ your app.src file \"{app_ver}\""
                     location: None,
                 }
             }
-
-            Error::InvalidSourceDigest(details) => Diagnostic {
-                title: "Source digest in the cache metadata has invalid format".into(),
-                text: format!("Details:\n\n  {details}"),
-                level: Level::Error,
-                hint: None,
-                location: None,
-            },
 
             Error::ShellProgramNotFound { program } => {
                 let mut text = format!("The program `{program}` was not found. Is it installed?");

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -185,6 +185,9 @@ pub enum Error {
         package: String,
         build_tools: Vec<String>,
     },
+
+    #[error("Invalid source digest: {0}")]
+    InvalidSourceDigest(String),
 }
 
 impl Error {
@@ -446,6 +449,14 @@ your app.src file \"{app_ver}\""
                     location: None,
                 }
             }
+
+            Error::InvalidSourceDigest(details) => Diagnostic {
+                title: "Source digest in the cache metadata has invalid format".into(),
+                text: format!("Details:\n\n  {details}"),
+                level: Level::Error,
+                hint: None,
+                location: None,
+            },
 
             Error::ShellProgramNotFound { program } => {
                 let mut text = format!("The program `{program}` was not found. Is it installed?");
@@ -2258,16 +2269,16 @@ package to Hex.\n"
                         .to_string();
                 text.push_str(if *description_missing && *licence_missing {
                     r#"Add the licences and description fields to your gleam.toml file.
-                
+
 description = "A Gleam library"
 licences = ["Apache-2.0"]"#
                 } else if *description_missing {
                     r#"Add the description field to your gleam.toml file.
-                
+
 description = "A Gleam library""#
                 } else {
                     r#"Add the licences field to your gleam.toml file.
-                
+
 licences = ["Apache-2.0"]"#
                 });
                 Diagnostic {

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 9
 expression: "./cases/alias_unqualified_import"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -27,7 +26,7 @@ id(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<32 byte binary>
+<104 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 33
 expression: "./cases/erlang_app_generation"
 ---
 //// /out/lib/the_package/_gleam_artefacts/main.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 45
 expression: "./cases/erlang_bug_752"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_bug_752"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<32 byte binary>
+<104 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 57
 expression: "./cases/erlang_empty"
 ---
 //// /out/lib/the_package/_gleam_artefacts/empty.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.erl
 -module(empty).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 69
 expression: "./cases/erlang_escape_names"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_escape_names"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<32 byte binary>
+<104 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 81
 expression: "./cases/erlang_import"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<32 byte binary>
+<104 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -25,7 +24,7 @@ unbox(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 93
 expression: "./cases/erlang_import_shadowing_prelude"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_import_shadowing_prelude"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<32 byte binary>
+<104 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 105
 expression: "./cases/erlang_nested"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 117
 expression: "./cases/erlang_nested_qualified_constant"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_nested_qualified_constant"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<36 byte binary>
+<108 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 129
 expression: "./cases/hello_joe"
 ---
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.erl
 -module(hello_joe).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 153
 expression: "./cases/import_shadowed_name_warning"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<32 byte binary>
+<104 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 165
 expression: "./cases/imported_constants"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -28,7 +27,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<32 byte binary>
+<104 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 177
 expression: "./cases/imported_external_fns"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ thing() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<43 byte binary>
+<115 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 189
 expression: "./cases/imported_record_constructors"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.erl
 -module(one@one).
@@ -28,7 +27,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<51 byte binary>
+<123 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 201
 expression: "./cases/javascript_d_ts"
 ---
 //// /out/lib/the_package/_gleam_artefacts/hello.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/gleam.d.ts
 <prelude>

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 213
 expression: "./cases/javascript_empty"
 ---
 //// /out/lib/the_package/_gleam_artefacts/empty.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/empty.mjs
 export {}

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -1,19 +1,18 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 225
 expression: "./cases/javascript_import"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<36 byte binary>
+<108 byte binary>
 
 //// /out/lib/the_package/gleam.d.ts
 <prelude>

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 321
 expression: "./cases/variable_or_module"
 ---
 //// /out/lib/the_package/_gleam_artefacts/main.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<34 byte binary>
+<106 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).
@@ -28,7 +27,7 @@ record_field(Power) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.cache_meta
-<21 byte binary>
+<93 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.erl
 -module(power).


### PR DESCRIPTION
Resolves #1914.

Currently, gleam module loader checks if the modification time of the source file is greater than the one stored in the cache. If it is, the module gets recompiled. This PR changes this behaviour by adding one more check to ensure that both modification time AND source code changed before recompiling the module.