### PR TITLE
LSP analyse on edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lsp analyzes files on edit.
 - Added support for negation of integers with the new `-` unary operator.
 - The deprecated `try` expression has been removed.
 - The deprecated `assert ... = ...` syntax has been removed.

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -752,19 +752,6 @@ impl LanguageServer {
         gleam_core::format::pretty(&mut new_text, &src, Path::new(path))?;
         let line_count = src.lines().count() as u32;
 
-        // match self.edited.get(path) {
-        //     // If we have a cached version of the file in memory format that
-        //     Some(src) => {
-        //         gleam_core::format::pretty(&mut new_text, src, Path::new(path))?;
-        //     }
-
-        //     // Otherwise format the file from disc
-        //     None => {
-        //         let src = crate::fs::read(path)?.into();
-        //         gleam_core::format::pretty(&mut new_text, &src, Path::new(path))?;
-        //     }
-        // };
-
         let edit = TextEdit {
             range: Range {
                 start: Position {

--- a/compiler-cli/src/lsp_fs_proxy.rs
+++ b/compiler-cli/src/lsp_fs_proxy.rs
@@ -168,9 +168,7 @@ impl FileSystemReader for LspFsProxy {
     }
 
     fn modification_time(&self, path: &Path) -> Result<SystemTime, Error> {
-        let in_mem_result = self
-            .cache
-            .modification_time(path.canonicalize().unwrap().as_path());
+        let in_mem_result = self.cache.modification_time(abs_path(path)?.as_path());
         match in_mem_result {
             Ok(time) => {
                 tracing::info!(
@@ -213,7 +211,7 @@ fn abs_path(path: &Path) -> Result<PathBuf, Error> {
     let abs_path = path.canonicalize().or(Err(Error::FileIo {
         kind: FileKind::File,
         action: gleam_core::error::FileIoAction::Canonicalise,
-        path: path.to_path_buf().clone(),
+        path: path.to_path_buf(),
         err: None,
     }))?;
     Ok(abs_path)

--- a/compiler-cli/src/lsp_fs_proxy.rs
+++ b/compiler-cli/src/lsp_fs_proxy.rs
@@ -1,0 +1,174 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use gleam_core::{
+    io::{
+        memory::InMemoryFileSystem, CommandExecutor, FileSystemIO, FileSystemReader,
+        FileSystemWriter, ReadDir, Stdio, WrappedReader,
+    },
+    Error, Result,
+};
+use im::HashSet;
+
+use crate::fs::ProjectIO;
+
+#[derive(Debug, Clone)]
+pub struct LspFsProxy {
+    project_io: ProjectIO,
+    cache: InMemoryFileSystem,
+}
+
+impl LspFsProxy {
+    pub fn new() -> Self {
+        Self {
+            project_io: ProjectIO::new(),
+            cache: InMemoryFileSystem::new(),
+        }
+    }
+
+    pub fn write_mem_cache(&mut self, path: &Path, content: &str) -> Result<(), Error> {
+        // println!("Writing cache for {}", path.to_string_lossy());
+        tracing::info!("Writing file to cache: {}", path.to_string_lossy());
+        self.cache.write(path, content)
+    }
+
+    pub fn delete_mem_cache(&self, path: &Path) -> Result<(), Error> {
+        tracing::info!("Delete file from cache: {}", path.to_string_lossy());
+        self.cache.delete(path)
+    }
+
+    pub fn clear_mem_cache(&mut self) {
+        self.cache = InMemoryFileSystem::new();
+    }
+}
+
+impl FileSystemIO for LspFsProxy {}
+
+impl FileSystemWriter for LspFsProxy {
+    fn mkdir(&self, path: &Path) -> Result<(), Error> {
+        self.project_io.mkdir(path)
+    }
+
+    fn write(&self, path: &Path, content: &str) -> Result<(), Error> {
+        self.project_io.write(path, content)
+    }
+
+    fn write_bytes(&self, path: &Path, content: &[u8]) -> Result<(), Error> {
+        self.project_io.write_bytes(path, content)
+    }
+
+    fn delete(&self, path: &Path) -> Result<(), Error> {
+        self.project_io.delete(path)
+    }
+
+    fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        self.project_io.copy(from, to)
+    }
+
+    fn copy_dir(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        self.project_io.copy_dir(from, to)
+    }
+
+    fn hardlink(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        self.project_io.hardlink(from, to)
+    }
+
+    fn symlink_dir(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        self.project_io.symlink_dir(from, to)
+    }
+
+    fn delete_file(&self, path: &Path) -> Result<(), Error> {
+        self.project_io.delete_file(path)
+    }
+}
+
+impl FileSystemReader for LspFsProxy {
+    fn gleam_source_files(&self, dir: &Path) -> Vec<PathBuf> {
+        self.project_io.gleam_source_files(dir)
+    }
+
+    fn gleam_cache_files(&self, dir: &Path) -> Vec<PathBuf> {
+        self.project_io.gleam_cache_files(dir)
+    }
+
+    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+        self.project_io.read_dir(path)
+    }
+
+    fn read(&self, path: &Path) -> Result<String, Error> {
+        let in_mem_result = self.cache.read(path.canonicalize().unwrap().as_path());
+        match in_mem_result {
+            Ok(_) => {
+                tracing::info!("Reading file from cache: {}", path.to_string_lossy());
+                in_mem_result
+            }
+            Err(e) => {
+                tracing::info!(
+                    "Got {} => Reading file from disk: {}",
+                    e,
+                    path.to_string_lossy()
+                );
+                self.project_io.read(path)
+            }
+        }
+    }
+
+    fn read_bytes(&self, path: &Path) -> Result<Vec<u8>, Error> {
+        let in_mem_result = self
+            .cache
+            .read_bytes(path.canonicalize().unwrap().as_path());
+        match in_mem_result {
+            Ok(_) => {
+                tracing::info!(
+                    "Reading (bytes) file from cache: {}",
+                    path.to_string_lossy()
+                );
+                in_mem_result
+            }
+            Err(e) => {
+                tracing::info!(
+                    "Got {} => Reading file from disk: {}",
+                    e,
+                    path.to_string_lossy()
+                );
+                self.project_io.read_bytes(path)
+            }
+        }
+    }
+
+    fn reader(&self, path: &Path) -> Result<WrappedReader, Error> {
+        self.project_io.reader(path)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.project_io.is_file(path)
+    }
+
+    fn is_directory(&self, path: &Path) -> bool {
+        self.project_io.is_directory(path)
+    }
+
+    fn current_dir(&self) -> Result<PathBuf, Error> {
+        self.project_io.current_dir()
+    }
+
+    fn modification_time(&self, path: &Path) -> Result<SystemTime, Error> {
+        self.project_io.modification_time(path)
+    }
+}
+
+impl CommandExecutor for LspFsProxy {
+    fn exec(
+        &self,
+        program: &str,
+        args: &[String],
+        env: &[(&str, String)],
+        cwd: Option<&Path>,
+        stdio: Stdio,
+    ) -> Result<i32, Error> {
+        self.project_io.exec(program, args, env, cwd, stdio)
+    }
+}

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -64,6 +64,7 @@ mod fs;
 mod hex;
 mod http;
 mod lsp;
+mod lsp_fs_proxy;
 mod new;
 mod panic;
 mod publish;

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -65,7 +65,7 @@ impl InMemoryFileSystem {
             .ok_or_else(|| Error::FileIo {
                 kind: FileKind::File,
                 action: FileIoAction::Open,
-                path: path.to_path_buf().clone(),
+                path: path.to_path_buf(),
                 err: None,
             })?
             .modification_time = time;

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -134,6 +134,7 @@ impl FileSystemReader for InMemoryFileSystem {
     fn read(&self, path: &Path) -> Result<String, Error> {
         let path = path.to_path_buf();
         let files = self.files.deref().borrow();
+        tracing::info!("Files: {:?}", files);
         let file = files.get(&path).ok_or_else(|| Error::FileIo {
             kind: FileKind::File,
             action: FileIoAction::Open,

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -56,6 +56,21 @@ impl InMemoryFileSystem {
             .unwrap()
             .modification_time = time;
     }
+
+    pub fn try_set_modification_time(&self, path: &Path, time: SystemTime) -> Result<(), Error> {
+        self.files
+            .deref()
+            .borrow_mut()
+            .get_mut(path)
+            .ok_or_else(|| Error::FileIo {
+                kind: FileKind::File,
+                action: FileIoAction::Open,
+                path: path.to_path_buf().clone(),
+                err: None,
+            })?
+            .modification_time = time;
+        Ok(())
+    }
 }
 
 impl FileSystemIO for InMemoryFileSystem {}
@@ -134,7 +149,6 @@ impl FileSystemReader for InMemoryFileSystem {
     fn read(&self, path: &Path) -> Result<String, Error> {
         let path = path.to_path_buf();
         let files = self.files.deref().borrow();
-        tracing::info!("Files: {:?}", files);
         let file = files.get(&path).ok_or_else(|| Error::FileIo {
             kind: FileKind::File,
             action: FileIoAction::Open,

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -1,7 +1,14 @@
 use lazy_static::__Deref;
 
 use super::*;
-use std::{cell::RefCell, collections::HashMap, ffi::OsStr, rc::Rc, time::Duration};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    ffi::OsStr,
+    io::{Error as IoError, Read},
+    rc::Rc,
+    time::Duration,
+};
 
 // An in memory sharable collection of pretend files that can be used in place
 // of a real file system. It is a shared reference to a set of buffer than can
@@ -190,9 +197,23 @@ impl FileSystemReader for InMemoryFileSystem {
             .any(|file_path| file_path.starts_with(path))
     }
 
-    fn reader(&self, _path: &Path) -> Result<WrappedReader, Error> {
-        // TODO
-        unreachable!("Memory reader unimplemented")
+    /// # Panics
+    ///
+    /// Panics if this is not the only reference to the underlying files.
+    ///
+    fn reader(&self, path: &Path) -> Result<WrappedReader, Error> {
+        let path = path.to_path_buf();
+        let files = self.files.deref().borrow();
+        let file = files.get(&path).ok_or_else(|| Error::FileIo {
+            kind: FileKind::File,
+            action: FileIoAction::Open,
+            path: path.clone(),
+            err: None,
+        })?;
+        Ok(WrappedReader::new(
+            path.clone().as_path(),
+            Box::new(file.clone()),
+        ))
     }
 
     fn read_dir(&self, path: &Path) -> Result<ReadDir> {
@@ -253,6 +274,29 @@ impl InMemoryFile {
         match String::from_utf8(contents) {
             Ok(s) => Content::Text(s),
             Err(e) => Content::Binary(e.into_bytes()),
+        }
+    }
+}
+
+impl Read for InMemoryFile {
+    #[allow(clippy::indexing_slicing)]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let contents = Rc::try_unwrap(self.buffer.clone())
+            .expect("InMemoryFile::read called with multiple references")
+            .into_inner();
+        // let mut i = 0;
+        if contents.len() > buf.len() {
+            Err(IoError::new(
+                io::ErrorKind::Other,
+                "Provided buffer to small",
+            ))
+        } else {
+            for (i, byte) in contents.clone().into_iter().enumerate() {
+                // for byte in contents.clone() {
+                buf[i] = byte;
+                // i += 1;
+            }
+            Ok(contents.len())
         }
     }
 }


### PR DESCRIPTION
Implementation for #2031 

Using `InMemoryFileSystem` as a mem-cache in order to provide the edited files to the compiler.

There is one known caveat in this implementation: If the window is reloaded in VS Code the cache will be destroyed, but VS Code will keep the unsaved changes which leaves the diagnostics shown in VS Code not consistent with the open file(s). Once the file is saved the diagnostics will be in sync. I guess there is a way to load the current state of the files into LSP at startup, but unsure if we should do this as part of this issue, or create a new one for that potential fix?