### PR TITLE
Quick fix: Removed call to mem-cache for reader (crashing lsp)

### DIFF
--- a/compiler-cli/src/lsp/fs_proxy.rs
+++ b/compiler-cli/src/lsp/fs_proxy.rs
@@ -148,26 +148,8 @@ impl FileSystemReader for FileSystemProxy {
         }
     }
 
-    /// # Panics
-    ///
-    /// Panics if this is not the only reference to the underlying files.
-    ///
     fn reader(&self, path: &Path) -> Result<WrappedReader, Error> {
-        let in_mem_result = self.cache.reader(abs_path(path)?.as_path());
-        match in_mem_result {
-            Ok(_) => {
-                tracing::info!("Creating reader from cache: {}", path.to_string_lossy());
-                in_mem_result
-            }
-            Err(e) => {
-                tracing::info!(
-                    "Got {} => Creating reader from disk: {}",
-                    e,
-                    path.to_string_lossy()
-                );
-                self.project_io.reader(path)
-            }
-        }
+        self.project_io.reader(path)
     }
 
     // Cache overides existence of file


### PR DESCRIPTION
Follow up quick fix for #2031 

I realised that I forgot to test the last change where I introduced the unimplemented `reader` for `InMemoryFileSystem`. Unfortunately it crashes the LSP in startup. Long term we should really implement reader, but meanwhile created this PR to remove the call to it from `FileSystemProxy`.