### PR TITLE
Cache file and compile on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Warnings are now immediately emitted rather than being buffered until the end
   of the compilation.
 - The `--warnings-as-errors` flag is now supported by `gleam build`.
+- Fixed a bug where language server diagnostics would become out-of-sync
+  when server was restarted with unsaved files.
 - Fixed a bug where the formatter would incorrectly remove `{ ... }` from bit
   string segment value expressions.
 - Fixed a bug where the compiler used VSCode specific behaviour in the language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@
 - Warnings are now immediately emitted rather than being buffered until the end
   of the compilation.
 - The `--warnings-as-errors` flag is now supported by `gleam build`.
-- Fixed a bug where language server diagnostics would become out-of-sync
-  when server was restarted with unsaved files.
 - Fixed a bug where the formatter would incorrectly remove `{ ... }` from bit
   string segment value expressions.
 - Fixed a bug where the compiler used VSCode specific behaviour in the language


### PR DESCRIPTION
Fix for #2054 

Note: Needs #2055 (otherwise LSP will crash on startup)

Fixed this by triggering load to mem-cache on the open document notification. One side effect of this is that LSP will always use cached versions of the open files (even if they are already saved) until the file is explicitly saved. I could not find a workaround for this since there is no indication from the client that the file is unsaved. I don't think this has any functional implications, but if there are lots of open files it could become a memory issue.