### PR TITLE
formatter removes block around pipline

### DIFF
--- a/compiler-core/src/format/tests/use_.rs
+++ b/compiler-core/src/format/tests/use_.rs
@@ -268,3 +268,17 @@ fn multiple_long_patterns() {
 "#
     );
 }
+
+#[test]
+fn preserve_blocks() {
+    assert_format!(
+        r#"pub fn main() {
+  {
+     ""
+    |> Ok
+    |> result.map
+  }(fn(str) { io.print(str) })
+}
+"#
+    );
+}


### PR DESCRIPTION
The formatter removes the block around the pipeline, but it should not.

I wasn't sure if this test should go into the `use` test file or the general test file.
Also not sure how to name the test. I tried to make it similar to the single expression block test.
