### PR TITLE
attempt to disable nightly builder for forked repos by default

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -14,6 +14,7 @@ jobs:
     name: Check latest commit
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
+    if: github.repository_owner == "lpil"
     steps:
       - uses: actions/checkout@v3
       - name: print latest_commit
@@ -23,12 +24,12 @@ jobs:
         continue-on-error: true
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "should_run=false" >> $GITHUB_OUTPUT
+        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "should_run=false" >> $GITHUB_OUTPUT
 
   build-nightly-clean:
     runs-on: ubuntu-latest
     needs: [ nightly-last-run ]
-    if: ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
+    if: github.repository_owner == "lpil" && ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
     steps:
       - name: Delete old release assets
         uses: mknejp/delete-release-assets@v1
@@ -47,6 +48,7 @@ jobs:
     name: build-release
     runs-on: ${{ matrix.os }}
     needs: [ build-nightly-clean ]
+    if: github.repository_owner == "lpil"
     strategy:
       matrix:
         target:
@@ -176,7 +178,7 @@ jobs:
   build-nightly-container-images:
     runs-on: ubuntu-latest
     needs: [ build-nightly ]
-    if: ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
+    if: github.repository_owner == "lpil" && ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
     strategy:
       matrix:
         base-image:

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Check latest commit
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
-    if: github.repository_owner == "lpil"
+    if: github.repository_owner == "gleam-lang"
     steps:
       - uses: actions/checkout@v3
       - name: print latest_commit
@@ -29,8 +29,8 @@ jobs:
   build-nightly-clean:
     runs-on: ubuntu-latest
     needs: [ nightly-last-run ]
-    if: github.repository_owner == "lpil" && ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
-    steps:
+    if: github.repository_owner == "gleam-lang" && ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
+    steps
       - name: Delete old release assets
         uses: mknejp/delete-release-assets@v1
         with:
@@ -48,7 +48,7 @@ jobs:
     name: build-release
     runs-on: ${{ matrix.os }}
     needs: [ build-nightly-clean ]
-    if: github.repository_owner == "lpil"
+    if: github.repository_owner == "gleam-lang"
     strategy:
       matrix:
         target:
@@ -178,7 +178,7 @@ jobs:
   build-nightly-container-images:
     runs-on: ubuntu-latest
     needs: [ build-nightly ]
-    if: github.repository_owner == "lpil" && ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
+    if: github.repository_owner == "gleam-lang" && ${{ needs.nightly-last-run.outputs.should_run != 'false' }}
     strategy:
       matrix:
         base-image:


### PR DESCRIPTION
Do not build nightlies out of the box for people who fork gleam.

- Those nightlies are probably almost never used
- The innocent forking creates a lot of energy overhead in the mid long run if lots of people fork