### PR TITLE
Add proper module name for prelude

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -379,7 +379,7 @@ pub fn register_import(
 }
 
 fn validate_module_name(name: &SmolStr) -> Result<(), Error> {
-    if name == "gleam" {
+    if name == PRELUDE_MODULE_NAME {
         return Err(Error::ReservedModuleName { name: name.clone() });
     };
     for segment in name.split('/') {

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -10,6 +10,7 @@ use crate::{
     uid::UniqueIdGenerator,
     warning::TypeWarningEmitter,
 };
+use crate::type_::PRELUDE_MODULE_NAME;
 
 use super::{Statement, TypedModule, TypedStatement};
 
@@ -22,7 +23,7 @@ fn compile_module(src: &str) -> TypedModule {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".into(), build_prelude(&ids));
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
     crate::analyse::infer_module(
         crate::build::Target::Erlang,
         &ids,
@@ -53,7 +54,7 @@ fn compile_expression(src: &str) -> TypedStatement {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".into(), type_::build_prelude(&ids));
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), type_::build_prelude(&ids));
     let emitter = TypeWarningEmitter::null();
     let mut environment = Environment::new(ids, "mymod", &modules, &emitter);
 
@@ -469,7 +470,7 @@ fn find_node_bool() {
                 arity: 0,
                 field_map: None,
                 location: SrcSpan { start: 0, end: 0 },
-                module: "".into(),
+                module: PRELUDE_MODULE_NAME.into(),
             },
             type_: type_::bool(),
         },

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -25,6 +25,7 @@ use std::{
     collections::HashSet,
     path::{Path, PathBuf},
 };
+use crate::type_::PRELUDE_MODULE_NAME;
 
 use super::{ErlangAppCodegenConfiguration, TargetCodegenConfiguration};
 
@@ -375,7 +376,7 @@ fn analyse(
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = module_types.insert("gleam".into(), type_::build_prelude(ids));
+    let _ = module_types.insert(PRELUDE_MODULE_NAME.into(), type_::build_prelude(ids));
 
     for UncompiledModule {
         name,

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -26,6 +26,7 @@ use pattern::pattern;
 use smol_str::SmolStr;
 use std::{char, collections::HashMap, ops::Deref, str::FromStr, sync::Arc};
 use vec1::Vec1;
+use crate::type_::is_prelude_module;
 
 const INDENT: isize = 4;
 const MAX_COLUMNS: isize = 80;
@@ -1928,7 +1929,7 @@ impl<'a> TypePrinter<'a> {
 
             Type::App {
                 name, module, args, ..
-            } if module.is_empty() => self.print_prelude_type(name, args),
+            } if is_prelude_module(module) => self.print_prelude_type(name, args),
 
             Type::App {
                 name, module, args, ..

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -5,6 +5,7 @@ use crate::{
     uid::UniqueIdGenerator,
     warning::TypeWarningEmitter,
 };
+use crate::type_::PRELUDE_MODULE_NAME;
 
 mod assert;
 mod bit_strings;
@@ -31,7 +32,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".into(), crate::type_::build_prelude(&ids));
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), crate::type_::build_prelude(&ids));
     if let Some((dep_package, dep_name, dep_src)) = dep {
         let (mut ast, _) = crate::parse::parse_module(dep_src).expect("dep syntax error");
         ast.name = dep_name.into();

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use itertools::Itertools;
 use smol_str::SmolStr;
+use crate::type_::PRELUDE_MODULE_NAME;
 
 use self::import::{Imports, Member};
 
@@ -147,7 +148,7 @@ impl<'a> Generator<'a> {
         name: &'static str,
         alias: Option<&'static str>,
     ) {
-        let path = self.import_path(&self.module.type_info.package, "gleam");
+        let path = self.import_path(&self.module.type_info.package, PRELUDE_MODULE_NAME);
         let member = Member {
             name: name.to_doc(),
             alias: alias.map(|a| a.to_doc()),

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -78,7 +78,7 @@ pub fn compile(src: &str, dep: Option<(&str, &str, &str)>) -> TypedModule {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".into(), crate::type_::build_prelude(&ids));
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), crate::type_::build_prelude(&ids));
 
     if let Some((dep_package, dep_name, dep_src)) = dep {
         let (mut ast, _) = crate::parse::parse_module(dep_src).expect("dep syntax error");

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -27,6 +27,7 @@ use crate::{
     pretty::{break_, Document, Documentable},
     type_::{Type, TypeVar},
 };
+use crate::type_::{is_prelude_module, PRELUDE_MODULE_NAME};
 
 use super::{concat, import::Imports, line, lines, wrap_args, Output, INDENT};
 
@@ -213,7 +214,7 @@ impl<'a> TypeScriptGenerator<'a> {
         // Put it all together
 
         if self.prelude_used() {
-            let path = self.import_path(&self.module.type_info.package, "gleam");
+            let path = self.import_path(&self.module.type_info.package, PRELUDE_MODULE_NAME);
             imports.register_module(path, ["_".into()], []);
         }
 
@@ -629,7 +630,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
             Type::App {
                 name, module, args, ..
-            } if module.is_empty() => self.print_prelude_type(name, args, generic_usages),
+            } if is_prelude_module(module) => self.print_prelude_type(name, args, generic_usages),
 
             Type::App {
                 name, args, module, ..
@@ -647,7 +648,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
             Type::App {
                 name, module, args, ..
-            } if module.is_empty() => self.print_prelude_type(name, args, None),
+            } if is_prelude_module(module) => self.print_prelude_type(name, args, None),
 
             Type::App {
                 name, args, module, ..

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -84,7 +84,7 @@ impl Type {
     }
 
     pub fn is_result(&self) -> bool {
-        matches!(self, Self::App { name, module, .. } if "Result" == name && module.is_empty())
+        matches!(self, Self::App { name, module, .. } if "Result" == name && is_prelude_module(module))
     }
 
     pub fn is_unbound(&self) -> bool {
@@ -111,7 +111,7 @@ impl Type {
 
     pub fn is_nil(&self) -> bool {
         match self {
-            Self::App { module, name, .. } if "Nil" == name && module.is_empty() => true,
+            Self::App { module, name, .. } if "Nil" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_nil(),
             _ => false,
         }
@@ -119,7 +119,7 @@ impl Type {
 
     pub fn is_bool(&self) -> bool {
         match self {
-            Self::App { module, name, .. } if "Bool" == name && module.is_empty() => true,
+            Self::App { module, name, .. } if "Bool" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_bool(),
             _ => false,
         }
@@ -127,7 +127,7 @@ impl Type {
 
     pub fn is_int(&self) -> bool {
         match self {
-            Self::App { module, name, .. } if "Int" == name && module.is_empty() => true,
+            Self::App { module, name, .. } if "Int" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_int(),
             _ => false,
         }
@@ -135,7 +135,7 @@ impl Type {
 
     pub fn is_float(&self) -> bool {
         match self {
-            Self::App { module, name, .. } if "Float" == name && module.is_empty() => true,
+            Self::App { module, name, .. } if "Float" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_float(),
             _ => false,
         }
@@ -143,7 +143,7 @@ impl Type {
 
     pub fn is_string(&self) -> bool {
         match self {
-            Self::App { module, name, .. } if "String" == name && module.is_empty() => true,
+            Self::App { module, name, .. } if "String" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_string(),
             _ => false,
         }

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -59,7 +59,7 @@ impl<'a> Environment<'a> {
         warnings: &'a TypeWarningEmitter,
     ) -> Self {
         let prelude = importable_modules
-            .get("gleam")
+            .get(PRELUDE_MODULE_NAME)
             .expect("Unable to find prelude in importable modules");
         Self {
             previous_id: ids.next(),
@@ -223,7 +223,7 @@ impl<'a> Environment<'a> {
         let location = info.origin;
         match self.module_types.insert(type_name, info) {
             None => Ok(()),
-            Some(prelude_type) if prelude_type.module.is_empty() => Ok(()),
+            Some(prelude_type) if is_prelude_module(&prelude_type.module) => Ok(()),
             Some(previous) => Err(Error::DuplicateTypeName {
                 name,
                 location,

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -310,7 +310,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 elements,
                 tail,
                 ..
-            } => match type_.get_app_args(true, "", "List", 1, self.environment) {
+            } => match type_.get_app_args(true, PRELUDE_MODULE_NAME, "List", 1, self.environment) {
                 Some(args) => {
                     let type_ = args
                         .get(0)

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -2,6 +2,7 @@ use crate::{ast::SrcSpan, build::Origin, uid::UniqueIdGenerator};
 
 use super::{Module, Type, TypeConstructor, TypeVar, ValueConstructor, ValueConstructorVariant};
 use std::{cell::RefCell, collections::HashMap, sync::Arc};
+use smol_str::SmolStr;
 
 const BIT_STRING: &str = "BitString";
 const BOOL: &str = "Bool";
@@ -13,13 +14,17 @@ const RESULT: &str = "Result";
 const STRING: &str = "String";
 const UTF_CODEPOINT: &str = "UtfCodepoint";
 
-// TODO: use "gleam" as the prelude module name, not ""
+pub const PRELUDE_MODULE_NAME: &str = "gleam";
+
+pub fn is_prelude_module(module: &SmolStr) -> bool {
+    module == PRELUDE_MODULE_NAME
+}
 
 pub fn int() -> Arc<Type> {
     Arc::new(Type::App {
         public: true,
         name: INT.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
         args: vec![],
     })
 }
@@ -29,7 +34,7 @@ pub fn float() -> Arc<Type> {
         args: vec![],
         public: true,
         name: FLOAT.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
     })
 }
 
@@ -38,7 +43,7 @@ pub fn bool() -> Arc<Type> {
         args: vec![],
         public: true,
         name: BOOL.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
     })
 }
 
@@ -47,7 +52,7 @@ pub fn string() -> Arc<Type> {
         args: vec![],
         public: true,
         name: STRING.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
     })
 }
 
@@ -56,7 +61,7 @@ pub fn nil() -> Arc<Type> {
         args: vec![],
         public: true,
         name: NIL.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
     })
 }
 
@@ -64,7 +69,7 @@ pub fn list(t: Arc<Type>) -> Arc<Type> {
     Arc::new(Type::App {
         public: true,
         name: LIST.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
         args: vec![t],
     })
 }
@@ -73,7 +78,7 @@ pub fn result(a: Arc<Type>, e: Arc<Type>) -> Arc<Type> {
     Arc::new(Type::App {
         public: true,
         name: RESULT.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
         args: vec![a, e],
     })
 }
@@ -91,7 +96,7 @@ pub fn bit_string() -> Arc<Type> {
         args: vec![],
         public: true,
         name: BIT_STRING.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
     })
 }
 
@@ -100,7 +105,7 @@ pub fn utf_codepoint() -> Arc<Type> {
         args: vec![],
         public: true,
         name: UTF_CODEPOINT.into(),
-        module: "".into(),
+        module: PRELUDE_MODULE_NAME.into(),
     })
 }
 
@@ -131,7 +136,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
     };
 
     let mut prelude = Module {
-        name: "gleam".into(),
+        name: PRELUDE_MODULE_NAME.into(),
         package: "".into(),
         origin: Origin::Src,
         types: HashMap::new(),
@@ -146,7 +151,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             parameters: vec![],
             typ: int(),
             origin: Default::default(),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -160,7 +165,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
         value(
             ValueConstructorVariant::Record {
                 documentation: None,
-                module: "".into(),
+                module: PRELUDE_MODULE_NAME.into(),
                 name: "True".into(),
                 field_map: None,
                 arity: 0,
@@ -175,7 +180,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
         value(
             ValueConstructorVariant::Record {
                 documentation: None,
-                module: "".into(),
+                module: PRELUDE_MODULE_NAME.into(),
                 name: "False".into(),
                 field_map: None,
                 arity: 0,
@@ -191,7 +196,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![],
             typ: bool(),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -203,7 +208,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![list_parameter.clone()],
             typ: list(list_parameter),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -214,7 +219,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![],
             typ: float(),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -225,7 +230,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![],
             typ: string(),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -238,7 +243,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![result_value.clone(), result_error.clone()],
             typ: result(result_value, result_error),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -252,7 +257,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
         value(
             ValueConstructorVariant::Record {
                 documentation: None,
-                module: "".into(),
+                module: PRELUDE_MODULE_NAME.into(),
                 name: NIL.into(),
                 arity: 0,
                 field_map: None,
@@ -268,7 +273,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![],
             typ: nil(),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -279,7 +284,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![],
             typ: bit_string(),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -290,7 +295,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
             origin: Default::default(),
             parameters: vec![],
             typ: utf_codepoint(),
-            module: "".into(),
+            module: PRELUDE_MODULE_NAME.into(),
             public: true,
         },
     );
@@ -302,7 +307,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
         value(
             ValueConstructorVariant::Record {
                 documentation: None,
-                module: "".into(),
+                module: PRELUDE_MODULE_NAME.into(),
                 name: "Ok".into(),
                 field_map: None,
                 arity: 1,
@@ -320,7 +325,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> Module {
         value(
             ValueConstructorVariant::Record {
                 documentation: None,
-                module: "".into(),
+                module: PRELUDE_MODULE_NAME.into(),
                 name: "Error".into(),
                 field_map: None,
                 arity: 1,

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -159,11 +159,7 @@ impl Printer {
 
 fn qualify_type_name(module: &str, type_name: &str) -> Document<'static> {
     let type_name = Document::String(type_name.to_string());
-    if module.is_empty() {
-        docvec!["gleam.", type_name]
-    } else {
-        docvec![Document::String(module.to_string()), ".", type_name]
-    }
+    docvec![Document::String(module.to_string()), ".", type_name]
 }
 
 #[test]

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -174,7 +174,7 @@ fn compile_statement_sequence(src: &str) -> Result<Vec1<TypedStatement>, crate::
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".into(), build_prelude(&ids));
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
     crate::type_::ExprTyper::new(&mut crate::type_::Environment::new(
         ids,
         "themodule",
@@ -229,7 +229,7 @@ pub fn compile_module(
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".into(), build_prelude(&ids));
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
 
     for (name, module_src) in dep {
         let (mut ast, _) = crate::parse::parse_module(module_src).expect("syntax error");
@@ -425,7 +425,7 @@ fn infer_module_type_retention_test() {
     // TODO: Currently we do this here and also in the tests. It would be better
     // to have one place where we create all this required state for use in each
     // place.
-    let _ = modules.insert("gleam".into(), build_prelude(&ids));
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
     let module = crate::analyse::infer_module(
         Target::Erlang,
         &ids,


### PR DESCRIPTION
Hi, this is my first contribution to the project!

## Summary
This main change in this PR is to start using a proper name for the prelude module instead of the empty string that was used up until now. 


## Why
The existing solution is causing some issue: if you define a type "A" in a module and try to build that module, this type will have an empty module name because it's in the current module being build. Sadly it means that as soon as you create a type that has the same name as one from the prelude, they will both end up with empty module name and many part of the compiler will then be confused because of that and might end up choosing one or the other resulting in some type errors.

## Solution
I added a new PRELUDE_MODULE_NAME public constant is used instead of the empty string and also updated any related code that was performing a random `module.is_empty()` (not explicit or clear) check with a proper `is_prelude_module` call. 

Should resolve #2108 