### PR TITLE
Add support for type annotations in use statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where the language server would unset error diagnostics when
   displaying information on hover.
+- Added support for type annotations in use statements.
 
 ## v0.28.0 - 2023-04-03
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1643,3 +1643,10 @@ impl TypedAssignment {
         self.value.type_()
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UseAssignment {
+    pub location: SrcSpan,
+    pub pattern: UntypedPattern,
+    pub annotation: Option<TypeAst>,
+}

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -187,5 +187,5 @@ impl HasLocation for UntypedExpr {
 pub struct Use {
     pub location: SrcSpan,
     pub call: Box<UntypedExpr>,
-    pub assignments: Vec<UntypedPattern>,
+    pub assignments: Vec<UseAssignment>,
 }

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -102,8 +102,8 @@ impl<'a> CallGraphBuilder<'a> {
             }
             Statement::Use(use_) => {
                 self.expression(&use_.call);
-                for pattern in &use_.assignments {
-                    self.pattern(pattern);
+                for assignment in &use_.assignments {
+                    self.pattern(&assignment.pattern);
                 }
             }
         };

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1536,7 +1536,15 @@ impl<'comments> Formatter<'comments> {
         if use_.assignments.is_empty() {
             docvec!["use <-", call]
         } else {
-            let assignments = use_.assignments.iter().map(|pattern| self.pattern(pattern));
+            let assignments = use_.assignments.iter().map(|use_assignment| {
+                let pattern = self.pattern(&use_assignment.pattern);
+                let annotation = use_assignment
+                    .annotation
+                    .as_ref()
+                    .map(|a| ": ".to_doc().append(self.type_ast(a)));
+
+                pattern.append(annotation).group()
+            });
             let assignments = Itertools::intersperse(assignments, break_(",", ", "));
             let left = ["use".to_doc(), break_("", " ")]
                 .into_iter()

--- a/compiler-core/src/format/tests/use_.rs
+++ b/compiler-core/src/format/tests/use_.rs
@@ -232,6 +232,19 @@ fn patterns() {
     );
 }
 
+
+#[test]
+fn patterns_with_annotation() {
+    assert_format!(
+        r#"pub fn main() {
+  use Box(x): Box(Int) <- apply(Box(1))
+  x
+}
+"#
+    );
+}
+
+
 #[test]
 fn long_patterns() {
     assert_format!(
@@ -261,6 +274,42 @@ fn multiple_long_patterns() {
     ),
     Box(_),
     Box(_),
+    Box(_)
+  <- apply(Box(1))
+  x
+}
+"#
+    );
+}
+
+
+#[test]
+fn multiple_long_patterns_with_annotations() {
+    assert_format!(
+        r#"pub fn main() {
+  use
+    Box(
+      xxxxxxxxxxxxxxxxxxxxxxx,
+      yyyyyyyyyyyyyyyyyyyyyyyyyyy,
+      zzzzzzzzzzzzzzzzzzzzzzzzzzzz,
+    ): Box(Int, Bool, String),
+    Box(_)
+  <- apply(Box(1))
+  x
+}
+"#
+    );
+}
+
+#[test]
+fn multiple_long_annotations() {
+    assert_format!(
+        r#"pub fn main() {
+  use
+    Box(_, _): Box(
+      Xxzxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+      Yyyyyyyyyyyyyyyyyyyyyyyy,
+    ),
     Box(_)
   <- apply(Box(1))
   x

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___typed_pattern_wrong_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___typed_pattern_wrong_type.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/use_.rs
+expression: "\npub fn main() {\n  use Box(x): Box(Bool), Box(y), Box(z) <- apply(Box(1))\n  x + y + z\n}\n\ntype Box(a) {\n  Box(a)\n}\n\nfn apply(arg, fun) {\n  fun(arg, arg, arg)\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:7
+  │
+3 │   use Box(x): Box(Bool), Box(y), Box(z) <- apply(Box(1))
+  │       ^^^^^^^^^^^^^^^^^
+
+Expected type:
+
+    Box(Bool)
+
+Found type:
+
+    Box(Int)
+

--- a/compiler-core/src/type_/tests/use_.rs
+++ b/compiler-core/src/type_/tests/use_.rs
@@ -1,4 +1,4 @@
-use crate::{assert_error, assert_infer, assert_module_infer, assert_warning};
+use crate::{assert_error, assert_infer, assert_module_error, assert_module_infer, assert_warning};
 
 #[test]
 fn arity_1() {
@@ -217,5 +217,46 @@ fn apply(arg, fun) {
 }
 "#,
         vec![("main", "fn() -> Int")],
+    );
+}
+
+#[test]
+fn typed_pattern() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+  use Box(x): Box(Int), Box(y), Box(z) <- apply(Box(1))
+  x + y + z
+}
+
+type Box(a) {
+  Box(a)
+}
+
+fn apply(arg, fun) {
+  fun(arg, arg, arg)
+}
+"#,
+        vec![("main", "fn() -> Int")],
+    );
+}
+
+#[test]
+fn typed_pattern_wrong_type() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  use Box(x): Box(Bool), Box(y), Box(z) <- apply(Box(1))
+  x + y + z
+}
+
+type Box(a) {
+  Box(a)
+}
+
+fn apply(arg, fun) {
+  fun(arg, arg, arg)
+}
+"#
     );
 }


### PR DESCRIPTION
Right now you cannot use type annotations in use statements.

This PR adds support for such syntax:
```gleam
fn main() {
    use blah: Int <- foo
}
```

Solves #1864 