### PR TITLE
Type alias ordering

### DIFF
--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
 
-mod dep_tree;
 mod module_loader;
 mod native_file_copier;
 pub mod package_compiler;

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -2,7 +2,6 @@ use crate::type_::PRELUDE_MODULE_NAME;
 use crate::{
     ast::{SrcSpan, TypedModule, UntypedModule},
     build::{
-        dep_tree,
         module_loader::SourceFingerprint,
         native_file_copier::NativeFileCopier,
         package_loader::{CodegenRequired, PackageLoader},
@@ -10,7 +9,7 @@ use crate::{
     },
     codegen::{Erlang, ErlangApp, JavaScript, TypeScriptDeclarations},
     config::PackageConfig,
-    error,
+    dep_tree, error,
     io::{CommandExecutor, FileSystemReader, FileSystemWriter, Stdio},
     metadata::ModuleEncoder,
     parse::extra::ModuleExtra,

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -13,8 +13,9 @@ use itertools::Itertools;
 use smol_str::SmolStr;
 
 use crate::{
-    build::{dep_tree, module_loader::ModuleLoader, package_compiler::module_name, Module, Origin},
+    build::{module_loader::ModuleLoader, package_compiler::module_name, Module, Origin},
     config::PackageConfig,
+    dep_tree,
     error::{FileIoAction, FileKind},
     io::{CommandExecutor, FileSystemReader, FileSystemWriter},
     metadata, type_,

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -1,10 +1,11 @@
 use crate::{
     build::{
-        dep_tree, package_compiler, package_compiler::PackageCompiler, project_compiler,
+        package_compiler, package_compiler::PackageCompiler, project_compiler,
         telemetry::Telemetry, Mode, Module, Origin, Package, Target,
     },
     codegen::{self, ErlangApp},
     config::PackageConfig,
+    dep_tree,
     error::{FileIoAction, FileKind},
     io::{CommandExecutor, FileSystemReader, FileSystemWriter, Stdio},
     manifest::ManifestPackage,

--- a/compiler-core/src/dep_tree.rs
+++ b/compiler-core/src/dep_tree.rs
@@ -1,17 +1,9 @@
 use petgraph::{algo::Cycle, graph::NodeIndex, Direction};
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
-use std::hash::Hash;
 
 #[cfg(test)]
 use pretty_assertions::assert_eq;
-
-#[derive(Debug, Default)]
-pub struct DependencyTree<T> {
-    graph: petgraph::Graph<T, ()>,
-    indexes: HashMap<T, NodeIndex>,
-    values: HashMap<NodeIndex, T>,
-}
 
 /// Take a sequence of values and their deps, and return the values in
 /// order so that deps come before the dependants.
@@ -58,7 +50,7 @@ fn import_cycle(
 ) -> Vec<SmolStr> {
     let origin = cycle.node_id();
     let mut path = vec![];
-    let _ = find_cycle(origin, origin, &graph, &mut path, &mut HashSet::new());
+    let _ = find_cycle(origin, origin, graph, &mut path, &mut HashSet::new());
     path.iter()
         .map(|index| {
             values

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -78,6 +78,7 @@ pub mod version;
 pub mod warning;
 
 mod call_graph;
+mod dep_tree;
 pub(crate) mod graph;
 
 pub use error::{Error, Result};

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -248,6 +248,15 @@ pub enum Error {
     UnlabelledAfterlabelled {
         location: SrcSpan,
     },
+
+    /// A type alias was defined directly or indirectly in terms of itself, which would
+    /// cause it to expand to infinite size.
+    /// e.g.
+    ///     type ForkBomb = #(ForkBomb, ForkBomb)
+    RecursiveTypeAlias {
+        location: SrcSpan,
+        cycle: Vec<SmolStr>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -19,6 +19,7 @@ mod functions;
 mod imports;
 mod pretty;
 mod statement_if;
+mod type_alias;
 mod use_;
 mod warnings;
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__alias_cycle.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__alias_cycle.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/type_alias.rs
+expression: "\ntype A = B\ntype B = C\ntype C = D\ntype D = E\ntype E = A\n"
+---
+error: Type cycle
+  ┌─ /src/one/two.gleam:2:1
+  │
+2 │ type A = B
+  │ ^^^^^^^^^^
+
+This type alias is defined in terms of itself.
+
+    ┌─────┐
+    │     E
+    │     ↓
+    │     D
+    │     ↓
+    │     C
+    │     ↓
+    │     B
+    │     ↓
+    │     A
+    └─────┘
+f we tried to compile this recursive type it would expand forever in a loop, and we'd never get the final type.
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__alias_direct_cycle.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__alias_direct_cycle.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/type_alias.rs
+expression: "\ntype A = #(A, A)\n"
+---
+error: Type cycle
+  ┌─ /src/one/two.gleam:2:1
+  │
+2 │ type A = #(A, A)
+  │ ^^^^^^^^^^
+
+This type alias is defined in terms of itself.
+
+    ┌─────┐
+    │     A
+    └─────┘
+f we tried to compile this recursive type it would expand forever in a loop, and we'd never get the final type.
+

--- a/compiler-core/src/type_/tests/type_alias.rs
+++ b/compiler-core/src/type_/tests/type_alias.rs
@@ -1,0 +1,74 @@
+use crate::{assert_infer_with_module, assert_module_error, assert_module_infer};
+
+#[test]
+fn alias_dep() {
+    assert_module_infer!(
+        r#"
+type E = #(F, C)
+type F = fn(CustomA) -> CustomB(B)
+type A = Int
+type B = C
+type C = CustomA
+type D = CustomB(C)
+
+type CustomA {
+  CustomA()
+}
+type CustomB(a) {
+  CustomB(a)
+}
+"#,
+        vec![],
+    )
+}
+
+#[test]
+fn custom_type_dep() {
+    assert_module_infer!(
+        r#"
+type A {
+    A(Blah)
+}
+
+type Blah {
+    B(Int)
+}
+"#,
+        vec![],
+    )
+}
+
+#[test]
+fn alias_cycle() {
+    assert_module_error!(
+        r#"
+type A = B
+type B = C
+type C = D
+type D = E
+type E = A
+"#
+    );
+}
+
+#[test]
+fn alias_direct_cycle() {
+    assert_module_error!(
+        r#"
+type A = #(A, A)
+"#
+    );
+}
+
+#[test]
+fn alias_different_module() {
+    assert_infer_with_module!(
+        ("other", "pub type Blah = Bool"),
+        r#"
+            import other
+
+            type Blah = #(other.Blah, other.Blah)
+        "#,
+        vec![],
+    );
+}

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle.snap
@@ -8,7 +8,7 @@ error: Import cycle
 The import statements for these modules form a cycle:
 
     ┌─────┐
-    │    one
+    │     one
     └─────┘
 Gleam doesn't support dependency cycles like these, please break the
 cycle to continue.


### PR DESCRIPTION
Right now type aliases are registered in their definition order. It means they must be defined in the correct order in the source file. 

This PR is changing that so that we compute type alias dependencies, detect type alias "cycles" and then register them in topological order.

Long term it would probably makes sense to do that for all types and not just alias. 

This PR solves #1925.