### PR TITLE
Odd/incorrect formatter behaviour when a comment occurs before a `use`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug where comments above a `use` expression would be formatted
+  incorrectly.
+
 ## v0.28.1 - 2023-04-05
 
 - Fixed a bug where the languag server would unset too many error diagnostics

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1526,6 +1526,8 @@ impl<'comments> Formatter<'comments> {
     }
 
     fn use_<'a>(&mut self, use_: &'a Use) -> Document<'a> {
+        let comments = self.pop_comments(use_.location.start);
+
         let call = if use_.call.is_call() {
             docvec![" ", self.expr(&use_.call)]
         } else {
@@ -1533,7 +1535,7 @@ impl<'comments> Formatter<'comments> {
         }
         .group();
 
-        if use_.assignments.is_empty() {
+        let doc = if use_.assignments.is_empty() {
             docvec!["use <-", call]
         } else {
             let assignments = use_.assignments.iter().map(|use_assignment| {
@@ -1551,7 +1553,9 @@ impl<'comments> Formatter<'comments> {
                 .chain(assignments);
             let left = concat(left).nest(INDENT).append(break_("", " ")).group();
             docvec![left, "<-", call].group()
-        }
+        };
+
+        commented(doc, comments)
     }
 
     fn bit_string_segment_expr<'a>(&mut self, expr: &'a UntypedExpr) -> Document<'a> {

--- a/compiler-core/src/format/tests/use_.rs
+++ b/compiler-core/src/format/tests/use_.rs
@@ -314,3 +314,15 @@ fn multiple_long_annotations() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2114
+#[test]
+fn comment() {
+    assert_format!(
+        r#"fn main() {
+  // comment
+  use x <- result.then(y)
+}
+"#
+    );
+}


### PR DESCRIPTION
Fixes the formatter issue in #2114 🎨 