### PR TITLE
2103 Allow spread when constructor has no labeled fields

### DIFF
--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -486,7 +486,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                         },
                                         location: spread_location,
                                         label: None,
-                                        implicit: false,
+                                        implicit: true,
                                     });
                                 }
                             };

--- a/compiler-core/src/type_/tests/assignments.rs
+++ b/compiler-core/src/type_/tests/assignments.rs
@@ -129,6 +129,11 @@ fn let_23() {
     assert_infer!("let [] = [] 1", "Int");
 }
 
+#[test]
+fn let_24() {
+    assert_infer!("let assert Ok(..) = Ok(10)", "Result(Int, a)");
+}
+
 // // https://github.com/gleam-lang/gleam/issues/1991
 // #[test]
 // fn block() {


### PR DESCRIPTION
Fixes #2103. This change allows the spread operator to be used on a record constructor.

