### PR TITLE
feat: Local dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,13 @@ jobs:
         working-directory: ./test/project_javascript
         if: ${{ matrix.run-integration-tests }}
 
+      - name: test/project_path_deps
+        run: |
+          gleam update
+          gleam check
+        working-directory: ./test/project_path_deps/project_a
+        if: ${{ matrix.run-integration-tests }}
+
       - name: Test project generation
         run: |
           gleam new lib_project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Dependencies can now be loaded from paths. Path dependencies currently use
+  the same semantics as hex dependencies, and must be updated using the command
+  `gleam deps update` to load changes.
 - Type aliases can now refer to type aliases defined later in the same module.
 - Fixed a bug where unapplied record constructors in constant expressions would
   generate invalid Erlang.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "lsp-types",
  "petgraph",
  "pretty_assertions",
+ "pubgrub",
  "pulldown-cmark",
  "rand",
  "regex",

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -210,6 +210,7 @@ async fn add_missing_packages<Telem: Telemetry>(
         match &package.source {
             ManifestPackageSource::Hex { .. } => Ok(()),
             ManifestPackageSource::Local { path } => {
+                fs.delete(&package_dest)?;
                 fs.mkdir(&package_dest)?;
                 fs.copy_dir(&path.join("src"), &package_dest)?;
                 fs.copy(&path.join("gleam.toml"), &package_dest.join("gleam.toml"))
@@ -322,7 +323,12 @@ impl LocalPackages {
         manifest
             .packages
             .iter()
-            .filter(|p| p.name != root && self.packages.get(&p.name) != Some(&p.version))
+            .filter(|p| {
+                p.name != root && {
+                    self.packages.get(&p.name) != Some(&p.version)
+                        || matches!(p.source, ManifestPackageSource::Local { .. })
+                }
+            })
             .collect()
     }
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -794,7 +794,7 @@ fn provide_wrong_package() {
     let mut provided = HashMap::new();
     let result = provide_local_package(
         "wrong_name".into(),
-        &Path::new("../test/hello_world"),
+        &Path::new("./test/hello_world"),
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
@@ -815,7 +815,7 @@ fn provide_existing_package() {
 
     let result = provide_local_package(
         "hello_world".into(),
-        &Path::new("../test/hello_world"),
+        &Path::new("./test/hello_world"),
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
@@ -826,7 +826,7 @@ fn provide_existing_package() {
 
     let result = provide_local_package(
         "hello_world".into(),
-        &Path::new("../test/hello_world"),
+        &Path::new("./test/hello_world"),
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
@@ -842,7 +842,7 @@ fn provide_conflicting_package() {
 
     let result = provide_local_package(
         "hello_world".into(),
-        &Path::new("../test/hello_world"),
+        &Path::new("./test/hello_world"),
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
@@ -853,9 +853,9 @@ fn provide_conflicting_package() {
 
     let result = provide_package(
         "hello_world".into(),
-        &Path::new("../test/other"),
+        &Path::new("./test/other"),
         ProvidedPackageSource::Local {
-            path: Path::new("../test/other").to_path_buf(),
+            path: Path::new("./test/other").to_path_buf(),
         },
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
@@ -872,7 +872,7 @@ fn provided_is_absolute() {
     let mut provided = HashMap::new();
     let result = provide_local_package(
         "hello_world".into(),
-        &Path::new("../test/hello_world"),
+        &Path::new("./test/hello_world"),
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
@@ -893,7 +893,7 @@ fn provided_recursive() {
     let mut provided = HashMap::new();
     let result = provide_local_package(
         "hello_world".into(),
-        &Path::new("../test/hello_world"),
+        &Path::new("./test/hello_world"),
         &mut provided,
         &mut vec!["root".into(), "hello_world".into(), "subpackage".into()],
     );

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -213,6 +213,7 @@ async fn add_missing_packages<Telem: Telemetry>(
                 fs.delete(&package_dest)?;
                 fs.mkdir(&package_dest)?;
                 fs.copy_dir(&path.join("src"), &package_dest)?;
+                fs.copy_dir(&path.join("priv"), &package_dest)?;
                 fs.copy(&path.join("gleam.toml"), &package_dest.join("gleam.toml"))
             }
             ManifestPackageSource::Git { .. } => Ok(()),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -218,10 +218,7 @@ async fn add_missing_packages<Telem: Telemetry>(
     let mut num_to_download = 0;
     let mut missing_hex_packages = missing_packages
         .into_iter()
-        .filter(|package| match package.source {
-            ManifestPackageSource::Hex { .. } => true,
-            _ => false,
-        })
+        .filter(|package| package.is_hex())
         .map(|package| {
             num_to_download += 1;
             package

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -543,7 +543,7 @@ fn resolve_versions<Telem: Telemetry>(
     let resolved = dependency::resolve_versions(
         PackageFetcher::boxed(runtime.clone()),
         provided_packages.clone(),
-        config.name.to_string(),
+        config.name.clone(),
         version_requirements.into_iter(),
         &locked,
     )?;
@@ -577,7 +577,7 @@ fn resolve_versions<Telem: Telemetry>(
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 enum ProviderInfo {
-    Git { repo: String, commit: String },
+    Git { repo: SmolStr, commit: SmolStr },
     Local { path: PathBuf },
 }
 
@@ -626,8 +626,8 @@ fn provide_git_package(
 ) -> Result<hexpm::version::Range> {
     // TODO
     let _git = ProviderInfo::Git {
-        repo: "repo".to_string(),
-        commit: "commit".to_string(),
+        repo: SmolStr::new_inline("repo"),
+        commit: SmolStr::new_inline("commit")
     };
     Err(Error::DependencyResolutionFailed(
         "Git dependencies are not supported".to_string(),
@@ -724,8 +724,8 @@ async fn lookup_package(
                 build_tools: vec!["gleam".to_string()],
                 requirements,
                 source: ManifestPackageSource::Git {
-                    repo: repo.to_string(),
-                    commit: commit.to_string(),
+                    repo: repo.clone(),
+                    commit: commit.clone(),
                 },
             })
         }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -208,9 +208,10 @@ async fn add_missing_packages<Telem: Telemetry>(
     // Link local paths
     let packages_dir = paths.build_packages_directory();
     for package in missing_packages.iter() {
+        let package_dest = packages_dir.join(project_name.to_string());
         match &package.source {
             ManifestPackageSource::Hex { .. } => Ok(()),
-            ManifestPackageSource::Local { path } => fs.symlink_dir(&path, &packages_dir),
+            ManifestPackageSource::Local { path } => fs.symlink_dir(&path, &package_dest),
             ManifestPackageSource::Git { .. } => Ok(()),
         }?
     }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -785,7 +785,7 @@ fn provide_wrong_package() {
         "wrong_name".into(),
         &Path::new("../test/hello_world"),
         &mut provided,
-        &mut vec!["root".into(), "subpackage".into()]
+        &mut vec!["root".into(), "subpackage".into()],
     );
     let error = Err(Error::DependencyResolutionFailed(
         "wrong_name was expected but hello_world was found".to_string(),
@@ -801,7 +801,7 @@ fn provide_existing_package() {
         "hello_world".into(),
         &Path::new("../test/hello_world"),
         &mut provided,
-        &mut vec!["root".into(), "subpackage".into()]
+        &mut vec!["root".into(), "subpackage".into()],
     );
     assert_eq!(
         result,
@@ -812,7 +812,7 @@ fn provide_existing_package() {
         "hello_world".into(),
         &Path::new("../test/hello_world"),
         &mut provided,
-        &mut vec!["root".into(), "subpackage".into()]
+        &mut vec!["root".into(), "subpackage".into()],
     );
     assert_eq!(
         result,
@@ -828,7 +828,7 @@ fn provide_conflicting_package() {
         "hello_world".into(),
         &Path::new("../test/hello_world"),
         &mut provided,
-        &mut vec!["root".into(), "subpackage".into()]
+        &mut vec!["root".into(), "subpackage".into()],
     );
     assert_eq!(
         result,
@@ -842,7 +842,7 @@ fn provide_conflicting_package() {
             path: Path::new("../test/other").to_path_buf(),
         },
         &mut provided,
-        &mut vec!["root".into(), "subpackage".into()]
+        &mut vec!["root".into(), "subpackage".into()],
     );
     assert!(result.is_err()); // Error contains canonical path, so we cannot assert against the actual error value
 }
@@ -854,7 +854,7 @@ fn provided_is_absolute() {
         "hello_world".into(),
         &Path::new("../test/hello_world"),
         &mut provided,
-        &mut vec!["root".into(), "subpackage".into()]
+        &mut vec!["root".into(), "subpackage".into()],
     );
     assert_eq!(
         result,
@@ -875,11 +875,14 @@ fn provided_recursive() {
         "hello_world".into(),
         &Path::new("../test/hello_world"),
         &mut provided,
-        &mut vec!["root".into(), "hello_world".into(), "subpackage".into()]
+        &mut vec!["root".into(), "hello_world".into(), "subpackage".into()],
     );
     assert_eq!(
         result,
-        Err(Error::ProvidedDependencyCycle("hello_world".to_string(), "root -> hello_world -> subpackage".to_string()))
+        Err(Error::ProvidedDependencyCycle(
+            "hello_world".to_string(),
+            "root -> hello_world -> subpackage".to_string()
+        ))
     )
 }
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -502,7 +502,7 @@ fn resolve_versions<Telem: Telemetry>(
     telemetry: &Telem,
 ) -> Result<Manifest, Error> {
     telemetry.resolving_package_versions();
-    let resolved = dependency::resolve_versions(
+    let resolved = dependency::resolve_versions_from_config(
         PackageFetcher::boxed(runtime.clone()),
         mode,
         config,
@@ -576,7 +576,7 @@ impl TarUnpacker for Untar {
     }
 }
 
-impl hexpm::version::PackageFetcher for PackageFetcher {
+impl dependency::PackageFetcher for PackageFetcher {
     fn get_dependencies(
         &self,
         package: &str,

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -207,7 +207,7 @@ async fn add_missing_packages<Telem: Telemetry>(
     // Link local paths
     let packages_dir = paths.build_packages_directory();
     for package in missing_packages.iter() {
-        let package_dest = packages_dir.join(project_name.to_string());
+        let package_dest = packages_dir.join(package.name.to_string());
         match &package.source {
             ManifestPackageSource::Hex { .. } => Ok(()),
             ManifestPackageSource::Local { path } => fs.symlink_dir(&path, &package_dest),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -823,3 +823,196 @@ impl dependency::PackageFetcher for PackageFetcher {
         hexpm::get_package_response(response, HEXPM_PUBLIC_KEY).map_err(|e| e.into())
     }
 }
+
+#[test]
+fn provided_local_to_hex() {
+    let provided_package = ProvidedPackage {
+        version: hexpm::version::Version::new(1, 0, 0),
+        source: ProvidedPackageSource::Local {
+            path: "canonical/path/to/package".into(),
+        },
+        requirements: [
+            (
+                "req_1".into(),
+                hexpm::version::Range::new("~> 1.0.0".to_string()),
+            ),
+            (
+                "req_2".into(),
+                hexpm::version::Range::new("== 1.0.0".to_string()),
+            ),
+        ]
+        .into(),
+    };
+
+    let hex_package = hexpm::Package {
+        name: "package".to_string(),
+        repository: "local".to_string(),
+        releases: vec![hexpm::Release {
+            version: hexpm::version::Version::new(1, 0, 0),
+            retirement_status: None,
+            outer_checksum: vec![],
+            meta: (),
+            requirements: [
+                (
+                    "req_1".into(),
+                    hexpm::Dependency {
+                        requirement: hexpm::version::Range::new("~> 1.0.0".to_string()),
+                        optional: false,
+                        app: None,
+                        repository: None,
+                    },
+                ),
+                (
+                    "req_2".into(),
+                    hexpm::Dependency {
+                        requirement: hexpm::version::Range::new("== 1.0.0".to_string()),
+                        optional: false,
+                        app: None,
+                        repository: None,
+                    },
+                ),
+            ]
+            .into(),
+        }],
+    };
+
+    assert_eq!(
+        provided_package.to_hex_package(&SmolStr::new_inline("package")),
+        hex_package
+    );
+}
+
+#[test]
+fn provided_git_to_hex() {
+    let provided_package = ProvidedPackage {
+        version: hexpm::version::Version::new(1, 0, 0),
+        source: ProvidedPackageSource::Git {
+            repo: "https://github.com/gleam-lang/gleam.git".into(),
+            commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+        },
+        requirements: [
+            (
+                "req_1".into(),
+                hexpm::version::Range::new("~> 1.0.0".to_string()),
+            ),
+            (
+                "req_2".into(),
+                hexpm::version::Range::new("== 1.0.0".to_string()),
+            ),
+        ]
+        .into(),
+    };
+
+    let hex_package = hexpm::Package {
+        name: "package".to_string(),
+        repository: "local".to_string(),
+        releases: vec![hexpm::Release {
+            version: hexpm::version::Version::new(1, 0, 0),
+            retirement_status: None,
+            outer_checksum: vec![],
+            meta: (),
+            requirements: [
+                (
+                    "req_1".into(),
+                    hexpm::Dependency {
+                        requirement: hexpm::version::Range::new("~> 1.0.0".to_string()),
+                        optional: false,
+                        app: None,
+                        repository: None,
+                    },
+                ),
+                (
+                    "req_2".into(),
+                    hexpm::Dependency {
+                        requirement: hexpm::version::Range::new("== 1.0.0".to_string()),
+                        optional: false,
+                        app: None,
+                        repository: None,
+                    },
+                ),
+            ]
+            .into(),
+        }],
+    };
+
+    assert_eq!(
+        provided_package.to_hex_package(&SmolStr::new_inline("package")),
+        hex_package
+    );
+}
+
+#[test]
+fn provided_local_to_manifest() {
+    let provided_package = ProvidedPackage {
+        version: hexpm::version::Version::new(1, 0, 0),
+        source: ProvidedPackageSource::Local {
+            path: "canonical/path/to/package".into(),
+        },
+        requirements: [
+            (
+                "req_1".into(),
+                hexpm::version::Range::new("~> 1.0.0".to_string()),
+            ),
+            (
+                "req_2".into(),
+                hexpm::version::Range::new("== 1.0.0".to_string()),
+            ),
+        ]
+        .into(),
+    };
+
+    let manifest_package = ManifestPackage {
+        name: "package".to_string(),
+        version: hexpm::version::Version::new(1, 0, 0),
+        otp_app: None,
+        build_tools: vec!["gleam".to_string()],
+        requirements: vec!["req_2".into(), "req_1".into()],
+        source: ManifestPackageSource::Local {
+            path: "canonical/path/to/package".into(),
+        },
+    };
+
+    assert_eq!(
+        provided_package.to_manifest_package(&SmolStr::new_inline("package")),
+        manifest_package
+    );
+}
+
+#[test]
+fn provided_git_to_manifest() {
+    let provided_package = ProvidedPackage {
+        version: hexpm::version::Version::new(1, 0, 0),
+        source: ProvidedPackageSource::Git {
+            repo: "https://github.com/gleam-lang/gleam.git".into(),
+            commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+        },
+        requirements: [
+            (
+                "req_1".into(),
+                hexpm::version::Range::new("~> 1.0.0".to_string()),
+            ),
+            (
+                "req_2".into(),
+                hexpm::version::Range::new("== 1.0.0".to_string()),
+            ),
+        ]
+        .into(),
+    };
+
+    let manifest_package = ManifestPackage {
+        name: "package".to_string(),
+        version: hexpm::version::Version::new(1, 0, 0),
+        otp_app: None,
+        build_tools: vec!["gleam".to_string()],
+        requirements: vec!["req_2".into(), "req_1".into()],
+        source: ManifestPackageSource::Git {
+            repo: "https://github.com/gleam-lang/gleam.git".into(),
+            commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+        },
+    };
+
+    assert_eq!(
+        provided_package.to_manifest_package(&SmolStr::new_inline("package")),
+        manifest_package
+    );
+}

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -205,12 +205,14 @@ async fn add_missing_packages<Telem: Telemetry>(
     let missing_packages = local.missing_local_packages(manifest, &project_name);
 
     // Link local paths
-    let packages_dir = paths.build_packages_directory();
     for package in missing_packages.iter() {
-        let package_dest = packages_dir.join(&package.name);
+        let package_dest = paths.build_packages_package(&package.name);
         match &package.source {
             ManifestPackageSource::Hex { .. } => Ok(()),
-            ManifestPackageSource::Local { path } => fs.symlink_dir(path, &package_dest),
+            ManifestPackageSource::Local { path } => {
+                fs.copy_dir(&path.join("src"), &package_dest.join("src"))?;
+                fs.copy(&path.join("gleam.toml"), &package_dest.join("gleam.toml"))
+            }
             ManifestPackageSource::Git { .. } => Ok(()),
         }?
     }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -6,7 +6,8 @@ use std::{
 use flate2::read::GzDecoder;
 use futures::future;
 use gleam_core::{
-    build::{Mode, Target, Telemetry},
+    dependency,
+    build::{Mode, Target Telemetry},
     config::PackageConfig,
     error::{FileIoAction, FileKind, StandardIoAction},
     hex::{self, HEXPM_PUBLIC_KEY},
@@ -501,7 +502,7 @@ fn resolve_versions<Telem: Telemetry>(
     telemetry: &Telem,
 ) -> Result<Manifest, Error> {
     telemetry.resolving_package_versions();
-    let resolved = hex::resolve_versions(
+    let resolved = dependency::resolve_versions(
         PackageFetcher::boxed(runtime.clone()),
         mode,
         config,

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -10,6 +10,7 @@ use gleam_core::{
     config::PackageConfig,
     error::{FileIoAction, FileKind, StandardIoAction},
     hex::{self, HEXPM_PUBLIC_KEY},
+    recipe::Recipe,
     io::{HttpClient as _, TarUnpacker, WrappedReader},
     manifest::{Base16Checksum, Manifest, ManifestPackage, ManifestPackageSource},
     paths::ProjectPaths,
@@ -146,7 +147,7 @@ pub fn download<Telem: Telemetry>(
     // Insert the new packages to add, if it exists
     if let Some((packages, dev)) = new_package {
         for package in packages {
-            let version = hexpm::version::Range::new(">= 0.0.0".into());
+            let version = Recipe::hex(">= 0.0.0");
             let _ = if dev {
                 config.dev_dependencies.insert(package.to_string(), version)
             } else {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -617,8 +617,8 @@ fn resolve_versions<Telem: Telemetry>(
     let mut root_requirements = HashMap::new();
 
     // Populate the provided_packages and root_requrements maps
-    for (name, recipe) in dependencies.into_iter() {
-        let version = match recipe {
+    for (name, requirement) in dependencies.into_iter() {
+        let version = match requirement {
             Requirement::Hex { version } => version,
             Requirement::Path { path } => {
                 provide_local_package(&name, &path, &mut provided_packages)?
@@ -717,8 +717,8 @@ fn provide_package(
         )));
     };
     let mut requirements = HashMap::new();
-    for (name, recipe) in config.dependencies.into_iter() {
-        let version = match recipe {
+    for (name, requirement) in config.dependencies.into_iter() {
+        let version = match requirement {
             Requirement::Hex { version } => version,
             Requirement::Path { path } => {
                 let resolved_path = if path.is_absolute() {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -628,7 +628,10 @@ fn provide_git_package(
     _provided: &mut HashMap<String, hexpm::Package>,
 ) -> Result<hexpm::version::Range> {
     // TODO
-    let _git = ProviderInfo::Git { repo: "repo".to_string(), commit: "commit".to_string() };
+    let _git = ProviderInfo::Git {
+        repo: "repo".to_string(),
+        commit: "commit".to_string(),
+    };
     Err(Error::DependencyResolutionFailed(
         "Git dependencies are not supported".to_string(),
     ))
@@ -652,8 +655,13 @@ fn provide_package(
         let version = match recipe {
             Recipe::Hex { version } => version,
             Recipe::Path { path } => {
+                let resolved_path = if path.is_absolute() {
+                    path
+                } else {
+                    package_path.join(path)
+                };
                 // Recursively walk local packages
-                provide_local_package(&name, &package_path.join(path), info, provided)?
+                provide_local_package(&name, &resolved_path, info, provided)?
             }
             Recipe::Git { git } => provide_git_package(&name, &git, info, provided)?,
         };

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -15,7 +15,7 @@ use gleam_core::{
     io::{FileSystemWriter, HttpClient as _, TarUnpacker, WrappedReader},
     manifest::{Base16Checksum, Manifest, ManifestPackage, ManifestPackageSource},
     paths::ProjectPaths,
-    recipe::Recipe,
+    requirement::Requirement,
     Error, Result,
 };
 use hexpm::version::Version;
@@ -147,7 +147,7 @@ pub fn download<Telem: Telemetry>(
     // Insert the new packages to add, if it exists
     if let Some((packages, dev)) = new_package {
         for package in packages {
-            let version = Recipe::hex(">= 0.0.0");
+            let version = Requirement::hex(">= 0.0.0");
             let _ = if dev {
                 config.dev_dependencies.insert(package.to_string(), version)
             } else {
@@ -529,11 +529,11 @@ fn resolve_versions<Telem: Telemetry>(
     let mut provider_info = HashMap::new();
     for (name, recipe) in dependencies.into_iter() {
         let version = match recipe {
-            Recipe::Hex { version } => version,
-            Recipe::Path { path } => {
+            Requirement::Hex { version } => version,
+            Requirement::Path { path } => {
                 provide_local_package(&name, &path, &mut provider_info, &mut provided_packages)?
             }
-            Recipe::Git { git } => {
+            Requirement::Git { git } => {
                 provide_git_package(&name, &git, &mut provider_info, &mut provided_packages)?
             }
         };
@@ -650,8 +650,8 @@ fn provide_package(
     let mut requirements = HashMap::new();
     for (name, recipe) in config.dependencies.into_iter() {
         let version = match recipe {
-            Recipe::Hex { version } => version,
-            Recipe::Path { path } => {
+            Requirement::Hex { version } => version,
+            Requirement::Path { path } => {
                 let resolved_path = if path.is_absolute() {
                     path
                 } else {
@@ -660,7 +660,7 @@ fn provide_package(
                 // Recursively walk local packages
                 provide_local_package(&name, &resolved_path, info, provided)?
             }
-            Recipe::Git { git } => provide_git_package(&name, &git, info, provided)?,
+            Requirement::Git { git } => provide_git_package(&name, &git, info, provided)?,
         };
         let _ = requirements.insert(
             name,

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -291,7 +291,7 @@ fn write_manifest_to_disc(paths: &ProjectPaths, manifest: &Manifest) -> Result<(
 }
 
 // This is the container for locally pinned packages.
-// Fpr packages provided by paths and git deps, see the ProvidedPackage struct
+// For packages provided by paths and git deps, see the ProvidedPackage struct
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct LocalPackages {
     packages: HashMap<String, Version>,

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -295,8 +295,10 @@ fn write_manifest_to_disc(paths: &ProjectPaths, manifest: &Manifest) -> Result<(
     fs::write(&path, &manifest.to_toml())
 }
 
-// This is the container for locally pinned packages.
-// For packages provided by paths and git deps, see the ProvidedPackage struct
+// This is the container for locally pinned packages, representing the current contents of
+// the `project/build/packages` directory.
+// For descriptions of packages provided by paths and git deps, see the ProvidedPackage struct.
+// The same package may appear in both at different times.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct LocalPackages {
     packages: HashMap<String, Version>,

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -207,7 +207,7 @@ async fn add_missing_packages<Telem: Telemetry>(
     // Link local paths
     let packages_dir = paths.build_packages_directory();
     for package in missing_packages.iter() {
-        let package_dest = packages_dir.join(package.name.to_string());
+        let package_dest = packages_dir.join(&package.name);
         match &package.source {
             ManifestPackageSource::Hex { .. } => Ok(()),
             ManifestPackageSource::Local { path } => fs.symlink_dir(&path, &package_dest),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -662,7 +662,7 @@ fn provide_local_package(
 ) -> Result<hexpm::version::Range> {
     let canonical_path = package_path
         .canonicalize()
-        .expect("local package cannonical path");
+        .map_err(|_| Error::DependencyCanonicalizationFailed(package_name.to_string()))?;
     let package_source = ProvidedPackageSource::Local {
         path: canonical_path.clone(),
     };

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -213,7 +213,9 @@ async fn add_missing_packages<Telem: Telemetry>(
                 fs.delete(&package_dest)?;
                 fs.mkdir(&package_dest)?;
                 fs.copy_dir(&path.join("src"), &package_dest)?;
-                fs.copy_dir(&path.join("priv"), &package_dest)?;
+                if path.join("priv").exists() {
+                    fs.copy_dir(&path.join("priv"), &package_dest)?;
+                }
                 fs.copy(&path.join("gleam.toml"), &package_dest.join("gleam.toml"))
             }
             ManifestPackageSource::Git { .. } => Ok(()),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -585,10 +585,8 @@ impl ProvidedPackageSource {
             }
         }
     }
-}
 
-impl ToString for ProvidedPackageSource {
-    fn to_string(&self) -> String {
+    fn to_toml(&self) -> String {
         match self {
             ProvidedPackageSource::Git { repo, commit } => {
                 format!(r#"{{ repo: "{}", commit: "{}" }}"#, repo, commit)
@@ -684,8 +682,8 @@ fn provide_local_package(
             // A different source for this package has already been found
             Err(Error::ProvidedDependencyConflict(
                 package_name.to_string(),
-                package_source.to_string(),
-                package.source.to_string(),
+                package_source.to_toml(),
+                package.source.to_toml(),
             ))
         }
     }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -210,7 +210,8 @@ async fn add_missing_packages<Telem: Telemetry>(
         match &package.source {
             ManifestPackageSource::Hex { .. } => Ok(()),
             ManifestPackageSource::Local { path } => {
-                fs.copy_dir(&path.join("src"), &package_dest.join("src"))?;
+                fs.mkdir(&package_dest)?;
+                fs.copy_dir(&path.join("src"), &package_dest)?;
                 fs.copy(&path.join("gleam.toml"), &package_dest.join("gleam.toml"))
             }
             ManifestPackageSource::Git { .. } => Ok(()),

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -196,7 +196,7 @@ fn metadata_config<'a>(
     let requirements: Result<Vec<ReleaseRequirement<'a>>> = config
         .dependencies
         .iter()
-        .map(|(name, recipe)| match recipe {
+        .map(|(name, requirement)| match requirement {
             Requirement::Hex { version } => Ok(ReleaseRequirement {
                 name,
                 requirement: version,

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -4,7 +4,7 @@ use gleam_core::{
     config::{PackageConfig, SpdxLicense},
     hex, paths,
     paths::ProjectPaths,
-    recipe::Recipe,
+    requirement::Requirement,
     Error, Result,
 };
 use hexpm::version::{Range, Version};
@@ -197,7 +197,7 @@ fn metadata_config<'a>(
         .dependencies
         .iter()
         .map(|(name, recipe)| match recipe {
-            Recipe::Hex { version } => Ok(ReleaseRequirement {
+            Requirement::Hex { version } => Ok(ReleaseRequirement {
                 name,
                 requirement: version,
             }),

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -508,6 +508,34 @@ fn release_metadata_as_erlang() {
     );
 }
 
+#[test]
+fn prevent_publish_local_dependency() {
+    let mut config = PackageConfig::default();
+    config.dependencies = [("provided".into(), Requirement::path("./path/to/package"))].into();
+    assert_eq!(
+        metadata_config(&config, &[], &[]),
+        Err(Error::PublishNonHexDependencies {
+            package: "provided".into()
+        })
+    );
+}
+
+#[test]
+fn prevent_publish_git_dependency() {
+    let mut config = PackageConfig::default();
+    config.dependencies = [(
+        "provided".into(),
+        Requirement::git("https://github.com/gleam-lang/gleam.git"),
+    )]
+    .into();
+    assert_eq!(
+        metadata_config(&config, &[], &[]),
+        Err(Error::PublishNonHexDependencies {
+            package: "provided".into()
+        })
+    );
+}
+
 pub fn get_hostname() -> String {
     hostname::get()
         .expect("Looking up hostname")

--- a/compiler-cli/test/hello_world/gleam.toml
+++ b/compiler-cli/test/hello_world/gleam.toml
@@ -1,0 +1,8 @@
+name = "hello_world"
+version = "0.1.0"
+
+[dependencies]
+gleam_stdlib = "~> 0.28"
+
+[dev-dependencies]
+gleeunit = "~> 0.10"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -77,6 +77,8 @@ xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 # Language server protocol server plumbing
 lsp-server = "0.5"
 lsp-types = "0.92"
+# Pubgrub dependency resolution algorithm
+pubgrub = "0.2"
 
 [build-dependencies]
 # Data (de)serialisation

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -4,7 +4,7 @@ use crate::manifest::Manifest;
 use crate::requirement::Requirement;
 use crate::{Error, Result};
 use globset::{Glob, GlobSetBuilder};
-use hexpm::version::{Range, Version};
+use hexpm::version::Version;
 use http::Uri;
 use serde::Deserialize;
 use smol_str::SmolStr;
@@ -102,13 +102,6 @@ impl PackageConfig {
             Mode::Dev | Mode::Lsp => self.all_dependencies(),
             Mode::Prod => Ok(self.dependencies.clone()),
         }
-    }
-
-    pub fn dependency_versions_for(&self, mode: Mode) -> Result<HashMap<String, Range>> {
-        self.dependencies_for(mode)?
-            .iter()
-            .map(|(package, requirement)| Ok((package.clone(), requirement.version_range()?)))
-            .collect()
     }
 
     pub fn all_dependencies(&self) -> Result<Dependencies> {

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -107,15 +107,15 @@ impl PackageConfig {
     pub fn dependency_versions_for(&self, mode: Mode) -> Result<HashMap<String, Range>> {
         self.dependencies_for(mode)?
             .iter()
-            .map(|(package, recipe)| Ok((package.clone(), recipe.version_range()?)))
+            .map(|(package, requirement)| Ok((package.clone(), requirement.version_range()?)))
             .collect()
     }
 
     pub fn all_dependencies(&self) -> Result<Dependencies> {
         let mut deps =
             HashMap::with_capacity(self.dependencies.len() + self.dev_dependencies.len());
-        for (name, recipe) in self.dependencies.iter().chain(&self.dev_dependencies) {
-            let already_inserted = deps.insert(name.clone(), recipe.clone()).is_some();
+        for (name, requirement) in self.dependencies.iter().chain(&self.dev_dependencies) {
+            let already_inserted = deps.insert(name.clone(), requirement.clone()).is_some();
             if already_inserted {
                 return Err(Error::DuplicateDependency(name.clone()));
             }

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -1,7 +1,7 @@
 use crate::error::{FileIoAction, FileKind};
 use crate::io::FileSystemReader;
 use crate::manifest::Manifest;
-use crate::recipe::Recipe;
+use crate::requirement::Requirement;
 use crate::{Error, Result};
 use globset::{Glob, GlobSetBuilder};
 use hexpm::version::{Range, Version};
@@ -30,7 +30,7 @@ fn default_javascript_runtime() -> Runtime {
     Runtime::NodeJs
 }
 
-pub type Dependencies = HashMap<String, Recipe>;
+pub type Dependencies = HashMap<String, Requirement>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SpdxLicense {
@@ -192,7 +192,7 @@ struct StalePackageRemover<'a> {
 
 impl<'a> StalePackageRemover<'a> {
     pub fn fresh_and_locked(
-        requirements: &'a HashMap<String, Recipe>,
+        requirements: &'a HashMap<String, Requirement>,
         manifest: &'a Manifest,
     ) -> HashMap<String, Version> {
         let locked = manifest
@@ -209,7 +209,7 @@ impl<'a> StalePackageRemover<'a> {
 
     fn run(
         &mut self,
-        requirements: &'a HashMap<String, Recipe>,
+        requirements: &'a HashMap<String, Requirement>,
         manifest: &'a Manifest,
     ) -> HashMap<String, Version> {
         // Record all the requirements that have not changed
@@ -257,13 +257,13 @@ impl<'a> StalePackageRemover<'a> {
 fn locked_no_manifest() {
     let mut config = PackageConfig::default();
     config.dependencies = [
-        ("prod1".into(), Recipe::hex("~> 1.0")),
-        ("prod2".into(), Recipe::hex("~> 2.0")),
+        ("prod1".into(), Requirement::hex("~> 1.0")),
+        ("prod2".into(), Requirement::hex("~> 2.0")),
     ]
     .into();
     config.dev_dependencies = [
-        ("dev1".into(), Recipe::hex("~> 1.0")),
-        ("dev2".into(), Recipe::hex("~> 2.0")),
+        ("dev1".into(), Requirement::hex("~> 1.0")),
+        ("dev2".into(), Requirement::hex("~> 2.0")),
     ]
     .into();
     assert_eq!(config.locked(None).unwrap(), [].into());
@@ -273,13 +273,13 @@ fn locked_no_manifest() {
 fn locked_no_changes() {
     let mut config = PackageConfig::default();
     config.dependencies = [
-        ("prod1".into(), Recipe::hex("~> 1.0")),
-        ("prod2".into(), Recipe::hex("~> 2.0")),
+        ("prod1".into(), Requirement::hex("~> 1.0")),
+        ("prod2".into(), Requirement::hex("~> 2.0")),
     ]
     .into();
     config.dev_dependencies = [
-        ("dev1".into(), Recipe::hex("~> 1.0")),
-        ("dev2".into(), Recipe::hex("~> 2.0")),
+        ("dev1".into(), Requirement::hex("~> 1.0")),
+        ("dev2".into(), Requirement::hex("~> 2.0")),
     ]
     .into();
     let manifest = Manifest {
@@ -306,8 +306,8 @@ fn locked_no_changes() {
 #[test]
 fn locked_some_removed() {
     let mut config = PackageConfig::default();
-    config.dependencies = [("prod1".into(), Recipe::hex("~> 1.0"))].into();
-    config.dev_dependencies = [("dev2".into(), Recipe::hex("~> 2.0"))].into();
+    config.dependencies = [("prod1".into(), Requirement::hex("~> 1.0"))].into();
+    config.dev_dependencies = [("dev2".into(), Requirement::hex("~> 2.0"))].into();
     let manifest = Manifest {
         requirements: config.all_dependencies().unwrap(),
         packages: vec![
@@ -333,21 +333,21 @@ fn locked_some_removed() {
 fn locked_some_changed() {
     let mut config = PackageConfig::default();
     config.dependencies = [
-        ("prod1".into(), Recipe::hex("~> 3.0")), // Does not match manifest
-        ("prod2".into(), Recipe::hex("~> 2.0")),
+        ("prod1".into(), Requirement::hex("~> 3.0")), // Does not match manifest
+        ("prod2".into(), Requirement::hex("~> 2.0")),
     ]
     .into();
     config.dev_dependencies = [
-        ("dev1".into(), Recipe::hex("~> 3.0")), // Does not match manifest
-        ("dev2".into(), Recipe::hex("~> 2.0")),
+        ("dev1".into(), Requirement::hex("~> 3.0")), // Does not match manifest
+        ("dev2".into(), Requirement::hex("~> 2.0")),
     ]
     .into();
     let manifest = Manifest {
         requirements: [
-            ("prod1".into(), Recipe::hex("~> 1.0")),
-            ("prod2".into(), Recipe::hex("~> 2.0")),
-            ("dev1".into(), Recipe::hex("~> 1.0")),
-            ("dev2".into(), Recipe::hex("~> 2.0")),
+            ("prod1".into(), Requirement::hex("~> 1.0")),
+            ("prod2".into(), Requirement::hex("~> 2.0")),
+            ("dev1".into(), Requirement::hex("~> 1.0")),
+            ("dev2".into(), Requirement::hex("~> 2.0")),
         ]
         .into(),
         packages: vec![
@@ -373,15 +373,15 @@ fn locked_some_changed() {
 fn locked_nested_are_removed_too() {
     let mut config = PackageConfig::default();
     config.dependencies = [
-        ("1".into(), Recipe::hex("~> 2.0")), // Does not match manifest
-        ("2".into(), Recipe::hex("~> 1.0")),
+        ("1".into(), Requirement::hex("~> 2.0")), // Does not match manifest
+        ("2".into(), Requirement::hex("~> 1.0")),
     ]
     .into();
     config.dev_dependencies = [].into();
     let manifest = Manifest {
         requirements: [
-            ("1".into(), Recipe::hex("~> 1.0")),
-            ("2".into(), Recipe::hex("~> 1.0")),
+            ("1".into(), Requirement::hex("~> 1.0")),
+            ("2".into(), Requirement::hex("~> 1.0")),
         ]
         .into(),
         packages: vec![

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -119,26 +119,6 @@ but it is locked to {version}, which is incompatible.",
     }
 
     Ok(requirements)
-    // let locked = locked
-    //     .iter()
-    //     .map(|(name, version)| (name.to_string(), Range::new(version.to_string())));
-    // // Add the locked versions as new requirements that override any existing
-    // // entry in the dependencies list. Collection into a HashMap is used for
-    // // de-duplication.
-    // let deps: HashMap<_, _> = dependencies.chain(locked).collect();
-    // deps.into_iter()
-    //     .map(|(package, requirement)| {
-    //         (
-    //             package,
-    //             Dependency {
-    //                 app: None,
-    //                 optional: false,
-    //                 repository: None,
-    //                 requirement,
-    //             },
-    //         )
-    //     })
-    //     .collect()
 }
 
 pub trait PackageFetcher {

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, cell::RefCell, collections::HashMap, error::Error as StdError};
 
-use crate::{build::Mode, config::PackageConfig, manifest::Manifest, Error, Result};
+use crate::{Error, Result};
 
 use hexpm::{
     version::{Range, Version},
@@ -20,7 +20,7 @@ type PubgrubRange = pubgrub::range::Range<Version>;
 
 pub fn resolve_versions<Requirements>(
     package_fetcher: Box<dyn PackageFetcher>,
-    mut provided_packages: HashMap<String, hexpm::Package>,
+    provided_packages: HashMap<String, hexpm::Package>,
     root_name: String,
     dependencies: Requirements,
     locked: &HashMap<String, Version>,

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -38,14 +38,14 @@ where
             version: root_version.clone(),
             outer_checksum: vec![],
             retirement_status: None,
-            requirements: root_dependencies(dependencies, &locked)
+            requirements: root_dependencies(dependencies, locked)
                 .map_err(Error::dependency_resolution_failed)?,
             meta: (),
         }],
     };
 
     let packages = pubgrub::solver::resolve(
-        &DependencyProvider::new(package_fetcher, provided_packages, root, &locked),
+        &DependencyProvider::new(package_fetcher, provided_packages, root, locked),
         root_name.to_string(),
         root_version,
     )
@@ -101,16 +101,14 @@ where
             Some(locked_version) => {
                 let compatible = range
                     .to_pubgrub()
-                    .map_err(|e| {
-                        ResolutionError::Failure(format!("Failed to parse range {}", e.to_string()))
-                    })?
+                    .map_err(|e| ResolutionError::Failure(format!("Failed to parse range {}", e)))?
                     .contains(locked_version);
                 if !compatible {
                     return Err(ResolutionError::Failure(format!(
                         "{package} is specified with the requirement `{requirement}`, \
 but it is locked to {version}, which is incompatible.",
                         package = name,
-                        requirement = range.to_string(),
+                        requirement = range,
                         version = locked_version,
                     )));
                 }

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -11,6 +11,7 @@ use pubgrub::{
     solver::{choose_package_with_fewest_versions, Dependencies},
     type_aliases::Map,
 };
+use smol_str::SmolStr;
 
 pub type PackageVersions = HashMap<String, Version>;
 
@@ -21,7 +22,7 @@ type PubgrubRange = pubgrub::range::Range<Version>;
 pub fn resolve_versions<Requirements>(
     package_fetcher: Box<dyn PackageFetcher>,
     provided_packages: HashMap<String, hexpm::Package>,
-    root_name: String,
+    root_name: SmolStr,
     dependencies: Requirements,
     locked: &HashMap<String, Version>,
 ) -> Result<PackageVersions>
@@ -403,7 +404,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![("gleam_stdlib".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
             &vec![locked_stdlib].into_iter().collect(),
         )
@@ -421,7 +422,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![].into_iter(),
             &vec![].into_iter().collect(),
         )
@@ -434,7 +435,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![("gleam_stdlib".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
             &vec![].into_iter().collect(),
         )
@@ -455,7 +456,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![("gleam_otp".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
             &vec![].into_iter().collect(),
         )
@@ -479,7 +480,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![("gleam_otp".to_string(), Range::new("~> 0.1.0".to_string()))].into_iter(),
             &vec![].into_iter().collect(),
         )
@@ -503,7 +504,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![(
                 "package_with_retired".to_string(),
                 Range::new("> 0.0.0".to_string()),
@@ -529,7 +530,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![(
                 "package_with_retired".to_string(),
                 Range::new("> 0.0.0".to_string()),
@@ -557,7 +558,7 @@ mod tests {
         let result = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![(
                 "gleam_otp".to_string(),
                 Range::new("~> 0.3.0-rc1".to_string()),
@@ -588,7 +589,7 @@ mod tests {
         let _ = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![("unknown".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
             &vec![].into_iter().collect(),
         )
@@ -600,7 +601,7 @@ mod tests {
         let _ = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![(
                 "gleam_stdlib".to_string(),
                 Range::new("~> 99.0".to_string()),
@@ -616,7 +617,7 @@ mod tests {
         let err = resolve_versions(
             make_remote(),
             HashMap::new(),
-            "app".to_string(),
+            SmolStr::new_inline("app"),
             vec![(
                 "gleam_stdlib".to_string(),
                 Range::new("~> 0.1.0".to_string()),

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -1,8 +1,25 @@
-use crate::{build::Mode, config::PackageConfig, manifest::Manifest, Error, Result};
-use hexpm::version::PackageVersions;
+use std::{borrow::Borrow, cell::RefCell, collections::HashMap, error::Error as StdError};
 
-pub fn resolve_versions(
-    package_fetcher: Box<dyn hexpm::version::PackageFetcher>,
+use crate::{build::Mode, config::PackageConfig, manifest::Manifest, Error, Result};
+
+use hexpm::{
+    version::{Range, Version},
+    Dependency, Release,
+};
+use pubgrub::{
+    error::PubGrubError,
+    solver::{choose_package_with_fewest_versions, Dependencies},
+    type_aliases::Map,
+};
+
+pub type PackageVersions = HashMap<String, Version>;
+
+pub type ResolutionError = PubGrubError<String, Version>;
+
+type PubgrubRange = pubgrub::range::Range<Version>;
+
+pub fn resolve_versions_from_config(
+    package_fetcher: Box<dyn PackageFetcher>,
     mode: Mode,
     config: &PackageConfig,
     manifest: Option<&Manifest>,
@@ -10,11 +27,618 @@ pub fn resolve_versions(
     let specified_dependencies = config.dependency_versions_for(mode)?.into_iter();
     let locked = config.locked(manifest)?;
     tracing::info!("resolving_versions");
-    hexpm::version::resolve_versions(
+
+    resolve_versions(
         package_fetcher,
         config.name.to_string(),
         specified_dependencies,
         &locked,
     )
-    .map_err(Error::dependency_resolution_failed)
+}
+
+fn resolve_versions<Requirements>(
+    package_fetcher: Box<dyn PackageFetcher>,
+    root_name: String,
+    dependencies: Requirements,
+    locked: &HashMap<String, Version>,
+) -> Result<PackageVersions>
+where
+    Requirements: Iterator<Item = (String, Range)>,
+{
+    let root_version = Version::new(0, 0, 0);
+    let root = hexpm::Package {
+        name: root_name.to_string(),
+        repository: "local".to_string(),
+        releases: vec![Release {
+            version: root_version.clone(),
+            outer_checksum: vec![],
+            retirement_status: None,
+            requirements: root_dependencies(dependencies, &locked)
+                .map_err(Error::dependency_resolution_failed)?,
+            meta: (),
+        }],
+    };
+
+    let packages = pubgrub::solver::resolve(
+        &DependencyProvider::new(package_fetcher, root, &locked),
+        root_name.to_string(),
+        root_version,
+    )
+    .map_err(Error::dependency_resolution_failed)?
+    .into_iter()
+    .filter(|(name, _)| name.as_str() != root_name.as_str())
+    .collect();
+
+    Ok(packages)
+}
+
+fn root_dependencies<Requirements>(
+    base_requirements: Requirements,
+    locked: &HashMap<String, Version>,
+) -> Result<HashMap<String, Dependency>, ResolutionError>
+where
+    Requirements: Iterator<Item = (String, Range)>,
+{
+    // Record all of the already locked versions as hard requirements
+    let mut requirements: HashMap<_, _> = locked
+        .iter()
+        .map(|(name, version)| {
+            (
+                name.to_string(),
+                Dependency {
+                    app: None,
+                    optional: false,
+                    repository: None,
+                    requirement: Range::new(version.to_string()),
+                },
+            )
+        })
+        .collect();
+
+    for (name, range) in base_requirements {
+        match locked.get(&name) {
+            // If the package was not already locked then we can use the
+            // specified version requirement without modification.
+            None => {
+                let _ = requirements.insert(
+                    name,
+                    Dependency {
+                        app: None,
+                        optional: false,
+                        repository: None,
+                        requirement: range,
+                    },
+                );
+            }
+
+            // If the version was locked we verify that the requirement is
+            // compatible with the locked version.
+            Some(locked_version) => {
+                let compatible = range
+                    .to_pubgrub()
+                    .map_err(|e| {
+                        ResolutionError::Failure(format!("Failed to parse range {}", e.to_string()))
+                    })?
+                    .contains(locked_version);
+                if !compatible {
+                    return Err(ResolutionError::Failure(format!(
+                        "{package} is specified with the requirement `{requirement}`, \
+but it is locked to {version}, which is incompatible.",
+                        package = name,
+                        requirement = range.to_string(),
+                        version = locked_version,
+                    )));
+                }
+            }
+        };
+    }
+
+    Ok(requirements)
+    // let locked = locked
+    //     .iter()
+    //     .map(|(name, version)| (name.to_string(), Range::new(version.to_string())));
+    // // Add the locked versions as new requirements that override any existing
+    // // entry in the dependencies list. Collection into a HashMap is used for
+    // // de-duplication.
+    // let deps: HashMap<_, _> = dependencies.chain(locked).collect();
+    // deps.into_iter()
+    //     .map(|(package, requirement)| {
+    //         (
+    //             package,
+    //             Dependency {
+    //                 app: None,
+    //                 optional: false,
+    //                 repository: None,
+    //                 requirement,
+    //             },
+    //         )
+    //     })
+    //     .collect()
+}
+
+pub trait PackageFetcher {
+    fn get_dependencies(&self, package: &str) -> Result<hexpm::Package, Box<dyn StdError>>;
+}
+
+struct DependencyProvider<'a> {
+    packages: RefCell<HashMap<String, hexpm::Package>>,
+    remote: Box<dyn PackageFetcher>,
+    locked: &'a HashMap<String, Version>,
+}
+
+impl<'a> DependencyProvider<'a> {
+    fn new(
+        remote: Box<dyn PackageFetcher>,
+        root: hexpm::Package,
+        locked: &'a HashMap<String, Version>,
+    ) -> Self {
+        let mut packages = HashMap::new();
+        let _ = packages.insert(root.name.clone(), root);
+        Self {
+            packages: RefCell::new(packages),
+            locked,
+            remote,
+        }
+    }
+
+    /// Download information about the package from the registry into the local
+    /// store. Does nothing if the packages are already known.
+    ///
+    /// Package versions are sorted from newest to oldest, with all pre-releases
+    /// at the end to ensure that a non-prerelease version will be picked first
+    /// if there is one.
+    //
+    fn ensure_package_fetched(
+        // We would like to use `&mut self` but the pubgrub library enforces
+        // `&self` with interop mutability.
+        &self,
+        name: &str,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut packages = self.packages.borrow_mut();
+        if packages.get(name).is_none() {
+            let mut package = self.remote.get_dependencies(name)?;
+            // Sort the packages from newest to oldest, pres after all others
+            package.releases.sort_by(|a, b| a.version.cmp(&b.version));
+            package.releases.reverse();
+            let (pre, mut norm): (_, Vec<_>) = package
+                .releases
+                .into_iter()
+                .partition(|r| r.version.is_pre());
+            norm.extend(pre);
+            package.releases = norm;
+            let _ = packages.insert(name.to_string(), package);
+        }
+        Ok(())
+    }
+}
+
+type PackageName = String;
+
+impl<'a> pubgrub::solver::DependencyProvider<PackageName, Version> for DependencyProvider<'a> {
+    fn choose_package_version<Name: Borrow<PackageName>, Ver: Borrow<PubgrubRange>>(
+        &self,
+        potential_packages: impl Iterator<Item = (Name, Ver)>,
+    ) -> Result<(Name, Option<Version>), Box<dyn StdError>> {
+        let potential_packages: Vec<_> = potential_packages
+            .map::<Result<_, Box<dyn StdError>>, _>(|pair| {
+                self.ensure_package_fetched(pair.0.borrow())?;
+                Ok(pair)
+            })
+            .collect::<Result<_, _>>()?;
+        let list_available_versions = |name: &String| {
+            self.packages
+                .borrow()
+                .get(name)
+                .cloned()
+                .into_iter()
+                .flat_map(|p| p.releases.into_iter())
+                .map(|p| p.version)
+        };
+        Ok(choose_package_with_fewest_versions(
+            list_available_versions,
+            potential_packages.into_iter(),
+        ))
+    }
+
+    fn get_dependencies(
+        &self,
+        name: &PackageName,
+        version: &Version,
+    ) -> Result<Dependencies<PackageName, Version>, Box<dyn StdError>> {
+        self.ensure_package_fetched(name)?;
+        let packages = self.packages.borrow();
+        let release = match packages
+            .get(name)
+            .into_iter()
+            .flat_map(|p| p.releases.iter())
+            .find(|r| &r.version == version)
+        {
+            Some(release) => release,
+            None => return Ok(Dependencies::Unknown),
+        };
+
+        // Only use retired versions if they have been locked
+        if release.is_retired() && self.locked.get(name) != Some(version) {
+            return Ok(Dependencies::Unknown);
+        }
+
+        let mut deps: Map<String, PubgrubRange> = Default::default();
+        for (name, d) in &release.requirements {
+            let range = d.requirement.to_pubgrub()?;
+            let _ = deps.insert(name.clone(), range);
+        }
+        Ok(Dependencies::Known(deps))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Remote {
+        deps: HashMap<String, hexpm::Package>,
+    }
+
+    impl PackageFetcher for Remote {
+        fn get_dependencies(&self, package: &str) -> Result<hexpm::Package, Box<dyn StdError>> {
+            self.deps
+                .get(package)
+                .cloned()
+                .ok_or(Box::new(hexpm::ApiError::NotFound))
+        }
+    }
+
+    fn make_remote() -> Box<Remote> {
+        let mut deps = HashMap::new();
+        let _ = deps.insert(
+            "gleam_stdlib".to_string(),
+            hexpm::Package {
+                name: "gleam_stdlib".to_string(),
+                repository: "hexpm".to_string(),
+                releases: vec![
+                    Release {
+                        version: Version::try_from("0.1.0").unwrap(),
+                        requirements: [].into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                    Release {
+                        version: Version::try_from("0.2.0").unwrap(),
+                        requirements: [].into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                    Release {
+                        version: Version::try_from("0.2.2").unwrap(),
+                        requirements: [].into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                    Release {
+                        version: Version::try_from("0.3.0").unwrap(),
+                        requirements: [].into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                ],
+            },
+        );
+        let _ = deps.insert(
+            "gleam_otp".to_string(),
+            hexpm::Package {
+                name: "gleam_otp".to_string(),
+                repository: "hexpm".to_string(),
+                releases: vec![
+                    Release {
+                        version: Version::try_from("0.1.0").unwrap(),
+                        requirements: [(
+                            "gleam_stdlib".to_string(),
+                            Dependency {
+                                app: None,
+                                optional: false,
+                                repository: None,
+                                requirement: Range::new(">= 0.1.0".to_string()),
+                            },
+                        )]
+                        .into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                    Release {
+                        version: Version::try_from("0.2.0").unwrap(),
+                        requirements: [(
+                            "gleam_stdlib".to_string(),
+                            Dependency {
+                                app: None,
+                                optional: false,
+                                repository: None,
+                                requirement: Range::new(">= 0.1.0".to_string()),
+                            },
+                        )]
+                        .into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                    Release {
+                        version: Version::try_from("0.3.0-rc1").unwrap(),
+                        requirements: [(
+                            "gleam_stdlib".to_string(),
+                            Dependency {
+                                app: None,
+                                optional: false,
+                                repository: None,
+                                requirement: Range::new(">= 0.1.0".to_string()),
+                            },
+                        )]
+                        .into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                ],
+            },
+        );
+        let _ = deps.insert(
+            "package_with_retired".to_string(),
+            hexpm::Package {
+                name: "package_with_retired".to_string(),
+                repository: "hexpm".to_string(),
+                releases: vec![
+                    Release {
+                        version: Version::try_from("0.1.0").unwrap(),
+                        requirements: [].into(),
+                        retirement_status: None,
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                    Release {
+                        version: Version::try_from("0.2.0").unwrap(),
+                        requirements: [].into(),
+                        retirement_status: Some(hexpm::RetirementStatus {
+                            reason: hexpm::RetirementReason::Security,
+                            message: "It's bad".to_string(),
+                        }),
+                        outer_checksum: vec![1, 2, 3],
+                        meta: (),
+                    },
+                ],
+            },
+        );
+        Box::new(Remote { deps })
+    }
+
+    #[test]
+    fn resolution_with_locked() {
+        let locked_stdlib = ("gleam_stdlib".to_string(), Version::parse("0.1.0").unwrap());
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![("gleam_stdlib".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+            &vec![locked_stdlib].into_iter().collect(),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            vec![("gleam_stdlib".to_string(), Version::parse("0.1.0").unwrap())]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn resolution_without_deps() {
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![].into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap();
+        assert_eq!(result, vec![].into_iter().collect())
+    }
+
+    #[test]
+    fn resolution_1_dep() {
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![("gleam_stdlib".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            vec![(
+                "gleam_stdlib".to_string(),
+                Version::try_from("0.3.0").unwrap()
+            )]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn resolution_with_nested_deps() {
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![("gleam_otp".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            vec![
+                ("gleam_otp".to_string(), Version::try_from("0.2.0").unwrap()),
+                (
+                    "gleam_stdlib".to_string(),
+                    Version::try_from("0.3.0").unwrap()
+                )
+            ]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn resolution_locked_to_older_version() {
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![("gleam_otp".to_string(), Range::new("~> 0.1.0".to_string()))].into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            vec![
+                ("gleam_otp".to_string(), Version::try_from("0.1.0").unwrap()),
+                (
+                    "gleam_stdlib".to_string(),
+                    Version::try_from("0.3.0").unwrap()
+                )
+            ]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn resolution_retired_versions_not_used_by_default() {
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![(
+                "package_with_retired".to_string(),
+                Range::new("> 0.0.0".to_string()),
+            )]
+            .into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            vec![(
+                "package_with_retired".to_string(),
+                // Uses the older version that hasn't been retired
+                Version::try_from("0.1.0").unwrap()
+            ),]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn resolution_retired_versions_can_be_used_if_locked() {
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![(
+                "package_with_retired".to_string(),
+                Range::new("> 0.0.0".to_string()),
+            )]
+            .into_iter(),
+            &vec![("package_with_retired".to_string(), Version::new(0, 2, 0))]
+                .into_iter()
+                .collect(),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            vec![(
+                "package_with_retired".to_string(),
+                // Uses the locked version even though it's retired
+                Version::new(0, 2, 0)
+            ),]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn resolution_prerelease_can_be_selected() {
+        let result = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![(
+                "gleam_otp".to_string(),
+                Range::new("~> 0.3.0-rc1".to_string()),
+            )]
+            .into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            vec![
+                (
+                    "gleam_otp".to_string(),
+                    Version::try_from("0.3.0-rc1").unwrap()
+                ),
+                (
+                    "gleam_stdlib".to_string(),
+                    Version::try_from("0.3.0").unwrap()
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+    }
+
+    #[test]
+    fn resolution_not_found_dep() {
+        let _ = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![("unknown".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap_err();
+    }
+
+    #[test]
+    fn resolution_no_matching_version() {
+        let _ = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![(
+                "gleam_stdlib".to_string(),
+                Range::new("~> 99.0".to_string()),
+            )]
+            .into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap_err();
+    }
+
+    #[test]
+    fn resolution_locked_version_doesnt_satisfy_requirements() {
+        let err = resolve_versions(
+            make_remote(),
+            "app".to_string(),
+            vec![(
+                "gleam_stdlib".to_string(),
+                Range::new("~> 0.1.0".to_string()),
+            )]
+            .into_iter(),
+            &vec![("gleam_stdlib".into(), Version::new(0, 2, 0))]
+                .into_iter()
+                .collect(),
+        )
+        .unwrap_err();
+
+        match err {
+        Error::DependencyResolutionFailed(msg) => assert_eq!(
+            msg,
+            "gleam_stdlib is specified with the requirement `~> 0.1.0`, but it is locked to 0.2.0, which is incompatible."
+        ),
+        _ => panic!("wrong error: {}", err),
+        }
+    }
 }

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -1,0 +1,20 @@
+use crate::{build::Mode, config::PackageConfig, manifest::Manifest, Error, Result};
+use hexpm::version::PackageVersions;
+
+pub fn resolve_versions(
+    package_fetcher: Box<dyn hexpm::version::PackageFetcher>,
+    mode: Mode,
+    config: &PackageConfig,
+    manifest: Option<&Manifest>,
+) -> Result<PackageVersions> {
+    let specified_dependencies = config.dependency_versions_for(mode)?.into_iter();
+    let locked = config.locked(manifest)?;
+    tracing::info!("resolving_versions");
+    hexpm::version::resolve_versions(
+        package_fetcher,
+        config.name.to_string(),
+        specified_dependencies,
+        &locked,
+    )
+    .map_err(Error::dependency_resolution_failed)
+}

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -186,6 +186,9 @@ pub enum Error {
     #[error("Git dependencies are currently unsupported")]
     GitDependencyUnsuported,
 
+    #[error("Failed to create canonical path for package {0}")]
+    DependencyCanonicalizationFailed(String),
+
     #[error("Dependency tree resolution failed: {0}")]
     DependencyResolutionFailed(String),
 
@@ -2282,6 +2285,18 @@ The error from the parser was:
                 );
                 Diagnostic {
                     title: "Invalid version format".into(),
+                    text,
+                    hint: None,
+                    location: None,
+                    level: Level::Error,
+                }
+            }
+
+            Error::DependencyCanonicalizationFailed(package) => {
+                let text = format!("Local package {} has no canonical path", package);
+
+                Diagnostic {
+                    title: "Failed to create canonical path".into(),
                     text,
                     hint: None,
                     location: None,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -183,11 +183,17 @@ pub enum Error {
     #[error("{0}")]
     Http(String),
 
+    #[error("Git dependencies are currently unsupported")]
+    GitDependencyUnsuported,
+
     #[error("Dependency tree resolution failed: {0}")]
     DependencyResolutionFailed(String),
 
     #[error("The package {0} is listed in dependencies and dev-dependencies")]
     DuplicateDependency(String),
+
+    #[error("The package {0} is provided multiple times, as {1} and {2}")]
+    ProvidedDependencyConflict(String, String, String),
 
     #[error("The package was missing required fields for publishing")]
     MissingHexPublishFields {
@@ -2294,6 +2300,28 @@ The error from the version resolver library was:
                 );
                 Diagnostic {
                     title: "Dependency resolution failed".into(),
+                    text,
+                    hint: None,
+                    location: None,
+                    level: Level::Error,
+                }
+            }
+
+            Error::GitDependencyUnsuported => {
+                Diagnostic {
+                    title: "Git dependencies are not currently supported".into(),
+                    text: "Please remove all git dependencies from the gleam.toml file".into(),
+                    hint: None,
+                    location: None,
+                    level: Level::Error,
+                }
+            }
+
+            Error::ProvidedDependencyConflict(name, pkg1, pkg2) => {
+                let text = format!("The package {} resolves to both {} nad {}", name, pkg1, pkg2);
+
+                Diagnostic {
+                    title: "Conflicting provided dependencies".into(),
                     text,
                     hint: None,
                     location: None,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -198,6 +198,9 @@ pub enum Error {
     #[error("The package {0} is provided multiple times, as {1} and {2}")]
     ProvidedDependencyConflict(String, String, String),
 
+    #[error("The package {0} has a dependency cycle: {1} -> {0}")]
+    ProvidedDependencyCycle(String, String),
+
     #[error("The package was missing required fields for publishing")]
     MissingHexPublishFields {
         description_missing: bool,
@@ -2337,6 +2340,18 @@ The error from the version resolver library was:
 
                 Diagnostic {
                     title: "Conflicting provided dependencies".into(),
+                    text,
+                    hint: None,
+                    location: None,
+                    level: Level::Error,
+                }
+            }
+
+            Error::ProvidedDependencyCycle(name, path) => {
+                let text = format!("The package {0} has a dependency cycle: {1} -> {0}", name, path);
+
+                Diagnostic {
+                    title: "Provided dependencies are recursive".into(),
                     text,
                     hint: None,
                     location: None,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -195,6 +195,9 @@ pub enum Error {
         licence_missing: bool,
     },
 
+    #[error("Dependency {package:?} has not been published to Hex")]
+    PublishNonHexDependencies { package: String },
+
     #[error("The package {package} uses unsupported build tools {build_tools:?}")]
     UnsupportedBuildTool {
         package: String,
@@ -2340,6 +2343,18 @@ licences = ["Apache-2.0"]"#
                     hint: None,
                     location: None,
                     level: Level::Error,
+                }
+            }
+
+            Error::PublishNonHexDependencies {
+                package
+            } => {
+                Diagnostic {
+                    title: "Unblished dependencies".into(),
+                    text: wrap_format!("The package cannot be published to Hex because dependency {} is not a Hex dependency", package),
+                    hint: None,
+                    location: None,
+                    level: Level::Error
                 }
             }
 

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -1,15 +1,13 @@
 use debug_ignore::DebugIgnore;
 use flate2::read::GzDecoder;
 use futures::future;
-use hexpm::version::{PackageVersions, Version};
+use hexpm::version::Version;
 use std::path::Path;
 use tar::Archive;
 
 use crate::{
-    build::Mode,
-    config::PackageConfig,
     io::{FileSystemReader, FileSystemWriter, HttpClient, TarUnpacker},
-    manifest::{Manifest, ManifestPackage, ManifestPackageSource},
+    manifest::{ManifestPackage, ManifestPackageSource},
     paths::{self, ProjectPaths},
     Error, Result,
 };
@@ -24,24 +22,6 @@ J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
 0wIDAQAB
 -----END PUBLIC KEY-----
 ";
-
-pub fn resolve_versions(
-    package_fetcher: Box<dyn hexpm::version::PackageFetcher>,
-    mode: Mode,
-    config: &PackageConfig,
-    manifest: Option<&Manifest>,
-) -> Result<PackageVersions> {
-    let specified_dependencies = config.dependency_versions_for(mode)?.into_iter();
-    let locked = config.locked(manifest)?;
-    tracing::info!("resolving_versions");
-    hexpm::version::resolve_versions(
-        package_fetcher,
-        config.name.to_string(),
-        specified_dependencies,
-        &locked,
-    )
-    .map_err(Error::dependency_resolution_failed)
-}
 
 fn key_name(hostname: &str) -> String {
     format!("gleam-{hostname}")

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -158,9 +158,7 @@ impl Downloader {
         {
             outer_checksum
         } else {
-            return Err(Error::DependencyResolutionFailed(
-                "Attempt to download non-hex package from hex".to_string(),
-            ));
+            panic!("Attempt to download non-hex package from hex")
         };
 
         let tarball_path = paths::global_package_cache_package_tarball(

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -31,7 +31,7 @@ pub fn resolve_versions(
     config: &PackageConfig,
     manifest: Option<&Manifest>,
 ) -> Result<PackageVersions> {
-    let specified_dependencies = config.dependencies_for(mode)?.into_iter();
+    let specified_dependencies = config.dependency_versions_for(mode)?.into_iter();
     let locked = config.locked(manifest)?;
     tracing::info!("resolving_versions");
     hexpm::version::resolve_versions(

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -154,12 +154,15 @@ impl Downloader {
         &self,
         package: &ManifestPackage,
     ) -> Result<bool, Error> {
-        let outer_checksum = if let ManifestPackageSource::Hex { outer_checksum } = &package.source {
+        let outer_checksum = if let ManifestPackageSource::Hex { outer_checksum } = &package.source
+        {
             outer_checksum
         } else {
-            return Err(Error::DependencyResolutionFailed("Attempt to download non-hex package from hex".to_string()))
+            return Err(Error::DependencyResolutionFailed(
+                "Attempt to download non-hex package from hex".to_string(),
+            ));
         };
-        
+
         let tarball_path = paths::global_package_cache_package_tarball(
             &package.name,
             &package.version.to_string(),

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -73,7 +73,7 @@ pub mod metadata;
 pub mod parse;
 pub mod paths;
 pub mod pretty;
-pub mod recipe;
+pub mod requirement;
 pub mod type_;
 pub mod uid;
 pub mod version;

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -57,6 +57,7 @@ pub mod bit_string;
 pub mod build;
 pub mod codegen;
 pub mod config;
+pub mod dependency;
 pub mod diagnostic;
 pub mod docs;
 pub mod erlang;

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -72,6 +72,7 @@ pub mod metadata;
 pub mod parse;
 pub mod paths;
 pub mod pretty;
+pub mod recipe;
 pub mod type_;
 pub mod uid;
 pub mod version;

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -85,14 +85,14 @@ impl Manifest {
                 }
                 ManifestPackageSource::Git { repo, commit } => {
                     buffer.push_str(r#", source = "git", repo = ""#);
-                    buffer.push_str(&repo);
+                    buffer.push_str(repo);
                     buffer.push_str(r#", commit = ""#);
-                    buffer.push_str(&commit);
+                    buffer.push_str(commit);
                     buffer.push('"');
                 }
                 ManifestPackageSource::Local { path } => {
                     buffer.push_str(r#", source = "local", path = ""#);
-                    buffer.push_str(&path.to_str().expect("local path non utf-8"));
+                    buffer.push_str(path.to_str().expect("local path non utf-8"));
                     buffer.push('"');
                 }
             };
@@ -107,7 +107,7 @@ impl Manifest {
             buffer.push_str(name);
             buffer.push_str(" = ");
             buffer.push_str(&recipe.to_string());
-            buffer.push_str("\n");
+            buffer.push('\n');
         }
 
         buffer
@@ -242,10 +242,7 @@ impl ManifestPackage {
     }
 
     pub fn is_hex(&self) -> bool {
-        match self.source {
-            ManifestPackageSource::Hex { .. } => true,
-            _ => false,
-        }
+        matches!(self.source, ManifestPackageSource::Hex { .. })
     }
 }
 

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -106,7 +106,7 @@ impl Manifest {
         for (name, recipe) in requirements.iter().sorted_by(|a, b| a.0.cmp(b.0)) {
             buffer.push_str(name);
             buffer.push_str(" = ");
-            buffer.push_str(&recipe.to_string());
+            buffer.push_str(&recipe.to_toml());
             buffer.push('\n');
         }
 

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 
+use crate::recipe::Recipe;
 use crate::Result;
-use hexpm::version::{Range, Version};
+use hexpm::version::Version;
 use itertools::Itertools;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct Manifest {
     #[serde(serialize_with = "ordered_map")]
-    pub requirements: HashMap<String, Range>,
+    pub requirements: HashMap<String, Recipe>,
     #[serde(serialize_with = "sorted_vec")]
     pub packages: Vec<ManifestPackage>,
 }
@@ -103,10 +104,10 @@ impl Manifest {
 fn manifest_toml_format() {
     let mut manifest = Manifest {
         requirements: [
-            ("zzz".into(), Range::new("> 0.0.0".into())),
-            ("aaa".into(), Range::new("> 0.0.0".into())),
-            ("gleam_stdlib".into(), Range::new("~> 0.17".into())),
-            ("gleeunit".into(), Range::new("~> 0.1".into())),
+            ("zzz".into(), Recipe::hex("> 0.0.0")),
+            ("aaa".into(), Recipe::hex("> 0.0.0")),
+            ("gleam_stdlib".into(), Recipe::hex("~> 0.17")),
+            ("gleeunit".into(), Recipe::hex("~> 0.1")),
         ]
         .into(),
         packages: vec![

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -90,7 +90,7 @@ impl Manifest {
                     buffer.push('"');
                 }
                 ManifestPackageSource::Local { path } => {
-                    buffer.push_str(r#", source = "local""#);
+                    buffer.push_str(r#", source = "local", path = ""#);
                     buffer.push_str(&path.to_str().expect("local path non utf-8"));
                     buffer.push('"');
                 }
@@ -104,9 +104,9 @@ impl Manifest {
         buffer.push_str("[requirements]\n");
         for (name, recipe) in requirements.iter().sorted_by(|a, b| a.0.cmp(b.0)) {
             buffer.push_str(name);
-            buffer.push_str(" = \"");
+            buffer.push_str(" = ");
             buffer.push_str(&recipe.to_string());
-            buffer.push_str("\"\n");
+            buffer.push_str("\n");
         }
 
         buffer

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::recipe::Recipe;
+use crate::requirement::Requirement;
 use crate::Result;
 use hexpm::version::Version;
 use itertools::Itertools;
@@ -10,7 +10,7 @@ use smol_str::SmolStr;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct Manifest {
     #[serde(serialize_with = "ordered_map")]
-    pub requirements: HashMap<String, Recipe>,
+    pub requirements: HashMap<String, Requirement>,
     #[serde(serialize_with = "sorted_vec")]
     pub packages: Vec<ManifestPackage>,
 }
@@ -118,10 +118,10 @@ impl Manifest {
 fn manifest_toml_format() {
     let mut manifest = Manifest {
         requirements: [
-            ("zzz".into(), Recipe::hex("> 0.0.0")),
-            ("aaa".into(), Recipe::hex("> 0.0.0")),
-            ("gleam_stdlib".into(), Recipe::hex("~> 0.17")),
-            ("gleeunit".into(), Recipe::hex("~> 0.1")),
+            ("zzz".into(), Requirement::hex("> 0.0.0")),
+            ("aaa".into(), Requirement::hex("> 0.0.0")),
+            ("gleam_stdlib".into(), Requirement::hex("~> 0.17")),
+            ("gleeunit".into(), Requirement::hex("~> 0.1")),
         ]
         .into(),
         packages: vec![

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -239,6 +239,13 @@ impl ManifestPackage {
         self.build_tools = build_tools.iter().map(|s| (*s).to_string()).collect();
         self
     }
+
+    pub fn is_hex(&self) -> bool {
+        match self.source {
+            ManifestPackageSource::Hex { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -89,10 +89,10 @@ impl Manifest {
 
         // Requirements
         buffer.push_str("[requirements]\n");
-        for (name, range) in requirements.iter().sorted_by(|a, b| a.0.cmp(b.0)) {
+        for (name, recipe) in requirements.iter().sorted_by(|a, b| a.0.cmp(b.0)) {
             buffer.push_str(name);
             buffer.push_str(" = \"");
-            buffer.push_str(&range.to_string());
+            buffer.push_str(&recipe.to_string());
             buffer.push_str("\"\n");
         }
 

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -86,7 +86,7 @@ impl Manifest {
                 ManifestPackageSource::Git { repo, commit } => {
                     buffer.push_str(r#", source = "git", repo = ""#);
                     buffer.push_str(repo);
-                    buffer.push_str(r#", commit = ""#);
+                    buffer.push_str(r#"", commit = ""#);
                     buffer.push_str(commit);
                     buffer.push('"');
                 }
@@ -120,6 +120,14 @@ fn manifest_toml_format() {
         requirements: [
             ("zzz".into(), Requirement::hex("> 0.0.0")),
             ("aaa".into(), Requirement::hex("> 0.0.0")),
+            (
+                "awsome_local2".into(),
+                Requirement::git("https://github.com/gleam-lang/gleam.git"),
+            ),
+            (
+                "awsome_local1".into(),
+                Requirement::path("../path/to/package"),
+            ),
             ("gleam_stdlib".into(), Requirement::hex("~> 0.17")),
             ("gleeunit".into(), Requirement::hex("~> 0.1")),
         ]
@@ -156,6 +164,27 @@ fn manifest_toml_format() {
                 },
             },
             ManifestPackage {
+                name: "awsome_local2".into(),
+                version: Version::new(1, 2, 3),
+                build_tools: ["gleam".into()].into(),
+                otp_app: None,
+                requirements: vec![],
+                source: ManifestPackageSource::Git {
+                    repo: "https://github.com/gleam-lang/gleam.git".into(),
+                    commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+                },
+            },
+            ManifestPackage {
+                name: "awsome_local1".into(),
+                version: Version::new(1, 2, 3),
+                build_tools: ["gleam".into()].into(),
+                otp_app: None,
+                requirements: vec![],
+                source: ManifestPackageSource::Local {
+                    path: "/home/louis/packages/path/to/package".into(),
+                },
+            },
+            ManifestPackage {
                 name: "gleeunit".into(),
                 version: Version::new(0, 4, 0),
                 build_tools: ["gleam".into()].into(),
@@ -175,6 +204,8 @@ fn manifest_toml_format() {
 
 packages = [
   { name = "aaa", version = "0.4.0", build_tools = ["rebar3", "make"], requirements = ["zzz", "gleam_stdlib"], otp_app = "aaa_app", source = "hex", outer_checksum = "0316" },
+  { name = "awsome_local1", version = "1.2.3", build_tools = ["gleam"], requirements = [], source = "local", path = "/home/louis/packages/path/to/package" },
+  { name = "awsome_local2", version = "1.2.3", build_tools = ["gleam"], requirements = [], source = "git", repo = "https://github.com/gleam-lang/gleam.git", commit = "bd9fe02f72250e6a136967917bcb1bdccaffa3c8" },
   { name = "gleam_stdlib", version = "0.17.1", build_tools = ["gleam"], requirements = [], source = "hex", outer_checksum = "0116" },
   { name = "gleeunit", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], source = "hex", outer_checksum = "032E" },
   { name = "zzz", version = "0.4.0", build_tools = ["mix"], requirements = [], source = "hex", outer_checksum = "0316" },
@@ -182,6 +213,8 @@ packages = [
 
 [requirements]
 aaa = { version = "> 0.0.0" }
+awsome_local1 = { path = "../path/to/package" }
+awsome_local2 = { git = "https://github.com/gleam-lang/gleam.git" }
 gleam_stdlib = { version = "~> 0.17" }
 gleeunit = { version = "~> 0.1" }
 zzz = { version = "> 0.0.0" }

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use crate::recipe::Recipe;
 use crate::Result;
@@ -88,8 +89,10 @@ impl Manifest {
                     buffer.push_str(&commit);
                     buffer.push('"');
                 }
-                ManifestPackageSource::Local => {
+                ManifestPackageSource::Local { path } => {
                     buffer.push_str(r#", source = "local""#);
+                    buffer.push_str(&path.to_str().expect("local path non utf-8"));
+                    buffer.push('"');
                 }
             };
 
@@ -262,7 +265,7 @@ pub enum ManifestPackageSource {
     #[serde(rename = "git")]
     Git { repo: String, commit: String },
     #[serde(rename = "local")]
-    Local,
+    Local { path: PathBuf }, // should be the canonical path
 }
 
 fn ordered_map<S, K, V>(value: &HashMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -180,10 +180,10 @@ packages = [
 ]
 
 [requirements]
-aaa = "> 0.0.0"
-gleam_stdlib = "~> 0.17"
-gleeunit = "~> 0.1"
-zzz = "> 0.0.0"
+aaa = { version = "> 0.0.0" }
+gleam_stdlib = { version = "~> 0.17" }
+gleeunit = { version = "~> 0.1" }
+zzz = { version = "> 0.0.0" }
 "#
     );
     let deserialised: Manifest = toml::from_str(&buffer).unwrap();

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -5,6 +5,7 @@ use crate::recipe::Recipe;
 use crate::Result;
 use hexpm::version::Version;
 use itertools::Itertools;
+use smol_str::SmolStr;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct Manifest {
@@ -270,7 +271,7 @@ pub enum ManifestPackageSource {
     #[serde(rename = "hex")]
     Hex { outer_checksum: Base16Checksum },
     #[serde(rename = "git")]
-    Git { repo: String, commit: String },
+    Git { repo: SmolStr, commit: SmolStr },
     #[serde(rename = "local")]
     Local { path: PathBuf }, // should be the canonical path
 }

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -81,6 +81,16 @@ impl Manifest {
                     buffer.push_str(&outer_checksum.to_string());
                     buffer.push('"');
                 }
+                ManifestPackageSource::Git { repo, commit } => {
+                    buffer.push_str(r#", source = "git", repo = ""#);
+                    buffer.push_str(&repo);
+                    buffer.push_str(r#", commit = ""#);
+                    buffer.push_str(&commit);
+                    buffer.push('"');
+                }
+                ManifestPackageSource::Local => {
+                    buffer.push_str(r#", source = "local""#);
+                }
             };
 
             buffer.push_str(" },\n");
@@ -207,6 +217,7 @@ impl<'de> serde::Deserialize<'de> for Base16Checksum {
             .map_err(serde::de::Error::custom)
     }
 }
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct ManifestPackage {
     pub name: String,
@@ -248,6 +259,10 @@ impl Default for ManifestPackage {
 pub enum ManifestPackageSource {
     #[serde(rename = "hex")]
     Hex { outer_checksum: Base16Checksum },
+    #[serde(rename = "git")]
+    Git { repo: String, commit: String },
+    #[serde(rename = "local")]
+    Local,
 }
 
 fn ordered_map<S, K, V>(value: &HashMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -103,10 +103,10 @@ impl Manifest {
 
         // Requirements
         buffer.push_str("[requirements]\n");
-        for (name, recipe) in requirements.iter().sorted_by(|a, b| a.0.cmp(b.0)) {
+        for (name, requirement) in requirements.iter().sorted_by(|a, b| a.0.cmp(b.0)) {
             buffer.push_str(name);
             buffer.push_str(" = ");
-            buffer.push_str(&recipe.to_toml());
+            buffer.push_str(&requirement.to_toml());
             buffer.push('\n');
         }
 

--- a/compiler-core/src/recipe.rs
+++ b/compiler-core/src/recipe.rs
@@ -63,9 +63,11 @@ impl Recipe {
 impl ToString for Recipe {
     fn to_string(&self) -> String {
         match self {
-            Recipe::Hex { version: range } => range.to_string(),
-            Recipe::Path { path } => format!("{{path: {}}}", path.display()),
-            Recipe::Git { git: url } => format!("{{git: {}}}", url),
+            Recipe::Hex { version: range } => {
+                format!(r#"{{ "version" = "{}" }}"#, range.to_string())
+            }
+            Recipe::Path { path } => format!(r#"{{ "path" = "{}" }}"#, path.display()),
+            Recipe::Git { git: url } => format!(r#"{{ "git" = "{}" }}"#, url),
         }
     }
 }

--- a/compiler-core/src/recipe.rs
+++ b/compiler-core/src/recipe.rs
@@ -8,13 +8,14 @@ use hexpm::version::Range;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, Serializer};
 use serde::Deserialize;
+use smol_str::SmolStr;
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(untagged, remote = "Self")]
 pub enum Recipe {
     Hex { version: Range },
     Path { path: PathBuf },
-    Git { git: String },
+    Git { git: SmolStr },
 }
 
 impl Recipe {
@@ -31,7 +32,7 @@ impl Recipe {
                         "Local dependency config could not be parsed".into(),
                     )
                 })?;
-                Ok(Range::new(format!("== {}", config.version.to_string())))
+                Ok(Range::new(format!("== {}", config.version)))
             }
             Recipe::Git { .. } => Err(Error::DependencyResolutionFailed(
                 "Git dependencies are currently unsuported".to_string(),
@@ -50,9 +51,7 @@ impl Recipe {
     }
 
     pub fn git(url: &str) -> Recipe {
-        Recipe::Git {
-            git: url.to_string(),
-        }
+        Recipe::Git { git: url.into() }
     }
 }
 

--- a/compiler-core/src/recipe.rs
+++ b/compiler-core/src/recipe.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -64,10 +63,10 @@ impl ToString for Recipe {
     fn to_string(&self) -> String {
         match self {
             Recipe::Hex { version: range } => {
-                format!(r#"{{ "version" = "{}" }}"#, range.to_string())
+                format!(r#"{{ version = "{}" }}"#, range.to_string())
             }
-            Recipe::Path { path } => format!(r#"{{ "path" = "{}" }}"#, path.display()),
-            Recipe::Git { git: url } => format!(r#"{{ "git" = "{}" }}"#, url),
+            Recipe::Path { path } => format!(r#"{{ path = "{}" }}"#, path.display()),
+            Recipe::Git { git: url } => format!(r#"{{ git = "{}" }}"#, url),
         }
     }
 }
@@ -133,20 +132,27 @@ impl<'de> Deserialize<'de> for Recipe {
     }
 }
 
-#[test]
-fn read_recipe() {
-    let toml = r#"
-        short = "~> 0.5"
-        hex = { version = "~> 1.0.0" }
-        local = { path = "/path/to/package" }
-        github = { git = "https://github.com/gleam-lang/otp.git" }
-    "#;
-    let deps: HashMap<String, Recipe> = toml::from_str(toml).unwrap();
-    assert_eq!(deps["short"], Recipe::hex("~> 0.5"));
-    assert_eq!(deps["hex"], Recipe::hex("~> 1.0.0"));
-    assert_eq!(deps["local"], Recipe::path("/path/to/package"));
-    assert_eq!(
-        deps["github"],
-        Recipe::git("https://github.com/gleam-lang/otp.git")
-    );
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn read_recipe() {
+        let toml = r#"
+            short = "~> 0.5"
+            hex = { version = "~> 1.0.0" }
+            local = { path = "/path/to/package" }
+            github = { git = "https://github.com/gleam-lang/otp.git" }
+        "#;
+        let deps: HashMap<String, Recipe> = toml::from_str(toml).unwrap();
+        assert_eq!(deps["short"], Recipe::hex("~> 0.5"));
+        assert_eq!(deps["hex"], Recipe::hex("~> 1.0.0"));
+        assert_eq!(deps["local"], Recipe::path("/path/to/package"));
+        assert_eq!(
+            deps["github"],
+            Recipe::git("https://github.com/gleam-lang/otp.git")
+        );
+    }
 }

--- a/compiler-core/src/recipe.rs
+++ b/compiler-core/src/recipe.rs
@@ -1,0 +1,120 @@
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::{Error, Result};
+use hexpm::version::Range;
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::ser::{Serialize, SerializeMap, Serializer};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(untagged, remote = "Self")]
+pub enum Recipe {
+    Hex { version: Range },
+    Path { path: PathBuf },
+    Git { git: String },
+}
+
+impl Recipe {
+    pub fn version_range(&self) -> Result<Range, Error> {
+        match self {
+            Recipe::Hex { version: range } => Ok(range.clone()),
+            Recipe::Path { .. } => Err(Error::DependencyResolutionFailed(
+                "Path dependencies are currently unsuported".to_string(),
+            )),
+            Recipe::Git { .. } => Err(Error::DependencyResolutionFailed(
+                "Git dependencies are currently unsuported".to_string(),
+            )),
+        }
+    }
+
+    pub fn hex(range: &str) -> Recipe {
+        Recipe::Hex {
+            version: Range::new(range.to_string()),
+        }
+    }
+
+    pub fn path(path: &str) -> Recipe {
+        Recipe::Path { path: path.into() }
+    }
+
+    pub fn git(url: &str) -> Recipe {
+        Recipe::Git {
+            git: url.to_string(),
+        }
+    }
+}
+
+// Serialization
+
+impl ToString for Recipe {
+    fn to_string(&self) -> String {
+        match self {
+            Recipe::Hex { version: range } => range.to_string(),
+            Recipe::Path { path } => format!("{{path: {}}}", path.display()),
+            Recipe::Git { git: url } => format!("{{git: {}}}", url),
+        }
+    }
+}
+
+impl Serialize for Recipe {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(1))?;
+        match self {
+            Recipe::Hex { version: range } => map.serialize_entry("version", range)?,
+            Recipe::Path { path } => map.serialize_entry("path", path)?,
+            Recipe::Git { git: url } => map.serialize_entry("git", url)?,
+        }
+        map.end()
+    }
+}
+
+// Deserialization
+
+#[derive(Debug, Copy, Clone)]
+pub struct Void;
+
+impl FromStr for Recipe {
+    type Err = Void;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Recipe::hex(s))
+    }
+}
+
+struct RecipeVisitor;
+
+impl<'de> Visitor<'de> for RecipeVisitor {
+    type Value = Recipe;
+
+    fn expecting<'a>(&self, formatter: &mut fmt::Formatter<'a>) -> fmt::Result {
+        formatter.write_str("string or map")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(FromStr::from_str(value).unwrap())
+    }
+
+    fn visit_map<M>(self, visitor: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        Recipe::deserialize(de::value::MapAccessDeserializer::new(visitor))
+    }
+}
+
+impl<'de> Deserialize<'de> for Recipe {
+    fn deserialize<D>(deserializer: D) -> Result<Recipe, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(RecipeVisitor)
+    }
+}

--- a/compiler-core/src/recipe.rs
+++ b/compiler-core/src/recipe.rs
@@ -22,8 +22,7 @@ impl Recipe {
         match self {
             Recipe::Hex { version: range } => Ok(range.clone()),
             Recipe::Path { path } => {
-                let mut config_path = path.clone();
-                config_path.push("gleam.toml");
+                let config_path = path.join("gleam.toml");
                 let toml = std::fs::read_to_string(&config_path).map_err(|_| {
                     Error::DependencyResolutionFailed("Local dependency could not be found".into())
                 })?;

--- a/compiler-core/src/requirement.rs
+++ b/compiler-core/src/requirement.rs
@@ -24,7 +24,7 @@ impl Requirement {
             Requirement::Hex { version: range } => Ok(range.clone()),
             Requirement::Path { path } => {
                 let config_path = path.join("gleam.toml");
-                let toml = std::fs::read_to_string(&config_path).map_err(|_| {
+                let toml = std::fs::read_to_string(config_path).map_err(|_| {
                     Error::DependencyResolutionFailed("Local dependency could not be found".into())
                 })?;
                 let config: PackageConfig = toml::from_str(&toml).map_err(|_| {
@@ -61,7 +61,7 @@ impl ToString for Requirement {
     fn to_string(&self) -> String {
         match self {
             Requirement::Hex { version: range } => {
-                format!(r#"{{ version = "{}" }}"#, range.to_string())
+                format!(r#"{{ version = "{}" }}"#, range)
             }
             Requirement::Path { path } => format!(r#"{{ path = "{}" }}"#, path.display()),
             Requirement::Git { git: url } => format!(r#"{{ git = "{}" }}"#, url),
@@ -102,7 +102,7 @@ struct RequirementVisitor;
 impl<'de> Visitor<'de> for RequirementVisitor {
     type Value = Requirement;
 
-    fn expecting<'a>(&self, formatter: &mut fmt::Formatter<'a>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("string or map")
     }
 
@@ -110,7 +110,7 @@ impl<'de> Visitor<'de> for RequirementVisitor {
     where
         E: de::Error,
     {
-        Ok(FromStr::from_str(value).unwrap())
+        Ok(FromStr::from_str(value).expect("expected string"))
     }
 
     fn visit_map<M>(self, visitor: M) -> Result<Self::Value, M::Error>

--- a/compiler-core/src/requirement.rs
+++ b/compiler-core/src/requirement.rs
@@ -55,12 +55,8 @@ impl Requirement {
     pub fn git(url: &str) -> Requirement {
         Requirement::Git { git: url.into() }
     }
-}
 
-// Serialization
-
-impl ToString for Requirement {
-    fn to_string(&self) -> String {
+    pub fn to_toml(&self) -> String {
         match self {
             Requirement::Hex { version: range } => {
                 format!(r#"{{ version = "{}" }}"#, range)
@@ -70,6 +66,8 @@ impl ToString for Requirement {
         }
     }
 }
+
+// Serialization
 
 impl Serialize for Requirement {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/compiler-core/src/requirement.rs
+++ b/compiler-core/src/requirement.rs
@@ -137,7 +137,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn read_recipe() {
+    fn read_requirement() {
         let toml = r#"
             short = "~> 0.5"
             hex = { version = "~> 1.0.0" }

--- a/compiler-core/src/requirement.rs
+++ b/compiler-core/src/requirement.rs
@@ -19,29 +19,6 @@ pub enum Requirement {
 }
 
 impl Requirement {
-    pub fn version_range(&self) -> Result<Range, Error> {
-        match self {
-            Requirement::Hex { version: range } => Ok(range.clone()),
-            Requirement::Path { path } => {
-                let config_path = path.join("gleam.toml");
-                let toml =
-                    std::fs::read_to_string(&config_path).map_err(|error| Error::FileIo {
-                        kind: FileKind::File,
-                        action: FileIoAction::Read,
-                        path: config_path,
-                        err: Some(error.to_string()),
-                    })?;
-                let config: PackageConfig = toml::from_str(&toml).map_err(|_| {
-                    Error::DependencyResolutionFailed(
-                        "Local dependency config could not be parsed".into(),
-                    )
-                })?;
-                Ok(Range::new(format!("== {}", config.version)))
-            }
-            Requirement::Git { .. } => Err(Error::GitDependencyUnsuported),
-        }
-    }
-
     pub fn hex(range: &str) -> Requirement {
         Requirement::Hex {
             version: Range::new(range.to_string()),

--- a/compiler-core/src/requirement.rs
+++ b/compiler-core/src/requirement.rs
@@ -2,8 +2,7 @@ use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use crate::config::PackageConfig;
-use crate::error::{Error, FileIoAction, FileKind, Result};
+use crate::error::Result;
 use hexpm::version::Range;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, Serializer};

--- a/test/project_path_deps/README.md
+++ b/test/project_path_deps/README.md
@@ -1,0 +1,12 @@
+This directory contains four projects used in CI test `test/project_path_deps`.
+
+The dependency graph of these projects is as follows:
+
+```
+         _-> project_b -_
+        /                v
+project_a                project_d
+        \                ^
+         '-> project_c -'
+```
+

--- a/test/project_path_deps/project_a/gleam.toml
+++ b/test/project_path_deps/project_a/gleam.toml
@@ -1,0 +1,9 @@
+name = "project_a"
+version = "0.1.0"
+
+[dependencies]
+project_b = { path = "../project_b" }
+project_c = { path = "../project_c" }
+
+[dev-dependencies]
+gleeunit = "~> 0.10"

--- a/test/project_path_deps/project_a/src/project_a.gleam
+++ b/test/project_path_deps/project_a/src/project_a.gleam
@@ -1,0 +1,12 @@
+import project_b
+import project_c
+
+pub type TypeA {
+  VariantB(project_b.TypeB)
+  VariantC(project_c.TypeC)
+}
+
+pub fn main() {
+  let _ = VariantB(project_b.new("thing", "name"))
+  let _ = VariantC(project_c.new("thing"))
+}

--- a/test/project_path_deps/project_a/test/project_a_test.gleam
+++ b/test/project_path_deps/project_a/test/project_a_test.gleam
@@ -1,0 +1,12 @@
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// gleeunit test functions end in `_test`
+pub fn hello_world_test() {
+  1
+  |> should.equal(1)
+}

--- a/test/project_path_deps/project_b/gleam.toml
+++ b/test/project_path_deps/project_b/gleam.toml
@@ -1,0 +1,6 @@
+name = "project_b"
+version = "0.1.0"
+description = "A Gleam project"
+
+[dependencies]
+project_d = { path = "../project_d" }

--- a/test/project_path_deps/project_b/src/project_b.gleam
+++ b/test/project_path_deps/project_b/src/project_b.gleam
@@ -1,0 +1,9 @@
+import project_d
+
+pub type TypeB {
+  ConstructorB(contained: project_d.TypeD, name: String)
+}
+
+pub fn new(contained, name) {
+  ConstructorB(project_d.ConstructorD(contained), name)
+}

--- a/test/project_path_deps/project_c/gleam.toml
+++ b/test/project_path_deps/project_c/gleam.toml
@@ -1,0 +1,5 @@
+name = "project_c"
+version = "0.1.0"
+
+[dependencies]
+project_b = { path = "../project_b" }

--- a/test/project_path_deps/project_c/src/project_c.gleam
+++ b/test/project_path_deps/project_c/src/project_c.gleam
@@ -1,0 +1,9 @@
+import project_d
+
+pub type TypeC {
+  ConstructorC(project_d.TypeD)
+}
+
+pub fn new(str) {
+  ConstructorC(project_d.ConstructorD(str))
+}

--- a/test/project_path_deps/project_d/gleam.toml
+++ b/test/project_path_deps/project_d/gleam.toml
@@ -1,0 +1,2 @@
+name = "project_d"
+version = "1.0.0"

--- a/test/project_path_deps/project_d/src/project_d.gleam
+++ b/test/project_path_deps/project_d/src/project_d.gleam
@@ -1,0 +1,3 @@
+pub type TypeD {
+  ConstructorD(String)
+}


### PR DESCRIPTION
Resolves #1409. Includes the groundwork for #1338.

Dependencies can now be specified in multiple ways in `gleam.toml`.
```toml
dep1 = "~> 1.0.0"
dep2 = { version = "== 2.1.4" }
dep3 = { path = "./relative/path/to/project" }
```

Path dependencies are walked recursively, so that local dependencies of local dependencies can still be located.

Todo:
- [x] Fix package linking
- [x] Fix `Recipe` toml encoding
- [x] Fix `ManifestPackage::Local` toml encoding
- [x] Prevent path cycles and infinite loops
- [x] Add support for absolute paths
- [x] Ensure that local packages are added to `packages.toml` after linking
- [x] Verify that packages with local dependencies cannot be pushed to hex
- [x] Fix checks and format

Future work related to this PR:
+ #1338
+ #1964
+ Add optional version range specified to local dependencies as a fallback/for publishing (like in rust)
+ Change detection