### PR TITLE
Unhide lsp documentation, print start up message

### DIFF
--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -7,6 +7,7 @@ use gleam_core::{
 };
 
 pub fn main() -> Result<()> {
+    eprintln!("Starting language server...");
     tracing::info!("language_server_starting");
 
     // Create the transport. Includes the stdio (stdin and stdout) versions but this could

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -211,7 +211,7 @@ enum Command {
     Clean,
 
     /// Run the language server, to be used by editors
-    #[clap(name = "lsp", hide = true)]
+    #[clap(name = "lsp")]
     LanguageServer,
 
     /// Export something useful from the Gleam project


### PR DESCRIPTION
Below, you'll see the entry in the `gleam help` as well as the stderr output to indicate that the subcommand is doing something.

Stylistically, I don't know if there is some string that is better to print so I just picked something. I checked a few language servers from my machine and they range from simple `[Info] Starting server` (static-ls for Haskell), a wall of text (haskell-language-server), and nothing (rust-analyzer). So...

```
[0] barry@rickman:~/p/r/g/compiler-cli|chiroptical/issue-2157-lsp-subcommand⚡*
➤ cargo install --path .
  Installing gleam v0.29.0-rc1 (/home/barry/programming/rust/gleam/compiler-cli)
    Updating crates.io index
    Finished release [optimized] target(s) in 0.69s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v6.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 2`
   Replacing /home/barry/.cargo/bin/gleam
    Replaced package `gleam v0.29.0-rc1 (/home/barry/programming/rust/gleam/compiler-cli)` with `gleam v0.29.0-rc1 (/home/barry/programming/rust/gleam/compiler-cli)` (executable `gleam`)
warning: be sure to add `/home/barry/.cargo/bin` to your PATH to be able to run the installed binaries
[0] barry@rickman:~/p/r/g/compiler-cli|chiroptical/issue-2157-lsp-subcommand⚡*
➤ ~/.cargo/bin/gleam help
gleam 0.29.0-rc1

USAGE:
    gleam <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    add        Add new project dependencies
    build      Build the project
    check      Type check the project
    clean      Clean build artifacts
    deps       Work with dependency packages
    docs       Render HTML documentation
    export     Export something useful from the Gleam project
    format     Format source code
    help       Print this message or the help of the given subcommand(s)
    hex        Work with the Hex package manager
    lsp        Run the language server, to be used by editors
    new        Create a new project
    publish    Publish the project to the Hex package manager
    run        Run the project
    shell      Start an Erlang shell
    test       Run the project tests
    update     Update dependency packages to their latest versions
[0] barry@rickman:~/p/r/g/compiler-cli|chiroptical/issue-2157-lsp-subcommand⚡*
➤ ~/.cargo/bin/gleam lsp
Starting language server...
^C⏎
```