### PR TITLE
Update documentation

### DIFF
--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -73,7 +73,7 @@ pub fn build() -> Result<()> {
     crate::fs::write_outputs_under(&outputs, &out)?;
 
     println!(
-        "\nThe documentation for {package} has been rendered to \n./{out}/index.html",
+        "\nThe documentation for {package} has been rendered to \n{out}/index.html",
         package = config.name,
         out = out.to_string_lossy()
     );


### PR DESCRIPTION
Fixes documentation issue #2168 by removing the `./` before the absolute file path.