### PR TITLE
Promote comments to doc comments, where applicable

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1685,9 +1685,9 @@ fn variable_name(name: &str) -> String {
     first_uppercased.chain(chars).collect()
 }
 
-// When rendering a type variable to an erlang type spec we need all type variables with the
-// same id to end up with the same name in the generated erlang.
-// This function converts a usize into base 26 A-Z for this purpose.
+/// When rendering a type variable to an erlang type spec we need all type variables with the
+/// same id to end up with the same name in the generated erlang.
+/// This function converts a usize into base 26 A-Z for this purpose.
 fn id_to_type_var(id: u64) -> Document<'static> {
     if id < 26 {
         let mut name = "".to_string();

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -92,8 +92,8 @@ impl<'comments> Formatter<'comments> {
             .unwrap_or(false)
     }
 
-    // Pop comments that occur before a byte-index in the source, consuming
-    // and retaining any empty lines contained within.
+    /// Pop comments that occur before a byte-index in the source, consuming
+    /// and retaining any empty lines contained within.
     fn pop_comments(&mut self, limit: u32) -> impl Iterator<Item = Option<&'comments str>> {
         let (popped, rest, empty_lines) =
             comments_before(self.comments, self.empty_lines, limit, true);
@@ -102,8 +102,8 @@ impl<'comments> Formatter<'comments> {
         popped
     }
 
-    // Pop doc comments that occur before a byte-index in the source, consuming
-    // and dropping any empty lines contained within.
+    /// Pop doc comments that occur before a byte-index in the source, consuming
+    /// and dropping any empty lines contained within.
     fn pop_doc_comments(&mut self, limit: u32) -> impl Iterator<Item = Option<&'comments str>> {
         let (popped, rest, empty_lines) =
             comments_before(self.doc_comments, self.empty_lines, limit, false);
@@ -112,8 +112,8 @@ impl<'comments> Formatter<'comments> {
         popped
     }
 
-    // Remove between 0 and `limit` empty lines following the current position,
-    // returning true if any empty lines were removed.
+    /// Remove between 0 and `limit` empty lines following the current position,
+    /// returning true if any empty lines were removed.
     fn pop_empty_lines(&mut self, limit: u32) -> bool {
         let mut end = 0;
         for (i, &position) in self.empty_lines.iter().enumerate() {

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -810,7 +810,8 @@ pub(crate) fn assign_subjects<'a>(
     }
     out
 }
-// Helper function to calculate length of str as utf16 without escape characters
+
+/// Calculates the length of str as utf16 without escape characters.
 fn utf16_no_escape_len(str: &SmolStr) -> usize {
     let mut filtered_str = String::new();
     let mut str_iter = str.chars();

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -31,9 +31,9 @@ use crate::{
 
 use super::{concat, import::Imports, line, lines, wrap_args, Output, INDENT};
 
-// When rendering a type variable to an TypeScript type spec we need all type
-// variables with the same id to end up with the same name in the generated
-// TypeScript. This function converts a usize into base 26 A-Z for this purpose.
+/// When rendering a type variable to an TypeScript type spec we need all type
+/// variables with the same id to end up with the same name in the generated
+/// TypeScript. This function converts a usize into base 26 A-Z for this purpose.
 fn id_to_type_var(id: u64) -> Document<'static> {
     if id < 26 {
         return std::iter::once(
@@ -73,15 +73,15 @@ fn name_with_generics<'a>(
     ]
 }
 
-// A generic can either be rendered as an actual type variable such as `A` or `B`,
-// or it can be rendered as `any` depending on how many usages it has. If it
-// has only 1 usage it is an `any` type. If it has more than 1 usage it is a
-// TS generic. This function gathers usages for this determination.
-//
-//   Examples:
-//     fn(a) -> String       // `a` is `any`
-//     fn() -> Result(a, b)  // `a` and `b` are `any`
-//     fn(a) -> a            // `a` is a generic
+/// A generic can either be rendered as an actual type variable such as `A` or `B`,
+/// or it can be rendered as `any` depending on how many usages it has. If it
+/// has only 1 usage it is an `any` type. If it has more than 1 usage it is a
+/// TS generic. This function gathers usages for this determination.
+///
+///   Examples:
+///     fn(a) -> String       // `a` is `any`
+///     fn() -> Result(a, b)  // `a` and `b` are `any`
+///     fn(a) -> a            // `a` is a generic
 fn collect_generic_usages<'a>(
     mut ids: HashMap<u64, u64>,
     types: impl IntoIterator<Item = &'a Arc<Type>>,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2771,7 +2771,7 @@ fn concat_pattern_variable_left_hand_side_error<T>(start: u32, end: u32) -> Resu
 // Higher number means higher precedence.
 // All operators are left associative.
 
-// Simple-Precedence-Parser, handle seeing an operator or end
+/// Simple-Precedence-Parser, handle seeing an operator or end
 fn handle_op<A>(
     next_op: Option<(Spanned, u8)>,
     opstack: &mut Vec<(Spanned, u8)>,
@@ -2853,7 +2853,7 @@ fn tok_to_binop(t: &Token) -> Option<BinOp> {
         _ => None,
     }
 }
-// Simple-Precedence-Parser, perform reduction for expression
+/// Simple-Precedence-Parser, perform reduction for expression
 fn do_reduce_expression(op: Spanned, estack: &mut Vec<UntypedExpr>) {
     match (estack.pop(), estack.pop()) {
         (Some(er), Some(el)) => {
@@ -2864,7 +2864,7 @@ fn do_reduce_expression(op: Spanned, estack: &mut Vec<UntypedExpr>) {
     }
 }
 
-// Simple-Precedence-Parser, perform reduction for clause guard
+/// Simple-Precedence-Parser, perform reduction for clause guard
 fn do_reduce_clause_guard(op: Spanned, estack: &mut Vec<UntypedClauseGuard>) {
     match (estack.pop(), estack.pop()) {
         (Some(er), Some(el)) => {
@@ -3050,7 +3050,9 @@ fn parse_error<T>(error: ParseErrorType, location: SrcSpan) -> Result<T, ParseEr
 // Misc Helpers
 //
 
-// useful for checking if a user tried to enter a reserved word as a name
+/// Returns whether the given token is a reserved word.
+///
+/// Useful for checking if a user tried to enter a reserved word as a name.
 fn is_reserved_word(tok: Token) -> bool {
     matches![
         tok,


### PR DESCRIPTION
While I was working in the compiler I noticed a number of cases where functions had regular comments instead of doc comments above them.

This PR promotes those comments to doc comments so that they show up in the editor/related tooling.