### PR TITLE
Add blockquote styling

### DIFF
--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -231,6 +231,13 @@ p {
   font-size: 1.3rem;
 }
 
+blockquote {
+  border-left: 4px solid var(--accent);
+  padding: var(--small-gap) var(--gap);
+  background-color: var(--accented-background);
+  margin: var(--small-gap) 0;
+}
+
 /* Code */
 
 pre,


### PR DESCRIPTION
This PR adds styling to block quote elements in Gleam documentation. It just mimics the style of the `.member-name` class adding a vertical accent color border and an accented background.

Here's how it looks with the light theme on:
![Screenshot 2023-05-29 alle 08 49 19](https://github.com/gleam-lang/gleam/assets/20598369/69ee43f1-1a9b-46f1-85d6-90bf1febd42b)

And here's with the dark theme:
![Screenshot 2023-05-29 alle 08 43 27](https://github.com/gleam-lang/gleam/assets/20598369/41393cd7-7008-4c7d-92f1-bcf05aee6409)
