### PR TITLE
Fix path dependency paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "lazy_static",
  "lsp-server",
  "lsp-types",
+ "pathdiff",
  "pretty_assertions",
  "regex",
  "reqwest",
@@ -1361,6 +1362,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,11 +717,11 @@ dependencies = [
  "lazy_static",
  "lsp-server",
  "lsp-types",
- "pathdiff",
  "pretty_assertions",
  "regex",
  "reqwest",
  "rpassword",
+ "same-file",
  "serde",
  "serde_json",
  "sha2",
@@ -1362,12 +1362,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -78,6 +78,8 @@ lsp-types = "0.92"
 fslock = "0.2.1"
 # Compact and cheap to clone immutable string type
 smol_str = "0.1"
+# Absolute to relitive path function extracted from the rust compiler
+pathdiff = "0.2.1"
 
 [dev-dependencies]
 # Test assertion errors with diffs

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -78,8 +78,8 @@ lsp-types = "0.92"
 fslock = "0.2.1"
 # Compact and cheap to clone immutable string type
 smol_str = "0.1"
-# Absolute to relitive path function extracted from the rust compiler
-pathdiff = "0.2.1"
+# Provides a way to determine if two files are the same using filesystem node ids
+same-file = "1.0.6"
 
 [dev-dependencies]
 # Test assertion errors with diffs


### PR DESCRIPTION
Resolves #2182.

This adds a dependency to the [pathdiff](https://docs.rs/pathdiff) package, a utility for turning absolute paths into relative ones. Normally I don't like to add tiny packages like this in PRs but in this case its a somewhat complex implementation extracted from the rust compiler backed so I feel it's warranted.