### PR TITLE
Add ability to open docs in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   completion.
 - A warning is now emitted when using `list.length` to check for the empty list,
   which is slow compared to checking for equality or pattern matching (#2180).
+- The `gleam docs build` command gains the `--open` flag to open the docs after they are generated (#2188).
 
 ## v0.29.0 - 2023-05-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
+ "once_cell",
+ "regex-automata",
  "serde",
 ]
 
@@ -717,6 +719,7 @@ dependencies = [
  "lazy_static",
  "lsp-server",
  "lsp-types",
+ "opener",
  "pretty_assertions",
  "regex",
  "reqwest",
@@ -1265,6 +1268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1346,17 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opener"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
+dependencies = [
+ "bstr",
+ "normpath",
+ "winapi",
+]
 
 [[package]]
 name = "openssl-probe"

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -78,6 +78,8 @@ lsp-types = "0.92"
 fslock = "0.2.1"
 # Compact and cheap to clone immutable string type
 smol_str = "0.1"
+# Open generated docs in browser
+opener = "0.6"
 
 [dev-dependencies]
 # Test assertion errors with diffs

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -5,7 +5,7 @@ use crate::{cli, hex::ApiKeyCommand, http::HttpClient};
 use gleam_core::{
     build::{Codegen, Mode, Options, Package},
     config::{DocsPage, PackageConfig},
-    error::{Error, FileIoAction, FileKind},
+    error::Error,
     hex,
     io::HttpClient as _,
     Result,

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Instant;
 
 use crate::{cli, hex::ApiKeyCommand, http::HttpClient};
@@ -49,7 +50,12 @@ impl ApiKeyCommand for RemoveCommand {
     }
 }
 
-pub fn build() -> Result<()> {
+#[derive(Debug)]
+pub struct BuildOptions {
+    pub open: bool,
+}
+
+pub fn build(options: BuildOptions) -> Result<()> {
     let paths = crate::project_paths_at_current_directory();
     let config = crate::config::root_config()?;
 
@@ -72,14 +78,30 @@ pub fn build() -> Result<()> {
     crate::fs::delete_dir(&out)?;
     crate::fs::write_outputs_under(&outputs, &out)?;
 
+    let index_html = out.join("index.html");
+
     println!(
-        "\nThe documentation for {package} has been rendered to \n{out}/index.html",
+        "\nThe documentation for {package} has been rendered to \n{index_html}",
         package = config.name,
-        out = out.to_string_lossy()
+        index_html = index_html.to_string_lossy()
     );
+
+    if options.open {
+        open_docs(&index_html);
+    }
 
     // We're done!
     Ok(())
+}
+
+/// Opens the indicated path in the default program configured by the system.
+///
+/// For the docs this will generally be a browser (unless some other program is
+/// configured as the default for `.html` files).
+fn open_docs(path: &Path) {
+    if let Err(error) = opener::open(path) {
+        eprintln!("Failed to open docs:\n{}", error);
+    }
 }
 
 pub(crate) fn build_documentation(

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -100,11 +100,9 @@ pub fn build(options: BuildOptions) -> Result<()> {
 /// For the docs this will generally be a browser (unless some other program is
 /// configured as the default for `.html` files).
 fn open_docs(path: &Path) -> Result<()> {
-    opener::open(path).map_err(|error| Error::FileIo {
-        kind: FileKind::File,
-        action: FileIoAction::Open,
+    opener::open(path).map_err(|error| Error::FailedToOpenDocs {
         path: path.to_path_buf(),
-        err: Some(error.to_string()),
+        error: error.to_string(),
     })?;
 
     Ok(())

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -52,6 +52,7 @@ impl ApiKeyCommand for RemoveCommand {
 
 #[derive(Debug)]
 pub struct BuildOptions {
+    /// Whether to open the docs after building.
     pub open: bool,
 }
 

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -101,7 +101,20 @@ pub fn build(options: BuildOptions) -> Result<()> {
 /// configured as the default for `.html` files).
 fn open_docs(path: &Path) {
     if let Err(error) = opener::open(path) {
-        eprintln!("Failed to open docs:\n{}", error);
+        use std::io::Write;
+
+        let buffer_writer = crate::cli::stderr_buffer_writer();
+        let mut buffer = buffer_writer.buffer();
+
+        buffer
+            .write_all(b"\n")
+            .expect("error pretty buffer write space before");
+
+        write!(buffer, "Failed to open docs:\n{}", error).unwrap();
+
+        buffer_writer
+            .print(&buffer)
+            .expect("Writing warning to stderr");
     }
 }
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -324,7 +324,11 @@ enum Hex {
 #[derive(Subcommand, Debug)]
 enum Docs {
     /// Render HTML docs locally
-    Build,
+    Build {
+        /// Opens the docs in a browser after rendering
+        #[clap(long)]
+        open: bool,
+    },
 
     /// Publish HTML docs to HexDocs
     ///
@@ -366,7 +370,7 @@ fn main() {
 
         Command::Check => command_check(),
 
-        Command::Docs(Docs::Build) => docs::build(),
+        Command::Docs(Docs::Build { open }) => docs::build(docs::BuildOptions { open }),
 
         Command::Docs(Docs::Publish) => docs::publish(),
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -223,6 +223,9 @@ pub enum Error {
         package: String,
         build_tools: Vec<String>,
     },
+
+    #[error("Opening docs at {path} failed: {error}")]
+    FailedToOpenDocs { path: PathBuf, error: String },
 }
 
 impl Error {
@@ -2455,6 +2458,29 @@ issue in our tracker: https://github.com/gleam-lang/gleam/issues",
                     level: Level::Error,
                 }
             }
+
+            Error::FailedToOpenDocs {
+                path,
+                error,
+            } => {
+                let error = format!("\nThe error message from the library was:\n\n    {error}\n");
+                let text = format!(
+                    "An error occurred while trying to open the docs:
+
+    {}
+{}",
+                    path.to_string_lossy(),
+                    error,
+                );
+                Diagnostic {
+                    title: "Failed to open docs".into(),
+                    text,
+                    hint: None,
+                    level: Level::Error,
+                    location: None,
+                }
+            }
+
             Error::InvalidRuntime {
                 target,
                 invalid_runtime,


### PR DESCRIPTION
This PR adds the ability to have `gleam docs build` automatically open the docs in the browser after they are built.

`gleam docs build` now accepts an optional `--open` flag to indicate that the docs should be opened after generation:

```
λ gleam docs build --help
gleam-docs-build
Render HTML docs locally

USAGE:
    gleam docs build [OPTIONS]

OPTIONS:
    -h, --help    Print help information
        --open    Opens the docs in a browser after rendering
```

Passing the `--open` flag will cause the `index.html` file for the docs to be opened in the system default program for `.html` files (typically the browser):

<img width="1150" alt="Screenshot 2023-05-29 at 9 49 09 PM" src="https://github.com/gleam-lang/gleam/assets/1486634/3a7c18aa-5270-406c-9dae-f776bf540d3a">
