### PR TITLE
Compile and cache local dependency sources on build

### DIFF
--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -4,7 +4,7 @@ use crate::{
     CompilePackage,
 };
 use gleam_core::{
-    build::{Mode, PackageCompiler, Target, TargetCodegenConfiguration},
+    build::{Mode, PackageCompiler, StaleTracker, Target, TargetCodegenConfiguration},
     metadata,
     paths::{self, ProjectPaths},
     type_::ModuleInterface,
@@ -44,7 +44,12 @@ pub fn command(options: CompilePackage) -> Result<()> {
     compiler.write_entrypoint = false;
     compiler.write_metadata = true;
     compiler.compile_beam_bytecode = !options.skip_beam_compilation;
-    let _ = compiler.compile(&warnings, &mut type_manifests, &mut defined_modules)?;
+    let _ = compiler.compile(
+        &warnings,
+        &mut type_manifests,
+        &mut defined_modules,
+        &mut StaleTracker::default(),
+    )?;
 
     Ok(())
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -312,10 +312,9 @@ impl LocalPackages {
             .packages
             .iter()
             .filter(|p| {
-                p.name != root && {
-                    self.packages.get(&p.name) != Some(&p.version)
-                        || matches!(p.source, ManifestPackageSource::Local { .. })
-                }
+                let is_local = matches!(p.source, ManifestPackageSource::Local { .. });
+                let is_outdated = self.packages.get(&p.name) != Some(&p.version);
+                p.name != root && is_outdated && !is_local
             })
             .collect()
     }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -12,7 +12,7 @@ use gleam_core::{
     dependency,
     error::{FileIoAction, FileKind, StandardIoAction},
     hex::{self, HEXPM_PUBLIC_KEY},
-    io::{FileSystemWriter, HttpClient as _, TarUnpacker, WrappedReader},
+    io::{HttpClient as _, TarUnpacker, WrappedReader},
     manifest::{Base16Checksum, Manifest, ManifestPackage, ManifestPackageSource},
     paths::ProjectPaths,
     requirement::Requirement,
@@ -204,24 +204,6 @@ async fn add_missing_packages<Telem: Telemetry>(
     telemetry: &Telem,
 ) -> Result<(), Error> {
     let missing_packages = local.missing_local_packages(manifest, &project_name);
-
-    // Link local paths
-    for package in missing_packages.iter() {
-        let package_dest = paths.build_packages_package(&package.name);
-        match &package.source {
-            ManifestPackageSource::Hex { .. } => Ok(()),
-            ManifestPackageSource::Local { path } => {
-                fs.delete(&package_dest)?;
-                fs.mkdir(&package_dest)?;
-                fs.copy_dir(&path.join("src"), &package_dest)?;
-                if path.join("priv").exists() {
-                    fs.copy_dir(&path.join("priv"), &package_dest)?;
-                }
-                fs.copy(&path.join("gleam.toml"), &package_dest.join("gleam.toml"))
-            }
-            ManifestPackageSource::Git { .. } => Ok(()),
-        }?
-    }
 
     let mut num_to_download = 0;
     let mut missing_hex_packages = missing_packages

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -311,11 +311,12 @@ impl LocalPackages {
         manifest
             .packages
             .iter()
-            .filter(|p| {
-                let is_local = matches!(p.source, ManifestPackageSource::Local { .. });
-                let is_outdated = self.packages.get(&p.name) != Some(&p.version);
-                p.name != root && is_outdated && !is_local
-            })
+            // We don't need to download the root package
+            .filter(|p| p.name != root)
+            // We don't need to download local packages because we use the linked source directly
+            .filter(|p| !p.is_local())
+            // We don't need to download packages which we have the correct version of
+            .filter(|p| self.packages.get(&p.name) != Some(&p.version))
             .collect()
     }
 

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -12,7 +12,7 @@ mod tests;
 
 pub use self::package_compiler::PackageCompiler;
 pub use self::package_loader::StaleTracker;
-pub use self::project_compiler::{Built, CheckpointState, Options, ProjectCompiler};
+pub use self::project_compiler::{Built, Options, ProjectCompiler};
 pub use self::telemetry::{NullTelemetry, Telemetry};
 
 use crate::ast::{

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -11,6 +11,7 @@ mod telemetry;
 mod tests;
 
 pub use self::package_compiler::PackageCompiler;
+pub use self::package_loader::StaleTracker;
 pub use self::project_compiler::{Built, CheckpointState, Options, ProjectCompiler};
 pub use self::telemetry::{NullTelemetry, Telemetry};
 

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -4,7 +4,7 @@ use crate::{
     build::{
         module_loader::SourceFingerprint,
         native_file_copier::NativeFileCopier,
-        package_loader::{CodegenRequired, PackageLoader},
+        package_loader::{CodegenRequired, PackageLoader, StaleTracker},
         Mode, Module, Origin, Package, Target,
     },
     codegen::{Erlang, ErlangApp, JavaScript, TypeScriptDeclarations},
@@ -92,6 +92,7 @@ where
         warnings: &WarningEmitter,
         existing_modules: &mut im::HashMap<SmolStr, type_::ModuleInterface>,
         already_defined_modules: &mut im::HashMap<SmolStr, PathBuf>,
+        stale_modules: &mut StaleTracker,
     ) -> Result<Vec<Module>, Error> {
         let span = tracing::info_span!("compile", package = %self.config.name.as_str());
         let _enter = span.enter();
@@ -115,6 +116,7 @@ where
             &artefact_directory,
             self.target.target(),
             &self.config.name,
+            stale_modules,
             already_defined_modules,
         )
         .run()?;

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -245,6 +245,10 @@ impl StaleTracker {
     fn includes_any(&self, names: &[SmolStr]) -> bool {
         names.iter().any(|n| self.0.contains(n.as_str()))
     }
+
+    pub fn empty(&mut self) {
+        let _ = self.0.drain(); // Clears the set but retains allocated memory
+    }
 }
 
 #[derive(Debug)]

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -70,6 +70,7 @@ fn run_loader(fs: InMemoryFileSystem, root: &Path, artefact: &Path) -> LoaderTes
         artefact_directory: &artefact,
         package_name: &"my_package".into(),
         target: Target::JavaScript,
+        stale_modules: &mut StaleTracker::default(),
         already_defined_modules: &mut defined,
     };
     let loaded = loader.run().unwrap();

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -273,7 +273,7 @@ where
 
         // TODO: test
         if !self.options.codegen.should_codegen(false) {
-            tracing::debug!(%name, "skipping_mix_build_as_codegen_disabled");
+            tracing::debug!(%name, "skipping_rebar3_build_as_codegen_disabled");
             return Ok(());
         }
 

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -155,6 +155,7 @@ where
         self.check_gleam_version()?;
         self.compile_dependencies()?;
         self.warnings.reset_count();
+        self.stale_modules.empty();
 
         match self.options.codegen {
             Codegen::All => self.telemetry.compiling_package(&self.config.name),

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -1,7 +1,7 @@
 use crate::{
     build::{
-        package_compiler, package_compiler::PackageCompiler, project_compiler,
-        telemetry::Telemetry, Mode, Module, Origin, Package, Target,
+        package_compiler, package_compiler::PackageCompiler, package_loader::StaleTracker,
+        project_compiler, telemetry::Telemetry, Mode, Module, Origin, Package, Target,
     },
     codegen::{self, ErlangApp},
     config::PackageConfig,
@@ -75,6 +75,7 @@ pub struct ProjectCompiler<IO> {
     packages: HashMap<String, ManifestPackage>,
     importable_modules: im::HashMap<SmolStr, type_::ModuleInterface>,
     defined_modules: im::HashMap<SmolStr, PathBuf>,
+    stale_modules: StaleTracker,
     warnings: WarningEmitter,
     telemetry: Box<dyn Telemetry>,
     options: Options,
@@ -110,6 +111,7 @@ where
         Self {
             importable_modules: im::HashMap::new(),
             defined_modules: im::HashMap::new(),
+            stale_modules: StaleTracker::default(),
             ids: UniqueIdGenerator::new(),
             warnings: WarningEmitter::new(warning_emitter),
             subprocess_stdio: Stdio::Inherit,
@@ -479,6 +481,7 @@ where
             &mut self.warnings,
             &mut self.importable_modules,
             &mut self.defined_modules,
+            &mut self.stale_modules,
         )?;
 
         Ok(compiled)

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -35,13 +35,13 @@ pub enum Compilation {
 
 #[derive(Debug)]
 pub struct LanguageServerEngine<IO, Reporter> {
-    paths: ProjectPaths,
+    pub(crate) paths: ProjectPaths,
 
     /// A compiler for the project that supports repeat compilation of the root
     /// package.
     /// In the event the the project config changes this will need to be
     /// discarded and reloaded to handle any changes to dependencies.
-    pub compiler: LspProjectCompiler<FileSystemProxy<IO>>,
+    pub(crate) compiler: LspProjectCompiler<FileSystemProxy<IO>>,
 
     modules_compiled_since_last_feedback: Vec<PathBuf>,
     compiled_since_last_feedback: bool,

--- a/compiler-core/src/language_server/tests/compilation.rs
+++ b/compiler-core/src/language_server/tests/compilation.rs
@@ -95,3 +95,66 @@ fn compile_error_in_test() {
         ]
     )
 }
+
+#[test]
+fn compile_recompile() {
+    let io = LanguageServerTestIO::new();
+    let mut engine = setup_engine(&io);
+
+    io.src_module("app/src", "pub fn main() { 0 }");
+
+    // The first time it compiles.
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+    assert!(response.warnings.is_empty());
+    assert_eq!(
+        response.compilation,
+        Compilation::Yes(vec!["/src/app/src.gleam".into()])
+    );
+
+    // The source file has been updated, so the file is compiled again.
+    io.src_module("app/src", "pub fn main() { 1 }");
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+    assert!(response.warnings.is_empty());
+    assert_eq!(
+        response.compilation,
+        Compilation::Yes(vec!["/src/app/src.gleam".into()])
+    );
+
+    // This time it does not compile the module again, instead using the
+    // cache from the previous run.
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+    assert!(response.warnings.is_empty());
+    assert_eq!(response.compilation, Compilation::Yes(vec![]));
+
+    drop(engine);
+    let actions = io.into_actions();
+    assert_eq!(
+        actions,
+        vec![
+            // new
+            Action::DependencyDownloadingStarted,
+            Action::DownloadDependencies,
+            Action::DependencyDownloadingFinished,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            // compile_please
+            Action::CompilationStarted,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            Action::CompilationFinished,
+            // compile_please
+            Action::CompilationStarted,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            Action::CompilationFinished,
+            // compile_please
+            Action::CompilationStarted,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            Action::CompilationFinished,
+        ]
+    )
+}

--- a/compiler-core/src/language_server/tests/compilation.rs
+++ b/compiler-core/src/language_server/tests/compilation.rs
@@ -101,7 +101,7 @@ fn compile_recompile() {
     let io = LanguageServerTestIO::new();
     let mut engine = setup_engine(&io);
 
-    io.src_module("app/src", "pub fn main() { 0 }");
+    io.src_module("app", "pub fn main() { 0 }");
 
     // The first time it compiles.
     let response = engine.compile_please();
@@ -109,18 +109,79 @@ fn compile_recompile() {
     assert!(response.warnings.is_empty());
     assert_eq!(
         response.compilation,
-        Compilation::Yes(vec!["/src/app/src.gleam".into()])
+        Compilation::Yes(vec!["/src/app.gleam".into()])
     );
 
     // The source file has been updated, so the file is compiled again.
-    io.src_module("app/src", "pub fn main() { 1 }");
+    io.src_module("app", "pub fn main() { 1 }");
     let response = engine.compile_please();
     assert!(response.result.is_ok());
     assert!(response.warnings.is_empty());
     assert_eq!(
         response.compilation,
-        Compilation::Yes(vec!["/src/app/src.gleam".into()])
+        Compilation::Yes(vec!["/src/app.gleam".into()])
     );
+
+    // This time it does not compile the module again, instead using the
+    // cache from the previous run.
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+    assert!(response.warnings.is_empty());
+    assert_eq!(response.compilation, Compilation::Yes(vec![]));
+
+    drop(engine);
+    let actions = io.into_actions();
+    assert_eq!(
+        actions,
+        vec![
+            // new
+            Action::DependencyDownloadingStarted,
+            Action::DownloadDependencies,
+            Action::DependencyDownloadingFinished,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            // compile_please
+            Action::CompilationStarted,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            Action::CompilationFinished,
+            // compile_please
+            Action::CompilationStarted,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            Action::CompilationFinished,
+            // compile_please
+            Action::CompilationStarted,
+            Action::LockBuild,
+            Action::UnlockBuild,
+            Action::CompilationFinished,
+        ]
+    )
+}
+
+#[test]
+fn dep_compile_recompile() {
+    let io = LanguageServerTestIO::new();
+    let mut engine = setup_engine(&io);
+    add_path_dep(&mut engine, "mydep", "/mydep");
+    let path = "/mydep/src/thingy.gleam";
+
+    io.module(&PathBuf::from(path), "pub fn main() { 0 }");
+
+    // The first time it compiles.
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+    assert!(response.warnings.is_empty());
+    assert_eq!(response.compilation, Compilation::Yes(vec![path.into()]));
+
+    assert!(!engine.compiler.project_compiler.packages.is_empty());
+
+    // The source file has been updated, so the file is compiled again.
+    io.module(&PathBuf::from(path), "pub fn main() { 1 }");
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+    assert!(response.warnings.is_empty());
+    assert_eq!(response.compilation, Compilation::Yes(vec![path.into()]));
 
     // This time it does not compile the module again, instead using the
     // cache from the previous run.

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -23,8 +23,8 @@ fn positioned_expression_completions(
     let io = LanguageServerTestIO::new();
     let mut engine = setup_engine(&io);
 
-    io.src_module("dep", dep);
-    io.src_module("app", src);
+    _ = io.src_module("dep", dep);
+    _ = io.src_module("app", src);
     let response = engine.compile_please();
     assert!(response.result.is_ok());
 

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -58,7 +58,8 @@ impl LanguageServerTestIO {
     pub fn src_module(&self, name: &str, code: &str) {
         let src_dir = self.paths.src_directory();
         let path = src_dir.join(name).with_extension("gleam");
-        self.io.write(&path, code).unwrap()
+        self.io.write(&path, code).unwrap();
+        self.io.set_modification_time(&path, SystemTime::now());
     }
 
     pub fn test_module(&self, name: &str, code: &str) {

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -58,21 +58,30 @@ impl LanguageServerTestIO {
         Arc::try_unwrap(self.actions).unwrap().into_inner().unwrap()
     }
 
-    pub fn module(&self, path: &Path, code: &str) {
-        self.io.write(&path, code).unwrap();
-        self.io.set_modification_time(&path, SystemTime::now());
-    }
-
-    pub fn src_module(&self, name: &str, code: &str) {
+    pub fn src_module(&self, name: &str, code: &str) -> PathBuf {
         let src_dir = self.paths.src_directory();
         let path = src_dir.join(name).with_extension("gleam");
         self.module(&path, code);
+        path
     }
 
-    pub fn test_module(&self, name: &str, code: &str) {
+    pub fn test_module(&self, name: &str, code: &str) -> PathBuf {
         let test_dir = self.paths.test_directory();
         let path = test_dir.join(name).with_extension("gleam");
         self.module(&path, code);
+        path
+    }
+
+    pub fn dep_module(&self, dep: &str, name: &str, code: &str) -> PathBuf {
+        let dep_dir = self.paths.root().join(dep).join("src");
+        let path = dep_dir.join(name).with_extension("gleam");
+        self.module(&path, code);
+        path
+    }
+
+    fn module(&self, path: &Path, code: &str) {
+        self.io.write(&path, code).unwrap();
+        self.io.set_modification_time(&path, SystemTime::now());
     }
 
     fn record(&self, action: Action) {
@@ -238,17 +247,13 @@ impl ProgressReporter for LanguageServerTestIO {
     }
 }
 
-fn add_path_dep<B>(
-    engine: &mut LanguageServerEngine<LanguageServerTestIO, B>,
-    name: &str,
-    path: &str,
-) {
+fn add_path_dep<B>(engine: &mut LanguageServerEngine<LanguageServerTestIO, B>, name: &str) {
+    let path = engine.paths.root().join(name);
     let compiler = &mut engine.compiler.project_compiler;
     _ = compiler
         .config
         .dependencies
-        .insert(name.into(), Requirement::path(path));
-    let path = PathBuf::from(path);
+        .insert(name.into(), Requirement::Path { path: path.clone() });
     _ = compiler.packages.insert(
         name.into(),
         ManifestPackage {

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -274,8 +274,14 @@ impl ManifestPackage {
         self
     }
 
+    #[inline]
     pub fn is_hex(&self) -> bool {
         matches!(self.source, ManifestPackageSource::Hex { .. })
+    }
+
+    #[inline]
+    pub fn is_local(&self) -> bool {
+        matches!(self.source, ManifestPackageSource::Local { .. })
     }
 }
 

--- a/test-package-compiler/src/lib.rs
+++ b/test-package-compiler/src/lib.rs
@@ -4,7 +4,9 @@
 mod generated_tests;
 
 use gleam_core::{
-    build::{ErlangAppCodegenConfiguration, Mode, Target, TargetCodegenConfiguration},
+    build::{
+        ErlangAppCodegenConfiguration, Mode, StaleTracker, Target, TargetCodegenConfiguration,
+    },
     config::PackageConfig,
     io::{memory::InMemoryFileSystem, Content, FileSystemWriter},
     warning::{VectorWarningEmitterIO, WarningEmitter},
@@ -59,7 +61,12 @@ pub fn prepare(path: &str) -> String {
     compiler.write_metadata = true;
     compiler.compile_beam_bytecode = false;
     compiler.copy_native_files = false;
-    let result = compiler.compile(&warning_emitter, &mut modules, &mut im::HashMap::new());
+    let result = compiler.compile(
+        &warning_emitter,
+        &mut modules,
+        &mut im::HashMap::new(),
+        &mut StaleTracker::default(),
+    );
     match result {
         Ok(_) => {
             for path in initial_files {


### PR DESCRIPTION
Resolves #2183. Potentially also #2185.

This PR makes the compiler use the "live" sources when compiling a local dependency so users no longer have to run `gleam deps update` to update local packages. As an optimization, this PR also enables per-module caching for gleam-based local dependencies, and project-level dependency cache invalidation.

This is a draft because I want to verify that everything works correctly, but this should be feature complete. Still need to double-check that cache invalidation works between packages properly.