### PR TITLE
Add supported compiler version to config

### DIFF
--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -55,12 +55,14 @@ pub fn find_package_config_for_module(
 
 pub fn read(config_path: PathBuf) -> Result<PackageConfig, Error> {
     let toml = crate::fs::read(&config_path)?;
-    toml::from_str(&toml).map_err(|e| Error::FileIo {
+    let config: PackageConfig = toml::from_str(&toml).map_err(|e| Error::FileIo {
         action: FileIoAction::Parse,
         kind: FileKind::File,
         path: config_path,
         err: Some(e.to_string()),
-    })
+    })?;
+    config.check_gleam_compatability()?;
+    Ok(config)
 }
 
 pub fn ensure_config_exists(paths: &ProjectPaths) -> Result<(), Error> {

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -82,6 +82,7 @@ use gleam_core::{
     build::{Codegen, Mode, Options, Runtime, Target},
     hex::RetirementReason,
     paths::ProjectPaths,
+    version::COMPILER_VERSION,
 };
 use hex::ApiKeyCommand as _;
 
@@ -89,8 +90,6 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 use strum::VariantNames;
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -396,7 +395,7 @@ fn main() {
 
         Command::Deps(Dependencies::Update) => dependencies::update(),
 
-        Command::New(options) => new::create(options, VERSION),
+        Command::New(options) => new::create(options, COMPILER_VERSION),
 
         Command::Shell => shell::command(),
 

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -96,6 +96,9 @@ where
         let span = tracing::info_span!("compile", package = %self.config.name.as_str());
         let _enter = span.enter();
 
+        // Ensure that the package is compatable with this version of Gleam
+        self.config.check_gleam_compatability()?;
+
         let artefact_directory = self.out.join(paths::ARTEFACT_DIRECTORY_NAME);
         let codegen_required = if self.perform_codegen {
             CodegenRequired::Yes

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -129,7 +129,6 @@ impl PackageConfig {
             path: path.as_ref().to_path_buf(),
             err: Some(e.to_string()),
         })?;
-        config.check_gleam_compatability()?;
         Ok(config)
     }
 

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -2,6 +2,7 @@ use crate::error::{FileIoAction, FileKind};
 use crate::io::FileSystemReader;
 use crate::manifest::Manifest;
 use crate::requirement::Requirement;
+use crate::version::COMPILER_VERSION;
 use crate::{Error, Result};
 use globset::{Glob, GlobSetBuilder};
 use hexpm::version::Version;
@@ -181,7 +182,7 @@ impl PackageConfig {
     // with the current compiler version
     pub fn check_gleam_compatability(&self) -> Result<(), Error> {
         if let Some(required_version) = &self.gleam_version {
-            let compiler_version = hexpm::version::Version::parse(env!("CARGO_PKG_VERSION"))
+            let compiler_version = hexpm::version::Version::parse(COMPILER_VERSION)
                 .expect("Parse compiler semantic version");
             let range = hexpm::version::Range::new(required_version.to_string())
                 .to_pubgrub()
@@ -193,7 +194,7 @@ impl PackageConfig {
                 return Err(Error::IncompatibleCompilerVersion {
                     package: self.name.to_string(),
                     required_version: required_version.to_string(),
-                    gleam_version: env!("CARGO_PKG_VERSION").to_string(),
+                    gleam_version: COMPILER_VERSION.to_string(),
                 });
             }
         }

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -72,7 +72,7 @@ pub struct PackageConfig {
     pub name: SmolStr,
     #[serde(default = "default_version")]
     pub version: Version,
-    #[serde(default, rename = "gleam-version")]
+    #[serde(default, rename = "gleam")]
     pub gleam_version: Option<SmolStr>,
     #[serde(default, alias = "licenses")]
     pub licences: Vec<SpdxLicense>,

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -123,12 +123,14 @@ impl PackageConfig {
         fs: &FS,
     ) -> Result<PackageConfig, Error> {
         let toml = fs.read(path.as_ref())?;
-        toml::from_str(&toml).map_err(|e| Error::FileIo {
+        let config: PackageConfig = toml::from_str(&toml).map_err(|e| Error::FileIo {
             action: FileIoAction::Parse,
             kind: FileKind::File,
             path: path.as_ref().to_path_buf(),
             err: Some(e.to_string()),
-        })
+        })?;
+        config.check_gleam_compatability()?;
+        Ok(config)
     }
 
     /// Get the locked packages for the current config and a given (optional)

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -15,6 +15,7 @@ use crate::{
     io::OutputFile,
     paths::ProjectPaths,
     pretty,
+    version::COMPILER_VERSION,
 };
 use askama::Template;
 use itertools::Itertools;
@@ -23,7 +24,6 @@ use serde_json::to_string as serde_to_string;
 use smol_str::SmolStr;
 
 const MAX_COLUMNS: isize = 65;
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn generate_html(
     paths: &ProjectPaths,
@@ -98,7 +98,7 @@ pub fn generate_html(
         };
 
         let temp = PageTemplate {
-            gleam_version: VERSION,
+            gleam_version: COMPILER_VERSION,
             links: &links,
             pages: &pages,
             modules: &modules_links,
@@ -227,7 +227,7 @@ pub fn generate_html(
         let page_meta_description = "";
 
         let template = ModuleTemplate {
-            gleam_version: VERSION,
+            gleam_version: COMPILER_VERSION,
             unnest,
             links: &links,
             pages: &pages,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -227,7 +227,7 @@ pub enum Error {
     #[error("Opening docs at {path} failed: {error}")]
     FailedToOpenDocs { path: PathBuf, error: String },
 
-    #[error("The package {package} requires gleam version {required_version} and you are using {gleam_version}")]
+    #[error("The package {package} requires a Gleam version satisfying {required_version} and you are using v{gleam_version}")]
     IncompatibleCompilerVersion {
         package: String,
         required_version: String,
@@ -2494,14 +2494,14 @@ issue in our tracker: https://github.com/gleam-lang/gleam/issues",
                 gleam_version
             } => {
                 let text = format!(
-                    "The package {} requires gleam version {} \
-but you are using version {}.",
+                    "The package {} requires a Gleam version satisfying {} \
+but you are using v{}.",
                     package,
                     required_version,
                     gleam_version
                 );
                 Diagnostic {
-                    title: "Incompatible gleam version".into(),
+                    title: "Incompatible Gleam version".into(),
                     text,
                     hint: None,
                     location: None,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -226,6 +226,13 @@ pub enum Error {
 
     #[error("Opening docs at {path} failed: {error}")]
     FailedToOpenDocs { path: PathBuf, error: String },
+
+    #[error("The package {package} requires gleam version {required_version} and you are using {gleam_version}")]
+    IncompatibleCompilerVersion {
+        package: String,
+        required_version: String,
+        gleam_version: String,
+    },
 }
 
 impl Error {
@@ -2478,6 +2485,27 @@ issue in our tracker: https://github.com/gleam-lang/gleam/issues",
                     hint: None,
                     level: Level::Error,
                     location: None,
+                }
+            }
+
+            Error::IncompatibleCompilerVersion {
+                package,
+                required_version,
+                gleam_version
+            } => {
+                let text = format!(
+                    "The package {} requires gleam version {} \
+but you are using version {}.",
+                    package,
+                    required_version,
+                    gleam_version
+                );
+                Diagnostic {
+                    title: "Incompatible gleam version".into(),
+                    text,
+                    hint: None,
+                    location: None,
+                    level: Level::Error
                 }
             }
 


### PR DESCRIPTION
Resolves #1813.

This PR adds a new optional entry to the config called `gleam-version` which uses the normal dependency range syntax and describes the supported compiler versions. You can add something like
```
name = "example"
version = "0.1.0"
gleam-version = "~> 0.29"
```
to support compiler versions between the current release and `1.0`.

Whenever a config file is loaded the compiler checks to see if it is compatible with the compiler version and produces a helpful error if it is not. The main config file and all gleam-based dependencies are validated during build.

This option doesn't effect dependency resolution. The value of `gleam-version` should probably not change between minor releases.