### PR TITLE
feat: add unstable flag for Deno config

### DIFF
--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -9,7 +9,7 @@ use gleam_core::{
 use lazy_static::lazy_static;
 use std::path::PathBuf;
 
-use crate::fs::ProjectIO;
+use crate::{add, fs::ProjectIO};
 
 #[derive(Debug, Clone, Copy)]
 pub enum Which {
@@ -186,6 +186,11 @@ fn run_javascript_deno(
 
     // Run the main function.
     args.push("run".into());
+
+    // Enable unstable features and APIs
+    if config.javascript.deno.unstable {
+        args.push("--unstable".into())
+    }
 
     // Set deno permissions
     if config.javascript.deno.allow_all {

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -9,7 +9,7 @@ use gleam_core::{
 use lazy_static::lazy_static;
 use std::path::PathBuf;
 
-use crate::{add, fs::ProjectIO};
+use crate::fs::ProjectIO;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Which {

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -646,6 +646,8 @@ pub struct DenoConfig {
     pub allow_write: DenoFlag,
     #[serde(default)]
     pub allow_all: bool,
+    #[serde(default)]
+    pub unstable: bool,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Adds the `unstable` flag to the Deno config so that Gleam projects can opt into new features.