### PR TITLE
Unlock new dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Adding a new dependency unlocks the target package.
 - Dependencies can now be loaded from paths. Path dependencies currently use
   the same semantics as hex dependencies, and must be updated using the command
   `gleam deps update` to load changes.

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -221,11 +221,14 @@ impl<'a> StalePackageRemover<'a> {
             .packages
             .iter()
             .filter(|package| {
+                let new = requirements.contains_key(package.name.as_str())
+                    && !manifest.requirements.contains_key(package.name.as_str());
                 let fresh = self.fresh.contains(package.name.as_str());
-                if !fresh {
+                let locked = !new && fresh;
+                if !locked {
                     tracing::info!(name = package.name.as_str(), "unlocking_stale_package");
                 }
-                fresh
+                locked
             })
             .map(|package| (package.name.clone(), package.version.clone()))
             .collect()

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -416,6 +416,34 @@ fn locked_nested_are_removed_too() {
 }
 
 #[test]
+fn locked_unlock_new() {
+    let mut config = PackageConfig::default();
+    config.dependencies = [
+        ("1".into(), Requirement::hex("~> 1.0")),
+        ("2".into(), Requirement::hex("~> 1.0")),
+        ("3".into(), Requirement::hex("~> 3.0")), // Does not match manifest
+    ]
+    .into();
+    config.dev_dependencies = [].into();
+    let manifest = Manifest {
+        requirements: [
+            ("1".into(), Requirement::hex("~> 1.0")),
+            ("2".into(), Requirement::hex("~> 1.0")),
+        ]
+        .into(),
+        packages: vec![
+            manifest_package("1", "1.1.0", &["3"]),
+            manifest_package("2", "1.1.0", &["3"]),
+            manifest_package("3", "1.1.0", &[]),
+        ],
+    };
+    assert_eq!(
+        config.locked(Some(&manifest)).unwrap(),
+        [locked_version("1", "1.1.0"), locked_version("2", "1.1.0"),].into()
+    )
+}
+
+#[test]
 fn default_internal_modules() {
     // When no internal modules are specified then we default to
     // `["$package/internal", "$package/internal/*"]`


### PR DESCRIPTION
Resolves #1754.

Unlocks newly added packages. Previously you would get a version conflict error if you added a top-level dependency to package which was already pinned as a sub-dependency of another package. Now the old version will be unpinned, and dependency resolution will be used to find a new version.

Sorry about the PR spam by the way! Several of these package management tweaks are tiny, and I thought it would be good to knock them out all at once.