### PR TITLE
Remove `local` when loading fonts in generated docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   which is slow compared to checking for equality or pattern matching (#2180).
 - The new `gleam remove <package_name>` can be used to remove dependencies
   from a Gleam project.
+- Updated font loading in generated HTML documentation to fix an issue with fonts not loading properly in some browsers (#2209).
 
 ## v0.29.0 - 2023-05-23
 

--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -4,9 +4,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Karla', 'Karla Regular', 'Karla-Regular', 'KarlaRegular', 'Karla_Regular'),
-    url('../fonts/karla-v23-regular-latin-ext.woff2') format('woff2');
+  src: url('../fonts/karla-v23-regular-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* karla regular latin */
@@ -15,9 +13,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Karla', 'Karla Regular', 'Karla-Regular', 'KarlaRegular', 'Karla_Regular'),
-    url('../fonts/karla-v23-regular-latin.woff2') format('woff2');
+  src: url('../fonts/karla-v23-regular-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* karla bold latin-ext */
@@ -26,9 +22,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src:
-    local('Karla-700', 'Karla Bold', 'Karla-Bold', 'KarlaBold', 'Karla_Bold'),
-    url('../fonts/karla-v23-bold-latin-ext.woff2') format('woff2');
+  src: url('../fonts/karla-v23-bold-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* karla bold latin */
@@ -37,9 +31,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src:
-    local('Karla-700', 'Karla Bold', 'Karla-Bold', 'KarlaBold', 'Karla_Bold'),
-    url('../fonts/karla-v23-bold-latin.woff2') format('woff2');
+  src: url('../fonts/karla-v23-bold-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* ubuntu mono cyrillic-ext */
@@ -48,9 +40,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Ubuntu Mono', 'Ubuntu-Mono', 'UbuntuMono', 'Ubuntu_Mono'),
-    url('../fonts/ubuntu-mono-v15-regular-cyrillic-ext.woff2') format('woff2');
+  src: url('../fonts/ubuntu-mono-v15-regular-cyrillic-ext.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* ubuntu mono cyrillic */
@@ -59,9 +49,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Ubuntu Mono', 'Ubuntu-Mono', 'UbuntuMono', 'Ubuntu_Mono'),
-    url('../fonts/ubuntu-mono-v15-regular-cyrillic.woff2') format('woff2');
+  src: url('../fonts/ubuntu-mono-v15-regular-cyrillic.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* ubuntu mono greek-ext */
@@ -70,9 +58,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Ubuntu Mono', 'Ubuntu-Mono', 'UbuntuMono', 'Ubuntu_Mono'),
-    url('../fonts/ubuntu-mono-v15-regular-greek-ext.woff2') format('woff2');
+  src: url('../fonts/ubuntu-mono-v15-regular-greek-ext.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* ubuntu mono greek */
@@ -81,9 +67,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Ubuntu Mono', 'Ubuntu-Mono', 'UbuntuMono', 'Ubuntu_Mono'),
-    url('../fonts/ubuntu-mono-v15-regular-greek.woff2') format('woff2');
+  src: url('../fonts/ubuntu-mono-v15-regular-greek.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* ubuntu mono latin-ext */
@@ -92,9 +76,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Ubuntu Mono', 'Ubuntu-Mono', 'UbuntuMono', 'Ubuntu_Mono'),
-    url('../fonts/ubuntu-mono-v15-regular-latin-ext.woff2') format('woff2');
+  src: url('../fonts/ubuntu-mono-v15-regular-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* ubuntu mono latin */
@@ -103,9 +85,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    local('Ubuntu Mono', 'Ubuntu-Mono', 'UbuntuMono', 'Ubuntu_Mono'),
-    url('../fonts/ubuntu-mono-v15-regular-latin.woff2') format('woff2');
+  src: url('../fonts/ubuntu-mono-v15-regular-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 


### PR DESCRIPTION
This PR removes the `local` function in the `@font-face` rules used to load fonts in the docs.

### Motivation

Removing the `local` function and always loading the font from the URL fixes an issue where fonts would sometimes not load properly (observed in Chrome on macOS).

Looking at the Google Fonts URL that we [used to load](https://github.com/gleam-lang/gleam/commit/4ec57a689c6637aad9b2076f5610cd67409f1590#diff-0a2b885976116f3f1750e64dbd5bad302d7261a174ec104e53b48940ee765e67L1):


```css
@import url("https://fonts.googleapis.com/css2?family=Karla:wght@400;700&family=Ubuntu+Mono&display=swap");
```

If we load this URL directly now this is what we get back: https://gist.github.com/maxdeviant/4ef9752063fbcb0ad15bb2cc0d2229b6

Notably, what _isn't_ present (at least at time of writing) is any use of `local()`:

```css
/* latin-ext */
@font-face {
  font-family: 'Karla';
  font-style: normal;
  font-weight: 400;
  font-display: swap;
  src: url(https://fonts.gstatic.com/s/karla/v30/qkB9XvYC6trAT55ZBi1ueQVIjQTD-JrIH2G7nytkHRyQ8p4wUjm6bmMorHBiTg.woff2) format('woff2');
  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
}
```

### Explanation

After removing the `local()` function calls I observed that the fonts now load properly across all of the browsers, including the one where it wasn't before.

There shouldn't be any reason to use `local()`, as it's quite unlikely that anyone will already have these fonts present on their system. And even if they do, the overhead of downloading a font file that we distribute is going to be negligible. 

Fixes #2208.