### PR TITLE
Added possibility to generate cli-completions from gleam command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-- Added possibility to generate cli-completions for gleam
+- The new `gleam shell-completions` command can be used to generate
+  completions for zsh, bash, fish, powershell and elvish.
 - The new `@target(erlang)` and `@target(javascript)` attribute syntax has been
   added for conditional compilation. The existing `if` conditional compilation
   syntax has been deprecated. Run `gleam format` to update your code.
 - The new `type TypeName` syntax syntax replaces the `external type TypeName`
-  syntax. The existing external type syntax has been deprecated. Run `gleam
-  format` to update your code.
+  syntax. The existing external type syntax has been deprecated. Run `gleam format`
+  to update your code.
 - Adding a new dependency now unlocks the target package. This helps avoid
   failing to find a suitable version for the package due to already being
   locked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added possibility to generate cli-completions for gleam
 - The new `@target(erlang)` and `@target(javascript)` attribute syntax has been
   added for conditional compilation. The existing `if` conditional compilation
   syntax has been deprecated. Run `gleam format` to update your code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +718,7 @@ dependencies = [
  "base16",
  "bytes",
  "clap",
+ "clap_complete",
  "ctrlc",
  "debug-ignore",
  "flate2",

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -14,6 +14,8 @@ im = "15.1.0"
 ctrlc = { version = "3.2.1", features = ["termination"] }
 # Command line interface
 clap = { version = "3.0", features = ["derive"] }
+# Command line completions
+clap_complete = { version = "3.2.5" }
 # Extra iter methods
 itertools = "0.10.1"
 # Parsing

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -231,7 +231,7 @@ enum Command {
     /// Outputs a completion script for given `shell`
     ///
     /// Output can be piped to the corresponding "completion-file" for your shell.
-    Completions {
+    ShellCompletions {
         /// Which shell to generate completions for
         #[clap(long, required = true, value_enum)]
         shell: Shell,
@@ -453,7 +453,7 @@ fn main() {
 
         Command::Export(ExportTarget::ErlangShipment) => export::erlang_shipment(),
         Command::Export(ExportTarget::HexTarball) => export::hex_tarball(),
-        Command::Completions { shell } => print_completions(shell),
+        Command::ShellCompletions { shell } => print_completions(shell),
     };
 
     match result {


### PR DESCRIPTION
Only tested for zsh on my side. Maybe it would be possible to ask if people in the gleam-community could test for some other shells, or I could do an exercise setting up at least the ones possible to run in linux in a container.

Issue: #2214