### PR TITLE
Add gap at end of doc page

### DIFF
--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -255,6 +255,7 @@ p code {
 
 .content {
   margin-left: var(--sidebar-width);
+  margin-bottom: var(--large-gap);
   padding: calc(var(--header-height) + var(--gap)) var(--gap) 0 var(--gap);
   width: calc(100% - var(--sidebar-width));
   max-width: var(--content-width);
@@ -469,6 +470,10 @@ body.drawer-open .label-closed {
 
 .module-members {
   margin-top: var(--large-gap);
+}
+
+.module-members:last-of-type .member:last-of-type {
+  margin-bottom: 0;
 }
 
 .module-member-kind {


### PR DESCRIPTION
Right now the doc pages have no bottom margin, this can make the page feel a bit cramped and the Lucy message, when toggled, can cover the README text:
<img width="861" alt="Screenshot 2023-06-20 alle 11 03 11" src="https://github.com/gleam-lang/gleam/assets/20598369/d71036e7-00ee-4f95-9f77-a725d04e1d91">
<img width="861" alt="Screenshot 2023-06-20 alle 11 03 14" src="https://github.com/gleam-lang/gleam/assets/20598369/a77a43d6-5070-4c7b-93cc-014c08f875ac">

In this PR I added a gap at the end of the page to make it breath a little:
<img width="932" alt="Screenshot 2023-06-20 alle 11 27 57" src="https://github.com/gleam-lang/gleam/assets/20598369/c0154b0a-080e-4123-b697-0fc3a910a895">
<img width="932" alt="Screenshot 2023-06-20 alle 11 28 01" src="https://github.com/gleam-lang/gleam/assets/20598369/a3d2182c-a4d6-418c-bf50-f03a379630a3">