### PR TITLE
feat: allow `gleam new` in existing directories

### DIFF
--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -50,11 +50,11 @@ enum FileToCreate {
 impl FileToCreate {
     pub fn location(&self, project_name: &str) -> PathBuf {
         match self {
-            FileToCreate::Readme => PathBuf::from("README.md"),
-            FileToCreate::Gitignore => PathBuf::from(".gitignore"),
-            FileToCreate::ProjectGleam => PathBuf::from(format!("{}.gleam", project_name)),
-            FileToCreate::TestGleam => PathBuf::from(format!("{}_test.gleam", project_name)),
-            FileToCreate::ConfigToml => PathBuf::from("gleam.toml"),
+            Self::Readme => PathBuf::from("README.md"),
+            Self::Gitignore => PathBuf::from(".gitignore"),
+            Self::ProjectGleam => PathBuf::from(format!("{}.gleam", project_name)),
+            Self::TestGleam => PathBuf::from(format!("{}_test.gleam", project_name)),
+            Self::ConfigToml => PathBuf::from("gleam.toml"),
         }
     }
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -149,6 +149,12 @@ pub enum Error {
     #[error("project root already exists")]
     ProjectRootAlreadyExist { path: String },
 
+    #[error("File(s) already exist in {path}: {}", file_names.join(", "))]
+    OutputFilesAlreadyExist {
+        path: String,
+        file_names: Vec<String>,
+    },
+
     #[error("unable to find project root")]
     UnableToFindProjectRoot { path: String },
 
@@ -545,6 +551,23 @@ to `src/{module}.gleam`"
             Error::ProjectRootAlreadyExist { path } => Diagnostic {
                 title: "Project folder already exists".into(),
                 text: format!("Project folder root:\n\n  {path}"),
+                level: Level::Error,
+                hint: None,
+                location: None,
+            },
+
+            Error::OutputFilesAlreadyExist { path, file_names } => Diagnostic {
+                title: "File(s) already exists in target directory".into(),
+                text: format!(
+                    "{}
+                
+If you want to overwrite these files, delete them and run the command again.
+",
+                    file_names
+                        .iter()
+                        .map(|name| format!("- {}/{}", path, name))
+                        .join("\n")
+                ),
                 level: Level::Error,
                 hint: None,
                 location: None,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -149,10 +149,10 @@ pub enum Error {
     #[error("project root already exists")]
     ProjectRootAlreadyExist { path: String },
 
-    #[error("File(s) already exist in {path}: {}", file_names.join(", "))]
+    #[error("File(s) already exist in {path}: {}", file_names.iter().map(|x| x.as_path().display().to_string()).join(", "))]
     OutputFilesAlreadyExist {
-        path: String,
-        file_names: Vec<String>,
+        path: PathBuf,
+        file_names: Vec<PathBuf>,
     },
 
     #[error("unable to find project root")]
@@ -565,7 +565,7 @@ If you want to overwrite these files, delete them and run the command again.
 ",
                     file_names
                         .iter()
-                        .map(|name| format!("- {}/{}", path, name))
+                        .map(|name| format!("- {}/{}", path.display(), name.display()))
                         .join("\n")
                 ),
                 level: Level::Error,


### PR DESCRIPTION
Fixes #1879. Per the feedback from @lpil in #1881, this also allows running in an existing folder as long as the generated files do not already exist. It'll produce an output like the screenshot below.

![image](https://github.com/gleam-lang/gleam/assets/784953/c5f2b7cd-8a65-421d-90d5-ae4a93f233c3)

This will allow you to:
- `gleam new --name something .` (in an existing folder)
- `gleam new --name existing existing` (will add in generated files in addition to whatever exists when not empty)

I opted for the `enum` to prevent typos. I saw that this same treatment could be applied to the compiler... perhaps it worth adopting across both workspaces?

Anddd, we could also consider a `--force` flag here to overwrite the existing files, but will wait on feedback before considering.

Thanks and let me know if you have any feedback! I'd be happy to address it 🎉 
