### PR TITLE
Poor formatting of external function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug where the formatter would incorrectly format external functions
+  by breaking the return annotation instead of the function arguments.
+
 ## v0.30.1 - 2023-07-13
 
 - Fixed a bug where the language server could fail to import path dependencies
@@ -41,7 +46,7 @@
 - The Erlang error raised by `let assert` is now tagged `let_assert`.
 - Types named `Dynamic` are now called `dynamic_` in Erlang to avoid a clash
   with the new Erlang `dynamic` type introduced in OTP26.
-- Dependencies can now be loaded from paths using the 
+- Dependencies can now be loaded from paths using the
   `packagename = { path = "..." }` syntax in `gleam.toml`.
 - The `javascript.deno.unstable` field in `gleam.toml` can now be used to
   enable Deno's unstable APIs when targeting JavaScript.

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -495,34 +495,35 @@ impl<'comments> Formatter<'comments> {
     }
 
     fn statement_fn<'a>(&mut self, function: &'a Function<(), UntypedExpr>) -> Document<'a> {
-        let doc = docvec![];
+        let attributes = docvec![];
 
         // Attributes
         let external = |t: &'static str, m: &'a str, f: &'a str| {
             docvec!["@external(", t, ", \"", m, "\", \"", f, "\")", line()]
         };
-        let doc = match function.external_erlang.as_ref() {
-            Some((m, f)) => doc.append(external("erlang", m, f)),
-            None => doc,
+        let attributes = match function.external_erlang.as_ref() {
+            Some((m, f)) => attributes.append(external("erlang", m, f)),
+            None => attributes,
         };
-        let doc = match function.external_javascript.as_ref() {
-            Some((m, f)) => doc.append(external("javascript", m, f)),
-            None => doc,
+        let attributes = match function.external_javascript.as_ref() {
+            Some((m, f)) => attributes.append(external("javascript", m, f)),
+            None => attributes,
         };
 
         // Fn name and args
-        let head = doc
-            .append(pub_(function.public))
+        let signature = pub_(function.public)
             .append("fn ")
             .append(&function.name)
             .append(wrap_args(function.arguments.iter().map(|e| self.fn_arg(e))));
 
         // Add return annotation
-        let head = match &function.return_annotation {
-            Some(anno) => head.append(" -> ").append(self.type_ast(anno)),
-            None => head,
+        let signature = match &function.return_annotation {
+            Some(anno) => signature.append(" -> ").append(self.type_ast(anno)),
+            None => signature,
         }
         .group();
+
+        let head = attributes.append(signature);
 
         let body = &function.body;
         if body.len() == 1 && body.first().is_placeholder() {

--- a/compiler-core/src/format/tests/external_fn.rs
+++ b/compiler-core/src/format/tests/external_fn.rs
@@ -61,3 +61,17 @@ fn one(x: Int) -> Int {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2259
+#[test]
+fn break_external_fn_arguments() {
+    assert_format!(
+        r#"@external(erlang, "ffi", "improper_list_append")
+fn improper_list_append(
+  a: item_a,
+  b: item_b,
+  c: improper_tail,
+) -> List(anything)
+"#
+    );
+}


### PR DESCRIPTION
#2259 

👋 

I think the line in the annotation meant the formatter was ignoring the head group.
Fixed this by adding a group for the signature before appending it to the attributes.