### PR TITLE
use UTF8 paths from camino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Replaced std::path::{Path, PathBuf} with camino::{Utf8Path, Utf8PathBuf}
 - Fixed a bug where the formatter would incorrectly format external functions
   by breaking the return annotation instead of the function arguments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Replaced std::path::{Path, PathBuf} with camino::{Utf8Path, Utf8PathBuf}
 - Fixed a bug where the formatter would incorrectly format external functions
   by breaking the return annotation instead of the function arguments.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "capnp"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +717,7 @@ dependencies = [
  "atty",
  "base16",
  "bytes",
+ "camino",
  "clap",
  "ctrlc",
  "debug-ignore",
@@ -757,6 +767,7 @@ dependencies = [
  "base16",
  "bincode",
  "bytes",
+ "camino",
  "capnp",
  "capnpc",
  "codespan-reporting",
@@ -801,6 +812,7 @@ dependencies = [
 name = "gleam-wasm"
 version = "0.30.1"
 dependencies = [
+ "camino",
  "console_error_panic_hook",
  "gleam-core",
  "hexpm",
@@ -2107,6 +2119,7 @@ dependencies = [
 name = "test-package-compiler"
 version = "0.30.1"
 dependencies = [
+ "camino",
  "gleam-core",
  "im",
  "insta",

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -82,6 +82,7 @@ smol_str = "0.1"
 same-file = "1.0.6"
 # Open generated docs in browser
 opener = "0.6"
+camino = { version = "1.1.6", features = ["serde1"] }
 
 [dev-dependencies]
 # Test assertion errors with diffs

--- a/compiler-cli/clippy.toml
+++ b/compiler-cli/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+  { path = "std::path::Path::new", reason = "Manually constructed paths should use camino::Utf8Path" },
+  { path = "std::path::PathBuf::new", reason = "Manually constructed pathbufs should use camino::Utf8Path" },
+]

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use camino::{Utf8Path, Utf8PathBuf};
 
 use gleam_core::{
     error::{FileIoAction, FileKind},
@@ -25,7 +25,7 @@ pub fn command(packages: Vec<String>, dev: bool) -> Result<()> {
         .map_err(|e| Error::FileIo {
             kind: FileKind::File,
             action: FileIoAction::Parse,
-            path: PathBuf::from("gleam.toml"),
+            path: Utf8PathBuf::from("gleam.toml"),
             err: Some(e.to_string()),
         })?;
 
@@ -56,7 +56,7 @@ pub fn command(packages: Vec<String>, dev: bool) -> Result<()> {
     }
 
     // Write the updated config
-    fs::write(Path::new("gleam.toml"), &toml.to_string())?;
+    fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
 
     Ok(())
 }

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -2,9 +2,10 @@ use std::{sync::Arc, time::Instant};
 
 use gleam_core::{
     build::{Built, Codegen, Options, ProjectCompiler},
+    io::utf8_or_panic,
     manifest::Manifest,
     paths::ProjectPaths,
-    Result, io::utf8_or_panic,
+    Result,
 };
 
 use crate::{
@@ -31,9 +32,8 @@ pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
         options.mode,
         options.target.unwrap_or(root_config.target),
     )?;
-    let current_dir = utf8_or_panic(
-        std::env::current_dir().expect("Failed to get current directory"),
-    );
+    let current_dir =
+        utf8_or_panic(std::env::current_dir().expect("Failed to get current directory"));
 
     tracing::info!("Compiling packages");
     let compiled = {

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -1,11 +1,10 @@
-use camino::Utf8PathBuf;
 use std::{sync::Arc, time::Instant};
 
 use gleam_core::{
     build::{Built, Codegen, Options, ProjectCompiler},
     manifest::Manifest,
     paths::ProjectPaths,
-    Result,
+    Result, io::utf8_or_panic,
 };
 
 use crate::{
@@ -32,10 +31,9 @@ pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
         options.mode,
         options.target.unwrap_or(root_config.target),
     )?;
-    let current_dir = Utf8PathBuf::from_path_buf(
+    let current_dir = utf8_or_panic(
         std::env::current_dir().expect("Failed to get current directory"),
-    )
-    .expect("Non Utf-8 Path");
+    );
 
     tracing::info!("Compiling packages");
     let compiled = {

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -2,7 +2,6 @@ use std::{sync::Arc, time::Instant};
 
 use gleam_core::{
     build::{Built, Codegen, Options, ProjectCompiler},
-    io::utf8_or_panic,
     manifest::Manifest,
     paths::ProjectPaths,
     Result,
@@ -12,7 +11,7 @@ use crate::{
     build_lock::BuildLock,
     cli,
     dependencies::UseManifest,
-    fs::{self, ConsoleWarningEmitter},
+    fs::{self, utf8_or_panic, ConsoleWarningEmitter},
 };
 
 pub fn download_dependencies() -> Result<Manifest> {

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -11,7 +11,7 @@ use crate::{
     build_lock::BuildLock,
     cli,
     dependencies::UseManifest,
-    fs::{self, utf8_or_panic, ConsoleWarningEmitter},
+    fs::{self, get_current_directory, ConsoleWarningEmitter},
 };
 
 pub fn download_dependencies() -> Result<Manifest> {
@@ -31,8 +31,7 @@ pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
         options.mode,
         options.target.unwrap_or(root_config.target),
     )?;
-    let current_dir =
-        utf8_or_panic(std::env::current_dir().expect("Failed to get current directory"));
+    let current_dir = get_current_directory().expect("Failed to get current directory");
 
     tracing::info!("Compiling packages");
     let compiled = {

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -1,3 +1,4 @@
+use camino::Utf8PathBuf;
 use std::{sync::Arc, time::Instant};
 
 use gleam_core::{
@@ -31,7 +32,10 @@ pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
         options.mode,
         options.target.unwrap_or(root_config.target),
     )?;
-    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let current_dir = Utf8PathBuf::from_path_buf(
+        std::env::current_dir().expect("Failed to get current directory"),
+    )
+    .expect("Non Utf-8 Path");
 
     tracing::info!("Compiling packages");
     let compiled = {

--- a/compiler-cli/src/build_lock.rs
+++ b/compiler-cli/src/build_lock.rs
@@ -36,7 +36,7 @@ impl BuildLock {
         crate::fs::mkdir(&self.directory).expect("Could not create lock directory");
 
         let lock_path = self.directory.join("gleam.lock");
-        let mut file = fslock::LockFile::open(&lock_path.to_string()).expect("LockFile creation");
+        let mut file = fslock::LockFile::open(lock_path.as_str()).expect("LockFile creation");
 
         if !file.try_lock_with_pid().expect("Trying build locking") {
             telemetry.waiting_for_build_directory_lock();

--- a/compiler-cli/src/build_lock.rs
+++ b/compiler-cli/src/build_lock.rs
@@ -1,14 +1,14 @@
+use camino::Utf8PathBuf;
 use gleam_core::{
     build::{Mode, Target, Telemetry},
     paths::ProjectPaths,
     Result,
 };
-use std::path::PathBuf;
 use strum::IntoEnumIterator;
 
 #[derive(Debug)]
 pub(crate) struct BuildLock {
-    directory: PathBuf,
+    directory: Utf8PathBuf,
 }
 
 impl BuildLock {
@@ -36,7 +36,7 @@ impl BuildLock {
         crate::fs::mkdir(&self.directory).expect("Could not create lock directory");
 
         let lock_path = self.directory.join("gleam.lock");
-        let mut file = fslock::LockFile::open(&lock_path).expect("LockFile creation");
+        let mut file = fslock::LockFile::open(&lock_path.to_string()).expect("LockFile creation");
 
         if !file.try_lock_with_pid().expect("Trying build locking") {
             telemetry.waiting_for_build_directory_lock();

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -11,7 +11,7 @@ use gleam_core::{
     type_::ModuleInterface,
     uid::UniqueIdGenerator,
     warning::WarningEmitter,
-    Result
+    Result,
 };
 use smol_str::SmolStr;
 use std::sync::Arc;

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -3,7 +3,7 @@ use crate::{
     fs::{self, ConsoleWarningEmitter, ProjectIO},
     CompilePackage,
 };
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use gleam_core::{
     build::{Mode, PackageCompiler, StaleTracker, Target, TargetCodegenConfiguration},
     metadata,
@@ -11,7 +11,7 @@ use gleam_core::{
     type_::ModuleInterface,
     uid::UniqueIdGenerator,
     warning::WarningEmitter,
-    Result,
+    Result
 };
 use smol_str::SmolStr;
 use std::sync::Arc;
@@ -62,8 +62,7 @@ fn load_libraries(
     tracing::info!("Reading precompiled module metadata files");
     let mut manifests = im::HashMap::new();
     for lib in fs::read_dir(lib)?.filter_map(Result::ok) {
-        let path = Utf8PathBuf::from_path_buf(lib.path().join(paths::ARTEFACT_DIRECTORY_NAME))
-            .expect("Non Utf-8 Path");
+        let path = lib.path().join(paths::ARTEFACT_DIRECTORY_NAME);
         if !path.is_dir() {
             continue;
         }
@@ -73,5 +72,6 @@ fn load_libraries(
             let _ = manifests.insert(module.name.clone(), module);
         }
     }
+
     Ok(manifests)
 }

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -3,6 +3,7 @@ use crate::{
     fs::{self, ConsoleWarningEmitter, ProjectIO},
     CompilePackage,
 };
+use camino::{Utf8Path, Utf8PathBuf};
 use gleam_core::{
     build::{Mode, PackageCompiler, StaleTracker, Target, TargetCodegenConfiguration},
     metadata,
@@ -13,7 +14,7 @@ use gleam_core::{
     Result,
 };
 use smol_str::SmolStr;
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 pub fn command(options: CompilePackage) -> Result<()> {
     let ids = UniqueIdGenerator::new();
@@ -56,12 +57,13 @@ pub fn command(options: CompilePackage) -> Result<()> {
 
 fn load_libraries(
     ids: &UniqueIdGenerator,
-    lib: &Path,
+    lib: &Utf8Path,
 ) -> Result<im::HashMap<SmolStr, ModuleInterface>> {
     tracing::info!("Reading precompiled module metadata files");
     let mut manifests = im::HashMap::new();
     for lib in fs::read_dir(lib)?.filter_map(Result::ok) {
-        let path = lib.path().join(paths::ARTEFACT_DIRECTORY_NAME);
+        let path = Utf8PathBuf::from_path_buf(lib.path().join(paths::ARTEFACT_DIRECTORY_NAME))
+            .expect("Non Utf-8 Path");
         if !path.is_dir() {
             continue;
         }

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -7,11 +7,10 @@ use gleam_core::{
     paths::ProjectPaths,
 };
 
-use crate::fs::utf8_or_panic;
+use crate::fs::get_current_directory;
 
 pub fn root_config() -> Result<PackageConfig, Error> {
-    let current_dir =
-        utf8_or_panic(std::env::current_dir().expect("Could not get current directory"));
+    let current_dir = get_current_directory().expect("Failed to get current directory");
     let paths = ProjectPaths::new(current_dir);
     read(paths.root_config())
 }

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -3,10 +3,11 @@ use camino::Utf8PathBuf;
 use gleam_core::{
     config::PackageConfig,
     error::{Error, FileIoAction, FileKind},
-    io::utf8_or_panic,
     manifest::Manifest,
     paths::ProjectPaths,
 };
+
+use crate::fs::utf8_or_panic;
 
 pub fn root_config() -> Result<PackageConfig, Error> {
     let current_dir =

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -4,14 +4,13 @@ use gleam_core::{
     config::PackageConfig,
     error::{Error, FileIoAction, FileKind},
     manifest::Manifest,
-    paths::ProjectPaths,
+    paths::ProjectPaths, io::utf8_or_panic,
 };
 
 pub fn root_config() -> Result<PackageConfig, Error> {
-    let current_dir = Utf8PathBuf::from_path_buf(
+    let current_dir = utf8_or_panic(
         std::env::current_dir().expect("Could not get current directory"),
-    )
-    .expect("Non Utf-8 Path");
+    );
     let paths = ProjectPaths::new(current_dir);
     read(paths.root_config())
 }

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use gleam_core::{
     config::PackageConfig,
@@ -8,7 +8,10 @@ use gleam_core::{
 };
 
 pub fn root_config() -> Result<PackageConfig, Error> {
-    let current_dir = std::env::current_dir().expect("Could not get current directory");
+    let current_dir = Utf8PathBuf::from_path_buf(
+        std::env::current_dir().expect("Could not get current directory"),
+    )
+    .expect("Non Utf-8 Path");
     let paths = ProjectPaths::new(current_dir);
     read(paths.root_config())
 }
@@ -53,7 +56,7 @@ pub fn find_package_config_for_module(
     }
 }
 
-pub fn read(config_path: PathBuf) -> Result<PackageConfig, Error> {
+pub fn read(config_path: Utf8PathBuf) -> Result<PackageConfig, Error> {
     let toml = crate::fs::read(&config_path)?;
     let config: PackageConfig = toml::from_str(&toml).map_err(|e| Error::FileIo {
         action: FileIoAction::Parse,

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -3,14 +3,14 @@ use camino::Utf8PathBuf;
 use gleam_core::{
     config::PackageConfig,
     error::{Error, FileIoAction, FileKind},
+    io::utf8_or_panic,
     manifest::Manifest,
-    paths::ProjectPaths, io::utf8_or_panic,
+    paths::ProjectPaths,
 };
 
 pub fn root_config() -> Result<PackageConfig, Error> {
-    let current_dir = utf8_or_panic(
-        std::env::current_dir().expect("Could not get current directory"),
-    );
+    let current_dir =
+        utf8_or_panic(std::env::current_dir().expect("Could not get current directory"));
     let paths = ProjectPaths::new(current_dir);
     read(paths.root_config())
 }

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -1,5 +1,6 @@
-use std::path::Path;
 use std::time::Instant;
+
+use camino::Utf8Path;
 
 use crate::{cli, hex::ApiKeyCommand, http::HttpClient};
 use gleam_core::{
@@ -84,7 +85,7 @@ pub fn build(options: BuildOptions) -> Result<()> {
     println!(
         "\nThe documentation for {package} has been rendered to \n{index_html}",
         package = config.name,
-        index_html = index_html.to_string_lossy()
+        index_html = index_html
     );
 
     if options.open {
@@ -99,7 +100,7 @@ pub fn build(options: BuildOptions) -> Result<()> {
 ///
 /// For the docs this will generally be a browser (unless some other program is
 /// configured as the default for `.html` files).
-fn open_docs(path: &Path) -> Result<()> {
+fn open_docs(path: &Utf8Path) -> Result<()> {
     opener::open(path).map_err(|error| Error::FailedToOpenDocs {
         path: path.to_path_buf(),
         error: error.to_string(),

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -46,9 +46,9 @@ pub(crate) fn erlang_shipment() -> Result<()> {
             continue;
         }
 
-        let name = path.file_name().expect("Directory name").to_string_lossy();
-        let build = build.join(name.as_ref());
-        let out = out.join(name.as_ref());
+        let name = path.file_name().expect("Directory name");
+        let build = build.join(name);
+        let out = out.join(name);
         crate::fs::mkdir(&out)?;
 
         // Copy desired package subdirectories

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -79,8 +79,8 @@ the entrypoint.sh script.
 
     {entrypoint}
 ",
-        path = out.to_string_lossy(),
-        entrypoint = entrypoint.to_string_lossy(),
+        path = out,
+        entrypoint = entrypoint,
     );
 
     Ok(())
@@ -97,7 +97,7 @@ pub fn hex_tarball() -> Result<()> {
         "
 Your hex tarball has been generated in {}.
 ",
-        &path.display()
+        &path
     );
     Ok(())
 }

--- a/compiler-cli/src/fix.rs
+++ b/compiler-cli/src/fix.rs
@@ -1,18 +1,19 @@
+use camino::Utf8PathBuf;
 use gleam_core::{
     build::Target,
     error::{FileIoAction, FileKind},
     Error, Result,
 };
-use std::{path::PathBuf, str::FromStr};
+use std::str::FromStr;
 
 pub fn run(target: Option<Target>, files: Vec<String>) -> Result<()> {
     let mut complete = true;
 
     for file_path in files {
-        let path = PathBuf::from_str(&file_path).map_err(|e| Error::FileIo {
+        let path = Utf8PathBuf::from_str(&file_path).map_err(|e| Error::FileIo {
             action: FileIoAction::Open,
             kind: FileKind::File,
-            path: PathBuf::from(file_path),
+            path: Utf8PathBuf::from(file_path),
             err: Some(e.to_string()),
         })?;
 
@@ -35,7 +36,7 @@ pub fn run(target: Option<Target>, files: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn fix_file(target: Option<Target>, path: PathBuf) -> Result<bool> {
+fn fix_file(target: Option<Target>, path: Utf8PathBuf) -> Result<bool> {
     let src = crate::fs::read(&path)?;
     let (out, complete) = gleam_core::fix::parse_fix_and_format(target, &src.into(), &path)?;
     crate::fs::write(&path, &out)?;

--- a/compiler-cli/src/format.rs
+++ b/compiler-cli/src/format.rs
@@ -3,11 +3,9 @@ use gleam_core::{
     io::Content,
     io::OutputFile,
 };
-use std::{
-    io::Read,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{io::Read, str::FromStr};
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 pub fn run(stdin: bool, check: bool, files: Vec<String>) -> Result<()> {
     if stdin {
@@ -20,7 +18,7 @@ pub fn run(stdin: bool, check: bool, files: Vec<String>) -> Result<()> {
 fn process_stdin(check: bool) -> Result<()> {
     let src = read_stdin()?.into();
     let mut out = String::new();
-    gleam_core::format::pretty(&mut out, &src, Path::new("<stdin>"))?;
+    gleam_core::format::pretty(&mut out, &src, Utf8Path::new("<stdin>"))?;
 
     if !check {
         print!("{out}");
@@ -30,8 +28,8 @@ fn process_stdin(check: bool) -> Result<()> {
     if src != out {
         return Err(Error::Format {
             problem_files: vec![Unformatted {
-                source: PathBuf::from("<standard input>"),
-                destination: PathBuf::from("<standard output>"),
+                source: Utf8PathBuf::from("<standard input>"),
+                destination: Utf8PathBuf::from("<standard output>"),
                 input: src,
                 output: out,
             }],
@@ -73,10 +71,10 @@ pub fn unformatted_files(files: Vec<String>) -> Result<Vec<Unformatted>> {
     let mut problem_files = Vec::with_capacity(files.len());
 
     for file_path in files {
-        let path = PathBuf::from_str(&file_path).map_err(|e| Error::FileIo {
+        let path = Utf8PathBuf::from_str(&file_path).map_err(|e| Error::FileIo {
             action: FileIoAction::Open,
             kind: FileKind::File,
-            path: PathBuf::from(file_path),
+            path: Utf8PathBuf::from(file_path),
             err: Some(e.to_string()),
         })?;
 
@@ -92,7 +90,7 @@ pub fn unformatted_files(files: Vec<String>) -> Result<Vec<Unformatted>> {
     Ok(problem_files)
 }
 
-fn format_file(problem_files: &mut Vec<Unformatted>, path: PathBuf) -> Result<()> {
+fn format_file(problem_files: &mut Vec<Unformatted>, path: Utf8PathBuf) -> Result<()> {
     let src = crate::fs::read(&path)?.into();
     let mut output = String::new();
     gleam_core::format::pretty(&mut output, &src, &path)?;

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -27,6 +27,13 @@ use crate::{dependencies::UseManifest, lsp::LspLocker};
 #[cfg(test)]
 mod tests;
 
+/// This is a helper function for converting from `PathBuf` to `Utf8PathBuf`.
+/// We simply panic on non-utf8 paths.
+///
+pub fn utf8_or_panic(input: std::path::PathBuf) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(input).expect("Non Utf8 Path")
+}
+
 /// A `FileWriter` implementation that writes to the file system.
 #[derive(Debug, Clone, Copy)]
 pub struct ProjectIO;

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -17,9 +17,10 @@ use std::{
     fmt::Debug,
     fs::File,
     io::{self, BufRead, BufReader, Write},
-    path::{Path, PathBuf},
     time::SystemTime,
 };
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::{dependencies::UseManifest, lsp::LspLocker};
 
@@ -41,7 +42,7 @@ impl ProjectIO {
 }
 
 impl FileSystemReader for ProjectIO {
-    fn gleam_source_files(&self, dir: &Path) -> Vec<PathBuf> {
+    fn gleam_source_files(&self, dir: &Utf8Path) -> Vec<Utf8PathBuf> {
         if !dir.is_dir() {
             return vec![];
         }
@@ -53,10 +54,11 @@ impl FileSystemReader for ProjectIO {
             .filter(|e| e.file_type().is_file())
             .map(|d| d.into_path())
             .filter(move |d| d.extension() == Some(OsStr::new("gleam")))
+            .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
             .collect()
     }
 
-    fn gleam_cache_files(&self, dir: &Path) -> Vec<PathBuf> {
+    fn gleam_cache_files(&self, dir: &Utf8Path) -> Vec<Utf8PathBuf> {
         if !dir.is_dir() {
             return vec![];
         }
@@ -68,38 +70,45 @@ impl FileSystemReader for ProjectIO {
             .filter(|e| e.file_type().is_file())
             .map(|d| d.into_path())
             .filter(|p| p.extension().and_then(OsStr::to_str) == Some("cache"))
+            .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
             .collect()
     }
 
-    fn read(&self, path: &Path) -> Result<String, Error> {
+    fn read(&self, path: &Utf8Path) -> Result<String, Error> {
         read(path)
     }
 
-    fn read_bytes(&self, path: &Path) -> Result<Vec<u8>, Error> {
+    fn read_bytes(&self, path: &Utf8Path) -> Result<Vec<u8>, Error> {
         read_bytes(path)
     }
 
-    fn is_file(&self, path: &Path) -> bool {
+    fn is_file(&self, path: &Utf8Path) -> bool {
         path.is_file()
     }
 
-    fn is_directory(&self, path: &Path) -> bool {
+    fn is_directory(&self, path: &Utf8Path) -> bool {
         path.is_dir()
     }
 
-    fn reader(&self, path: &Path) -> Result<WrappedReader, Error> {
+    fn reader(&self, path: &Utf8Path) -> Result<WrappedReader, Error> {
         reader(path)
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+    fn read_dir(&self, path: &Utf8Path) -> Result<ReadDir> {
         read_dir(path).map(|entries| {
             entries
-                .map(|result| result.map(|entry| DirEntry::from_path(entry.path())))
+                .map(|result| {
+                    result.map(|entry| {
+                        DirEntry::from_path(
+                            Utf8PathBuf::from_path_buf(entry.path()).expect("Non Utf-8 Path"),
+                        )
+                    })
+                })
                 .collect()
         })
     }
 
-    fn modification_time(&self, path: &Path) -> Result<SystemTime, Error> {
+    fn modification_time(&self, path: &Utf8Path) -> Result<SystemTime, Error> {
         path.metadata()
             .map(|m| m.modified().unwrap_or_else(|_| SystemTime::now()))
             .map_err(|e| Error::FileIo {
@@ -110,45 +119,45 @@ impl FileSystemReader for ProjectIO {
             })
     }
 
-    fn canonicalise(&self, path: &Path) -> Result<PathBuf, Error> {
+    fn canonicalise(&self, path: &Utf8Path) -> Result<Utf8PathBuf, Error> {
         canonicalise(path)
     }
 }
 
 impl FileSystemWriter for ProjectIO {
-    fn delete(&self, path: &Path) -> Result<()> {
+    fn delete(&self, path: &Utf8Path) -> Result<()> {
         delete_dir(path)
     }
 
-    fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+    fn copy(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         copy(from, to)
     }
 
-    fn copy_dir(&self, from: &Path, to: &Path) -> Result<()> {
+    fn copy_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         copy_dir(from, to)
     }
 
-    fn mkdir(&self, path: &Path) -> Result<(), Error> {
+    fn mkdir(&self, path: &Utf8Path) -> Result<(), Error> {
         mkdir(path)
     }
 
-    fn hardlink(&self, from: &Path, to: &Path) -> Result<(), Error> {
+    fn hardlink(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error> {
         hardlink(from, to)
     }
 
-    fn symlink_dir(&self, from: &Path, to: &Path) -> Result<(), Error> {
+    fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error> {
         symlink_dir(from, to)
     }
 
-    fn delete_file(&self, path: &Path) -> Result<()> {
+    fn delete_file(&self, path: &Utf8Path) -> Result<()> {
         delete_file(path)
     }
 
-    fn write(&self, path: &Path, content: &str) -> Result<(), Error> {
+    fn write(&self, path: &Utf8Path, content: &str) -> Result<(), Error> {
         write(path, content)
     }
 
-    fn write_bytes(&self, path: &Path, content: &[u8]) -> Result<(), Error> {
+    fn write_bytes(&self, path: &Utf8Path, content: &[u8]) -> Result<(), Error> {
         write_bytes(path, content)
     }
 }
@@ -159,7 +168,7 @@ impl CommandExecutor for ProjectIO {
         program: &str,
         args: &[String],
         env: &[(&str, String)],
-        cwd: Option<&Path>,
+        cwd: Option<&Utf8Path>,
         stdio: Stdio,
     ) -> Result<i32, Error> {
         tracing::trace!(program=program, args=?args.join(" "), env=?env, cwd=?cwd, "command_exec");
@@ -168,7 +177,7 @@ impl CommandExecutor for ProjectIO {
             .stdin(stdio.get_process_stdio())
             .stdout(stdio.get_process_stdio())
             .envs(env.iter().map(|(a, b)| (a, b)))
-            .current_dir(cwd.unwrap_or_else(|| Path::new("./")))
+            .current_dir(cwd.unwrap_or_else(|| Utf8Path::new("./")))
             .status();
 
         match result {
@@ -201,7 +210,7 @@ impl DownloadDependencies for ProjectIO {
     }
 }
 
-pub fn delete_dir(dir: &Path) -> Result<(), Error> {
+pub fn delete_dir(dir: &Utf8Path) -> Result<(), Error> {
     tracing::trace!(path=?dir, "deleting_directory");
     if dir.exists() {
         std::fs::remove_dir_all(dir).map_err(|e| Error::FileIo {
@@ -216,7 +225,7 @@ pub fn delete_dir(dir: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn delete_file(file: &Path) -> Result<(), Error> {
+pub fn delete_file(file: &Utf8Path) -> Result<(), Error> {
     tracing::trace!("Deleting file {:?}", file);
     if file.exists() {
         std::fs::remove_file(file).map_err(|e| Error::FileIo {
@@ -231,7 +240,7 @@ pub fn delete_file(file: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn write_outputs_under(outputs: &[OutputFile], base: &Path) -> Result<(), Error> {
+pub fn write_outputs_under(outputs: &[OutputFile], base: &Utf8Path) -> Result<(), Error> {
     for file in outputs {
         let path = base.join(&file.path);
         match &file.content {
@@ -250,12 +259,12 @@ pub fn write_output(file: &OutputFile) -> Result<(), Error> {
     }
 }
 
-pub fn write(path: &Path, text: &str) -> Result<(), Error> {
+pub fn write(path: &Utf8Path, text: &str) -> Result<(), Error> {
     write_bytes(path, text.as_bytes())
 }
 
 #[cfg(target_family = "unix")]
-pub fn make_executable(path: impl AsRef<Path>) -> Result<(), Error> {
+pub fn make_executable(path: impl AsRef<Utf8Path>) -> Result<(), Error> {
     use std::os::unix::fs::PermissionsExt;
     tracing::trace!(path = ?path.as_ref(), "setting_permissions");
 
@@ -271,11 +280,11 @@ pub fn make_executable(path: impl AsRef<Path>) -> Result<(), Error> {
 }
 
 #[cfg(not(target_family = "unix"))]
-pub fn make_executable(_path: impl AsRef<Path>) -> Result<(), Error> {
+pub fn make_executable(_path: impl AsRef<Utf8Path>) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn write_bytes(path: &Path, bytes: &[u8]) -> Result<(), Error> {
+pub fn write_bytes(path: &Utf8Path, bytes: &[u8]) -> Result<(), Error> {
     tracing::trace!(path=?path, "writing_file");
 
     let dir_path = path.parent().ok_or_else(|| Error::FileIo {
@@ -308,7 +317,7 @@ pub fn write_bytes(path: &Path, bytes: &[u8]) -> Result<(), Error> {
     Ok(())
 }
 
-fn is_gleam_path(path: &Path, dir: impl AsRef<Path>) -> bool {
+fn is_gleam_path(path: &Utf8Path, dir: impl AsRef<Utf8Path>) -> bool {
     use regex::Regex;
     lazy_static! {
         static ref RE: Regex = Regex::new(&format!(
@@ -320,14 +329,13 @@ fn is_gleam_path(path: &Path, dir: impl AsRef<Path>) -> bool {
     }
 
     RE.is_match(
-        path.strip_prefix(dir)
+        path.strip_prefix(dir.as_ref())
             .expect("is_gleam_path(): strip_prefix")
-            .to_str()
-            .expect("is_gleam_path(): to_str"),
+            .as_str(),
     )
 }
 
-pub fn gleam_files_excluding_gitignore(dir: &Path) -> impl Iterator<Item = PathBuf> + '_ {
+pub fn gleam_files_excluding_gitignore(dir: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
     ignore::WalkBuilder::new(dir)
         .follow_links(true)
         .require_git(false)
@@ -335,24 +343,22 @@ pub fn gleam_files_excluding_gitignore(dir: &Path) -> impl Iterator<Item = PathB
         .filter_map(Result::ok)
         .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
         .map(ignore::DirEntry::into_path)
+        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
         .filter(move |d| is_gleam_path(d, dir))
 }
 
-pub fn native_files(dir: &Path) -> Result<impl Iterator<Item = PathBuf> + '_> {
+pub fn native_files(dir: &Utf8Path) -> Result<impl Iterator<Item = Utf8PathBuf> + '_> {
     Ok(read_dir(dir)?
         .flat_map(Result::ok)
         .map(|e| e.path())
+        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
         .filter(|path| {
-            let extension = path
-                .extension()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+            let extension = path.extension().unwrap_or_default();
             matches!(extension, "erl" | "hrl" | "ex" | "js" | "mjs" | "ts")
         }))
 }
 
-pub fn private_files_excluding_gitignore(dir: &Path) -> impl Iterator<Item = PathBuf> + '_ {
+pub fn private_files_excluding_gitignore(dir: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
     ignore::WalkBuilder::new(dir)
         .follow_links(true)
         .require_git(false)
@@ -360,18 +366,16 @@ pub fn private_files_excluding_gitignore(dir: &Path) -> impl Iterator<Item = Pat
         .filter_map(Result::ok)
         .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
         .map(ignore::DirEntry::into_path)
+        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
 }
 
-pub fn erlang_files(dir: &Path) -> Result<impl Iterator<Item = PathBuf> + '_> {
+pub fn erlang_files(dir: &Utf8Path) -> Result<impl Iterator<Item = Utf8PathBuf> + '_> {
     Ok(read_dir(dir)?
         .flat_map(Result::ok)
         .map(|e| e.path())
+        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
         .filter(|path| {
-            let extension = path
-                .extension()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+            let extension = path.extension().unwrap_or_default();
             extension == "erl" || extension == "hrl"
         }))
 }
@@ -405,102 +409,106 @@ pub fn create_tar_archive(outputs: Vec<OutputFile>) -> Result<Vec<u8>, Error> {
         .map_err(|e| Error::Gzip(e.to_string()))
 }
 
-pub fn mkdir(path: impl AsRef<Path> + Debug) -> Result<(), Error> {
+pub fn mkdir(path: impl AsRef<Utf8Path> + Debug) -> Result<(), Error> {
     if path.as_ref().exists() {
         return Ok(());
     }
 
     tracing::trace!(path=?path, "creating_directory");
 
-    std::fs::create_dir_all(&path).map_err(|err| Error::FileIo {
+    std::fs::create_dir_all(path.as_ref()).map_err(|err| Error::FileIo {
         kind: FileKind::Directory,
-        path: PathBuf::from(path.as_ref()),
+        path: Utf8PathBuf::from(path.as_ref()),
         action: FileIoAction::Create,
         err: Some(err.to_string()),
     })
 }
 
-pub fn read_dir(path: impl AsRef<Path> + Debug) -> Result<std::fs::ReadDir, Error> {
+pub fn read_dir(path: impl AsRef<Utf8Path> + Debug) -> Result<std::fs::ReadDir, Error> {
     tracing::trace!(path=?path,"reading_directory");
 
-    std::fs::read_dir(&path).map_err(|e| Error::FileIo {
+    std::fs::read_dir(path.as_ref()).map_err(|e| Error::FileIo {
         action: FileIoAction::Read,
         kind: FileKind::Directory,
-        path: PathBuf::from(path.as_ref()),
+        path: Utf8PathBuf::from(path.as_ref()),
         err: Some(e.to_string()),
     })
 }
 
 pub fn module_caches_paths(
-    path: impl AsRef<Path> + Debug,
-) -> Result<impl Iterator<Item = PathBuf>, Error> {
+    path: impl AsRef<Utf8Path> + Debug,
+) -> Result<impl Iterator<Item = Utf8PathBuf>, Error> {
     Ok(read_dir(path)?
         .filter_map(Result::ok)
         .map(|f| f.path())
-        .filter(|p| p.extension().and_then(OsStr::to_str) == Some("cache")))
+        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
+        .filter(|p| p.extension() == Some("cache")))
 }
 
-pub fn read(path: impl AsRef<Path> + Debug) -> Result<String, Error> {
+pub fn read(path: impl AsRef<Utf8Path> + Debug) -> Result<String, Error> {
     tracing::trace!(path=?path,"reading_file");
 
-    std::fs::read_to_string(&path).map_err(|err| Error::FileIo {
+    std::fs::read_to_string(path.as_ref()).map_err(|err| Error::FileIo {
         action: FileIoAction::Read,
         kind: FileKind::File,
-        path: PathBuf::from(path.as_ref()),
+        path: Utf8PathBuf::from(path.as_ref()),
         err: Some(err.to_string()),
     })
 }
 
-pub fn read_bytes(path: impl AsRef<Path> + Debug) -> Result<Vec<u8>, Error> {
+pub fn read_bytes(path: impl AsRef<Utf8Path> + Debug) -> Result<Vec<u8>, Error> {
     tracing::trace!(path=?path,"reading_file");
 
-    std::fs::read(&path).map_err(|err| Error::FileIo {
+    std::fs::read(path.as_ref()).map_err(|err| Error::FileIo {
         action: FileIoAction::Read,
         kind: FileKind::File,
-        path: PathBuf::from(path.as_ref()),
+        path: Utf8PathBuf::from(path.as_ref()),
         err: Some(err.to_string()),
     })
 }
 
-pub fn reader(path: impl AsRef<Path> + Debug) -> Result<WrappedReader, Error> {
+pub fn reader(path: impl AsRef<Utf8Path> + Debug) -> Result<WrappedReader, Error> {
     tracing::trace!(path=?path,"opening_file_reader");
 
-    let reader = File::open(&path).map_err(|err| Error::FileIo {
+    let reader = File::open(path.as_ref()).map_err(|err| Error::FileIo {
         action: FileIoAction::Open,
         kind: FileKind::File,
-        path: PathBuf::from(path.as_ref()),
+        path: Utf8PathBuf::from(path.as_ref()),
         err: Some(err.to_string()),
     })?;
 
     Ok(WrappedReader::new(path.as_ref(), Box::new(reader)))
 }
 
-pub fn buffered_reader<P: AsRef<Path> + Debug>(path: P) -> Result<impl BufRead, Error> {
+pub fn buffered_reader<P: AsRef<Utf8Path> + Debug>(path: P) -> Result<impl BufRead, Error> {
     tracing::trace!(path=?path,"opening_file_buffered_reader");
-    let reader = File::open(&path).map_err(|err| Error::FileIo {
+    let reader = File::open(path.as_ref()).map_err(|err| Error::FileIo {
         action: FileIoAction::Open,
         kind: FileKind::File,
-        path: PathBuf::from(path.as_ref()),
+        path: Utf8PathBuf::from(path.as_ref()),
         err: Some(err.to_string()),
     })?;
     Ok(BufReader::new(reader))
 }
 
-pub fn copy(path: impl AsRef<Path> + Debug, to: impl AsRef<Path> + Debug) -> Result<(), Error> {
+pub fn copy(
+    path: impl AsRef<Utf8Path> + Debug,
+    to: impl AsRef<Utf8Path> + Debug,
+) -> Result<(), Error> {
     tracing::trace!(from=?path, to=?to, "copying_file");
 
     // TODO: include the destination in the error message
-    std::fs::copy(&path, &to)
+    std::fs::copy(path.as_ref(), to.as_ref())
         .map_err(|err| Error::FileIo {
             action: FileIoAction::Copy,
             kind: FileKind::File,
-            path: PathBuf::from(path.as_ref()),
+            path: Utf8PathBuf::from(path.as_ref()),
             err: Some(err.to_string()),
         })
         .map(|_| ())
 }
 
-// pub fn rename(path: impl AsRef<Path> + Debug, to: impl AsRef<Path> + Debug) -> Result<(), Error> {
+// pub fn rename(path: impl AsRef<Utf8Path> + Debug, to: impl AsRef<Utf8Path> + Debug) -> Result<(), Error> {
 //     tracing::trace!(from=?path, to=?to, "renaming_file");
 
 //     // TODO: include the destination in the error message
@@ -508,49 +516,59 @@ pub fn copy(path: impl AsRef<Path> + Debug, to: impl AsRef<Path> + Debug) -> Res
 //         .map_err(|err| Error::FileIo {
 //             action: FileIoAction::Rename,
 //             kind: FileKind::File,
-//             path: PathBuf::from(path.as_ref()),
+//             path: Utf8PathBuf::from(path.as_ref()),
 //             err: Some(err.to_string()),
 //         })
 //         .map(|_| ())
 // }
 
-pub fn copy_dir(path: impl AsRef<Path> + Debug, to: impl AsRef<Path> + Debug) -> Result<(), Error> {
+pub fn copy_dir(
+    path: impl AsRef<Utf8Path> + Debug,
+    to: impl AsRef<Utf8Path> + Debug,
+) -> Result<(), Error> {
     tracing::trace!(from=?path, to=?to, "copying_directory");
 
     // TODO: include the destination in the error message
-    fs_extra::dir::copy(&path, &to, &fs_extra::dir::CopyOptions::new())
-        .map_err(|err| Error::FileIo {
-            action: FileIoAction::Copy,
-            kind: FileKind::Directory,
-            path: PathBuf::from(path.as_ref()),
-            err: Some(err.to_string()),
-        })
-        .map(|_| ())
+    fs_extra::dir::copy(
+        path.as_ref(),
+        to.as_ref(),
+        &fs_extra::dir::CopyOptions::new(),
+    )
+    .map_err(|err| Error::FileIo {
+        action: FileIoAction::Copy,
+        kind: FileKind::Directory,
+        path: Utf8PathBuf::from(path.as_ref()),
+        err: Some(err.to_string()),
+    })
+    .map(|_| ())
 }
 
 pub fn symlink_dir(
-    src: impl AsRef<Path> + Debug,
-    dest: impl AsRef<Path> + Debug,
+    src: impl AsRef<Utf8Path> + Debug,
+    dest: impl AsRef<Utf8Path> + Debug,
 ) -> Result<(), Error> {
     tracing::trace!(src=?src, dest=?dest, "symlinking");
     symlink::symlink_dir(canonicalise(src.as_ref())?, dest.as_ref()).map_err(|err| {
         Error::FileIo {
             action: FileIoAction::Link,
             kind: FileKind::File,
-            path: PathBuf::from(dest.as_ref()),
+            path: Utf8PathBuf::from(dest.as_ref()),
             err: Some(err.to_string()),
         }
     })?;
     Ok(())
 }
 
-pub fn hardlink(from: impl AsRef<Path> + Debug, to: impl AsRef<Path> + Debug) -> Result<(), Error> {
+pub fn hardlink(
+    from: impl AsRef<Utf8Path> + Debug,
+    to: impl AsRef<Utf8Path> + Debug,
+) -> Result<(), Error> {
     tracing::trace!(from=?from, to=?to, "hardlinking");
-    std::fs::hard_link(&from, &to)
+    std::fs::hard_link(from.as_ref(), to.as_ref())
         .map_err(|err| Error::FileIo {
             action: FileIoAction::Link,
             kind: FileKind::File,
-            path: PathBuf::from(from.as_ref()),
+            path: Utf8PathBuf::from(from.as_ref()),
             err: Some(err.to_string()),
         })
         .map(|_| ())
@@ -561,7 +579,7 @@ pub fn hardlink(from: impl AsRef<Path> + Debug, to: impl AsRef<Path> + Debug) ->
 /// given path. If git is not installed then we assume we're not in a git work
 /// tree.
 ///
-pub fn is_inside_git_work_tree(path: &Path) -> Result<bool, Error> {
+pub fn is_inside_git_work_tree(path: &Utf8Path) -> Result<bool, Error> {
     tracing::trace!(path=?path, "checking_for_git_repo");
 
     let args: Vec<&str> = vec!["rev-parse", "--is-inside-work-tree", "--quiet"];
@@ -592,7 +610,7 @@ pub fn is_inside_git_work_tree(path: &Path) -> Result<bool, Error> {
 
 /// Run `git init` in the given path.
 /// If git is not installed then we do nothing.
-pub fn git_init(path: &Path) -> Result<(), Error> {
+pub fn git_init(path: &Utf8Path) -> Result<(), Error> {
     tracing::trace!(path=?path, "initializing git");
 
     if is_inside_git_work_tree(path)? {
@@ -600,7 +618,7 @@ pub fn git_init(path: &Path) -> Result<(), Error> {
         return Ok(());
     }
 
-    let args = vec!["init".into(), "--quiet".into(), path.display().to_string()];
+    let args = vec!["init".into(), "--quiet".into(), path.to_string()];
 
     match ProjectIO::new().exec("git", &args, &[], None, Stdio::Inherit) {
         Ok(_) => Ok(()),
@@ -613,13 +631,15 @@ pub fn git_init(path: &Path) -> Result<(), Error> {
     }
 }
 
-pub fn canonicalise(path: &Path) -> Result<PathBuf, Error> {
-    std::fs::canonicalize(path).map_err(|err| Error::FileIo {
-        action: FileIoAction::Canonicalise,
-        kind: FileKind::File,
-        path: PathBuf::from(path),
-        err: Some(err.to_string()),
-    })
+pub fn canonicalise(path: &Utf8Path) -> Result<Utf8PathBuf, Error> {
+    std::fs::canonicalize(path)
+        .map_err(|err| Error::FileIo {
+            action: FileIoAction::Canonicalise,
+            kind: FileKind::File,
+            path: Utf8PathBuf::from(path),
+            err: Some(err.to_string()),
+        })
+        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf8 Path"))
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -27,11 +27,9 @@ use crate::{dependencies::UseManifest, lsp::LspLocker};
 #[cfg(test)]
 mod tests;
 
-/// This is a helper function for converting from `PathBuf` to `Utf8PathBuf`.
-/// We simply panic on non-utf8 paths.
-///
-pub fn utf8_or_panic(input: std::path::PathBuf) -> Utf8PathBuf {
-    Utf8PathBuf::from_path_buf(input).expect("Non Utf8 Path")
+pub fn get_current_directory() -> Result<Utf8PathBuf, &'static str> {
+    let curr_dir = std::env::current_dir().map_err(|_| "Failed to get current directory")?;
+    Utf8PathBuf::from_path_buf(curr_dir).map_err(|_| "Non Utf8 Path")
 }
 
 /// A `FileWriter` implementation that writes to the file system.

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -20,7 +20,7 @@ use std::{
     time::SystemTime,
 };
 
-use camino::{Utf8Path, Utf8PathBuf, ReadDirUtf8};
+use camino::{ReadDirUtf8, Utf8Path, Utf8PathBuf};
 
 use crate::{dependencies::UseManifest, lsp::LspLocker};
 
@@ -97,13 +97,7 @@ impl FileSystemReader for ProjectIO {
     fn read_dir(&self, path: &Utf8Path) -> Result<ReadDir> {
         read_dir(path).map(|entries| {
             entries
-                .map(|result| {
-                    result.map(|entry| {
-                        DirEntry::from_path(
-                           entry.path()
-                        )
-                    })
-                })
+                .map(|result| result.map(|entry| DirEntry::from_path(entry.path())))
                 .collect()
         })
     }

--- a/compiler-cli/src/fs/tests.rs
+++ b/compiler-cli/src/fs/tests.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
+use camino::Utf8Path;
 
 #[test]
 fn is_inside_git_work_tree_ok() {
     let tmp_dir = tempfile::tempdir().unwrap();
-    let path = tmp_dir.path();
+    let path = Utf8Path::from_path(tmp_dir.path()).expect("Non Utf-8 Path");
 
     assert!(!super::is_inside_git_work_tree(path).unwrap());
     assert_eq!(super::git_init(path), Ok(()));
@@ -13,7 +13,7 @@ fn is_inside_git_work_tree_ok() {
 #[test]
 fn git_init_success() {
     let tmp_dir = tempfile::tempdir().unwrap();
-    let path = tmp_dir.path();
+    let path = Utf8Path::from_path(tmp_dir.path()).expect("Non Utf-8 Path");
     let git = path.join(".git");
 
     assert!(!git.exists());
@@ -24,12 +24,19 @@ fn git_init_success() {
 #[test]
 fn git_init_already_in_git() {
     let tmp_dir = tempfile::tempdir().unwrap();
-    let git = tmp_dir.path().join(".git");
+    let git = Utf8Path::from_path(tmp_dir.path())
+        .expect("Non Utf-8 Path")
+        .join(".git");
     assert!(!git.exists());
-    assert_eq!(super::git_init(tmp_dir.path()), Ok(()));
+    assert_eq!(
+        super::git_init(Utf8Path::from_path(tmp_dir.path()).expect("Non Utf-8 Path")),
+        Ok(())
+    );
     assert!(git.exists());
 
-    let sub = tmp_dir.path().join("subproject");
+    let sub = Utf8Path::from_path(tmp_dir.path())
+        .expect("Non Utf-8 Path")
+        .join("subproject");
     let git = sub.join(".git");
     crate::fs::mkdir(&sub).unwrap();
     assert!(!git.exists());
@@ -40,22 +47,22 @@ fn git_init_already_in_git() {
 #[test]
 fn is_gleam_path_test() {
     assert!(super::is_gleam_path(
-        Path::new("/some-prefix/a.gleam"),
-        Path::new("/some-prefix/")
+        Utf8Path::new("/some-prefix/a.gleam"),
+        Utf8Path::new("/some-prefix/")
     ));
 
     assert!(super::is_gleam_path(
-        Path::new("/some-prefix/one_two/a.gleam"),
-        Path::new("/some-prefix/")
+        Utf8Path::new("/some-prefix/one_two/a.gleam"),
+        Utf8Path::new("/some-prefix/")
     ));
 
     assert!(super::is_gleam_path(
-        Path::new("/some-prefix/one_two/a123.gleam"),
-        Path::new("/some-prefix/")
+        Utf8Path::new("/some-prefix/one_two/a123.gleam"),
+        Utf8Path::new("/some-prefix/")
     ));
 
     assert!(super::is_gleam_path(
-        Path::new("/some-prefix/one_2/a123.gleam"),
-        Path::new("/some-prefix/")
+        Utf8Path::new("/some-prefix/one_2/a123.gleam"),
+        Utf8Path::new("/some-prefix/")
     ));
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -74,6 +74,7 @@ mod shell;
 
 use config::root_config;
 use dependencies::UseManifest;
+use fs::get_current_directory;
 pub use gleam_core::{
     error::{Error, Result},
     warning::Warning,
@@ -520,10 +521,7 @@ fn initialise_logger() {
 }
 
 fn project_paths_at_current_directory() -> ProjectPaths {
-    let current_dir = Utf8PathBuf::from_path_buf(
-        std::env::current_dir().expect("Could not get current directory"),
-    )
-    .expect("Non Utf-8 Path");
+    let current_dir = get_current_directory().expect("Failed to get current directory");
     ProjectPaths::new(current_dir)
 }
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -87,7 +87,7 @@ use gleam_core::{
 };
 use hex::ApiKeyCommand as _;
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 use strum::VariantNames;
@@ -283,15 +283,15 @@ pub struct CompilePackage {
 
     /// The directory of the Gleam package
     #[clap(long = "package")]
-    package_directory: PathBuf,
+    package_directory: Utf8PathBuf,
 
     /// A directory to write compiled package to
     #[clap(long = "out")]
-    output_directory: PathBuf,
+    output_directory: Utf8PathBuf,
 
     /// A directories of precompiled Gleam projects
     #[clap(long = "lib")]
-    libraries_directory: PathBuf,
+    libraries_directory: Utf8PathBuf,
 
     /// Skip Erlang to BEAM bytecode compilation if given
     #[clap(long = "no-beam")]
@@ -520,7 +520,10 @@ fn initialise_logger() {
 }
 
 fn project_paths_at_current_directory() -> ProjectPaths {
-    let current_dir = std::env::current_dir().expect("Could not get current directory");
+    let current_dir = Utf8PathBuf::from_path_buf(
+        std::env::current_dir().expect("Could not get current directory"),
+    )
+    .expect("Non Utf-8 Path");
     ProjectPaths::new(current_dir)
 }
 

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -1,3 +1,4 @@
+use camino::{Utf8Path, Utf8PathBuf};
 use gleam_core::{
     erlang,
     error::{Error, FileIoAction, FileKind, InvalidProjectNameReason},
@@ -5,7 +6,6 @@ use gleam_core::{
 };
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::path::{Path, PathBuf};
 use std::{env, io::Write};
 use strum::{Display, EnumString, EnumVariantNames};
 
@@ -28,11 +28,11 @@ pub enum Template {
 
 #[derive(Debug)]
 pub struct Creator {
-    root: PathBuf,
-    src: PathBuf,
-    test: PathBuf,
-    github: PathBuf,
-    workflows: PathBuf,
+    root: Utf8PathBuf,
+    src: Utf8PathBuf,
+    test: Utf8PathBuf,
+    github: Utf8PathBuf,
+    workflows: Utf8PathBuf,
     gleam_version: &'static str,
     options: NewOptions,
     project_name: String,
@@ -51,7 +51,7 @@ impl Creator {
         validate_name(&project_name)?;
         validate_root_folder(&options.project_root)?;
 
-        let root = PathBuf::from(&options.project_root);
+        let root = Utf8PathBuf::from(&options.project_root);
         let src = root.join("src");
         let test = root.join("test");
         let github = root.join(".github");
@@ -266,7 +266,7 @@ The project can be compiled and tested by running these commands:
     Ok(())
 }
 
-fn write(path: PathBuf, contents: &str) -> Result<()> {
+fn write(path: Utf8PathBuf, contents: &str) -> Result<()> {
     let mut f = File::create(&path).map_err(|err| Error::FileIo {
         kind: FileKind::File,
         path: path.clone(),
@@ -285,7 +285,7 @@ fn write(path: PathBuf, contents: &str) -> Result<()> {
 }
 
 fn validate_root_folder(name: &str) -> Result<(), Error> {
-    if Path::new(name).exists() {
+    if Utf8Path::new(name).exists() {
         Err(Error::ProjectRootAlreadyExist {
             path: name.to_string(),
         })
@@ -343,9 +343,8 @@ fn get_foldername(path: &str) -> Result<String, Error> {
             .ok_or(Error::UnableToFindProjectRoot {
                 path: path.to_string(),
             }),
-        _ => Path::new(path)
+        _ => Utf8Path::new(path)
             .file_name()
-            .and_then(|x| x.to_str())
             .map(ToString::to_string)
             .ok_or(Error::UnableToFindProjectRoot {
                 path: path.to_string(),

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -1,3 +1,5 @@
+use camino::Utf8PathBuf;
+
 #[test]
 fn new() {
     let tmp = tempfile::tempdir().unwrap();
@@ -25,7 +27,8 @@ fn new() {
     assert!(path.join("test/my_project_test.gleam").exists());
     assert!(path.join(".github/workflows/test.yml").exists());
 
-    let toml = crate::fs::read(path.join("gleam.toml")).unwrap();
+    let toml =
+        crate::fs::read(Utf8PathBuf::from_path_buf(path.join("gleam.toml")).unwrap()).unwrap();
     assert!(toml.contains("name = \"my_project\""));
     assert!(toml.contains("description = \"Wibble wobble\""));
 }

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -1,13 +1,13 @@
-use camino::Utf8PathBuf;
+use gleam_core::io::utf8_or_panic;
 
 #[test]
 fn new() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("my_project");
+    let path = utf8_or_panic(tmp.path().join("my_project"));
 
     let creator = super::Creator::new(
         super::NewOptions {
-            project_root: path.to_str().unwrap().to_string(),
+            project_root: path.to_string(),
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
@@ -28,7 +28,7 @@ fn new() {
     assert!(path.join(".github/workflows/test.yml").exists());
 
     let toml =
-        crate::fs::read(Utf8PathBuf::from_path_buf(path.join("gleam.toml")).unwrap()).unwrap();
+        crate::fs::read(path.join("gleam.toml")).unwrap();
     assert!(toml.contains("name = \"my_project\""));
     assert!(toml.contains("description = \"Wibble wobble\""));
 }
@@ -36,11 +36,11 @@ fn new() {
 #[test]
 fn new_with_skip_git() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("my_project");
+    let path = utf8_or_panic(tmp.path().join("my_project"));
 
     let creator = super::Creator::new(
         super::NewOptions {
-            project_root: path.to_str().unwrap().to_string(),
+            project_root: path.to_string(),
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
@@ -58,11 +58,11 @@ fn new_with_skip_git() {
 #[test]
 fn new_with_skip_github() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("my_project");
+    let path = utf8_or_panic(tmp.path().join("my_project"));
 
     let creator = super::Creator::new(
         super::NewOptions {
-            project_root: path.to_str().unwrap().to_string(),
+            project_root: path.to_string(),
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
@@ -83,11 +83,11 @@ fn new_with_skip_github() {
 #[test]
 fn new_with_skip_git_and_github() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("my_project");
+    let path = utf8_or_panic(tmp.path().join("my_project"));
 
     let creator = super::Creator::new(
         super::NewOptions {
-            project_root: path.to_str().unwrap().to_string(),
+            project_root: path.to_string(),
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
@@ -108,11 +108,11 @@ fn new_with_skip_git_and_github() {
 #[test]
 fn invalid_path() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("-------");
+    let path = utf8_or_panic(tmp.path().join("-------"));
 
     assert!(super::Creator::new(
         super::NewOptions {
-            project_root: path.to_str().unwrap().to_string(),
+            project_root: path.to_string(),
             template: super::Template::Lib,
             name: None,
             description: "Wibble wobble".into(),
@@ -127,11 +127,11 @@ fn invalid_path() {
 #[test]
 fn invalid_name() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("projec");
+    let path = utf8_or_panic(tmp.path().join("projec"));
 
     assert!(super::Creator::new(
         super::NewOptions {
-            project_root: path.to_str().unwrap().to_string(),
+            project_root: path.to_string(),
             template: super::Template::Lib,
             name: Some("-".into()),
             description: "Wibble wobble".into(),

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -27,8 +27,7 @@ fn new() {
     assert!(path.join("test/my_project_test.gleam").exists());
     assert!(path.join(".github/workflows/test.yml").exists());
 
-    let toml =
-        crate::fs::read(path.join("gleam.toml")).unwrap();
+    let toml = crate::fs::read(path.join("gleam.toml")).unwrap();
     assert!(toml.contains("name = \"my_project\""));
     assert!(toml.contains("description = \"Wibble wobble\""));
 }

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -1,9 +1,9 @@
-use crate::fs::utf8_or_panic;
+use camino::Utf8PathBuf;
 
 #[test]
 fn new() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = utf8_or_panic(tmp.path().join("my_project"));
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
 
     let creator = super::Creator::new(
         super::NewOptions {
@@ -35,7 +35,7 @@ fn new() {
 #[test]
 fn new_with_skip_git() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = utf8_or_panic(tmp.path().join("my_project"));
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
 
     let creator = super::Creator::new(
         super::NewOptions {
@@ -57,7 +57,7 @@ fn new_with_skip_git() {
 #[test]
 fn new_with_skip_github() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = utf8_or_panic(tmp.path().join("my_project"));
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
 
     let creator = super::Creator::new(
         super::NewOptions {
@@ -82,7 +82,7 @@ fn new_with_skip_github() {
 #[test]
 fn new_with_skip_git_and_github() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = utf8_or_panic(tmp.path().join("my_project"));
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
 
     let creator = super::Creator::new(
         super::NewOptions {
@@ -107,7 +107,7 @@ fn new_with_skip_git_and_github() {
 #[test]
 fn invalid_path() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = utf8_or_panic(tmp.path().join("-------"));
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("-------")).expect("Non Utf8 Path");
 
     assert!(super::Creator::new(
         super::NewOptions {
@@ -126,7 +126,7 @@ fn invalid_path() {
 #[test]
 fn invalid_name() {
     let tmp = tempfile::tempdir().unwrap();
-    let path = utf8_or_panic(tmp.path().join("projec"));
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("projec")).expect("Non Utf8 Path");
 
     assert!(super::Creator::new(
         super::NewOptions {

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -1,4 +1,4 @@
-use gleam_core::io::utf8_or_panic;
+use crate::fs::utf8_or_panic;
 
 #[test]
 fn new() {

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use camino::{Utf8Path, Utf8PathBuf};
 
 use gleam_core::{
     error::{FileIoAction, FileKind},
@@ -14,7 +14,7 @@ pub fn command(packages: Vec<String>) -> Result<()> {
         .map_err(|e| Error::FileIo {
             kind: FileKind::File,
             action: FileIoAction::Parse,
-            path: PathBuf::from("gleam.toml"),
+            path: Utf8PathBuf::from("gleam.toml"),
             err: Some(e.to_string()),
         })?;
 
@@ -31,7 +31,7 @@ pub fn command(packages: Vec<String>) -> Result<()> {
     }
 
     // Write the updated config
-    fs::write(Path::new("gleam.toml"), &toml.to_string())?;
+    fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
     let paths = crate::project_paths_at_current_directory();
     _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)?;
     for package_to_remove in packages {

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -1,3 +1,4 @@
+use camino::Utf8PathBuf;
 use gleam_core::{
     build::{Codegen, Mode, Options, Runtime, Target},
     config::{DenoFlag, PackageConfig},
@@ -7,7 +8,6 @@ use gleam_core::{
     type_::ModuleFunction,
 };
 use lazy_static::lazy_static;
-use std::path::PathBuf;
 
 use crate::fs::ProjectIO;
 
@@ -165,13 +165,13 @@ fn write_javascript_entrypoint(
         .strip_prefix(paths.root())
         .expect("Failed to strip prefix from path")
         .to_path_buf();
-    let entrypoint = format!("./{}/gleam.main.mjs", entry.to_string_lossy());
+    let entrypoint = format!("./{}/gleam.main.mjs", entry);
     let module = format!(
         r#"import {{ main }} from "./{module}.mjs";
 main();
 "#,
     );
-    crate::fs::write(&PathBuf::from(&entrypoint), &module)?;
+    crate::fs::write(&Utf8PathBuf::from(&entrypoint), &module)?;
     Ok(entrypoint)
 }
 

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -116,7 +116,7 @@ fn run_erlang(
 
     for entry in crate::fs::read_dir(packages)?.filter_map(Result::ok) {
         args.push("-pa".into());
-        args.push(entry.path().join("ebin").to_string_lossy().into());
+        args.push(entry.path().join("ebin").into());
     }
 
     // gleam modules are seperated by `/`. Erlang modules are seperated by `@`.

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -79,6 +79,7 @@ lsp-server = "0.5"
 lsp-types = "0.92"
 # Pubgrub dependency resolution algorithm
 pubgrub = "0.2"
+camino = { version = "1.1.6", features = ["serde1"] }
 
 [build-dependencies]
 # Data (de)serialisation

--- a/compiler-core/clippy.toml
+++ b/compiler-core/clippy.toml
@@ -9,4 +9,18 @@ disallowed-methods = [
   { path = "std::path::Path::read_link", reason = "IO is not permitted in core" },
   { path = "std::path::Path::symlink_metadata", reason = "IO is not permitted in core" },
   { path = "std::path::Path::try_exists", reason = "IO is not permitted in core" },
+  
+  { path = "camino::Utf8Path::canonicalize", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::exists", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::is_dir", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::is_file", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::is_symlink", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::read_dir", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::read_link", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::symlink_metadata", reason = "IO is not permitted in core" },
+  { path = "camino::Utf8Path::try_exists", reason = "IO is not permitted in core" },
+
+
+  { path = "std::path::Path::new", reason = "Manually constructed paths should use camino::Utf8Path" },
+  { path = "std::path::PathBuf::new", reason = "Manually constructed pathbufs should use camino::Utf8Path" },
 ]

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -27,13 +27,12 @@ use crate::{
     parse::extra::{Comment, ModuleExtra},
     type_,
 };
+use camino::Utf8PathBuf;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::time::SystemTime;
-use std::{
-    collections::HashMap, ffi::OsString, fs::DirEntry, iter::Peekable, path::PathBuf, process,
-};
+use std::{collections::HashMap, ffi::OsString, fs::DirEntry, iter::Peekable, process};
 use strum::{Display, EnumIter, EnumString, EnumVariantNames, VariantNames};
 
 #[derive(
@@ -185,7 +184,7 @@ pub struct Module {
     pub name: SmolStr,
     pub code: SmolStr,
     pub mtime: SystemTime,
-    pub input_path: PathBuf,
+    pub input_path: Utf8PathBuf,
     pub origin: Origin,
     pub ast: TypedModule,
     pub extra: ModuleExtra,
@@ -193,10 +192,10 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn compiled_erlang_path(&self) -> PathBuf {
+    pub fn compiled_erlang_path(&self) -> Utf8PathBuf {
         let mut path = self.name.replace("/", "@");
         path.push_str(".erl");
-        PathBuf::from(path)
+        Utf8PathBuf::from(path)
     }
 
     pub fn is_test(&self) -> bool {

--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -1,11 +1,9 @@
 #[cfg(test)]
 mod tests;
 
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    time::SystemTime,
-};
+use std::{collections::HashMap, time::SystemTime};
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
@@ -39,8 +37,8 @@ pub(crate) struct ModuleLoader<'a, IO> {
     pub target: Target,
     pub codegen: CodegenRequired,
     pub package_name: &'a SmolStr,
-    pub source_directory: &'a Path,
-    pub artefact_directory: &'a Path,
+    pub source_directory: &'a Utf8Path,
+    pub artefact_directory: &'a Utf8Path,
     pub origin: Origin,
 }
 
@@ -56,7 +54,7 @@ where
     /// Whether the module has changed or not is determined by comparing the
     /// modification time of the source file with the value recorded in the
     /// `.timestamp` file in the artefact directory.
-    pub fn load(&self, path: PathBuf) -> Result<Input> {
+    pub fn load(&self, path: Utf8PathBuf) -> Result<Input> {
         let name = module_name(self.source_directory, &path);
         let artefact = name.replace("/", "@");
         let source_mtime = self.io.modification_time(&path)?;
@@ -116,7 +114,7 @@ where
 
     fn read_source(
         &self,
-        path: PathBuf,
+        path: Utf8PathBuf,
         name: SmolStr,
         mtime: SystemTime,
     ) -> Result<UncompiledModule, Error> {
@@ -147,7 +145,7 @@ pub(crate) fn read_source<IO>(
     warnings: &WarningEmitter,
     target: Target,
     origin: Origin,
-    path: PathBuf,
+    path: Utf8PathBuf,
     name: SmolStr,
     package_name: SmolStr,
     mtime: SystemTime,

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -8,17 +8,17 @@ use std::time::Duration;
 #[test]
 fn no_cache_present() {
     let name = "package".into();
-    let src = Path::new("/src");
-    let artefact = Path::new("/artefact");
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
     let loader = make_loader(&warnings, &name, &fs, src, artefact);
 
-    fs.write(&Path::new("/src/main.gleam"), "const x = 1")
+    fs.write(&Utf8Path::new("/src/main.gleam"), "const x = 1")
         .unwrap();
 
     let result = loader
-        .load(Path::new("/src/main.gleam").to_path_buf())
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_new());
@@ -27,8 +27,8 @@ fn no_cache_present() {
 #[test]
 fn cache_present_and_fresh() {
     let name = "package".into();
-    let src = Path::new("/src");
-    let artefact = Path::new("/artefact");
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
     let loader = make_loader(&warnings, &name, &fs, src, artefact);
@@ -38,7 +38,7 @@ fn cache_present_and_fresh() {
     write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
-        .load(Path::new("/src/main.gleam").to_path_buf())
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_cached());
@@ -47,8 +47,8 @@ fn cache_present_and_fresh() {
 #[test]
 fn cache_present_and_stale() {
     let name = "package".into();
-    let src = Path::new("/src");
-    let artefact = Path::new("/artefact");
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
     let loader = make_loader(&warnings, &name, &fs, src, artefact);
@@ -58,7 +58,7 @@ fn cache_present_and_stale() {
     write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
-        .load(Path::new("/src/main.gleam").to_path_buf())
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_new());
@@ -67,8 +67,8 @@ fn cache_present_and_stale() {
 #[test]
 fn cache_present_and_stale_but_source_is_the_same() {
     let name = "package".into();
-    let src = Path::new("/src");
-    let artefact = Path::new("/artefact");
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
     let loader = make_loader(&warnings, &name, &fs, src, artefact);
@@ -78,7 +78,7 @@ fn cache_present_and_stale_but_source_is_the_same() {
     write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
-        .load(Path::new("/src/main.gleam").to_path_buf())
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_cached());
@@ -87,8 +87,8 @@ fn cache_present_and_stale_but_source_is_the_same() {
 #[test]
 fn cache_present_without_codegen_when_required() {
     let name = "package".into();
-    let src = Path::new("/src");
-    let artefact = Path::new("/artefact");
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
     let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
@@ -99,7 +99,7 @@ fn cache_present_without_codegen_when_required() {
     write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
-        .load(Path::new("/src/main.gleam").to_path_buf())
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_new());
@@ -108,8 +108,8 @@ fn cache_present_without_codegen_when_required() {
 #[test]
 fn cache_present_with_codegen_when_required() {
     let name = "package".into();
-    let src = Path::new("/src");
-    let artefact = Path::new("/artefact");
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
     let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
@@ -120,7 +120,7 @@ fn cache_present_with_codegen_when_required() {
     write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, true);
 
     let result = loader
-        .load(Path::new("/src/main.gleam").to_path_buf())
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_cached());
@@ -129,8 +129,8 @@ fn cache_present_with_codegen_when_required() {
 #[test]
 fn cache_present_without_codegen_when_not_required() {
     let name = "package".into();
-    let src = Path::new("/src");
-    let artefact = Path::new("/artefact");
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
     let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
@@ -141,7 +141,7 @@ fn cache_present_without_codegen_when_not_required() {
     write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let result = loader
-        .load(Path::new("/src/main.gleam").to_path_buf())
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
         .unwrap();
 
     assert!(result.is_cached());
@@ -163,12 +163,12 @@ fn write_cache(
         dependencies: vec![],
         fingerprint: SourceFingerprint::new(source),
     };
-    let path = Path::new(path);
+    let path = Utf8Path::new(path);
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();
 }
 
 fn write_src(fs: &InMemoryFileSystem, source: &str, path: &str, seconds: u64) {
-    let path = Path::new(path);
+    let path = Utf8Path::new(path);
     fs.write(&path, source).unwrap();
     fs.set_modification_time(&path, SystemTime::UNIX_EPOCH + Duration::from_secs(seconds));
 }
@@ -177,8 +177,8 @@ fn make_loader<'a>(
     warnings: &'a WarningEmitter,
     package_name: &'a SmolStr,
     fs: &InMemoryFileSystem,
-    src: &'a Path,
-    artefact: &'a Path,
+    src: &'a Utf8Path,
+    artefact: &'a Utf8Path,
 ) -> ModuleLoader<'a, InMemoryFileSystem> {
     ModuleLoader {
         warnings,

--- a/compiler-core/src/build/native_file_copier/tests.rs
+++ b/compiler-core/src/build/native_file_copier/tests.rs
@@ -6,19 +6,20 @@ use crate::{
 use lazy_static::lazy_static;
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use camino::{Utf8Path, Utf8PathBuf};
+
 lazy_static! {
-    static ref ROOT: PathBuf = PathBuf::from("/");
-    static ref OUT: PathBuf = PathBuf::from("/out");
+    static ref ROOT: Utf8PathBuf = Utf8PathBuf::from("/");
+    static ref OUT: Utf8PathBuf = Utf8PathBuf::from("/out");
 }
 
 #[test]
 fn javascript_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.js"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.js"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -27,8 +28,8 @@ fn javascript_files_are_copied_from_src() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.js"), "1".into()),
-            (PathBuf::from("/out/wibble.js"), "1".into())
+            (Utf8PathBuf::from("/src/wibble.js"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.js"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -37,7 +38,7 @@ fn javascript_files_are_copied_from_src() {
 #[test]
 fn javascript_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/test/wibble.js"), "1").unwrap();
+    fs.write(&Utf8Path::new("/test/wibble.js"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -46,8 +47,8 @@ fn javascript_files_are_copied_from_test() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/test/wibble.js"), "1".into()),
-            (PathBuf::from("/out/wibble.js"), "1".into())
+            (Utf8PathBuf::from("/test/wibble.js"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.js"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -56,7 +57,7 @@ fn javascript_files_are_copied_from_test() {
 #[test]
 fn mjavascript_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.mjs"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.mjs"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -65,8 +66,8 @@ fn mjavascript_files_are_copied_from_src() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.mjs"), "1".into()),
-            (PathBuf::from("/out/wibble.mjs"), "1".into())
+            (Utf8PathBuf::from("/src/wibble.mjs"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.mjs"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -75,7 +76,7 @@ fn mjavascript_files_are_copied_from_src() {
 #[test]
 fn mjavascript_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/test/wibble.mjs"), "1").unwrap();
+    fs.write(&Utf8Path::new("/test/wibble.mjs"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -84,8 +85,8 @@ fn mjavascript_files_are_copied_from_test() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/test/wibble.mjs"), "1".into()),
-            (PathBuf::from("/out/wibble.mjs"), "1".into())
+            (Utf8PathBuf::from("/test/wibble.mjs"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.mjs"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -94,7 +95,7 @@ fn mjavascript_files_are_copied_from_test() {
 #[test]
 fn typescript_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.ts"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.ts"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -103,8 +104,8 @@ fn typescript_files_are_copied_from_src() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.ts"), "1".into()),
-            (PathBuf::from("/out/wibble.ts"), "1".into())
+            (Utf8PathBuf::from("/src/wibble.ts"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.ts"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -113,7 +114,7 @@ fn typescript_files_are_copied_from_src() {
 #[test]
 fn typescript_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/test/wibble.ts"), "1").unwrap();
+    fs.write(&Utf8Path::new("/test/wibble.ts"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -122,8 +123,8 @@ fn typescript_files_are_copied_from_test() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/test/wibble.ts"), "1".into()),
-            (PathBuf::from("/out/wibble.ts"), "1".into())
+            (Utf8PathBuf::from("/test/wibble.ts"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.ts"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -132,7 +133,7 @@ fn typescript_files_are_copied_from_test() {
 #[test]
 fn erlang_header_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.hrl"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.hrl"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -141,8 +142,8 @@ fn erlang_header_files_are_copied_from_src() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.hrl"), "1".into()),
-            (PathBuf::from("/out/wibble.hrl"), "1".into())
+            (Utf8PathBuf::from("/src/wibble.hrl"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.hrl"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -151,7 +152,7 @@ fn erlang_header_files_are_copied_from_src() {
 #[test]
 fn erlang_header_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/test/wibble.hrl"), "1").unwrap();
+    fs.write(&Utf8Path::new("/test/wibble.hrl"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -160,8 +161,8 @@ fn erlang_header_files_are_copied_from_test() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/test/wibble.hrl"), "1".into()),
-            (PathBuf::from("/out/wibble.hrl"), "1".into())
+            (Utf8PathBuf::from("/test/wibble.hrl"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.hrl"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -170,17 +171,17 @@ fn erlang_header_files_are_copied_from_test() {
 #[test]
 fn erlang_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.erl"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.erl"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
-    assert_eq!(copied.to_compile, vec![PathBuf::from("wibble.erl")]);
+    assert_eq!(copied.to_compile, vec![Utf8PathBuf::from("wibble.erl")]);
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.erl"), "1".into()),
-            (PathBuf::from("/out/wibble.erl"), "1".into())
+            (Utf8PathBuf::from("/src/wibble.erl"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.erl"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -189,17 +190,17 @@ fn erlang_files_are_copied_from_src() {
 #[test]
 fn erlang_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/test/wibble.erl"), "1").unwrap();
+    fs.write(&Utf8Path::new("/test/wibble.erl"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
-    assert_eq!(copied.to_compile, vec![PathBuf::from("wibble.erl")]);
+    assert_eq!(copied.to_compile, vec![Utf8PathBuf::from("wibble.erl")]);
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/test/wibble.erl"), "1".into()),
-            (PathBuf::from("/out/wibble.erl"), "1".into())
+            (Utf8PathBuf::from("/test/wibble.erl"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.erl"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -208,17 +209,17 @@ fn erlang_files_are_copied_from_test() {
 #[test]
 fn elixir_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.ex"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.ex"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
-    assert_eq!(copied.to_compile, vec![PathBuf::from("wibble.ex")]);
+    assert_eq!(copied.to_compile, vec![Utf8PathBuf::from("wibble.ex")]);
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.ex"), "1".into()),
-            (PathBuf::from("/out/wibble.ex"), "1".into())
+            (Utf8PathBuf::from("/src/wibble.ex"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.ex"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -227,17 +228,17 @@ fn elixir_files_are_copied_from_src() {
 #[test]
 fn elixir_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/test/wibble.ex"), "1").unwrap();
+    fs.write(&Utf8Path::new("/test/wibble.ex"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
-    assert_eq!(copied.to_compile, vec![PathBuf::from("wibble.ex")]);
+    assert_eq!(copied.to_compile, vec![Utf8PathBuf::from("wibble.ex")]);
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/test/wibble.ex"), "1".into()),
-            (PathBuf::from("/out/wibble.ex"), "1".into())
+            (Utf8PathBuf::from("/test/wibble.ex"), "1".into()),
+            (Utf8PathBuf::from("/out/wibble.ex"), "1".into())
         ]),
         fs.into_contents(),
     );
@@ -246,7 +247,7 @@ fn elixir_files_are_copied_from_test() {
 #[test]
 fn other_files_are_ignored() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.cpp"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.cpp"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     let copied = copier.run().unwrap();
@@ -254,7 +255,7 @@ fn other_files_are_ignored() {
     assert!(!copied.any_elixir);
     assert!(copied.to_compile.is_empty());
     assert_eq!(
-        HashMap::from([(PathBuf::from("/src/wibble.cpp"), "1".into())]),
+        HashMap::from([(Utf8PathBuf::from("/src/wibble.cpp"), "1".into())]),
         fs.into_contents(),
     );
 }
@@ -262,8 +263,8 @@ fn other_files_are_ignored() {
 #[test]
 fn files_do_not_get_copied_if_there_already_is_a_new_version() {
     let fs = InMemoryFileSystem::new();
-    let out = Path::new("/out/wibble.mjs");
-    let src = Path::new("/src/wibble.mjs");
+    let out = Utf8Path::new("/out/wibble.mjs");
+    let src = Utf8Path::new("/src/wibble.mjs");
     fs.write(&out, "in-out").unwrap();
     fs.write(&src, "in-src").unwrap();
     fs.set_modification_time(&out, UNIX_EPOCH + Duration::from_secs(1));
@@ -276,8 +277,8 @@ fn files_do_not_get_copied_if_there_already_is_a_new_version() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.mjs"), "in-src".into()),
-            (PathBuf::from("/out/wibble.mjs"), "in-out".into())
+            (Utf8PathBuf::from("/src/wibble.mjs"), "in-src".into()),
+            (Utf8PathBuf::from("/out/wibble.mjs"), "in-out".into())
         ]),
         fs.into_contents(),
     );
@@ -286,8 +287,8 @@ fn files_do_not_get_copied_if_there_already_is_a_new_version() {
 #[test]
 fn files_get_copied_if_the_previously_copied_vesion_is_older() {
     let fs = InMemoryFileSystem::new();
-    let out = Path::new("/out/wibble.mjs");
-    let src = Path::new("/src/wibble.mjs");
+    let out = Utf8Path::new("/out/wibble.mjs");
+    let src = Utf8Path::new("/src/wibble.mjs");
     fs.write(&out, "in-out").unwrap();
     fs.write(&src, "in-src").unwrap();
     fs.set_modification_time(&out, UNIX_EPOCH);
@@ -300,8 +301,8 @@ fn files_get_copied_if_the_previously_copied_vesion_is_older() {
     assert!(copied.to_compile.is_empty());
     assert_eq!(
         HashMap::from([
-            (PathBuf::from("/src/wibble.mjs"), "in-src".into()),
-            (PathBuf::from("/out/wibble.mjs"), "in-src".into())
+            (Utf8PathBuf::from("/src/wibble.mjs"), "in-src".into()),
+            (Utf8PathBuf::from("/out/wibble.mjs"), "in-src".into())
         ]),
         fs.into_contents(),
     );
@@ -310,8 +311,8 @@ fn files_get_copied_if_the_previously_copied_vesion_is_older() {
 #[test]
 fn duplicate_native_files_result_in_an_error() {
     let fs = InMemoryFileSystem::new();
-    fs.write(&Path::new("/src/wibble.mjs"), "1").unwrap();
-    fs.write(&Path::new("/test/wibble.mjs"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.mjs"), "1").unwrap();
+    fs.write(&Utf8Path::new("/test/wibble.mjs"), "1").unwrap();
 
     let copier = NativeFileCopier::new(fs.clone(), &ROOT, &OUT);
     assert!(copier.run().is_err());

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -3,9 +3,10 @@ mod tests;
 
 use std::{
     collections::{HashMap, HashSet},
-    path::{Path, PathBuf},
     time::{Duration, SystemTime},
 };
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 // TODO: emit warnings for cached modules even if they are not compiled again.
 
@@ -52,14 +53,14 @@ pub struct PackageLoader<'a, IO> {
     io: IO,
     ids: UniqueIdGenerator,
     mode: Mode,
-    root: &'a Path,
+    root: &'a Utf8Path,
     warnings: &'a WarningEmitter,
     codegen: CodegenRequired,
-    artefact_directory: &'a Path,
+    artefact_directory: &'a Utf8Path,
     package_name: &'a SmolStr,
     target: Target,
     stale_modules: &'a mut StaleTracker,
-    already_defined_modules: &'a mut im::HashMap<SmolStr, PathBuf>,
+    already_defined_modules: &'a mut im::HashMap<SmolStr, Utf8PathBuf>,
 }
 
 impl<'a, IO> PackageLoader<'a, IO>
@@ -70,14 +71,14 @@ where
         io: IO,
         ids: UniqueIdGenerator,
         mode: Mode,
-        root: &'a Path,
+        root: &'a Utf8Path,
         warnings: &'a WarningEmitter,
         codegen: CodegenRequired,
-        artefact_directory: &'a Path,
+        artefact_directory: &'a Utf8Path,
         target: Target,
         package_name: &'a SmolStr,
         stale_modules: &'a mut StaleTracker,
-        already_defined_modules: &'a mut im::HashMap<SmolStr, PathBuf>,
+        already_defined_modules: &'a mut im::HashMap<SmolStr, Utf8PathBuf>,
     ) -> Self {
         Self {
             io,
@@ -156,7 +157,7 @@ where
         metadata::ModuleDecoder::new(self.ids.clone()).read(bytes.as_slice())
     }
 
-    pub fn is_gleam_path(&self, path: &Path, dir: &Path) -> bool {
+    pub fn is_gleam_path(&self, path: &Utf8Path, dir: &Utf8Path) -> bool {
         use regex::Regex;
         lazy_static! {
             static ref RE: Regex = Regex::new(&format!(
@@ -170,8 +171,7 @@ where
         RE.is_match(
             path.strip_prefix(dir)
                 .expect("is_gleam_path(): strip_prefix")
-                .to_str()
-                .expect("is_gleam_path(): to_str"),
+                .as_str(),
         )
     }
 
@@ -260,11 +260,11 @@ impl StaleTracker {
 #[derive(Debug)]
 pub struct Inputs<'a> {
     collection: HashMap<SmolStr, Input>,
-    already_defined_modules: &'a im::HashMap<SmolStr, PathBuf>,
+    already_defined_modules: &'a im::HashMap<SmolStr, Utf8PathBuf>,
 }
 
 impl<'a> Inputs<'a> {
-    fn new(already_defined_modules: &'a im::HashMap<SmolStr, PathBuf>) -> Self {
+    fn new(already_defined_modules: &'a im::HashMap<SmolStr, Utf8PathBuf>) -> Self {
         Self {
             collection: Default::default(),
             already_defined_modules,

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -3,18 +3,20 @@ use crate::{
     line_numbers::LineNumbers, Result,
 };
 use itertools::Itertools;
-use std::{fmt::Debug, path::Path};
+use std::fmt::Debug;
+
+use camino::Utf8Path;
 
 /// A code generator that creates a .erl Erlang module and record header files
 /// for each Gleam module in the package.
 #[derive(Debug)]
 pub struct Erlang<'a> {
-    build_directory: &'a Path,
-    include_directory: &'a Path,
+    build_directory: &'a Utf8Path,
+    include_directory: &'a Utf8Path,
 }
 
 impl<'a> Erlang<'a> {
-    pub fn new(build_directory: &'a Path, include_directory: &'a Path) -> Self {
+    pub fn new(build_directory: &'a Utf8Path, include_directory: &'a Utf8Path) -> Self {
         Self {
             build_directory,
             include_directory,
@@ -66,12 +68,12 @@ impl<'a> Erlang<'a> {
 /// A code generator that creates a .app Erlang application file for the package
 #[derive(Debug)]
 pub struct ErlangApp<'a> {
-    output_directory: &'a Path,
+    output_directory: &'a Utf8Path,
     include_dev_deps: bool,
 }
 
 impl<'a> ErlangApp<'a> {
-    pub fn new(output_directory: &'a Path, include_dev_deps: bool) -> Self {
+    pub fn new(output_directory: &'a Utf8Path, include_dev_deps: bool) -> Self {
         Self {
             output_directory,
             include_dev_deps,
@@ -147,12 +149,12 @@ pub enum TypeScriptDeclarations {
 
 #[derive(Debug)]
 pub struct JavaScript<'a> {
-    output_directory: &'a Path,
+    output_directory: &'a Utf8Path,
     typescript: TypeScriptDeclarations,
 }
 
 impl<'a> JavaScript<'a> {
-    pub fn new(output_directory: &'a Path, typescript: TypeScriptDeclarations) -> Self {
+    pub fn new(output_directory: &'a Utf8Path, typescript: TypeScriptDeclarations) -> Self {
         Self {
             output_directory,
             typescript,

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -4,6 +4,7 @@ use crate::manifest::Manifest;
 use crate::requirement::Requirement;
 use crate::version::COMPILER_VERSION;
 use crate::{Error, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use globset::{Glob, GlobSetBuilder};
 use hexpm::version::Version;
 use http::Uri;
@@ -12,7 +13,6 @@ use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::marker::PhantomData;
-use std::path::{Path, PathBuf};
 
 #[cfg(test)]
 use crate::manifest::ManifestPackage;
@@ -119,7 +119,7 @@ impl PackageConfig {
         Ok(deps)
     }
 
-    pub fn read<FS: FileSystemReader, P: AsRef<Path>>(
+    pub fn read<FS: FileSystemReader, P: AsRef<Utf8Path>>(
         path: P,
         fs: &FS,
     ) -> Result<PackageConfig, Error> {
@@ -750,7 +750,7 @@ pub struct Docs {
 pub struct DocsPage {
     pub title: String,
     pub path: String,
-    pub source: PathBuf,
+    pub source: Utf8PathBuf,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/compiler-core/src/diagnostic.rs
+++ b/compiler-core/src/diagnostic.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 pub use codespan_reporting::diagnostic::{LabelStyle, Severity};
 use codespan_reporting::{diagnostic::Label as CodespanLabel, files::SimpleFile};
@@ -22,7 +22,7 @@ pub struct Label {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Location {
     pub src: SmolStr,
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
     pub label: Label,
     pub extra_labels: Vec<Label>,
 }
@@ -61,10 +61,7 @@ impl Diagnostic {
     }
 
     fn write_span(&self, location: &Location, buffer: &mut Buffer) {
-        let file = SimpleFile::new(
-            location.path.to_string_lossy().to_string(),
-            location.src.as_str(),
-        );
+        let file = SimpleFile::new(location.path.to_string(), location.src.as_str());
         let labels = location
             .labels()
             .map(|l| {

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -1,6 +1,8 @@
 mod source_links;
 
-use std::{path::PathBuf, time::SystemTime};
+use std::time::SystemTime;
+
+use camino::Utf8PathBuf;
 
 use crate::{
     ast::{
@@ -112,7 +114,7 @@ pub fn generate_html(
         };
 
         files.push(OutputFile {
-            path: PathBuf::from(&page.path),
+            path: Utf8PathBuf::from(&page.path),
             content: Content::Text(temp.render().expect("Page template rendering")),
         });
 
@@ -245,7 +247,7 @@ pub fn generate_html(
         };
 
         files.push(OutputFile {
-            path: PathBuf::from(format!("{}.html", module.name)),
+            path: Utf8PathBuf::from(format!("{}.html", module.name)),
             content: Content::Text(
                 template
                     .render()
@@ -257,63 +259,63 @@ pub fn generate_html(
     // Render static assets
 
     files.push(OutputFile {
-        path: PathBuf::from("css/atom-one-light.min.css"),
+        path: Utf8PathBuf::from("css/atom-one-light.min.css"),
         content: Content::Text(
             std::include_str!("../templates/docs-css/atom-one-light.min.css").to_string(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("css/atom-one-dark.min.css"),
+        path: Utf8PathBuf::from("css/atom-one-dark.min.css"),
         content: Content::Text(
             std::include_str!("../templates/docs-css/atom-one-dark.min.css").to_string(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("css/index.css"),
+        path: Utf8PathBuf::from("css/index.css"),
         content: Content::Text(std::include_str!("../templates/docs-css/index.css").to_string()),
     });
 
     // highlightjs:
 
     files.push(OutputFile {
-        path: PathBuf::from("js/highlight.min.js"),
+        path: Utf8PathBuf::from("js/highlight.min.js"),
         content: Content::Text(
             std::include_str!("../templates/docs-js/highlight.min.js").to_string(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("js/highlightjs-gleam.js"),
+        path: Utf8PathBuf::from("js/highlightjs-gleam.js"),
         content: Content::Text(
             std::include_str!("../templates/docs-js/highlightjs-gleam.js").to_string(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("js/highlightjs-erlang.min.js"),
+        path: Utf8PathBuf::from("js/highlightjs-erlang.min.js"),
         content: Content::Text(
             std::include_str!("../templates/docs-js/highlightjs-erlang.min.js").to_string(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("js/highlightjs-elixir.min.js"),
+        path: Utf8PathBuf::from("js/highlightjs-elixir.min.js"),
         content: Content::Text(
             std::include_str!("../templates/docs-js/highlightjs-elixir.min.js").to_string(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("js/highlightjs-javascript.min.js"),
+        path: Utf8PathBuf::from("js/highlightjs-javascript.min.js"),
         content: Content::Text(
             std::include_str!("../templates/docs-js/highlightjs-javascript.min.js").to_string(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("js/highlightjs-typescript.min.js"),
+        path: Utf8PathBuf::from("js/highlightjs-typescript.min.js"),
         content: Content::Text(
             std::include_str!("../templates/docs-js/highlightjs-typescript.min.js").to_string(),
         ),
@@ -322,12 +324,12 @@ pub fn generate_html(
     // lunr.min.js, search-data.js and index.js:
 
     files.push(OutputFile {
-        path: PathBuf::from("js/lunr.min.js"),
+        path: Utf8PathBuf::from("js/lunr.min.js"),
         content: Content::Text(std::include_str!("../templates/docs-js/lunr.min.js").to_string()),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("search-data.js"),
+        path: Utf8PathBuf::from("search-data.js"),
         content: Content::Text(format!(
             "window.Gleam.initSearch({});",
             serde_to_string(&escape_html_contents(search_indexes))
@@ -336,42 +338,42 @@ pub fn generate_html(
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("js/index.js"),
+        path: Utf8PathBuf::from("js/index.js"),
         content: Content::Text(std::include_str!("../templates/docs-js/index.js").to_string()),
     });
 
     // web fonts:
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/karla-v23-regular-latin-ext.woff2"),
+        path: Utf8PathBuf::from("fonts/karla-v23-regular-latin-ext.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/karla-v23-regular-latin-ext.woff2").to_vec(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/karla-v23-regular-latin.woff2"),
+        path: Utf8PathBuf::from("fonts/karla-v23-regular-latin.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/karla-v23-regular-latin.woff2").to_vec(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/karla-v23-bold-latin-ext.woff2"),
+        path: Utf8PathBuf::from("fonts/karla-v23-bold-latin-ext.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/karla-v23-bold-latin-ext.woff2").to_vec(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/karla-v23-bold-latin.woff2"),
+        path: Utf8PathBuf::from("fonts/karla-v23-bold-latin.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/karla-v23-bold-latin.woff2").to_vec(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/ubuntu-mono-v15-regular-cyrillic-ext.woff2"),
+        path: Utf8PathBuf::from("fonts/ubuntu-mono-v15-regular-cyrillic-ext.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/ubuntu-mono-v15-regular-cyrillic-ext.woff2")
                 .to_vec(),
@@ -379,7 +381,7 @@ pub fn generate_html(
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/ubuntu-mono-v15-regular-cyrillic.woff2"),
+        path: Utf8PathBuf::from("fonts/ubuntu-mono-v15-regular-cyrillic.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/ubuntu-mono-v15-regular-cyrillic.woff2")
                 .to_vec(),
@@ -387,7 +389,7 @@ pub fn generate_html(
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/ubuntu-mono-v15-regular-greek-ext.woff2"),
+        path: Utf8PathBuf::from("fonts/ubuntu-mono-v15-regular-greek-ext.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/ubuntu-mono-v15-regular-greek-ext.woff2")
                 .to_vec(),
@@ -395,14 +397,14 @@ pub fn generate_html(
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/ubuntu-mono-v15-regular-greek.woff2"),
+        path: Utf8PathBuf::from("fonts/ubuntu-mono-v15-regular-greek.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/ubuntu-mono-v15-regular-greek.woff2").to_vec(),
         ),
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/ubuntu-mono-v15-regular-latin-ext.woff2"),
+        path: Utf8PathBuf::from("fonts/ubuntu-mono-v15-regular-latin-ext.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/ubuntu-mono-v15-regular-latin-ext.woff2")
                 .to_vec(),
@@ -410,7 +412,7 @@ pub fn generate_html(
     });
 
     files.push(OutputFile {
-        path: PathBuf::from("fonts/ubuntu-mono-v15-regular-latin.woff2"),
+        path: Utf8PathBuf::from("fonts/ubuntu-mono-v15-regular-latin.woff2"),
         content: Content::Binary(
             include_bytes!("../templates/docs-fonts/ubuntu-mono-v15-regular-latin.woff2").to_vec(),
         ),

--- a/compiler-core/src/docs/source_links.rs
+++ b/compiler-core/src/docs/source_links.rs
@@ -5,7 +5,8 @@ use crate::{
     line_numbers::LineNumbers,
     paths::ProjectPaths,
 };
-use std::path::{Component, Path};
+
+use camino::{Utf8Component, Utf8Path};
 
 pub struct SourceLinker {
     line_numbers: LineNumbers,
@@ -69,15 +70,11 @@ impl SourceLinker {
     }
 }
 
-fn to_url_path(path: &Path) -> Option<String> {
+fn to_url_path(path: &Utf8Path) -> Option<String> {
     let mut buf = String::new();
     for c in path.components() {
-        if let Component::Normal(s) = c {
-            if let Some(s) = s.to_str() {
-                buf.push_str(s);
-            } else {
-                return None;
-            }
+        if let Utf8Component::Normal(s) = c {
+            buf.push_str(s);
         }
         buf.push('/');
     }

--- a/compiler-core/src/fix.rs
+++ b/compiler-core/src/fix.rs
@@ -2,8 +2,10 @@
 mod tests;
 
 use smol_str::SmolStr;
-use std::{collections::HashMap, path::Path};
+use std::collections::HashMap;
 use vec1::vec1;
+
+use camino::Utf8Path;
 
 use crate::{
     ast::{
@@ -18,7 +20,7 @@ use crate::{
 pub fn parse_fix_and_format(
     assumed_target: Option<Target>,
     src: &SmolStr,
-    path: &Path,
+    path: &Utf8Path,
 ) -> Result<(String, bool)> {
     // Parse
     let parsed = crate::parse::parse_module(src).map_err(|error| Error::Parse {

--- a/compiler-core/src/fix/tests.rs
+++ b/compiler-core/src/fix/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+use camino::Utf8Path;
+
 fn fix(target: Option<Target>, src: &str) -> String {
-    let (out, complete) = parse_fix_and_format(target, &src.into(), Path::new("test")).unwrap();
+    let (out, complete) = parse_fix_and_format(target, &src.into(), Utf8Path::new("test")).unwrap();
     assert!(complete);
     out
 }
@@ -496,7 +498,7 @@ fn ambiguous_external() {
     let src = r#"pub external fn main(wibble: Int, wobble: Float) -> Int =
   "app" "main"
 "#;
-    let (out, complete) = parse_fix_and_format(None, &src.into(), Path::new("test")).unwrap();
+    let (out, complete) = parse_fix_and_format(None, &src.into(), Utf8Path::new("test")).unwrap();
     assert!(!complete);
     assert_eq!(out, src)
 }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -13,12 +13,14 @@ use crate::{
 };
 use itertools::Itertools;
 use smol_str::SmolStr;
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 use vec1::Vec1;
+
+use camino::Utf8Path;
 
 const INDENT: isize = 2;
 
-pub fn pretty(writer: &mut impl Utf8Writer, src: &SmolStr, path: &Path) -> Result<()> {
+pub fn pretty(writer: &mut impl Utf8Writer, src: &SmolStr, path: &Utf8Path) -> Result<()> {
     let parsed = crate::parse::parse_module(src).map_err(|error| Error::Parse {
         path: path.to_path_buf(),
         src: src.clone(),

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -14,7 +14,8 @@ mod use_;
 macro_rules! assert_format {
     ($src:expr $(,)?) => {
         let mut writer = String::new();
-        $crate::format::pretty(&mut writer, &$src.into(), std::path::Path::new("<stdin>")).unwrap();
+        $crate::format::pretty(&mut writer, &$src.into(), camino::Utf8Path::new("<stdin>"))
+            .unwrap();
         assert_eq!($src, writer);
     };
 }
@@ -23,7 +24,8 @@ macro_rules! assert_format {
 macro_rules! assert_format_rewrite {
     ($src:expr, $output:expr  $(,)?) => {
         let mut writer = String::new();
-        $crate::format::pretty(&mut writer, &$src.into(), std::path::Path::new("<stdin>")).unwrap();
+        $crate::format::pretty(&mut writer, &$src.into(), camino::Utf8Path::new("<stdin>"))
+            .unwrap();
         assert_eq!(writer, $output);
     };
 }

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -1,8 +1,8 @@
+use camino::Utf8Path;
 use debug_ignore::DebugIgnore;
 use flate2::read::GzDecoder;
 use futures::future;
 use hexpm::version::Version;
-use std::path::Path;
 use tar::Archive;
 
 use crate::{
@@ -209,7 +209,7 @@ impl Downloader {
 
     // It would be really nice if this was async but the library is sync
     pub fn extract_package_from_cache(&self, name: &str, version: &Version) -> Result<bool> {
-        let contents_path = Path::new("contents.tar.gz");
+        let contents_path = Utf8Path::new("contents.tar.gz");
         let destination = self.paths.build_packages_package(name);
 
         // If the directory already exists then there's nothing for us to do

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -9,10 +9,6 @@ use tar::{Archive, Entry};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-pub fn utf8_or_panic(input: std::path::PathBuf) -> Utf8PathBuf {
-    Utf8PathBuf::from_path_buf(input).expect("Non Utf8 Path")
-}
-
 pub trait Reader: std::io::Read {
     /// A wrapper around `std::io::Read` that has Gleam's error handling.
     fn read_bytes(&mut self, buffer: &mut [u8]) -> Result<usize> {

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -9,6 +9,10 @@ use tar::{Archive, Entry};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
+pub fn utf8_or_panic(input: std::path::PathBuf) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(input).expect("Non Utf8 Path")
+}
+
 pub trait Reader: std::io::Read {
     /// A wrapper around `std::io::Read` that has Gleam's error handling.
     fn read_bytes(&mut self, buffer: &mut [u8]) -> Result<usize> {

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -5,7 +5,7 @@ mod pattern;
 mod tests;
 mod typescript;
 
-use std::path::Path;
+use camino::Utf8Path;
 
 use crate::type_::PRELUDE_MODULE_NAME;
 use crate::{
@@ -522,7 +522,7 @@ fn external_fn_args<T>(arguments: &[ExternalFnArg<T>]) -> Document<'_> {
 pub fn module(
     module: &TypedModule,
     line_numbers: &LineNumbers,
-    path: &Path,
+    path: &Utf8Path,
     src: &SmolStr,
 ) -> Result<String, crate::Error> {
     let document = Generator::new(line_numbers, module)
@@ -537,7 +537,7 @@ pub fn module(
 
 pub fn ts_declaration(
     module: &TypedModule,
-    path: &Path,
+    path: &Utf8Path,
     src: &SmolStr,
 ) -> Result<String, crate::Error> {
     let document = typescript::TypeScriptGenerator::new(module)

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     uid::UniqueIdGenerator,
     warning::TypeWarningEmitter,
 };
-use std::path::Path;
+use camino::Utf8Path;
 
 mod assignments;
 mod bit_strings;
@@ -118,10 +118,10 @@ pub fn compile(src: &str, dep: Option<(&str, &str, &str)>) -> TypedModule {
 pub fn compile_js(src: &str, dep: Option<(&str, &str, &str)>) -> String {
     let ast = compile(src, dep);
     let line_numbers = LineNumbers::new(src);
-    module(&ast, &line_numbers, Path::new(""), &"".into()).unwrap()
+    module(&ast, &line_numbers, Utf8Path::new(""), &"".into()).unwrap()
 }
 
 pub fn compile_ts(src: &str, dep: Option<(&str, &str, &str)>) -> String {
     let ast = compile(src, dep);
-    ts_declaration(&ast, Path::new(""), &src.into()).unwrap()
+    ts_declaration(&ast, Utf8Path::new(""), &src.into()).unwrap()
 }

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -14,7 +14,9 @@ use crate::{
     warning::VectorWarningEmitterIO,
     Error, Result, Warning,
 };
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
+
+use camino::Utf8PathBuf;
 
 /// A wrapper around the project compiler which makes it possible to repeatedly
 /// recompile the top level package, reusing the information about the already
@@ -91,7 +93,7 @@ where
         })
     }
 
-    pub fn compile(&mut self) -> Result<Vec<PathBuf>, Error> {
+    pub fn compile(&mut self) -> Result<Vec<Utf8PathBuf>, Error> {
         // Lock the build directory to ensure to ensure we are the only one compiling
         let _lock_guard = self.locker.lock_for_build();
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -11,9 +11,9 @@ use crate::{
     type_::{pretty::Printer, PreludeType, ValueConstructorVariant},
     Error, Result, Warning,
 };
+use camino::Utf8PathBuf;
 use lsp_types::{self as lsp, Hover, HoverContents, MarkedString, Url};
 use smol_str::SmolStr;
-use std::path::PathBuf;
 use strum::IntoEnumIterator;
 
 use super::{src_span_to_lsp_range, DownloadDependencies, MakeLocker};
@@ -28,7 +28,7 @@ pub struct Response<T> {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Compilation {
     /// Compilation was attempted and succeeded for these modules.
-    Yes(Vec<PathBuf>),
+    Yes(Vec<Utf8PathBuf>),
     /// Compilation was not attempted for this operation.
     No,
 }
@@ -43,7 +43,7 @@ pub struct LanguageServerEngine<IO, Reporter> {
     /// discarded and reloaded to handle any changes to dependencies.
     pub(crate) compiler: LspProjectCompiler<FileSystemProxy<IO>>,
 
-    modules_compiled_since_last_feedback: Vec<PathBuf>,
+    modules_compiled_since_last_feedback: Vec<Utf8PathBuf>,
     compiled_since_last_feedback: bool,
 
     // Used to publish progress notifications to the client without waiting for
@@ -283,7 +283,7 @@ where
         let path = uri.to_file_path().expect("URL file");
 
         #[cfg(not(any(unix, windows, target_os = "redox", target_os = "wasi")))]
-        let path: PathBuf = uri.path().into();
+        let path: Utf8PathBuf = uri.path().into();
 
         let components = path
             .strip_prefix(self.paths.root())

--- a/compiler-core/src/language_server/feedback.rs
+++ b/compiler-core/src/language_server/feedback.rs
@@ -1,7 +1,7 @@
 use crate::{diagnostic::Diagnostic, Error, Warning};
 use std::collections::{HashMap, HashSet};
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 
 use super::engine::Compilation;
 
@@ -354,7 +354,7 @@ mod tests {
         let file1 = Utf8PathBuf::from("src/file1.gleam");
         let file2 = Utf8PathBuf::from("src/file2.gleam");
 
-        let error = |file: &Utf8Path| Error::Parse {
+        let error = |file: &camino::Utf8Path| Error::Parse {
             path: file.to_path_buf(),
             src: "blah".into(),
             error: ParseError {

--- a/compiler-core/src/language_server/feedback.rs
+++ b/compiler-core/src/language_server/feedback.rs
@@ -1,25 +1,24 @@
 use crate::{diagnostic::Diagnostic, Error, Warning};
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-};
+use std::collections::{HashMap, HashSet};
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 use super::engine::Compilation;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Feedback {
-    pub diagnostics: HashMap<PathBuf, Vec<Diagnostic>>,
+    pub diagnostics: HashMap<Utf8PathBuf, Vec<Diagnostic>>,
     pub messages: Vec<Diagnostic>,
 }
 
 impl Feedback {
     /// Set the diagnostics for a file to an empty vector. This will overwrite
     /// any existing diagnostics on the client.
-    pub fn unset_existing_diagnostics(&mut self, path: PathBuf) {
+    pub fn unset_existing_diagnostics(&mut self, path: Utf8PathBuf) {
         _ = self.diagnostics.insert(path, vec![]);
     }
 
-    pub fn append_diagnostic(&mut self, path: PathBuf, diagnostic: Diagnostic) {
+    pub fn append_diagnostic(&mut self, path: Utf8PathBuf, diagnostic: Diagnostic) {
         self.diagnostics
             .entry(path)
             .or_insert_with(Vec::new)
@@ -44,8 +43,8 @@ impl Feedback {
 ///
 #[derive(Debug, Default)]
 pub struct FeedbackBookKeeper {
-    files_with_warnings: HashSet<PathBuf>,
-    files_with_errors: HashSet<PathBuf>,
+    files_with_warnings: HashSet<Utf8PathBuf>,
+    files_with_errors: HashSet<Utf8PathBuf>,
 }
 
 impl FeedbackBookKeeper {
@@ -137,7 +136,6 @@ impl FeedbackBookKeeper {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
 
     use super::*;
     use crate::{
@@ -149,9 +147,9 @@ mod tests {
     #[test]
     fn feedback() {
         let mut book_keeper = FeedbackBookKeeper::default();
-        let file1 = PathBuf::from("src/file1.gleam");
-        let file2 = PathBuf::from("src/file2.gleam");
-        let file3 = PathBuf::from("src/file3.gleam");
+        let file1 = Utf8PathBuf::from("src/file1.gleam");
+        let file2 = Utf8PathBuf::from("src/file2.gleam");
+        let file3 = Utf8PathBuf::from("src/file3.gleam");
 
         let warning1 = Warning::Type {
             path: file1.clone(),
@@ -212,7 +210,7 @@ mod tests {
         // location.
 
         let mut book_keeper = FeedbackBookKeeper::default();
-        let file1 = PathBuf::from("src/file1.gleam");
+        let file1 = Utf8PathBuf::from("src/file1.gleam");
 
         let warning1 = Warning::Type {
             path: file1.clone(),
@@ -245,8 +243,8 @@ mod tests {
         // location.
 
         let mut book_keeper = FeedbackBookKeeper::default();
-        let file1 = PathBuf::from("src/file1.gleam");
-        let file3 = PathBuf::from("src/file2.gleam");
+        let file1 = Utf8PathBuf::from("src/file1.gleam");
+        let file3 = Utf8PathBuf::from("src/file2.gleam");
 
         let warning1 = Warning::Type {
             path: file1.clone(),
@@ -312,8 +310,8 @@ mod tests {
         // when a successful compilation occurs.
 
         let mut book_keeper = FeedbackBookKeeper::default();
-        let file1 = PathBuf::from("src/file1.gleam");
-        let file2 = PathBuf::from("src/file2.gleam");
+        let file1 = Utf8PathBuf::from("src/file1.gleam");
+        let file2 = Utf8PathBuf::from("src/file2.gleam");
 
         let error = Error::Parse {
             path: file1.clone(),
@@ -353,10 +351,10 @@ mod tests {
     #[test]
     fn second_failure_unsets_previous_error() {
         let mut book_keeper = FeedbackBookKeeper::default();
-        let file1 = PathBuf::from("src/file1.gleam");
-        let file2 = PathBuf::from("src/file2.gleam");
+        let file1 = Utf8PathBuf::from("src/file1.gleam");
+        let file2 = Utf8PathBuf::from("src/file2.gleam");
 
-        let error = |file: &Path| Error::Parse {
+        let error = |file: &Utf8Path| Error::Parse {
             path: file.to_path_buf(),
             src: "blah".into(),
             error: ParseError {
@@ -397,7 +395,7 @@ mod tests {
     #[test]
     fn successful_non_compilation_does_not_remove_error_diagnostic() {
         let mut book_keeper = FeedbackBookKeeper::default();
-        let file1 = PathBuf::from("src/file1.gleam");
+        let file1 = Utf8PathBuf::from("src/file1.gleam");
 
         let error = Error::Parse {
             path: file1.clone(),

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -1,6 +1,6 @@
 use crate::{
     diagnostic::{Diagnostic, Level},
-    io::{CommandExecutor, FileSystemReader, FileSystemWriter, utf8_or_panic},
+    io::{utf8_or_panic, CommandExecutor, FileSystemReader, FileSystemWriter},
     language_server::{
         engine::{self, LanguageServerEngine},
         feedback::{Feedback, FeedbackBookKeeper},

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -1,6 +1,6 @@
 use crate::{
     diagnostic::{Diagnostic, Level},
-    io::{utf8_or_panic, CommandExecutor, FileSystemReader, FileSystemWriter},
+    io::{CommandExecutor, FileSystemReader, FileSystemWriter},
     language_server::{
         engine::{self, LanguageServerEngine},
         feedback::{Feedback, FeedbackBookKeeper},
@@ -588,8 +588,9 @@ fn path_to_uri(path: Utf8PathBuf) -> Url {
 fn path(uri: &Url) -> Utf8PathBuf {
     // The to_file_path method is available on these platforms
     #[cfg(any(unix, windows, target_os = "redox", target_os = "wasi"))]
-    return utf8_or_panic(uri.to_file_path().expect("URL file"));
+    return Utf8PathBuf::from_path_buf(uri.to_file_path().expect("URL file"))
+        .expect("Non Utf8 Path");
 
     #[cfg(not(any(unix, windows, target_os = "redox", target_os = "wasi")))]
-    return utf8_or_panic(uri.path().into());
+    return Utf8PathBuf::from_path_buf(uri.path().into()).expect("Non Utf8 Path");
 }

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -1,6 +1,6 @@
 use crate::{
     diagnostic::{Diagnostic, Level},
-    io::{CommandExecutor, FileSystemReader, FileSystemWriter},
+    io::{CommandExecutor, FileSystemReader, FileSystemWriter, utf8_or_panic},
     language_server::{
         engine::{self, LanguageServerEngine},
         feedback::{Feedback, FeedbackBookKeeper},
@@ -588,9 +588,8 @@ fn path_to_uri(path: Utf8PathBuf) -> Url {
 fn path(uri: &Url) -> Utf8PathBuf {
     // The to_file_path method is available on these platforms
     #[cfg(any(unix, windows, target_os = "redox", target_os = "wasi"))]
-    return Utf8PathBuf::from_path_buf(uri.to_file_path().expect("URL file"))
-        .expect("Non Utf-8 Path");
+    return utf8_or_panic(uri.to_file_path().expect("URL file"));
 
     #[cfg(not(any(unix, windows, target_os = "redox", target_os = "wasi")))]
-    return Utf8PathBuf::from_path_buf(uri.path().into()).expect("Non Utf-8 Path");
+    return utf8_or_panic(uri.path().into());
 }

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -24,7 +24,9 @@ use lsp_types::{
     InitializeParams, PublishDiagnosticsParams,
 };
 use serde_json::Value as Json;
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
+
+use camino::Utf8PathBuf;
 
 use super::progress::ConnectionProgressReporter;
 
@@ -185,7 +187,7 @@ where
         self.publish_messages(feedback.messages);
     }
 
-    fn publish_diagnostics(&self, diagnostics: HashMap<PathBuf, Vec<Diagnostic>>) {
+    fn publish_diagnostics(&self, diagnostics: HashMap<Utf8PathBuf, Vec<Diagnostic>>) {
         for (path, diagnostics) in diagnostics {
             let diagnostics = diagnostics
                 .into_iter()
@@ -277,7 +279,7 @@ where
 
     fn respond_with_engine<T, Handler>(
         &mut self,
-        path: PathBuf,
+        path: Utf8PathBuf,
         handler: Handler,
     ) -> (Json, Feedback)
     where
@@ -314,7 +316,7 @@ where
 
     fn notified_with_engine(
         &mut self,
-        path: PathBuf,
+        path: Utf8PathBuf,
         handler: impl FnOnce(
             &mut LanguageServerEngine<IO, ConnectionProgressReporter<'a>>,
         ) -> engine::Response<()>,
@@ -577,17 +579,18 @@ fn diagnostic_to_lsp(diagnostic: Diagnostic) -> Vec<lsp::Diagnostic> {
     }
 }
 
-fn path_to_uri(path: PathBuf) -> Url {
+fn path_to_uri(path: Utf8PathBuf) -> Url {
     let mut file: String = "file://".into();
     file.push_str(&path.as_os_str().to_string_lossy());
     Url::parse(&file).expect("path_to_uri URL parse")
 }
 
-fn path(uri: &Url) -> PathBuf {
+fn path(uri: &Url) -> Utf8PathBuf {
     // The to_file_path method is available on these platforms
     #[cfg(any(unix, windows, target_os = "redox", target_os = "wasi"))]
-    return uri.to_file_path().expect("URL file");
+    return Utf8PathBuf::from_path_buf(uri.to_file_path().expect("URL file"))
+        .expect("Non Utf-8 Path");
 
     #[cfg(not(any(unix, windows, target_os = "redox", target_os = "wasi")))]
-    return uri.path().into();
+    return Utf8PathBuf::from_path_buf(uri.path().into()).expect("Non Utf-8 Path");
 }

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -28,7 +28,7 @@ fn positioned_expression_completions(
     let response = engine.compile_please();
     assert!(response.result.is_ok());
 
-    let path = PathBuf::from(if cfg!(target_family = "windows") {
+    let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
         r#"\\?\C:\src\app.gleam"#
     } else {
         "/src/app.gleam"

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -3,12 +3,13 @@ mod completion;
 
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::SystemTime,
 };
 
 use hexpm::version::Version;
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::{
     config::PackageConfig,
@@ -58,28 +59,28 @@ impl LanguageServerTestIO {
         Arc::try_unwrap(self.actions).unwrap().into_inner().unwrap()
     }
 
-    pub fn src_module(&self, name: &str, code: &str) -> PathBuf {
+    pub fn src_module(&self, name: &str, code: &str) -> Utf8PathBuf {
         let src_dir = self.paths.src_directory();
         let path = src_dir.join(name).with_extension("gleam");
         self.module(&path, code);
         path
     }
 
-    pub fn test_module(&self, name: &str, code: &str) -> PathBuf {
+    pub fn test_module(&self, name: &str, code: &str) -> Utf8PathBuf {
         let test_dir = self.paths.test_directory();
         let path = test_dir.join(name).with_extension("gleam");
         self.module(&path, code);
         path
     }
 
-    pub fn dep_module(&self, dep: &str, name: &str, code: &str) -> PathBuf {
+    pub fn dep_module(&self, dep: &str, name: &str, code: &str) -> Utf8PathBuf {
         let dep_dir = self.paths.root().join(dep).join("src");
         let path = dep_dir.join(name).with_extension("gleam");
         self.module(&path, code);
         path
     }
 
-    fn module(&self, path: &Path, code: &str) {
+    fn module(&self, path: &Utf8Path, code: &str) {
         self.io.write(path, code).unwrap();
         self.io.set_modification_time(path, SystemTime::now());
     }
@@ -90,81 +91,81 @@ impl LanguageServerTestIO {
 }
 
 impl FileSystemReader for LanguageServerTestIO {
-    fn gleam_source_files(&self, dir: &Path) -> Vec<PathBuf> {
+    fn gleam_source_files(&self, dir: &Utf8Path) -> Vec<Utf8PathBuf> {
         self.io.gleam_source_files(dir)
     }
 
-    fn gleam_cache_files(&self, dir: &Path) -> Vec<PathBuf> {
+    fn gleam_cache_files(&self, dir: &Utf8Path) -> Vec<Utf8PathBuf> {
         self.io.gleam_cache_files(dir)
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+    fn read_dir(&self, path: &Utf8Path) -> Result<ReadDir> {
         self.io.read_dir(path)
     }
 
-    fn read(&self, path: &Path) -> Result<String> {
+    fn read(&self, path: &Utf8Path) -> Result<String> {
         self.io.read(path)
     }
 
-    fn read_bytes(&self, path: &Path) -> Result<Vec<u8>> {
+    fn read_bytes(&self, path: &Utf8Path) -> Result<Vec<u8>> {
         self.io.read_bytes(path)
     }
 
-    fn reader(&self, path: &Path) -> Result<WrappedReader> {
+    fn reader(&self, path: &Utf8Path) -> Result<WrappedReader> {
         self.io.reader(path)
     }
 
-    fn is_file(&self, path: &Path) -> bool {
+    fn is_file(&self, path: &Utf8Path) -> bool {
         self.io.is_file(path)
     }
 
-    fn is_directory(&self, path: &Path) -> bool {
+    fn is_directory(&self, path: &Utf8Path) -> bool {
         self.io.is_directory(path)
     }
 
-    fn modification_time(&self, path: &Path) -> Result<SystemTime> {
+    fn modification_time(&self, path: &Utf8Path) -> Result<SystemTime> {
         self.io.modification_time(path)
     }
 
-    fn canonicalise(&self, path: &Path) -> Result<PathBuf, crate::Error> {
+    fn canonicalise(&self, path: &Utf8Path) -> Result<Utf8PathBuf, crate::Error> {
         self.io.canonicalise(path)
     }
 }
 
 impl FileSystemWriter for LanguageServerTestIO {
-    fn mkdir(&self, path: &Path) -> Result<()> {
+    fn mkdir(&self, path: &Utf8Path) -> Result<()> {
         self.io.mkdir(path)
     }
 
-    fn delete(&self, path: &Path) -> Result<()> {
+    fn delete(&self, path: &Utf8Path) -> Result<()> {
         self.io.delete(path)
     }
 
-    fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+    fn copy(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         self.io.copy(from, to)
     }
 
-    fn copy_dir(&self, from: &Path, to: &Path) -> Result<()> {
+    fn copy_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         self.io.copy_dir(from, to)
     }
 
-    fn hardlink(&self, from: &Path, to: &Path) -> Result<()> {
+    fn hardlink(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         self.io.hardlink(from, to)
     }
 
-    fn symlink_dir(&self, from: &Path, to: &Path) -> Result<()> {
+    fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         self.io.symlink_dir(from, to)
     }
 
-    fn delete_file(&self, path: &Path) -> Result<()> {
+    fn delete_file(&self, path: &Utf8Path) -> Result<()> {
         self.io.delete_file(path)
     }
 
-    fn write(&self, path: &Path, content: &str) -> Result<(), crate::Error> {
+    fn write(&self, path: &Utf8Path, content: &str) -> Result<(), crate::Error> {
         self.io.write(path, content)
     }
 
-    fn write_bytes(&self, path: &Path, content: &[u8]) -> Result<(), crate::Error> {
+    fn write_bytes(&self, path: &Utf8Path, content: &[u8]) -> Result<(), crate::Error> {
         self.io.write_bytes(path, content)
     }
 }
@@ -185,7 +186,7 @@ impl CommandExecutor for LanguageServerTestIO {
         program: &str,
         args: &[String],
         env: &[(&str, String)],
-        cwd: Option<&Path>,
+        cwd: Option<&Utf8Path>,
         stdio: crate::io::Stdio,
     ) -> Result<i32> {
         panic!(

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 use crate::requirement::Requirement;
 use crate::Result;
+use camino::Utf8PathBuf;
 use hexpm::version::Version;
 use itertools::Itertools;
 use smol_str::SmolStr;
@@ -92,7 +92,7 @@ impl Manifest {
                 }
                 ManifestPackageSource::Local { path } => {
                     buffer.push_str(r#", source = "local", path = ""#);
-                    buffer.push_str(path.to_str().expect("local path non utf-8"));
+                    buffer.push_str(path.as_str());
                     buffer.push('"');
                 }
             };
@@ -309,7 +309,7 @@ pub enum ManifestPackageSource {
     #[serde(rename = "git")]
     Git { repo: SmolStr, commit: SmolStr },
     #[serde(rename = "local")]
-    Local { path: PathBuf }, // should be the canonical path
+    Local { path: Utf8PathBuf }, // should be the canonical path
 }
 
 fn ordered_map<S, K, V>(value: &HashMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1,6 +1,6 @@
 use crate::ast::SrcSpan;
 use crate::parse::error::{LexicalError, LexicalErrorType, ParseError, ParseErrorType};
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use pretty_assertions::assert_eq;
 
@@ -33,7 +33,7 @@ pub fn expect_module_error(src: &str) -> String {
     let result = crate::parse::parse_module(src).expect_err("should not parse");
     let error = crate::error::Error::Parse {
         src: src.into(),
-        path: PathBuf::from("/src/parse/error.gleam"),
+        path: Utf8PathBuf::from("/src/parse/error.gleam"),
         error: result,
     };
     error.pretty_string()
@@ -43,7 +43,7 @@ pub fn expect_error(src: &str) -> String {
     let result = crate::parse::parse_statement_sequence(src).expect_err("should not parse");
     let error = crate::error::Error::Parse {
         src: src.into(),
-        path: PathBuf::from("/src/parse/error.gleam"),
+        path: Utf8PathBuf::from("/src/parse/error.gleam"),
         error: result,
     };
     error.pretty_string()

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -1,16 +1,16 @@
-use std::path::{Path, PathBuf};
-
 use crate::build::{Mode, Target};
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 pub const ARTEFACT_DIRECTORY_NAME: &str = "_gleam_artefacts";
 
 #[derive(Debug, Clone)]
 pub struct ProjectPaths {
-    root: PathBuf,
+    root: Utf8PathBuf,
 }
 
 impl ProjectPaths {
-    pub fn new(root: PathBuf) -> Self {
+    pub fn new(root: Utf8PathBuf) -> Self {
         Self { root }
     }
 
@@ -21,74 +21,74 @@ impl ProjectPaths {
             "/"
         };
 
-        Self::new(PathBuf::from(path))
+        Self::new(Utf8PathBuf::from(path))
     }
 
-    pub fn root(&self) -> &Path {
+    pub fn root(&self) -> &Utf8Path {
         &self.root
     }
 
-    pub fn root_config(&self) -> PathBuf {
+    pub fn root_config(&self) -> Utf8PathBuf {
         self.root.join("gleam.toml")
     }
 
-    pub fn readme(&self) -> PathBuf {
+    pub fn readme(&self) -> Utf8PathBuf {
         self.root.join("README.md")
     }
 
-    pub fn manifest(&self) -> PathBuf {
+    pub fn manifest(&self) -> Utf8PathBuf {
         self.root.join("manifest.toml")
     }
 
-    pub fn src_directory(&self) -> PathBuf {
+    pub fn src_directory(&self) -> Utf8PathBuf {
         self.root.join("src")
     }
 
-    pub fn test_directory(&self) -> PathBuf {
+    pub fn test_directory(&self) -> Utf8PathBuf {
         self.root.join("test")
     }
 
-    pub fn build_directory(&self) -> PathBuf {
+    pub fn build_directory(&self) -> Utf8PathBuf {
         self.root.join("build")
     }
 
-    pub fn build_packages_directory(&self) -> PathBuf {
+    pub fn build_packages_directory(&self) -> Utf8PathBuf {
         self.build_directory().join("packages")
     }
 
-    pub fn build_packages_toml(&self) -> PathBuf {
+    pub fn build_packages_toml(&self) -> Utf8PathBuf {
         self.build_packages_directory().join("packages.toml")
     }
 
-    pub fn build_packages_package(&self, package_name: &str) -> PathBuf {
+    pub fn build_packages_package(&self, package_name: &str) -> Utf8PathBuf {
         self.build_packages_directory().join(package_name)
     }
 
     // build_deps_package_config
-    pub fn build_packages_package_config(&self, package_name: &str) -> PathBuf {
+    pub fn build_packages_package_config(&self, package_name: &str) -> Utf8PathBuf {
         self.build_packages_package(package_name).join("gleam.toml")
     }
 
-    pub fn build_export_hex_tarball(&self, package_name: &str, version: &str) -> PathBuf {
+    pub fn build_export_hex_tarball(&self, package_name: &str, version: &str) -> Utf8PathBuf {
         self.build_directory()
             .join(format!("{package_name}-{version}.tar"))
     }
 
-    pub fn build_directory_for_mode(&self, mode: Mode) -> PathBuf {
+    pub fn build_directory_for_mode(&self, mode: Mode) -> Utf8PathBuf {
         self.build_directory().join(mode.to_string())
     }
 
-    pub fn erlang_shipment_directory(&self) -> PathBuf {
+    pub fn erlang_shipment_directory(&self) -> Utf8PathBuf {
         self.build_directory().join("erlang-shipment")
     }
 
-    pub fn build_documentation_directory(&self, package: &str) -> PathBuf {
+    pub fn build_documentation_directory(&self, package: &str) -> Utf8PathBuf {
         self.build_directory_for_mode(Mode::Dev)
             .join("docs")
             .join(package)
     }
 
-    pub fn build_directory_for_target(&self, mode: Mode, target: Target) -> PathBuf {
+    pub fn build_directory_for_target(&self, mode: Mode, target: Target) -> Utf8PathBuf {
         self.build_directory_for_mode(mode).join(target.to_string())
     }
 
@@ -97,11 +97,11 @@ impl ProjectPaths {
         mode: Mode,
         target: Target,
         package: &str,
-    ) -> PathBuf {
+    ) -> Utf8PathBuf {
         self.build_directory_for_target(mode, target).join(package)
     }
 
-    pub fn build_packages_ebins_glob(&self, mode: Mode, target: Target) -> PathBuf {
+    pub fn build_packages_ebins_glob(&self, mode: Mode, target: Target) -> Utf8PathBuf {
         self.build_directory_for_package(mode, target, "*")
             .join("ebin")
     }
@@ -109,31 +109,34 @@ impl ProjectPaths {
     /// A path to a special file that contains the version of gleam that last built
     /// the artifacts. If this file does not match the current version of gleam we
     /// will rebuild from scratch
-    pub fn build_gleam_version(&self, mode: Mode, target: Target) -> PathBuf {
+    pub fn build_gleam_version(&self, mode: Mode, target: Target) -> Utf8PathBuf {
         self.build_directory_for_target(mode, target)
             .join("gleam_version")
     }
 }
 
-pub fn global_package_cache_package_tarball(package_name: &str, version: &str) -> PathBuf {
+pub fn global_package_cache_package_tarball(package_name: &str, version: &str) -> Utf8PathBuf {
     global_packages_cache().join(format!("{package_name}-{version}.tar"))
 }
 
-fn global_packages_cache() -> PathBuf {
+fn global_packages_cache() -> Utf8PathBuf {
     default_global_gleam_cache()
         .join("hex")
         .join("hexpm")
         .join("packages")
 }
 
-pub fn default_global_gleam_cache() -> PathBuf {
-    dirs_next::cache_dir()
-        .expect("Failed to determine user cache directory")
-        .join("gleam")
+pub fn default_global_gleam_cache() -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(
+        dirs_next::cache_dir()
+            .expect("Failed to determine user cache directory")
+            .join("gleam"),
+    )
+    .expect("Non Utf8-Path")
 }
 
-pub fn unnest(within: &Path) -> PathBuf {
-    let mut path = PathBuf::new();
+pub fn unnest(within: &Utf8Path) -> Utf8PathBuf {
+    let mut path = Utf8PathBuf::new();
     for _ in within {
         path = path.join("..")
     }

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -1,7 +1,4 @@
-use crate::{
-    build::{Mode, Target},
-    io::utf8_or_panic,
-};
+use crate::build::{Mode, Target};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -130,11 +127,12 @@ fn global_packages_cache() -> Utf8PathBuf {
 }
 
 pub fn default_global_gleam_cache() -> Utf8PathBuf {
-    utf8_or_panic(
+    Utf8PathBuf::from_path_buf(
         dirs_next::cache_dir()
             .expect("Failed to determine user cache directory")
             .join("gleam"),
     )
+    .expect("Non Utf8 Path")
 }
 
 pub fn unnest(within: &Utf8Path) -> Utf8PathBuf {

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -1,4 +1,7 @@
-use crate::{build::{Mode, Target}, io::utf8_or_panic};
+use crate::{
+    build::{Mode, Target},
+    io::utf8_or_panic,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -1,4 +1,4 @@
-use crate::build::{Mode, Target};
+use crate::{build::{Mode, Target}, io::utf8_or_panic};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -127,12 +127,11 @@ fn global_packages_cache() -> Utf8PathBuf {
 }
 
 pub fn default_global_gleam_cache() -> Utf8PathBuf {
-    Utf8PathBuf::from_path_buf(
+    utf8_or_panic(
         dirs_next::cache_dir()
             .expect("Failed to determine user cache directory")
             .join("gleam"),
     )
-    .expect("Non Utf8-Path")
 }
 
 pub fn unnest(within: &Utf8Path) -> Utf8PathBuf {

--- a/compiler-core/src/requirement.rs
+++ b/compiler-core/src/requirement.rs
@@ -1,8 +1,8 @@
 use std::fmt;
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::error::Result;
+use camino::Utf8PathBuf;
 use hexpm::version::Range;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, Serializer};
@@ -13,7 +13,7 @@ use smol_str::SmolStr;
 #[serde(untagged, remote = "Self")]
 pub enum Requirement {
     Hex { version: Range },
-    Path { path: PathBuf },
+    Path { path: Utf8PathBuf },
     Git { git: SmolStr },
 }
 
@@ -37,7 +37,7 @@ impl Requirement {
             Requirement::Hex { version: range } => {
                 format!(r#"{{ version = "{}" }}"#, range)
             }
-            Requirement::Path { path } => format!(r#"{{ path = "{}" }}"#, path.display()),
+            Requirement::Path { path } => format!(r#"{{ path = "{}" }}"#, path),
             Requirement::Git { git: url } => format!(r#"{{ git = "{}" }}"#, url),
         }
     }

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -3,7 +3,8 @@ use crate::{
     type_::Type,
 };
 
-use std::{path::PathBuf, sync::Arc};
+use camino::Utf8PathBuf;
+use std::sync::Arc;
 
 #[cfg(test)]
 use pretty_assertions::assert_eq;
@@ -410,7 +411,7 @@ impl Error {
 }
 
 impl Warning {
-    pub fn into_warning(self, path: PathBuf, src: SmolStr) -> crate::Warning {
+    pub fn into_warning(self, path: Utf8PathBuf, src: SmolStr) -> crate::Warning {
         crate::Warning::Type {
             path,
             src,

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -9,8 +9,10 @@ use crate::{
 };
 use itertools::Itertools;
 use smol_str::SmolStr;
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 use vec1::Vec1;
+
+use camino::Utf8PathBuf;
 
 mod assert;
 mod assignments;
@@ -80,7 +82,7 @@ macro_rules! assert_error {
             .expect_err("should infer an error");
         let error = $crate::error::Error::Type {
             src: $src.into(),
-            path: std::path::PathBuf::from("/src/one/two.gleam"),
+            path: camino::Utf8PathBuf::from("/src/one/two.gleam"),
             error,
         };
         let output = error.pretty_string();
@@ -130,7 +132,7 @@ fn get_printed_warnings(src: &str, deps: Vec<DependencyModule<'_>>) -> String {
     let warnings = get_warnings(src, deps);
     let mut nocolor = termcolor::Buffer::no_color();
     for warning in warnings {
-        let path = std::path::PathBuf::from("/src/warning/wrn.gleam");
+        let path = Utf8PathBuf::from("/src/warning/wrn.gleam");
         let warning = warning.into_warning(path, src.into());
         warning.pretty(&mut nocolor);
     }
@@ -245,7 +247,7 @@ pub fn compile_module(
     let ids = UniqueIdGenerator::new();
     let mut modules = im::HashMap::new();
     let warnings = TypeWarningEmitter::new(
-        PathBuf::new(),
+        Utf8PathBuf::new(),
         "".into(),
         WarningEmitter::new(
             warnings.unwrap_or_else(|| Arc::new(VectorWarningEmitterIO::default())),
@@ -292,7 +294,7 @@ pub fn module_error(src: &str, deps: Vec<DependencyModule<'_>>) -> String {
     let error = compile_module(src, None, deps).expect_err("should infer an error");
     let error = Error::Type {
         src: src.into(),
-        path: PathBuf::from("/src/one/two.gleam"),
+        path: Utf8PathBuf::from("/src/one/two.gleam"),
         error,
     };
     error.pretty_string()
@@ -302,7 +304,7 @@ pub fn syntax_error(src: &str) -> String {
     let error = crate::parse::parse_module(src).expect_err("should trigger an error when parsing");
     let error = Error::Parse {
         src: src.into(),
-        path: PathBuf::from("/src/one/two.gleam"),
+        path: Utf8PathBuf::from("/src/one/two.gleam"),
         error,
     };
     error.pretty_string()

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -4,13 +4,14 @@ use crate::{
     diagnostic::{self, Diagnostic, Location},
     type_,
 };
+use camino::Utf8PathBuf;
 use debug_ignore::DebugIgnore;
 use smol_str::SmolStr;
+use std::sync::atomic::AtomicUsize;
 use std::{
     io::Write,
     sync::{atomic::Ordering, Arc},
 };
-use std::{path::PathBuf, sync::atomic::AtomicUsize};
 use termcolor::Buffer;
 
 pub trait WarningEmitterIO {
@@ -91,13 +92,13 @@ impl WarningEmitter {
 
 #[derive(Debug, Clone)]
 pub struct TypeWarningEmitter {
-    module_path: PathBuf,
+    module_path: Utf8PathBuf,
     module_src: SmolStr,
     emitter: WarningEmitter,
 }
 
 impl TypeWarningEmitter {
-    pub fn new(module_path: PathBuf, module_src: SmolStr, emitter: WarningEmitter) -> Self {
+    pub fn new(module_path: Utf8PathBuf, module_src: SmolStr, emitter: WarningEmitter) -> Self {
         Self {
             module_path,
             module_src,
@@ -107,7 +108,7 @@ impl TypeWarningEmitter {
 
     pub fn null() -> Self {
         Self {
-            module_path: PathBuf::new(),
+            module_path: Utf8PathBuf::new(),
             module_src: SmolStr::new(""),
             emitter: WarningEmitter::new(Arc::new(NullWarningEmitterIO)),
         }
@@ -125,17 +126,17 @@ impl TypeWarningEmitter {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Warning {
     Type {
-        path: PathBuf,
+        path: Utf8PathBuf,
         src: SmolStr,
         warning: crate::type_::Warning,
     },
     Parse {
-        path: PathBuf,
+        path: Utf8PathBuf,
         src: SmolStr,
         warning: crate::parse::Warning,
     },
     InvalidSource {
-        path: PathBuf,
+        path: Utf8PathBuf,
     },
 }
 
@@ -241,7 +242,7 @@ impl Warning {
                 location: None,
                 hint: Some(format!(
                     "Rename `{}` to be valid, or remove this file from the project source.",
-                    path.to_string_lossy()
+                    path
                 )),
             },
             Self::Type { path, warning, src } => match warning {

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -20,6 +20,7 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 tracing-wasm = "*"
 tracing = "*"
 termcolor = "1.1.2"
+camino = "1.1.6"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.28"

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, ffi::OsStr, path::Path, sync::Arc};
+use camino::Utf8Path;
+use std::{collections::HashMap, sync::Arc};
 
 use gleam_core::{
     build::{Built, Codegen, Mode, Options, ProjectCompiler, Target},
@@ -60,7 +61,7 @@ pub fn compile_(options: CompileOptions) -> Result<HashMap<String, String>, Stri
     Ok(gather_compiled_files(&paths, &wfs, options.target).unwrap())
 }
 
-fn write_source_file<P: AsRef<Path>>(source: &str, path: P, wfs: &mut WasmFileSystem) {
+fn write_source_file<P: AsRef<Utf8Path>>(source: &str, path: P, wfs: &mut WasmFileSystem) {
     wfs.write(path.as_ref(), source)
         .expect("should always succeed with the virtual file system");
 }
@@ -127,8 +128,8 @@ fn gather_compiled_files(
     let mut files: HashMap<String, String> = HashMap::new();
 
     let extension_to_search_for = match target {
-        Target::Erlang => OsStr::new("erl"),
-        Target::JavaScript => OsStr::new("mjs"),
+        Target::Erlang => "erl",
+        Target::JavaScript => "mjs",
     };
 
     wfs.read_dir(&paths.build_directory())
@@ -139,7 +140,7 @@ fn gather_compiled_files(
         .for_each(|dir_entry| {
             let path = dir_entry.as_path();
             let contents: String = wfs.read(path).expect("iterated dir entries should exist");
-            let path = path.to_str().unwrap().replace('\\', "/");
+            let path = path.as_str().replace('\\', "/");
 
             files.insert(path, contents);
         });

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -1,3 +1,4 @@
+use camino::{Utf8Path, Utf8PathBuf};
 use gleam_core::{
     io::{
         memory::InMemoryFileSystem, CommandExecutor, FileSystemReader, FileSystemWriter, ReadDir,
@@ -5,7 +6,6 @@ use gleam_core::{
     },
     Error, Result,
 };
-use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug)]
 pub struct WasmFileSystem {
@@ -26,7 +26,7 @@ impl CommandExecutor for WasmFileSystem {
         _program: &str,
         _args: &[String],
         _env: &[(&str, String)],
-        _cwd: Option<&Path>,
+        _cwd: Option<&Utf8Path>,
         _stdio: Stdio,
     ) -> Result<i32, Error> {
         Ok(0) // Always succeed.
@@ -34,91 +34,91 @@ impl CommandExecutor for WasmFileSystem {
 }
 
 impl FileSystemWriter for WasmFileSystem {
-    fn delete(&self, path: &Path) -> Result<(), Error> {
+    fn delete(&self, path: &Utf8Path) -> Result<(), Error> {
         tracing::trace!("delete {:?}", path);
         self.imfs.delete(path)
     }
 
-    fn copy(&self, _from: &Path, _to: &Path) -> Result<(), Error> {
+    fn copy(&self, _from: &Utf8Path, _to: &Utf8Path) -> Result<(), Error> {
         Ok(())
     }
-    fn copy_dir(&self, _: &Path, _: &Path) -> Result<(), Error> {
-        Ok(())
-    }
-
-    fn mkdir(&self, _: &Path) -> Result<(), Error> {
+    fn copy_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
         Ok(())
     }
 
-    fn hardlink(&self, _: &Path, _: &Path) -> Result<(), Error> {
+    fn mkdir(&self, _: &Utf8Path) -> Result<(), Error> {
         Ok(())
     }
 
-    fn symlink_dir(&self, _: &Path, _: &Path) -> Result<(), Error> {
+    fn hardlink(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
         Ok(())
     }
 
-    fn delete_file(&self, path: &Path) -> Result<(), Error> {
+    fn symlink_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn delete_file(&self, path: &Utf8Path) -> Result<(), Error> {
         tracing::trace!("delete file {:?}", path);
         self.imfs.delete_file(path)
     }
 
-    fn write(&self, path: &Path, content: &str) -> Result<(), Error> {
+    fn write(&self, path: &Utf8Path, content: &str) -> Result<(), Error> {
         tracing::trace!("write {:?}", path);
         self.imfs.write(path, content)
     }
 
-    fn write_bytes(&self, path: &Path, content: &[u8]) -> Result<(), Error> {
+    fn write_bytes(&self, path: &Utf8Path, content: &[u8]) -> Result<(), Error> {
         tracing::trace!("write_bytes {:?}", path);
         self.imfs.write_bytes(path, content)
     }
 }
 
 impl FileSystemReader for WasmFileSystem {
-    fn gleam_source_files(&self, dir: &Path) -> Vec<PathBuf> {
+    fn gleam_source_files(&self, dir: &Utf8Path) -> Vec<Utf8PathBuf> {
         tracing::trace!("gleam_source_files   {:?}", dir);
         self.imfs.gleam_source_files(dir)
     }
 
-    fn gleam_cache_files(&self, dir: &Path) -> Vec<PathBuf> {
+    fn gleam_cache_files(&self, dir: &Utf8Path) -> Vec<Utf8PathBuf> {
         tracing::trace!("gleam_metadata_files {:?}", dir);
         self.imfs.gleam_cache_files(dir)
     }
 
-    fn read(&self, path: &Path) -> Result<String, Error> {
+    fn read(&self, path: &Utf8Path) -> Result<String, Error> {
         tracing::trace!("read {:?}", path);
         self.imfs.read(path)
     }
 
-    fn is_file(&self, path: &Path) -> bool {
+    fn is_file(&self, path: &Utf8Path) -> bool {
         tracing::info!("is_file {:?}", path);
         self.imfs.is_file(path)
     }
 
-    fn is_directory(&self, path: &Path) -> bool {
+    fn is_directory(&self, path: &Utf8Path) -> bool {
         tracing::trace!("is_directory {:?}", path);
         false
     }
 
-    fn reader(&self, path: &Path) -> Result<WrappedReader, Error> {
+    fn reader(&self, path: &Utf8Path) -> Result<WrappedReader, Error> {
         tracing::trace!("reader {:?}", path);
         self.imfs.reader(path)
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+    fn read_dir(&self, path: &Utf8Path) -> Result<ReadDir> {
         tracing::trace!("read_dir {:?}", path);
         self.imfs.read_dir(path)
     }
 
-    fn modification_time(&self, path: &Path) -> Result<std::time::SystemTime, Error> {
+    fn modification_time(&self, path: &Utf8Path) -> Result<std::time::SystemTime, Error> {
         self.imfs.modification_time(path)
     }
 
-    fn read_bytes(&self, path: &Path) -> Result<Vec<u8>, Error> {
+    fn read_bytes(&self, path: &Utf8Path) -> Result<Vec<u8>, Error> {
         self.imfs.read_bytes(path)
     }
 
-    fn canonicalise(&self, path: &Path) -> Result<PathBuf, Error> {
+    fn canonicalise(&self, path: &Utf8Path) -> Result<Utf8PathBuf, Error> {
         self.imfs.canonicalise(path)
     }
 }

--- a/test-package-compiler/Cargo.toml
+++ b/test-package-compiler/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.10.1"
 walkdir = "2.3.2"
 # Regular expressions
 regex = "*"
+camino = "1.1.6"
 
 [dev-dependencies]
 # Snapshot testing to make test maintenance easier


### PR DESCRIPTION
closes #2079 

This pull request is a straight replacement of std::Path and std::PathBuf with their camino equivalents Utf8Path and Utf8PathBuf in the compiler-core, compiler-cli, compiler-wasm, and test-package-compiler crates. It's a lot of files, but there's absolutely nothing fancy.
When we get a Path or Pathbuf from a third party crate, we convert to Utf8 equivalent and expect with a nice error message. 