### PR TITLE
properly inline integer constants in bitstring patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   updated for the latest syntax.
 - Fixed a bug where mutually recursive functions could be incorrectly inferred
   as having an overly general type.
+- Fix a bug where constants where not being correctly inlined when used in the 
+  size option of a bitstring pattern match.
 
 ## v0.30.4 - 2023-07-26
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1087,6 +1087,7 @@ pub enum Pattern<Type> {
     VarUsage {
         location: SrcSpan,
         name: SmolStr,
+        constructor: Option<ValueConstructor>,
         type_: Type,
     },
 

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -31,7 +31,18 @@ fn print<'a>(
 
         Pattern::Discard { .. } => "_".to_doc(),
 
-        Pattern::VarUsage { name, .. } => env.local_var_name(name),
+        Pattern::VarUsage { name, constructor, .. } => {
+            let v = &constructor.as_ref().unwrap().variant;
+            match v {
+                ValueConstructorVariant::ModuleConstant{literal, ..} => {
+                    match literal {
+                        Constant::Int { value, .. } => int(&value),
+                        _ => env.local_var_name(name),
+                    }
+                },
+                _ => env.local_var_name(name)
+            }
+        }
 
         Pattern::Var { name, .. } if define_variables => {
             vars.push(name);

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -34,7 +34,12 @@ fn print<'a>(
         Pattern::VarUsage {
             name, constructor, ..
         } => {
-            let v = &constructor.as_ref().unwrap().variant;
+            let v = &constructor
+                .as_ref()
+                .expect(
+                    "Expected some constructor since this is a variable but instead none was found",
+                )
+                .variant;
             match v {
                 ValueConstructorVariant::ModuleConstant { literal, .. } => {
                     const_inline(literal, env)

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -36,9 +36,7 @@ fn print<'a>(
         } => {
             let v = &constructor
                 .as_ref()
-                .expect(
-                    "Expected Some constructor since this is a variable, instead None was found",
-                )
+                .expect("Constructor not found for variable usage")
                 .variant;
             match v {
                 ValueConstructorVariant::ModuleConstant { literal, .. } => {

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -31,13 +31,15 @@ fn print<'a>(
 
         Pattern::Discard { .. } => "_".to_doc(),
 
-        Pattern::VarUsage { name, constructor, .. } => {
+        Pattern::VarUsage {
+            name, constructor, ..
+        } => {
             let v = &constructor.as_ref().unwrap().variant;
             match v {
-                ValueConstructorVariant::ModuleConstant{literal, ..} => {
+                ValueConstructorVariant::ModuleConstant { literal, .. } => {
                     const_inline(literal, env)
-                },
-                _ => env.local_var_name(name)
+                }
+                _ => env.local_var_name(name),
             }
         }
 

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -35,10 +35,7 @@ fn print<'a>(
             let v = &constructor.as_ref().unwrap().variant;
             match v {
                 ValueConstructorVariant::ModuleConstant{literal, ..} => {
-                    match literal {
-                        Constant::Int { value, .. } => int(&value),
-                        _ => env.local_var_name(name),
-                    }
+                    const_inline(literal, env)
                 },
                 _ => env.local_var_name(name)
             }

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -37,7 +37,7 @@ fn print<'a>(
             let v = &constructor
                 .as_ref()
                 .expect(
-                    "Expected some constructor since this is a variable but instead none was found",
+                    "Expected Some constructor since this is a variable, instead None was found",
                 )
                 .variant;
             match v {

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__inline_const_pattern_option.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__inline_const_pattern_option.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/erlang/tests.rs
+assertion_line: 574
+expression: "pub fn main() {\n            let x = <<5:size(sixteen)>>\n            case x {\n              <<5:size(sixteen)>> -> <<5:size(sixteen)>>\n              <<6:size(15)>> -> <<5:size(15)>>\n            }\n          }\n          \n          pub const sixteen = 16"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars]).
+
+-export([main/0]).
+
+-spec main() -> bitstring().
+main() ->
+    Fifteen = 15,
+    X = <<5:(lists:max([(16), 0]))>>,
+    case X of
+        <<5:16>> ->
+            <<5:(lists:max([(16), 0]))>>;
+
+        <<6:Fifteen>> ->
+            <<5:(lists:max([(Fifteen), 0]))>>
+    end.
+

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -567,3 +567,19 @@ pub type Box {
 fn dynamic() {
     assert_erl!("pub external type Dynamic")
 }
+
+// https://github.com/gleam-lang/gleam/issues/2166
+#[test]
+fn inline_const_pattern_option() {
+    assert_erl!(
+        "pub fn main() {
+            let fifteen = 15
+            let x = <<5:size(sixteen)>>
+            case x {
+              <<5:size(sixteen)>> -> <<5:size(sixteen)>>
+              <<6:size(fifteen)>> -> <<5:size(fifteen)>>
+            }
+          }
+          
+          pub const sixteen = 16")
+}

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -581,5 +581,6 @@ fn inline_const_pattern_option() {
             }
           }
           
-          pub const sixteen = 16")
+          pub const sixteen = 16"
+    )
 }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2571,6 +2571,7 @@ where
             Some((start, Token::Name { name }, end)) => Ok(Pattern::VarUsage {
                 location: SrcSpan { start, end },
                 name,
+                constructor: None,
                 type_: (),
             }),
             Some((start, Token::Int { value }, end)) => Ok(Pattern::Int {

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -238,9 +238,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         variables: self.environment.local_value_names(),
                     })?;
                 self.environment.increment_usage(&name);
-                let typ = self
-                    .environment
-                    .instantiate(vc.type_.clone(), &mut hashmap![], self.hydrator);
+                let typ =
+                    self.environment
+                        .instantiate(vc.type_.clone(), &mut hashmap![], self.hydrator);
                 unify(int(), typ.clone()).map_err(|e| convert_unify_error(e, location))?;
 
                 Ok(Pattern::VarUsage {

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -228,7 +228,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             }
 
             Pattern::VarUsage { name, location, .. } => {
-                let ValueConstructor { type_, .. } = self
+                let vc = self
                     .environment
                     .get_variable(&name)
                     .cloned()
@@ -240,12 +240,13 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 self.environment.increment_usage(&name);
                 let typ = self
                     .environment
-                    .instantiate(type_, &mut hashmap![], self.hydrator);
+                    .instantiate(vc.type_.clone(), &mut hashmap![], self.hydrator);
                 unify(int(), typ.clone()).map_err(|e| convert_unify_error(e, location))?;
 
                 Ok(Pattern::VarUsage {
                     name,
                     location,
+                    constructor: Some(vc),
                     type_: typ,
                 })
             }


### PR DESCRIPTION
closes #2166 

To allow inlining of integer constants in bit string patterns, specifically in the bit string size option, I added an optional constructor field to Pattern::VarUsage. When the Pattern is typed, then the constructor field will hold Some(constructor), otherwise it is None. The constructor is used during codegen to get the const integer value to inline.

I still need to write tests for the new behavior as well as show that variables used in an option in a bitstring pattern still work as intended.


Gleam code that I wrote to replicate the issue:
```
pub fn main() {
  reveal_bug()
}

pub const sixteen = 16

fn reveal_bug() {
  let x = 16
  case arbitrary() {
    <<5:size(sixteen)>> -> <<5:size(sixteen)>>
    <<6:size(x)>> -> <<5:size(x)>>
  }
}

fn arbitrary() -> BitString {
  <<5:size(sixteen)>>
}
```

and corrected erlang output showing that "Sixteen" has been replaced by "16":
```
-spec arbitrary() -> bitstring().
arbitrary() ->
    <<5:(lists:max([(16), 0]))>>.

-spec reveal_bug() -> bitstring().
reveal_bug() ->
    X = 16,
    case arbitrary() of
        <<5:16>> ->
            <<5:(lists:max([(16), 0]))>>;

        <<6:X>> ->
            <<5:(lists:max([(X), 0]))>>
    end.

-spec main() -> bitstring().
main() ->
    reveal_bug().
```