### PR TITLE
Use `import type` for importing type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   that doesn't type check.
 - Hovering over a function definition will now display the function signature,
   or the type of the hovered argument.
+- Use `import type` for importing types from typescript declarations.
 
 ## v0.30.4 - 2023-07-26
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -26,6 +26,12 @@ pub const PRELUDE_TS_DEF: &str = include_str!("../templates/prelude.d.ts");
 
 pub type Output<'a> = Result<Document<'a>, Error>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JavaScriptCodegenTarget {
+    JavaScript,
+    TypeScriptDeclarations,
+}
+
 #[derive(Debug)]
 pub struct Generator<'a> {
     line_numbers: &'a LineNumbers,
@@ -134,9 +140,14 @@ impl<'a> Generator<'a> {
             statements.push(line());
             Ok(statements.to_doc())
         } else if statements.is_empty() {
-            Ok(imports.into_doc())
+            Ok(imports.into_doc(JavaScriptCodegenTarget::JavaScript))
         } else {
-            Ok(docvec![imports.into_doc(), line(), statements, line()])
+            Ok(docvec![
+                imports.into_doc(JavaScriptCodegenTarget::JavaScript),
+                line(),
+                statements,
+                line()
+            ])
         }
     }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__bit_string_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__bit_string_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/bit_strings.rs
 assertion_line: 148
 expression: "\npub fn go(x) {\n  <<x:bit_string, \"Gleam\":utf8>>\n}\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export function go(x: _.BitString): _.BitString;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__utf8_codepoint_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_strings__utf8_codepoint_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/bit_strings.rs
 assertion_line: 126
 expression: "\npub fn go(x) {\n  <<x:utf8_codepoint, \"Gleam\":utf8>>\n}\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export function go(x: _.UtfCodepoint): _.BitString;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/bools.rs
 assertion_line: 81
 expression: "\npub type True { True False Nil }\npub fn go(x, y) {\n  let assert True = x\n  let assert False = x\n  let assert Nil = y\n}\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export class True extends _.CustomType {}
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 154
 expression: "\npub type Mine {\n  Mine(a: Int, b: Int)\n}\n\npub const labels = Mine(b: 2, a: 1)\npub const no_labels = Mine(3, 4)\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export class Mine extends _.CustomType {
   constructor(a: number, b: number);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 225
 expression: "\npub type TypeWithALongNameAndSeveralArguments{\n  TypeWithALongNameAndSeveralArguments(String, String, String, a: String, b: String)\n}\n\npub const local = TypeWithALongNameAndSeveralArguments(\"one\", \"two\", \"three\", \"four\", \"five\")\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export class TypeWithALongNameAndSeveralArguments extends _.CustomType {
   constructor(

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 662
 expression: "pub opaque type Animal {\n  Cat(goes_outside: Bool)\n  Dog(plays_fetch: Bool)\n}\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 class Cat extends _.CustomType {
   constructor(goes_outside: boolean);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 650
 expression: "pub type Cat { Cat(name: String) }\n\npub fn return_unapplied_cat() {\n  Cat\n}\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export class Cat extends _.CustomType {
   constructor(name: string);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 195
 expression: "\npub type Ip{\n    Ip(String)\n}\n\npub const local = Ip(\"0.0.0.0\")\n\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export class Ip extends _.CustomType {
   constructor(argument$0: string);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 416
 expression: "import other.{Two}\npub fn main() {\n  Two(1)\n}"
 ---
-import * as other from "../other.d.ts";
+import type * as other from "../other.d.ts";
 
 export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 49
 expression: "import other\npub fn main() {\n  other.Two\n}"
 ---
-import * as other from "../other.d.ts";
+import type * as other from "../other.d.ts";
 
 export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 93
 expression: "import other.{Two as Three}\npub fn main() {\n  Three\n}"
 ---
-import * as other from "../other.d.ts";
+import type * as other from "../other.d.ts";
 
 export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 71
 expression: "import other.{Two}\npub fn main() {\n  Two\n}"
 ---
-import * as other from "../other.d.ts";
+import type * as other from "../other.d.ts";
 
 export function main(): other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/generics.rs
 assertion_line: 15
 expression: "pub type Animal(t) {\n  Cat(type_: t)\n  Dog(type_: t)\n}\n\npub fn main() {\n  Cat(type_: 6)\n}\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export class Cat<I> extends _.CustomType {
   constructor(type_: I);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__result_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__result_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/generics.rs
 assertion_line: 40
 expression: "pub fn map(result, fun) {\n            case result {\n              Ok(a) -> Ok(fun(a))\n              Error(e) -> Error(e)\n            }\n          }"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export function map<S, T, V>(result: _.Result<T, S>, fun: (x0: T) => V): _.Result<
   V,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/lists.rs
 assertion_line: 52
 expression: "\npub const a = []\npub const b = [1, 2, 3]\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export const a: _.List<any>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
@@ -3,8 +3,8 @@ source: compiler-core/src/javascript/tests/modules.rs
 assertion_line: 182
 expression: "import one/two/three.{Custom, One, Two}\n\npub fn go() -> List(Custom) { [One, Two] }\n"
 ---
-import * as _ from "../gleam.d.ts";
-import * as three from "../one/two/three.d.ts";
+import type * as _ from "../gleam.d.ts";
+import type * as three from "../one/two/three.d.ts";
 
 export function go(): _.List<three.Custom$>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/prelude.rs
 assertion_line: 41
 expression: "import gleam\npub fn go() { gleam.Nil }\n"
 ---
-import * as gleam from "../gleam.d.ts";
+import type * as gleam from "../gleam.d.ts";
 
 export function go(): null;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
@@ -3,8 +3,8 @@ source: compiler-core/src/javascript/tests/prelude.rs
 assertion_line: 14
 expression: "import gleam\npub fn go() { gleam.Ok(1) }\n"
 ---
-import * as _ from "../gleam.d.ts";
-import * as gleam from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
+import type * as gleam from "../gleam.d.ts";
 
 export function go(): _.Result<number, any>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__type_alias.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__type_alias.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/type_alias.rs
 assertion_line: 5
 expression: "\npub type Headers = List(#(String, String))\n"
 ---
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export type Headers = _.List<[string, string]>;
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -23,6 +23,7 @@ use crate::{
         TypedConstant, TypedDefinition, TypedModule, TypedRecordConstructor,
     },
     docvec,
+    javascript::JavaScriptCodegenTarget,
     pretty::{break_, Document, Documentable},
     type_::{Type, TypeVar},
 };
@@ -222,9 +223,14 @@ impl<'a> TypeScriptGenerator<'a> {
             statements.push(line());
             Ok(statements.to_doc())
         } else if statements.is_empty() {
-            Ok(imports.into_doc())
+            Ok(imports.into_doc(JavaScriptCodegenTarget::TypeScriptDeclarations))
         } else {
-            Ok(docvec![imports.into_doc(), line(), statements, line()])
+            Ok(docvec![
+                imports.into_doc(JavaScriptCodegenTarget::TypeScriptDeclarations),
+                line(),
+                statements,
+                line()
+            ])
         }
     }
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -16,7 +16,7 @@ expression: "./cases/javascript_d_ts"
 <prelude>
 
 //// /out/lib/the_package/hello.d.ts
-import * as _ from "./gleam.d.ts";
+import type * as _ from "./gleam.d.ts";
 
 export class Woo extends _.CustomType {}
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -22,7 +22,7 @@ expression: "./cases/javascript_import"
 <prelude>
 
 //// /out/lib/the_package/one/two.d.ts
-import * as _ from "../gleam.d.ts";
+import type * as _ from "../gleam.d.ts";
 
 export class A extends _.CustomType {}
 
@@ -36,7 +36,7 @@ export class A extends $CustomType {}
 
 
 //// /out/lib/the_package/two.d.ts
-import * as two from "./one/two.d.ts";
+import type * as two from "./one/two.d.ts";
 
 export const x: two.A$;
 


### PR DESCRIPTION
Right now when I open a generated typescript declaration there are errors about imports of types, like those:
```ts
import * as _ from "../gleam.d.ts";
```
```
A declaration file cannot be imported without 'import type'. 
Did you mean to import an implementation file '../gleam.js' instead?
```

This one changes printing of import statements - if an import path ends with `.d.ts` add the type modifier.

There is a downside through - `import type` was [introduced at the start of 2020](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports) with 3.8 release. 3.5 years have passed but I don't know what minimum version of typescript is supposed to be supported by gleam.