### PR TITLE
Display type when hovering over function arguments

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -151,6 +151,16 @@ impl<A> Arg<A> {
     }
 }
 
+impl TypedArg {
+    pub fn find_node(&self, byte_index: u32) -> Option<Located<'_>> {
+        if self.location.contains(byte_index) {
+            Some(Located::FunctionArgument(self))
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArgNames {
     Discard { name: SmolStr },
@@ -489,6 +499,14 @@ impl TypedDefinition {
         match self {
             Definition::Function(function) => {
                 if let Some(found) = function.body.iter().find_map(|s| s.find_node(byte_index)) {
+                    return Some(found);
+                };
+
+                if let Some(found) = function
+                    .arguments
+                    .iter()
+                    .find_map(|a| a.find_node(byte_index))
+                {
                     return Some(found);
                 };
 

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -16,7 +16,8 @@ pub use self::project_compiler::{Built, Options, ProjectCompiler};
 pub use self::telemetry::{NullTelemetry, Telemetry};
 
 use crate::ast::{
-    CustomType, DefinitionLocation, TypedDefinition, TypedExpr, TypedPattern, TypedStatement,
+    CustomType, DefinitionLocation, TypedArg, TypedDefinition, TypedExpr, TypedPattern,
+    TypedStatement,
 };
 use crate::{
     ast::{Definition, SrcSpan, TypedModule},
@@ -266,6 +267,7 @@ pub enum Located<'a> {
     Statement(&'a TypedStatement),
     Expression(&'a TypedExpr),
     ModuleStatement(&'a TypedDefinition),
+    FunctionArgument(&'a TypedArg),
 }
 
 impl<'a> Located<'a> {
@@ -277,6 +279,10 @@ impl<'a> Located<'a> {
             Self::ModuleStatement(statement) => Some(DefinitionLocation {
                 module: None,
                 span: statement.location(),
+            }),
+            Self::FunctionArgument(arg) => Some(DefinitionLocation {
+                module: None,
+                span: arg.location,
             }),
         }
     }

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1,0 +1,76 @@
+use lsp_types::{
+    Hover, HoverContents, HoverParams, MarkedString, Position, Range, TextDocumentIdentifier,
+    TextDocumentPositionParams, Url,
+};
+
+use super::*;
+
+fn hover_information(src: &str, dep: &str, position: Position) -> Option<Hover> {
+    let io = LanguageServerTestIO::new();
+    let mut engine = setup_engine(&io);
+
+    _ = io.src_module("dep", dep);
+    _ = io.src_module("app", src);
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+
+    let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
+        r"\\?\C:\src\app.gleam"
+    } else {
+        "/src/app.gleam"
+    });
+
+    let url = Url::from_file_path(path).unwrap();
+
+    let response = engine.hover(HoverParams {
+        text_document_position_params: TextDocumentPositionParams::new(
+            TextDocumentIdentifier::new(url),
+            position,
+        ),
+        work_done_progress_params: Default::default(),
+    });
+
+    response.result.unwrap()
+}
+
+#[test]
+fn nil_expression() {
+    let code = "
+fn wobble() {
+  Nil
+}";
+
+    assert_eq!(
+        hover_information(code, "", Position::new(2, 2)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nNil\n```\n".to_string()
+            )),
+            range: Some(Range {
+                start: Position::new(2, 2),
+                end: Position::new(2, 5)
+            }),
+        })
+    );
+}
+
+#[test]
+fn function_argument() {
+    let code = "
+fn wobble(x) {
+  x <> \"!\"
+}";
+
+    assert_eq!(
+        hover_information(code, "", Position::new(1, 10)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nString\n```\nA function argument.".to_string()
+            )),
+            range: Some(Range {
+                start: Position::new(1, 10),
+                end: Position::new(1, 11)
+            }),
+        })
+    );
+}

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -1,5 +1,6 @@
 mod compilation;
 mod completion;
+mod hover;
 
 use std::{
     collections::HashMap,

--- a/docs/annoyances.md
+++ b/docs/annoyances.md
@@ -34,9 +34,10 @@ case str == "+" {
         case all(str, is_digit) {
           True -> {
             let assert Ok(int) = int.parse(str)
-            Keep(Number(int)
+            Keep(Number(int))
           }
           False -> Next
+        }
     }
 }
 ```
@@ -49,7 +50,7 @@ use <- bool.guard(
 )
 use <- bool.guard(
   when: all(str, is_ascii_letter),
-  return: Keep(Ident(str),
+  return: Keep(Ident(str)),
 )
 use <- bool.guard(
   when: !all(str, is_digit),


### PR DESCRIPTION
Initial pass at adding LSP hover support for function arguments.

Closes #2240