### PR TITLE
Prefix module names with dollar in typescript to avoid name collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   or the type of the hovered argument.
 - Use `import type` for importing types from typescript declarations.
 - Use `.d.mts` extension for typescript declarations to match `.mjs`.
+- Prefix module names with dollar sign in typescript to avoid name collisions.
 
 ## v0.30.4 - 2023-07-26
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 416
 expression: "import other.{Two}\npub fn main() {\n  Two(1)\n}"
 ---
-import type * as other from "../other.d.mts";
+import type * as $other from "../other.d.mts";
 
-export function main(): other.One$;
+export function main(): $other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_typscript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 49
 expression: "import other\npub fn main() {\n  other.Two\n}"
 ---
-import type * as other from "../other.d.mts";
+import type * as $other from "../other.d.mts";
 
-export function main(): other.One$;
+export function main(): $other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 93
 expression: "import other.{Two as Three}\npub fn main() {\n  Three\n}"
 ---
-import type * as other from "../other.d.mts";
+import type * as $other from "../other.d.mts";
 
-export function main(): other.One$;
+export function main(): $other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 assertion_line: 71
 expression: "import other.{Two}\npub fn main() {\n  Two\n}"
 ---
-import type * as other from "../other.d.mts";
+import type * as $other from "../other.d.mts";
 
-export function main(): other.One$;
+export function main(): $other.One$;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__imported_custom_types_do_get_rendered_in_typescript.snap
@@ -4,7 +4,7 @@ assertion_line: 182
 expression: "import one/two/three.{Custom, One, Two}\n\npub fn go() -> List(Custom) { [One, Two] }\n"
 ---
 import type * as _ from "../gleam.d.mts";
-import type * as three from "../one/two/three.d.mts";
+import type * as $three from "../one/two/three.d.mts";
 
-export function go(): _.List<three.Custom$>;
+export function go(): _.List<$three.Custom$>;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
@@ -3,7 +3,7 @@ source: compiler-core/src/javascript/tests/prelude.rs
 assertion_line: 41
 expression: "import gleam\npub fn go() { gleam.Nil }\n"
 ---
-import type * as gleam from "../gleam.d.mts";
+import type * as $gleam from "../gleam.d.mts";
 
 export function go(): null;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
@@ -3,8 +3,8 @@ source: compiler-core/src/javascript/tests/prelude.rs
 assertion_line: 14
 expression: "import gleam\npub fn go() { gleam.Ok(1) }\n"
 ---
+import type * as $gleam from "../gleam.d.mts";
 import type * as _ from "../gleam.d.mts";
-import type * as gleam from "../gleam.d.mts";
 
 export function go(): _.Result<number, any>;
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -538,14 +538,16 @@ impl<'a> TypeScriptGenerator<'a> {
             return "_".into();
         }
 
-        match self.aliased_module_names.get(name) {
+        let name = match self.aliased_module_names.get(name) {
             Some(name) => (*name).to_string(),
             None => name
                 .split('/')
                 .last()
                 .expect("Non empty module path")
                 .to_string(),
-        }
+        };
+
+        format!("${name}")
     }
 
     fn do_print(

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -36,9 +36,9 @@ export class A extends $CustomType {}
 
 
 //// /out/lib/the_package/two.d.mts
-import type * as two from "./one/two.d.mts";
+import type * as $two from "./one/two.d.mts";
 
-export const x: two.A$;
+export const x: $two.A$;
 
 
 //// /out/lib/the_package/two.mjs


### PR DESCRIPTION
```gleam
// foo.gleam
pub fn stuff() {
  0
}
```
```gleam
// bar.gleam
import foo

pub fn foo() {
  foo.stuff()
}
```
Produces declaration for bar:
```ts
// bar.d.ts
import type * as foo from "./foo.d.mts";

export function foo(): number;
```
Which shows this error on `foo` in imports:
```
Import declaration conflicts with local declaration of 'foo'.
```
Js file does not have such conflict as star imports are prefixed with dollar sign:
```js
// bar.mjs
import * as $foo from "./foo.mjs";

export function foo() {
  return $foo.stuff();
}
```
The same method was used in typescript before, there is still a comment that module names are supposed to be prefixed with "$".

So this PR returns that prefixing with dollar for typescript.