### PR TITLE
Adjust the location field on the import to include the keyword

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -105,7 +105,7 @@ impl UntypedModule {
 #[test]
 fn module_dependencies_test() {
     let parsed = crate::parse::parse_module(
-        "import one 
+        "import one
          @target(erlang)
          import two
 
@@ -119,9 +119,9 @@ fn module_dependencies_test() {
 
     assert_eq!(
         vec![
-            ("one".into(), SrcSpan::new(7, 10)),
-            ("two".into(), SrcSpan::new(53, 56)),
-            ("four".into(), SrcSpan::new(126, 130)),
+            ("one".into(), SrcSpan::new(0, 10)),
+            ("two".into(), SrcSpan::new(45, 55)),
+            ("four".into(), SrcSpan::new(118, 129)),
         ],
         module.dependencies(Target::Erlang)
     );

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -522,10 +522,9 @@ import gleam
     );
 
     assert!(module.find_node(0).is_none());
-    assert!(module.find_node(7).is_none());
 
     // The import
-    assert!(module.find_node(8).is_some());
+    assert!(module.find_node(1).is_some());
     assert!(module.find_node(12).is_some());
 
     assert!(module.find_node(13).is_none());

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -230,9 +230,9 @@ where
 
         let def = match (self.tok0.take(), self.tok1.as_ref()) {
             // Imports
-            (Some((_, Token::Import, _)), _) => {
+            (Some((start, Token::Import, _)), _) => {
                 let _ = self.next_tok();
-                self.parse_import()
+                self.parse_import(start)
             }
             // Module Constants
             (Some((_, Token::Const, _)), _) => {
@@ -1888,7 +1888,7 @@ where
     //   import a/b
     //   import a/b.{c}
     //   import a/b.{c as d} as e
-    fn parse_import(&mut self) -> Result<Option<UntypedDefinition>, ParseError> {
+    fn parse_import(&mut self, import_start: u32) -> Result<Option<UntypedDefinition>, ParseError> {
         let mut start = 0;
         let mut end;
         let mut module = String::new();
@@ -1941,7 +1941,10 @@ where
 
         Ok(Some(Definition::Import(Import {
             documentation,
-            location: SrcSpan { start, end },
+            location: SrcSpan {
+                start: import_start,
+                end,
+            },
             unqualified,
             module: module.into(),
             as_name,

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1614
 expression: "\n        import foo/sub\n        import foo2/sub\n        pub fn main() {\n            sub.bar()\n        }\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import foo/sub
-  │                ^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^ First imported here
 3 │         import foo2/sub
-  │                ^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^ Reimported here
 
 sub has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1629
 expression: "\n        import foo/sub\n        import foo2/sub.{bar}\n        pub fn main() {\n            sub.bar()\n        }\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import foo/sub
-  │                ^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^ First imported here
 3 │         import foo2/sub.{bar}
-  │                ^^^^^^^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
 sub has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1644
 expression: "\n        import gleam/foo.{bar}\n        import gleam/foo.{zoo}\n        pub fn go() { bar() + zoo() }\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import gleam/foo.{bar}
-  │                ^^^^^^^^^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^^^^^^^^^ First imported here
 3 │         import gleam/foo.{zoo}
-  │                ^^^^^^^^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
 foo has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1662
 expression: "\n        import one\n        import two as one\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import one
-  │                ^^^ First imported here
+  │         ^^^^^^^^^^ First imported here
 3 │         import two as one
-  │                ^^^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^^^ Reimported here
 
 one has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1684
 expression: "\n        import one as two\n        import two\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import one as two
-  │                ^^^^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^^^^ First imported here
 3 │         import two
-  │                ^^^ Reimported here
+  │         ^^^^^^^^^^ Reimported here
 
 two has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1706
 expression: "\n        import one as x\n        import two as x\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import one as x
-  │                ^^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^^ First imported here
 3 │         import two as x
-  │                ^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^ Reimported here
 
 x has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1728
 expression: "\n        import one.{fn1}\n        import two.{fn2} as one\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import one.{fn1}
-  │                ^^^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^^^ First imported here
 3 │         import two.{fn2} as one
-  │                ^^^^^^^^^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
 one has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1750
 expression: "\n        import one.{fn1} as two\n        import two.{fn2}\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import one.{fn1} as two
-  │                ^^^^^^^^^^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^^^^^^^^^^ First imported here
 3 │         import two.{fn2}
-  │                ^^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^^ Reimported here
 
 two has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1772
 expression: "\n        import one.{fn1} as x\n        import two.{fn2} as x\n        "
 ---
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:16
+  ┌─ /src/one/two.gleam:2:9
   │
 2 │         import one.{fn1} as x
-  │                ^^^^^^^^^^^^^^ First imported here
+  │         ^^^^^^^^^^^^^^^^^^^^^ First imported here
 3 │         import two.{fn2} as x
-  │                ^^^^^^^^^^^^^^ Reimported here
+  │         ^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
 x has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 236
 expression: import xpto
 ---
 error: Unknown module
-  ┌─ /src/one/two.gleam:1:8
+  ┌─ /src/one/two.gleam:1:1
   │
 1 │ import xpto
-  │        ^^^^
+  │ ^^^^^^^^^^^
 
 No module has been found with the name `xpto`.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__importing_non_direct_dep_package.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__importing_non_direct_dep_package.snap
@@ -1,14 +1,13 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 841
 expression: "\nimport some_module\npub const x = some_module.x\n        "
 ---
 
 warning: Transative dependency imported
-  ┌─ /src/warning/wrn.gleam:2:8
+  ┌─ /src/warning/wrn.gleam:2:1
   │
 2 │ import some_module
-  │        ^^^^^^^^^^^
+  │ ^^^^^^^^^^^^^^^^^^
 
 The module `some_module` is being imported, but `non-dependency-package`,
 the package it belongs to, is not a direct dependency of your package.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -417,7 +417,7 @@ fn unused_imported_module_warnings_test() {
         "import gleam/foo",
         Warning::UnusedImportedModule {
             name: "foo".into(),
-            location: SrcSpan { start: 7, end: 16 },
+            location: SrcSpan { start: 0, end: 16 },
         }
     );
 }
@@ -429,7 +429,7 @@ fn unused_imported_module_with_alias_warnings_test() {
         "import gleam/foo as bar",
         Warning::UnusedImportedModule {
             name: "bar".into(),
-            location: SrcSpan { start: 7, end: 23 },
+            location: SrcSpan { start: 0, end: 23 },
         }
     );
 }
@@ -494,7 +494,7 @@ fn alternative_case_clause_pattern_variable_usage() {
 pub fn main(s) {
   case s {
     [a] | [a, _] -> a
-    _ -> 0 
+    _ -> 0
   }
 }"
     );

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__src_importing_test.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__src_importing_test.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 273
 expression: "./cases/src_importing_test"
 ---
 error: App importing test module
-  ┌─ src/one.gleam:3:8
+  ┌─ src/one.gleam:3:1
   │
 3 │ import two
-  │        ^ Imported here
+  │ ^ Imported here
 
 The application module `one` is importing the test module `two`.
 


### PR DESCRIPTION
This change updates the parser to include the "import" keyword in the ast location.