### PR TITLE
Fix links in error messages

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -580,12 +580,12 @@ your app.src file \"{app_ver}\""
                     "erl" | "erlc" | "escript" => text.push_str(
                         "
 Documentation for installing Erlang can be viewed here:
-https://gleam.run/getting-started/",
+https://gleam.run/getting-started/installing/",
                     ),
                     "rebar3" => text.push_str(
                         "
 Documentation for installing rebar3 can be viewed here:
-https://gleam.run/getting-started/",
+https://gleam.run/getting-started/installing/",
                     ),
                     _ => (),
                 }


### PR DESCRIPTION
The [getting-started](https://gleam.run/getting-started/) page linked in the existing error messages don't actually reference Erlang or rebar3 at all -- I think the documentation being referenced is the material in [installing](https://gleam.run/getting-started/installing/). 