### PR TITLE
Add support for module access in case clause guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - A warning is now emitted if a module from a transitive dependency is imported.
 - Record access can now be used in case clause guards.
+- Module access can now be used in case clause guards.
 - Fixed a bug where `manifest.toml` could contain absolute paths for path
   dependencies.
 - The `as` keyword can now be used to assign the literal prefix to a variable

--- a/compiler-core/src/erlang/tests/guards.rs
+++ b/compiler-core/src/erlang/tests/guards.rs
@@ -487,3 +487,66 @@ pub fn a(a: A) {
 "#
     );
 }
+
+#[test]
+fn module_access() {
+    assert_erl!(
+        (
+            "package",
+            "hero",
+            r#"
+              pub type Hero {
+                Hero(name: String)
+              }
+
+              pub const ironman = Hero("Tony Stark")
+            "#
+        ),
+        r#"
+          import hero
+
+          pub fn main() {
+            let name = "Tony Stark"
+
+            case name {
+              n if n == hero.ironman.name -> True
+              _ -> False
+            }
+          }
+        "#
+    );
+}
+
+#[test]
+fn module_nested_access() {
+    assert_erl!(
+        (
+            "package",
+            "hero",
+            r#"
+              pub type Person {
+                Person(name: String)
+              }
+
+              pub type Hero {
+                Hero(secret_identity: Person)
+              }
+
+              const bruce = Person("Bruce Wayne")
+              pub const batman = Hero(bruce)
+            "#
+        ),
+        r#"
+          import hero
+
+          pub fn main() {
+            let name = "Bruce Wayne"
+
+            case name {
+              n if n == hero.batman.secret_identity.name -> True
+              _ -> False
+            }
+          }
+        "#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_access.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests/guards.rs
+assertion_line: 493
+expression: "\n          import hero\n\n          pub fn main() {\n            let name = \"Tony Stark\"\n\n            case name {\n              n if n == hero.ironman.name -> True\n              _ -> False\n            }\n          }\n        "
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars]).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() ->
+    Name = <<"Tony Stark"/utf8>>,
+    case Name of
+        N when N =:= erlang:element(2, {hero, <<"Tony Stark"/utf8>>}) ->
+            true;
+
+        _ ->
+            false
+    end.
+

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_nested_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_nested_access.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/erlang/tests/guards.rs
+assertion_line: 522
+expression: "\n          import hero\n\n          pub fn main() {\n            let name = \"Bruce Wayne\"\n\n            case name {\n              n if n == hero.batman.secret_identity.name -> True\n              _ -> False\n            }\n          }\n        "
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars]).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() ->
+    Name = <<"Bruce Wayne"/utf8>>,
+    case Name of
+        N when N =:= erlang:element(
+            2,
+            erlang:element(2, {hero, {person, <<"Bruce Wayne"/utf8>>}})
+        ) ->
+            true;
+
+        _ ->
+            false
+    end.
+

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1087,6 +1087,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         match self.environment.imported_modules.get(&name) {
                             Some((location, module)) => match module.get_public_value(&label) {
                                 Some(constructor) => {
+                                    let _ = self.environment.unused_modules.remove(&module.name);
+
                                     match &constructor.variant {
                                         ValueConstructorVariant::LocalVariable { .. } => (),
                                         ValueConstructorVariant::ModuleFn { .. }


### PR DESCRIPTION
There is still a problem with the js side and that is why it's a draft.

Consider the following module(`hero.gleam`):
```gleam
pub type Hero {
  Hero(name: String)
}

pub const ironman = Hero("Tony Stark")
```

The following code:
```gleam
import hero

pub fn main() {
  let name = "Tony Stark"

  case name {
    n if n == hero.ironman.name -> True
    _ -> False
  }
}
```

Would produce:

```javascript
import * as $hero from "./hero.mjs";

export function main() {
  let name = "Tony Stark";
  if (name === new Hero("Tony Stark").name) {
    let n = name;
    return true;
  } else {
    return false;
  }
}
```