### PR TITLE
add target flag for gleam check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Module access can now be used in case clause guards.
 - The JS target now supports bit syntax for module consts.
+- The `gleam check` command supports the `target` flag now.
 
 ## v0.31.0 - 2023-09-25
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -107,7 +107,11 @@ enum Command {
     },
 
     /// Type check the project
-    Check,
+    Check {
+        /// The platform to target
+        #[clap(short, long, ignore_case = true, possible_values = Target::VARIANTS)]
+        target: Option<Target>,
+    },
 
     /// Publish the project to the Hex package manager
     ///
@@ -372,7 +376,7 @@ fn main() {
             warnings_as_errors,
         } => command_build(target, warnings_as_errors),
 
-        Command::Check => command_check(),
+        Command::Check { target } => command_check(target),
 
         Command::Docs(Docs::Build { open }) => docs::build(docs::BuildOptions { open }),
 
@@ -454,13 +458,13 @@ fn main() {
     }
 }
 
-fn command_check() -> Result<(), Error> {
+fn command_check(target: Option<Target>) -> Result<(), Error> {
     let _ = build::main(
         Options {
             warnings_as_errors: false,
             codegen: Codegen::DepsOnly,
             mode: Mode::Dev,
-            target: None,
+            target,
         },
         build::download_dependencies()?,
     )?;


### PR DESCRIPTION
The `check` command for `gleam` CLI was missing the `--target` option which is used to specify the platform to target.
This PR adds support for the `--target` option to `gleam check`.

Corresponding Docs PR: https://github.com/gleam-lang/website/pull/280

Closes #2346 