### PR TITLE
Add deprecated annotation support for types

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -256,6 +256,7 @@ fn register_type_alias(
             public: *public,
             parameters,
             typ,
+            deprecation: Deprecation::NotDeprecated,
         },
     )?;
     if !public {
@@ -277,6 +278,7 @@ fn register_types_from_custom_type<'a>(
         parameters,
         location,
         constructors,
+        deprecation,
         ..
     } = t;
     assert_unique_type_name(names, name, *location)?;
@@ -298,6 +300,7 @@ fn register_types_from_custom_type<'a>(
             origin: *location,
             module: module.clone(),
             public: *public,
+            deprecation: deprecation.clone(),
             parameters,
             typ,
         },

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -323,6 +323,7 @@ fn register_values_from_custom_type(
         opaque,
         name,
         constructors,
+        deprecation,
         ..
     } = t;
     let mut hydrator = hydrators
@@ -382,7 +383,7 @@ fn register_values_from_custom_type(
         environment.insert_module_value(
             constructor.name.clone(),
             ValueConstructor {
-                deprecation: Deprecation::NotDeprecated,
+                deprecation: deprecation.clone(),
                 public: *public && !opaque,
                 type_: typ.clone(),
                 variant: constructor_info.clone(),
@@ -402,7 +403,7 @@ fn register_values_from_custom_type(
             constructor_info,
             typ,
             *public,
-            Deprecation::NotDeprecated,
+            deprecation.clone(),
         );
     }
     Ok(())
@@ -700,6 +701,7 @@ fn infer_custom_type(
         name,
         parameters,
         constructors,
+        deprecation,
         ..
     } = t;
     let constructors = constructors
@@ -768,6 +770,7 @@ fn infer_custom_type(
         parameters,
         constructors,
         typed_parameters,
+        deprecation,
     }))
 }
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -241,6 +241,7 @@ fn register_type_alias(
         parameters: args,
         alias: name,
         type_ast: resolved_type,
+        deprecation,
         ..
     } = t;
     assert_unique_type_name(names, name, *location)?;
@@ -256,7 +257,7 @@ fn register_type_alias(
             public: *public,
             parameters,
             typ,
-            deprecation: Deprecation::NotDeprecated,
+            deprecation: deprecation.clone(),
         },
     )?;
     if !public {
@@ -673,6 +674,7 @@ fn insert_type_alias(
         alias,
         parameters: args,
         type_ast: resolved_type,
+        deprecation,
         ..
     } = t;
     let typ = environment
@@ -688,6 +690,7 @@ fn insert_type_alias(
         parameters: args,
         type_ast: resolved_type,
         type_: typ,
+        deprecation,
     }))
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -468,6 +468,7 @@ pub struct CustomType<T> {
     pub public: bool,
     pub constructors: Vec<RecordConstructor<T>>,
     pub documentation: Option<SmolStr>,
+    pub deprecation: Deprecation,
     pub opaque: bool,
     /// The names of the type parameters.
     pub parameters: Vec<SmolStr>,

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -505,6 +505,7 @@ pub struct TypeAlias<T> {
     pub type_: T,
     pub public: bool,
     pub documentation: Option<SmolStr>,
+    pub deprecation: Deprecation,
 }
 
 pub type TypedDefinition = Definition<Arc<Type>, TypedExpr, SmolStr, SmolStr>;

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -551,6 +551,10 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
             definition: print(formatter.custom_type(ct)),
             documentation: markdown_documentation(&ct.documentation),
             text_documentation: text_documentation(&ct.documentation),
+            deprecation_message: match &ct.deprecation {
+                Deprecation::NotDeprecated => "".to_string(),
+                Deprecation::Deprecated { message } => message.to_string(),
+            },
             constructors: ct
                 .constructors
                 .iter()
@@ -580,6 +584,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
             parameters,
             documentation: doc,
             location,
+            deprecation,
             ..
         }) => Some(Type {
             name,
@@ -592,6 +597,10 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
             text_documentation: text_documentation(doc),
             constructors: vec![],
             source_url: source_links.url(*location),
+            deprecation_message: match deprecation {
+                Deprecation::NotDeprecated => "".to_string(),
+                Deprecation::Deprecated { message } => message.to_string(),
+            },
         }),
 
         Definition::TypeAlias(TypeAlias {
@@ -609,6 +618,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
             text_documentation: text_documentation(doc),
             constructors: vec![],
             source_url: source_links.url(*location),
+            deprecation_message: "".to_string(),
         }),
 
         _ => None,
@@ -682,6 +692,7 @@ struct Type<'a> {
     constructors: Vec<TypeConstructor>,
     text_documentation: String,
     source_url: String,
+    deprecation_message: String,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -610,15 +610,23 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
             documentation: doc,
             parameters: args,
             location,
+            deprecation,
             ..
         }) => Some(Type {
             name,
-            definition: print(formatter.type_alias(true, name, args, typ).group()),
+            definition: print(
+                formatter
+                    .type_alias(true, name, args, typ, deprecation)
+                    .group(),
+            ),
             documentation: markdown_documentation(doc),
             text_documentation: text_documentation(doc),
             constructors: vec![],
             source_url: source_links.url(*location),
-            deprecation_message: "".to_string(),
+            deprecation_message: match deprecation {
+                Deprecation::NotDeprecated => "".to_string(),
+                Deprecation::Deprecated { message } => message.to_string(),
+            },
         }),
 
         _ => None,

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/docs/tests.rs
-assertion_line: 56
 expression: "compile(config, modules)"
 ---
 //// app.html
@@ -264,6 +263,7 @@ expression: "compile(config, modules)"
       </h2>
       
     </div>
+    
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
       <pre><code class="hljs gleam">pub type Option(t) {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1085,13 +1085,13 @@ impl<'comments> Formatter<'comments> {
     }
 
     pub fn custom_type<'a, A>(&mut self, ct: &'a CustomType<A>) -> Document<'a> {
-
-        let _ = self.pop_empty_lines(location.start);
+        let _ = self.pop_empty_lines(ct.location.end);
 
         // @deprecated attribute
-        let doc = self.deprecation_attr(deprecation);
+        let doc = self.deprecation_attr(&ct.deprecation);
 
-        let doc =  doc.append(pub_(ct.public))
+        let doc = doc
+            .append(pub_(ct.public))
             .to_doc()
             .append(if ct.opaque { "opaque type " } else { "type " })
             .append(if ct.parameters.is_empty() {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -19,8 +19,8 @@ use smol_str::SmolStr;
 use std::sync::Arc;
 use vec1::Vec1;
 
-use camino::Utf8Path;
 use crate::type_::Deprecation;
+use camino::Utf8Path;
 
 const INDENT: isize = 2;
 
@@ -1079,6 +1079,7 @@ impl<'comments> Formatter<'comments> {
     pub fn custom_type<'a, A>(&mut self, ct: &'a CustomType<A>) -> Document<'a> {
 
         let _ = self.pop_empty_lines(ct.location.end);
+    
         let doc = docvec![];
 
         // @deprecated attribute

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1079,7 +1079,6 @@ impl<'comments> Formatter<'comments> {
     pub fn custom_type<'a, A>(&mut self, ct: &'a CustomType<A>) -> Document<'a> {
 
         let _ = self.pop_empty_lines(ct.location.end);
-    
         let doc = docvec![];
 
         // @deprecated attribute

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use vec1::Vec1;
 
 use camino::Utf8Path;
+use crate::type_::Deprecation;
 
 const INDENT: isize = 2;
 
@@ -1076,8 +1077,21 @@ impl<'comments> Formatter<'comments> {
     }
 
     pub fn custom_type<'a, A>(&mut self, ct: &'a CustomType<A>) -> Document<'a> {
+
         let _ = self.pop_empty_lines(ct.location.end);
-        let doc = pub_(ct.public)
+        let doc = docvec![];
+
+        // @deprecated attribute
+        let doc = match &ct.deprecation {
+            Deprecation::NotDeprecated => doc,
+            Deprecation::Deprecated { message } => doc
+                .append("@deprecated(\"")
+                .append(message)
+                .append("\")")
+                .append(line()),
+        };
+
+        let doc =  doc.append(pub_(ct.public))
             .to_doc()
             .append(if ct.opaque { "opaque type " } else { "type " })
             .append(if ct.parameters.is_empty() {

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5123,3 +5123,46 @@ fn comment_at_end_of_type() {
 "#
     );
 }
+
+#[test]
+fn deprecated_type_annotation() {
+    assert_format_rewrite!(
+        r#"
+            @deprecated(
+            "Deprecated type"
+            )
+            pub type One {
+                One
+            }
+"#,
+        r#"@deprecated("Deprecated type")
+pub type One {
+  One
+}
+"#
+    );
+}
+
+#[test]
+fn deprecated_type_alias_annotation() {
+    assert_format_rewrite!(
+        r#"
+            pub type Animal{
+                Cat(name:String)
+            }
+
+            @deprecated(
+            "Deprecated type"
+            )
+            pub type Tiger = Animal
+"#,
+        r#"pub type Animal {
+  Cat(name: String)
+}
+
+@deprecated("Deprecated type")
+pub type Tiger =
+  Animal
+"#
+    );
+}

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5125,16 +5125,8 @@ fn comment_at_end_of_type() {
 }
 
 #[test]
-fn deprecated_type_annotation() {
-    assert_format_rewrite!(
-        r#"
-            @deprecated(
-            "Deprecated type"
-            )
-            pub type One {
-                One
-            }
-"#,
+fn deprecated_custom_type() {
+    assert_format!(
         r#"@deprecated("Deprecated type")
 pub type One {
   One
@@ -5144,25 +5136,11 @@ pub type One {
 }
 
 #[test]
-fn deprecated_type_alias_annotation() {
+fn deprecated_type_alias() {
     assert_format_rewrite!(
-        r#"
-            pub type Animal{
-                Cat(name:String)
-            }
-
-            @deprecated(
-            "Deprecated type"
-            )
-            pub type Tiger = Animal
-"#,
-        r#"pub type Animal {
-  Cat(name: String)
-}
-
-@deprecated("Deprecated type")
+        r#"@deprecated("Deprecated type")
 pub type Tiger =
-  Animal
+  Nil
 "#
     );
 }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5137,7 +5137,7 @@ pub type One {
 
 #[test]
 fn deprecated_type_alias() {
-    assert_format_rewrite!(
+    assert_format!(
         r#"@deprecated("Deprecated type")
 pub type Tiger =
   Nil

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -90,6 +90,7 @@ impl ModuleDecoder {
             module: reader.get_module()?.into(),
             parameters: read_vec!(reader.get_parameters()?, self, type_),
             typ: type_,
+            deprecation: Deprecation::NotDeprecated,
         })
     }
 

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -97,6 +97,7 @@ fn module_with_private_type() {
                 origin: Default::default(),
                 module: "the/module".into(),
                 parameters: vec![],
+                deprecation: Deprecation::NotDeprecated,
             },
         )]
         .into(),
@@ -140,6 +141,7 @@ fn module_with_app_type() {
                 origin: Default::default(),
                 module: "the/module".into(),
                 parameters: vec![],
+                deprecation: Deprecation::NotDeprecated,
             },
         )]
         .into(),
@@ -165,6 +167,7 @@ fn module_with_fn_type() {
                 origin: Default::default(),
                 module: "the/module".into(),
                 parameters: vec![],
+                deprecation: Deprecation::NotDeprecated,
             },
         )]
         .into(),
@@ -190,6 +193,7 @@ fn module_with_tuple_type() {
                 origin: Default::default(),
                 module: "the/module".into(),
                 parameters: vec![],
+                deprecation: Deprecation::NotDeprecated,
             },
         )]
         .into(),
@@ -221,6 +225,7 @@ fn module_with_generic_type() {
                     origin: Default::default(),
                     module: "the/module".into(),
                     parameters: vec![t1, t2],
+                    deprecation: Deprecation::NotDeprecated,
                 },
             )]
             .into(),
@@ -252,6 +257,7 @@ fn module_with_type_links() {
                     origin: Default::default(),
                     module: "a".into(),
                     parameters: vec![],
+                    deprecation: Deprecation::NotDeprecated,
                 },
             )]
             .into(),

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -260,18 +260,18 @@ where
             // Custom Types, and Type Aliases
             (Some((start, Token::Type, _)), _) => {
                 let _ = self.next_tok();
-                self.parse_custom_type(start, false, false)
+                self.parse_custom_type(start, false, false, &mut attributes)
             }
             (Some((start, Token::Pub, _)), Some((_, Token::Opaque, _))) => {
                 let _ = self.next_tok();
                 let _ = self.next_tok();
                 let _ = self.expect_one(&Token::Type)?;
-                self.parse_custom_type(start, true, true)
+                self.parse_custom_type(start, true, true, &mut attributes)
             }
             (Some((start, Token::Pub, _)), Some((_, Token::Type, _))) => {
                 let _ = self.next_tok();
                 let _ = self.next_tok();
-                self.parse_custom_type(start, true, false)
+                self.parse_custom_type(start, true, false, &mut attributes)
             }
 
             (t0, _) => {
@@ -1658,6 +1658,7 @@ where
         start: u32,
         public: bool,
         opaque: bool,
+        attributes: &mut Attributes,
     ) -> Result<Option<UntypedDefinition>, ParseError> {
         let documentation = self.take_documentation(start);
         let (_, name, parameters, end) = self.expect_type_name()?;
@@ -1718,6 +1719,7 @@ where
             parameters,
             constructors,
             typed_parameters: vec![],
+            deprecation: std::mem::take(&mut attributes.deprecated),
         })))
     }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1702,6 +1702,7 @@ where
                     parameters,
                     type_ast: t,
                     type_: (),
+                    deprecation: std::mem::take(&mut attributes.deprecated),
                 })));
             } else {
                 return parse_error(ParseErrorType::ExpectedType, SrcSpan::new(eq_s, eq_e));

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -643,6 +643,7 @@ pub struct TypeConstructor {
     pub module: SmolStr,
     pub parameters: Vec<Arc<Type>>,
     pub typ: Arc<Type>,
+    pub deprecation: Deprecation,
 }
 impl TypeConstructor {
     pub(crate) fn with_location(mut self, location: SrcSpan) -> Self {

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -6,6 +6,7 @@ use crate::{
 use camino::Utf8PathBuf;
 use std::sync::Arc;
 
+use crate::ast::Layer;
 #[cfg(test)]
 use pretty_assertions::assert_eq;
 use smol_str::SmolStr;
@@ -393,9 +394,10 @@ pub enum Warning {
         package: SmolStr,
     },
 
-    DeprecatedValue {
+    DeprecatedItem {
         location: SrcSpan,
         message: SmolStr,
+        layer: Layer,
     },
 
     DeprecatedBitString {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1720,9 +1720,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         // Emit a warning if the value being used is deprecated.
         if let Deprecation::Deprecated { message } = &deprecation {
-            self.environment.warnings.emit(Warning::DeprecatedValue {
+            self.environment.warnings.emit(Warning::DeprecatedItem {
                 location: *location,
                 message: message.clone(),
+                layer: Layer::Value,
             })
         }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1406,9 +1406,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             // Emit a warning if the value being used is deprecated.
             if let Deprecation::Deprecated { message } = &constructor.deprecation {
-                self.environment.warnings.emit(Warning::DeprecatedValue {
+                self.environment.warnings.emit(Warning::DeprecatedItem {
                     location: select_location,
                     message: message.clone(),
+                    layer: Layer::Value,
                 })
             }
 

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -131,9 +131,10 @@ impl Hydrator {
                 match deprecation {
                     Deprecation::NotDeprecated => {}
                     Deprecation::Deprecated { message } => {
-                        environment.warnings.emit(Warning::DeprecatedValue {
+                        environment.warnings.emit(Warning::DeprecatedItem {
                             location: *location,
                             message: message.clone(),
+                            layer: Layer::Type,
                         })
                     }
                 }

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -121,11 +121,22 @@ impl Hydrator {
                 let TypeConstructor {
                     parameters,
                     typ: return_type,
+                    deprecation,
                     ..
                 } = environment
                     .get_type_constructor(module, name, *location)
                     .map_err(|e| convert_get_type_constructor_error(e, location))?
                     .clone();
+
+                match deprecation {
+                    Deprecation::NotDeprecated => {}
+                    Deprecation::Deprecated { message } => {
+                        environment.warnings.emit(Warning::DeprecatedValue {
+                            location: *location,
+                            message: message.clone(),
+                        })
+                    }
+                }
 
                 // Register the type constructor as being used if it is unqualified.
                 // We do not track use of qualified type constructors as they may be

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -574,9 +574,10 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 match constructor_deprecation {
                     Deprecation::NotDeprecated => {}
                     Deprecation::Deprecated { message } => {
-                        self.environment.warnings.emit(Warning::DeprecatedValue {
+                        self.environment.warnings.emit(Warning::DeprecatedItem {
                             location,
                             message: message.clone(),
+                            layer: Layer::Value,
                         })
                     }
                 }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -570,6 +570,17 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     }
                 };
 
+                let constructor_deprecation = cons.deprecation.clone();
+                match constructor_deprecation {
+                    Deprecation::NotDeprecated => {}
+                    Deprecation::Deprecated { message } => {
+                        self.environment.warnings.emit(Warning::DeprecatedValue {
+                            location,
+                            message: message.clone(),
+                        })
+                    }
+                }
+
                 let instantiated_constructor_type =
                     self.environment
                         .instantiate(constructor_typ, &mut hashmap![], self.hydrator);

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -3,9 +3,9 @@ use strum::{EnumIter, IntoEnumIterator};
 use crate::{ast::SrcSpan, build::Origin, uid::UniqueIdGenerator};
 
 use super::{
-    Deprecation, ModuleInterface, Type, TypeConstructor, TypeVar, ValueConstructor,
-    ValueConstructorVariant,
+    ModuleInterface, Type, TypeConstructor, TypeVar, ValueConstructor, ValueConstructorVariant,
 };
+use crate::type_::Deprecation::NotDeprecated;
 use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
 const BIT_ARRAY: &str = "BitArray";
@@ -165,7 +165,7 @@ pub fn link(type_: Arc<Type>) -> Arc<Type> {
 pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
     let value = |variant, type_| ValueConstructor {
         public: true,
-        deprecation: Deprecation::NotDeprecated,
+        deprecation: NotDeprecated,
         variant,
         type_,
     };
@@ -190,6 +190,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     typ: bits(),
                     module: PRELUDE_MODULE_NAME.into(),
                     public: true,
+                    deprecation: NotDeprecated,
                 };
                 let _ = prelude.types.insert(BIT_ARRAY.into(), v.clone());
                 let _ = prelude.types.insert(BIT_STRING.into(), v);
@@ -237,6 +238,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         typ: bool(),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
             }
@@ -250,6 +252,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         typ: float(),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
             }
@@ -263,6 +266,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         origin: Default::default(),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
             }
@@ -277,6 +281,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         typ: list(list_parameter),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
             }
@@ -305,6 +310,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         typ: nil(),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
             }
@@ -320,6 +326,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         typ: result(result_value, result_error),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
                 let _ = prelude
@@ -370,6 +377,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         typ: string(),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
             }
@@ -383,6 +391,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         typ: utf_codepoint(),
                         module: PRELUDE_MODULE_NAME.into(),
                         public: true,
+                        deprecation: NotDeprecated,
                     },
                 );
             }

--- a/compiler-core/src/type_/tests/custom_types.rs
+++ b/compiler-core/src/type_/tests/custom_types.rs
@@ -1,4 +1,4 @@
-use crate::assert_module_infer;
+use crate::{assert_module_infer, assert_warning};
 
 // https://github.com/gleam-lang/gleam/issues/2215
 #[test]
@@ -10,5 +10,22 @@ pub type Test(a) {
 }
 "#,
         vec![("MakeTest", "fn(Test(Int)) -> Test(a)")]
+    );
+}
+
+#[test]
+fn deprecated_type() {
+    assert_warning!(
+               r#"
+@deprecated("Dont use this!")
+pub type Cat {
+  Cat(name: String, cuteness: Int)
+}
+
+pub fn name() -> String {
+  let c = Cat("Numi", 20)
+  c.name
+}
+        "#
     );
 }

--- a/compiler-core/src/type_/tests/custom_types.rs
+++ b/compiler-core/src/type_/tests/custom_types.rs
@@ -16,7 +16,7 @@ pub type Test(a) {
 #[test]
 fn deprecated_type() {
     assert_warning!(
-               r#"
+        r#"
 @deprecated("Dont use this!")
 pub type Cat {
   Cat(name: String, cuteness: Int)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__deprecated_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__deprecated_type.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/custom_types.rs
+expression: "\n@deprecated(\"Dont use this!\")\npub type Cat {\n  Cat(name: String, cuteness: Int)\n}\n\npub fn name() -> String {\n  let c = Cat(\"Numi\", 20)\n  c.name\n}\n        "
+---
+
+warning: Deprecated value used
+  ┌─ /src/warning/wrn.gleam:8:11
+  │
+8 │   let c = Cat("Numi", 20)
+  │           ^^^ This value has been deprecated
+
+It was deprecated with this message: Dont use this!
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_as_arg.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_as_arg.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@deprecated(\"Don't use this!\")\npub type Cat {\n    Cat(name: String)\n}\n\npub fn cat_name(cat: Cat) {\n  cat.name\n}\n        "
+---
+
+warning: Deprecated value used
+  ┌─ /src/warning/wrn.gleam:7:22
+  │
+7 │ pub fn cat_name(cat: Cat) {
+  │                      ^^^ This value has been deprecated
+
+It was deprecated with this message: Don't use this!
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_as_arg.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_as_arg.snap
@@ -3,11 +3,11 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\n@deprecated(\"Don't use this!\")\npub type Cat {\n    Cat(name: String)\n}\n\npub fn cat_name(cat: Cat) {\n  cat.name\n}\n        "
 ---
 
-warning: Deprecated value used
+warning: Deprecated type used
   ┌─ /src/warning/wrn.gleam:7:22
   │
 7 │ pub fn cat_name(cat: Cat) {
-  │                      ^^^ This value has been deprecated
+  │                      ^^^ This type has been deprecated
 
 It was deprecated with this message: Don't use this!
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_as_case_clause.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_as_case_clause.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@deprecated(\"The type Animal has been deprecated.\")\npub type Animal {\n    Cat\n    Dog\n}\n\npub fn sound(animal) -> String {\n  case animal {\n    Dog -> \"Woof\"\n    Cat -> \"Meow\"\n  }\n}\n\npub fn main(){\n    let cat = Cat\n    sound(cat)\n}\n        "
+---
+
+warning: Deprecated value used
+   ┌─ /src/warning/wrn.gleam:10:5
+   │
+10 │     Dog -> "Woof"
+   │     ^^^ This value has been deprecated
+
+It was deprecated with this message: The type Animal has been deprecated.
+
+warning: Deprecated value used
+   ┌─ /src/warning/wrn.gleam:11:5
+   │
+11 │     Cat -> "Meow"
+   │     ^^^ This value has been deprecated
+
+It was deprecated with this message: The type Animal has been deprecated.
+
+warning: Deprecated value used
+   ┌─ /src/warning/wrn.gleam:16:15
+   │
+16 │     let cat = Cat
+   │               ^^^ This value has been deprecated
+
+It was deprecated with this message: The type Animal has been deprecated.
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_in_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_in_alias.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@deprecated(\"Don't use this!\")\npub type Cat {\n    Cat(name: String)\n}\n\npub type Dog = Cat\n\npub fn b() {\n  let c = Dog(\"Bob\")\n}\n        "
+---
+
+warning: Deprecated value used
+  ┌─ /src/warning/wrn.gleam:7:16
+  │
+7 │ pub type Dog = Cat
+  │                ^^^ This value has been deprecated
+
+It was deprecated with this message: Don't use this!
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_in_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_type_used_in_alias.snap
@@ -3,11 +3,11 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\n@deprecated(\"Don't use this!\")\npub type Cat {\n    Cat(name: String)\n}\n\npub type Dog = Cat\n\npub fn b() {\n  let c = Dog(\"Bob\")\n}\n        "
 ---
 
-warning: Deprecated value used
+warning: Deprecated type used
   ┌─ /src/warning/wrn.gleam:7:16
   │
 7 │ pub type Dog = Cat
-  │                ^^^ This value has been deprecated
+  │                ^^^ This type has been deprecated
 
 It was deprecated with this message: Don't use this!
 

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -978,10 +978,6 @@ pub type Cat {
 }
 
 pub type Dog = Cat
-
-pub fn b() {
-  let c = Dog("Bob")
-}
         "#
     );
 }

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -969,6 +969,65 @@ pub fn b() {
 }
 
 #[test]
+fn deprecated_type_used_in_alias() {
+    assert_warning!(
+        r#"
+@deprecated("Don't use this!")
+pub type Cat {
+    Cat(name: String)
+}
+
+pub type Dog = Cat
+
+pub fn b() {
+  let c = Dog("Bob")
+}
+        "#
+    );
+}
+
+#[test]
+fn deprecated_type_used_as_arg() {
+    assert_warning!(
+        r#"
+@deprecated("Don't use this!")
+pub type Cat {
+    Cat(name: String)
+}
+
+pub fn cat_name(cat: Cat) {
+  cat.name
+}
+        "#
+    );
+}
+
+#[test]
+fn deprecated_type_used_as_case_clause() {
+    assert_warning!(
+        r#"
+@deprecated("The type Animal has been deprecated.")
+pub type Animal {
+    Cat
+    Dog
+}
+
+pub fn sound(animal) -> String {
+  case animal {
+    Dog -> "Woof"
+    Cat -> "Meow"
+  }
+}
+
+pub fn main(){
+    let cat = Cat
+    sound(cat)
+}
+        "#
+    );
+}
+
+#[test]
 fn deprecated_bit_array_type() {
     assert_warning!(r#"pub type B = BitString"#);
 }

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1,3 +1,4 @@
+use crate::ast::Layer;
 use crate::{
     ast::TodoKind,
     diagnostic::{self, Diagnostic, Location},
@@ -559,10 +560,26 @@ Run this command to add it to your dependencies:
                     }
                 }
 
-                type_::Warning::DeprecatedValue { location, message } => {
+                type_::Warning::DeprecatedItem {
+                    location,
+                    message,
+                    layer,
+                } => {
                     let text = wrap(&format!("It was deprecated with this message: {message}"));
+                    let (title, diagnostic_label_text) = if layer.is_value() {
+                        (
+                            "Deprecated value used".into(),
+                            Some("This value has been deprecated".into()),
+                        )
+                    } else {
+                        (
+                            "Deprecated type used".into(),
+                            Some("This type has been deprecated".into()),
+                        )
+                    };
+
                     Diagnostic {
-                        title: "Deprecated value used".into(),
+                        title,
                         text,
                         hint: None,
                         level: diagnostic::Level::Warning,
@@ -570,7 +587,7 @@ Run this command to add it to your dependencies:
                             src: src.clone(),
                             path: path.to_path_buf(),
                             label: diagnostic::Label {
-                                text: Some("This value has been deprecated".into()),
+                                text: diagnostic_label_text,
                                 span: *location,
                             },
                             extra_labels: Vec::new(),

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1,4 +1,3 @@
-use crate::ast::Layer;
 use crate::{
     ast::TodoKind,
     diagnostic::{self, Diagnostic, Location},

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -57,6 +57,11 @@
       </a>
       {% endif %}
     </div>
+    {% if !typ.deprecation_message.is_empty() %}
+    <p>
+      <b>Deprecated:</b> {{ typ.deprecation_message }}
+    </p>
+    {% endif %}
     <div class="custom-type-constructors">
       <div class="rendered-markdown">{{ typ.documentation|safe }}</div>
       <pre><code class="hljs gleam">{{ typ.definition }}</code></pre>


### PR DESCRIPTION
Add deprecated annotation support for types.

Added updated snapshots here as well. The docs snapshot has been updated as the deprecated annotation is included in the generated documentation for types now. (the updated snapshot seems to lose the assertion_line metadata that is usually added by the insta crate.)