### PR TITLE
Fix span for error reporting in UnknownRecordField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   been improved.
 - The error message for when the elements of a list's tail don't match the
   previous ones has been improved.
+- The error message for when one tries to access an unknown field has been
+  improved.
 - The `__gleam_prelude_variant__` property has been removed from the classes
   defined in the JavaScript prelude.
 - The deprecated `todo("...")` syntax has been removed.

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -68,7 +68,14 @@ pub enum UntypedExpr {
     },
 
     FieldAccess {
+        // This is the location of the whole record and field
+        //   user.name
+        //   ^^^^^^^^^
         location: SrcSpan,
+        // This is the location of just the field access
+        //   user.name
+        //       ^^^^^
+        access_location: SrcSpan,
         label: SmolStr,
         container: Box<Self>,
     },

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -282,9 +282,10 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
             UntypedExpr::FieldAccess {
                 location,
+                access_location,
                 label,
                 container,
-            } => self.fold_field_access(location, label, container),
+            } => self.fold_field_access(location, access_location, label, container),
 
             UntypedExpr::Tuple { location, elems } => self.fold_tuple(location, elems),
 
@@ -449,12 +450,14 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
             UntypedExpr::FieldAccess {
                 location,
+                access_location,
                 label,
                 container,
             } => {
                 let container = Box::new(self.fold_expr(*container));
                 UntypedExpr::FieldAccess {
                     location,
+                    access_location,
                     label,
                     container,
                 }
@@ -708,11 +711,13 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
     fn fold_field_access(
         &mut self,
         location: SrcSpan,
+        access_location: SrcSpan,
         label: SmolStr,
         container: Box<UntypedExpr>,
     ) -> UntypedExpr {
         UntypedExpr::FieldAccess {
             location,
+            access_location,
             label,
             container,
         }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -617,7 +617,7 @@ where
 
         // field access and call can stack up
         loop {
-            if let Some((_, _)) = self.maybe_one(&Token::Dot) {
+            if let Some((dot_start, _)) = self.maybe_one(&Token::Dot) {
                 let start = expr.location().start;
                 // field access
                 match self.tok0.take() {
@@ -643,6 +643,10 @@ where
                         let _ = self.next_tok();
                         expr = UntypedExpr::FieldAccess {
                             location: SrcSpan { start, end },
+                            access_location: SrcSpan {
+                                start: dot_start,
+                                end,
+                            },
                             label,
                             container: Box::new(expr),
                         }
@@ -652,6 +656,10 @@ where
                         let _ = self.next_tok();
                         expr = UntypedExpr::FieldAccess {
                             location: SrcSpan { start, end },
+                            access_location: SrcSpan {
+                                start: dot_start,
+                                end,
+                            },
                             label,
                             container: Box::new(expr),
                         }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -146,11 +146,13 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             } => self.infer_binop(name, *left, *right, location),
 
             UntypedExpr::FieldAccess {
-                location,
+                access_location,
                 label,
                 container,
                 ..
-            } => self.infer_field_access(*container, label, location, FieldAccessUsage::Other),
+            } => {
+                self.infer_field_access(*container, label, access_location, FieldAccessUsage::Other)
+            }
 
             UntypedExpr::TupleIndex {
                 location,
@@ -2035,10 +2037,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     ) -> Result<(TypedExpr, Vec<TypedCallArg>, Arc<Type>), Error> {
         let fun = match fun {
             UntypedExpr::FieldAccess {
-                location,
                 label,
                 container,
-            } => self.infer_field_access(*container, label, location, FieldAccessUsage::MethodCall),
+                access_location,
+                ..
+            } => self.infer_field_access(
+                *container,
+                label,
+                access_location,
+                FieldAccessUsage::MethodCall,
+            ),
 
             fun => self.infer(fun),
         }?;

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__access_int.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__access_int.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 378
 expression: let x = 1 x.whatever
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:1:11
+  ┌─ /src/one/two.gleam:1:12
   │
 1 │ let x = 1 x.whatever
-  │           ^^^^^^^^^^ This field does not exist
+  │            ^^^^^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 617
 expression: "\npub type Person {\n    Teacher(name: String, title: String, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:7:34
+  ┌─ /src/one/two.gleam:7:40
   │
 7 │ pub fn get_age(person: Person) { person.age }
-  │                                  ^^^^^^^^^^ Did you mean `name`?
+  │                                        ^^^^ Did you mean `name`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 631
 expression: "\npub type Person {\n    Teacher(title: String, age: Int, name: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:35
+  ┌─ /src/one/two.gleam:6:41
   │
 6 │ pub fn get_name(person: Person) { person.name }
-  │                                   ^^^^^^^^^^^ Did you mean `age`?
+  │                                         ^^^^^ Did you mean `age`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 579
 expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_title(person: Person) { person.title }"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:36
+  ┌─ /src/one/two.gleam:6:42
   │
 6 │ pub fn get_title(person: Person) { person.title }
-  │                                    ^^^^^^^^^^^^ Did you mean `age`?
+  │                                          ^^^^^^ Did you mean `age`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_any_variant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_any_variant.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 591
 expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_height(person: Person) { person.height }"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:37
+  ┌─ /src/one/two.gleam:6:43
   │
 6 │ pub fn get_height(person: Person) { person.height }
-  │                                     ^^^^^^^^^^^^^ Did you mean `age`?
+  │                                           ^^^^^^^ Did you mean `age`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 603
 expression: "\npub type Shape {\n    Square(x: Int, y: Int)\n    Rectangle(x: String, y: String)\n}\npub fn get_x(shape: Shape) { shape.x }\npub fn get_y(shape: Shape) { shape.y }"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:30
+  ┌─ /src/one/two.gleam:6:35
   │
 6 │ pub fn get_x(shape: Shape) { shape.x }
-  │                              ^^^^^^^ This field does not exist
+  │                                   ^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__hint_for_method_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__hint_for_method_call.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1813
 expression: "\npub type User {\n  User(id: Int, name: String)\n}\n\npub fn main(user: User) {\n  user.login()\n}\n"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:7:3
+  ┌─ /src/one/two.gleam:7:7
   │
 7 │   user.login()
-  │   ^^^^^^^^^^ Did you mean `id`?
+  │       ^^^^^^ Did you mean `id`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_hint_for_non_method_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_hint_for_non_method_call.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1828
 expression: "\npub type User {\n  User(id: Int, name: String)\n}\n\nfn login(user: User) {\n  user\n}\n\npub fn main(user: User) {\n  login(user.wibble)\n}\n"
 ---
 error: Unknown record field
-   ┌─ /src/one/two.gleam:11:9
+   ┌─ /src/one/two.gleam:11:13
    │
 11 │   login(user.wibble)
-   │         ^^^^^^^^^^^ Did you mean `id`?
+   │             ^^^^^^^ Did you mean `id`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 574
 expression: "fn(a: a) { a.field }"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:1:12
+  ┌─ /src/one/two.gleam:1:13
   │
 1 │ fn(a: a) { a.field }
-  │            ^^^^^^^ This field does not exist
+  │             ^^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 859
 expression: "\npub type Box(a) { Box(inner: a) }\npub fn main(box: Box(Int)) { box.unknown }\n"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:3:30
+  ┌─ /src/one/two.gleam:3:33
   │
 3 │ pub fn main(box: Box(Int)) { box.unknown }
-  │                              ^^^^^^^^^^^ Did you mean `inner`?
+  │                                 ^^^^^^^^ Did you mean `inner`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field_2.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 870
 expression: "\npub type Box(a) { Box(inner: a) }\npub fn main(box: Box(Box(Int))) { box.inner.unknown }"
 ---
 error: Unknown record field
-  ┌─ /src/one/two.gleam:3:35
+  ┌─ /src/one/two.gleam:3:44
   │
 3 │ pub fn main(box: Box(Box(Int))) { box.inner.unknown }
-  │                                   ^^^^^^^^^^^^^^^^^ Did you mean `inner`?
+  │                                            ^^^^^^^^ Did you mean `inner`?
 
 The value being accessed has this type:
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_accessor.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_accessor.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 237
 expression: "./cases/opaque_type_accessor"
 ---
 error: Unknown record field
-  ┌─ src/two.gleam:7:14
+  ┌─ src/two.gleam:7:18
   │
 7 │   let name = user.name
-  │              ^ This field does not exist
+  │                  ^ This field does not exist
 
 The value being accessed has this type:
 


### PR DESCRIPTION
This PR addresses #2374
(I've also made [a PR](https://github.com/gleam-lang/website/pull/282) to update the homepage's look accordingly!)
 
I decided to add another field in the field access data structure instead of changing the current `location` because it was used by a lot more of error messages that would then break. The new field holds a span for just the thing being accessed so error reporting can be more precise when giving hints instead of highlighting the whole record and field