### PR TITLE
update lsp-server and lsp-types to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,9 +1193,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lsp-server"
-version = "0.5.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c351c75989da23b355226dc188dc2b52538a7f4f218d70fd7393c6b62b110444"
+checksum = "b52dccdf3302eefab8c8a1273047f0a3c3dca4b527c8458d00c09484c8371928"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.92.1"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79d4897790e8fd2550afa6d6125821edb5716e60e0e285046e070f0f6a06e0e"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
 dependencies = [
  "bitflags 1.3.2",
  "serde",

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -72,8 +72,8 @@ toml_edit = "0.9"
 # Cross platform symlink creation helper
 symlink = "0.1"
 # Language server protocol server plumbing
-lsp-server = "0.5"
-lsp-types = "0.92"
+lsp-server = "0.7"
+lsp-types = "0.94"
 # File locking
 fslock = "0.2.1"
 # Compact clone-on-write vector & string type

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -75,8 +75,8 @@ ecow = { version = "0.2.0", features = ["serde"] }
 # Checksums
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 # Language server protocol server plumbing
-lsp-server = "0.5"
-lsp-types = "0.92"
+lsp-server = "0.7"
+lsp-types = "0.94"
 # Pubgrub dependency resolution algorithm
 pubgrub = "0.2"
 # Drop in replacement for std::path but with only utf-8

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -241,7 +241,7 @@ where
             register_options: Some(
                 serde_json::value::to_value(lsp::DidChangeWatchedFilesRegistrationOptions {
                     watchers: vec![lsp::FileSystemWatcher {
-                        glob_pattern: "**/gleam.toml".into(),
+                        glob_pattern: "**/gleam.toml".to_string().into(),
                         kind: Some(lsp::WatchKind::Change),
                     }],
                 })
@@ -470,6 +470,7 @@ fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializePa
             work_done_progress_options: lsp::WorkDoneProgressOptions {
                 work_done_progress: None,
             },
+            completion_item: None,
         }),
         signature_help_provider: None,
         definition_provider: Some(lsp::OneOf::Left(true)),
@@ -496,6 +497,10 @@ fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializePa
         moniker_provider: None,
         linked_editing_range_provider: None,
         experimental: None,
+        position_encoding: None,
+        inline_value_provider: None,
+        inlay_hint_provider: None,
+        diagnostic_provider: None,
     };
     let server_capabilities_json =
         serde_json::to_value(server_capabilities).expect("server_capabilities_serde");

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -36,6 +36,7 @@ fn remove_unused_action(src: &str, line: u32) -> String {
         context: CodeActionContext {
             diagnostics: vec![],
             only: None,
+            trigger_kind: None,
         },
         range: Range::new(Position::new(0, 0), Position::new(line + 1, 0)),
         work_done_progress_params: WorkDoneProgressParams {


### PR DESCRIPTION
~whilst i'm not committing to anything yet~, I was going to take a look at https://github.com/gleam-lang/gleam/issues/2319

First thing I noticed is that the types weren't up to date enough to even include inlay hints 😄 so this PR simply updates them along with the lsp-server crate 