### PR TITLE
Bump dependencies in new project template

### DIFF
--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -14,8 +14,8 @@ mod tests;
 
 use crate::NewOptions;
 
-const GLEAM_STDLIB_VERSION: &str = "0.31";
-const GLEEUNIT_VERSION: &str = "0.10";
+const GLEAM_STDLIB_VERSION: &str = "0.32";
+const GLEEUNIT_VERSION: &str = "1.0";
 const ERLANG_OTP_VERSION: &str = "26.0.2";
 const REBAR3_VERSION: &str = "3";
 const ELIXIR_VERSION: &str = "1.15.4";


### PR DESCRIPTION
First time trying Gleam today 👋  A fresh project created via `gleam new` warns about `Deprecated type import` syntax in `gleeunit`. Bumping `gleeunit` to the latest (1.0.0) fixes the warning. Also bumped `stdlib` to latest.

```
❯ gleam --version
gleam 0.32.1

❯ gleam build
  Resolving versions
Downloading packages
 Downloaded 2 packages in 0.02s
  Compiling gleam_stdlib
  Compiling gleeunit

warning: Deprecated type import
   ┌─ /Projects/testing_gleam/build/packages/gleeunit/src/gleeunit.gleam:24:23
   │
24 │ import gleam/dynamic.{Dynamic}
   │                       ^^^^^^^

The syntax for importing a type has changed. The new syntax is:

    import module.{type Dynamic}
```