### PR TITLE
Add inlay hints for function definitions and module constants

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -420,6 +420,7 @@ impl<T> Import<T> {
     }
 }
 
+pub type TypedModuleConstant = ModuleConstant<Arc<Type>, EcoString>;
 pub type UntypedModuleConstant = ModuleConstant<(), ()>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1055,6 +1055,13 @@ impl SrcSpan {
     pub fn contains(&self, byte_index: u32) -> bool {
         byte_index >= self.start && byte_index < self.end
     }
+
+    /// Returns true if this `SrcSpan` overlaps the given `SrcSpan` in any way.
+    pub fn overlaps(&self, other: &SrcSpan) -> bool {
+        (other.start > self.start && other.start < self.end) // Is the start of other within this span
+                        || (other.end > self.start && other.end < self.end) // or is the end of other within this span
+                        || (self.start > other.start && self.end < other.end) // or is the span entirely contained within other
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/compiler-core/src/language_server.rs
+++ b/compiler-core/src/language_server.rs
@@ -1,5 +1,6 @@
 mod code_action;
 mod compiler;
+mod configuration;
 mod engine;
 mod feedback;
 mod files;

--- a/compiler-core/src/language_server.rs
+++ b/compiler-core/src/language_server.rs
@@ -6,6 +6,7 @@ mod files;
 mod progress;
 mod router;
 mod server;
+mod type_annotations;
 
 #[cfg(test)]
 mod tests;

--- a/compiler-core/src/language_server/configuration.rs
+++ b/compiler-core/src/language_server/configuration.rs
@@ -1,33 +1,7 @@
 use serde::Deserialize;
+use std::sync::{Arc, RwLock};
 
-#[derive(Debug, Clone, Default)]
-pub struct VersionedConfig {
-    version: u32,
-    config: Configuration,
-}
-impl VersionedConfig {
-    #[cfg(test)]
-    pub fn new(config: Configuration) -> Self {
-        Self { version: 0, config }
-    }
-
-    pub fn update(&mut self, config: Configuration) {
-        self.version += 1;
-        self.config = config;
-    }
-}
-impl PartialEq for VersionedConfig {
-    fn eq(&self, other: &Self) -> bool {
-        self.version == other.version
-    }
-}
-impl std::ops::Deref for VersionedConfig {
-    type Target = Configuration;
-
-    fn deref(&self) -> &Self::Target {
-        &self.config
-    }
-}
+pub type SharedConfig = Arc<RwLock<Configuration>>;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/compiler-core/src/language_server/configuration.rs
+++ b/compiler-core/src/language_server/configuration.rs
@@ -6,6 +6,11 @@ pub struct VersionedConfig {
     config: Configuration,
 }
 impl VersionedConfig {
+    #[cfg(test)]
+    pub fn new(config: Configuration) -> Self {
+        Self { version: 0, config }
+    }
+
     pub fn update(&mut self, config: Configuration) {
         self.version += 1;
         self.config = config;

--- a/compiler-core/src/language_server/configuration.rs
+++ b/compiler-core/src/language_server/configuration.rs
@@ -1,0 +1,49 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default)]
+pub struct VersionedConfig {
+    pub version: u32,
+    pub config: Configuration,
+}
+
+impl std::ops::Deref for VersionedConfig {
+    type Target = Configuration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.config
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Configuration {
+    pub inlay_hints: InlayHintsConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlayHintsConfig {
+    #[serde(default = "InlayHintsConfig::default_function_definitions")]
+    pub function_definitions: bool,
+
+    #[serde(default = "InlayHintsConfig::default_module_constants")]
+    pub module_constants: bool,
+}
+
+impl Default for InlayHintsConfig {
+    fn default() -> Self {
+        Self {
+            function_definitions: Self::default_function_definitions(),
+            module_constants: Self::default_module_constants(),
+        }
+    }
+}
+
+impl InlayHintsConfig {
+    fn default_function_definitions() -> bool {
+        false
+    }
+    fn default_module_constants() -> bool {
+        false
+    }
+}

--- a/compiler-core/src/language_server/configuration.rs
+++ b/compiler-core/src/language_server/configuration.rs
@@ -2,10 +2,20 @@ use serde::Deserialize;
 
 #[derive(Debug, Clone, Default)]
 pub struct VersionedConfig {
-    pub version: u32,
-    pub config: Configuration,
+    version: u32,
+    config: Configuration,
 }
-
+impl VersionedConfig {
+    pub fn update(&mut self, config: Configuration) {
+        self.version += 1;
+        self.config = config;
+    }
+}
+impl PartialEq for VersionedConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.version == other.version
+    }
+}
 impl std::ops::Deref for VersionedConfig {
     type Target = Configuration;
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -661,14 +661,14 @@ fn code_action_annotate_types(
         Located::ModuleStatement(Definition::Function(function)) => {
             if let Some(annotation) =
                 TypeAnnotations::from_function_definition(function, &line_numbers)
-                    .into_code_action(uri.clone())
+                    .into_code_action(uri)
             {
                 annotation.push_to(actions)
             }
         }
         Located::ModuleStatement(Definition::ModuleConstant(constant)) => {
-            if let Some(annotation) = TypeAnnotations::from_module_constant(constant, &line_numbers)
-                .into_code_action(uri.clone())
+            if let Some(annotation) =
+                TypeAnnotations::from_module_constant(constant, &line_numbers).into_code_action(uri)
             {
                 annotation.push_to(actions)
             }

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -416,10 +416,10 @@ where
         completions
     }
 
-    pub fn inlay_hint(&mut self, params: lsp::InlayHintParams) -> Response<Option<Vec<InlayHint>>> {
+    pub fn inlay_hint(&mut self, params: lsp::InlayHintParams) -> Response<Vec<InlayHint>> {
         self.respond(|this| {
             let Some(module) = this.module_for_uri(&params.text_document.uri) else {
-                return Ok(None);
+                return Ok(vec![]);
             };
             let line_numbers = LineNumbers::new(&module.code);
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -15,13 +15,15 @@ use crate::{
 };
 use camino::Utf8PathBuf;
 use ecow::EcoString;
-use lsp::{CodeAction, InlayHint, Position};
-use lsp_types::{self as lsp, Hover, HoverContents, MarkedString, Url};
+use lsp_types::{
+    self as lsp, CodeAction, Hover, HoverContents, InlayHint, MarkedString, Position, Url,
+};
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
 use super::{
-    code_action::CodeActionBuilder, src_span_to_lsp_range, DownloadDependencies, MakeLocker,
+    code_action::CodeActionBuilder, src_span_to_lsp_range, type_annotations::TypeAnnotations,
+    DownloadDependencies, MakeLocker,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -639,170 +641,40 @@ fn code_action_annotate_types(
     };
 
     match located {
-        Located::Pattern(_) => {}
-        Located::Statement(_) => {}
-        Located::Expression(_) => {}
-        Located::ModuleStatement(Definition::Function(func)) => {
-            code_action_annotate_types_for_function_def(func, &line_numbers, uri, actions)
+        Located::ModuleStatement(Definition::Function(function)) => {
+            if let Some(annotation) =
+                TypeAnnotations::from_function_definition(function, &line_numbers)
+                    .into_code_action(uri.clone())
+            {
+                annotation.push_to(actions)
+            }
         }
-        Located::ModuleStatement(Definition::ModuleConstant(con)) => {
-            code_action_annotate_types_for_module_constant(con, &line_numbers, uri, actions)
+        Located::ModuleStatement(Definition::ModuleConstant(constant)) => {
+            if let Some(annotation) = TypeAnnotations::from_module_constant(constant, &line_numbers)
+                .into_code_action(uri.clone())
+            {
+                annotation.push_to(actions)
+            }
         }
-        Located::ModuleStatement(_) => {}
-        Located::FunctionBody(_) => {}
-        Located::Arg(_) => {}
-    }
-}
-
-fn code_action_annotate_types_for_function_def(
-    func: &Function<Arc<Type>, TypedExpr>,
-    line_numbers: &LineNumbers,
-    uri: &Url,
-    actions: &mut Vec<CodeAction>,
-) {
-    let mut edits = vec![];
-    if func.return_annotation.is_none() {
-        let linecol = line_numbers.line_and_column_number(func.location.end);
-        let position = Position::new(linecol.line - 1, linecol.column - 1);
-        let hint_text = Printer::new().pretty_print(&func.return_type, 0);
-        edits.push(lsp::TextEdit {
-            range: lsp::Range::new(position, position),
-            new_text: format!(" -> {hint_text}"),
-        })
-    }
-    for arg in &func.arguments {
-        if arg.annotation.is_none() {
-            let linecol = line_numbers.line_and_column_number(arg.location.end);
-            let position = Position::new(linecol.line - 1, linecol.column - 1);
-            let hint_text = Printer::new().pretty_print(&arg.type_, 0);
-            edits.push(lsp::TextEdit {
-                range: lsp::Range::new(position, position),
-                new_text: format!(": {hint_text}"),
-            });
-        }
-    }
-
-    if !edits.is_empty() {
-        CodeActionBuilder::new("Add type annotations")
-            .kind(lsp_types::CodeActionKind::REFACTOR_REWRITE)
-            .changes(uri.clone(), edits)
-            .preferred(true)
-            .push_to(actions);
-    }
-}
-
-fn code_action_annotate_types_for_module_constant(
-    con: &ModuleConstant<Arc<Type>, EcoString>,
-    line_numbers: &LineNumbers,
-    uri: &Url,
-    actions: &mut Vec<CodeAction>,
-) {
-    if con.annotation.is_none() {
-        let linecol = line_numbers.line_and_column_number(con.location.end);
-        let position = Position::new(linecol.line - 1, linecol.column - 1);
-        let hint_text = Printer::new().pretty_print(&con.type_, 0);
-
-        CodeActionBuilder::new("Add type annotation")
-            .kind(lsp_types::CodeActionKind::REFACTOR_REWRITE)
-            .changes(
-                uri.clone(),
-                vec![lsp::TextEdit::new(
-                    lsp::Range::new(position, position),
-                    format!(": {hint_text}"),
-                )],
-            )
-            .preferred(true)
-            .push_to(actions);
+        _ => {}
     }
 }
 
 fn add_hints_for_definitions(
-    definitions: &[Definition<Arc<Type>, TypedExpr, EcoString, EcoString>],
+    definitions: &[TypedDefinition],
     line_numbers: &LineNumbers,
     hints: &mut Vec<InlayHint>,
 ) {
     for def in definitions {
         match def {
-            Definition::Function(func) => {
-                add_hints_for_function_def(func, line_numbers, hints);
-            }
-            Definition::TypeAlias(_) => {}
-            Definition::CustomType(_) => {}
-            Definition::Import(_) => {}
-            Definition::ModuleConstant(con) => {
-                add_hints_for_module_constant(con, line_numbers, hints);
-            }
+            Definition::Function(function) => hints.extend(
+                TypeAnnotations::from_function_definition(function, line_numbers)
+                    .into_inlay_hints(),
+            ),
+            Definition::ModuleConstant(constant) => hints.extend(
+                TypeAnnotations::from_module_constant(constant, line_numbers).into_inlay_hints(),
+            ),
+            _ => {}
         }
-    }
-}
-
-fn add_hints_for_function_def(
-    func: &Function<Arc<Type>, TypedExpr>,
-    line_numbers: &LineNumbers,
-    hints: &mut Vec<InlayHint>,
-) {
-    if func.return_annotation.is_none() {
-        let linecol = line_numbers.line_and_column_number(func.location.end);
-        let position = Position::new(linecol.line - 1, linecol.column - 1);
-        let hint_text = Printer::new().pretty_print(&func.return_type, 0);
-        hints.push(InlayHint {
-            position,
-            kind: Some(lsp::InlayHintKind::TYPE),
-            text_edits: Some(vec![lsp::TextEdit {
-                range: lsp::Range::new(position, position),
-                new_text: format!(" -> {hint_text}"),
-            }]),
-            label: lsp::InlayHintLabel::String(format!("-> {hint_text}")),
-            tooltip: None,
-            padding_left: Some(true),
-            padding_right: None,
-            data: None,
-        })
-    }
-
-    for arg in &func.arguments {
-        if arg.annotation.is_none() {
-            let linecol = line_numbers.line_and_column_number(arg.location.end);
-            let position = Position::new(linecol.line - 1, linecol.column - 1);
-            let hint_text = Printer::new().pretty_print(&arg.type_, 0);
-            hints.push(InlayHint {
-                position,
-                kind: Some(lsp::InlayHintKind::TYPE),
-                text_edits: Some(vec![lsp::TextEdit {
-                    range: lsp::Range::new(position, position),
-                    new_text: format!(": {hint_text}"),
-                }]),
-                label: lsp::InlayHintLabel::String(format!(": {hint_text}")),
-                tooltip: None,
-                padding_left: None,
-                padding_right: None,
-                data: None,
-            })
-        }
-    }
-}
-
-fn add_hints_for_module_constant(
-    con: &ModuleConstant<Arc<Type>, EcoString>,
-    line_numbers: &LineNumbers,
-    hints: &mut Vec<InlayHint>,
-) {
-    if con.annotation.is_none() {
-        let linecol = line_numbers.line_and_column_number(con.location.end);
-        let position = Position::new(linecol.line - 1, linecol.column - 1);
-        let hint_text = Printer::new().pretty_print(&con.type_, 0);
-        hints.push(InlayHint {
-            position,
-            kind: Some(lsp::InlayHintKind::TYPE),
-            text_edits: Some(vec![lsp::TextEdit {
-                range: lsp::Range::new(position, position),
-                new_text: format!(": {hint_text}"),
-            }]),
-            label: lsp::InlayHintLabel::String(format!(": {hint_text}")),
-            tooltip: None,
-            padding_left: None,
-            padding_right: None,
-            data: None,
-        })
     }
 }

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -61,6 +61,7 @@ pub struct LanguageServerEngine<IO, Reporter> {
     // the usual request-response loop.
     progress_reporter: Reporter,
 
+    /// Cached version of the user's settings. Updates automatically as the user makes changes.
     pub(crate) user_config: VersionedConfig,
 }
 
@@ -436,7 +437,7 @@ where
                 &mut hints,
             );
 
-            Ok(Some(hints))
+            Ok(hints)
         })
     }
 }
@@ -677,6 +678,7 @@ fn code_action_annotate_types(
     }
 }
 
+/// Collect inlay hints for top level definitions such as functions and constants.
 fn add_hints_for_definitions<'a>(
     config: &InlayHintsConfig,
     definitions: impl Iterator<Item = &'a TypedDefinition>,

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -424,16 +424,13 @@ where
             let line_numbers = LineNumbers::new(&module.code);
 
             let mut hints = vec![];
-            let start =
-                line_numbers.byte_index(params.range.start.line, params.range.start.character);
-            let end = line_numbers.byte_index(params.range.end.line, params.range.end.character);
+            let requested_range = line_numbers.src_span(params.range);
+
             add_hints_for_definitions(
                 &this.user_config.inlay_hints,
                 module.ast.definitions.iter().filter(|stmt| {
-                    let loc = stmt.location();
-                    (loc.start > start && loc.start < end) // Is the start of the node in the range
-                        || (loc.end > start && loc.end < end) // or is the end of the node in the range
-                        || (start > loc.start && end < loc.end) // or is range within the node
+                    // Only consider definitions in the requested range
+                    requested_range.overlaps(&stmt.location())
                 }),
                 &line_numbers,
                 &mut hints,

--- a/compiler-core/src/language_server/router.rs
+++ b/compiler-core/src/language_server/router.rs
@@ -12,7 +12,7 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-use super::feedback::FeedbackBookKeeper;
+use super::{configuration::VersionedConfig, feedback::FeedbackBookKeeper};
 
 /// The language server instance serves a language client, typically a text
 /// editor. The editor could have multiple Gleam projects open at once, so run
@@ -51,6 +51,7 @@ where
     pub fn project_for_path(
         &mut self,
         path: &Utf8Path,
+        user_config: &VersionedConfig,
     ) -> Result<Option<&mut Project<IO, Reporter>>> {
         let path = match find_gleam_project_parent(&self.io, path) {
             Some(x) => x,
@@ -78,6 +79,7 @@ where
             self.progress_reporter.clone(),
             self.io.clone(),
             paths,
+            user_config.clone(),
         )?;
         let project = Project {
             engine,

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -547,6 +547,19 @@ where
     }
 
     fn request_configuration(&mut self) {
+        let supports_configuration = self
+            .initialise_params
+            .capabilities
+            .workspace
+            .as_ref()
+            .and_then(|w| w.configuration)
+            .unwrap_or(false);
+
+        if !supports_configuration {
+            tracing::warn!("lsp_client_cannot_request_configuration");
+            return;
+        }
+
         self.request(
             "workspace/configuration",
             lsp::ConfigurationParams {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -162,25 +162,35 @@ pub fn main() {
 #[test]
 fn test_add_function_types() {
     let code = "
-pub fn main() {
-    add(1, 2)
-}
-
 fn add(lhs, rhs) {
     lhs + rhs
 }
 ";
     let expected = "
-pub fn main() {
-    add(1, 2)
-}
-
 fn add(lhs: Int, rhs: Int) -> Int {
     lhs + rhs
 }
 ";
     assert_eq!(
-        trigger_action(code, Position::new(5, 0), ANNOTATE_TYPES_ACTION),
+        trigger_action(code, Position::new(1, 0), ANNOTATE_TYPES_ACTION),
+        expected.to_string()
+    )
+}
+
+#[test]
+fn test_add_function_types_partially_annotated() {
+    let code = "
+fn add(lhs, rhs: Int) {
+    lhs + rhs
+}
+";
+    let expected = "
+fn add(lhs: Int, rhs: Int) -> Int {
+    lhs + rhs
+}
+";
+    assert_eq!(
+        trigger_action(code, Position::new(1, 0), ANNOTATE_TYPES_ACTION),
         expected.to_string()
     )
 }

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -199,7 +199,7 @@ Int
             range: Some(Range {
                 start: Position {
                     line: 3,
-                    character: 6
+                    character: 0
                 },
                 end: Position {
                     line: 3,

--- a/compiler-core/src/language_server/tests/inlay_hints.rs
+++ b/compiler-core/src/language_server/tests/inlay_hints.rs
@@ -1,0 +1,117 @@
+use super::*;
+use lsp_types::{
+    InlayHint, InlayHintKind, InlayHintParams, Position, Range, TextDocumentIdentifier, TextEdit,
+    Url,
+};
+
+fn expect_hints(src: &str, expected_hints: Vec<InlayHint>) {
+    let hints = inlay_hints(src).expect("should return hints");
+
+    // InlayHint doesn't implement PartialEq so we're serialising to compare them
+    let hints = serde_json::to_value(hints).expect("serialisation shouldn't fail");
+    let expected_hints =
+        serde_json::to_value(expected_hints).expect("serialisation shouldn't fail");
+    assert_eq!(hints, expected_hints);
+}
+
+fn inlay_hints(src: &str) -> Option<Vec<InlayHint>> {
+    let io = LanguageServerTestIO::new();
+    let mut engine = setup_engine(&io);
+
+    _ = io.src_module("app", src);
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+
+    let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
+        r"\\?\C:\src\app.gleam"
+    } else {
+        "/src/app.gleam"
+    });
+
+    let url = Url::from_file_path(path).expect("should be valid path for url");
+
+    let params = InlayHintParams {
+        text_document: TextDocumentIdentifier::new(url),
+        work_done_progress_params: Default::default(),
+        range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+    };
+    let response = engine.inlay_hint(params);
+
+    response.result.expect("inlay hint request should not fail")
+}
+
+#[test]
+fn module_constants() {
+    let code = "
+const n = 42
+";
+    expect_hints(
+        code,
+        vec![InlayHint {
+            position: Position::new(1, 7),
+            label: ": Int".to_owned().into(),
+            kind: Some(InlayHintKind::TYPE),
+            text_edits: Some(vec![TextEdit {
+                range: Range::new(Position::new(1, 7), Position::new(1, 7)),
+                new_text: ": Int".to_owned(),
+            }]),
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        }],
+    );
+}
+
+#[test]
+fn function_definitions() {
+    let code = "
+fn add(lhs, rhs) {
+    lhs + rhs
+}
+";
+    expect_hints(
+        code,
+        vec![
+            InlayHint {
+                position: Position::new(1, 16),
+                label: "-> Int".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 16), Position::new(1, 16)),
+                    new_text: " -> Int".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: Some(true),
+                padding_right: None,
+                data: None,
+            },
+            InlayHint {
+                position: Position::new(1, 10),
+                label: ": Int".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 10), Position::new(1, 10)),
+                    new_text: ": Int".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: None,
+                padding_right: None,
+                data: None,
+            },
+            InlayHint {
+                position: Position::new(1, 15),
+                label: ": Int".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 15), Position::new(1, 15)),
+                    new_text: ": Int".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: None,
+                padding_right: None,
+                data: None,
+            },
+        ],
+    );
+}

--- a/compiler-core/src/language_server/tests/inlay_hints.rs
+++ b/compiler-core/src/language_server/tests/inlay_hints.rs
@@ -371,3 +371,124 @@ fn add(lhs, rhs) {
         vec![],
     );
 }
+
+#[test]
+fn function_definition_with_single_type_parameter() {
+    let code = "
+fn identity(value: some_value) {
+    value
+}
+";
+    expect_hints(
+        code,
+        InlayHintsConfig {
+            function_definitions: true,
+            ..Default::default()
+        },
+        None,
+        vec![InlayHint {
+            position: Position::new(1, 30),
+            label: "-> some_value".to_owned().into(),
+            kind: Some(InlayHintKind::TYPE),
+            text_edits: Some(vec![TextEdit {
+                range: Range::new(Position::new(1, 30), Position::new(1, 30)),
+                new_text: " -> some_value".to_owned(),
+            }]),
+            tooltip: None,
+            padding_left: Some(true),
+            padding_right: None,
+            data: None,
+        }],
+    );
+}
+
+#[test]
+fn function_definition_with_type_parameter_within_function_body() {
+    let code = "
+fn identity(x) {
+    let y: value = x
+    y
+}
+";
+    expect_hints(
+        code,
+        InlayHintsConfig {
+            function_definitions: true,
+            ..Default::default()
+        },
+        None,
+        vec![
+            InlayHint {
+                position: Position::new(1, 14),
+                label: "-> value".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 14), Position::new(1, 14)),
+                    new_text: " -> value".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: Some(true),
+                padding_right: None,
+                data: None,
+            },
+            InlayHint {
+                position: Position::new(1, 13),
+                label: ": value".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 13), Position::new(1, 13)),
+                    new_text: ": value".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: None,
+                padding_right: None,
+                data: None,
+            },
+        ],
+    );
+}
+
+#[test]
+fn function_definition_with_partially_defined_type_parameter() {
+    let code = "
+fn equals(a: value, b) {
+    a == b
+}
+";
+    expect_hints(
+        code,
+        InlayHintsConfig {
+            function_definitions: true,
+            ..Default::default()
+        },
+        None,
+        vec![
+            InlayHint {
+                position: Position::new(1, 22),
+                label: "-> Bool".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 22), Position::new(1, 22)),
+                    new_text: " -> Bool".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: Some(true),
+                padding_right: None,
+                data: None,
+            },
+            InlayHint {
+                position: Position::new(1, 21),
+                label: ": value".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 21), Position::new(1, 21)),
+                    new_text: ": value".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: None,
+                padding_right: None,
+                data: None,
+            },
+        ],
+    );
+}

--- a/compiler-core/src/language_server/tests/inlay_hints.rs
+++ b/compiler-core/src/language_server/tests/inlay_hints.rs
@@ -75,6 +75,21 @@ const n = 42
 }
 
 #[test]
+fn module_constants_already_annotated() {
+    let code = "
+const n: Int = 42
+";
+    expect_hints(
+        code,
+        InlayHintsConfig {
+            module_constants: true,
+            ..Default::default()
+        },
+        vec![],
+    );
+}
+
+#[test]
 fn module_constants_disabled() {
     let code = "
 const n = 42
@@ -135,6 +150,67 @@ fn add(lhs, rhs) {
                 kind: Some(InlayHintKind::TYPE),
                 text_edits: Some(vec![TextEdit {
                     range: Range::new(Position::new(1, 15), Position::new(1, 15)),
+                    new_text: ": Int".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: None,
+                padding_right: None,
+                data: None,
+            },
+        ],
+    );
+}
+
+#[test]
+fn function_definitions_already_annotated() {
+    let code = "
+fn add(lhs: Int, rhs: Int) -> Int {
+    lhs + rhs
+}
+";
+    expect_hints(
+        code,
+        InlayHintsConfig {
+            function_definitions: true,
+            ..Default::default()
+        },
+        vec![],
+    );
+}
+
+#[test]
+fn function_definitions_partially_annotated() {
+    let code = "
+fn add(lhs, rhs: Int) {
+    lhs + rhs
+}
+";
+    expect_hints(
+        code,
+        InlayHintsConfig {
+            function_definitions: true,
+            ..Default::default()
+        },
+        vec![
+            InlayHint {
+                position: Position::new(1, 21),
+                label: "-> Int".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 21), Position::new(1, 21)),
+                    new_text: " -> Int".to_owned(),
+                }]),
+                tooltip: None,
+                padding_left: Some(true),
+                padding_right: None,
+                data: None,
+            },
+            InlayHint {
+                position: Position::new(1, 10),
+                label: ": Int".to_owned().into(),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(1, 10), Position::new(1, 10)),
                     new_text: ": Int".to_owned(),
                 }]),
                 tooltip: None,

--- a/compiler-core/src/language_server/tests/inlay_hints.rs
+++ b/compiler-core/src/language_server/tests/inlay_hints.rs
@@ -11,7 +11,7 @@ fn expect_hints(
     range: Option<Range>,
     expected_hints: Vec<InlayHint>,
 ) {
-    let hints = inlay_hints(src, config, range).expect("should return hints");
+    let hints = inlay_hints(src, config, range);
 
     // InlayHint doesn't implement PartialEq so we're serialising to compare them
     let hints = serde_json::to_value(hints).expect("serialisation shouldn't fail");
@@ -20,11 +20,7 @@ fn expect_hints(
     assert_eq!(hints, expected_hints);
 }
 
-fn inlay_hints(
-    src: &str,
-    config: InlayHintsConfig,
-    range: Option<Range>,
-) -> Option<Vec<InlayHint>> {
+fn inlay_hints(src: &str, config: InlayHintsConfig, range: Option<Range>) -> Vec<InlayHint> {
     let io = LanguageServerTestIO::new();
     let mut engine = setup_engine_with_config(
         &io,

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -14,6 +14,7 @@ use hexpm::version::Version;
 
 use camino::{Utf8Path, Utf8PathBuf};
 
+use super::configuration::{Configuration, VersionedConfig};
 use crate::{
     config::PackageConfig,
     io::{
@@ -283,11 +284,19 @@ version = "1.0.0""#
 fn setup_engine(
     io: &LanguageServerTestIO,
 ) -> LanguageServerEngine<LanguageServerTestIO, LanguageServerTestIO> {
+    setup_engine_with_config(io, Configuration::default())
+}
+
+fn setup_engine_with_config(
+    io: &LanguageServerTestIO,
+    config: Configuration,
+) -> LanguageServerEngine<LanguageServerTestIO, LanguageServerTestIO> {
     LanguageServerEngine::new(
         PackageConfig::default(),
         io.clone(),
         FileSystemProxy::new(io.clone()),
         io.paths.clone(),
+        VersionedConfig { version: 0, config },
     )
     .unwrap()
 }

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -6,7 +6,7 @@ mod inlay_hints;
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
     time::SystemTime,
 };
 
@@ -14,7 +14,7 @@ use hexpm::version::Version;
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-use super::configuration::{Configuration, VersionedConfig};
+use super::configuration::Configuration;
 use crate::{
     config::PackageConfig,
     io::{
@@ -296,7 +296,7 @@ fn setup_engine_with_config(
         io.clone(),
         FileSystemProxy::new(io.clone()),
         io.paths.clone(),
-        VersionedConfig::new(config),
+        Arc::new(RwLock::new(config)),
     )
     .unwrap()
 }

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -2,6 +2,7 @@ mod action;
 mod compilation;
 mod completion;
 mod hover;
+mod inlay_hints;
 
 use std::{
     collections::HashMap,

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -296,7 +296,7 @@ fn setup_engine_with_config(
         io.clone(),
         FileSystemProxy::new(io.clone()),
         io.paths.clone(),
-        VersionedConfig { version: 0, config },
+        VersionedConfig::new(config),
     )
     .unwrap()
 }

--- a/compiler-core/src/language_server/type_annotations.rs
+++ b/compiler-core/src/language_server/type_annotations.rs
@@ -1,0 +1,92 @@
+use super::code_action::CodeActionBuilder;
+use crate::{
+    ast::{TypedFunction, TypedModuleConstant},
+    line_numbers::LineNumbers,
+    type_::pretty::Printer,
+};
+use lsp_types::{
+    CodeActionKind, InlayHint, InlayHintKind, InlayHintLabel, Position, Range, TextEdit, Url,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct TypeAnnotations {
+    annotations: Vec<(Position, String)>,
+}
+
+impl TypeAnnotations {
+    pub fn from_module_constant(
+        constant: &TypedModuleConstant,
+        line_numbers: &LineNumbers,
+    ) -> Self {
+        if constant.annotation.is_none() {
+            let linecol = line_numbers.line_and_column_number(constant.location.end);
+            let position = Position::new(linecol.line - 1, linecol.column - 1);
+            let type_text = Printer::new().pretty_print(&constant.type_, 0);
+            let text = format!(": {type_text}");
+
+            Self {
+                annotations: vec![(position, text)],
+            }
+        } else {
+            Self::default()
+        }
+    }
+
+    pub fn from_function_definition(function: &TypedFunction, line_numbers: &LineNumbers) -> Self {
+        let mut annotations = vec![];
+        if function.return_annotation.is_none() {
+            let linecol = line_numbers.line_and_column_number(function.location.end);
+            let position = Position::new(linecol.line - 1, linecol.column - 1);
+            let type_text = Printer::new().pretty_print(&function.return_type, 0);
+            let text = format!(" -> {type_text}");
+            annotations.push((position, text))
+        }
+        for argument in &function.arguments {
+            if argument.annotation.is_none() {
+                let linecol = line_numbers.line_and_column_number(argument.location.end);
+                let position = Position::new(linecol.line - 1, linecol.column - 1);
+                let type_text = Printer::new().pretty_print(&argument.type_, 0);
+                let text = format!(": {type_text}");
+                annotations.push((position, text));
+            }
+        }
+
+        Self { annotations }
+    }
+
+    pub fn into_inlay_hints(self) -> impl Iterator<Item = InlayHint> {
+        self.annotations
+            .into_iter()
+            .map(|(position, text)| InlayHint {
+                position,
+                kind: Some(InlayHintKind::TYPE),
+                tooltip: None,
+                padding_left: text.starts_with(' ').then_some(true),
+                padding_right: None,
+                data: None,
+                label: InlayHintLabel::String(text.trim_start().to_owned()),
+                text_edits: Some(vec![TextEdit::new(Range::new(position, position), text)]),
+            })
+    }
+
+    pub fn into_code_action(self, uri: Url) -> Option<CodeActionBuilder> {
+        if self.annotations.is_empty() {
+            None
+        } else {
+            Some(
+                CodeActionBuilder::new("Annotate type(s)")
+                    .kind(CodeActionKind::REFACTOR_REWRITE)
+                    .changes(
+                        uri,
+                        self.annotations
+                            .into_iter()
+                            .map(|(position, text)| {
+                                TextEdit::new(Range::new(position, position), text)
+                            })
+                            .collect(),
+                    )
+                    .preferred(true),
+            )
+        }
+    }
+}

--- a/compiler-core/src/language_server/type_annotations.rs
+++ b/compiler-core/src/language_server/type_annotations.rs
@@ -69,7 +69,7 @@ impl TypeAnnotations {
             })
     }
 
-    pub fn into_code_action(self, uri: Url) -> Option<CodeActionBuilder> {
+    pub fn into_code_action(self, uri: &Url) -> Option<CodeActionBuilder> {
         if self.annotations.is_empty() {
             None
         } else {
@@ -77,7 +77,7 @@ impl TypeAnnotations {
                 CodeActionBuilder::new("Annotate type(s)")
                     .kind(CodeActionKind::REFACTOR_REWRITE)
                     .changes(
-                        uri,
+                        uri.clone(),
                         self.annotations
                             .into_iter()
                             .map(|(position, text)| {

--- a/compiler-core/src/line_numbers.rs
+++ b/compiler-core/src/line_numbers.rs
@@ -1,3 +1,5 @@
+use crate::ast::SrcSpan;
+
 #[derive(Debug)]
 pub struct LineNumbers {
     line_starts: Vec<u32>,
@@ -42,6 +44,13 @@ impl LineNumbers {
             Some(line_index) => *line_index + character,
             None => self.length,
         }
+    }
+
+    /// Convert an LSP `Range` into a `SrcSpan`
+    pub fn src_span(&self, range: lsp_types::Range) -> SrcSpan {
+        let start = self.byte_index(range.start.line, range.start.character);
+        let end = self.byte_index(range.end.line, range.end.character);
+        SrcSpan::new(start, end)
     }
 }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -235,14 +235,14 @@ where
                 self.parse_import(start)
             }
             // Module Constants
-            (Some((_, Token::Const, _)), _) => {
+            (Some((start, Token::Const, _)), _) => {
                 let _ = self.next_tok();
-                self.parse_module_const(false)
+                self.parse_module_const(false, start)
             }
-            (Some((_, Token::Pub, _)), Some((_, Token::Const, _))) => {
+            (Some((start, Token::Pub, _)), Some((_, Token::Const, _))) => {
                 let _ = self.next_tok();
                 let _ = self.next_tok();
-                self.parse_module_const(true)
+                self.parse_module_const(true, start)
             }
 
             // Function
@@ -2106,8 +2106,9 @@ where
     fn parse_module_const(
         &mut self,
         public: bool,
+        start: u32,
     ) -> Result<Option<UntypedDefinition>, ParseError> {
-        let (start, name, end) = self.expect_name()?;
+        let (_, name, end) = self.expect_name()?;
         let documentation = self.take_documentation(start);
 
         let annotation = self.parse_type_annotation(&Token::Colon)?;

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_and_function_names_const_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_and_function_names_const_fn.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1036
 expression: "const duplicate = 1\nfn duplicate() { 2 }"
 ---
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:7
+  ┌─ /src/one/two.gleam:1:1
   │
 1 │ const duplicate = 1
-  │       ^^^^^^^^^ First defined here
+  │ ^^^^^^^^^^^^^^^ First defined here
 2 │ fn duplicate() { 2 }
   │ ^^^^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_const.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1044
 expression: "const foo = 1\nconst foo = 2"
 ---
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:7
+  ┌─ /src/one/two.gleam:1:1
   │
 1 │ const foo = 1
-  │       ^^^ First defined here
+  │ ^^^^^^^^^ First defined here
 2 │ const foo = 2
-  │       ^^^ Redefined here
+  │ ^^^^^^^^^ Redefined here
 
 `foo` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_extfn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_extfn.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1094
 expression: "const foo = 1\n\n@external(erlang, \"module2\", \"function2\")\nfn foo() -> Float\n"
 ---
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:7
+  ┌─ /src/one/two.gleam:1:1
   │
 1 │ const foo = 1
-  │       ^^^ First defined here
+  │ ^^^^^^^^^ First defined here
   ·
 4 │ fn foo() -> Float
   │ ^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_fn.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1116
 expression: "const foo = 1\nfn foo() { 2 }"
 ---
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:7
+  ┌─ /src/one/two.gleam:1:1
   │
 1 │ const foo = 1
-  │       ^^^ First defined here
+  │ ^^^^^^^^^ First defined here
 2 │ fn foo() { 2 }
   │ ^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_names.snap
@@ -1,15 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1026
 expression: "const duplicate = 1\npub const duplicate = 1"
 ---
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:7
+  ┌─ /src/one/two.gleam:1:1
   │
 1 │ const duplicate = 1
-  │       ^^^^^^^^^ First defined here
+  │ ^^^^^^^^^^^^^^^ First defined here
 2 │ pub const duplicate = 1
-  │           ^^^^^^^^^ Redefined here
+  │ ^^^^^^^^^^^^^^^^^^^ Redefined here
 
 `duplicate` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_const.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1105
 expression: "\n@external(erlang, \"module1\", \"function1\")\nfn foo() -> Float\n\nconst foo = 2"
 ---
 error: Duplicate definition
@@ -10,7 +9,7 @@ error: Duplicate definition
   │ ^^^^^^^^ First defined here
 4 │ 
 5 │ const foo = 2
-  │       ^^^ Redefined here
+  │ ^^^^^^^^^ Redefined here
 
 `foo` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_const.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1124
 expression: "fn foo() { 1 }\nconst foo = 2"
 ---
 error: Duplicate definition
@@ -9,7 +8,7 @@ error: Duplicate definition
 1 │ fn foo() { 1 }
   │ ^^^^^^^^ First defined here
 2 │ const foo = 2
-  │       ^^^ Redefined here
+  │ ^^^^^^^^^ Redefined here
 
 `foo` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1129,7 +1129,7 @@ fn unused_alias_warning_test() {
         "#,
         Warning::UnusedPrivateModuleConstant {
             name: "one".into(),
-            location: SrcSpan { start: 61, end: 64 },
+            location: SrcSpan { start: 55, end: 64 },
         },
         Warning::UnusedImportedModuleAlias {
             name:"bar".into(),
@@ -1166,7 +1166,7 @@ fn unused_alias_for_duplicate_module_no_warning_for_alias_test() {
         "#,
         Warning::UnusedPrivateModuleConstant {
             name: "one".into(),
-            location: SrcSpan { start: 76, end: 79 },
+            location: SrcSpan { start: 70, end: 79 },
         },
         Warning::UnusedImportedModule {
             name: "bar".into(),

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -328,7 +328,7 @@ fn unused_private_const_warnings_test() {
         "const a = 1",
         Warning::UnusedPrivateModuleConstant {
             name: "a".into(),
-            location: SrcSpan { start: 6, end: 7 },
+            location: SrcSpan { start: 0, end: 7 },
         }
     );
 }


### PR DESCRIPTION
- Add inlay hints for function definitions and module constants
- Add config options to enable/disable specific inlay hints
  - Before now the language server had no config so this this PR adds the requesting of the config, as well as listening for config updates.
  - These will need to be exposed by the vscode plugin which I can put a PR in for too
- Adds code actions to annotate types for function definitions and module constants
- This PR also expands the 'location' on module constants to include the `(pub) const` tokens to make it easier to target a module constant with a code action as, without this change, the cursor would need to specifically be on the name to trigger it.
- The code for the code action and inlay hints are similar enough that it made sense to share some code between them. This is done with the `TypeAnnotations` struct which once created can be turned into either a code action or inlay hint.

I have made the inlay hints default to being disabled as I think the consensus is that they may add too much noise and also, particularly for function definitions, may undesirably discourage annotating top level types.

This PR does not yet address all the use cases for inlay hints as presented in #2319 
Specifically called out in that issue are function calls and variable assignments. These are a little more involved to support than what this PR adds support for, due to needing to walk the ast to find these nodes within function bodies. A subsequent PR may add support for these.