### PR TITLE
CLI: Add target short flag for gleam run & test

### DIFF
--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -167,7 +167,7 @@ enum Command {
     #[clap(trailing_var_arg = true)]
     Run {
         /// The platform to target
-        #[clap(long, ignore_case = true, possible_values = Target::VARIANTS)]
+        #[clap(short, long, ignore_case = true, possible_values = Target::VARIANTS)]
         target: Option<Target>,
 
         #[clap(long, ignore_case = true)]
@@ -184,7 +184,7 @@ enum Command {
     #[clap(trailing_var_arg = true)]
     Test {
         /// The platform to target
-        #[clap(long, ignore_case = true, possible_values = Target::VARIANTS)]
+        #[clap(short, long, ignore_case = true, possible_values = Target::VARIANTS)]
         target: Option<Target>,
 
         #[clap(long, ignore_case = true)]


### PR DESCRIPTION
This PR resolves issue #2395.

Here is the output for `gleam run` and `gleam test` - 
* `gleam run -h`
```shell
Run the project

USAGE:
    gleam run [OPTIONS] [ARGUMENTS]...

ARGS:
    <ARGUMENTS>...    

OPTIONS:
    -h, --help                 Print help information
    -m, --module <MODULE>      The module to run
        --runtime <RUNTIME>    
    -t, --target <TARGET>      The platform to target [possible values: erlang, javascript]
```

* `gleam test -h`
```shell
Run the project tests

USAGE:
    gleam test [OPTIONS] [ARGUMENTS]...

ARGS:
    <ARGUMENTS>...    

OPTIONS:
    -h, --help                 Print help information
        --runtime <RUNTIME>    
    -t, --target <TARGET>      The platform to target [possible values: erlang, javascript]
```