### PR TITLE
Allow as to take an expression when used together with panic

### DIFF
--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -121,7 +121,7 @@ pub enum TypedExpr {
 
     Panic {
         location: SrcSpan,
-        message: Option<EcoString>,
+        message: Option<Box<Self>>,
         type_: Arc<Type>,
     },
 

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -99,7 +99,7 @@ pub enum UntypedExpr {
 
     Panic {
         location: SrcSpan,
-        message: Option<EcoString>,
+        message: Option<Box<Self>>,
     },
 
     BitArray {

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -326,12 +326,16 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             UntypedExpr::Int { .. }
             | UntypedExpr::Var { .. }
             | UntypedExpr::Todo { .. }
-            | UntypedExpr::Panic { .. }
             | UntypedExpr::Float { .. }
             | UntypedExpr::String { .. }
             | UntypedExpr::NegateInt { .. }
             | UntypedExpr::NegateBool { .. }
             | UntypedExpr::Placeholder { .. } => e,
+
+            UntypedExpr::Panic { location, message } => UntypedExpr::Panic {
+                location,
+                message: message.map(|msg_expr| Box::new(self.fold_expr(*msg_expr))),
+            },
 
             UntypedExpr::Block {
                 location,
@@ -753,7 +757,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         }
     }
 
-    fn fold_panic(&mut self, location: SrcSpan, message: Option<EcoString>) -> UntypedExpr {
+    fn fold_panic(&mut self, location: SrcSpan, message: Option<Box<UntypedExpr>>) -> UntypedExpr {
         UntypedExpr::Panic { location, message }
     }
 

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -115,9 +115,14 @@ impl<'a> CallGraphBuilder<'a> {
             UntypedExpr::Todo { .. }
             | UntypedExpr::Int { .. }
             | UntypedExpr::Float { .. }
-            | UntypedExpr::Panic { .. }
             | UntypedExpr::String { .. }
             | UntypedExpr::Placeholder { .. } => (),
+
+            UntypedExpr::Panic { message, .. } => {
+                if let Some(msg_expr) = message {
+                    self.expression(msg_expr)
+                }
+            }
 
             // Aha! A variable is being referenced.
             UntypedExpr::Var { name, .. } => {

--- a/compiler-core/src/erlang/tests/panic.rs
+++ b/compiler-core/src/erlang/tests/panic.rs
@@ -22,6 +22,20 @@ pub fn main() {
     );
 }
 
+#[test]
+fn panic_as_function() {
+    assert_erl!(
+        r#"
+pub fn retstring() {
+  "wibble"
+}
+pub fn main() {
+  panic as retstring() <> "wobble"
+}
+"#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/2176
 #[test]
 fn piped() {

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__panic_as_function.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__panic_as_function.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests/panic.rs
+expression: "\npub fn retstring() {\n  \"wibble\"\n}\npub fn main() {\n  panic as retstring() <> \"wobble\"\n}\n"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function]).
+
+-export([retstring/0, main/0]).
+
+-spec retstring() -> binary().
+retstring() ->
+    <<"wibble"/utf8>>.
+
+-spec main() -> any().
+main() ->
+    erlang:error(#{gleam_error => panic,
+            message => <<(retstring())/binary, "wobble"/utf8>>,
+            module => <<"my/mod"/utf8>>,
+            function => <<"main"/utf8>>,
+            line => 6}).
+

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -630,7 +630,7 @@ impl<'comments> Formatter<'comments> {
 
             UntypedExpr::Panic {
                 message: Some(m), ..
-            } => docvec!["panic as \"", m, "\""],
+            } => docvec!["panic as ", self.expr(m)],
 
             UntypedExpr::Panic { .. } => "panic".to_doc(),
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3158,6 +3158,18 @@ fn expr_panic_as() {
 }
 
 #[test]
+fn expr_panic_as_value(){
+    assert_format!(
+        r#"fn main() {
+  let x = "panicking" <> "with a value"
+  panic as x
+}
+"#
+    );
+}
+
+
+#[test]
 fn expr_todo() {
     assert_format!(
         "fn main() {

--- a/compiler-core/src/javascript/tests/panic.rs
+++ b/compiler-core/src/javascript/tests/panic.rs
@@ -12,6 +12,18 @@ fn go() {
 }
 
 #[test]
+fn panic_as(){
+    assert_js!(
+        r#"
+fn go() {
+  let x = "wibble"
+  panic as x
+}
+"#,
+    );
+}
+
+#[test]
 fn bare_typescript() {
     assert_ts_def!(
         r#"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__panic__panic_as.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__panic__panic_as.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/javascript/tests/panic.rs
+expression: "\nfn go() {\n  let x = \"wibble\"\n  panic as x\n}\n"
+---
+import { makeError } from "../gleam.mjs";
+
+function go() {
+  let x = "wibble";
+  throw makeError("todo", "my/mod", 4, "go", x, {})
+}
+

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -416,9 +416,10 @@ where
                 let mut label = None;
                 let _ = self.next_tok();
                 if self.maybe_one(&Token::As).is_some() {
-                    let (_, l, e) = self.expect_string()?;
-                    label = Some(l);
-                    end = e;
+                    label = self.parse_expression()?.map(Box::new);
+                    if let Some(msg_expr_val) = &label {
+                        end = msg_expr_val.location().end;
+                    }
                 }
                 UntypedExpr::Panic {
                     location: SrcSpan { start, end },


### PR DESCRIPTION
Allow as to take an expression when used together with panic. Expression given should evaluate to a string.