### PR TITLE
Fix: `delete` should be `delete_file`

### DIFF
--- a/compiler-core/src/build/elixir_libraries.rs
+++ b/compiler-core/src/build/elixir_libraries.rs
@@ -49,7 +49,7 @@ where
 
     fn cleanup(&self) {
         self.io
-            .delete(&self.paths_cache_path())
+            .delete_file(&self.paths_cache_path())
             .expect("deleting paths cache in cleanup");
     }
 


### PR DESCRIPTION
Incorrect use when delete files.