### PR TITLE
Fix a bug with case branch formatting

### DIFF
--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1247,6 +1247,7 @@ impl<'comments> Formatter<'comments> {
 
             _ => break_("", " ").append(self.expr(expr)).nest(INDENT),
         }
+        .next_break_fits(NextBreakFitsMode::Disabled)
         .group()
     }
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5159,3 +5159,19 @@ fn prefix_as() {
 "#
     );
 }
+
+#[test]
+fn case_splits_function_on_newline() {
+    assert_format!(
+        r#"pub fn main() {
+  case x {
+    1 ->
+      some_module.some_long_name_function([
+        some_module.some_long_name_function(),
+      ])
+    _ -> todo
+  }
+}
+"#
+    );
+}


### PR DESCRIPTION
There was a little bug I overlooked in the formatter.
It would format case branches like this:
```gleam
case x {
  1 -> some_module.some_long_name_function([
      some_module.some_long_name_function(),
    ])
  _ -> todo
}
```
Now it works correctly and does this:
```gleam
case x {
  1 ->
    some_module.some_long_name_function([
      some_module.some_long_name_function(),
    ])
  _ -> todo
}
```