### PR TITLE
Fix a bug where the formatter would move comments out of blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Formatter
 
 - The formatter now tries to keep a function body and its arguments on a single
-  line by first trying to split only its last argument on multiple lines
+  line by first trying to split only its last argument on multiple lines.
+- Fixed a bug where the formatter would move comments out of blocks.
 
 ### Language changes
 

--- a/compiler-core/src/format/tests/blocks.rs
+++ b/compiler-core/src/format/tests/blocks.rs
@@ -45,3 +45,42 @@ fn block_comment() {
 "#
     );
 }
+
+#[test]
+fn last_comments_are_not_moved_out_of_blocks() {
+    assert_format!(
+        r#"fn main() {
+  {
+    hello
+    // Hope I'm not yeeted out of this block!
+  }
+}
+"#
+    );
+
+    assert_format!(
+        r#"fn main() {
+  {
+    hello
+    {
+      { hi }
+      // Some nested comments
+    }
+    // At the end of multiple blocks
+  }
+}
+"#
+    );
+
+    assert_format!(
+        r#"fn main() {
+  case foo {
+    bar -> {
+      1
+      // Hope I can stay inside this clause
+    }
+  }
+}
+"#
+    );
+}


### PR DESCRIPTION
Before the formatter would yeet comments out of blocks:
```gleam
{
  1
  // I'm a comment
}
```
would turn into:
```gleam
{ 1 }
// I'm a comment
```

Now it's a bit more respectful of comments inside of blocks (even case clause blocks!)
```gleam
case foo {
  1 -> {
    1
    // I'm a comment
  }
}
```
no longer turns into:
```gleam
case foo {
  1 -> {
    1
  }
}
// I'm a comment
```