### PR TITLE
Hide const implementation from docs

### DIFF
--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -377,8 +377,6 @@ impl<'comments> Formatter<'comments> {
             .append(name)
             .append(": ")
             .append(printer.print(&value.type_()))
-            .append(" = ")
-            .append(self.const_expr(value))
     }
 
     fn documented_definition<'a>(&mut self, s: &'a UntypedDefinition) -> Document<'a> {


### PR DESCRIPTION
Possible solution for https://github.com/gleam-lang/gleam/issues/2111

The PR hides entirely the the value of a const, for every possible value

Example:
```gleam
pub const person: Person
```

