### PR TITLE
Add leading wildcard to doc searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   patterns.
 - Fixed a bug where the formatter would misplace comments at the start of a
   block.
+- Searching in rendered HTML documentation now also matches words that do not
+  start with the input but do contain it.
 
 
 ## v0.32.4 - 2023-11-09

--- a/compiler-core/templates/docs-js/index.js
+++ b/compiler-core/templates/docs-js/index.js
@@ -215,7 +215,11 @@ window.Gleam = (function () {
           boost: 10,
         });
         query.term(tokens, {
+          boost: 5,
           wildcard: lunr.Query.wildcard.TRAILING,
+        });
+        query.term(tokens, {
+          wildcard: lunr.Query.wildcard.LEADING | lunr.Query.wildcard.TRAILING,
         });
       });
 


### PR DESCRIPTION
Previously, searches only matched the beginning of a word. For example searching for "shift" showed no results, while it should clearly be able to find `int.bitwise_shift_(left/right)`.

I'm not sure if the chosen solution is the best way or if the boost values are optimal, so please do give feedback and suggestions for improvement.