### PR TITLE
Make Unicode escape sequences 1 to 6 digits long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   `test` are now reserved for future use. If used they will emit a warning. In
   a future version this may be upgraded to an error.
 - The `\u{...}` syntax can be used in strings to specify unicode codepoints via a
-  hexadecimal number. 2, 4, or 8 digits can be used.
+  hexadecimal number with 1 to 6 digits.
 - The `todo as` and `panic as` syntaxes now accept an expression that evaluates
   to a string rather than just a string literal.
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode1.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-expression: "\npub fn emoji() -> String {\n  \"\\u{0001f600}\"\n}\n"
+expression: "\npub fn emoji() -> String {\n  \"\\u{1f600}\"\n}\n"
 ---
 -module(my@mod).
 -compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function]).
@@ -9,5 +9,5 @@ expression: "\npub fn emoji() -> String {\n  \"\\u{0001f600}\"\n}\n"
 
 -spec emoji() -> binary().
 emoji() ->
-    <<"\x{0001f600}"/utf8>>.
+    <<"\x{1f600}"/utf8>>.
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_escape_sequence_6_digits.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_escape_sequence_6_digits.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/erlang/tests/strings.rs
+expression: "\npub fn unicode_escape_sequence_6_digits() -> String {\n  \"\\u{10abcd}\"\n}\n"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function]).
+
+-export([unicode_escape_sequence_6_digits/0]).
+
+-spec unicode_escape_sequence_6_digits() -> binary().
+unicode_escape_sequence_6_digits() ->
+    <<"\x{10abcd}"/utf8>>.
+

--- a/compiler-core/src/erlang/tests/strings.rs
+++ b/compiler-core/src/erlang/tests/strings.rs
@@ -5,7 +5,7 @@ fn unicode1() {
     assert_erl!(
         r#"
 pub fn emoji() -> String {
-  "\u{0001f600}"
+  "\u{1f600}"
 }
 "#,
     );
@@ -52,6 +52,17 @@ fn unicode3() {
         r#"
 pub fn y_with_dieresis_with_slash() -> String {
   "\\\u{0308}y"
+}
+"#,
+    );
+}
+
+#[test]
+fn unicode_escape_sequence_6_digits() {
+    assert_erl!(
+        r#"
+pub fn unicode_escape_sequence_6_digits() -> String {
+  "\u{10abcd}"
 }
 "#,
     );

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__unicode1.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__unicode1.snap
@@ -1,8 +1,8 @@
 ---
 source: compiler-core/src/javascript/tests/strings.rs
-expression: "\npub fn emoji() -> String {\n  \"\\u{0001f600}\"\n}\n"
+expression: "\npub fn emoji() -> String {\n  \"\\u{1f600}\"\n}\n"
 ---
 export function emoji() {
-  return "\u{0001f600}";
+  return "\u{1f600}";
 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__unicode_escape_sequence_6_digits.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__unicode_escape_sequence_6_digits.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/strings.rs
+expression: "\npub fn unicode_escape_sequence_6_digits() -> String {\n  \"\\u{10abcd}\"\n}\n"
+---
+export function unicode_escape_sequence_6_digits() {
+  return "\u{10abcd}";
+}
+

--- a/compiler-core/src/javascript/tests/strings.rs
+++ b/compiler-core/src/javascript/tests/strings.rs
@@ -5,7 +5,7 @@ fn unicode1() {
     assert_js!(
         r#"
 pub fn emoji() -> String {
-  "\u{0001f600}"
+  "\u{1f600}"
 }
 "#,
     );
@@ -31,6 +31,17 @@ pub fn y() -> String {
 }
 "#,
     )
+}
+
+#[test]
+fn unicode_escape_sequence_6_digits() {
+    assert_js!(
+        r#"
+pub fn unicode_escape_sequence_6_digits() -> String {
+  "\u{10abcd}"
+}
+"#,
+    );
 }
 
 #[test]

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -13,7 +13,7 @@ pub struct LexicalError {
 pub enum InvalidUnicodeEscapeError {
     MissingOpeningBrace,          // Expected '{'
     ExpectedHexDigitOrCloseBrace, // Expected hex digit or '}'
-    InvalidNumberOfHexDigits,     // Expected 2, 4, or 8 hex digits
+    InvalidNumberOfHexDigits,     // Expected between 1 and 6 hex digits
     InvalidCodepoint,             // Invalid Unicode codepoint
 }
 
@@ -337,8 +337,8 @@ impl LexicalError {
             LexicalErrorType::InvalidUnicodeEscape(
                 InvalidUnicodeEscapeError::InvalidNumberOfHexDigits,
             ) => (
-                "Expected 2, 4, or 8 hex digits in Unicode escape sequence",
-                vec!["Hint: Consider adding leading zeroes.".into()],
+                "Expected between 1 and 6 hex digits in Unicode escape sequence",
+                vec![],
             ),
             LexicalErrorType::InvalidUnicodeEscape(InvalidUnicodeEscapeError::InvalidCodepoint) => {
                 ("Invalid Unicode codepoint", vec![])

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -783,7 +783,9 @@ where
                                         break;
                                     };
 
-                                    if chr == '}' || hex_digits.len() > 8 {
+                                    // Don't break early when we've reached 6 digits to ensure a
+                                    // useful error message
+                                    if chr == '}' {
                                         break;
                                     }
 
@@ -816,11 +818,7 @@ where
 
                                 let _ = self.next_char();
 
-                                let hex_digits_amount = hex_digits.len();
-                                if hex_digits_amount != 2
-                                    && hex_digits_amount != 4
-                                    && hex_digits_amount != 8
-                                {
+                                if !(1..=6).contains(&hex_digits.len()) {
                                     return Err(LexicalError {
                                         error: LexicalErrorType::InvalidUnicodeEscape(
                                             InvalidUnicodeEscapeError::InvalidNumberOfHexDigits,
@@ -851,7 +849,9 @@ where
                                     });
                                 }
 
-                                string_content.push_str(&format!("\\u{{{hex_digits}}}"));
+                                string_content.push_str("\\u{");
+                                string_content.push_str(&hex_digits);
+                                string_content.push('}');
                             }
                             _ => {
                                 return Err(LexicalError {

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -135,8 +135,7 @@ fn int_tests() {
 }
 
 #[test]
-fn string() {
-    // bad character escape
+fn string_bad_character_escape() {
     assert_error!(
         r#""\g""#,
         ParseError {
@@ -152,8 +151,7 @@ fn string() {
 }
 
 #[test]
-fn string2() {
-    // still bad character escape
+fn string_bad_character_escape_leading_backslash() {
     assert_error!(
         r#""\\\g""#,
         ParseError {
@@ -169,25 +167,7 @@ fn string2() {
 }
 
 #[test]
-fn string3() {
-    assert_error!(
-        r#""\u{0011f601}""#,
-        ParseError {
-            error: ParseErrorType::LexError {
-                error: LexicalError {
-                    error: LexicalErrorType::InvalidUnicodeEscape(
-                        InvalidUnicodeEscapeError::InvalidCodepoint,
-                    ),
-                    location: SrcSpan { start: 1, end: 13 },
-                }
-            },
-            location: SrcSpan { start: 1, end: 13 },
-        }
-    );
-}
-
-#[test]
-fn string4() {
+fn string_freestanding_unicode_escape_sequence() {
     assert_error!(
         r#""\u""#,
         ParseError {
@@ -205,7 +185,25 @@ fn string4() {
 }
 
 #[test]
-fn string5() {
+fn string_unicode_escape_sequence_no_braces() {
+    assert_error!(
+        r#""\u65""#,
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::InvalidUnicodeEscape(
+                        InvalidUnicodeEscapeError::MissingOpeningBrace,
+                    ),
+                    location: SrcSpan { start: 2, end: 3 },
+                }
+            },
+            location: SrcSpan { start: 2, end: 3 },
+        }
+    );
+}
+
+#[test]
+fn string_unicode_escape_sequence_invalid_hex() {
     assert_error!(
         r#""\u{z}""#,
         ParseError {
@@ -223,7 +221,7 @@ fn string5() {
 }
 
 #[test]
-fn string6() {
+fn string_unclosed_unicode_escape_sequence() {
     assert_error!(
         r#""\u{039a""#,
         ParseError {
@@ -241,19 +239,55 @@ fn string6() {
 }
 
 #[test]
-fn string7() {
+fn string_empty_unicode_escape_sequence() {
     assert_error!(
-        r#""\u{039}""#,
+        r#""\u{}""#,
         ParseError {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::InvalidUnicodeEscape(
                         InvalidUnicodeEscapeError::InvalidNumberOfHexDigits,
                     ),
-                    location: SrcSpan { start: 1, end: 8 },
+                    location: SrcSpan { start: 1, end: 5 },
                 }
             },
-            location: SrcSpan { start: 1, end: 8 },
+            location: SrcSpan { start: 1, end: 5 },
+        }
+    );
+}
+
+#[test]
+fn string_overlong_unicode_escape_sequence() {
+    assert_error!(
+        r#""\u{0011f601}""#,
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::InvalidUnicodeEscape(
+                        InvalidUnicodeEscapeError::InvalidNumberOfHexDigits,
+                    ),
+                    location: SrcSpan { start: 1, end: 13 },
+                }
+            },
+            location: SrcSpan { start: 1, end: 13 },
+        }
+    );
+}
+
+#[test]
+fn string_invalid_unicode_escape_sequence() {
+    assert_error!(
+        r#""\u{110000}""#,
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::InvalidUnicodeEscape(
+                        InvalidUnicodeEscapeError::InvalidCodepoint,
+                    ),
+                    location: SrcSpan { start: 1, end: 11 },
+                }
+            },
+            location: SrcSpan { start: 1, end: 11 },
         }
     );
 }


### PR DESCRIPTION
The maximum length of 6 hex digits fits a 21 bit Unicode codepoint, and being clearly designated by the surrounding braces there is no reason not to allow 1, 3 or 5 digits too.

This behaviour seems to be in line with most other languages that have a similar feature.