### PR TITLE
String alias bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fixed a bug where string prefix aliases defined in alternative case branches
+  would all be bound to the same constant.
+
 ## v0.33.0-rc2 - 2023-12-07
 
 ### Language changes

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -85,13 +85,23 @@ fn print<'a>(
         Pattern::StringPrefix {
             left_side_string: left,
             right_side_assignment: right,
+            left_side_assignment,
             ..
         } => {
             let right = match right {
                 AssignName::Variable(right) if define_variables => env.next_local_var_name(right),
                 AssignName::Variable(_) | AssignName::Discard(_) => "_".to_doc(),
             };
-            docvec!["<<\"", left, "\"/utf8, ", right, "/binary>>"]
+
+            let left = docvec!["\"", left, "\"/utf8"];
+            let left = if let Some((left_name, _)) = left_side_assignment {
+                left.append(" = ")
+                    .append(env.next_local_var_name(left_name))
+            } else {
+                left
+            };
+
+            docvec!["<<", left, ", ", right, "/binary>>"]
         }
     }
 }

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -95,6 +95,12 @@ fn print<'a>(
 
             let left = docvec!["\"", left, "\"/utf8"];
             let left = if let Some((left_name, _)) = left_side_assignment {
+                // "foo" as prefix <> rest
+                //       ^^^^^^^^^ In case the left prefix of the pattern matching is given an alias
+                //                 we bind it to a local variable so that it can be correctly
+                //                 referenced inside the case branch.
+                // <<"foo"/utf8 = Prefix, rest/binary>>
+                //              ^^^^^^^^ this is the piece we're adding here
                 left.append(" = ")
                     .append(env.next_local_var_name(left_name))
             } else {

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 153
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as greeting <> name -> greeting\n    _ -> \"Unknown\"\n  }\n}\n"
 ---
 -module(my@mod).
@@ -11,8 +10,8 @@ expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as greeting <> name -
 -spec go(binary()) -> binary().
 go(X) ->
     case X of
-        <<"Hello, "/utf8, Name/binary>> ->
-            <<"Hello, "/utf8>>;
+        <<"Hello, "/utf8 = Greeting, Name/binary>> ->
+            Greeting;
 
         _ ->
             <<"Unknown"/utf8>>

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as x <> name -> x\n    _ -> \"Unknown\"\n  }\n}\n"
+expression: "\npub fn go(x) {\n  case x {\n    \"1\" as digit <> _ | \"2\" as digit <> _ -> digit\n    _ -> \"Unknown\"\n  }\n}\n"
 ---
 -module(my@mod).
 -compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
@@ -10,8 +10,11 @@ expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as x <> name -> x\n  
 -spec go(binary()) -> binary().
 go(X) ->
     case X of
-        <<"Hello, "/utf8 = X@1, Name/binary>> ->
-            X@1;
+        <<"1"/utf8 = Digit, _/binary>> ->
+            Digit;
+
+        <<"2"/utf8 = Digit, _/binary>> ->
+            Digit;
 
         _ ->
             <<"Unknown"/utf8>>

--- a/compiler-core/src/erlang/tests/strings.rs
+++ b/compiler-core/src/erlang/tests/strings.rs
@@ -162,6 +162,21 @@ pub fn go(x) {
     )
 }
 
+// https://github.com/gleam-lang/gleam/issues/2471
+#[test]
+fn string_prefix_assignment_with_multiple_subjects() {
+    assert_erl!(
+        r#"
+pub fn go(x) {
+  case x {
+    "1" as digit <> _ | "2" as digit <> _ -> digit
+    _ -> "Unknown"
+  }
+}
+"#,
+    )
+}
+
 #[test]
 fn string_prefix_shadowing() {
     assert_erl!(

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -406,9 +406,18 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 if let AssignName::Variable(right) = right_side_assignment {
                     self.push_string_prefix_slice(utf16_no_escape_len(left_side_string));
                     self.push_assignment(subject.clone(), right);
+                    // We remove the string slicing that was needed to push the correct assignment
+                    // this way the following assignments will only be sliced if necessary.
+                    self.pop();
                 }
                 if let Some((left, _)) = left_side_assignment {
-                    self.pop();
+                    // "foo" as prefix <> rest
+                    //       ^^^^^^^^^ In case the left prefix of the pattern matching is given an
+                    //                 alias we bind it to a local variable so that it can be
+                    //                 correctly referenced inside the case branch.
+                    // let prefix = "foo";
+                    // ^^^^^^^^^^^^^^^^^^^ we're adding this assignment inside the if clause
+                    //                     the case branch gets translated into.
                     self.push_assignment(super::expression::string(left_side_string), left);
                 }
                 self.pop();

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -399,12 +399,17 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
             Pattern::StringPrefix {
                 left_side_string,
                 right_side_assignment,
+                left_side_assignment,
                 ..
             } => {
                 self.push_string_prefix_check(subject.clone(), left_side_string);
-                self.push_string_prefix_slice(utf16_no_escape_len(left_side_string));
                 if let AssignName::Variable(right) = right_side_assignment {
+                    self.push_string_prefix_slice(utf16_no_escape_len(left_side_string));
                     self.push_assignment(subject.clone(), right);
+                }
+                if let Some((left, _)) = left_side_assignment {
+                    self.pop();
+                    self.push_assignment(super::expression::string(left_side_string), left);
                 }
                 self.pop();
                 Ok(())

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_assignment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_assignment.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/javascript/tests/strings.rs
-assertion_line: 121
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as greeting <> name -> greeting\n    _ -> \"Unknown\"\n  }\n}\n"
 ---
 export function go(x) {
   if (x.startsWith("Hello, ")) {
     let name = x.slice(7);
-    return "Hello, ";
+    let greeting = "Hello, ";
+    return greeting;
   } else {
     return "Unknown";
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/javascript/tests/strings.rs
+expression: "\npub fn go(x) {\n  case x {\n    \"1\" as prefix <> _ | \"11\" as prefix <> _ -> prefix\n    _ -> \"Unknown\"\n  }\n}\n"
+---
+export function go(x) {
+  if (x.startsWith("1")) {
+    let prefix = "1";
+    return prefix;
+  } else if (x.startsWith("11")) {
+    let prefix = "11";
+    return prefix;
+  } else {
+    return "Unknown";
+  }
+}
+

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_shadowing.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_shadowing.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/javascript/tests/strings.rs
-assertion_line: 135
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as x <> name -> x\n    _ -> \"Unknown\"\n  }\n}\n"
 ---
 export function go(x) {
   if (x.startsWith("Hello, ")) {
     let name = x.slice(7);
-    return "Hello, ";
+    let x$1 = "Hello, ";
+    return x$1;
   } else {
     return "Unknown";
   }

--- a/compiler-core/src/javascript/tests/strings.rs
+++ b/compiler-core/src/javascript/tests/strings.rs
@@ -192,3 +192,18 @@ pub fn go(x) {
 "#,
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/2471
+#[test]
+fn string_prefix_assignment_with_multiple_subjects() {
+    assert_js!(
+        r#"
+pub fn go(x) {
+  case x {
+    "1" as prefix <> _ | "11" as prefix <> _ -> prefix
+    _ -> "Unknown"
+  }
+}
+"#,
+    )
+}

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -75,47 +75,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
         }
     }
 
-    fn insert_constant(
-        &mut self,
-        name: &str,
-        literal: Constant<Arc<Type>, EcoString>,
-        location: SrcSpan,
-    ) -> Result<(), UnifyError> {
-        match &mut self.mode {
-            PatternMode::Initial => {
-                // Register usage for the unused variable detection
-                self.environment
-                    .init_usage(name.into(), EntityKind::PrivateConstant, location);
-                // Ensure there are no duplicate constant names in the pattern
-                if self.initial_pattern_vars.contains(name) {
-                    return Err(UnifyError::DuplicateVarInPattern { name: name.into() });
-                }
-                // Record that this variable originated in this pattern so any
-                // following alternative patterns can be checked to ensure they
-                // have the same variables.
-                let _ = self.initial_pattern_vars.insert(name.into());
-                // And now insert the variable for use in the code that comes
-                // after the pattern.
-                self.environment.insert_local_constant(name.into(), literal);
-                Ok(())
-            }
-
-            PatternMode::Alternative(assigned) => {
-                match self.environment.scope.get(name) {
-                    // This variable was defined in the Initial multi-pattern
-                    Some(initial) if self.initial_pattern_vars.contains(name) => {
-                        assigned.push(name.into());
-                        let initial_typ = initial.type_.clone();
-                        unify(initial_typ, literal.type_())
-                    }
-
-                    // This variable was not defined in the Initial multi-pattern
-                    _ => Err(UnifyError::ExtraVarInAlternativePattern { name: name.into() }),
-                }
-            }
-        }
-    }
-
     pub fn infer_alternative_multi_pattern(
         &mut self,
         multi_pattern: UntypedMultiPattern,
@@ -300,16 +259,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 unify(type_, string()).map_err(|e| convert_unify_error(e, location))?;
 
                 // The left hand side may assign a variable, which is the prefix of the string
-                if let Some((name, name_location)) = &left_side_assignment {
-                    self.insert_constant(
-                        name.as_ref(),
-                        Constant::String {
-                            location: left_location,
-                            value: left_side_string.clone(),
-                        },
-                        *name_location,
-                    )
-                    .map_err(|e| convert_unify_error(e, location))?;
+                if let Some((left, left_location)) = &left_side_assignment {
+                    self.insert_variable(left.as_ref(), string(), *left_location)
+                        .map_err(|e| convert_unify_error(e, location))?;
                 }
 
                 // The right hand side may assign a variable, which is the suffix of the string


### PR DESCRIPTION
This PR closes #2471

Now aliases for string prefixes are treated similarly to aliases for list items: if there's an alias for a string prefix the compiler assigns that to a local variable with the given name.
