### PR TITLE
Formatter fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed a bug where `gleam add` would not update `manifest.toml` correctly.
 - `Utf8Codepoint` has been renamed to `UtfCodepoint` in `prelude.d.mts`.
 
+### Formatter
+
+- Fixed some quirk with the formatting of binary operators.
+
 
 ## v0.33.0 - 2023-12-18
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -747,6 +747,40 @@ impl BinOp {
             Self::Concatenate => "<>",
         }
     }
+
+    pub fn can_be_grouped_with(self, other: BinOp) -> bool {
+        let is_boolean_binop = |binop| matches!(binop, BinOp::And | BinOp::Or);
+        let is_int_comparison = |binop| {
+            matches!(
+                binop,
+                BinOp::GtInt | BinOp::LtInt | BinOp::GtEqInt | BinOp::LtEqInt
+            )
+        };
+        let is_float_comparison = |binop| {
+            matches!(
+                binop,
+                BinOp::GtFloat | BinOp::LtFloat | BinOp::GtEqFloat | BinOp::LtEqFloat
+            )
+        };
+        let is_int_math = |binop| {
+            matches!(
+                binop,
+                BinOp::AddInt | BinOp::SubInt | BinOp::DivInt | BinOp::MultInt
+            )
+        };
+        let is_float_math = |binop| {
+            matches!(
+                binop,
+                BinOp::AddFloat | BinOp::SubFloat | BinOp::DivFloat | BinOp::MultFloat
+            )
+        };
+        self == other
+            || (is_boolean_binop(self) && is_boolean_binop(other))
+            || (is_float_comparison(self) && is_float_comparison(other))
+            || (is_int_comparison(self) && is_int_comparison(other))
+            || (is_float_math(self) && is_float_math(other))
+            || (is_int_math(self) && is_int_math(other))
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -179,6 +179,13 @@ impl UntypedExpr {
         }
     }
 
+    pub fn binop_name(&self) -> Option<&BinOp> {
+        match self {
+            UntypedExpr::BinOp { name, .. } => Some(name),
+            _ => None,
+        }
+    }
+
     pub fn is_simple_constant(&self) -> bool {
         matches!(
             self,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1240,7 +1240,10 @@ impl<'comments> Formatter<'comments> {
             ),
             None => nil(),
         }
-        .append(self.expr(&arg.value))
+        .append(match &arg.value {
+            UntypedExpr::BinOp { .. } => self.expr(&arg.value).group().nest(INDENT),
+            _ => self.expr(&arg.value).group(),
+        })
     }
 
     fn record_update_arg<'a>(&mut self, arg: &'a UntypedRecordUpdateArg) -> Document<'a> {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -950,50 +950,32 @@ impl<'comments> Formatter<'comments> {
         left: &'a UntypedExpr,
         right: &'a UntypedExpr,
     ) -> Document<'a> {
-        let precedence = name.precedence();
-        let left_precedence = left.binop_precedence();
-        let right_precedence = right.binop_precedence();
-        let left_doc = self.expr(left);
-        let right_doc = self.expr(right);
+        self.binop_side(name, left)
+            .append(break_("", " "))
+            .append(name)
+            .append(" ")
+            .append(self.binop_side(name, right))
+    }
 
-        let mut doc = docvec!();
-        doc = match Self::binop_name(left) {
-            // In case the left side is a binary operation as well and it can
+    fn binop_side<'a>(&mut self, operator: &'a BinOp, side: &'a UntypedExpr) -> Document<'a> {
+        let side_doc = self.expr(side);
+        match side.binop_name() {
+            // In case the other side is a binary operation as well and it can
             // be grouped together with the current binary operation, the two
             // docs are simply concatenated, so that they will end up in the
             // same group and the formatter will try to keep those on a single
             // line.
-            Some(left_name) if Self::should_be_grouped_together(left_name, name) => {
-                doc.append(left_doc)
-            }
-            // In case the binary operations cannot be grouped together the left
-            // side is treated as a group on its own so that this operation can
-            // be broken independently.
-            _ => doc.append(self.operator_side(left_doc.group(), precedence, left_precedence)),
-        };
-        doc = doc.append(break_("", " ")).append(name).append(" ");
-        doc = match Self::binop_name(right) {
-            // This works the same as the left side
-            Some(right_name) if Self::should_be_grouped_together(right_name, name) => {
-                doc.append(right_doc)
-            }
-            _ => doc.append(self.operator_side(right_doc.group(), precedence, right_precedence)),
-        };
-        doc
-    }
-
-    fn binop_name(expr: &UntypedExpr) -> Option<&BinOp> {
-        match expr {
-            UntypedExpr::BinOp { name, .. } => Some(name),
-            _ => None,
+            Some(side_name) if side_name.can_be_grouped_with(*operator) => side_doc,
+            // In case the binary operations cannot be grouped together the
+            // other side is treated as a group on its own so that it can be
+            // broken independently of other pieces of the binary operations
+            // chain.
+            _ => self.operator_side(
+                side_doc.group(),
+                operator.precedence(),
+                side.binop_precedence(),
+            ),
         }
-    }
-
-    fn should_be_grouped_together(one: &BinOp, other: &BinOp) -> bool {
-        // Try to keep on a single line groups of binary operations with the
-        // same name, or binary operations on booleans.
-        let is_boolean_binop = |binop| matches!(binop, BinOp::And | BinOp::Or);
-        one == other || (is_boolean_binop(*one) && is_boolean_binop(*other))
     }
 
     pub fn operator_side<'a>(&self, doc: Document<'a>, op: u8, side: u8) -> Document<'a> {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -568,12 +568,7 @@ impl<'comments> Formatter<'comments> {
             Some(t) => header.append(" -> ").append(self.type_ast(t)),
         };
 
-        header
-            .append(" ")
-            .append(wrap_block(
-                body.next_break_fits(NextBreakFitsMode::Disabled),
-            ))
-            .group()
+        header.append(" ").append(wrap_block(body)).group()
     }
 
     fn statements<'a>(&mut self, statements: &'a Vec1<UntypedStatement>) -> Document<'a> {
@@ -1013,7 +1008,7 @@ impl<'comments> Formatter<'comments> {
         let mut docs = Vec::with_capacity(expressions.len() * 3);
         let first = expressions.first();
         let first_precedence = first.binop_precedence();
-        let first = self.expr(first);
+        let first = self.expr(first).group();
         docs.push(self.operator_side(first, 5, first_precedence));
 
         for expr in expressions.iter().skip(1) {
@@ -1283,7 +1278,7 @@ impl<'comments> Formatter<'comments> {
                 ..
             } => " ".to_doc().append(self.block(location, statements, true)),
 
-            _ => break_("", " ").append(self.expr(expr)).nest(INDENT),
+            _ => break_("", " ").append(self.expr(expr).group()).nest(INDENT),
         }
         .next_break_fits(NextBreakFitsMode::Disabled)
         .group()

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -965,7 +965,7 @@ impl<'comments> Formatter<'comments> {
             // docs are simply concatenated, so that they will end up in the
             // same group and the formatter will try to keep those on a single
             // line.
-            Some(side_name) if side_name.can_be_grouped_with(*operator) => side_doc,
+            Some(side_name) if side_name.can_be_grouped_with(operator) => side_doc,
             // In case the binary operations cannot be grouped together the
             // other side is treated as a group on its own so that it can be
             // broken independently of other pieces of the binary operations

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5341,15 +5341,3 @@ fn single_argument_call_nested_nested() {
 "#
     );
 }
-
-#[test]
-fn arithmetic_binops_kept_on_a_single_line_in_pipes() {
-    assert_format!(
-        r#"pub fn main() {
-  1 + 2
-  |> foo
-  |> bar
-}
-"#
-    );
-}

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -1,6 +1,7 @@
 use pretty_assertions::assert_eq;
 
 mod asignments;
+mod binary_operators;
 mod bit_array;
 mod blocks;
 mod conditional_compilation;
@@ -5342,35 +5343,12 @@ fn single_argument_call_nested_nested() {
 }
 
 #[test]
-pub fn long_binary_operation_sequence() {
+fn arithmetic_binops_kept_on_a_single_line_in_pipes() {
     assert_format!(
         r#"pub fn main() {
-  int.to_string(color.red)
-  <> ", "
-  <> int.to_string(color.green)
-  <> ", "
-  <> int.to_string(color.blue)
-  <> ", "
-  <> float.to_string(color.alpha)
-}
-"#
-    );
-}
-
-#[test]
-pub fn long_comparison_chain() {
-    assert_format!(
-        r#"pub fn main() {
-  trying_a_comparison(this, is, a, function) > with_ints
-  && trying_other_comparisons < with_ints
-  || trying_other_comparisons <= with_ints
-  && trying_other_comparisons >= with_ints
-  || and_now_an_equality_check == with_a_function(foo, bar)
-  && trying_other_comparisons >. with_floats
-  || trying_other_comparisons <. with_floats(baz)
-  && trying_other_comparisons <=. with_floats
-  || trying_other_comparisons(foo, bar) >=. with_floats
-  && foo <> bar
+  1 + 2
+  |> foo
+  |> bar
 }
 "#
     );

--- a/compiler-core/src/format/tests/binary_operators.rs
+++ b/compiler-core/src/format/tests/binary_operators.rs
@@ -50,3 +50,81 @@ fn case_branch_is_not_broken_if_can_fit_on_line() {
 "#
     );
 }
+
+// https://discord.com/channels/768594524158427167/1187508793945378847/1187508793945378847
+#[test]
+fn binary_operation_in_assignment_that_is_almost_80_chars() {
+    assert_format!(
+        r#"pub fn main() {
+  let is_vr_implicit =
+    dicom_read_context.transfer_syntax == transfer_syntax.ImplicitVrLittleEndian
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2480
+#[test]
+fn labelled_field_with_binary_operators_are_not_broken_if_they_can_fit() {
+    assert_format!(
+        r#"pub fn main() {
+  Ok(Lesson(
+    name: names.name,
+    text: text,
+    code: code,
+    path: chapter_path <> "/",
+    previous: None,
+    next: None,
+  ))
+}
+"#
+    );
+
+    assert_format!(
+        r#"pub fn main() {
+  Ok(Lesson(
+    name: names.name,
+    text: text,
+    code: code,
+    path: chapter_path
+      <> "/"
+      <> this_one_doesnt_fit
+      <> "and ends up on multiple lines",
+    previous: None,
+    next: None,
+  ))
+}
+"#
+    );
+
+    assert_format!(
+        r#"pub fn main() {
+  Ok(foo(
+    name: names.name,
+    text: text,
+    code: code,
+    path: chapter_path <> "/",
+    previous: None,
+    next: None,
+  ))
+}
+"#
+    );
+
+    assert_format!(
+        r#"pub fn main() {
+  Ok(foo(
+    name: names.name,
+    text: text,
+    code: code,
+    path: chapter_path
+      <> "/"
+      <> this_one_doesnt_fit
+      <> "and ends up on multiple lines",
+    previous: None,
+    next: None,
+  ))
+}
+"#
+    );
+}

--- a/compiler-core/src/format/tests/binary_operators.rs
+++ b/compiler-core/src/format/tests/binary_operators.rs
@@ -36,6 +36,27 @@ pub fn long_comparison_chain() {
     );
 }
 
+#[test]
+pub fn long_chain_mixing_operators() {
+    assert_format!(
+        r#"pub fn main() {
+  variable + variable - variable * variable / variable
+  == variable * variable / variable - variable + variable
+  || foo * bar > 11
+}
+"#
+    );
+
+    assert_format!(
+        r#"pub fn main() {
+  variable +. variable -. variable *. variable /. variable
+  == variable *. variable /. variable -. variable +. variable
+  || foo *. bar >=. 11
+}
+"#
+    );
+}
+
 // Thanks Hayleigh for pointing this out!
 #[test]
 fn case_branch_is_not_broken_if_can_fit_on_line() {
@@ -124,6 +145,27 @@ fn labelled_field_with_binary_operators_are_not_broken_if_they_can_fit() {
     previous: None,
     next: None,
   ))
+}
+"#
+    );
+}
+
+#[test]
+fn math_binops_kept_on_a_single_line_in_pipes() {
+    assert_format!(
+        r#"pub fn main() {
+  1 + 2 * 3 / 4 - 5
+  |> foo
+  |> bar
+}
+"#
+    );
+
+    assert_format!(
+        r#"pub fn main() {
+  1 +. 2 *. 3 /. 4 -. 5
+  |> foo
+  |> bar
 }
 "#
     );

--- a/compiler-core/src/format/tests/binary_operators.rs
+++ b/compiler-core/src/format/tests/binary_operators.rs
@@ -1,0 +1,52 @@
+use crate::assert_format;
+
+// https://github.com/gleam-lang/gleam/issues/835
+#[test]
+pub fn long_binary_operation_sequence() {
+    assert_format!(
+        r#"pub fn main() {
+  int.to_string(color.red)
+  <> ", "
+  <> int.to_string(color.green)
+  <> ", "
+  <> int.to_string(color.blue)
+  <> ", "
+  <> float.to_string(color.alpha)
+}
+"#
+    );
+}
+
+#[test]
+pub fn long_comparison_chain() {
+    assert_format!(
+        r#"pub fn main() {
+  trying_a_comparison(this, is, a, function) > with_ints
+  && trying_other_comparisons < with_ints
+  || trying_other_comparisons <= with_ints
+  && trying_other_comparisons >= with_ints
+  || and_now_an_equality_check == with_a_function(foo, bar)
+  && trying_other_comparisons >. with_floats
+  || trying_other_comparisons <. with_floats(baz)
+  && trying_other_comparisons <=. with_floats
+  || trying_other_comparisons(foo, bar) >=. with_floats
+  && foo <> bar
+}
+"#
+    );
+}
+
+// Thanks Hayleigh for pointing this out!
+#[test]
+fn case_branch_is_not_broken_if_can_fit_on_line() {
+    assert_format!(
+        r#"pub fn main() {
+  case remainder {
+    _ if remainder >=. 0.5 && x >=. 0.0 ->
+      float_sign(x) *. truncate_float(xabs +. 1.0) /. p
+    _ -> float_sign(x) *. xabs_truncated /. p
+  }
+}
+"#
+    );
+}


### PR DESCRIPTION
This PR fixes some quirks with the formatting of binary operations:
- binary operations at the beginning of a pipe are now kept together
  ```diff
  // this
  + 1 * 2
  + |> inc
  // not this
  - 1
  - * 2
  - |> inc
  ```
- binary operations in constructors/function calls only get broken if needed (and are indented, if actually broken)
  ```diff
  // this
  +Dog(
  +  name: "James " <> last_name,
  +  age: 12,
  +)
  // not this
  -Dog(
  -  name: "James "
  -  <> last_name,
  -  age: 12,
  -)
  ```
- binary operations in case branches only get broken if needed
  ```diff
  // this
  +case foo {
  +  _ -> 1 + 2
  +}
  // not this
  -case foo {
  -  _ ->
  -    1
  -    + 2
  -}
  ```

Thanks to everyone who pointed out all the little quirks I missed in the previous release, turns out binary operations are quite challenging to print correctly 