### PR TITLE
fix(cli): change `deps list` to look in current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed a bug where `gleam add` would not update `manifest.toml` correctly.
 - `Utf8Codepoint` has been renamed to `UtfCodepoint` in `prelude.d.mts`.
+- Fixed a bug where `gleam deps list` would look in filesystem root instead of
+  the current directory.
 
 
 ## v0.33.0 - 2023-12-18

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -34,7 +34,7 @@ use crate::{
 pub fn list() -> Result<()> {
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
 
-    let paths = ProjectPaths::at_filesystem_root();
+    let paths = ProjectPaths::new(fs::get_current_directory()?);
     let config = crate::config::root_config()?;
     let (_, manifest) = get_manifest(
         &paths,


### PR DESCRIPTION
Previously this was looking at the file system root, which meant it could not find the `manifest.toml` or resolve relative paths to local libraries.

fixes #2439 