### PR TITLE
compile deps aimed to other targets

### DIFF
--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -38,6 +38,7 @@ pub fn command(options: CompilePackage) -> Result<()> {
 
     tracing::info!("Compiling package");
 
+    let is_root = false;
     let mut compiler = PackageCompiler::new(
         &config,
         Mode::Dev,
@@ -47,7 +48,9 @@ pub fn command(options: CompilePackage) -> Result<()> {
         &target,
         ids,
         ProjectIO::new(),
+        is_root,
     );
+
     compiler.write_entrypoint = false;
     compiler.write_metadata = true;
     compiler.compile_beam_bytecode = !options.skip_beam_compilation;

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -177,6 +177,7 @@ impl CommandExecutor for ProjectIO {
         stdio: Stdio,
     ) -> Result<i32, Error> {
         tracing::trace!(program=program, args=?args.join(" "), env=?env, cwd=?cwd, "command_exec");
+        #[allow(clippy::map_identity)]
         let result = std::process::Command::new(program)
             .args(args)
             .stdin(stdio.get_process_stdio())

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -2686,6 +2686,7 @@ pub mod value_constructor_variant {
       self.builder.set_data_field::<u16>(1, 0u16);
       self.builder.get_pointer_field(3).clear();
       self.builder.get_pointer_field(4).clear();
+      self.builder.get_pointer_field(5).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
@@ -2734,7 +2735,7 @@ pub mod value_constructor_variant {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
     pub const TYPE_ID: u64 = 0xe14c_79e9_2bd0_a81a;
   }
   pub enum Which<A0,A1,A2> {
@@ -2955,7 +2956,7 @@ pub mod value_constructor_variant {
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
       pub const TYPE_ID: u64 = 0x9579_9d69_8196_fbd0;
     }
   }
@@ -3049,6 +3050,14 @@ pub mod value_constructor_variant {
       #[inline]
       pub fn has_documentation(&self) -> bool {
         !self.reader.get_pointer_field(4).is_null()
+      }
+      #[inline]
+      pub fn get_targets(self) -> ::capnp::Result<::capnp::primitive_list::Reader<'a,u16>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn has_targets(&self) -> bool {
+        !self.reader.get_pointer_field(5).is_null()
       }
     }
 
@@ -3188,6 +3197,22 @@ pub mod value_constructor_variant {
       pub fn has_documentation(&self) -> bool {
         !self.builder.get_pointer_field(4).is_null()
       }
+      #[inline]
+      pub fn get_targets(self) -> ::capnp::Result<::capnp::primitive_list::Builder<'a,u16>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_targets(&mut self, value: ::capnp::primitive_list::Reader<'a,u16>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(5), value, false)
+      }
+      #[inline]
+      pub fn init_targets(self, size: u32) -> ::capnp::primitive_list::Builder<'a,u16> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), size)
+      }
+      #[inline]
+      pub fn has_targets(&self) -> bool {
+        !self.builder.get_pointer_field(5).is_null()
+      }
     }
 
     pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -3206,7 +3231,7 @@ pub mod value_constructor_variant {
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
       pub const TYPE_ID: u64 = 0xaea6_15c5_9871_3779;
     }
   }
@@ -3481,7 +3506,7 @@ pub mod value_constructor_variant {
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
       pub const TYPE_ID: u64 = 0xf00b_1526_e923_3dd5;
     }
   }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -107,6 +107,7 @@ struct ValueConstructorVariant {
       arity @6 :UInt16;
       location @7 :SrcSpan;
       documentation @15 :Text;
+      targets @18 :List(UInt16);
     }
 
     record :group {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1275,7 +1275,7 @@ fn get_compatible_record_fields<A>(
 ) -> Vec<(usize, &EcoString, &TypeAst)> {
     let mut compatible = vec![];
 
-    let first = match constructors.get(0) {
+    let first = match constructors.first() {
         Some(first) => first,
         None => return compatible,
     };

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -112,15 +112,15 @@ impl UntypedModule {
 
         self.definitions
             .into_iter()
-            .filter(move |def| {
-                if let Definition::Function(f) = &def.definition {
+            .filter(move |def| match &def.definition {
+                Definition::Import(_) => true,
+                Definition::Function(f) => {
                     let targets = function_implementation_sum
                         .get(&f.name)
                         .expect("inserted all funcs");
                     f.targets.implements(&target) || !targets.implements(&target)
-                } else {
-                    def.is_for(target)
                 }
+                _ => def.is_for(target),
             })
             .map(move |def| def.definition)
     }
@@ -145,7 +145,7 @@ fn module_dependencies_test() {
         vec![
             ("one".into(), SrcSpan::new(0, 10)),
             ("two".into(), SrcSpan::new(45, 55)),
-            ("three".into(), SrcSpan::new(95, 107)),
+            //("three".into(), SrcSpan::new(95, 107)),
             ("four".into(), SrcSpan::new(118, 129)),
         ],
         module.dependencies(Target::Erlang)

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -77,12 +77,17 @@ impl TargetedDefinition {
 }
 
 impl UntypedModule {
-    pub fn dependencies(&self, target: Target) -> Vec<(EcoString, SrcSpan)> {
-        self.iter_statements(target)
+    pub fn dependencies(&self) -> Vec<(EcoString, SrcSpan)> {
+        self.definitions
+            .iter()
             .flat_map(|s| match s {
-                Definition::Import(Import {
-                    module, location, ..
-                }) => Some((module.clone(), *location)),
+                TargetedDefinition {
+                    definition:
+                        Definition::Import(Import {
+                            module, location, ..
+                        }),
+                    ..
+                } => Some((module.clone(), *location)),
                 _ => None,
             })
             .collect()
@@ -145,10 +150,10 @@ fn module_dependencies_test() {
         vec![
             ("one".into(), SrcSpan::new(0, 10)),
             ("two".into(), SrcSpan::new(45, 55)),
-            //("three".into(), SrcSpan::new(95, 107)),
+            ("three".into(), SrcSpan::new(95, 107)),
             ("four".into(), SrcSpan::new(118, 129)),
         ],
-        module.dependencies(Target::Erlang)
+        module.dependencies()
     );
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -901,7 +901,7 @@ impl TypedClause {
         SrcSpan {
             start: self
                 .pattern
-                .get(0)
+                .first()
                 .map(|p| p.location().start)
                 .unwrap_or_default(),
             end: self.then.location().end,

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -4,6 +4,7 @@ use crate::build::Target;
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME};
 use crate::{
     ast::{SrcSpan, TypedExpr},
+    build::BuildTargets,
     build::Located,
     type_::{
         self, AccessorsMap, Environment, ExprTyper, FieldMap, ModuleValueConstructor,
@@ -28,6 +29,7 @@ fn compile_module(src: &str) -> TypedModule {
     let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
     crate::analyse::infer_module::<()>(
         Target::Erlang,
+        true,
         &ids,
         ast,
         crate::build::Origin::Src,
@@ -115,7 +117,7 @@ fn compile_expression(src: &str) -> TypedStatement {
             .into(),
         },
     );
-    ExprTyper::new(&mut environment)
+    ExprTyper::new(&mut environment, BuildTargets::all())
         .infer_statements(ast)
         .expect("should successfully infer")
         .first()

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -74,6 +74,71 @@ impl Target {
     }
 }
 
+// the point of this is to support more than 2 targets on the apis
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub struct BuildTargets {
+    pub erlang: bool,
+    pub javascript: bool,
+}
+
+impl BuildTargets {
+    pub fn all() -> Self {
+        BuildTargets {
+            erlang: true,
+            javascript: true,
+        }
+    }
+
+    pub fn to_int_list(&self) -> Vec<u16> {
+        let mut n = Vec::new();
+        if self.erlang {
+            n.push(1)
+        }
+        if self.javascript {
+            n.push(2)
+        }
+        n
+    }
+
+    pub fn from_int_list(vals: Vec<u16>) -> Self {
+        let n = Self {
+            erlang: vals.contains(&1),
+            javascript: vals.contains(&2),
+        };
+        n
+    }
+
+    pub fn and(&self, other: Self) -> Self {
+        BuildTargets {
+            erlang: self.erlang & other.erlang,
+            javascript: self.javascript & other.javascript,
+        }
+    }
+    pub fn and_mut(&mut self, other: Self) {
+        self.erlang = self.erlang & other.erlang;
+        self.javascript = self.javascript & other.javascript;
+    }
+
+    pub fn or_mut(&mut self, other: Self) {
+        self.erlang = self.erlang | other.erlang;
+        self.javascript = self.javascript | other.javascript;
+    }
+
+    pub fn add_target(&mut self, target: Target) {
+        match target {
+            Target::Erlang => self.erlang = true,
+            Target::JavaScript => self.javascript = true,
+        }
+    }
+
+    pub fn implements(&self, target: &Target) -> bool {
+        match target {
+            Target::Erlang => self.erlang,
+            Target::JavaScript => self.javascript,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Codegen {
     All,

--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -170,7 +170,7 @@ where
 
     let mut ast = parsed.module;
     let extra = parsed.extra;
-    let dependencies = ast.dependencies(target);
+    let dependencies = ast.dependencies();
 
     ast.name = name.clone();
     let module = UncompiledModule {

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -44,6 +44,7 @@ pub struct PackageCompiler<'a, IO> {
     pub copy_native_files: bool,
     pub compile_beam_bytecode: bool,
     pub subprocess_stdio: Stdio,
+    pub is_root: bool,
 }
 
 impl<'a, IO> PackageCompiler<'a, IO>
@@ -59,6 +60,7 @@ where
         target: &'a TargetCodegenConfiguration,
         ids: UniqueIdGenerator,
         io: IO,
+        is_root: bool,
     ) -> Self {
         Self {
             io,
@@ -69,6 +71,7 @@ where
             mode,
             config,
             target,
+            is_root,
             write_metadata: true,
             perform_codegen: true,
             write_entrypoint: false,
@@ -136,6 +139,7 @@ where
         let modules = analyse(
             &self.config,
             self.target.target(),
+            self.is_root,
             self.mode,
             &self.ids,
             loaded.to_compile,
@@ -385,6 +389,7 @@ where
 fn analyse(
     package_config: &PackageConfig,
     target: Target,
+    is_root: bool,
     mode: Mode,
     ids: &UniqueIdGenerator,
     mut parsed_modules: Vec<UncompiledModule>,
@@ -417,6 +422,7 @@ fn analyse(
 
         let ast = crate::analyse::infer_module(
             target,
+            is_root,
             ids,
             ast,
             origin,

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -549,12 +549,14 @@ where
             &target,
             self.ids.clone(),
             self.io.clone(),
+            is_root,
         );
         compiler.write_metadata = true;
         compiler.write_entrypoint = is_root;
         compiler.perform_codegen = self.options.codegen.should_codegen(is_root);
         compiler.compile_beam_bytecode = self.options.codegen.should_codegen(is_root);
         compiler.subprocess_stdio = self.subprocess_stdio;
+        compiler.is_root = is_root;
 
         // Compile project to Erlang or JavaScript source code
         let compiled = compiler.compile(

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{
     ast::{Arg, Function},
+    build::BuildTargets,
     type_::Deprecation,
 };
 use ecow::EcoString;
@@ -37,6 +38,7 @@ fn parse_and_order(
             documentation: None,
             external_erlang: None,
             external_javascript: None,
+            targets: BuildTargets::all(),
         })
         .collect_vec();
     let constants = constants

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -93,8 +93,18 @@ fn compile(config: PackageConfig, modules: Vec<(&str, &str)>) -> EcoString {
     let build = root.join("build");
     let lib = root.join("lib");
     let paths = ProjectPaths::new(root.clone());
-    let mut compiler =
-        PackageCompiler::new(&config, Mode::Dev, &root, &build, &lib, &target, ids, fs);
+    let is_root = true;
+    let mut compiler = PackageCompiler::new(
+        &config,
+        Mode::Dev,
+        &root,
+        &build,
+        &lib,
+        &target,
+        ids,
+        fs,
+        is_root,
+    );
     compiler.write_entrypoint = false;
     compiler.write_metadata = false;
     compiler.compile_beam_bytecode = true;

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1072,7 +1072,7 @@ fn clause<'a>(clause: &'a TypedClause, env: &mut Env<'a>) -> Document<'a> {
                 env.erl_function_scope_vars = initial_erlang_vars.clone();
 
                 let patterns_doc = if patterns.len() == 1 {
-                    let p = patterns.get(0).expect("Single pattern clause printing");
+                    let p = patterns.first().expect("Single pattern clause printing");
                     pattern(p, env)
                 } else {
                     tuple(patterns.iter().map(|p| pattern(p, env)))
@@ -1238,7 +1238,7 @@ fn clauses<'a>(cs: &'a [TypedClause], env: &mut Env<'a>) -> Document<'a> {
 fn case<'a>(subjects: &'a [TypedExpr], cs: &'a [TypedClause], env: &mut Env<'a>) -> Document<'a> {
     let subjects_doc = if subjects.len() == 1 {
         let subject = subjects
-            .get(0)
+            .first()
             .expect("erl case printing of single subject");
         maybe_block_expr(subject, env).group()
     } else {
@@ -1969,11 +1969,11 @@ impl<'a> TypePrinter<'a> {
             "Float" => "float()".to_doc(),
             "BitArray" => "bitstring()".to_doc(),
             "List" => {
-                let arg0 = self.print(args.get(0).expect("print_prelude_type list"));
+                let arg0 = self.print(args.first().expect("print_prelude_type list"));
                 "list(".to_doc().append(arg0).append(")")
             }
             "Result" => {
-                let arg_ok = self.print(args.get(0).expect("print_prelude_type result ok"));
+                let arg_ok = self.print(args.first().expect("print_prelude_type result ok"));
                 let arg_err = self.print(args.get(1).expect("print_prelude_type result err"));
                 let ok = tuple(["ok".to_doc(), arg_ok]);
                 let error = tuple(["error".to_doc(), arg_err]);

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -45,6 +45,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
         ast.name = dep_name.into();
         let dep = crate::analyse::infer_module::<()>(
             Target::Erlang,
+            false,
             &ids,
             ast,
             Origin::Src,
@@ -62,6 +63,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
     ast.name = "my/mod".into();
     let ast = crate::analyse::infer_module::<()>(
         Target::Erlang,
+        true,
         &ids,
         ast,
         Origin::Src,

--- a/compiler-core/src/erlang/tests/conditional_compilation.rs
+++ b/compiler-core/src/erlang/tests/conditional_compilation.rs
@@ -2,9 +2,10 @@ use crate::assert_erl;
 
 #[test]
 fn excluded_attribute_syntax() {
+    //can't have a pub fn on the top pkg without an implementation
     assert_erl!(
         "@target(javascript)
-  pub fn main() { 1 }
+  fn main() { 1 }
 "
     );
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1283,12 +1283,12 @@ But this argument has this type:
                     // Remap the pipe function type into just the type expected by the pipe.
                     let expected = expected
                         .fn_types()
-                        .and_then(|(args, _)| args.get(0).cloned());
+                        .and_then(|(args, _)| args.first().cloned());
 
                     // Remap the argument as well, if it's a function.
                     let given = given
                         .fn_types()
-                        .and_then(|(args, _)| args.get(0).cloned())
+                        .and_then(|(args, _)| args.first().cloned())
                         .unwrap_or_else(|| given.clone());
 
                     let mut printer = Printer::new();

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1118,6 +1118,32 @@ Hint: Add some type annotations and try again."
                         }),
                     }
                 }
+                TypeError::UnimplementedPublicFunction {
+                    function,
+                    module,
+                    location,
+                } => {
+                    let text = format!(
+                        "The public function `{}` on module `{}` isn't implemented for this target",
+                        function, module
+                    );
+
+                    Diagnostic {
+                        title: "Unimplemented Public Function".into(),
+                        text,
+                        hint: None,
+                        level: Level::Error,
+                        location: Some(Location {
+                            label: Label {
+                                text: None,
+                                span: *location,
+                            },
+                            path: path.clone(),
+                            src: src.clone(),
+                            extra_labels: vec![],
+                        }),
+                    }
+                }
 
                 TypeError::NotFn { location, typ } => {
                     let mut printer = Printer::new();

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -731,7 +731,7 @@ impl<'a> Compiler<'a> {
                 module, name, args, ..
             } if is_prelude_module(module) && name == "List" => BranchMode::List {
                 variable,
-                element_type: args.get(0).expect("Lists have 1 argument").clone(),
+                element_type: args.first().expect("Lists have 1 argument").clone(),
             },
 
             Type::Named { module, name, .. } => {

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -99,6 +99,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
         ast.name = (*dep_name).into();
         let dep = crate::analyse::infer_module::<()>(
             Target::JavaScript,
+            false,
             &ids,
             ast,
             Origin::Src,
@@ -117,6 +118,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
     ast.name = "my/mod".into();
     crate::analyse::infer_module::<()>(
         Target::JavaScript,
+        true,
         &ids,
         ast,
         Origin::Src,

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -8,7 +8,7 @@ use crate::{
         BitArrayOption, BitArraySegment, CallArg, Constant, SrcSpan, TypedConstant,
         TypedConstantBitArraySegment, TypedConstantBitArraySegmentOption,
     },
-    build::Origin,
+    build::{BuildTargets, Origin},
     schema_capnp::{self as schema, *},
     type_::{
         self, AccessorsMap, Deprecation, FieldMap, ModuleInterface, RecordAccessor, Type,
@@ -439,6 +439,7 @@ impl ModuleDecoder {
             field_map: self.field_map(&reader.get_field_map()?)?,
             location: self.src_span(&reader.get_location()?)?,
             documentation: self.optional_string(reader.get_documentation()?),
+            targets: BuildTargets::from_int_list(reader.get_targets()?.iter().collect()),
         })
     }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -264,6 +264,7 @@ impl<'a> ModuleEncoder<'a> {
                 name,
                 location,
                 documentation: doc,
+                targets,
             } => {
                 let mut builder = builder.init_module_fn();
                 builder.set_name(name);
@@ -271,7 +272,14 @@ impl<'a> ModuleEncoder<'a> {
                 builder.set_arity(*arity as u16);
                 builder.set_documentation(doc.as_ref().map(EcoString::as_str).unwrap_or_default());
                 self.build_optional_field_map(builder.reborrow().init_field_map(), field_map);
-                self.build_src_span(builder.init_location(), *location);
+                self.build_src_span(builder.reborrow().init_location(), *location);
+                let targets = targets.to_int_list();
+                let tar = builder.init_targets(targets.len() as u32);
+                {
+                    for (i, item) in targets.iter().enumerate() {
+                        tar.reborrow().set(i as u32, *item);
+                    }
+                }
             }
         }
     }

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -7,6 +7,7 @@ use crate::{
         BitArrayOption, BitArraySegment, CallArg, Constant, SrcSpan, TypedConstant,
         TypedConstantBitArraySegmentOption,
     },
+    build::BuildTargets,
     build::Origin,
     type_::{
         self, Deprecation, ModuleInterface, Type, TypeConstructor, TypeValueConstructor,
@@ -320,6 +321,8 @@ fn module_fn_value() {
                         start: 535,
                         end: 1100,
                     },
+
+                    targets: BuildTargets::all(),
                 },
             },
         )]
@@ -356,6 +359,8 @@ fn deprecated_module_fn_value() {
                         start: 535,
                         end: 1100,
                     },
+
+                    targets: BuildTargets::all(),
                 },
             },
         )]
@@ -390,6 +395,7 @@ fn private_module_fn_value() {
                         start: 535,
                         end: 1100,
                     },
+                    targets: BuildTargets::all(),
                 },
             },
         )]
@@ -426,6 +432,7 @@ fn module_fn_value_regression() {
                         start: 52,
                         end: 1100,
                     },
+                    targets: BuildTargets::all(),
                 },
             },
         )]
@@ -461,6 +468,7 @@ fn module_fn_value_with_field_map() {
                     module: "a".into(),
                     arity: 5,
                     location: SrcSpan { start: 2, end: 11 },
+                    targets: BuildTargets::all(),
                 },
             },
         )]

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -254,7 +254,6 @@ where
                     targets = BuildTargets::all();
                 };
 
-                attributes.target = None;
                 self.parse_import(start, targets)
             }
             // Module Constants
@@ -271,16 +270,12 @@ where
             // Function
             (Some((start, Token::Fn, _)), _) => {
                 let _ = self.next_tok();
-                let f = self.parse_function(start, false, false, &mut attributes);
-                attributes.target = None;
-                f
+                self.parse_function(start, false, false, &mut attributes)
             }
             (Some((start, Token::Pub, _)), Some((_, Token::Fn, _))) => {
                 let _ = self.next_tok();
                 let _ = self.next_tok();
-                let f = self.parse_function(start, true, false, &mut attributes);
-                attributes.target = None;
-                f
+                self.parse_function(start, true, false, &mut attributes)
             }
 
             // Custom Types, and Type Aliases

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -48,6 +48,10 @@ Parsed {
                             },
                         ],
                         package: (),
+                        targets: BuildTargets {
+                            erlang: true,
+                            javascript: true,
+                        },
                     },
                 ),
                 target: None,

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -24,6 +24,7 @@ use crate::{
         UntypedMultiPattern, UntypedPattern, UntypedRecordUpdateArg,
     },
     bit_array,
+    build::BuildTargets,
     build::Origin,
 };
 use error::*;
@@ -309,6 +310,7 @@ pub enum ValueConstructorVariant {
         arity: usize,
         location: SrcSpan,
         documentation: Option<EcoString>,
+        targets: BuildTargets,
     },
 
     /// A constructor for a custom type
@@ -325,6 +327,13 @@ pub enum ValueConstructorVariant {
 }
 
 impl ValueConstructorVariant {
+    pub fn targets(&self) -> Option<&BuildTargets> {
+        match self {
+            Self::ModuleFn { targets, .. } => Some(targets),
+            _ => None,
+        }
+    }
+
     fn to_module_value_constructor(
         &self,
         type_: Arc<Type>,

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -71,6 +71,12 @@ pub enum Error {
         type_constructors: Vec<EcoString>,
     },
 
+    UnimplementedPublicFunction {
+        module: EcoString,
+        function: EcoString,
+        location: SrcSpan,
+    },
+
     NotFn {
         location: SrcSpan,
         typ: Arc<Type>,

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -318,7 +318,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             } => match type_.get_app_args(true, PRELUDE_MODULE_NAME, "List", 1, self.environment) {
                 Some(args) => {
                     let type_ = args
-                        .get(0)
+                        .first()
                         .expect("Failed to get type argument of List")
                         .clone();
                     let elements = elements

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -287,7 +287,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
 
         match types {
             (Type::Fn { args: a, .. }, Type::Fn { args: b, .. }) if a.len() == b.len() => {
-                match (a.get(0), b.get(0)) {
+                match (a.first(), b.first()) {
                     (Some(a), Some(b)) => unify(a.clone(), b.clone()).is_err(),
                     _ => false,
                 }

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -230,13 +230,16 @@ fn compile_statement_sequence(src: &str) -> Result<Vec1<TypedStatement>, crate::
     // to have one place where we create all this required state for use in each
     // place.
     let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
-    crate::type_::ExprTyper::new(&mut crate::type_::Environment::new(
-        ids,
-        "themodule".into(),
-        Target::Erlang,
-        &modules,
-        &TypeWarningEmitter::null(),
-    ))
+    crate::type_::ExprTyper::new(
+        &mut crate::type_::Environment::new(
+            ids,
+            "themodule".into(),
+            Target::Erlang,
+            &modules,
+            &TypeWarningEmitter::null(),
+        ),
+        BuildTargets::all(),
+    )
     .infer_statements(ast)
 }
 
@@ -303,6 +306,7 @@ pub fn compile_module(
         ast.name = name.into();
         let module = crate::analyse::infer_module::<()>(
             Target::Erlang,
+            false,
             &ids,
             ast,
             Origin::Src,
@@ -323,6 +327,7 @@ pub fn compile_module(
     let ast = parsed.module;
     crate::analyse::infer_module(
         Target::Erlang,
+        true,
         &ids,
         ast,
         Origin::Src,
@@ -503,6 +508,7 @@ fn infer_module_type_retention_test() {
     let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
     let module = crate::analyse::infer_module::<()>(
         Target::Erlang,
+        true,
         &ids,
         module,
         Origin::Src,

--- a/compiler-core/src/type_/tests/conditional_compilation.rs
+++ b/compiler-core/src/type_/tests/conditional_compilation.rs
@@ -52,14 +52,15 @@ pub fn x() { id(1) }
 }
 
 #[test]
-fn excluded_generalising() {
+fn exposed_after_generalising() {
+    // the values are exposed but marked as javascript only
     assert_module_infer!(
         "
 @target(javascript)
-pub fn id(x) { x }
+fn id(x) { x }
 
 @target(javascript)
-pub fn x() { id(1) }
+fn x() { id(1) }
 
 pub const y = 1
 ",

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -190,6 +190,7 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
     let lib = Utf8PathBuf::from("/lib");
     let out = Utf8PathBuf::from("/build");
     let package = Utf8PathBuf::from("/");
+    let is_root = true;
     let mut compiler = PackageCompiler::new(
         &config,
         Mode::Dev,
@@ -199,6 +200,7 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
         &target,
         ids,
         project.fs,
+        is_root,
     );
     compiler.write_entrypoint = false;
     compiler.write_metadata = false;

--- a/test-package-compiler/src/lib.rs
+++ b/test-package-compiler/src/lib.rs
@@ -50,6 +50,7 @@ pub fn prepare(path: &str) -> String {
     let root = Utf8PathBuf::from("");
     let out = Utf8PathBuf::from("/out/lib/the_package");
     let lib = Utf8PathBuf::from("/out/lib");
+    let is_root = true;
     let mut compiler = gleam_core::build::PackageCompiler::new(
         &config,
         Mode::Dev,
@@ -59,6 +60,7 @@ pub fn prepare(path: &str) -> String {
         &target,
         ids,
         filesystem.clone(),
+        is_root,
     );
     compiler.write_entrypoint = false;
     compiler.write_metadata = true;


### PR DESCRIPTION
propagate `targets` from parse to type inference, 
when a function doesn't have an implementation for this target, replace with a placeholder to keep the call graph correct for pure gleam functions.