### PR TITLE
feat(cli): add recursive path traversal to cli calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 - Fixed a bug where `gleam add` would not update `manifest.toml` correctly.
 - Fixed a bug where the build tool would make unnecessary calls to the Hex API
   when path dependencies are used.
+- Fixed a bug where `gleam new` would generate a gitignore with `build` rather
+  than `/build`.
 - Fixed where the types of generic constants could be incorrecly inferred.
 - `Utf8Codepoint` has been renamed to `UtfCodepoint` in `prelude.d.mts`.
 - Fixed a bug where `gleam deps list` would look in filesystem root instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@
 - The `repository` section now supports additional VCS types in the form of
   codeberg, forgejo and gitea allowing a `user`, `repo` and additionally a
   `host` url.
-- TypeScript declaration for the prelude exports previously missing functions and classes. Additionally, swaps interfaces for classes and adds missing attributes to classes.
+- TypeScript declaration for the prelude exports previously missing functions
+  and classes. Additionally, swaps interfaces for classes and adds missing
+  attributes to classes.
+- `gleam` commands now look in parent directories for a `gleam.toml` file.
 
 ### Bug fixes
 

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -8,7 +8,7 @@ use gleam_core::{
 use crate::{cli, dependencies::UseManifest, fs};
 
 pub fn command(packages: Vec<String>, dev: bool) -> Result<()> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
 
     // Insert the new packages into the manifest and perform dependency
     // resolution to determine suitable versions

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -8,7 +8,7 @@ use gleam_core::{
 use crate::{cli, dependencies::UseManifest, fs};
 
 pub fn command(packages: Vec<String>, dev: bool) -> Result<()> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
 
     // Insert the new packages into the manifest and perform dependency
     // resolution to determine suitable versions

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -11,7 +11,7 @@ use crate::{
     build_lock::BuildLock,
     cli,
     dependencies::UseManifest,
-    fs::{self, get_current_directory, ConsoleWarningEmitter},
+    fs::{self, get_current_directory, get_project_root, ConsoleWarningEmitter},
 };
 
 pub fn download_dependencies() -> Result<Manifest> {
@@ -31,7 +31,7 @@ pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
         options.mode,
         options.target.unwrap_or(root_config.target),
     )?;
-    let current_dir = get_current_directory().expect("Failed to get current directory");
+    let current_dir = get_project_root(get_current_directory()?)?;
 
     tracing::info!("Compiling packages");
     let compiled = {

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -15,12 +15,12 @@ use crate::{
 };
 
 pub fn download_dependencies() -> Result<Manifest> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)
 }
 
 pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     let perform_codegen = options.codegen;
     let root_config = crate::config::root_config()?;
     let telemetry = Box::new(cli::Reporter::new());

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -15,12 +15,12 @@ use crate::{
 };
 
 pub fn download_dependencies() -> Result<Manifest> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)
 }
 
 pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     let perform_codegen = options.codegen;
     let root_config = crate::config::root_config()?;
     let telemetry = Box::new(cli::Reporter::new());

--- a/compiler-cli/src/build_lock.rs
+++ b/compiler-cli/src/build_lock.rs
@@ -66,7 +66,7 @@ pub(crate) struct Guard(fslock::LockFile);
 
 #[test]
 fn locking_global() {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory_without_toml();
     let lock = BuildLock::new_packages(&paths).expect("make lock");
     let _guard1 = lock.lock(&gleam_core::build::NullTelemetry);
     println!("Locked!")
@@ -74,7 +74,7 @@ fn locking_global() {
 
 #[test]
 fn locking_dev_erlang() {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory_without_toml();
     let lock = BuildLock::new_target(&paths, Mode::Dev, Target::Erlang).expect("make lock");
     let _guard1 = lock.lock(&gleam_core::build::NullTelemetry);
     println!("Locked!")
@@ -82,7 +82,7 @@ fn locking_dev_erlang() {
 
 #[test]
 fn locking_prod_erlang() {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory_without_toml();
     let lock = BuildLock::new_target(&paths, Mode::Prod, Target::Erlang).expect("make lock");
     let _guard1 = lock.lock(&gleam_core::build::NullTelemetry);
     println!("Locked!")
@@ -90,7 +90,7 @@ fn locking_prod_erlang() {
 
 #[test]
 fn locking_lsp_erlang() {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory_without_toml();
     let lock = BuildLock::new_target(&paths, Mode::Lsp, Target::Erlang).expect("make lock");
     let _guard1 = lock.lock(&gleam_core::build::NullTelemetry);
     println!("Locked!")
@@ -98,7 +98,7 @@ fn locking_lsp_erlang() {
 
 #[test]
 fn locking_dev_javascript() {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory_without_toml();
     let lock = BuildLock::new_target(&paths, Mode::Dev, Target::JavaScript).expect("make lock");
     let _guard1 = lock.lock(&gleam_core::build::NullTelemetry);
     println!("Locked!")
@@ -106,7 +106,7 @@ fn locking_dev_javascript() {
 
 #[test]
 fn locking_prod_javascript() {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory_without_toml();
     let lock = BuildLock::new_target(&paths, Mode::Prod, Target::JavaScript).expect("make lock");
     let _guard1 = lock.lock(&gleam_core::build::NullTelemetry);
     println!("Locked!")
@@ -114,7 +114,7 @@ fn locking_prod_javascript() {
 
 #[test]
 fn locking_lsp_javascript() {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory_without_toml();
     let lock = BuildLock::new_target(&paths, Mode::Lsp, Target::JavaScript).expect("make lock");
     let _guard1 = lock.lock(&gleam_core::build::NullTelemetry);
     println!("Locked!")

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -7,11 +7,11 @@ use gleam_core::{
     paths::ProjectPaths,
 };
 
-use crate::fs::get_current_directory;
+use crate::fs::{get_current_directory, get_project_root};
 
 pub fn root_config() -> Result<PackageConfig, Error> {
-    let current_dir = get_current_directory().expect("Failed to get current directory");
-    let paths = ProjectPaths::new(current_dir);
+    let dir = get_project_root(get_current_directory()?)?;
+    let paths = ProjectPaths::new(dir);
     read(paths.root_config())
 }
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -113,7 +113,7 @@ pub enum UseManifest {
 }
 
 pub fn update() -> Result<()> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     _ = download(&paths, cli::Reporter::new(), None, UseManifest::No)?;
     Ok(())
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -33,8 +33,8 @@ use crate::{
 
 pub fn list() -> Result<()> {
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
-
-    let paths = ProjectPaths::new(fs::get_current_directory()?);
+    let project = fs::get_project_root(fs::get_current_directory()?)?;
+    let paths = ProjectPaths::new(project);
     let config = crate::config::root_config()?;
     let (_, manifest) = get_manifest(
         &paths,
@@ -869,7 +869,7 @@ fn provide_package(
 #[test]
 fn provide_wrong_package() {
     let mut provided = HashMap::new();
-    let project_paths = crate::project_paths_at_current_directory();
+    let project_paths = crate::project_paths_at_current_directory_without_toml();
     let result = provide_local_package(
         "wrong_name".into(),
         Utf8Path::new("./test/hello_world"),
@@ -892,7 +892,7 @@ fn provide_wrong_package() {
 #[test]
 fn provide_existing_package() {
     let mut provided = HashMap::new();
-    let project_paths = crate::project_paths_at_current_directory();
+    let project_paths = crate::project_paths_at_current_directory_without_toml();
 
     let result = provide_local_package(
         "hello_world".into(),
@@ -918,7 +918,7 @@ fn provide_existing_package() {
 #[test]
 fn provide_conflicting_package() {
     let mut provided = HashMap::new();
-    let project_paths = crate::project_paths_at_current_directory();
+    let project_paths = crate::project_paths_at_current_directory_without_toml();
     let result = provide_local_package(
         "hello_world".into(),
         Utf8Path::new("./test/hello_world"),
@@ -949,7 +949,7 @@ fn provide_conflicting_package() {
 #[test]
 fn provided_is_absolute() {
     let mut provided = HashMap::new();
-    let project_paths = crate::project_paths_at_current_directory();
+    let project_paths = crate::project_paths_at_current_directory_without_toml();
     let result = provide_local_package(
         "hello_world".into(),
         Utf8Path::new("./test/hello_world"),
@@ -970,7 +970,7 @@ fn provided_is_absolute() {
 #[test]
 fn provided_recursive() {
     let mut provided = HashMap::new();
-    let project_paths = crate::project_paths_at_current_directory();
+    let project_paths = crate::project_paths_at_current_directory_without_toml();
     let result = provide_local_package(
         "hello_world".into(),
         Utf8Path::new("./test/hello_world"),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -113,7 +113,7 @@ pub enum UseManifest {
 }
 
 pub fn update() -> Result<()> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     _ = download(&paths, cli::Reporter::new(), None, UseManifest::No)?;
     Ok(())
 }

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -58,7 +58,7 @@ pub struct BuildOptions {
 }
 
 pub fn build(options: BuildOptions) -> Result<()> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     let config = crate::config::root_config()?;
 
     // Reset the build directory so we know the state of the project
@@ -115,7 +115,7 @@ pub(crate) fn build_documentation(
 ) -> Result<Vec<gleam_core::io::OutputFile>, Error> {
     compiled.attach_doc_and_module_comments();
     cli::print_generating_documentation();
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     let mut pages = vec![DocsPage {
         title: "README".into(),
         path: "index.html".into(),
@@ -143,7 +143,7 @@ pub fn publish() -> Result<()> {
 
 impl PublishCommand {
     pub fn new() -> Result<Self> {
-        let paths = crate::project_paths_at_current_directory();
+        let paths = crate::project_paths_at_current_directory()?;
         let config = crate::config::root_config()?;
 
         // Reset the build directory so we know the state of the project

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -58,7 +58,7 @@ pub struct BuildOptions {
 }
 
 pub fn build(options: BuildOptions) -> Result<()> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     let config = crate::config::root_config()?;
 
     // Reset the build directory so we know the state of the project
@@ -115,7 +115,7 @@ pub(crate) fn build_documentation(
 ) -> Result<Vec<gleam_core::io::OutputFile>, Error> {
     compiled.attach_doc_and_module_comments();
     cli::print_generating_documentation();
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     let mut pages = vec![DocsPage {
         title: "README".into(),
         path: "index.html".into(),
@@ -143,7 +143,7 @@ pub fn publish() -> Result<()> {
 
 impl PublishCommand {
     pub fn new() -> Result<Self> {
-        let paths = crate::project_paths_at_current_directory()?;
+        let paths = crate::find_project_paths()?;
         let config = crate::config::root_config()?;
 
         // Reset the build directory so we know the state of the project

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -25,7 +25,7 @@ static ENTRYPOINT_TEMPLATE: &str = include_str!("../templates/erlang-shipment-en
 /// - include
 /// - priv
 pub(crate) fn erlang_shipment() -> Result<()> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     let target = Target::Erlang;
     let mode = Mode::Prod;
     let build = paths.build_directory_for_target(mode, target);
@@ -99,7 +99,7 @@ the {file} script.
 }
 
 pub fn hex_tarball() -> Result<()> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     let config = crate::config::root_config()?;
     let data: Vec<u8> = crate::publish::build_hex_tarball(&paths, &config)?;
 

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -25,7 +25,7 @@ static ENTRYPOINT_TEMPLATE: &str = include_str!("../templates/erlang-shipment-en
 /// - include
 /// - priv
 pub(crate) fn erlang_shipment() -> Result<()> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     let target = Target::Erlang;
     let mode = Mode::Prod;
     let build = paths.build_directory_for_target(mode, target);
@@ -99,7 +99,7 @@ the {file} script.
 }
 
 pub fn hex_tarball() -> Result<()> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     let config = crate::config::root_config()?;
     let data: Vec<u8> = crate::publish::build_hex_tarball(&paths, &config)?;
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -38,6 +38,22 @@ pub fn get_current_directory() -> Result<Utf8PathBuf, Error> {
     Utf8PathBuf::from_path_buf(curr_dir.clone()).map_err(|_| Error::NonUtf8Path { path: curr_dir })
 }
 
+// Return the first directory with a gleam.toml as a UTF-8 Path
+pub fn get_project_root(path: Utf8PathBuf) -> Result<Utf8PathBuf, Error> {
+    fn walk(dir: Utf8PathBuf) -> Option<Utf8PathBuf> {
+        match dir.join("gleam.toml").is_file() {
+            true => Some(dir),
+            false => match dir.parent() {
+                Some(p) => walk(p.into()),
+                None => None,
+            },
+        }
+    }
+    walk(path.clone()).ok_or(Error::UnableToFindProjectRoot {
+        path: path.to_string(),
+    })
+}
+
 /// A `FileWriter` implementation that writes to the file system.
 #[derive(Debug, Clone, Copy)]
 pub struct ProjectIO;

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -74,7 +74,7 @@ mod shell;
 
 use config::root_config;
 use dependencies::UseManifest;
-use fs::get_current_directory;
+use fs::{get_current_directory, get_project_root};
 pub use gleam_core::error::{Error, Result};
 
 use gleam_core::{
@@ -526,6 +526,13 @@ fn initialise_logger() {
 }
 
 fn project_paths_at_current_directory() -> ProjectPaths {
+    let current_dir = get_current_directory().expect("Failed to get current directory");
+    let dir = get_project_root(current_dir).expect("Failed to get any gleam.toml file");
+    ProjectPaths::new(dir)
+}
+
+#[allow(dead_code)]
+fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
     let current_dir = get_current_directory().expect("Failed to get current directory");
     ProjectPaths::new(current_dir)
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -531,7 +531,7 @@ fn project_paths_at_current_directory() -> ProjectPaths {
     ProjectPaths::new(dir)
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
     let current_dir = get_current_directory().expect("Failed to get current directory");
     ProjectPaths::new(current_dir)

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -510,7 +510,7 @@ fn print_config() -> Result<()> {
 }
 
 fn clean() -> Result<()> {
-    let paths = project_paths_at_current_directory();
+    let paths = project_paths_at_current_directory()?;
     fs::delete_directory(&paths.build_directory())
 }
 
@@ -525,10 +525,9 @@ fn initialise_logger() {
         .init();
 }
 
-fn project_paths_at_current_directory() -> ProjectPaths {
+fn project_paths_at_current_directory() -> Result<ProjectPaths> {
     let current_dir = get_current_directory().expect("Failed to get current directory");
-    let dir = get_project_root(current_dir).expect("Failed to get any gleam.toml file");
-    ProjectPaths::new(dir)
+    get_project_root(current_dir).map(ProjectPaths::new)
 }
 
 #[cfg(test)]
@@ -538,7 +537,7 @@ fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
 }
 
 fn download_dependencies() -> Result<(), Error> {
-    let paths = project_paths_at_current_directory();
+    let paths = project_paths_at_current_directory()?;
     _ = dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)?;
     Ok(())
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -510,7 +510,7 @@ fn print_config() -> Result<()> {
 }
 
 fn clean() -> Result<()> {
-    let paths = project_paths_at_current_directory()?;
+    let paths = find_project_paths()?;
     fs::delete_directory(&paths.build_directory())
 }
 
@@ -525,7 +525,7 @@ fn initialise_logger() {
         .init();
 }
 
-fn project_paths_at_current_directory() -> Result<ProjectPaths> {
+fn find_project_paths() -> Result<ProjectPaths> {
     let current_dir = get_current_directory().expect("Failed to get current directory");
     get_project_root(current_dir).map(ProjectPaths::new)
 }
@@ -537,7 +537,7 @@ fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
 }
 
 fn download_dependencies() -> Result<(), Error> {
-    let paths = project_paths_at_current_directory()?;
+    let paths = find_project_paths()?;
     _ = dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)?;
     Ok(())
 }

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -33,7 +33,7 @@ pub struct PublishCommand {
 
 impl PublishCommand {
     pub fn setup(replace: bool, i_am_sure: bool) -> Result<Option<Self>> {
-        let paths = crate::project_paths_at_current_directory();
+        let paths = crate::project_paths_at_current_directory()?;
         let config = crate::config::root_config()?;
 
         // Ask for confirmation if the package name if `gleam_*`

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -33,7 +33,7 @@ pub struct PublishCommand {
 
 impl PublishCommand {
     pub fn setup(replace: bool, i_am_sure: bool) -> Result<Option<Self>> {
-        let paths = crate::project_paths_at_current_directory()?;
+        let paths = crate::find_project_paths()?;
         let config = crate::config::root_config()?;
 
         // Ask for confirmation if the package name if `gleam_*`

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -32,7 +32,7 @@ pub fn command(packages: Vec<String>) -> Result<()> {
 
     // Write the updated config
     fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
     _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)?;
     for package_to_remove in packages {
         cli::print_removed(&package_to_remove);

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -32,7 +32,7 @@ pub fn command(packages: Vec<String>) -> Result<()> {
 
     // Write the updated config
     fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
     _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)?;
     for package_to_remove in packages {
         cli::print_removed(&package_to_remove);

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -27,7 +27,7 @@ pub fn command(
     module: Option<String>,
     which: Which,
 ) -> Result<(), Error> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
 
     // Validate the module path
     if let Some(mod_path) = &module {

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -27,7 +27,7 @@ pub fn command(
     module: Option<String>,
     which: Which,
 ) -> Result<(), Error> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
 
     // Validate the module path
     if let Some(mod_path) = &module {

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -5,7 +5,7 @@ use gleam_core::{
 use std::process::Command;
 
 pub fn command() -> Result<(), Error> {
-    let paths = crate::project_paths_at_current_directory();
+    let paths = crate::project_paths_at_current_directory()?;
 
     // Build project
     let _ = crate::build::main(

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -5,7 +5,7 @@ use gleam_core::{
 use std::process::Command;
 
 pub fn command() -> Result<(), Error> {
-    let paths = crate::project_paths_at_current_directory()?;
+    let paths = crate::find_project_paths()?;
 
     // Build project
     let _ = crate::build::main(


### PR DESCRIPTION
resolves #2134 

First pass at this, seems to work but don't think the error print is quite what we're looking for and I think there's probably a better way to write this than having a `project_paths_at_current_directory_without_toml()` function. Any pointers/feedback would be appreciated, my brains going a bit dull ^^;

```
error: Fatal compiler bug!

This is a bug in the Gleam compiler, sorry!

Please report this crash to https://github.com/gleam-lang/gleam/issues/new
with this information and the code that produces the crash.

	compiler-cli/src/main.rs:530
	Failed to get any gleam.toml file: FileIo { kind: Directory, action: Open, path: "/home/bgw/vcs/test", err: None }
```