### PR TITLE
Permit to define target specific functions without needlessly failing compilation for a different target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Warn about function body not being used, because it already has external
   implementations for all targets.
+- It's now possible to compile a project with external functions that are not
+  supported by the compilation target as long as those are not actually used.
 
 ### Language Server Changes
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -182,7 +182,7 @@ impl CommandExecutor for ProjectIO {
             .args(args)
             .stdin(stdio.get_process_stdio())
             .stdout(stdio.get_process_stdio())
-            .envs(env.iter().map(|(a, b): &(&str, String)| (a, b)))
+            .envs(env.iter().map(|(a, b)| (a, b)))
             .current_dir(cwd.unwrap_or_else(|| Utf8Path::new("./")))
             .status();
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -182,7 +182,7 @@ impl CommandExecutor for ProjectIO {
             .args(args)
             .stdin(stdio.get_process_stdio())
             .stdout(stdio.get_process_stdio())
-            .envs(env.iter().map(|(a, b)| (a, b)))
+            .envs(env.iter().map(|(a, b): &(&str, String)| (a, b)))
             .current_dir(cwd.unwrap_or_else(|| Utf8Path::new("./")))
             .status();
 

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -2549,6 +2549,143 @@ pub mod value_constructor {
   }
 }
 
+pub mod supported_targets {
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  #[derive(Clone, Copy)]
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+
+  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      Reader { reader,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Reader { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn get_erlang(self) -> bool {
+      self.reader.get_bool_field(0)
+    }
+    #[inline]
+    pub fn get_javascript(self) -> bool {
+      self.reader.get_bool_field(1)
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
+    #[inline]
+    fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
+  }
+  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      Builder { builder,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { .. *self }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.into_reader().total_size()
+    }
+    #[inline]
+    pub fn get_erlang(self) -> bool {
+      self.builder.get_bool_field(0)
+    }
+    #[inline]
+    pub fn set_erlang(&mut self, value: bool)  {
+      self.builder.set_bool_field(0, value);
+    }
+    #[inline]
+    pub fn get_javascript(self) -> bool {
+      self.builder.get_bool_field(1)
+    }
+    #[inline]
+    pub fn set_javascript(&mut self, value: bool)  {
+      self.builder.set_bool_field(1, value);
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      Pipeline { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+  }
+  mod _private {
+    use capnp::private::layout;
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 0 };
+    pub const TYPE_ID: u64 = 0xda80_1514_9b62_7317;
+  }
+}
+
 pub mod value_constructor_variant {
   pub use self::Which::{ModuleConstant,ModuleFn,Record};
 
@@ -2675,6 +2812,7 @@ pub mod value_constructor_variant {
       self.builder.get_pointer_field(1).clear();
       self.builder.get_pointer_field(2).clear();
       self.builder.get_pointer_field(3).clear();
+      self.builder.get_pointer_field(4).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
@@ -2686,6 +2824,7 @@ pub mod value_constructor_variant {
       self.builder.set_data_field::<u16>(1, 0u16);
       self.builder.get_pointer_field(3).clear();
       self.builder.get_pointer_field(4).clear();
+      self.builder.get_pointer_field(5).clear();
       ::capnp::traits::FromStructBuilder::new(self.builder)
     }
     #[inline]
@@ -2734,7 +2873,7 @@ pub mod value_constructor_variant {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
     pub const TYPE_ID: u64 = 0xe14c_79e9_2bd0_a81a;
   }
   pub enum Which<A0,A1,A2> {
@@ -2822,6 +2961,14 @@ pub mod value_constructor_variant {
       #[inline]
       pub fn has_documentation(&self) -> bool {
         !self.reader.get_pointer_field(3).is_null()
+      }
+      #[inline]
+      pub fn get_supported_targets(self) -> ::capnp::Result<crate::schema_capnp::supported_targets::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn has_supported_targets(&self) -> bool {
+        !self.reader.get_pointer_field(4).is_null()
       }
     }
 
@@ -2937,6 +3084,22 @@ pub mod value_constructor_variant {
       pub fn has_documentation(&self) -> bool {
         !self.builder.get_pointer_field(3).is_null()
       }
+      #[inline]
+      pub fn get_supported_targets(self) -> ::capnp::Result<crate::schema_capnp::supported_targets::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_supported_targets(&mut self, value: crate::schema_capnp::supported_targets::Reader<'_>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+      }
+      #[inline]
+      pub fn init_supported_targets(self, ) -> crate::schema_capnp::supported_targets::Builder<'a> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), 0)
+      }
+      #[inline]
+      pub fn has_supported_targets(&self) -> bool {
+        !self.builder.get_pointer_field(4).is_null()
+      }
     }
 
     pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -2952,10 +3115,13 @@ pub mod value_constructor_variant {
       pub fn get_location(&self) -> crate::schema_capnp::src_span::Pipeline {
         ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
       }
+      pub fn get_supported_targets(&self) -> crate::schema_capnp::supported_targets::Pipeline {
+        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(4))
+      }
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
       pub const TYPE_ID: u64 = 0x9579_9d69_8196_fbd0;
     }
   }
@@ -3049,6 +3215,14 @@ pub mod value_constructor_variant {
       #[inline]
       pub fn has_documentation(&self) -> bool {
         !self.reader.get_pointer_field(4).is_null()
+      }
+      #[inline]
+      pub fn get_supported_targets(self) -> ::capnp::Result<crate::schema_capnp::supported_targets::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn has_supported_targets(&self) -> bool {
+        !self.reader.get_pointer_field(5).is_null()
       }
     }
 
@@ -3188,6 +3362,22 @@ pub mod value_constructor_variant {
       pub fn has_documentation(&self) -> bool {
         !self.builder.get_pointer_field(4).is_null()
       }
+      #[inline]
+      pub fn get_supported_targets(self) -> ::capnp::Result<crate::schema_capnp::supported_targets::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_supported_targets(&mut self, value: crate::schema_capnp::supported_targets::Reader<'_>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(5), value, false)
+      }
+      #[inline]
+      pub fn init_supported_targets(self, ) -> crate::schema_capnp::supported_targets::Builder<'a> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), 0)
+      }
+      #[inline]
+      pub fn has_supported_targets(&self) -> bool {
+        !self.builder.get_pointer_field(5).is_null()
+      }
     }
 
     pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -3203,10 +3393,13 @@ pub mod value_constructor_variant {
       pub fn get_location(&self) -> crate::schema_capnp::src_span::Pipeline {
         ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
       }
+      pub fn get_supported_targets(&self) -> crate::schema_capnp::supported_targets::Pipeline {
+        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(5))
+      }
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
       pub const TYPE_ID: u64 = 0xaea6_15c5_9871_3779;
     }
   }
@@ -3481,7 +3674,7 @@ pub mod value_constructor_variant {
     }
     mod _private {
       use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
       pub const TYPE_ID: u64 = 0xf00b_1526_e923_3dd5;
     }
   }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -91,6 +91,11 @@ struct ValueConstructor {
   deprecated @3 :Text;
 }
 
+struct SupportedTargets {
+  erlang @0 :Bool;
+  javascript @1 :Bool;
+}
+
 struct ValueConstructorVariant {
   union {
     moduleConstant :group {
@@ -98,6 +103,7 @@ struct ValueConstructorVariant {
       location @1 :SrcSpan;
       module @2 :Text;
       documentation @14 :Text;
+      supportedTargets @19 :SupportedTargets;
     }
 
     moduleFn :group {
@@ -107,6 +113,7 @@ struct ValueConstructorVariant {
       arity @6 :UInt16;
       location @7 :SrcSpan;
       documentation @15 :Text;
+      supportedTargets @18 :SupportedTargets;
     }
 
     record :group {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -609,21 +609,14 @@ fn infer_function(
         // think you should always specify types for external functions for
         // clarity + to avoid accidental mistakes.
         ensure_annotations_present(&arguments, return_annotation.as_ref(), location)?;
-
-        if external_javascript.is_some()
-            && external_erlang.is_some()
-            && !body.first().is_placeholder()
-        {
-            environment
-                .warnings
-                .emit(Warning::UnusedFunctionBody { location })
-        }
-    } else {
-        // There was no external implementation, so a Gleam one must be given.
-        ensure_body_given(&body, location)?;
     }
 
     let external_targets = external_supported_targets(&external_erlang, &external_javascript);
+    if external_targets.supports_all_targets() && !has_empty_body {
+        environment
+            .warnings
+            .emit(Warning::UnusedFunctionBody { location })
+    }
 
     // If the function has a target annotation, the only required target for its
     // body is the annotated target. Otherwise the required targets are all the

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -969,6 +969,8 @@ fn infer_module_constant(
     let mut expr_typer = ExprTyper::new(environment, required_targets);
     let typed_expr = expr_typer.infer_const(&annotation, *value)?;
     let type_ = typed_expr.type_();
+    let supported_targets = expr_typer.supported_targets;
+
     let variant = ValueConstructor {
         public,
         deprecation: Deprecation::NotDeprecated,
@@ -977,7 +979,7 @@ fn infer_module_constant(
             location,
             literal: typed_expr.clone(),
             module: module_name.clone(),
-            supported_targets: expr_typer.supported_targets,
+            supported_targets,
         },
         type_: type_.clone(),
     };
@@ -1004,6 +1006,7 @@ fn infer_module_constant(
         value: Box::new(typed_expr),
         target,
         type_,
+        supported_targets,
     }))
 }
 
@@ -1084,6 +1087,8 @@ fn generalise_module_constant(
         public,
         value,
         type_,
+        target,
+        supported_targets,
     } = constant;
     let typ = type_.clone();
     let type_ = type_::generalise(typ);
@@ -1092,6 +1097,7 @@ fn generalise_module_constant(
         location,
         literal: *value.clone(),
         module: module_name.clone(),
+        supported_targets,
     };
     environment.insert_variable(
         name.clone(),
@@ -1119,6 +1125,8 @@ fn generalise_module_constant(
         public,
         value,
         type_,
+        target,
+        supported_targets,
     })
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -373,7 +373,6 @@ pub struct Function<T, Expr> {
     pub documentation: Option<EcoString>,
     pub external_erlang: Option<(EcoString, EcoString)>,
     pub external_javascript: Option<(EcoString, EcoString)>,
-    pub target: Option<Target>,
     pub supported_targets: SupportedTargets,
 }
 
@@ -441,7 +440,6 @@ pub struct ModuleConstant<T, ConstantRecordTag> {
     pub name: EcoString,
     pub annotation: Option<TypeAst>,
     pub value: Box<Constant<T, ConstantRecordTag>>,
-    pub target: Option<Target>,
     pub type_: T,
     pub supported_targets: SupportedTargets,
 }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -373,6 +373,7 @@ pub struct Function<T, Expr> {
     pub documentation: Option<EcoString>,
     pub external_erlang: Option<(EcoString, EcoString)>,
     pub external_javascript: Option<(EcoString, EcoString)>,
+    pub target: Option<Target>,
     pub supported_targets: SupportedTargets,
 }
 
@@ -440,6 +441,7 @@ pub struct ModuleConstant<T, ConstantRecordTag> {
     pub name: EcoString,
     pub annotation: Option<TypeAst>,
     pub value: Box<Constant<T, ConstantRecordTag>>,
+    pub target: Option<Target>,
     pub type_: T,
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -12,6 +12,7 @@ pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 
 use crate::analyse::Inferred;
 use crate::build::{Located, Target};
+use crate::type_::expression::SupportedTargets;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
@@ -372,6 +373,7 @@ pub struct Function<T, Expr> {
     pub documentation: Option<EcoString>,
     pub external_erlang: Option<(EcoString, EcoString)>,
     pub external_javascript: Option<(EcoString, EcoString)>,
+    pub supported_targets: SupportedTargets,
 }
 
 pub type TypedFunction = Function<Arc<Type>, TypedExpr>;

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -443,6 +443,7 @@ pub struct ModuleConstant<T, ConstantRecordTag> {
     pub value: Box<Constant<T, ConstantRecordTag>>,
     pub target: Option<Target>,
     pub type_: T,
+    pub supported_targets: SupportedTargets,
 }
 
 pub type UntypedCustomType = CustomType<()>;

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::analyse::TargetSupport;
 use crate::build::Target;
 use crate::type_::expression::SupportedTargets;
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME};
@@ -36,6 +37,7 @@ fn compile_module(src: &str) -> TypedModule {
         &modules,
         &TypeWarningEmitter::null(),
         &std::collections::HashMap::new(),
+        TargetSupport::Enforced,
     )
     .expect("should successfully infer")
 }
@@ -60,7 +62,14 @@ fn compile_expression(src: &str) -> TypedStatement {
     // place.
     let _ = modules.insert(PRELUDE_MODULE_NAME.into(), type_::build_prelude(&ids));
     let emitter = TypeWarningEmitter::null();
-    let mut environment = Environment::new(ids, "mymod".into(), Target::Erlang, &modules, &emitter);
+    let mut environment = Environment::new(
+        ids,
+        "mymod".into(),
+        Target::Erlang,
+        &modules,
+        &emitter,
+        TargetSupport::Enforced,
+    );
 
     // Insert a cat record to use in the tests
     let cat_type = Arc::new(Type::Named {
@@ -116,7 +125,7 @@ fn compile_expression(src: &str) -> TypedStatement {
             .into(),
         },
     );
-    ExprTyper::new(&mut environment, SupportedTargets::all())
+    ExprTyper::new(&mut environment, SupportedTargets::none())
         .infer_statements(ast)
         .expect("should successfully infer")
         .first()

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -116,7 +116,7 @@ fn compile_expression(src: &str) -> TypedStatement {
             .into(),
         },
     );
-    ExprTyper::new(&mut environment, SupportedTargets::none())
+    ExprTyper::new(&mut environment, SupportedTargets::all())
         .infer_statements(ast)
         .expect("should successfully infer")
         .first()

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::build::Target;
+use crate::type_::expression::SupportedTargets;
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME};
 use crate::{
     ast::{SrcSpan, TypedExpr},
@@ -115,7 +116,7 @@ fn compile_expression(src: &str) -> TypedStatement {
             .into(),
         },
     );
-    ExprTyper::new(&mut environment)
+    ExprTyper::new(&mut environment, SupportedTargets::none())
         .infer_statements(ast)
         .expect("should successfully infer")
         .first()

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -72,6 +72,14 @@ impl Target {
     pub fn is_javascript(&self) -> bool {
         matches!(self, Self::JavaScript)
     }
+
+    /// Returns `true` if the target is [`Erlang`].
+    ///
+    /// [`Erlang`]: Target::Erlang
+    #[must_use]
+    pub fn is_erlang(&self) -> bool {
+        matches!(self, Self::Erlang)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -1,4 +1,5 @@
 use crate::{
+    analyse::TargetSupport,
     build::{
         package_compiler, package_compiler::PackageCompiler, package_loader::StaleTracker,
         project_compiler, telemetry::Telemetry, Mode, Module, Origin, Package, Target,
@@ -555,6 +556,9 @@ where
         compiler.perform_codegen = self.options.codegen.should_codegen(is_root);
         compiler.compile_beam_bytecode = self.options.codegen.should_codegen(is_root);
         compiler.subprocess_stdio = self.subprocess_stdio;
+        if is_root {
+            compiler.target_support = TargetSupport::Enforced;
+        }
 
         // Compile project to Erlang or JavaScript source code
         let compiled = compiler.compile(

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -37,7 +37,6 @@ fn parse_and_order(
             documentation: None,
             external_erlang: None,
             external_javascript: None,
-            target: None,
             supported_targets: SupportedTargets::all(),
         })
         .collect_vec();
@@ -53,7 +52,6 @@ fn parse_and_order(
                 annotation: None,
                 value: Box::from(const_value),
                 supported_targets: SupportedTargets::all(),
-                target: None,
                 type_: (),
             }
         })

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -37,6 +37,7 @@ fn parse_and_order(
             documentation: None,
             external_erlang: None,
             external_javascript: None,
+            target: None,
             supported_targets: SupportedTargets::all(),
         })
         .collect_vec();

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -52,6 +52,8 @@ fn parse_and_order(
                 name: EcoString::from(*name),
                 annotation: None,
                 value: Box::from(const_value),
+                supported_targets: SupportedTargets::all(),
+                target: None,
                 type_: (),
             }
         })

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     ast::{Arg, Function},
-    type_::Deprecation,
+    type_::{expression::SupportedTargets, Deprecation},
 };
 use ecow::EcoString;
 
@@ -37,6 +37,7 @@ fn parse_and_order(
             documentation: None,
             external_erlang: None,
             external_javascript: None,
+            supported_targets: SupportedTargets::all(),
         })
         .collect_vec();
     let constants = constants

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -1,3 +1,4 @@
+use crate::analyse::TargetSupport;
 use crate::type_::PRELUDE_MODULE_NAME;
 use crate::{
     build::{Origin, Target},
@@ -52,6 +53,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
             &modules,
             &TypeWarningEmitter::null(),
             &std::collections::HashMap::new(),
+            TargetSupport::Enforced,
         )
         .expect("should successfully infer");
         let _ = modules.insert(dep_name.into(), dep.type_info);
@@ -69,6 +71,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
         &modules,
         &TypeWarningEmitter::null(),
         &direct_dependencies,
+        TargetSupport::Enforced,
     )
     .expect("should successfully infer");
     let line_numbers = LineNumbers::new(src);

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2235,6 +2235,36 @@ implementation but the function name `{function}` is not valid."
                         }),
                     }
                 }
+
+                TypeError::UnsupportedTarget {
+                    location,
+                    target: current_target,
+                    kind,
+                } => {
+                    let text = wrap_format!(
+                        "This {} doesn't have an implementation for the {} target.",
+                        kind,
+                        match current_target {
+                            Target::Erlang => "Erlang",
+                            Target::JavaScript => "JavaScript",
+                        }
+                    );
+                    Diagnostic {
+                        title: "Unsupported target".into(),
+                        text,
+                        hint: None,
+                        level: Level::Error,
+                        location: Some(Location {
+                            path: path.clone(),
+                            src: src.clone(),
+                            label: Label {
+                                text: None,
+                                span: *location,
+                            },
+                            extra_labels: vec![],
+                        }),
+                    }
+                }
             },
 
             Error::Parse { path, src, error } => {

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -1,4 +1,5 @@
 use crate::{
+    analyse::TargetSupport,
     build::{Origin, Target},
     javascript::*,
     uid::UniqueIdGenerator,
@@ -106,6 +107,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
             &modules,
             &TypeWarningEmitter::null(),
             &std::collections::HashMap::new(),
+            TargetSupport::Enforced,
         )
         .expect("should successfully infer");
         let _ = modules.insert((*dep_name).into(), dep.type_info);
@@ -124,6 +126,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
         &modules,
         &TypeWarningEmitter::null(),
         &direct_dependencies,
+        TargetSupport::Enforced,
     )
     .expect("should successfully infer")
 }

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -447,10 +447,10 @@ impl ModuleDecoder {
     fn supported_targets(&self, reader: supported_targets::Reader<'_>) -> SupportedTargets {
         let mut supported_targets = SupportedTargets::none();
         if reader.get_erlang() {
-            supported_targets.add(&Target::Erlang);
+            supported_targets = supported_targets.add(Target::Erlang);
         }
         if reader.get_javascript() {
-            supported_targets.add(&Target::JavaScript);
+            supported_targets = supported_targets.add(Target::JavaScript);
         }
         supported_targets
     }

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -8,12 +8,12 @@ use crate::{
         BitArrayOption, BitArraySegment, CallArg, Constant, SrcSpan, TypedConstant,
         TypedConstantBitArraySegment, TypedConstantBitArraySegmentOption,
     },
-    build::Origin,
+    build::{Origin, Target},
     schema_capnp::{self as schema, *},
     type_::{
-        self, AccessorsMap, Deprecation, FieldMap, ModuleInterface, RecordAccessor, Type,
-        TypeConstructor, TypeValueConstructor, TypeValueConstructorParameter, ValueConstructor,
-        ValueConstructorVariant,
+        self, expression::SupportedTargets, AccessorsMap, Deprecation, FieldMap, ModuleInterface,
+        RecordAccessor, Type, TypeConstructor, TypeValueConstructor, TypeValueConstructorParameter,
+        ValueConstructor, ValueConstructorVariant,
     },
     uid::UniqueIdGenerator,
     Result,
@@ -410,6 +410,7 @@ impl ModuleDecoder {
             location: self.src_span(&reader.get_location()?)?,
             literal: self.constant(&reader.get_literal()?)?,
             module: reader.get_module()?.into(),
+            supported_targets: self.supported_targets(reader.get_supported_targets()?),
         })
     }
 
@@ -439,7 +440,19 @@ impl ModuleDecoder {
             field_map: self.field_map(&reader.get_field_map()?)?,
             location: self.src_span(&reader.get_location()?)?,
             documentation: self.optional_string(reader.get_documentation()?),
+            supported_targets: self.supported_targets(reader.get_supported_targets()?),
         })
+    }
+
+    fn supported_targets(&self, reader: supported_targets::Reader<'_>) -> SupportedTargets {
+        let mut supported_targets = SupportedTargets::none();
+        if reader.get_erlang() {
+            supported_targets.add(&Target::Erlang);
+        }
+        if reader.get_javascript() {
+            supported_targets.add(&Target::JavaScript);
+        }
+        supported_targets
     }
 
     fn record(

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -489,7 +489,7 @@ impl<'a> ModuleEncoder<'a> {
         mut builder: supported_targets::Builder<'_>,
         supported_targets: SupportedTargets,
     ) {
-        builder.set_erlang(supported_targets.supports(&Target::Erlang));
-        builder.set_javascript(supported_targets.supports(&Target::JavaScript));
+        builder.set_erlang(supported_targets.supports(Target::Erlang));
+        builder.set_javascript(supported_targets.supports(Target::JavaScript));
     }
 }

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -9,8 +9,8 @@ use crate::{
     },
     build::Origin,
     type_::{
-        self, Deprecation, ModuleInterface, Type, TypeConstructor, TypeValueConstructor,
-        ValueConstructor, ValueConstructorVariant,
+        self, expression::SupportedTargets, Deprecation, ModuleInterface, Type, TypeConstructor,
+        TypeValueConstructor, ValueConstructor, ValueConstructorVariant,
     },
     uid::UniqueIdGenerator,
 };
@@ -46,6 +46,7 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
                     literal: constant,
                     location: SrcSpan::default(),
                     module: "one/two".into(),
+                    supported_targets: SupportedTargets::all(),
                 },
             },
         )]
@@ -320,6 +321,7 @@ fn module_fn_value() {
                         start: 535,
                         end: 1100,
                     },
+                    supported_targets: SupportedTargets::all(),
                 },
             },
         )]
@@ -356,6 +358,7 @@ fn deprecated_module_fn_value() {
                         start: 535,
                         end: 1100,
                     },
+                    supported_targets: SupportedTargets::all(),
                 },
             },
         )]
@@ -390,6 +393,7 @@ fn private_module_fn_value() {
                         start: 535,
                         end: 1100,
                     },
+                    supported_targets: SupportedTargets::all(),
                 },
             },
         )]
@@ -426,6 +430,7 @@ fn module_fn_value_regression() {
                         start: 52,
                         end: 1100,
                     },
+                    supported_targets: SupportedTargets::all(),
                 },
             },
         )]
@@ -461,6 +466,7 @@ fn module_fn_value_with_field_map() {
                     module: "a".into(),
                     arity: 5,
                     location: SrcSpan { start: 2, end: 11 },
+                    supported_targets: SupportedTargets::all(),
                 },
             },
         )]
@@ -752,6 +758,7 @@ fn constant_var() {
                 literal: one_original.clone(),
                 location: SrcSpan::default(),
                 module: "one/two".into(),
+                supported_targets: SupportedTargets::all(),
             },
         })),
     };
@@ -776,6 +783,7 @@ fn constant_var() {
                         literal: one,
                         location: SrcSpan::default(),
                         module: "one/two".into(),
+                        supported_targets: SupportedTargets::all(),
                     },
                 },
             ),
@@ -790,6 +798,7 @@ fn constant_var() {
                         literal: one_original,
                         location: SrcSpan::default(),
                         module: "one/two".into(),
+                        supported_targets: SupportedTargets::all(),
                     },
                 },
             ),

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2143,6 +2143,7 @@ where
                 value: Box::new(value),
                 target: attributes.target,
                 type_: (),
+                supported_targets: SupportedTargets::all(),
             })))
         } else {
             parse_error(

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -66,6 +66,7 @@ use crate::ast::{
 };
 use crate::build::Target;
 use crate::parse::extra::ModuleExtra;
+use crate::type_::expression::SupportedTargets;
 use crate::type_::Deprecation;
 use ecow::EcoString;
 use error::{LexicalError, ParseError, ParseErrorType};
@@ -1535,6 +1536,7 @@ where
             deprecation: std::mem::take(&mut attributes.deprecated),
             external_erlang: attributes.external_erlang.take(),
             external_javascript: attributes.external_javascript.take(),
+            supported_targets: SupportedTargets::all(),
         })))
     }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -251,12 +251,12 @@ where
             // Module Constants
             (Some((_, Token::Const, _)), _) => {
                 let _ = self.next_tok();
-                self.parse_module_const(false, &attributes)
+                self.parse_module_const(false)
             }
             (Some((_, Token::Pub, _)), Some((_, Token::Const, _))) => {
                 let _ = self.next_tok();
                 let _ = self.next_tok();
-                self.parse_module_const(true, &attributes)
+                self.parse_module_const(true)
             }
 
             // Function
@@ -1536,7 +1536,6 @@ where
             deprecation: std::mem::take(&mut attributes.deprecated),
             external_erlang: attributes.external_erlang.take(),
             external_javascript: attributes.external_javascript.take(),
-            target: attributes.target,
             supported_targets: SupportedTargets::all(),
         })))
     }
@@ -2125,7 +2124,6 @@ where
     fn parse_module_const(
         &mut self,
         public: bool,
-        attributes: &Attributes,
     ) -> Result<Option<UntypedDefinition>, ParseError> {
         let (start, name, end) = self.expect_name()?;
         let documentation = self.take_documentation(start);
@@ -2141,7 +2139,6 @@ where
                 name,
                 annotation,
                 value: Box::new(value),
-                target: attributes.target,
                 type_: (),
                 supported_targets: SupportedTargets::all(),
             })))

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -251,12 +251,12 @@ where
             // Module Constants
             (Some((_, Token::Const, _)), _) => {
                 let _ = self.next_tok();
-                self.parse_module_const(false)
+                self.parse_module_const(false, &attributes)
             }
             (Some((_, Token::Pub, _)), Some((_, Token::Const, _))) => {
                 let _ = self.next_tok();
                 let _ = self.next_tok();
-                self.parse_module_const(true)
+                self.parse_module_const(true, &attributes)
             }
 
             // Function
@@ -1536,6 +1536,7 @@ where
             deprecation: std::mem::take(&mut attributes.deprecated),
             external_erlang: attributes.external_erlang.take(),
             external_javascript: attributes.external_javascript.take(),
+            target: attributes.target,
             supported_targets: SupportedTargets::all(),
         })))
     }
@@ -2124,6 +2125,7 @@ where
     fn parse_module_const(
         &mut self,
         public: bool,
+        attributes: &Attributes,
     ) -> Result<Option<UntypedDefinition>, ParseError> {
         let (start, name, end) = self.expect_name()?;
         let documentation = self.take_documentation(start);
@@ -2139,6 +2141,7 @@ where
                 name,
                 annotation,
                 value: Box::new(value),
+                target: attributes.target,
                 type_: (),
             })))
         } else {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -36,6 +36,8 @@ use std::{
     sync::Arc,
 };
 
+use self::expression::SupportedTargets;
+
 pub trait HasType {
     fn type_(&self) -> Arc<Type>;
 }
@@ -294,6 +296,7 @@ pub enum ValueConstructorVariant {
         location: SrcSpan,
         module: EcoString,
         literal: Constant<Arc<Type>, EcoString>,
+        supported_targets: SupportedTargets,
     },
 
     /// A constant defined locally, for example when pattern matching on string literals
@@ -309,6 +312,7 @@ pub enum ValueConstructorVariant {
         arity: usize,
         location: SrcSpan,
         documentation: Option<EcoString>,
+        supported_targets: SupportedTargets,
     },
 
     /// A constructor for a custom type

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -1,5 +1,6 @@
 use crate::{
-    ast::PIPE_VARIABLE, build::Target, uid::UniqueIdGenerator, warning::TypeWarningEmitter,
+    analyse::TargetSupport, ast::PIPE_VARIABLE, build::Target, uid::UniqueIdGenerator,
+    warning::TypeWarningEmitter,
 };
 
 use super::*;
@@ -49,6 +50,10 @@ pub struct Environment<'a> {
     /// stack for an entity with that name and mark it as used.
     /// NOTE: The bool in the tuple here tracks if the entity has been used
     pub entity_usages: Vec<HashMap<EcoString, (EntityKind, SrcSpan, bool)>>,
+
+    /// Used to determine if all functions/constants need to support the current
+    /// compilation target.
+    pub target_support: TargetSupport,
 }
 
 impl<'a> Environment<'a> {
@@ -58,6 +63,7 @@ impl<'a> Environment<'a> {
         target: Target,
         importable_modules: &'a im::HashMap<EcoString, ModuleInterface>,
         warnings: &'a TypeWarningEmitter,
+        target_support: TargetSupport,
     ) -> Self {
         let prelude = importable_modules
             .get(PRELUDE_MODULE_NAME)
@@ -81,6 +87,7 @@ impl<'a> Environment<'a> {
             current_module,
             warnings,
             entity_usages: vec![HashMap::new()],
+            target_support,
         }
     }
 }

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1,5 +1,6 @@
 use crate::{
     ast::{BinOp, SrcSpan, TodoKind},
+    build::Target,
     type_::Type,
 };
 
@@ -25,6 +26,7 @@ pub enum Error {
         error: crate::bit_array::ErrorType,
         location: SrcSpan,
     },
+
     UnknownLabels {
         unknown: Vec<(EcoString, SrcSpan)>,
         valid: Vec<EcoString>,
@@ -272,6 +274,14 @@ pub enum Error {
     // external one.
     NoImplementation {
         location: SrcSpan,
+    },
+
+    // A function/constant that is used doesn't have an implementation for the
+    // current compilation target.
+    UnsupportedTarget {
+        location: SrcSpan,
+        target: Target,
+        kind: EcoString,
     },
 
     // A function's JavaScript implementation has been given but it does not

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -101,6 +101,10 @@ impl SupportedTargets {
         }
     }
 
+    pub fn supports_all_targets(&self) -> bool {
+        self.javascript && self.erlang
+    }
+
     pub fn to_vec(self) -> Vec<Target> {
         let SupportedTargets { erlang, javascript } = self;
         match (erlang, javascript) {

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_used_by_javascript_module.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_used_by_javascript_module.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@external(erlang, \"foo\", \"bar\")\npub fn erlang_only() -> Int\n\npub fn main() {\n  erlang_only()\n}\n"
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:5:3
+  │
+5 │   erlang_only()
+  │   ^^^^^^^^^^^
+
+This function doesn't have an implementation for the JavaScript target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_with_erlang_external-2.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_with_erlang_external-2.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@external(erlang, \"foo\", \"bar\")\npub fn erlang_only() -> Int\n\n@external(erlang, \"foo\", \"bar\")\npub fn uh_oh() -> Int {\n  erlang_only()\n}\n"
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:6:3
+  │
+6 │   erlang_only()
+  │   ^^^^^^^^^^^
+
+This function doesn't have an implementation for the JavaScript target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_with_erlang_external.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_with_erlang_external.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@external(erlang, \"foo\", \"bar\")\npub fn erlang_only() -> Int\n\n@external(erlang, \"foo\", \"bar\")\npub fn uh_oh() -> Int {\n  erlang_only()\n}\n"
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:6:3
+  │
+6 │   erlang_only()
+  │   ^^^^^^^^^^^
+
+This function doesn't have an implementation for the JavaScript target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_with_javascript_external.snap.new
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_only_function_with_javascript_external.snap.new
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests.rs
+assertion_line: 2030
+expression: "\n@external(erlang, \"foo\", \"bar\")\npub fn erlang_only() -> Int\n\n@external(javascript, \"foo\", \"bar\")\npub fn all_targets() -> Int {\n  erlang_only()\n}\n\npub fn main() {\n  all_targets()\n}\n    "
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:7:3
+  │
+7 │   erlang_only()
+  │   ^^^^^^^^^^^
+
+This function doesn't have an implementation for the JavaScript target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_targeted_function_cant_contain_javascript_only_function.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__erlang_targeted_function_cant_contain_javascript_only_function.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@target(erlang)\npub fn erlang_only() -> Int {\n  javascript_only()\n}\n\n@external(javascript, \"foo\", \"bar\")\npub fn javascript_only() -> Int\n    "
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:3:3
+  │
+3 │   javascript_only()
+  │   ^^^^^^^^^^^^^^^
+
+This function doesn't have an implementation for the Erlang target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_only_function_used_by_erlang_module.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_only_function_used_by_erlang_module.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@external(javascript, \"foo\", \"bar\")\npub fn js_only() -> Int\n\npub fn main() {\n  js_only()\n}\n"
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:5:3
+  │
+5 │   js_only()
+  │   ^^^^^^^
+
+This function doesn't have an implementation for the Erlang target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_only_function_with_javascript_external-2.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_only_function_with_javascript_external-2.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@external(javascript, \"foo\", \"bar\")\npub fn javascript_only() -> Int\n\n@external(javascript, \"foo\", \"bar\")\npub fn uh_oh() -> Int {\n  javascript_only()\n}\n"
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:6:3
+  │
+6 │   javascript_only()
+  │   ^^^^^^^^^^^^^^^
+
+This function doesn't have an implementation for the Erlang target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_only_function_with_javascript_external.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_only_function_with_javascript_external.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@external(javascript, \"foo\", \"bar\")\npub fn javascript_only() -> Int\n\n@external(javascript, \"foo\", \"bar\")\npub fn uh_oh() -> Int {\n  javascript_only()\n}\n"
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:6:3
+  │
+6 │   javascript_only()
+  │   ^^^^^^^^^^^^^^^
+
+This function doesn't have an implementation for the Erlang target.
+

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_targeted_function_cant_contain_erlang_only_function.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__javascript_targeted_function_cant_contain_erlang_only_function.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "@target(javascript)\npub fn javascript_only() -> Int {\n  erlang_only()\n}\n\n@external(erlang, \"foo\", \"bar\")\npub fn erlang_only() -> Int\n    "
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:3:3
+  │
+3 │   erlang_only()
+  │   ^^^^^^^^^^^
+
+This function doesn't have an implementation for the JavaScript target.
+

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{
+    analyse::TargetSupport,
     ast::{TypedModule, TypedStatement, UntypedExpr, UntypedModule},
     build::{Origin, Target},
     error::Error,
@@ -256,8 +257,9 @@ fn compile_statement_sequence(src: &str) -> Result<Vec1<TypedStatement>, crate::
             Target::Erlang,
             &modules,
             &TypeWarningEmitter::null(),
+            TargetSupport::Enforced,
         ),
-        SupportedTargets::all(),
+        SupportedTargets::none(),
     )
     .infer_statements(ast)
 }
@@ -350,6 +352,7 @@ pub fn compile_module_with_target(
             &modules,
             &warnings,
             &std::collections::HashMap::from_iter(vec![]),
+            TargetSupport::NotEnforced,
         )
         .expect("should successfully infer");
         let _ = modules.insert(name.into(), module.type_info);
@@ -370,6 +373,7 @@ pub fn compile_module_with_target(
         &modules,
         &warnings,
         &direct_dependencies,
+        TargetSupport::Enforced,
     )
 }
 
@@ -559,6 +563,7 @@ fn infer_module_type_retention_test() {
         &modules,
         &TypeWarningEmitter::null(),
         &direct_dependencies,
+        TargetSupport::Enforced,
     )
     .expect("Should infer OK");
 

--- a/test/project_erlang/gleam.toml
+++ b/test/project_erlang/gleam.toml
@@ -27,6 +27,7 @@ bcrypt = "~> 1.1"
 # This is a rebar3 dep where the application name (hpack, used by the BEAM)
 # doesn't match the package name (hpack_erl, used by Hex).
 hpack_erl = "~> 0.1"
+gleam_javascript = "~> 0.7"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/test/project_erlang/manifest.toml
+++ b/test/project_erlang/manifest.toml
@@ -8,6 +8,7 @@ packages = [
   { name = "cowboy", version = "2.10.0", build_tools = ["make", "rebar3"], requirements = ["ranch", "cowlib"], otp_app = "cowboy", source = "hex", outer_checksum = "3AFDCCB7183CC6F143CB14D3CF51FA00E53DB9EC80CDCD525482F5E99BC41D6B" },
   { name = "cowlib", version = "2.12.1", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "163B73F6367A7341B33C794C4E88E7DBFE6498AC42DCD69EF44C5BC5507C8DB0" },
   { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
+  { name = "gleam_javascript", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "B5E05F479C52217C02BA2E8FC650A716BFB62D4F8D20A90909C908598E12FBE0" },
   { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
   { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
@@ -23,6 +24,7 @@ certifi = { version = "~> 2.8" }
 countries = { version = "~> 1.6" }
 cowboy = { version = "~> 2.9" }
 gleam_erlang = { version = "~> 0.5" }
+gleam_javascript = { version = "~> 0.7" }
 gleam_stdlib = { version = "~> 0.18" }
 gleeunit = { version = "~> 1.0" }
 hpack_erl = { version = "~> 0.1" }

--- a/test/project_javascript/gleam.toml
+++ b/test/project_javascript/gleam.toml
@@ -8,5 +8,6 @@ runtime = "node"
 
 [dependencies]
 gleam_stdlib = "~> 0.18"
+gleam_erlang = "~> 0.23"
 
 [dev-dependencies]

--- a/test/project_javascript/manifest.toml
+++ b/test/project_javascript/manifest.toml
@@ -2,8 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
   { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
 ]
 
 [requirements]
+gleam_erlang = { version = "~> 0.23" }
 gleam_stdlib = { version = "~> 0.18" }


### PR DESCRIPTION
This closes #2324

To get a better feeling of the problem this PR addresses you can have a look at this code snippet:
```gleam
import gleam/io

@external(javascript, "foo", "bar")
pub fn js_only() -> Int

pub fn main() {
  io.println("I'm Erlang code!")
}
```
Trying to compile it on the Erlang target would fail with an error complaining that `js_only` doesn't have an implementation for the Erlang target. But this is needlessly limiting! Since `js_only` is never actually referenced by functions that are going to be compiled down to Erlang this code is still safe to compile and run!

After this PR compilation will only fail if someone tries to use a target-specific function in a code path that could be used in a different target:
```gleam
import gleam/io

@external(javascript, "foo", "bar")
pub fn js_only() -> Int

pub fn main() {
  io.println("I'm Erlang code!")
  js_only()
//^^^^^^^^^ error: this function doesn't have an implementation for the Erlang target.
}
```