### PR TITLE
updated types on `prelude.d.mts` to match `prelude.mjs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - The `repository` section now supports additional VCS types in the form of
   codeberg, forgejo and gitea allowing a `user`, `repo` and additionally a
   `host` url.
+- TypeScript declaration for the prelude exports previously missing functions and classes. Additionally, swaps interfaces for classes and adds missing attributes to classes.
 
 ### Bug fixes
 

--- a/compiler-core/templates/prelude.d.mts
+++ b/compiler-core/templates/prelude.d.mts
@@ -2,55 +2,65 @@ export class CustomType {
   withFields<K extends keyof this>(fields: { [P in K]: this[P] }): this;
 }
 
-export interface ListStatic {
-  fromArray<T>(array: Array<T>): List<T>;
-}
-
-export interface List<T> extends Iterable<T> {
+export class List<T> implements Iterable<T> {
   head?: T;
   tail?: List<T>;
+  static fromArray<T>(array: Array<T>): List<T>
   toArray(): Array<T>;
   atLeastLength(desired: number): boolean;
   hasLength(desired: number): boolean;
   countLength(): number;
+
+  [Symbol.iterator](): Iterator<T>
 }
 
 export function toList<T>(array: Array<T>): List<T>;
 
-export interface BitArray {
+export class Empty<T = never> extends List<T> {}
+
+export class NonEmpty<T> extends List<T> {}
+
+export class BitArray {
+  buffer: Uint8Array;
   get length(): number;
   byteAt(index: number): number;
   floatAt(index: number): number;
   intFromSlice(start: number, end: number): number;
+  binaryFromSlice(state: number, end: number): BitArray;
   sliceAfter(index: number): BitArray;
 }
 
-export interface UtfCodepoint {}
+export class Utf8Codepoint {
+    value: string;
+}
 
 export function toBitArray(segments: Array<number | Uint8Array>): BitArray;
 
-export function sizedInt(number: number, size: number): BitArray;
+export function sizedInt(int: number, size: number): Uint8Array;
+
+export function byteArrayToInt(byteArray: Uint8Array): number;
+
+export function byteArrayToFloat(byteArray: Uint8Array): number;
 
 export function stringBits(string: string): Uint8Array;
 
-export function codepointBits(codepoint: UtfCodepoint): Uint8Array;
+export function codepointBits(codepoint: Utf8Codepoint): Uint8Array;
 
 export function float64Bits(float: number): Uint8Array;
 
-export interface Result<T, E> {
+export class Result<T, E> extends CustomType {
+  static isResult(data: unknown): boolean;
   isOk(): boolean;
 }
 
-export interface ResultStatic {
-  isResult(value: unknown): boolean;
+export class Ok<T, E> extends Result<T, E> {
+  0: T;
+  constructor(value: T);
 }
 
-export interface OkStatic extends ResultStatic {
-  new <T, E>(value: T): Result<T, E>;
-}
-
-export interface ErrorStatic extends ResultStatic {
-  new <T, E>(value: E): Result<T, E>;
+export class Error<T, E> extends Result<T, E> {
+  0: E;
+  constructor(value: E);
 }
 
 export function isEqual(a: any, b: any): boolean;


### PR DESCRIPTION
Closes #2500 

- interfaces swapped out for classes
- added static methods and removed static instances of classes
- filled in missing information for all classes
- new functions regarding `byteArray` added