### PR TITLE
JS codegen: export prelude.d.mts in gleam.d.mts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Fixed a bug with the `isEqual` function in `prelude.js` where RegExps were
   being incorrectly structurally compared and being falsely reported as being
   equal.
+- JavaScript: export from `prelude.d.mts` in `gleam.d.mts` to fix the error:
+  "Type 'Result' is not generic".
 
 
 ## v0.33.0 - 2023-12-18

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -211,12 +211,13 @@ impl<'a> JavaScript<'a> {
 
     fn write_prelude(&self, writer: &impl FileSystemWriter) -> Result<()> {
         let rexport = format!("export * from \"{}\";\n", self.prelude_location);
-
         writer.write(&self.output_directory.join("gleam.mjs"), &rexport)?;
 
         if self.typescript == TypeScriptDeclarations::Emit {
+            let rexport = rexport.replace(".mjs", ".d.mts");
             writer.write(&self.output_directory.join("gleam.d.mts"), &rexport)?;
         }
+
         Ok(())
     }
 

--- a/test-package-compiler/src/lib.rs
+++ b/test-package-compiler/src/lib.rs
@@ -113,13 +113,7 @@ impl TestCompileOutput {
             let extension = path.extension();
             match content {
                 _ if extension == Some("cache") => buffer.push_str("<.cache binary>"),
-
-                _ if path.ends_with("gleam.mjs") || path.ends_with("gleam.d.mts") => {
-                    buffer.push_str("<prelude>")
-                }
-
                 Content::Binary(data) => write!(buffer, "<{} byte binary>", data.len()).unwrap(),
-
                 Content::Text(text) => buffer.push_str(text),
             };
             buffer.push('\n');

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -10,10 +10,12 @@ expression: "./cases/javascript_d_ts"
 <29 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
-<prelude>
+export * from "../prelude.d.mts";
+
 
 //// /out/lib/the_package/gleam.mjs
-<prelude>
+export * from "../prelude.mjs";
+
 
 //// /out/lib/the_package/hello.d.mts
 import type * as _ from "./gleam.d.mts";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
@@ -14,6 +14,7 @@ export {}
 
 
 //// /out/lib/the_package/gleam.mjs
-<prelude>
+export * from "../prelude.mjs";
+
 
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -16,10 +16,12 @@ expression: "./cases/javascript_import"
 <44 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
-<prelude>
+export * from "../prelude.d.mts";
+
 
 //// /out/lib/the_package/gleam.mjs
-<prelude>
+export * from "../prelude.mjs";
+
 
 //// /out/lib/the_package/one/two.d.mts
 import type * as _ from "../gleam.d.mts";


### PR DESCRIPTION
This should fix #2487.