### PR TITLE
Fix some inconsistencies with error messages

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -290,8 +290,7 @@ impl Error {
                 version,
                 source,
             } => format!(
-                "An error occured while trying to retrieve dependencies of {}@{}: {}",
-                package, version, source
+                "An error occured while trying to retrieve dependencies of {package}@{version}: {source}",
             ),
 
             ResolutionError::DependencyOnTheEmptySet {
@@ -299,25 +298,23 @@ impl Error {
                 version,
                 dependent,
             } => format!(
-                "{}@{} has an imposible dependency on {}",
-                package, version, dependent
+                "{package}@{version} has an impossible dependency on {dependent}",
             ),
 
             ResolutionError::SelfDependency { package, version } => {
-                format!("{}@{} somehow depends on itself", package, version)
+                format!("{package}@{version} somehow depends on itself.")
             }
 
             ResolutionError::ErrorChoosingPackageVersion(err) => {
-                format!("Unable to determine package versions: {}", err)
+                format!("Unable to determine package versions: {err}")
             }
 
             ResolutionError::ErrorInShouldCancel(err) => {
-                format!("Dependency resolution was cancelled. {}", err)
+                format!("Dependency resolution was cancelled. {err}")
             }
 
             ResolutionError::Failure(err) => format!(
-                "An unrecoverable error happened while solving dependencies: {}",
-                err
+                "An unrecoverable error happened while solving dependencies: {err}"
             ),
         })
     }
@@ -513,12 +510,12 @@ forward slash and must not end with a slash."
 
             Error::ModuleDoesNotExist { module, suggestion } => {
                 let hint = match suggestion {
-                    Some(suggestion) => format!("Did you mean `{}`?", suggestion),
-                    None => format!("Try creating the file `src/{}.gleam`.", module),
+                    Some(suggestion) => format!("Did you mean `{suggestion}`?"),
+                    None => format!("Try creating the file `src/{module}.gleam`."),
                 };
                 Diagnostic {
                     title: "Module does not exist".into(),
-                    text: format!("Module `{module}` was not found"),
+                    text: format!("Module `{module}` was not found."),
                     level: Level::Error,
                     location: None,
                     hint: Some(hint),
@@ -534,7 +531,7 @@ forward slash and must not end with a slash."
                 location: None,
                 hint: Some(format!(
                     "Add a function with the singature `pub fn main() {{}}` \
-to `src/{module}.gleam`"
+to `src/{module}.gleam`."
                 )),
             },
 
@@ -545,7 +542,7 @@ to `src/{module}.gleam`"
                 ),
                 level: Level::Error,
                 location: None,
-                hint: Some("Change the function signature of main to `pub fn main() {}`".into()),
+                hint: Some("Change the function signature of main to `pub fn main() {}`.".into()),
             },
 
             Error::ProjectRootAlreadyExist { path } => Diagnostic {
@@ -567,7 +564,7 @@ to `src/{module}.gleam`"
             Error::VersionDoesNotMatch { toml_ver, app_ver } => {
                 let text = format!(
                     "The version in gleam.toml \"{toml_ver}\" does not match the version in
-your app.src file \"{app_ver}\""
+your app.src file \"{app_ver}\"."
                 );
                 Diagnostic {
                     title: "Version does not match".into(),
@@ -672,13 +669,12 @@ This was error from the gzip library:
 
             Error::AddTar { path, err } => {
                 let text = format!(
-                    "There was a problem when attempting to add the file {}
+                    "There was a problem when attempting to add the file {path}
 to a tar archive.
 
 This was error from the tar library:
 
-    {}",
-                    path, err
+    {err}"
                 );
                 Diagnostic {
                     title: "Failure creating tar archive".into(),
@@ -746,11 +742,10 @@ This was error from the Hex client library:
                 second,
             } => {
                 let text = format!(
-                    "The module `{}` is defined multiple times.
+                    "The module `{module}` is defined multiple times.
 
-First:  {}
-Second: {}",
-                    module, first, second,
+First:  {first}
+Second: {second}"
                 );
 
                 Diagnostic {
@@ -803,7 +798,7 @@ Second: {}",
 
             Error::NonUtf8Path { path: _ } => {
                 let text =
-                    "Encountered a non UTF-8 path, but only UTF-8 paths are supported".to_owned();
+                    "Encountered a non UTF-8 path, but only UTF-8 paths are supported.".to_owned();
                 Diagnostic {
                     title: "Non UTF-8 Path Encountered".into(),
                     text,
@@ -835,13 +830,10 @@ Second: {}",
                     test_module,
                 } => {
                     let text = wrap_format!(
-                        "The application module `{}` is importing the test module `{}`.
+                        "The application module `{src_module}` is importing the test module `{test_module}`.
 
 Test modules are not included in production builds so test \
-modules cannot import them. Perhaps move the `{}` module to the src directory.",
-                        src_module,
-                        test_module,
-                        test_module,
+modules cannot import them. Perhaps move the `{test_module}` module to the src directory.",
                     );
 
                     Diagnostic {
@@ -968,7 +960,7 @@ also be labelled."
                     name,
                 } => {
                     let text = format!(
-                        "{name} has been imported multiple times.
+                        "`{name}` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed."
                     );
                     Diagnostic {
@@ -1644,10 +1636,8 @@ Private types can only be used within the module that defines them.",
                     given,
                 } => {
                     let text = wrap_format!(
-                        "This case expression has {} subjects, but this pattern matches {}.
+                        "This case expression has {expected} subjects, but this pattern matches {given}.
 Each clause must have a pattern for every subject value.",
-                        expected,
-                        given
                     );
                     Diagnostic {
                         title: "Incorrect number of patterns".into(),
@@ -1669,8 +1659,7 @@ Each clause must have a pattern for every subject value.",
                 TypeError::NonLocalClauseGuardVariable { location, name } => {
                     let text = wrap_format!(
                         "Variables used in guards must be either defined in the \
-function, or be an argument to the function. The variable `{}` is not defined locally.",
-                        name
+function, or be an argument to the function. The variable `{name}` is not defined locally.",
                     );
                     Diagnostic {
                         title: "Invalid guard variable".into(),
@@ -1692,8 +1681,7 @@ function, or be an argument to the function. The variable `{}` is not defined lo
                 TypeError::ExtraVarInAlternativePattern { location, name } => {
                     let text = wrap_format!(
 "All alternative patterns must define the same variables as the initial pattern. \
-This variable `{}` has not been previously defined.",
-                        name
+This variable `{name}` has not been previously defined.",
                     );
                     Diagnostic {
                         title: "Extra alternative pattern variable".into(),
@@ -1715,8 +1703,7 @@ This variable `{}` has not been previously defined.",
                 TypeError::MissingVarInAlternativePattern { location, name } => {
                     let text = wrap_format!(
                         "All alternative patterns must define the same variables \
-as the initial pattern, but the `{}` variable is missing.",
-                        name
+as the initial pattern, but the `{name}` variable is missing.",
                     );
                     Diagnostic {
                         title: "Missing alternative pattern variable".into(),
@@ -1738,11 +1725,10 @@ as the initial pattern, but the `{}` variable is missing.",
                 TypeError::DuplicateVarInPattern { location, name } => {
                     let text = wrap_format!(
                         "Variables can only be used once per pattern. This \
-variable {} appears multiple times.
+variable `{name}` appears multiple times.
 If you used the same variable twice deliberately in order to check for equality \
 please use a guard clause instead.
 e.g. (x, y) if x == y -> ...",
-                        name
                     );
                     Diagnostic {
                         title: "Duplicate variable in pattern".into(),
@@ -1880,14 +1866,14 @@ function and try again."
                 TypeError::BitArraySegmentError { error, location } => {
                     let (label, mut extra) = match error {
                         bit_array::ErrorType::ConflictingTypeOptions { existing_type } => (
-                            "This is an extra type specifier.",
+                            "This is an extra type specifier",
                             vec![format!("Hint: This segment already has the type {existing_type}.")],
                         ),
 
                         bit_array::ErrorType::ConflictingSignednessOptions {
                             existing_signed
                         } => (
-                            "This is an extra signedness specifier.",
+                            "This is an extra signedness specifier",
                             vec![format!(
                                 "Hint: This segment already has a signedness of {existing_signed}."
                             )],
@@ -1896,40 +1882,40 @@ function and try again."
                         bit_array::ErrorType::ConflictingEndiannessOptions {
                             existing_endianness
                         } => (
-                            "This is an extra endianness specifier.",
+                            "This is an extra endianness specifier",
                             vec![format!(
                                 "Hint: This segment already has an endianness of {existing_endianness}."
                             )],
                         ),
 
                         bit_array::ErrorType::ConflictingSizeOptions => (
-                            "This is an extra size specifier.",
+                            "This is an extra size specifier",
                             vec!["Hint: This segment already has a size.".into()],
                         ),
 
                         bit_array::ErrorType::ConflictingUnitOptions => (
-                            "This is an extra unit specifier.",
+                            "This is an extra unit specifier",
                             vec!["Hint: A BitArray segment can have at most 1 unit.".into()],
                         ),
 
                         bit_array::ErrorType::FloatWithSize => (
-                            "Invalid float size.",
+                            "Invalid float size",
                             vec!["Hint: floats have an exact size of 16/32/64 bits.".into()],
                         ),
 
                         bit_array::ErrorType::InvalidEndianness => (
-                            "This option is invalid here.",
+                            "This option is invalid here",
                                 vec![wrap("Hint: signed and unsigned can only be used with \
 int, float, utf16 and utf32 types.")],
                         ),
 
                         bit_array::ErrorType::OptionNotAllowedInValue => (
-                            "This option is only allowed in BitArray patterns.",
+                            "This option is only allowed in BitArray patterns",
                             vec!["Hint: This option has no effect in BitArray values.".into()],
                         ),
 
                         bit_array::ErrorType::SignednessUsedOnNonInt { typ } => (
-                            "Signedness is only valid with int types.",
+                            "Signedness is only valid with int types",
                             vec![format!("Hint: This segment has a type of {typ}")],
                         ),
                         bit_array::ErrorType::TypeDoesNotAllowSize { typ } => (
@@ -2393,7 +2379,7 @@ Fix the warnings and try again."
             Error::JavaScript { src, path, error } => match error {
                 javascript::Error::Unsupported { feature, location } => Diagnostic {
                     title: "Unsupported feature for compilation target".into(),
-                    text: format!("{feature} is not supported for JavaScript compilation"),
+                    text: format!("{feature} is not supported for JavaScript compilation."),
                     hint: None,
                     level: Level::Error,
                     location: Some(Location {
@@ -2414,7 +2400,7 @@ Fix the warnings and try again."
                 error,
             } => {
                 let text = format!(
-                    "A problem was encountered when downloading {package_name} {package_version}.
+                    "A problem was encountered when downloading `{package_name}` {package_version}.
 The error from the package manager client was:
 
     {error}"
@@ -2446,7 +2432,7 @@ The error from the HTTP client was:
 
             Error::InvalidVersionFormat { input, error } => {
                 let text = format!(
-                    "I was unable to parse the version {input}.
+                    "I was unable to parse the version \"{input}\".
 The error from the parser was:
 
     {error}"
@@ -2461,7 +2447,7 @@ The error from the parser was:
             }
 
             Error::DependencyCanonicalizationFailed(package) => {
-                let text = format!("Local package {} has no canonical path", package);
+                let text = format!("Local package `{package}` has no canonical path");
 
                 Diagnostic {
                     title: "Failed to create canonical path".into(),
@@ -2504,8 +2490,7 @@ The error from the version resolver library was:
                 found,
             } => {
                 let text = format!(
-                    "Expected package {} at path {} but found {} instead",
-                    expected, path, found
+                    "Expected package `{expected}` at path `{path}` but found `{found}` instead.",
                 );
 
                 Diagnostic {
@@ -2523,8 +2508,7 @@ The error from the version resolver library was:
                 source_2,
             } => {
                 let text = format!(
-                    "The package {} is provided as both {} nad {}",
-                    package, source_1, source_2
+                    "The package `{package}` is provided as both `{source_1}` and `{source_2}`.",
                 );
 
                 Diagnostic {
@@ -2538,7 +2522,7 @@ The error from the version resolver library was:
 
             Error::DuplicateDependency(name) => {
                 let text = format!(
-                    "The package {name} is specified in both the dependencies and
+                    "The package `{name}` is specified in both the dependencies and
 dev-dependencies sections of the gleam.toml file."
                 );
                 Diagnostic {
@@ -2585,8 +2569,7 @@ licences = ["Apache-2.0"]"#
                 title: "Unblished dependencies".into(),
                 text: wrap_format!(
                     "The package cannot be published to Hex \
-because dependency {} is not a Hex dependency",
-                    package
+because dependency `{package}` is not a Hex dependency.",
                 ),
                 hint: None,
                 location: None,
@@ -2598,7 +2581,7 @@ because dependency {} is not a Hex dependency",
                 build_tools,
             } => {
                 let text = wrap_format!(
-                    "The package {} cannot be built as it does not use \
+                    "The package `{}` cannot be built as it does not use \
 a build tool supported by Gleam. It uses {:?}.
 
 If you would like us to support this package please let us know by opening an \
@@ -2620,9 +2603,8 @@ issue in our tracker: https://github.com/gleam-lang/gleam/issues",
                 let text = format!(
                     "An error occurred while trying to open the docs:
 
-    {}
-{}",
-                    path, error,
+    {path}
+{error}",
                 );
                 Diagnostic {
                     title: "Failed to open docs".into(),
@@ -2639,9 +2621,8 @@ issue in our tracker: https://github.com/gleam-lang/gleam/issues",
                 gleam_version,
             } => {
                 let text = format!(
-                    "The package {} requires a Gleam version satisfying {} \
-but you are using v{}.",
-                    package, required_version, gleam_version
+                    "The package `{package}` requires a Gleam version satisfying {required_version} \
+but you are using v{gleam_version}.",
                 );
                 Diagnostic {
                     title: "Incompatible Gleam version".into(),
@@ -2660,7 +2641,7 @@ but you are using v{}.",
 
                 let hint = match target {
                     Target::JavaScript => {
-                        Some("available runtimes for JavaScript are: node, deno".into())
+                        Some("available runtimes for JavaScript are: node, deno.".into())
                     }
                     Target::Erlang => Some(
                         "You can not set a runtime for Erlang. Did you mean to target JavaScript?"
@@ -2765,7 +2746,7 @@ fn hint_numeric_message(alt: &str, type_: &str) -> String {
 fn hint_string_message() -> String {
     wrap(
         "Strings can be joined using the `append` or `concat` \
-functions from the `gleam/string` module",
+functions from the `gleam/string` module.",
     )
 }
 

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -179,7 +179,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                     _ => messages.collect(),
                 };
 
-                ("I was not expecting this.", messages)
+                ("I was not expecting this", messages)
             }
             ParseErrorType::ExpectedBoolean => ("Did you mean to negate a boolean?", vec![]),
             ParseErrorType::ConcatPatternVariableLeftHandSide => (

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -57,7 +57,7 @@ impl ParseError {
             ),
             ParseErrorType::ExprLparStart => (
                 "This parenthesis cannot be understood here",
-                vec!["Hint: To group expressions in gleam use \"{\" and \"}\"".into()],
+                vec!["Hint: To group expressions in gleam use \"{\" and \"}\".".into()],
             ),
             ParseErrorType::IncorrectName => (
                 "I'm expecting a lowercase name here",
@@ -79,7 +79,7 @@ contain a-z, A-Z, or 0-9.",
                     "Hint: Valid BitArray segment options are:".into(),
                     wrap(
                         "bits, bytes, int, float, utf8, utf16, utf32, utf8_codepoint, \
-utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, unit",
+utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, unit.",
                     ),
                     "See: https://gleam.run/book/tour/bit-strings".into(),
                 ],
@@ -87,7 +87,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
             ParseErrorType::InvalidBitArrayUnit => (
                 "This is not a valid BitArray unit value",
                 vec![
-                    "Hint: unit must be an integer literal >= 1 and <= 256".into(),
+                    "Hint: unit must be an integer literal >= 1 and <= 256.".into(),
                     "See: https://gleam.run/book/tour/bit-strings".into(),
                 ],
             ),
@@ -119,7 +119,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
             ParseErrorType::NoLetBinding => (
                 "There must be a 'let' to bind variable to value",
                 vec![
-                    "Hint: Use let for binding".into(),
+                    "Hint: Use let for binding.".into(),
                     "See: https://gleam.run/book/tour/let-bindings".into(),
                 ],
             ),
@@ -160,7 +160,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
             ParseErrorType::LowcaseBooleanPattern => (
                 "Did you want a Bool instead of a variable?",
                 vec![
-                    "Hint: In Gleam boolean literals are True and False".into(),
+                    "Hint: In Gleam boolean literals are `True` and `False`.".into(),
                     "See: https://gleam.run/book/tour/bools.html".into(),
                 ],
             ),
@@ -189,7 +189,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                     "how to handle this pattern.".into(),
                     "".into(),
                     "If you want to match one character consider using `pop_grapheme`".into(),
-                    "from the stdlib's `gleam/string` module".into(),
+                    "from the stdlib's `gleam/string` module.".into(),
                 ],
             ),
             ParseErrorType::UnexpectedFunction => (

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assign_left_hand_side_of_concat_pattern.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assign_left_hand_side_of_concat_pattern.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 394
 expression: "\n        case \"\" {\n          first <> rest -> rest\n        }\n        "
 ---
 error: Syntax error
@@ -13,5 +12,5 @@ We can't tell what size this prefix should be so we don't know
 how to handle this pattern.
 
 If you want to match one character consider using `pop_grapheme`
-from the stdlib's `gleam/string` module
+from the stdlib's `gleam/string` module.
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__discard_left_hand_side_of_concat_pattern.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__discard_left_hand_side_of_concat_pattern.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 383
 expression: "\n        case \"\" {\n          _ <> rest -> rest\n        }\n        "
 ---
 error: Syntax error
@@ -13,5 +12,5 @@ We can't tell what size this prefix should be so we don't know
 how to handle this pattern.
 
 If you want to match one character consider using `pop_grapheme`
-from the stdlib's `gleam/string` module
+from the stdlib's `gleam/string` module.
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_1.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_1.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 353
 expression: foo = 4
 ---
 error: Syntax error
@@ -9,6 +8,6 @@ error: Syntax error
 1 │ foo = 4
   │     ^ There must be a 'let' to bind variable to value
 
-Hint: Use let for binding
+Hint: Use let for binding.
 See: https://gleam.run/book/tour/let-bindings
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_2.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_2.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 358
 expression: "foo:Int = 4"
 ---
 error: Syntax error
@@ -9,6 +8,6 @@ error: Syntax error
 1 │ foo:Int = 4
   │    ^ There must be a 'let' to bind variable to value
 
-Hint: Use let for binding
+Hint: Use let for binding.
 See: https://gleam.run/book/tour/let-bindings
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_3.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_3.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 363
 expression: "let bar:Int = 32\n        bar = 42"
 ---
 error: Syntax error
@@ -9,6 +8,6 @@ error: Syntax error
 2 │         bar = 42
   │             ^ There must be a 'let' to bind variable to value
 
-Hint: Use let for binding
+Hint: Use let for binding.
 See: https://gleam.run/book/tour/let-bindings
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1617
 expression: "\n        import foo/sub\n        import foo2/sub\n        pub fn main() {\n            sub.bar()\n        }\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import foo2/sub
   │         ^^^^^^^^^^^^^^^ Reimported here
 
-sub has been imported multiple times.
+`sub` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1632
 expression: "\n        import foo/sub\n        import foo2/sub.{bar}\n        pub fn main() {\n            sub.bar()\n        }\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import foo2/sub.{bar}
   │         ^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
-sub has been imported multiple times.
+`sub` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_bits_option_in_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_bits_option_in_value.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 195
 expression: "let x = <<<<1:1>>:bytes>> x"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:19
   │
 1 │ let x = <<<<1:1>>:bytes>> x
-  │                   ^^^^^ This option is only allowed in BitArray patterns.
+  │                   ^^^^^ This option is only allowed in BitArray patterns
 
 Hint: This option has no effect in BitArray values.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_float_size.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_float_size.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 190
 expression: "let x = <<1:8-float>> x"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ let x = <<1:8-float>> x
-  │             ^ Invalid float size.
+  │             ^ Invalid float size
 
 Hint: floats have an exact size of 16/32/64 bits.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_endianness1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_endianness1.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 89
 expression: "let x = <<1:big-little>> x"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:17
   │
 1 │ let x = <<1:big-little>> x
-  │                 ^^^^^^ This is an extra endianness specifier.
+  │                 ^^^^^^ This is an extra endianness specifier
 
 Hint: This segment already has an endianness of big.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_endianness2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_endianness2.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 94
 expression: "case <<1>> { <<1:native-big>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:25
   │
 1 │ case <<1>> { <<1:native-big>> -> 1 }
-  │                         ^^^ This is an extra endianness specifier.
+  │                         ^^^ This is an extra endianness specifier
 
 Hint: This segment already has an endianness of native.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_options_bit_array.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_options_bit_array.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 74
 expression: "case <<1>> { <<1:bits-bytes>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:23
   │
 1 │ case <<1>> { <<1:bits-bytes>> -> 1 }
-  │                       ^^^^^ This is an extra type specifier.
+  │                       ^^^^^ This is an extra type specifier
 
 Hint: This segment already has the type bits.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_options_int.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_options_int.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 69
 expression: "let x = <<1:int-bytes>> x"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:17
   │
 1 │ let x = <<1:int-bytes>> x
-  │                 ^^^^^ This is an extra type specifier.
+  │                 ^^^^^ This is an extra type specifier
 
 Hint: This segment already has the type int.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_signedness1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_signedness1.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 79
 expression: "let x = <<1:signed-unsigned>> x"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:20
   │
 1 │ let x = <<1:signed-unsigned>> x
-  │                    ^^^^^^^^ This is an extra signedness specifier.
+  │                    ^^^^^^^^ This is an extra signedness specifier
 
 Hint: This segment already has a signedness of signed.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_signedness2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_conflicting_signedness2.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 84
 expression: "case <<1>> { <<1:unsigned-signed>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:27
   │
 1 │ case <<1>> { <<1:unsigned-signed>> -> 1 }
-  │                           ^^^^^^ This is an extra signedness specifier.
+  │                           ^^^^^^ This is an extra signedness specifier
 
 Hint: This segment already has a signedness of unsigned.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_size.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_size.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 99
 expression: "let x = <<1:8-size(5)>> x"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:15
   │
 1 │ let x = <<1:8-size(5)>> x
-  │               ^^^^^^^ This is an extra size specifier.
+  │               ^^^^^^^ This is an extra size specifier
 
 Hint: This segment already has a size.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_size2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_size2.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 104
 expression: "case <<1>> { <<1:size(2)-size(8)>> -> a }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:26
   │
 1 │ case <<1>> { <<1:size(2)-size(8)>> -> a }
-  │                          ^^^^^^^ This is an extra size specifier.
+  │                          ^^^^^^^ This is an extra size specifier
 
 Hint: This segment already has a size.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_unit_unit.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_unit_unit.snap
@@ -1,13 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 109
 expression: "let x = <<1:unit(2)-unit(5)>> x"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:21
   │
 1 │ let x = <<1:unit(2)-unit(5)>> x
-  │                     ^^^^^^^ This is an extra unit specifier.
+  │                     ^^^^^^^ This is an extra unit specifier
 
 Hint: A BitArray segment can have at most 1 unit.
 See: https://gleam.run/book/tour/bit-strings.html

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_var_in_record_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_var_in_record_pattern.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 896
 expression: "type X { X(a: Int, b: Int, c: Int) }\nfn x() {\n  case X(1,2,3) { X(x, y, x) -> 1 }\n}"
 ---
 error: Duplicate variable in pattern
@@ -9,7 +8,7 @@ error: Duplicate variable in pattern
 3 │   case X(1,2,3) { X(x, y, x) -> 1 }
   │                           ^ This has already been used
 
-Variables can only be used once per pattern. This variable x appears
+Variables can only be used once per pattern. This variable `x` appears
 multiple times.
 If you used the same variable twice deliberately in order to check for
 equality please use a guard clause instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 539
 expression: "case #(1, 2) { #(x, x) -> 1 }"
 ---
 error: Duplicate variable in pattern
@@ -9,7 +8,7 @@ error: Duplicate variable in pattern
 1 │ case #(1, 2) { #(x, x) -> 1 }
   │                     ^ This has already been used
 
-Variables can only be used once per pattern. This variable x appears
+Variables can only be used once per pattern. This variable `x` appears
 multiple times.
 If you used the same variable twice deliberately in order to check for
 equality please use a guard clause instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars_2.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 544
 expression: "case [3.33], 1 { x, x if x > x -> 1 }"
 ---
 error: Duplicate variable in pattern
@@ -9,7 +8,7 @@ error: Duplicate variable in pattern
 1 │ case [3.33], 1 { x, x if x > x -> 1 }
   │                     ^ This has already been used
 
-Variables can only be used once per pattern. This variable x appears
+Variables can only be used once per pattern. This variable `x` appears
 multiple times.
 If you used the same variable twice deliberately in order to check for
 equality please use a guard clause instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars_3.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 549
 expression: "case [1, 2, 3] { [x, x, y] -> 1 }"
 ---
 error: Duplicate variable in pattern
@@ -9,7 +8,7 @@ error: Duplicate variable in pattern
 1 │ case [1, 2, 3] { [x, x, y] -> 1 }
   │                      ^ This has already been used
 
-Variables can only be used once per pattern. This variable x appears
+Variables can only be used once per pattern. This variable `x` appears
 multiple times.
 If you used the same variable twice deliberately in order to check for
 equality please use a guard clause instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1647
 expression: "\n        import gleam/foo.{bar}\n        import gleam/foo.{zoo}\n        pub fn go() { bar() + zoo() }\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import gleam/foo.{zoo}
   │         ^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
-foo has been imported multiple times.
+`foo` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1665
 expression: "\n        import one\n        import two as one\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import two as one
   │         ^^^^^^^^^^^^^^^^^ Reimported here
 
-one has been imported multiple times.
+`one` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1687
 expression: "\n        import one as two\n        import two\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import two
   │         ^^^^^^^^^^ Reimported here
 
-two has been imported multiple times.
+`two` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1709
 expression: "\n        import one as x\n        import two as x\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import two as x
   │         ^^^^^^^^^^^^^^^ Reimported here
 
-x has been imported multiple times.
+`x` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1731
 expression: "\n        import one.{fn1}\n        import two.{fn2} as one\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import two.{fn2} as one
   │         ^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
-one has been imported multiple times.
+`one` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1753
 expression: "\n        import one.{fn1} as two\n        import two.{fn2}\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import two.{fn2}
   │         ^^^^^^^^^^^^^^^^ Reimported here
 
-two has been imported multiple times.
+`two` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 1775
 expression: "\n        import one.{fn1} as x\n        import two.{fn2} as x\n        "
 ---
 error: Duplicate import
@@ -11,6 +10,6 @@ error: Duplicate import
 3 │         import two.{fn2} as x
   │         ^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
-x has been imported multiple times.
+`x` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_literal.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 551
 expression: "pub fn main() { let _ = !!True }"
 ---
 
-warning: Unnecessary double negation (!!) on bool.
+warning: Unnecessary double negation (!!) on bool
   ┌─ /src/warning/wrn.gleam:1:25
   │
 1 │ pub fn main() { let _ = !!True }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_variable.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_variable.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 557
 expression: "\n        pub fn main() {\n            let x = True\n            let _ = !!x\n        }\n        "
 ---
 
-warning: Unnecessary double negation (!!) on bool.
+warning: Unnecessary double negation (!!) on bool
   ┌─ /src/warning/wrn.gleam:4:21
   │
 4 │             let _ = !!x

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_literal.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_literal.snap
@@ -1,14 +1,13 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 532
 expression: "pub fn main() { let _ = --7 }"
 ---
 
-warning: Unnecessary double negation (--) on integer.
+warning: Unnecessary double negation (--) on integer
   ┌─ /src/warning/wrn.gleam:1:25
   │
 1 │ pub fn main() { let _ = --7 }
   │                         ^^^
 
-Hint: You can safely remove this
+Hint: You can safely remove this.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_variable.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_variable.snap
@@ -1,14 +1,13 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 538
 expression: "\n        pub fn main() {\n            let x = 7\n            let _ = --x\n        }\n        "
 ---
 
-warning: Unnecessary double negation (--) on integer.
+warning: Unnecessary double negation (--) on integer
   ┌─ /src/warning/wrn.gleam:4:21
   │
 4 │             let _ = --x
   │                     ^^^
 
-Hint: You can safely remove this
+Hint: You can safely remove this.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_0_eq_list_length.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_0_eq_list_length.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 610
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = 0 == list.length(a_list)\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = 0 == list.length(a_list)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_0_not_eq_list_length.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_0_not_eq_list_length.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 670
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = 0 != list.length(a_list)\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = 0 != list.length(a_list)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_eq_0.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_eq_0.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 570
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = list.length(a_list) == 0\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = list.length(a_list) == 0

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_eq_negative_0.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_eq_negative_0.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 590
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = list.length(a_list) == -0\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = list.length(a_list) == -0

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_lt_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_lt_1.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 710
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = list.length(a_list) < 1\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = list.length(a_list) < 1

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_lt_eq_0.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_lt_eq_0.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 690
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = list.length(a_list) <= 0\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = list.length(a_list) <= 0

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_not_eq_0.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_list_length_not_eq_0.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 650
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = list.length(a_list) != 0\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = list.length(a_list) != 0

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_negative_0_eq_list_length.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__prefer_list_is_empty_over_negative_0_eq_list_length.snap
@@ -1,10 +1,9 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 630
 expression: "\n        import gleam/list\n\n        pub fn main() {\n            let a_list = []\n            let _ = -0 == list.length(a_list)\n        }\n        "
 ---
 
-warning: Inefficient use of list.length
+warning: Inefficient use of `list.length`
   ┌─ /src/warning/wrn.gleam:6:21
   │
 6 │             let _ = -0 == list.length(a_list)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_many_at_same_time.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_many_at_same_time.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 72
 expression: "\nfn main() { let five = 5 }"
 ---
 
@@ -8,7 +7,7 @@ warning: Unused variable
   ┌─ /src/warning/wrn.gleam:2:17
   │
 2 │ fn main() { let five = 5 }
-  │                 ^^^^ This variable is never used.
+  │                 ^^^^ This variable is never used
 
 Hint: You can ignore it with an underscore: `_five`.
 
@@ -16,7 +15,7 @@ warning: Unused private function
   ┌─ /src/warning/wrn.gleam:2:1
   │
 2 │ fn main() { let five = 5 }
-  │ ^^^^^^^^^ This private function is never used.
+  │ ^^^^^^^^^ This private function is never used
 
 Hint: You can safely remove it.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_private_function_never_used.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_private_function_never_used.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 67
 expression: "fn main() { 5 }"
 ---
 
@@ -8,7 +7,7 @@ warning: Unused private function
   ┌─ /src/warning/wrn.gleam:1:1
   │
 1 │ fn main() { 5 }
-  │ ^^^^^^^^^ This private function is never used.
+  │ ^^^^^^^^^ This private function is never used
 
 Hint: You can safely remove it.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_variable_never_used_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_variable_never_used_test.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 58
 expression: "\npub fn foo() { Ok(5) }\npub fn main() { let five = foo() }"
 ---
 
@@ -8,7 +7,7 @@ warning: Unused variable
   ┌─ /src/warning/wrn.gleam:3:21
   │
 3 │ pub fn main() { let five = foo() }
-  │                     ^^^^ This variable is never used.
+  │                     ^^^^ This variable is never used
 
 Hint: You can ignore it with an underscore: `_five`.
 

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -184,15 +184,14 @@ a future version of Gleam."
             },
 
             Warning::InvalidSource { path } => Diagnostic {
-                title: "Invalid module name.".into(),
+                title: "Invalid module name".into(),
                 text: "Module names must begin with a lowercase letter and contain\
  only lowercase alphanumeric characters or underscores."
                     .into(),
                 level: diagnostic::Level::Warning,
                 location: None,
                 hint: Some(format!(
-                    "Rename `{}` to be valid, or remove this file from the project source.",
-                    path
+                    "Rename `{path}` to be valid, or remove this file from the project source."
                 )),
             },
             Self::Type { path, warning, src } => match warning {
@@ -264,7 +263,9 @@ expression.",
                 type_::Warning::ImplicitlyDiscardedResult { location } => Diagnostic {
                     title: "Unused result value".into(),
                     text: "".into(),
-                    hint: Some("If you are sure you don't need it you can assign it to `_`".into()),
+                    hint: Some(
+                        "If you are sure you don't need it you can assign it to `_`.".into(),
+                    ),
                     level: diagnostic::Level::Warning,
                     location: Some(Location {
                         path: path.to_path_buf(),
@@ -304,7 +305,7 @@ expression.",
                         path: path.to_path_buf(),
                         src: src.clone(),
                         label: diagnostic::Label {
-                            text: Some("This record update doesn't change any fields.".into()),
+                            text: Some("This record update doesn't change any fields".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
@@ -336,9 +337,9 @@ expression.",
                         "Unused private type".into()
                     };
                     let label = if *imported {
-                        "This imported type is never used.".into()
+                        "This imported type is never used".into()
                     } else {
-                        "This private type is never used.".into()
+                        "This private type is never used".into()
                     };
                     Diagnostic {
                         title,
@@ -366,9 +367,9 @@ expression.",
                         "Unused private constructor".into()
                     };
                     let label = if *imported {
-                        "This imported constructor is never used.".into()
+                        "This imported constructor is never used".into()
                     } else {
-                        "This private constructor is never used.".into()
+                        "This private constructor is never used".into()
                     };
                     Diagnostic {
                         title,
@@ -396,7 +397,7 @@ expression.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: Some("This imported module is never used.".into()),
+                            text: Some("This imported module is never used".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
@@ -412,7 +413,7 @@ expression.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: Some("This imported module alias is never used.".into()),
+                            text: Some("This imported module alias is never used".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
@@ -428,7 +429,7 @@ expression.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: Some("This imported value is never used.".into()),
+                            text: Some("This imported value is never used".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
@@ -444,7 +445,7 @@ expression.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: Some("This private constant is never used.".into()),
+                            text: Some("This private constant is never used".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
@@ -460,7 +461,7 @@ expression.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: Some("This private function is never used.".into()),
+                            text: Some("This private function is never used".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
@@ -476,16 +477,16 @@ expression.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: Some("This variable is never used.".into()),
+                            text: Some("This variable is never used".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
                     }),
                 },
                 type_::Warning::UnnecessaryDoubleIntNegation { location } => Diagnostic {
-                    title: "Unnecessary double negation (--) on integer.".into(),
+                    title: "Unnecessary double negation (--) on integer".into(),
                     text: "".into(),
-                    hint: Some("You can safely remove this".into()),
+                    hint: Some("You can safely remove this.".into()),
                     level: diagnostic::Level::Warning,
                     location: Some(Location {
                         src: src.clone(),
@@ -498,7 +499,7 @@ expression.",
                     }),
                 },
                 type_::Warning::UnnecessaryDoubleBoolNegation { location } => Diagnostic {
-                    title: "Unnecessary double negation (!!) on bool.".into(),
+                    title: "Unnecessary double negation (!!) on bool".into(),
                     text: "".into(),
                     hint: Some("You can safely remove this.".into()),
                     level: diagnostic::Level::Warning,
@@ -527,7 +528,7 @@ need to know if the list is empty or not.
                     });
 
                     Diagnostic {
-                        title: "Inefficient use of list.length".into(),
+                        title: "Inefficient use of `list.length`".into(),
                         text,
                         hint,
                         level: diagnostic::Level::Warning,

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -1,6 +1,5 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 153
 expression: "./cases/import_shadowed_name_warning"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
@@ -57,7 +56,7 @@ warning: Unused private constructor
   ┌─ src/two.gleam:9:3
   │
 9 │   Port
-  │   ^ This private constructor is never used.
+  │   ^ This private constructor is never used
 
 Hint: You can safely remove it.
 
@@ -68,7 +67,7 @@ warning: Unused private type
   ┌─ src/two.gleam:7:1
   │
 7 │ type Shadowing {
-  │ ^ This private type is never used.
+  │ ^ This private type is never used
 
 Hint: You can safely remove it.
 


### PR DESCRIPTION
This PR closes #2503.

I opted to:
- Never put a full stop `.` after an error/warning title or label pointing to code
- Put a full stop after an error/warning text and hint

Since I was there I've also fixed a couple of typos I found in the messages and rewrote some `format!` calls to do `format("{foo}")` instead of `format("{}", foo)` to be consistent with what other messages do.