### PR TITLE
change `build` to `build/` in generated .gitignore

### DIFF
--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -121,7 +121,7 @@ pub fn main() {{
             self.root.join(".gitignore"),
             "*.beam
 *.ez
-build
+/build
 erl_crash.dump
 ",
         )


### PR DESCRIPTION
Fixes #2517