### PR TITLE
Fix spelling of transitive in warning message

### DIFF
--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__importing_non_direct_dep_package.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__importing_non_direct_dep_package.snap
@@ -4,7 +4,7 @@ assertion_line: 877
 expression: "\nimport some_module\npub const x = some_module.x\n        "
 ---
 
-warning: Transative dependency imported
+warning: Transitive dependency imported
   ┌─ /src/warning/wrn.gleam:2:1
   │
 2 │ import some_module

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -563,7 +563,7 @@ Run this command to add it to your dependencies:
 "
                     ));
                     Diagnostic {
-                        title: "Transative dependency imported".into(),
+                        title: "Transitive dependency imported".into(),
                         text,
                         hint: None,
                         level: diagnostic::Level::Warning,


### PR DESCRIPTION
It is spelled correctly in the enum variant name but not the text of the warning message.