### PR TITLE
Make sure function heads don't go over the line limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Formatter
+
+- Fixed a bug where function heads would go over the line limit.
+
+
 ## v0.34.0-rc3 - 2023-01-12
 
 ### Language changes

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -527,15 +527,14 @@ impl<'comments> Formatter<'comments> {
         let signature = match &function.return_annotation {
             Some(anno) => signature.append(" -> ").append(self.type_ast(anno)),
             None => signature,
-        }
-        .group();
-
-        let head = attributes.append(signature);
+        };
 
         let body = &function.body;
         if body.len() == 1 && body.first().is_placeholder() {
-            return head;
+            return attributes.append(signature.group());
         }
+
+        let head = attributes.append(signature);
 
         // Format body
         let body = self.statements(body);
@@ -548,6 +547,7 @@ impl<'comments> Formatter<'comments> {
 
         // Stick it all together
         head.append(" {")
+            .group()
             .append(line().append(body).nest(INDENT).group())
             .append(line())
             .append("}")

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -801,7 +801,10 @@ fn statement_fn() {
     );
 
     assert_format!(
-        "fn order(first: Set(member), second: Set(member)) -> #(Set(member), Set(member)) {
+        "fn order(
+  first: Set(member),
+  second: Set(member),
+) -> #(Set(member), Set(member)) {
   Nil
 }
 "

--- a/compiler-core/src/format/tests/function.rs
+++ b/compiler-core/src/format/tests/function.rs
@@ -224,3 +224,15 @@ fn only_last_argument_can_be_broken() {
 "#
     );
 }
+
+#[test]
+fn function_that_is_a_little_over_the_limit() {
+    assert_format!(
+        r#"pub fn handle_request(
+  handler: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+) -> Nil {
+  todo
+}
+"#
+    );
+}


### PR DESCRIPTION
This fixes a strange behaviour with the formatter where function signatures would sometimes go over the line limit of 80 chars