### PR TITLE
Adds SourceHut as a code repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Build tool changes
+
+- Support has been added for using SourceHut as a repository.
+
 ## v0.34.0 - 2023-01-16
 
 ### Language changes

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -741,6 +741,10 @@ pub enum Repository {
         #[serde(with = "uri_serde_default_https")]
         host: Uri,
     },
+    SourceHut {
+        user: String,
+        repo: String,
+    },
     Custom {
         url: String,
     },
@@ -757,6 +761,9 @@ impl Repository {
             }
             Repository::CodeBerg { repo, user } => {
                 Some(format!("https://codeberg.org/{user}/{repo}"))
+            }
+            Repository::SourceHut { repo, user } => {
+                Some(format!("https://git.sr.ht/~{user}/{repo}"))
             }
             Repository::Gitea { repo, user, host } => Some(format!("{host}/{user}/{repo}")),
             Repository::Custom { url } => Some(url.clone()),

--- a/compiler-core/src/docs/source_links.rs
+++ b/compiler-core/src/docs/source_links.rs
@@ -56,6 +56,13 @@ impl SourceLinker {
                 ),
                 "-".into(),
             )),
+            Repository::SourceHut { user, repo } => Some((
+                format!(
+                    "https://git.sr.ht/~{}/{}/tree/{}/item/{}#L",
+                    user, repo, project_config.version, path_in_repo
+                ),
+                "-".into(),
+            )),
             Repository::Gitea { user, repo, host } => Some((
                 format!(
                     "{host}/{user}/{repo}/src/tag/{}/{}#L",


### PR DESCRIPTION
With many hugops to SourceHut: https://sourcehut.org/blog/2024-01-16-sourcehut-outage/