### PR TITLE
Fix formatting of pipelines and binary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - The search bar in generated docs now has a darker background color.
 
+### Formatter
+
+- Now the formatter will nest pipelines and binary operators that are used as
+  function arguments, list items or as tuple items.
+
+### Build tool
+
 - If a package contains a `todo` expression then the build tool will now refuse
   to publish it to Hex.
 

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -208,6 +208,16 @@ impl UntypedExpr {
     pub fn is_placeholder(&self) -> bool {
         matches!(self, Self::Placeholder { .. })
     }
+
+    #[must_use]
+    pub fn is_binop(&self) -> bool {
+        matches!(self, Self::BinOp { .. })
+    }
+
+    #[must_use]
+    pub fn is_pipeline(&self) -> bool {
+        matches!(self, Self::PipeLine { .. })
+    }
 }
 
 impl HasLocation for UntypedExpr {

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -2277,8 +2277,8 @@ fn expr_pipe() {
         r#"fn main() {
   #(
     1
-    |> succ
-    |> succ,
+      |> succ
+      |> succ,
     2,
     3,
   )
@@ -2290,8 +2290,8 @@ fn expr_pipe() {
         r#"fn main() {
   some_call(
     1
-    |> succ
-    |> succ,
+      |> succ
+      |> succ,
     2,
     3,
   )
@@ -2303,8 +2303,8 @@ fn expr_pipe() {
         r#"fn main() {
   [
     1
-    |> succ
-    |> succ,
+      |> succ
+      |> succ,
     2,
     3,
   ]
@@ -5382,7 +5382,7 @@ fn list_with_pipe_format() {
         r#"pub fn main() {
   [
     "Success!"
-    |> ansi(apply: [1, 31]),
+      |> ansi(apply: [1, 31]),
     "",
     "Wrote `" <> bin <> "`, `" <> pwsh_bin <> "`",
   ]
@@ -5456,6 +5456,50 @@ fn multiline_string_get_broken_on_newlines_as_function_arguments() {
        baz",
     foo,
     bar,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn pipeline_used_as_function_arguments_gets_nested() {
+    assert_format!(
+        r#"pub fn main() {
+  foo(
+    a_variable_with_a_long_name
+      |> another_variable_with_a_long_name
+      |> yet_another_variable_with_a_long_name,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn pipeline_inside_list_gets_nested() {
+    assert_format!(
+        r#"pub fn main() {
+  [
+    foo,
+    a_variable_with_a_long_name
+      |> another_variable_with_a_long_name
+      |> yet_another_variable_with_a_long_name,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn pipeline_inside_tuple_gets_nested() {
+    assert_format!(
+        r#"pub fn main() {
+  #(
+    foo,
+    a_variable_with_a_long_name
+      |> another_variable_with_a_long_name
+      |> yet_another_variable_with_a_long_name,
   )
 }
 "#

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5470,6 +5470,21 @@ fn pipeline_used_as_function_arguments_gets_nested() {
     a_variable_with_a_long_name
       |> another_variable_with_a_long_name
       |> yet_another_variable_with_a_long_name,
+    bar,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn pipeline_used_as_function_arguments_is_not_nested_if_it_is_the_only_argument() {
+    assert_format!(
+        r#"pub fn main() {
+  foo(
+    a_variable_with_a_long_name
+    |> another_variable_with_a_long_name
+    |> yet_another_variable_with_a_long_name,
   )
 }
 "#
@@ -5492,6 +5507,20 @@ fn pipeline_inside_list_gets_nested() {
 }
 
 #[test]
+fn pipeline_inside_list_is_not_nested_if_only_item() {
+    assert_format!(
+        r#"pub fn main() {
+  [
+    a_variable_with_a_long_name
+    |> another_variable_with_a_long_name
+    |> yet_another_variable_with_a_long_name,
+  ]
+}
+"#
+    );
+}
+
+#[test]
 fn pipeline_inside_tuple_gets_nested() {
     assert_format!(
         r#"pub fn main() {
@@ -5500,6 +5529,20 @@ fn pipeline_inside_tuple_gets_nested() {
     a_variable_with_a_long_name
       |> another_variable_with_a_long_name
       |> yet_another_variable_with_a_long_name,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn pipeline_inside_tuple_is_not_nested_if_only_item() {
+    assert_format!(
+        r#"pub fn main() {
+  #(
+    a_variable_with_a_long_name
+    |> another_variable_with_a_long_name
+    |> yet_another_variable_with_a_long_name,
   )
 }
 "#

--- a/compiler-core/src/format/tests/binary_operators.rs
+++ b/compiler-core/src/format/tests/binary_operators.rs
@@ -170,3 +170,47 @@ fn math_binops_kept_on_a_single_line_in_pipes() {
 "#
     );
 }
+
+#[test]
+fn binop_used_as_function_arguments_gets_nested() {
+    assert_format!(
+        r#"pub fn main() {
+  foo(
+    a_variable_with_a_long_name
+      <> another_variable_with_a_long_name
+      <> yet_another_variable_with_a_long_name,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn binop_inside_list_gets_nested() {
+    assert_format!(
+        r#"pub fn main() {
+  [
+    foo,
+    a_variable_with_a_long_name
+      <> another_variable_with_a_long_name
+      <> yet_another_variable_with_a_long_name,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn binop_inside_tuple_gets_nested() {
+    assert_format!(
+        r#"pub fn main() {
+  #(
+    foo,
+    a_variable_with_a_long_name
+      <> another_variable_with_a_long_name
+      <> yet_another_variable_with_a_long_name,
+  )
+}
+"#
+    );
+}

--- a/compiler-core/src/format/tests/binary_operators.rs
+++ b/compiler-core/src/format/tests/binary_operators.rs
@@ -179,6 +179,21 @@ fn binop_used_as_function_arguments_gets_nested() {
     a_variable_with_a_long_name
       <> another_variable_with_a_long_name
       <> yet_another_variable_with_a_long_name,
+    bar,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn binop_is_not_nested_if_the_only_argument() {
+    assert_format!(
+        r#"pub fn main() {
+  foo(
+    a_variable_with_a_long_name
+    <> another_variable_with_a_long_name
+    <> yet_another_variable_with_a_long_name,
   )
 }
 "#
@@ -201,6 +216,20 @@ fn binop_inside_list_gets_nested() {
 }
 
 #[test]
+fn binop_inside_list_is_not_nested_if_only_item() {
+    assert_format!(
+        r#"pub fn main() {
+  [
+    a_variable_with_a_long_name
+    <> another_variable_with_a_long_name
+    <> yet_another_variable_with_a_long_name,
+  ]
+}
+"#
+    );
+}
+
+#[test]
 fn binop_inside_tuple_gets_nested() {
     assert_format!(
         r#"pub fn main() {
@@ -209,6 +238,20 @@ fn binop_inside_tuple_gets_nested() {
     a_variable_with_a_long_name
       <> another_variable_with_a_long_name
       <> yet_another_variable_with_a_long_name,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn binop_inside_tuple_is_not_nested_if_only_item() {
+    assert_format!(
+        r#"pub fn main() {
+  #(
+    a_variable_with_a_long_name
+    <> another_variable_with_a_long_name
+    <> yet_another_variable_with_a_long_name,
   )
 }
 "#

--- a/compiler-core/src/format/tests/use_.rs
+++ b/compiler-core/src/format/tests/use_.rs
@@ -201,7 +201,7 @@ fn arity_1_var_call() {
         r#"pub fn main() {
   use x, y <- await(
     file.read()
-      |> promise.map(something),
+    |> promise.map(something),
   )
 }
 "#
@@ -214,7 +214,7 @@ fn arity_1_access_call() {
         r#"pub fn main() {
   use x, y <- promise.await(
     file.read()
-      |> promise.map(something),
+    |> promise.map(something),
   )
 }
 "#

--- a/compiler-core/src/format/tests/use_.rs
+++ b/compiler-core/src/format/tests/use_.rs
@@ -201,7 +201,7 @@ fn arity_1_var_call() {
         r#"pub fn main() {
   use x, y <- await(
     file.read()
-    |> promise.map(something),
+      |> promise.map(something),
   )
 }
 "#
@@ -214,7 +214,7 @@ fn arity_1_access_call() {
         r#"pub fn main() {
   use x, y <- promise.await(
     file.read()
-    |> promise.map(something),
+      |> promise.map(something),
   )
 }
 "#


### PR DESCRIPTION
This PR changes the formatter so that pipelines and binary operators that are used as function arguments, list items or as tuple items get nested. This way it should be easier to tell where an item starts and the other ends. 