### PR TITLE
Sort imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Formatter
 
 - The format used by the formatter has been improved in some niche cases.
+- Improved the formatting of long case guards.
+- The formatter can now format groups of imports alphabetically.
+
 
 ## v1.0.0-rc1 - 2024-02-10
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -16,7 +16,6 @@ use crate::type_::expression::Implementations;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
-use std::cmp::Ordering;
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -416,10 +415,6 @@ impl<T> Import<T> {
             Some((AssignName::Discard(_), _)) => None,
             None => self.module.split('/').last().map(EcoString::from),
         }
-    }
-
-    pub(crate) fn compare(&self, other: &Self) -> Ordering {
-        self.module.cmp(&other.module)
     }
 
     pub(crate) fn alias_location(&self) -> Option<SrcSpan> {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -16,6 +16,7 @@ use crate::type_::expression::Implementations;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -419,6 +420,20 @@ impl<T> Import<T> {
 
     pub(crate) fn alias_location(&self) -> Option<SrcSpan> {
         self.as_name.as_ref().map(|(_, location)| *location)
+    }
+
+    pub(crate) fn cmp(&self, other: &Self) -> Ordering {
+        let is_gleam = self.module.starts_with("gleam/");
+        let other_is_gleam = other.module.starts_with("gleam/");
+        // Gleam modules take precedence over non-gleam modules.
+        if is_gleam && !other_is_gleam {
+            std::cmp::Ordering::Less
+        } else if !is_gleam && other_is_gleam {
+            std::cmp::Ordering::Greater
+        } else {
+            // Otherwise imports are just sorted alphabetically.
+            self.module.cmp(&other.module)
+        }
     }
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -418,22 +418,12 @@ impl<T> Import<T> {
         }
     }
 
-    pub(crate) fn alias_location(&self) -> Option<SrcSpan> {
-        self.as_name.as_ref().map(|(_, location)| *location)
+    pub(crate) fn compare(&self, other: &Self) -> Ordering {
+        self.module.cmp(&other.module)
     }
 
-    pub(crate) fn cmp(&self, other: &Self) -> Ordering {
-        let is_gleam = self.module.starts_with("gleam/");
-        let other_is_gleam = other.module.starts_with("gleam/");
-        // Gleam modules take precedence over non-gleam modules.
-        if is_gleam && !other_is_gleam {
-            std::cmp::Ordering::Less
-        } else if !is_gleam && other_is_gleam {
-            std::cmp::Ordering::Greater
-        } else {
-            // Otherwise imports are just sorted alphabetically.
-            self.module.cmp(&other.module)
-        }
+    pub(crate) fn alias_location(&self) -> Option<SrcSpan> {
+        self.as_name.as_ref().map(|(_, location)| *location)
     }
 }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -214,8 +214,8 @@ impl<'comments> Formatter<'comments> {
         join(non_empty, line()).append(line())
     }
 
-    /// Separates the imports in groups delimited by comments and sorts each
-    /// group on its own.
+    /// Separates the imports in groups delimited by comments or empty lines and
+    /// sorts each group alphabetically.
     ///
     fn imports<'a>(&mut self, imports: Vec<&'a TargetedDefinition>) -> Vec<Document<'a>> {
         // The formatter needs to play nicely with import groups defined by the
@@ -262,7 +262,7 @@ impl<'comments> Formatter<'comments> {
             current_group.push(import);
         }
 
-        // We don't have to forget about the last import group!
+        // Let's not forget about the last import group!
         if !current_group.is_empty() {
             documents.append(&mut self.sorted_import_group(&mut current_group, group_comments));
         }
@@ -291,7 +291,7 @@ impl<'comments> Formatter<'comments> {
         };
 
         imports.sort_by(|one, other| match (&one.definition, &other.definition) {
-            (Definition::Import(one), Definition::Import(other)) => one.cmp(other),
+            (Definition::Import(one), Definition::Import(other)) => one.compare(other),
             // It shouldn't really be possible for a non import to be here so
             // we just return a default value.
             _ => std::cmp::Ordering::Equal,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -291,7 +291,7 @@ impl<'comments> Formatter<'comments> {
         };
 
         imports.sort_by(|one, other| match (&one.definition, &other.definition) {
-            (Definition::Import(one), Definition::Import(other)) => one.compare(other),
+            (Definition::Import(one), Definition::Import(other)) => one.module.cmp(&other.module),
             // It shouldn't really be possible for a non import to be here so
             // we just return a default value.
             _ => std::cmp::Ordering::Equal,

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -40,7 +40,7 @@ fn imports() {
     assert_format!("import one\n");
     assert_format!("import one\nimport two\n");
     assert_format!("import one/two/three\n");
-    assert_format!("import one/two/three\nimport four/five\n");
+    assert_format!("import four/five\nimport one/two/three\n");
     assert_format!("import one.{fun, fun2, fun3}\n");
     assert_format!("import one.{One, Two, fun1, fun2}\n");
     assert_format!("import one.{main as entrypoint}\n");
@@ -67,8 +67,8 @@ fn imports() {
 fn multiple_statements_test() {
     assert_format!(
         r#"import one
-import two
 import three
+import two
 
 pub type One
 

--- a/compiler-core/src/format/tests/imports.rs
+++ b/compiler-core/src/format/tests/imports.rs
@@ -1,4 +1,4 @@
-use crate::assert_format;
+use crate::{assert_format, assert_format_rewrite};
 
 #[test]
 fn types_and_values() {
@@ -20,6 +20,49 @@ fn discarded_import() {
 fn discarded_import_with_unqualified() {
     assert_format!(
         "import one/two.{type Abc, Bcd, abc} as _three
+"
+    );
+}
+
+#[test]
+fn imports_are_sorted_alphabetically() {
+    assert_format_rewrite!(
+        "import c import a/a import a/c import b import a/ab import a",
+        "import a
+import a/a
+import a/ab
+import a/c
+import b
+import c
+"
+    );
+}
+
+#[test]
+fn gleam_packages_are_always_on_top() {
+    assert_format_rewrite!(
+        "import a import gleam/list import gleam/int",
+        "import gleam/int
+import gleam/list
+import a
+"
+    );
+}
+
+#[test]
+fn import_groups_are_respected() {
+    assert_format_rewrite!(
+        "import c
+@target(javascript)
+import b
+// Another group
+import a",
+        "@target(javascript)
+import b
+import c
+
+// Another group
+import a
 "
     );
 }

--- a/compiler-core/src/format/tests/imports.rs
+++ b/compiler-core/src/format/tests/imports.rs
@@ -39,17 +39,6 @@ import c
 }
 
 #[test]
-fn gleam_packages_are_always_on_top() {
-    assert_format_rewrite!(
-        "import a import gleam/list import gleam/int",
-        "import gleam/int
-import gleam/list
-import a
-"
-    );
-}
-
-#[test]
 fn import_groups_are_respected() {
     assert_format_rewrite!(
         "import group_one/a

--- a/compiler-core/src/format/tests/imports.rs
+++ b/compiler-core/src/format/tests/imports.rs
@@ -52,17 +52,81 @@ import a
 #[test]
 fn import_groups_are_respected() {
     assert_format_rewrite!(
+        "import group_one/a
+import group_one/b
+// another group
+import group_two/wobble
+import group_two/wibble
+// yet another group
+import group_three/b
+import group_three/c
+import group_three/a
+",
+        "import group_one/a
+import group_one/b
+
+// another group
+import group_two/wibble
+import group_two/wobble
+
+// yet another group
+import group_three/a
+import group_three/b
+import group_three/c
+"
+    );
+}
+
+#[test]
+fn empty_lines_define_different_groups() {
+    assert_format_rewrite!(
         "import c
 @target(javascript)
 import b
-// Another group
-import a",
+
+import a
+
+import gleam/string
+import gleam/list",
         "@target(javascript)
 import b
 import c
 
-// Another group
 import a
+
+import gleam/list
+import gleam/string
+"
+    );
+}
+
+#[test]
+fn import_groups_with_empty_lines_and_comments() {
+    assert_format_rewrite!(
+        "import c
+@target(javascript)
+import b
+
+import a
+// third group
+import gleam/string
+import gleam/list
+
+import wobble
+import wibble
+",
+        "@target(javascript)
+import b
+import c
+
+import a
+
+// third group
+import gleam/list
+import gleam/string
+
+import wibble
+import wobble
 "
     );
 }


### PR DESCRIPTION
This PR closes #727

The formatter:
- Preserves comments
- Uses comments/empty lines to tell groups apart and sort those separately
- Sorts all imports of each group alphabetically