### PR TITLE
Allow dependency removal from both inline and regular tables

### DIFF
--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -22,11 +22,11 @@ pub fn command(packages: Vec<String>) -> Result<()> {
     for package_to_remove in packages.iter() {
         #[allow(clippy::indexing_slicing)]
         let _ = toml["dependencies"]
-            .as_table_mut()
+            .as_table_like_mut()
             .and_then(|deps| deps.remove(package_to_remove));
         #[allow(clippy::indexing_slicing)]
         let _ = toml["dev-dependencies"]
-            .as_table_mut()
+            .as_table_like_mut()
             .and_then(|deps| deps.remove(package_to_remove));
     }
 


### PR DESCRIPTION
Use `as_table_like_mut` in favor `as_table_mut` since the later doesn't allow for modifying inline tables and the first handles both.

Fixes https://github.com/gleam-lang/gleam/issues/2586