### PR TITLE
Js list prepending optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Language changes
+
+- Optimised prepending to lists in JavaScript (`[x, ..xs]` syntax).
+
 ### Formatter
 
 - Fixed a bug where a record update's arguments would not be indented correctly.

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -88,6 +88,10 @@ impl<'a> Generator<'a> {
             self.register_prelude_usage(&mut imports, "toList", None);
         };
 
+        if self.tracker.prepend_used {
+            self.register_prelude_usage(&mut imports, "prepend", Some("$prepend"));
+        };
+
         if self.tracker.custom_type_used {
             self.register_prelude_usage(&mut imports, "CustomType", Some("$CustomType"));
         };
@@ -673,6 +677,7 @@ fn maybe_escape_identifier_doc(word: &str) -> Document<'_> {
 pub(crate) struct UsageTracker {
     pub ok_used: bool,
     pub list_used: bool,
+    pub prepend_used: bool,
     pub error_used: bool,
     pub int_remainder_used: bool,
     pub make_error_used: bool,

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -141,16 +141,17 @@ impl<'module> Generator<'module> {
             TypedExpr::Int { value, .. } => Ok(int(value)),
             TypedExpr::Float { value, .. } => Ok(float(value)),
 
-            TypedExpr::List { elements, tail, .. } => {
-                self.tracker.list_used = true;
-                self.not_in_tail_position(|gen| {
-                    let tail = match tail {
-                        Some(tail) => Some(gen.wrap_expression(tail)?),
-                        None => None,
-                    };
-                    list(elements.iter().map(|e| gen.wrap_expression(e)), tail)
-                })
-            }
+            TypedExpr::List { elements, tail, .. } => self.not_in_tail_position(|gen| match tail {
+                Some(tail) => {
+                    gen.tracker.prepend_used = true;
+                    let tail = gen.wrap_expression(tail)?;
+                    prepend(elements.iter().map(|e| gen.wrap_expression(e)), tail)
+                }
+                None => {
+                    gen.tracker.list_used = true;
+                    list(elements.iter().map(|e| gen.wrap_expression(e)))
+                }
+            }),
 
             TypedExpr::Tuple { elems, .. } => self.tuple(elems),
             TypedExpr::TupleIndex { tuple, index, .. } => self.tuple_index(tuple, *index),
@@ -1179,7 +1180,6 @@ pub(crate) fn guard_constant_expression<'a>(
                 elements
                     .iter()
                     .map(|e| guard_constant_expression(assignments, tracker, e)),
-                None,
             )
         }
         Constant::Record { typ, name, .. } if typ.is_bool() && name == "True" => {
@@ -1234,10 +1234,7 @@ pub(crate) fn constant_expression<'a>(
 
         Constant::List { elements, .. } => {
             tracker.list_used = true;
-            list(
-                elements.iter().map(|e| constant_expression(tracker, e)),
-                None,
-            )
+            list(elements.iter().map(|e| constant_expression(tracker, e)))
         }
 
         Constant::Record { typ, name, .. } if typ.is_bool() && name == "True" => {
@@ -1354,20 +1351,22 @@ pub fn array<'a, Elements: IntoIterator<Item = Output<'a>>>(elements: Elements) 
     .group())
 }
 
-fn list<'a, I: IntoIterator<Item = Output<'a>>>(
-    elements: I,
-    tail: Option<Document<'a>>,
-) -> Output<'a>
+fn list<'a, I: IntoIterator<Item = Output<'a>>>(elements: I) -> Output<'a>
 where
     I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
 {
     let array = array(elements);
-    if let Some(tail) = tail {
-        let args = [array, Ok(tail)];
-        Ok(docvec!["toList", call_arguments(args)?])
-    } else {
-        Ok(docvec!["toList(", array?, ")"])
-    }
+    Ok(docvec!["toList(", array?, ")"])
+}
+
+fn prepend<'a, I: IntoIterator<Item = Output<'a>>>(elements: I, tail: Document<'a>) -> Output<'a>
+where
+    I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+{
+    elements.into_iter().rev().fold(Ok(tail), |tail, element| {
+        let args = [element, tail];
+        Ok(docvec!["$prepend", call_arguments(args)?])
+    })
 }
 
 fn call_arguments<'a, Elements: IntoIterator<Item = Output<'a>>>(elements: Elements) -> Output<'a> {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1363,9 +1363,9 @@ fn prepend<'a, I: IntoIterator<Item = Output<'a>>>(elements: I, tail: Document<'
 where
     I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
 {
-    elements.into_iter().rev().fold(Ok(tail), |tail, element| {
-        let args = [element, tail];
-        Ok(docvec!["$prepend", call_arguments(args)?])
+    elements.into_iter().rev().try_fold(tail, |tail, element| {
+        let args = call_arguments([element, Ok(tail)])?;
+        Ok(docvec!["$prepend", args])
     })
 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
@@ -1,14 +1,13 @@
 ---
 source: compiler-core/src/javascript/tests/lists.rs
-assertion_line: 5
 expression: "\nfn go(x) {\n    []\n    [1]\n    [1, 2]\n    [1, 2, ..x]\n}\n"
 ---
-import { toList } from "../gleam.mjs";
+import { toList, prepend as $prepend } from "../gleam.mjs";
 
 function go(x) {
   toList([]);
   toList([1]);
   toList([1, 2]);
-  return toList([1, 2], x);
+  return $prepend(1, $prepend(2, x));
 }
 

--- a/compiler-core/templates/prelude.d.mts
+++ b/compiler-core/templates/prelude.d.mts
@@ -14,6 +14,7 @@ export class List<T> implements Iterable<T> {
   [Symbol.iterator](): Iterator<T>;
 }
 
+export function prepend<T>(element: T, tail: List<T>): List<T>;
 export function toList<T>(array: Array<T>): List<T>;
 
 export class Empty<T = never> extends List<T> {}

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -13,7 +13,10 @@ export class CustomType {
 export class List {
   static fromArray(array, tail) {
     let t = tail || new Empty();
-    return array.reduceRight((xs, x) => new NonEmpty(x, xs), t);
+    for (let i = array.length - 1; i >= 0; --i) {
+      t = new NonEmpty(array[i], t);
+    }
+    return t;
   }
 
   [Symbol.iterator]() {
@@ -47,6 +50,10 @@ export class List {
     for (let _ of this) length++;
     return length;
   }
+}
+
+export function prepend(element, tail) {
+  return new NonEmpty(element, tail)
 }
 
 export function toList(elements, tail) {


### PR DESCRIPTION
This PR changes the compiled JS to call a `prepend` function instead of using the `toList` function, to improve runtime performance. For example `[1, ..xs]` is now compiled to `$prepend(1, xs)` instead of `toList([1], xs)`, where `$prepend` is a thin wrapper over the list constructor.

Related issue #2562

# Benchmarks

A couple of benchmarks comparing the nightly build against this branch.

## gleam-stdlib "time gleam test"

Runtime of the tests of gleam-stdlib measured using `time gleam test` (3 runs).

### before

```
2.98s user 0.37s system 135% cpu 2.471 total
2.85s user 0.37s system 133% cpu 2.409 total
3.00s user 0.39s system 134% cpu 2.516 total
```

### after

```
2.37s user 0.35s system 132% cpu 2.048 total
2.33s user 0.37s system 134% cpu 2.009 total
2.38s user 0.36s system 134% cpu 2.034 total
```

## gleamy_bench example benchmark

Running the example benchmark from the gleamy_bench library.

### before

```
Input               Function           IPS         Min         P99
pre-sorted list     list.sort()     6.5211    146.2742    168.8623
reversed list       list.sort()     5.8963    160.0505    194.4547
```

### after

```
Input               Function           IPS         Min         P99
pre-sorted list     list.sort()     8.2688    113.6544    136.9221
reversed list       list.sort()     8.2111    112.7967    138.6488
```
