### PR TITLE
Adds some documentation improvements on opaqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   though the functions that use them will not be available for use in the root
   package.
 
+### Documentation
+
+- Opaque types are now explicitly tagged in built documentation
+- Constant values are now hidden
 
 ## v1.0.0 - 2024-03-04
 

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -586,6 +586,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
                 })
                 .collect(),
             source_url: source_links.url(ct.location),
+            opaque: ct.opaque,
         }),
 
         Definition::CustomType(CustomType {
@@ -612,6 +613,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
                 Deprecation::NotDeprecated => "".to_string(),
                 Deprecation::Deprecated { message } => message.to_string(),
             },
+            opaque: true,
         }),
 
         Definition::TypeAlias(TypeAlias {
@@ -638,6 +640,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
                 Deprecation::NotDeprecated => "".to_string(),
                 Deprecation::Deprecated { message } => message.to_string(),
             },
+            opaque: false,
         }),
 
         _ => None,
@@ -712,6 +715,7 @@ struct Type<'a> {
     text_documentation: String,
     source_url: String,
     deprecation_message: String,
+    opaque: bool,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -487,8 +487,6 @@ impl<'comments> Formatter<'comments> {
             .append(name)
             .append(": ")
             .append(printer.print(&value.type_()))
-            .append(" = ")
-            .append(self.const_expr(value))
     }
 
     fn documented_definition<'a>(&mut self, s: &'a UntypedDefinition) -> Document<'a> {

--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -527,6 +527,19 @@ body.drawer-open .label-closed {
   margin: 0 0 0 var(--small-gap);
 }
 
+.visibility-tag {
+  background-color: var(--bg-shade-2); 
+  color: var(--text); 
+  padding: 2px 6px; 
+  border-radius: 4px; 
+  border-style: solid;
+  border-width: 1px;
+  border-color: var(--fg-shade-2);
+  font-size: 0.9em; 
+  margin-left: 8px;
+  float: right;
+}
+
 /* Custom type constructors */
 
 .constructor-list {

--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -540,17 +540,6 @@ body.drawer-open .label-closed {
   float: right;
 }
 
-.visibility-tag:hover::after {
-  content: attr(title);
-  display: block;
-  position: absolute;
-  background-color: var(--bg-shade-3);
-  color: var(--fg-shade-3);
-  padding: 6px; 
-  border-radius: 2px;
-  margin-top: 6px; 
-}
-
 /* Custom type constructors */
 
 .constructor-list {

--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -540,6 +540,17 @@ body.drawer-open .label-closed {
   float: right;
 }
 
+.visibility-tag:hover::after {
+  content: attr(title);
+  display: block;
+  position: absolute;
+  background-color: var(--bg-shade-3);
+  color: var(--fg-shade-3);
+  padding: 6px; 
+  border-radius: 2px;
+  margin-top: 6px; 
+}
+
 /* Custom type constructors */
 
 .constructor-list {

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -52,7 +52,7 @@
         </a>
       </h2>
       {% if typ.opaque %} 
-        <span class="visibility-tag">opaque</span>
+        <span class="visibility-tag" title="Direct access to this type's internals is restricted to the module">opaque</span>
       {% endif %}
       {% if !typ.source_url.is_empty() %}
       <a class="member-source" alt="View Source" title="View Source" href="{{ typ.source_url|safe }}">

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -5,7 +5,7 @@
 <h2>Types</h2>
 <ul>
   {% for typ in types %}
-  <li><a href="#{{ typ.name }}">{{ typ.name }}</a> </li>
+  <li><a href="#{{ typ.name }}">{{ typ.name }}</a></li>
   {% endfor %}
 </ul>
 {% endif %}
@@ -52,7 +52,7 @@
         </a>
       </h2>
       {% if typ.opaque %} 
-        <span class="visibility-tag" title="Direct access to this type's internals is restricted to the module">opaque</span>
+        <span class="visibility-tag">opaque</span>
       {% endif %}
       {% if !typ.source_url.is_empty() %}
       <a class="member-source" alt="View Source" title="View Source" href="{{ typ.source_url|safe }}">

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -52,7 +52,7 @@
         </a>
       </h2>
       {% if typ.opaque %} 
-        <span class="visibility-tag">opaque</span>
+      <span class="visibility-tag">opaque</span>
       {% endif %}
       {% if !typ.source_url.is_empty() %}
       <a class="member-source" alt="View Source" title="View Source" href="{{ typ.source_url|safe }}">
@@ -60,7 +60,6 @@
       </a>
       {% endif %}
     </div>
-    
     {% if !typ.deprecation_message.is_empty() %}
     <p>
       <b>Deprecated:</b> {{ typ.deprecation_message }}

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -5,7 +5,7 @@
 <h2>Types</h2>
 <ul>
   {% for typ in types %}
-  <li><a href="#{{ typ.name }}">{{ typ.name }}</a></li>
+  <li><a href="#{{ typ.name }}">{{ typ.name }}</a> </li>
   {% endfor %}
 </ul>
 {% endif %}
@@ -51,12 +51,16 @@
           {{ typ.name }}
         </a>
       </h2>
+      {% if typ.opaque %} 
+        <span class="visibility-tag">opaque</span>
+      {% endif %}
       {% if !typ.source_url.is_empty() %}
       <a class="member-source" alt="View Source" title="View Source" href="{{ typ.source_url|safe }}">
         &lt;/&gt;
       </a>
       {% endif %}
     </div>
+    
     {% if !typ.deprecation_message.is_empty() %}
     <p>
       <b>Deprecated:</b> {{ typ.deprecation_message }}

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -50,10 +50,7 @@
         <a href="#{{ typ.name }}">
           {{ typ.name }}
         </a>
-      </h2>
-      {% if typ.opaque %} 
-      <span class="visibility-tag">opaque</span>
-      {% endif %}
+      </h2>{% if typ.opaque %} <span class="visibility-tag">opaque</span> {% endif %}
       {% if !typ.source_url.is_empty() %}
       <a class="member-source" alt="View Source" title="View Source" href="{{ typ.source_url|safe }}">
         &lt;/&gt;


### PR DESCRIPTION
In an effort to get myself hacking on gleam, I attempted working on #2111. After some back and forth and asking in Discord, I ran with https://github.com/gleam-lang/gleam/pull/2446 and just hid the `const` implementation for the time being.

Since I also dove a bit into CSS, this offers an explicit marker should a type be `opaque`. I _think_ this should improve readability.

Potentially closes #2111.