### PR TITLE
Fix bug in target implementation enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-## Language changes
+## Compiler
 
 - Prepending to lists in JavaScript (`[x, ..xs]` syntax) has been optimised.
 - Function stubs are no longer generated for functions that do not have an
   implementation for the current targeting being compiled for.
+- Fixed a bug where some functions would not result in a compile error when
+  compiled for a target that they do not support.
 
 ### Formatter
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -16,7 +16,7 @@ use crate::{
         self,
         environment::*,
         error::{convert_unify_error, Error, MissingAnnotation},
-        expression::{ExprTyper, Implementations},
+        expression::{ExprTyper, Externals, Implementations},
         fields::{FieldMap, FieldMapBuilder},
         hydrator::Hydrator,
         prelude::*,
@@ -661,10 +661,9 @@ fn infer_function(
         ensure_annotations_present(&arguments, return_annotation.as_ref(), location)?;
     }
 
-    let external_implementations = Implementations {
-        gleam: false,
-        uses_erlang_externals: external_erlang.is_some(),
-        uses_javascript_externals: external_javascript.is_some(),
+    let externals = Externals {
+        erlang: external_erlang.is_some(),
+        javascript: external_javascript.is_some(),
     };
 
     // Infer the type using the preregistered args + return types as a starting point
@@ -674,7 +673,7 @@ fn infer_function(
             .zip(&args_types)
             .map(|(a, t)| a.set_type(t.clone()))
             .collect();
-        let mut expr_typer = ExprTyper::new(environment, external_implementations);
+        let mut expr_typer = ExprTyper::new(environment, externals);
         expr_typer.hydrator = hydrators
             .remove(&name)
             .expect("Could not find hydrator for fn");
@@ -984,10 +983,9 @@ fn infer_module_constant(
 
     let mut expr_typer = ExprTyper::new(
         environment,
-        Implementations {
-            gleam: false,
-            uses_erlang_externals: false,
-            uses_javascript_externals: false,
+        Externals {
+            erlang: false,
+            javascript: false,
         },
     );
     let typed_expr = expr_typer.infer_const(&annotation, *value)?;

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -16,7 +16,7 @@ use crate::{
         self,
         environment::*,
         error::{convert_unify_error, Error, MissingAnnotation},
-        expression::{ExprTyper, Externals, Implementations},
+        expression::{ExprTyper, Externals},
         fields::{FieldMap, FieldMapBuilder},
         hydrator::Hydrator,
         prelude::*,

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::analyse::TargetSupport;
 use crate::build::Target;
-use crate::type_::expression::Implementations;
+use crate::type_::expression::{Externals, Implementations};
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME};
 use crate::{
     ast::{SrcSpan, TypedExpr},
@@ -129,10 +129,9 @@ fn compile_expression(src: &str) -> TypedStatement {
     );
     ExprTyper::new(
         &mut environment,
-        Implementations {
-            gleam: false,
-            uses_erlang_externals: false,
-            uses_javascript_externals: false,
+        Externals {
+            erlang: false,
+            javascript: false,
         },
     )
     .infer_statements(ast)

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::analyse::TargetSupport;
 use crate::build::Target;
-use crate::type_::expression::{Externals, Implementations};
+use crate::type_::expression::Externals;
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME};
 use crate::{
     ast::{SrcSpan, TypedExpr},

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     bit_array,
     build::{Origin, Target},
+    type_::expression::Implementations,
 };
 use error::*;
 use hydrator::Hydrator;
@@ -36,8 +37,6 @@ use std::{
     ops::Deref,
     sync::Arc,
 };
-
-use self::expression::Implementations;
 
 pub trait HasType {
     fn type_(&self) -> Arc<Type>;

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -619,6 +619,8 @@ impl ModuleInterface {
             .get(&EcoString::from("main"))
             .ok_or_else(not_found)?;
 
+        dbg!(&value);
+
         assert_suitable_main_function(value, &self.name, target)?;
 
         Ok(ModuleFunction {


### PR DESCRIPTION
This code previously would not result in a compile error on Erlang:

```gleam
import gleam/io

@external(javascript, "test.mjs", "now")
fn now() -> Nil

pub fn main() {
  io.debug(now())
}
```

This was because when checking if the current function had an external implementation we looked at the implementation struct, but this struct was also being used to track whether any of the functions previously called had external implementations, so it was no longer a reliable indicator of externals for the current function.

To fix this I've split it into two structs. One is mutated over time (tracking all referenced functions), one remains the same (the current function's externals).