### PR TITLE
Add support for FORCE_COLOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Generated documentation no longer exposes the constructors of opaque types,
   no longer exposes the values of constants, and indicates which types are
   opaque.
-- Terminal colors can now be forced by setting the `FORCE_COLORS` environment
+- Terminal colors can now be forced by setting the `FORCE_COLOR` environment
   variable to any non-empty value.
 
 ## Language Server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Generated documentation no longer exposes the constructors of opaque types,
   no longer exposes the values of constants, and indicates which types are
   opaque.
+- Terminal colors can now be forced by setting the `FORCE_COLORS` environment
+  variable to any non-empty value.
 
 ## Language Server
 

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -185,7 +185,7 @@ pub fn stdout_buffer_writer() -> BufferWriter {
 }
 
 fn color_choice() -> ColorChoice {
-    if atty::is(atty::Stream::Stderr) {
+    if atty::is(atty::Stream::Stderr) || std::env::var("FORCE_COLOR").is_ok() {
         termcolor::ColorChoice::Auto
     } else {
         termcolor::ColorChoice::Never

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -184,8 +184,16 @@ pub fn stdout_buffer_writer() -> BufferWriter {
     termcolor::BufferWriter::stdout(color_choice())
 }
 
+fn should_force_color() -> bool {
+    if let Ok(force_color_value) = std::env::var("FORCE_COLOR") {
+        !force_color_value.is_empty()
+    } else {
+        false
+    }
+}
+
 fn color_choice() -> ColorChoice {
-    if atty::is(atty::Stream::Stderr) || std::env::var("FORCE_COLOR").is_ok() {
+    if atty::is(atty::Stream::Stderr) || should_force_color() {
         termcolor::ColorChoice::Auto
     } else {
         termcolor::ColorChoice::Never


### PR DESCRIPTION
Fixes #2652 

Added support for forcing colored output even if stderr is not connected to terminal using `FORCE_COLOR` environment variable.
Helpful in situations when running a command like `watch gleam build`.