### PR TITLE
Fixed broken link in strings escape code error message

### DIFF
--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -279,7 +279,7 @@ impl LexicalError {
                 "I don't understand this escape code",
                 vec![
                     "Hint: Add another backslash before it.".into(),
-                    "See: https://gleam.run/book/tour/strings.html#escape-sequences".into(),
+                    "See: https://tour.gleam.run/basics/strings".into(),
                 ],
             ),
             LexicalErrorType::DigitOutOfRadix => {


### PR DESCRIPTION
The error message for escape codes in strings included a broken link (https://github.com/gleam-lang/gleam/issues/2667). This replaces that with the correct url.