### PR TITLE
Add support for generating type references (javascript/typescript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Generate [type references](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-)
   when compiling to JavaScript with TypeScript definitions enabled.
 
+
 ### Formatter
 
 - The formatting of case expressions with multiple subjects has been improved.
@@ -47,6 +48,7 @@
 - Fixed a bug where hovering over an expression in the middle of a pipe would
   give the wrong node.
 
+
 ## v1.0.0 - 2024-03-04
 
 ### Language changes
@@ -73,6 +75,7 @@
 - The format used by the formatter has been improved in some niche cases.
 - Improved the formatting of long case guards.
 - The formatter can now format groups of imports alphabetically.
+
 
 ## v1.0.0-rc1 - 2024-02-10
 
@@ -119,6 +122,7 @@
 - Fixed a bug where external only functions would "successfully" compile for a
   target they do not support, leading to a runtime error.
 
+
 ## v0.34.1 - 2023-01-17
 
 ### Build tool changes
@@ -131,6 +135,7 @@
   format incorrectly.
 - The `@deprecated` attribute can now be used to annotate module constants.
   This will cause a warning to be emitted when the constant is used.
+
 
 ## v0.34.0 - 2023-01-16
 
@@ -149,6 +154,7 @@
 - Fixed a bug where function heads would go over the line limit in the
   formatter.
 
+
 ## v0.34.0-rc2 - 2023-01-11
 
 ### Bug fixes
@@ -158,6 +164,7 @@
 - Fixed a bug where the compiler would in some cases fail to error when an
   application uses functions that do not support the current compilation
   target.
+
 
 ## v0.34.0-rc1 - 2024-01-07
 
@@ -188,7 +195,7 @@
 
 - The `gleam new` command now accepts any existing path, as long as there are
   no conflicts with already existing files. Examples: `gleam new .`, `gleam new
-..`, `gleam new ~/projects/test`.
+  ..`, `gleam new ~/projects/test`.
 - The format for the README created by `gleam new` has been altered.
 - The `gleam.toml` created by `gleam new` now has a link to the full reference
   for its available options.
@@ -222,6 +229,7 @@
   "Type 'Result' is not generic".
 - Not providing a definition after some attributes is now a parse error.
 
+
 ## v0.33.0 - 2023-12-18
 
 ## v0.33.0-rc4 - 2023-12-17
@@ -231,6 +239,7 @@
 - The deprecated `BitString` type has been removed.
 - The deprecated `inspect` functions and `BitString` type has been removed from
   the JavaScript prelude.
+
 
 ## v0.33.0-rc3 - 2023-12-17
 
@@ -245,6 +254,7 @@
 - Fixed a bug where string prefix aliases defined in alternative case branches
   would all be bound to the same constant.
 
+
 ## v0.33.0-rc2 - 2023-12-07
 
 ### Language changes
@@ -257,6 +267,7 @@
 
 - Fixed a bug where the `\u` string escape sequence would not work with
   on Erlang on the right hand side of a string concatenation.
+
 
 ## v0.33.0-rc1 - 2023-12-06
 
@@ -327,6 +338,7 @@
 - Fixed a bug where using a string prefix pattern in `let assert` would generate
   incorrect JavaScript.
 
+
 ## v0.32.4 - 2023-11-09
 
 ### Build tool changes
@@ -341,6 +353,7 @@
   argument has the same name as the module function.
 - Fixed the `target` property of `gleam.toml` being ignored for local path
   dependencies by `gleam run -m module/name`
+
 
 ## v0.32.3 - 2023-11-07
 
@@ -359,6 +372,7 @@
 
 - Fixed a bug where some nested pipelines could fail to type check.
 
+
 ## v0.32.2 - 2023-11-03
 
 ### Build tool changes
@@ -374,6 +388,7 @@
 - Fixed a bug where aliased unqualified types and values of the same name could
   produce an incorrect error.
 
+
 ## v0.32.1 - 2023-11-02
 
 ### Bug fixes
@@ -383,12 +398,14 @@
 - Fixed a bug where incorrect JavaScript could be generated due to backwards
   compatibility with the deprecated import syntax.
 
+
 ## v0.32.0 - 2023-11-01
 
 ### Bug fixes
 
 - Fixed a bug where running `gleam fix` multiple times could produce incorrect
   results.
+
 
 ## v0.32.0-rc3 - 2023-10-26
 
@@ -397,12 +414,14 @@
 - Fixed a bug where `gleam fix` would fail to update the deprecated type import
   syntax for aliased unqualified types.
 
+
 ## v0.32.0-rc2 - 2023-10-26
 
 ### Bug fixes
 
 - Fixed a bug where the backward compatibility for the deprecated import syntax
   could result in an import error with some valid imports.
+
 
 ## v0.32.0-rc1 - 2023-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - URLs in error messages have been updated for the new language tour.
 - Improved error message when erroneously trying to append items to a list using
   the spread syntax (like `[..rest, last]`).
+- Generate [type references](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-)
+  when compiling to JavaScript with TypeScript definitions enabled.
 
 ### Formatter
 
@@ -45,7 +47,6 @@
 - Fixed a bug where hovering over an expression in the middle of a pipe would
   give the wrong node.
 
-
 ## v1.0.0 - 2024-03-04
 
 ### Language changes
@@ -72,7 +73,6 @@
 - The format used by the formatter has been improved in some niche cases.
 - Improved the formatting of long case guards.
 - The formatter can now format groups of imports alphabetically.
-
 
 ## v1.0.0-rc1 - 2024-02-10
 
@@ -119,7 +119,6 @@
 - Fixed a bug where external only functions would "successfully" compile for a
   target they do not support, leading to a runtime error.
 
-
 ## v0.34.1 - 2023-01-17
 
 ### Build tool changes
@@ -132,7 +131,6 @@
   format incorrectly.
 - The `@deprecated` attribute can now be used to annotate module constants.
   This will cause a warning to be emitted when the constant is used.
-
 
 ## v0.34.0 - 2023-01-16
 
@@ -151,7 +149,6 @@
 - Fixed a bug where function heads would go over the line limit in the
   formatter.
 
-
 ## v0.34.0-rc2 - 2023-01-11
 
 ### Bug fixes
@@ -161,7 +158,6 @@
 - Fixed a bug where the compiler would in some cases fail to error when an
   application uses functions that do not support the current compilation
   target.
-
 
 ## v0.34.0-rc1 - 2024-01-07
 
@@ -192,7 +188,7 @@
 
 - The `gleam new` command now accepts any existing path, as long as there are
   no conflicts with already existing files. Examples: `gleam new .`, `gleam new
-  ..`, `gleam new ~/projects/test`.
+..`, `gleam new ~/projects/test`.
 - The format for the README created by `gleam new` has been altered.
 - The `gleam.toml` created by `gleam new` now has a link to the full reference
   for its available options.
@@ -226,7 +222,6 @@
   "Type 'Result' is not generic".
 - Not providing a definition after some attributes is now a parse error.
 
-
 ## v0.33.0 - 2023-12-18
 
 ## v0.33.0-rc4 - 2023-12-17
@@ -236,7 +231,6 @@
 - The deprecated `BitString` type has been removed.
 - The deprecated `inspect` functions and `BitString` type has been removed from
   the JavaScript prelude.
-
 
 ## v0.33.0-rc3 - 2023-12-17
 
@@ -251,7 +245,6 @@
 - Fixed a bug where string prefix aliases defined in alternative case branches
   would all be bound to the same constant.
 
-
 ## v0.33.0-rc2 - 2023-12-07
 
 ### Language changes
@@ -264,7 +257,6 @@
 
 - Fixed a bug where the `\u` string escape sequence would not work with
   on Erlang on the right hand side of a string concatenation.
-
 
 ## v0.33.0-rc1 - 2023-12-06
 
@@ -335,7 +327,6 @@
 - Fixed a bug where using a string prefix pattern in `let assert` would generate
   incorrect JavaScript.
 
-
 ## v0.32.4 - 2023-11-09
 
 ### Build tool changes
@@ -350,7 +341,6 @@
   argument has the same name as the module function.
 - Fixed the `target` property of `gleam.toml` being ignored for local path
   dependencies by `gleam run -m module/name`
-
 
 ## v0.32.3 - 2023-11-07
 
@@ -369,7 +359,6 @@
 
 - Fixed a bug where some nested pipelines could fail to type check.
 
-
 ## v0.32.2 - 2023-11-03
 
 ### Build tool changes
@@ -385,7 +374,6 @@
 - Fixed a bug where aliased unqualified types and values of the same name could
   produce an incorrect error.
 
-
 ## v0.32.1 - 2023-11-02
 
 ### Bug fixes
@@ -395,14 +383,12 @@
 - Fixed a bug where incorrect JavaScript could be generated due to backwards
   compatibility with the deprecated import syntax.
 
-
 ## v0.32.0 - 2023-11-01
 
 ### Bug fixes
 
 - Fixed a bug where running `gleam fix` multiple times could produce incorrect
   results.
-
 
 ## v0.32.0-rc3 - 2023-10-26
 
@@ -411,14 +397,12 @@
 - Fixed a bug where `gleam fix` would fail to update the deprecated type import
   syntax for aliased unqualified types.
 
-
 ## v0.32.0-rc2 - 2023-10-26
 
 ### Bug fixes
 
 - Fixed a bug where the backward compatibility for the deprecated import syntax
   could result in an import error with some valid imports.
-
 
 ## v0.32.0-rc1 - 2023-10-25
 

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -253,6 +253,7 @@ impl<'a> JavaScript<'a> {
             &module.input_path,
             &module.code,
             self.target_support,
+            self.typescript,
         );
         tracing::debug!(name = ?js_name, "Generated js module");
         writer.write(&path, &output?)

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -164,7 +164,7 @@ impl<'a> Generator<'a> {
         // Put it all together
 
         if imports.is_empty() && statements.is_empty() {
-            Ok(docvec!(type_reference, "export {}", line()))
+            Ok(docvec![type_reference, "export {}", line()])
         } else if imports.is_empty() {
             statements.push(line());
             Ok(docvec![type_reference, statements])

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -70,7 +70,16 @@ impl<'a> Generator<'a> {
             return Document::Str("");
         }
 
-        let name = Document::EcoString(self.module.name.clone());
+        // Get the name of the module relative the directory (similar to basename)
+        let module = self
+            .module
+            .name
+            .as_str()
+            .split('/')
+            .last()
+            .expect("JavaScript generator could not identify imported module name.");
+
+        let name = Document::Str(module);
 
         docvec!["/// <reference types=\"./", name, ".d.mts\" />", line()]
     }

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -42,7 +42,6 @@ pub struct Generator<'a> {
     module_scope: im::HashMap<EcoString, usize>,
     current_module_name_segments_count: usize,
     target_support: TargetSupport,
-
     typescript: TypeScriptDeclarations,
 }
 

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -140,6 +140,7 @@ pub fn compile_js(src: &str, deps: Vec<(&str, &str, &str)>) -> String {
         Utf8Path::new(""),
         &"".into(),
         TargetSupport::NotEnforced,
+        TypeScriptDeclarations::None,
     )
     .unwrap()
 }

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -1,6 +1,5 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 201
 expression: "./cases/javascript_d_ts"
 ---
 //// /out/lib/the_package/_gleam_artefacts/hello.cache
@@ -28,6 +27,7 @@ export function wobble(): Wibble$;
 
 
 //// /out/lib/the_package/hello.mjs
+/// <reference types="./hello.d.mts" />
 import { CustomType as $CustomType } from "./gleam.mjs";
 
 export class Woo extends $CustomType {}
@@ -35,6 +35,3 @@ export class Woo extends $CustomType {}
 export function wobble() {
   return new Woo();
 }
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -1,6 +1,5 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 225
 expression: "./cases/javascript_import"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
@@ -32,6 +31,7 @@ export type A$ = A;
 
 
 //// /out/lib/the_package/one/two.mjs
+/// <reference types="./one/two.d.mts" />
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class A extends $CustomType {}
@@ -44,9 +44,7 @@ export const x: $two.A$;
 
 
 //// /out/lib/the_package/two.mjs
+/// <reference types="./two.d.mts" />
 import * as $two from "./one/two.mjs";
 
 export const x = new $two.A();
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -31,7 +31,7 @@ export type A$ = A;
 
 
 //// /out/lib/the_package/one/two.mjs
-/// <reference types="./one/two.d.mts" />
+/// <reference types="./two.d.mts" />
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class A extends $CustomType {}


### PR DESCRIPTION
Improves JavaScript codegen by adding [type references](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) to JS files when TypeScript types are generated.

Example:
```javascript
/// <reference types="./hello.d.mts" />
import { CustomType as $CustomType } from "./gleam.mjs";

export class Woo extends $CustomType {}

export function wobble() {
  return new Woo();
}
```

References are only generated when TypeScript definitions are enabled

I did my best to follow existing conventions around documents and formatting. Closes #2410