### PR TITLE
Fix the syntax example comment for `RightSquare` in the tokenizer

### DIFF
--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -15,7 +15,7 @@ pub enum Token {
     LeftParen,   // (
     RightParen,  // )
     LeftSquare,  // [
-    RightSquare, // }
+    RightSquare, // ]
     LeftBrace,   // {
     RightBrace,  // }
     // Int Operators


### PR DESCRIPTION
Closes #2677