### PR TITLE
Fix hovering over expressions in the middle of pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   implementation for the current targeting being compiled for.
 - Fixed a bug where some functions would not result in a compile error when
   compiled for a target that they do not support.
+- Fixed a bug where hovering over an expression in the middle of a pipe would
+  give the wrong node.
 
 ### Formatter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@
   implementation for the current targeting being compiled for.
 - Fixed a bug where some functions would not result in a compile error when
   compiled for a target that they do not support.
-- Fixed a bug where hovering over an expression in the middle of a pipe would
-  give the wrong node.
 
 ### Formatter
 
@@ -38,6 +36,8 @@
 - The `Compiling Gleam` message is no longer emitted each time code is compiled.
   This is to reduce noise in editors that show this message prominently such as
   Neovim.
+- Fixed a bug where hovering over an expression in the middle of a pipe would
+  give the wrong node.
 
 
 ## v1.0.0 - 2024-03-04

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1336,6 +1336,13 @@ impl TypedPattern {
             return None;
         }
 
+        if let Pattern::Variable { name, .. } = self {
+            // For pipes the pattern can't be pointed to
+            if name.as_str().eq(PIPE_VARIABLE) {
+                return None;
+            }
+        }
+
         match self {
             Pattern::Int { .. }
             | Pattern::Float { .. }

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -107,6 +107,7 @@ fn() -> Nil
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/2654
 #[test]
 fn hover_local_function_in_pipe() {
     let code = "

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -108,6 +108,113 @@ fn() -> Nil
 }
 
 #[test]
+fn hover_local_function_in_pipe() {
+    let code = "
+fn add1(num: Int) -> Int {
+  num + 1
+}
+
+pub fn main() {
+  add1(1)
+
+  1
+  |> add1
+  |> add1
+  |> add1
+}
+";
+
+    assert_eq!(
+        positioned_hover(code, Position::new(6, 3)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam
+fn(Int) -> Int
+```
+"
+                .to_string()
+            )),
+            range: Some(Range {
+                start: Position {
+                    line: 6,
+                    character: 2,
+                },
+                end: Position {
+                    line: 6,
+                    character: 6,
+                },
+            },),
+        })
+    );
+    assert_eq!(
+        positioned_hover(code, Position::new(9, 7)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam
+fn(Int) -> Int
+```
+"
+                .to_string()
+            )),
+            range: Some(Range {
+                start: Position {
+                    line: 9,
+                    character: 5,
+                },
+                end: Position {
+                    line: 9,
+                    character: 9,
+                },
+            },),
+        })
+    );
+    assert_eq!(
+        positioned_hover(code, Position::new(10, 7)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam
+fn(Int) -> Int
+```
+"
+                .to_string()
+            )),
+            range: Some(Range {
+                start: Position {
+                    line: 10,
+                    character: 5,
+                },
+                end: Position {
+                    line: 10,
+                    character: 9,
+                },
+            },),
+        })
+    );
+    assert_eq!(
+        positioned_hover(code, Position::new(11, 7)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam
+fn(Int) -> Int
+```
+"
+                .to_string()
+            )),
+            range: Some(Range {
+                start: Position {
+                    line: 11,
+                    character: 5,
+                },
+                end: Position {
+                    line: 11,
+                    character: 9,
+                },
+            },),
+        })
+    );
+}
+
+#[test]
 fn hover_imported_function() {
     let io = LanguageServerTestIO::new();
     _ = io.src_module("example_module", "pub fn my_fn() { Nil }");


### PR DESCRIPTION
Closes #2654 

The issue ultimately comes down to the fact that pipelines before the final one are rewritten as assignments to a temp pipe variable. As such the hover behavior treats the thing being hovered over as the pipeline return value instead of the pipeline itself. This doesn't feel like the idiomatic way to solve this (I don't have much rust experience and this feels like something that maybe should be treated differently at the AST level?) but at the very least it provides a nice test case