### PR TITLE
add lsp tests for some basic goto_def cases

### DIFF
--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -138,15 +138,6 @@ where
         self.compiler.take_warnings()
     }
 
-    // TODO: test local variables
-    // TODO: test same module constants
-    // TODO: test imported module constants
-    // TODO: test unqualified imported module constants
-    // TODO: test same module records
-    // TODO: test imported module records
-    // TODO: test unqualified imported module records
-    // TODO: test same module functions
-    // TODO: test module function calls
     // TODO: test different package module function calls
     //
     //

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -1,0 +1,367 @@
+use lsp_types::{
+    GotoDefinitionParams, Location, Position, Range, TextDocumentIdentifier,
+    TextDocumentPositionParams, Url,
+};
+
+use super::*;
+
+fn positioned_with_io(
+    src: &str,
+    position: Position,
+    io: &LanguageServerTestIO,
+) -> Option<Location> {
+    let mut engine = setup_engine(io);
+
+    let _ = io.src_module("app", src);
+    for package in &io.manifest.packages {
+        add_package_from_manifest(&mut engine, package.clone());
+    }
+    let response = engine.compile_please();
+    assert!(response.result.is_ok());
+
+    let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
+        r"\\?\C:\src\app.gleam"
+    } else {
+        "/src/app.gleam"
+    });
+
+    let url = Url::from_file_path(path).unwrap();
+
+    let params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams::new(
+            TextDocumentIdentifier::new(url),
+            position,
+        ),
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let response = engine.goto_definition(params);
+
+    response.result.unwrap()
+}
+
+fn positioned_goto_definition(src: &str, position: Position) -> Option<Location> {
+    positioned_with_io(src, position, &LanguageServerTestIO::new())
+}
+
+#[test]
+fn goto_definition_local_variable() {
+    let code = "
+pub fn main() {
+  let x = 1
+  x
+}";
+
+    assert_eq!(
+        positioned_goto_definition(code, Position::new(3, 2)),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\app.gleam"
+            } else {
+                "/src/app.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 6
+                },
+                end: Position {
+                    line: 2,
+                    character: 7
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_same_module_constants() {
+    let code = "
+const x = 1
+
+pub fn main() {
+  x
+}";
+
+    assert_eq!(
+        positioned_goto_definition(code, Position::new(4, 2)),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\app.gleam"
+            } else {
+                "/src/app.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 6
+                },
+                end: Position {
+                    line: 1,
+                    character: 7
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_same_module_functions() {
+    let code = "
+fn add_2(x) {
+  x + 2
+}
+
+pub fn main() {
+  add_2(1)
+}";
+
+    assert_eq!(
+        positioned_goto_definition(code, Position::new(6, 3)),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\app.gleam"
+            } else {
+                "/src/app.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0
+                },
+                end: Position {
+                    line: 1,
+                    character: 11
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_same_module_records() {
+    let code = "
+pub type Rec {
+  Var1(Int)
+  Var2(Int, Int)
+}
+
+pub fn main() {
+  let a = Var1(1)
+  let b = Var2(2, 3)
+}";
+
+    assert_eq!(
+        positioned_goto_definition(code, Position::new(7, 11)),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\app.gleam"
+            } else {
+                "/src/app.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 2
+                },
+                end: Position {
+                    line: 2,
+                    character: 11
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_imported_module_constants() {
+    let io = LanguageServerTestIO::new();
+    _ = io.src_module("example_module", "pub const my_num = 1");
+
+    let code = "
+import example_module
+fn main() {
+  example_module.my_num
+}
+";
+
+    assert_eq!(
+        positioned_with_io(code, Position::new(3, 19), &io),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 10
+                },
+                end: Position {
+                    line: 0,
+                    character: 16
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_unqualified_imported_module_constants() {
+    let io = LanguageServerTestIO::new();
+    _ = io.src_module("example_module", "pub const my_num = 1");
+
+    let code = "
+import example_module.{my_num}
+fn main() {
+  my_num
+}
+";
+
+    assert_eq!(
+        positioned_with_io(code, Position::new(3, 3), &io),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 10
+                },
+                end: Position {
+                    line: 0,
+                    character: 16
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_module_function_calls() {
+    let io = LanguageServerTestIO::new();
+    _ = io.src_module("example_module", "pub fn my_fn() { Nil }");
+
+    let code = "
+import example_module
+fn main() {
+  example_module.my_fn
+}
+";
+
+    assert_eq!(
+        positioned_with_io(code, Position::new(3, 19), &io),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0
+                },
+                end: Position {
+                    line: 0,
+                    character: 14
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_imported_module_records() {
+    let io = LanguageServerTestIO::new();
+    _ = io.src_module(
+        "example_module",
+        "
+pub type Rec {
+  Var1(Int)
+  Var2(Int, Int)
+}",
+    );
+
+    let code = "
+import example_module
+fn main() {
+  example_module.Var1(1)
+}
+";
+
+    assert_eq!(
+        positioned_with_io(code, Position::new(3, 20), &io),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 2
+                },
+                end: Position {
+                    line: 2,
+                    character: 11
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_unqualified_imported_module_records() {
+    let io = LanguageServerTestIO::new();
+    _ = io.src_module(
+        "example_module",
+        "
+pub type Rec {
+  Var1(Int)
+  Var2(Int, Int)
+}",
+    );
+
+    let code = "
+import example_module.{Var1}
+fn main() {
+  Var1(1)
+}
+";
+
+    assert_eq!(
+        positioned_with_io(code, Position::new(3, 3), &io),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 2
+                },
+                end: Position {
+                    line: 2,
+                    character: 11
+                }
+            }
+        })
+    )
+}

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -1,37 +1,16 @@
-use lsp_types::{
-    GotoDefinitionParams, Location, Position, Range, TextDocumentIdentifier,
-    TextDocumentPositionParams, Url,
-};
+use lsp_types::{GotoDefinitionParams, Location, Position, Range, Url};
 
 use super::*;
 
-fn positioned_with_io(
+fn positioned_with_io_definition(
     src: &str,
     position: Position,
     io: &LanguageServerTestIO,
 ) -> Option<Location> {
-    let mut engine = setup_engine(io);
-
-    let _ = io.src_module("app", src);
-    for package in &io.manifest.packages {
-        add_package_from_manifest(&mut engine, package.clone());
-    }
-    let response = engine.compile_please();
-    assert!(response.result.is_ok());
-
-    let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
-        r"\\?\C:\src\app.gleam"
-    } else {
-        "/src/app.gleam"
-    });
-
-    let url = Url::from_file_path(path).unwrap();
+    let (mut engine, position_param) = positioned_with_io(src, position, io);
 
     let params = GotoDefinitionParams {
-        text_document_position_params: TextDocumentPositionParams::new(
-            TextDocumentIdentifier::new(url),
-            position,
-        ),
+        text_document_position_params: position_param,
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
@@ -41,7 +20,7 @@ fn positioned_with_io(
 }
 
 fn positioned_goto_definition(src: &str, position: Position) -> Option<Location> {
-    positioned_with_io(src, position, &LanguageServerTestIO::new())
+    positioned_with_io_definition(src, position, &LanguageServerTestIO::new())
 }
 
 #[test]
@@ -190,7 +169,7 @@ fn main() {
 ";
 
     assert_eq!(
-        positioned_with_io(code, Position::new(3, 19), &io),
+        positioned_with_io_definition(code, Position::new(3, 19), &io),
         Some(Location {
             uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
                 r"\\?\C:\src\example_module.gleam"
@@ -225,7 +204,7 @@ fn main() {
 ";
 
     assert_eq!(
-        positioned_with_io(code, Position::new(3, 3), &io),
+        positioned_with_io_definition(code, Position::new(3, 3), &io),
         Some(Location {
             uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
                 r"\\?\C:\src\example_module.gleam"
@@ -260,7 +239,7 @@ fn main() {
 ";
 
     assert_eq!(
-        positioned_with_io(code, Position::new(3, 19), &io),
+        positioned_with_io_definition(code, Position::new(3, 19), &io),
         Some(Location {
             uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
                 r"\\?\C:\src\example_module.gleam"
@@ -302,7 +281,7 @@ fn main() {
 ";
 
     assert_eq!(
-        positioned_with_io(code, Position::new(3, 20), &io),
+        positioned_with_io_definition(code, Position::new(3, 20), &io),
         Some(Location {
             uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
                 r"\\?\C:\src\example_module.gleam"
@@ -344,7 +323,7 @@ fn main() {
 ";
 
     assert_eq!(
-        positioned_with_io(code, Position::new(3, 3), &io),
+        positioned_with_io_definition(code, Position::new(3, 3), &io),
         Some(Location {
             uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
                 r"\\?\C:\src\example_module.gleam"

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1,33 +1,16 @@
-use lsp_types::{
-    Hover, HoverContents, HoverParams, MarkedString, Position, Range, TextDocumentIdentifier,
-    TextDocumentPositionParams, Url,
-};
+use lsp_types::{Hover, HoverContents, HoverParams, MarkedString, Position, Range};
 
 use super::*;
 
-fn positioned_with_io(src: &str, position: Position, io: &LanguageServerTestIO) -> Option<Hover> {
-    let mut engine = setup_engine(io);
-
-    _ = io.src_module("app", src);
-    for package in &io.manifest.packages {
-        add_package_from_manifest(&mut engine, package.clone());
-    }
-    let response = engine.compile_please();
-    assert!(response.result.is_ok());
-
-    let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
-        r"\\?\C:\src\app.gleam"
-    } else {
-        "/src/app.gleam"
-    });
-
-    let url = Url::from_file_path(path).unwrap();
+fn positioned_with_io_hover(
+    src: &str,
+    position: Position,
+    io: &LanguageServerTestIO,
+) -> Option<Hover> {
+    let (mut engine, position_param) = positioned_with_io(src, position, io);
 
     let params = HoverParams {
-        text_document_position_params: TextDocumentPositionParams::new(
-            TextDocumentIdentifier::new(url),
-            position,
-        ),
+        text_document_position_params: position_param,
         work_done_progress_params: Default::default(),
     };
     let response = engine.hover(params);
@@ -36,7 +19,7 @@ fn positioned_with_io(src: &str, position: Position, io: &LanguageServerTestIO) 
 }
 
 fn positioned_hover(src: &str, position: Position) -> Option<Hover> {
-    positioned_with_io(src, position, &LanguageServerTestIO::new())
+    positioned_with_io_hover(src, position, &LanguageServerTestIO::new())
 }
 
 #[test]
@@ -228,7 +211,7 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io(code, Position::new(3, 19), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 19), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -246,7 +229,7 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io(code, Position::new(3, 19), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 19), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -264,7 +247,7 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io(code, Position::new(3, 5), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 5), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -282,7 +265,7 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io(code, Position::new(3, 22), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 22), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -300,7 +283,7 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io(code, Position::new(3, 6), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 6), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -323,7 +306,7 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io(code, Position::new(3, 22), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 22), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -348,7 +331,7 @@ fn main() {
 "#;
 
     // hovering over "my_fn"
-    let hover = positioned_with_io(code, Position::new(3, 22), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 22), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -366,7 +349,7 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io(code, Position::new(3, 19), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 19), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -384,7 +367,7 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io(code, Position::new(3, 5), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(3, 5), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -404,7 +387,7 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io(code, Position::new(4, 22), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(4, 22), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -424,7 +407,7 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io(code, Position::new(4, 8), &io).unwrap();
+    let hover = positioned_with_io_hover(code, Position::new(4, 8), &io).unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -1,6 +1,7 @@
 mod action;
 mod compilation;
 mod completion;
+mod definition;
 mod hover;
 
 use std::{


### PR DESCRIPTION
This pr just adds unit tests to the existing language server implementation. Was originally thinking about looking into https://github.com/gleam-lang/gleam/issues/2655 but realized I probably need to read more/wanted to start with something smaller so just leaving the test cases here that I saw in the todos (hopefully helps the next person with implementing)