### PR TITLE
Fix javascript return issue with multistatement blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   the spread syntax (like `[..rest, last]`).
 - Generate [type references](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-)
   when compiling to JavaScript with TypeScript definitions enabled.
+- Fix a bug where JavaScript code generation would not properly return the result of nested blocks.
 
 
 ### Formatter

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -265,7 +265,7 @@ impl<'module> Generator<'module> {
         Ok(docvec!["toBitArray(", segments_array, ")"])
     }
 
-    pub fn wrap_return<'a>(&self, document: Document<'a>) -> Document<'a> {
+    pub fn wrap_return<'a>(&mut self, document: Document<'a>) -> Document<'a> {
         if self.scope_position.is_tail() {
             docvec!["return ", document, ";"]
         } else {
@@ -343,7 +343,8 @@ impl<'module> Generator<'module> {
         self.scope_position = scope_position;
 
         // Wrap in iife document
-        Ok(self.immediately_involked_function_expression_document(result?))
+        let doc = self.immediately_involked_function_expression_document(result?);
+        Ok(self.wrap_return(doc))
     }
 
     /// Wrap a document in an immediately involked function expression

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -50,6 +50,25 @@ fn go() {
 }
 
 #[test]
+fn nested_multiexpr_non_ending_blocks() {
+    assert_js!(
+        r#"
+fn go() {
+  let x = {
+    1
+    {
+      2
+      3
+    }
+    4
+  }
+  x
+}
+"#,
+    );
+}
+
+#[test]
 fn nested_multiexpr_blocks_with_case() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -16,6 +16,60 @@ fn go() {
 }
 
 #[test]
+fn nested_simple_blocks() {
+    assert_js!(
+        r#"
+fn go() {
+  let x = {
+    {
+      3
+    }
+  }
+  x
+}
+"#,
+    );
+}
+
+#[test]
+fn nested_multiexpr_blocks() {
+    assert_js!(
+        r#"
+fn go() {
+  let x = {
+    1
+    {
+      2
+      3
+    }
+  }
+  x
+}
+"#,
+    );
+}
+
+#[test]
+fn nested_multiexpr_blocks_with_case() {
+    assert_js!(
+        r#"
+fn go() {
+  let x = {
+    1
+    {
+      2
+      case True {
+        _ -> 3
+      }
+    }
+  }
+  x
+}
+"#,
+    );
+}
+
+#[test]
 fn sequences() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -50,6 +50,27 @@ fn go() {
 }
 
 #[test]
+fn nested_multiexpr_blocks_with_pipe() {
+    assert_js!(
+        r#"
+fn add1(a) {
+  a + 1
+}
+fn go() {
+  let x = {
+    1
+    {
+      2
+      3 |> add1
+    } |> add1
+  }
+  x
+}
+"#,
+    );
+}
+
+#[test]
 fn nested_multiexpr_non_ending_blocks() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn go() {\n  let x = {\n    1\n    {\n      2\n      3\n    }\n  }\n  x\n}\n"
+---
+function go() {
+  let x = (() => {
+    1;
+    return (() => {
+      2;
+      return 3;
+    })();
+  })();
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks_with_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks_with_case.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn go() {\n  let x = {\n    1\n    {\n      2\n      case True {\n        _ -> 3\n      }\n    }\n  }\n  x\n}\n"
+---
+function go() {
+  let x = (() => {
+    1;
+    return (() => {
+      2;
+      let $ = true;
+      return 3;
+    })();
+  })();
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks_with_pipe.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks_with_pipe.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn add1(a) {\n  a + 1\n}\nfn go() {\n  let x = {\n    1\n    {\n      2\n      3 |> add1\n    } |> add1\n  }\n  x\n}\n"
+---
+function add1(a) {
+  return a + 1;
+}
+
+function go() {
+  let x = (() => {
+    1;
+    let _pipe = (() => {
+      2;
+      let _pipe = 3;
+      return add1(_pipe);
+    })();
+    return add1(_pipe);
+  })();
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn go() {\n  let x = {\n    1\n    {\n      2\n      3\n    }\n    4\n  }\n  x\n}\n"
+---
+function go() {
+  let x = (() => {
+    1;
+    (() => {
+      2;
+      return 3;
+    })()
+    return 4;
+  })();
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_simple_blocks.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_simple_blocks.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn go() {\n  let x = {\n    {\n      3\n    }\n  }\n  x\n}\n"
+---
+function go() {
+  let x = 3;
+  return x;
+}


### PR DESCRIPTION
Analysis in https://github.com/gleam-lang/gleam/issues/2693#issuecomment-1996771438 was dead on. Multistatement blocks did not get wrapped in returns. Added some test cases and a call to wrap_return. Closes #2693