### PR TITLE
fix issues with blocks returning functions in js

### DIFF
--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1497,14 +1497,14 @@ fn requires_semicolon(statement: &TypedStatement) -> bool {
             | TypedExpr::NegateBool { .. }
             | TypedExpr::RecordUpdate { .. }
             | TypedExpr::RecordAccess { .. }
-            | TypedExpr::ModuleSelect { .. },
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Block { .. },
         ) => true,
 
         Statement::Expression(
             TypedExpr::Todo { .. }
             | TypedExpr::Case { .. }
             | TypedExpr::Panic { .. }
-            | TypedExpr::Block { .. }
             | TypedExpr::Pipeline { .. },
         ) => false,
 

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -166,3 +166,39 @@ fn main(f, a, b) {
 "#,
     );
 }
+
+#[test]
+fn blocks_returning_functions() {
+    assert_js!(
+        r#"
+fn b() {
+  {
+    fn(cb) { cb(1) }
+  }
+  {
+    fn(cb) { cb(2) }
+  }
+  3
+}
+"#
+    );
+}
+
+#[test]
+fn blocks_returning_use() {
+    assert_js!(
+        r#"
+fn b() {
+  {
+    use a <- fn(cb) { cb(1) }
+    a
+  }
+  {
+    use b <- fn(cb) { cb(2) }
+    b
+  }
+  3
+}
+    "#
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_returning_functions.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_returning_functions.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn b() {\n  {\n    fn(cb) { cb(1) }\n  }\n  {\n    fn(cb) { cb(2) }\n  }\n  3\n}\n"
+---
+function b() {
+  ((cb) => { return cb(1); });
+  ((cb) => { return cb(2); });
+  return 3;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_returning_use.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_returning_use.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn b() {\n  {\n    use a <- fn(cb) { cb(1) }\n    a\n  }\n  {\n    use b <- fn(cb) { cb(2) }\n    b\n  }\n  3\n}\n    "
+---
+function b() {
+  ((cb) => { return cb(1); })((a) => { return a; });
+  ((cb) => { return cb(2); })((b) => { return b; });
+  return 3;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
@@ -8,7 +8,7 @@ function go() {
     (() => {
       2;
       return 3;
-    })()
+    })();
     return 4;
   })();
   return x;


### PR DESCRIPTION
Closes #2658 

Issue was ultimately because while functions require semicolons, blocks that happen to return functions do not. If a block returns a function then the function was immediately called on the next value if the value was parenthesised