### PR TITLE
Add links to hex package in generated docs

### DIFF
--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -65,7 +65,12 @@ pub fn generate_html(
         path,
     });
 
-    let links: Vec<_> = doc_links.chain(repo_link).collect();
+    let package_link = Link {
+        name: "Package".into(),
+        path: format!("https://hex.pm/packages/{0}", config.name).to_string(),
+    };
+
+    let links: Vec<_> = doc_links.chain(repo_link).chain([package_link]).collect();
 
     let mut files = vec![];
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
@@ -207,6 +207,13 @@ expression: "compile(config, modules)"
         
 
         
+        <h2>Links</h2>
+        <ul>
+        
+          <li><a href="https://hex.pm/packages/">Package</a></li>
+        
+        </ul>
+        
 
         <h2>Modules</h2>
         <ul>
@@ -348,5 +355,3 @@ expression: "compile(config, modules)"
     <script src="./search-data.js?v=0"></script>
   </body>
 </html>
-
-

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/docs/tests.rs
-assertion_line: 28
 expression: "compile(config, modules)"
 ---
 //// app.html
@@ -208,6 +207,13 @@ expression: "compile(config, modules)"
         
 
         
+        <h2>Links</h2>
+        <ul>
+        
+          <li><a href="https://hex.pm/packages/">Package</a></li>
+        
+        </ul>
+        
 
         <h2>Modules</h2>
         <ul>
@@ -350,5 +356,3 @@ expression: "compile(config, modules)"
     <script src="./search-data.js?v=0"></script>
   </body>
 </html>
-
-

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/docs/tests.rs
-assertion_line: 76
 expression: "compile(config, modules)"
 ---
 //// app.html
@@ -207,6 +206,13 @@ expression: "compile(config, modules)"
 
         
 
+        
+        <h2>Links</h2>
+        <ul>
+        
+          <li><a href="https://hex.pm/packages/">Package</a></li>
+        
+        </ul>
         
 
         <h2>Modules</h2>
@@ -423,5 +429,3 @@ function for a fallback value.</p>
     <script src="./search-data.js?v=0"></script>
   </body>
 </html>
-
-

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/docs/tests.rs
-assertion_line: 49
 expression: "compile(config, modules)"
 ---
 //// app.html
@@ -208,6 +207,13 @@ expression: "compile(config, modules)"
         
 
         
+        <h2>Links</h2>
+        <ul>
+        
+          <li><a href="https://hex.pm/packages/">Package</a></li>
+        
+        </ul>
+        
 
         <h2>Modules</h2>
         <ul>
@@ -353,5 +359,3 @@ expression: "compile(config, modules)"
     <script src="./search-data.js?v=0"></script>
   </body>
 </html>
-
-


### PR DESCRIPTION
Wanted to take a swing at this since I noticed the gap. Not sure if the team wants this or agrees on just adding it to links, but wanted to give it a go. Please lemme know what y'all think

Opened companion issue:
https://github.com/gleam-lang/gleam/issues/2716