### PR TITLE
Improve error messaging around types vs values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   JavaScript by using `gleam run --target javascript --runtime bun`
 - Fixed a bug where `tuple.0.1` was not recognised as a nested tuple access
   expression
+- Error messages are more clear about expecting values instead of types.
 
 ### Formatter
 
@@ -68,7 +69,6 @@
   give the wrong node.
 - Go to definition now works for values in dependency Gleam modules.
 
-
 ## v1.0.0 - 2024-03-04
 
 ### Language changes
@@ -95,7 +95,6 @@
 - The format used by the formatter has been improved in some niche cases.
 - Improved the formatting of long case guards.
 - The formatter can now format groups of imports alphabetically.
-
 
 ## v1.0.0-rc1 - 2024-02-10
 
@@ -142,7 +141,6 @@
 - Fixed a bug where external only functions would "successfully" compile for a
   target they do not support, leading to a runtime error.
 
-
 ## v0.34.1 - 2023-01-17
 
 ### Build tool changes
@@ -155,7 +153,6 @@
   format incorrectly.
 - The `@deprecated` attribute can now be used to annotate module constants.
   This will cause a warning to be emitted when the constant is used.
-
 
 ## v0.34.0 - 2023-01-16
 
@@ -174,7 +171,6 @@
 - Fixed a bug where function heads would go over the line limit in the
   formatter.
 
-
 ## v0.34.0-rc2 - 2023-01-11
 
 ### Bug fixes
@@ -184,7 +180,6 @@
 - Fixed a bug where the compiler would in some cases fail to error when an
   application uses functions that do not support the current compilation
   target.
-
 
 ## v0.34.0-rc1 - 2024-01-07
 
@@ -215,7 +210,7 @@
 
 - The `gleam new` command now accepts any existing path, as long as there are
   no conflicts with already existing files. Examples: `gleam new .`, `gleam new
-  ..`, `gleam new ~/projects/test`.
+..`, `gleam new ~/projects/test`.
 - The format for the README created by `gleam new` has been altered.
 - The `gleam.toml` created by `gleam new` now has a link to the full reference
   for its available options.
@@ -249,7 +244,6 @@
   "Type 'Result' is not generic".
 - Not providing a definition after some attributes is now a parse error.
 
-
 ## v0.33.0 - 2023-12-18
 
 ## v0.33.0-rc4 - 2023-12-17
@@ -259,7 +253,6 @@
 - The deprecated `BitString` type has been removed.
 - The deprecated `inspect` functions and `BitString` type has been removed from
   the JavaScript prelude.
-
 
 ## v0.33.0-rc3 - 2023-12-17
 
@@ -274,7 +267,6 @@
 - Fixed a bug where string prefix aliases defined in alternative case branches
   would all be bound to the same constant.
 
-
 ## v0.33.0-rc2 - 2023-12-07
 
 ### Language changes
@@ -287,7 +279,6 @@
 
 - Fixed a bug where the `\u` string escape sequence would not work with
   on Erlang on the right hand side of a string concatenation.
-
 
 ## v0.33.0-rc1 - 2023-12-06
 
@@ -358,7 +349,6 @@
 - Fixed a bug where using a string prefix pattern in `let assert` would generate
   incorrect JavaScript.
 
-
 ## v0.32.4 - 2023-11-09
 
 ### Build tool changes
@@ -373,7 +363,6 @@
   argument has the same name as the module function.
 - Fixed the `target` property of `gleam.toml` being ignored for local path
   dependencies by `gleam run -m module/name`
-
 
 ## v0.32.3 - 2023-11-07
 
@@ -392,7 +381,6 @@
 
 - Fixed a bug where some nested pipelines could fail to type check.
 
-
 ## v0.32.2 - 2023-11-03
 
 ### Build tool changes
@@ -408,7 +396,6 @@
 - Fixed a bug where aliased unqualified types and values of the same name could
   produce an incorrect error.
 
-
 ## v0.32.1 - 2023-11-02
 
 ### Bug fixes
@@ -418,14 +405,12 @@
 - Fixed a bug where incorrect JavaScript could be generated due to backwards
   compatibility with the deprecated import syntax.
 
-
 ## v0.32.0 - 2023-11-01
 
 ### Bug fixes
 
 - Fixed a bug where running `gleam fix` multiple times could produce incorrect
   results.
-
 
 ## v0.32.0-rc3 - 2023-10-26
 
@@ -434,14 +419,12 @@
 - Fixed a bug where `gleam fix` would fail to update the deprecated type import
   syntax for aliased unqualified types.
 
-
 ## v0.32.0-rc2 - 2023-10-26
 
 ### Bug fixes
 
 - Fixed a bug where the backward compatibility for the deprecated import syntax
   could result in an import error with some valid imports.
-
 
 ## v0.32.0-rc1 - 2023-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
   give the wrong node.
 - Go to definition now works for values in dependency Gleam modules.
 
+
 ## v1.0.0 - 2024-03-04
 
 ### Language changes
@@ -95,6 +96,7 @@
 - The format used by the formatter has been improved in some niche cases.
 - Improved the formatting of long case guards.
 - The formatter can now format groups of imports alphabetically.
+
 
 ## v1.0.0-rc1 - 2024-02-10
 
@@ -141,6 +143,7 @@
 - Fixed a bug where external only functions would "successfully" compile for a
   target they do not support, leading to a runtime error.
 
+
 ## v0.34.1 - 2023-01-17
 
 ### Build tool changes
@@ -153,6 +156,7 @@
   format incorrectly.
 - The `@deprecated` attribute can now be used to annotate module constants.
   This will cause a warning to be emitted when the constant is used.
+
 
 ## v0.34.0 - 2023-01-16
 
@@ -171,6 +175,7 @@
 - Fixed a bug where function heads would go over the line limit in the
   formatter.
 
+
 ## v0.34.0-rc2 - 2023-01-11
 
 ### Bug fixes
@@ -180,6 +185,7 @@
 - Fixed a bug where the compiler would in some cases fail to error when an
   application uses functions that do not support the current compilation
   target.
+
 
 ## v0.34.0-rc1 - 2024-01-07
 
@@ -210,7 +216,7 @@
 
 - The `gleam new` command now accepts any existing path, as long as there are
   no conflicts with already existing files. Examples: `gleam new .`, `gleam new
-..`, `gleam new ~/projects/test`.
+  ..`, `gleam new ~/projects/test`.
 - The format for the README created by `gleam new` has been altered.
 - The `gleam.toml` created by `gleam new` now has a link to the full reference
   for its available options.
@@ -244,6 +250,7 @@
   "Type 'Result' is not generic".
 - Not providing a definition after some attributes is now a parse error.
 
+
 ## v0.33.0 - 2023-12-18
 
 ## v0.33.0-rc4 - 2023-12-17
@@ -253,6 +260,7 @@
 - The deprecated `BitString` type has been removed.
 - The deprecated `inspect` functions and `BitString` type has been removed from
   the JavaScript prelude.
+
 
 ## v0.33.0-rc3 - 2023-12-17
 
@@ -267,6 +275,7 @@
 - Fixed a bug where string prefix aliases defined in alternative case branches
   would all be bound to the same constant.
 
+
 ## v0.33.0-rc2 - 2023-12-07
 
 ### Language changes
@@ -279,6 +288,7 @@
 
 - Fixed a bug where the `\u` string escape sequence would not work with
   on Erlang on the right hand side of a string concatenation.
+
 
 ## v0.33.0-rc1 - 2023-12-06
 
@@ -349,6 +359,7 @@
 - Fixed a bug where using a string prefix pattern in `let assert` would generate
   incorrect JavaScript.
 
+
 ## v0.32.4 - 2023-11-09
 
 ### Build tool changes
@@ -363,6 +374,7 @@
   argument has the same name as the module function.
 - Fixed the `target` property of `gleam.toml` being ignored for local path
   dependencies by `gleam run -m module/name`
+
 
 ## v0.32.3 - 2023-11-07
 
@@ -381,6 +393,7 @@
 
 - Fixed a bug where some nested pipelines could fail to type check.
 
+
 ## v0.32.2 - 2023-11-03
 
 ### Build tool changes
@@ -396,6 +409,7 @@
 - Fixed a bug where aliased unqualified types and values of the same name could
   produce an incorrect error.
 
+
 ## v0.32.1 - 2023-11-02
 
 ### Bug fixes
@@ -405,12 +419,14 @@
 - Fixed a bug where incorrect JavaScript could be generated due to backwards
   compatibility with the deprecated import syntax.
 
+
 ## v0.32.0 - 2023-11-01
 
 ### Bug fixes
 
 - Fixed a bug where running `gleam fix` multiple times could produce incorrect
   results.
+
 
 ## v0.32.0-rc3 - 2023-10-26
 
@@ -419,12 +435,14 @@
 - Fixed a bug where `gleam fix` would fail to update the deprecated type import
   syntax for aliased unqualified types.
 
+
 ## v0.32.0-rc2 - 2023-10-26
 
 ### Bug fixes
 
 - Fixed a bug where the backward compatibility for the deprecated import syntax
   could result in an import error with some valid imports.
+
 
 ## v0.32.0-rc1 - 2023-10-25
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1561,21 +1561,29 @@ constructing a new record with its values."
                     location,
                     variables,
                     name,
-                } => Diagnostic {
-                    title: "Unknown variable".into(),
-                    text: wrap_format!("The name `{name}` is not in scope here."),
-                    hint: None,
-                    level: Level::Error,
-                    location: Some(Location {
-                        label: Label {
-                            text: did_you_mean(name, variables),
-                            span: *location,
-                        },
-                        path: path.clone(),
-                        src: src.clone(),
-                        extra_labels: vec![],
-                    }),
-                },
+                    type_with_name_in_scope,
+                } => {
+                    let text = if *type_with_name_in_scope {
+                        wrap_format!("`{name}` is a type, it cannot be used as a value.")
+                    } else {
+                        wrap_format!("The name `{name}` is not in scope here.")
+                    };
+                    Diagnostic {
+                        title: "Unknown variable".into(),
+                        text,
+                        hint: None,
+                        level: Level::Error,
+                        location: Some(Location {
+                            label: Label {
+                                text: did_you_mean(name, variables),
+                                span: *location,
+                            },
+                            path: path.clone(),
+                            src: src.clone(),
+                            extra_labels: vec![],
+                        }),
+                    }
+                }
 
                 TypeError::PrivateTypeLeak { location, leaked } => {
                     let mut printer = Printer::new();

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -391,13 +391,14 @@ impl<'a> Environment<'a> {
         name: &EcoString,
     ) -> Result<&ValueConstructor, UnknownValueConstructorError> {
         match module {
-            None => self
-                .scope
-                .get(name)
-                .ok_or_else(|| UnknownValueConstructorError::Variable {
+            None => self.scope.get(name).ok_or_else(|| {
+                let type_with_name_in_scope = self.module_types.keys().any(|typ| typ == name);
+                UnknownValueConstructorError::Variable {
                     name: name.clone(),
                     variables: self.local_value_names(),
-                }),
+                    type_with_name_in_scope,
+                }
+            }),
 
             Some(module_name) => {
                 let (_, module) = self.imported_modules.get(module_name).ok_or_else(|| {

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -43,6 +43,7 @@ pub enum Error {
         location: SrcSpan,
         name: EcoString,
         variables: Vec<EcoString>,
+        type_with_name_in_scope: bool,
     },
 
     UnknownType {
@@ -538,6 +539,7 @@ pub enum UnknownValueConstructorError {
     Variable {
         name: EcoString,
         variables: Vec<EcoString>,
+        type_with_name_in_scope: bool,
     },
 
     Module {
@@ -557,10 +559,15 @@ pub fn convert_get_value_constructor_error(
     location: SrcSpan,
 ) -> Error {
     match e {
-        UnknownValueConstructorError::Variable { name, variables } => Error::UnknownVariable {
+        UnknownValueConstructorError::Variable {
+            name,
+            variables,
+            type_with_name_in_scope,
+        } => Error::UnknownVariable {
             location,
             name,
             variables,
+            type_with_name_in_scope,
         },
 
         UnknownValueConstructorError::Module {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1870,6 +1870,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             location: *location,
                             name: name.clone(),
                             variables: self.environment.local_value_names(),
+                            type_with_name_in_scope: self
+                                .environment
+                                .module_types
+                                .keys()
+                                .any(|typ| typ == name),
                         })?;
 
                 // Register the value as seen for detection of unused values

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -232,6 +232,11 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         location,
                         name: name.clone(),
                         variables: self.environment.local_value_names(),
+                        type_with_name_in_scope: self
+                            .environment
+                            .module_types
+                            .keys()
+                            .any(|typ| typ == &name),
                     })?;
                 self.environment.increment_usage(&name);
                 let typ =

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -231,6 +231,11 @@ fn unknown_variable() {
 }
 
 #[test]
+fn unknown_variable_type() {
+    assert_error!("Int");
+}
+
+#[test]
 fn unknown_module() {
     assert_module_error!("import xpto");
 }
@@ -303,7 +308,7 @@ fn function_return_annotation_mismatch_with_pipe() {
             1
             |> add_two
          }
-          
+
          fn add_two(i: Int) -> Int {
             i + 2
          }"
@@ -322,10 +327,10 @@ fn pipe_mismatch_error() {
             Orange
             |> eat_veggie
          }
-          
+
          type Fruit{ Orange }
          type Veg{ Lettuce }
-          
+
          fn eat_veggie(v: Veg) -> String {
             \"Ok\"
          }"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_type.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: Int
+---
+error: Unknown variable
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ Int
+  │ ^^^ Did you mean `Nil`?
+
+`Int` is a type, it cannot be used as a value.


### PR DESCRIPTION
Closes #2712 

Updates some of the error messaging to make more clear when the compiler is expecting a value instead of a type