### PR TITLE
Fix erlang code generation for empty list pattern with spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Fixed a bug where hovering over an expression in the middle of a pipe would
   give the wrong node.
 
+
 ## v1.0.0 - 2024-03-04
 
 ### Language changes
@@ -82,6 +83,7 @@
 - The format used by the formatter has been improved in some niche cases.
 - Improved the formatting of long case guards.
 - The formatter can now format groups of imports alphabetically.
+
 
 ## v1.0.0-rc1 - 2024-02-10
 
@@ -128,6 +130,7 @@
 - Fixed a bug where external only functions would "successfully" compile for a
   target they do not support, leading to a runtime error.
 
+
 ## v0.34.1 - 2023-01-17
 
 ### Build tool changes
@@ -140,6 +143,7 @@
   format incorrectly.
 - The `@deprecated` attribute can now be used to annotate module constants.
   This will cause a warning to be emitted when the constant is used.
+
 
 ## v0.34.0 - 2023-01-16
 
@@ -158,6 +162,7 @@
 - Fixed a bug where function heads would go over the line limit in the
   formatter.
 
+
 ## v0.34.0-rc2 - 2023-01-11
 
 ### Bug fixes
@@ -167,6 +172,7 @@
 - Fixed a bug where the compiler would in some cases fail to error when an
   application uses functions that do not support the current compilation
   target.
+
 
 ## v0.34.0-rc1 - 2024-01-07
 
@@ -197,7 +203,7 @@
 
 - The `gleam new` command now accepts any existing path, as long as there are
   no conflicts with already existing files. Examples: `gleam new .`, `gleam new
-..`, `gleam new ~/projects/test`.
+  ..`, `gleam new ~/projects/test`.
 - The format for the README created by `gleam new` has been altered.
 - The `gleam.toml` created by `gleam new` now has a link to the full reference
   for its available options.
@@ -231,6 +237,7 @@
   "Type 'Result' is not generic".
 - Not providing a definition after some attributes is now a parse error.
 
+
 ## v0.33.0 - 2023-12-18
 
 ## v0.33.0-rc4 - 2023-12-17
@@ -240,6 +247,7 @@
 - The deprecated `BitString` type has been removed.
 - The deprecated `inspect` functions and `BitString` type has been removed from
   the JavaScript prelude.
+
 
 ## v0.33.0-rc3 - 2023-12-17
 
@@ -254,6 +262,7 @@
 - Fixed a bug where string prefix aliases defined in alternative case branches
   would all be bound to the same constant.
 
+
 ## v0.33.0-rc2 - 2023-12-07
 
 ### Language changes
@@ -266,6 +275,7 @@
 
 - Fixed a bug where the `\u` string escape sequence would not work with
   on Erlang on the right hand side of a string concatenation.
+
 
 ## v0.33.0-rc1 - 2023-12-06
 
@@ -336,6 +346,7 @@
 - Fixed a bug where using a string prefix pattern in `let assert` would generate
   incorrect JavaScript.
 
+
 ## v0.32.4 - 2023-11-09
 
 ### Build tool changes
@@ -350,6 +361,7 @@
   argument has the same name as the module function.
 - Fixed the `target` property of `gleam.toml` being ignored for local path
   dependencies by `gleam run -m module/name`
+
 
 ## v0.32.3 - 2023-11-07
 
@@ -368,6 +380,7 @@
 
 - Fixed a bug where some nested pipelines could fail to type check.
 
+
 ## v0.32.2 - 2023-11-03
 
 ### Build tool changes
@@ -383,6 +396,7 @@
 - Fixed a bug where aliased unqualified types and values of the same name could
   produce an incorrect error.
 
+
 ## v0.32.1 - 2023-11-02
 
 ### Bug fixes
@@ -392,12 +406,14 @@
 - Fixed a bug where incorrect JavaScript could be generated due to backwards
   compatibility with the deprecated import syntax.
 
+
 ## v0.32.0 - 2023-11-01
 
 ### Bug fixes
 
 - Fixed a bug where running `gleam fix` multiple times could produce incorrect
   results.
+
 
 ## v0.32.0-rc3 - 2023-10-26
 
@@ -406,12 +422,14 @@
 - Fixed a bug where `gleam fix` would fail to update the deprecated type import
   syntax for aliased unqualified types.
 
+
 ## v0.32.0-rc2 - 2023-10-26
 
 ### Bug fixes
 
 - Fixed a bug where the backward compatibility for the deprecated import syntax
   could result in an import error with some valid imports.
+
 
 ## v0.32.0-rc1 - 2023-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   result of nested blocks.
 - Fix a bug where JavaScript code generation would not properly handle functions
   returned by blocks.
+- Fix a bug where Erlang code generation would not properly handle list case patterns
+  with no head and a spread tail.
 
 ### Formatter
 
@@ -54,7 +56,6 @@
 - Fixed a bug where hovering over an expression in the middle of a pipe would
   give the wrong node.
 
-
 ## v1.0.0 - 2024-03-04
 
 ### Language changes
@@ -81,7 +82,6 @@
 - The format used by the formatter has been improved in some niche cases.
 - Improved the formatting of long case guards.
 - The formatter can now format groups of imports alphabetically.
-
 
 ## v1.0.0-rc1 - 2024-02-10
 
@@ -128,7 +128,6 @@
 - Fixed a bug where external only functions would "successfully" compile for a
   target they do not support, leading to a runtime error.
 
-
 ## v0.34.1 - 2023-01-17
 
 ### Build tool changes
@@ -141,7 +140,6 @@
   format incorrectly.
 - The `@deprecated` attribute can now be used to annotate module constants.
   This will cause a warning to be emitted when the constant is used.
-
 
 ## v0.34.0 - 2023-01-16
 
@@ -160,7 +158,6 @@
 - Fixed a bug where function heads would go over the line limit in the
   formatter.
 
-
 ## v0.34.0-rc2 - 2023-01-11
 
 ### Bug fixes
@@ -170,7 +167,6 @@
 - Fixed a bug where the compiler would in some cases fail to error when an
   application uses functions that do not support the current compilation
   target.
-
 
 ## v0.34.0-rc1 - 2024-01-07
 
@@ -201,7 +197,7 @@
 
 - The `gleam new` command now accepts any existing path, as long as there are
   no conflicts with already existing files. Examples: `gleam new .`, `gleam new
-  ..`, `gleam new ~/projects/test`.
+..`, `gleam new ~/projects/test`.
 - The format for the README created by `gleam new` has been altered.
 - The `gleam.toml` created by `gleam new` now has a link to the full reference
   for its available options.
@@ -235,7 +231,6 @@
   "Type 'Result' is not generic".
 - Not providing a definition after some attributes is now a parse error.
 
-
 ## v0.33.0 - 2023-12-18
 
 ## v0.33.0-rc4 - 2023-12-17
@@ -245,7 +240,6 @@
 - The deprecated `BitString` type has been removed.
 - The deprecated `inspect` functions and `BitString` type has been removed from
   the JavaScript prelude.
-
 
 ## v0.33.0-rc3 - 2023-12-17
 
@@ -260,7 +254,6 @@
 - Fixed a bug where string prefix aliases defined in alternative case branches
   would all be bound to the same constant.
 
-
 ## v0.33.0-rc2 - 2023-12-07
 
 ### Language changes
@@ -273,7 +266,6 @@
 
 - Fixed a bug where the `\u` string escape sequence would not work with
   on Erlang on the right hand side of a string concatenation.
-
 
 ## v0.33.0-rc1 - 2023-12-06
 
@@ -344,7 +336,6 @@
 - Fixed a bug where using a string prefix pattern in `let assert` would generate
   incorrect JavaScript.
 
-
 ## v0.32.4 - 2023-11-09
 
 ### Build tool changes
@@ -359,7 +350,6 @@
   argument has the same name as the module function.
 - Fixed the `target` property of `gleam.toml` being ignored for local path
   dependencies by `gleam run -m module/name`
-
 
 ## v0.32.3 - 2023-11-07
 
@@ -378,7 +368,6 @@
 
 - Fixed a bug where some nested pipelines could fail to type check.
 
-
 ## v0.32.2 - 2023-11-03
 
 ### Build tool changes
@@ -394,7 +383,6 @@
 - Fixed a bug where aliased unqualified types and values of the same name could
   produce an incorrect error.
 
-
 ## v0.32.1 - 2023-11-02
 
 ### Bug fixes
@@ -404,14 +392,12 @@
 - Fixed a bug where incorrect JavaScript could be generated due to backwards
   compatibility with the deprecated import syntax.
 
-
 ## v0.32.0 - 2023-11-01
 
 ### Bug fixes
 
 - Fixed a bug where running `gleam fix` multiple times could produce incorrect
   results.
-
 
 ## v0.32.0-rc3 - 2023-10-26
 
@@ -420,14 +406,12 @@
 - Fixed a bug where `gleam fix` would fail to update the deprecated type import
   syntax for aliased unqualified types.
 
-
 ## v0.32.0-rc2 - 2023-10-26
 
 ### Bug fixes
 
 - Fixed a bug where the backward compatibility for the deprecated import syntax
   could result in an import error with some valid imports.
-
 
 ## v0.32.0-rc1 - 2023-10-25
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -937,7 +937,12 @@ fn expr_list<'a>(
 
 fn list<'a>(elems: Document<'a>, tail: Option<Document<'a>>) -> Document<'a> {
     let elems = if let Some(final_tail) = tail {
-        elems.append(break_(" |", " | ")).append(final_tail)
+        if !elems.is_empty() {
+            elems.append(break_(" |", " | "))
+        } else {
+            elems
+        }
+        .append(final_tail)
     } else {
         elems
     };

--- a/compiler-core/src/erlang/tests/case.rs
+++ b/compiler-core/src/erlang/tests/case.rs
@@ -73,3 +73,16 @@ fn not_two() {
 "#,
     );
 }
+
+#[test]
+fn spread_empty_list() {
+    assert_erl!(
+        r#"
+pub fn main() {
+  case [] {
+    [..] -> 1
+  }
+}
+"#,
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__spread_empty_list.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__spread_empty_list.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/erlang/tests/case.rs
+expression: "\npub fn main() {\n  case [] {\n    [..] -> 1\n  }\n}\n"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> integer().
+main() ->
+    case [] of
+        [_] ->
+            1
+    end.


### PR DESCRIPTION
Closes #2657

Issue was that we always assumed head has entries if a tail exists when generating. This is true for any validly constructed list but not true for a list matching case expression (i.e. you can't create a non-empty list without a comma but you can create a case pattern matching the rest of a list without accessing any heads technically). 