### PR TITLE
LSP go to definition supports dependency modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
   Neovim.
 - Fixed a bug where hovering over an expression in the middle of a pipe would
   give the wrong node.
+- Go to definition now works for types in external Gleam modules.
 
 
 ## v1.0.0 - 2024-03-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
   Neovim.
 - Fixed a bug where hovering over an expression in the middle of a pipe would
   give the wrong node.
-- Go to definition now works for types in external Gleam modules.
+- Go to definition now works for values in dependency Gleam modules.
 
 
 ## v1.0.0 - 2024-03-04

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -31,9 +31,6 @@ pub struct LspProjectCompiler<IO> {
     pub modules: HashMap<EcoString, Module>,
     pub sources: HashMap<EcoString, ModuleSourceInformation>,
 
-    // Information on compiled dependencies.
-    pub dependency_sources: HashMap<EcoString, ModuleSourceInformation>,
-
     /// The storage for the warning emitter.
     pub warnings: Arc<VectorWarningEmitterIO>,
 
@@ -95,7 +92,6 @@ where
             project_compiler,
             modules: HashMap::new(),
             sources: HashMap::new(),
-            dependency_sources: HashMap::new(),
         })
     }
 
@@ -115,7 +111,7 @@ where
             let path = module.input_path.as_os_str().to_string_lossy().to_string();
             let line_numbers = LineNumbers::new(&module.code);
             let source = ModuleSourceInformation { path, line_numbers };
-            _ = self.dependency_sources.insert(module.name.clone(), source);
+            _ = self.sources.insert(module.name.clone(), source);
         }
 
         // Warnings from dependencies are not fixable by the programmer so
@@ -161,10 +157,6 @@ impl<IO> LspProjectCompiler<IO> {
 
     pub fn get_source(&self, module: &str) -> Option<&ModuleSourceInformation> {
         self.sources.get(module)
-    }
-
-    pub fn get_dependency_source(&self, module: &str) -> Option<&ModuleSourceInformation> {
-        self.dependency_sources.get(module)
     }
 }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -161,12 +161,8 @@ where
             let (uri, line_numbers) = match location.module {
                 None => (params.text_document.uri, &line_numbers),
                 Some(name) => {
-                    let module = match (
-                        this.compiler.get_source(name),
-                        this.compiler.get_dependency_source(name),
-                    ) {
-                        (Some(module), _) => module,
-                        (_, Some(module)) => module,
+                    let module = match this.compiler.get_source(name) {
+                        Some(module) => module,
                         _ => return Ok(None),
                     };
                     let url = Url::parse(&format!("file:///{}", &module.path))

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -140,11 +140,7 @@ where
 
     // TODO: test different package module function calls
     //
-    //
-    //
     // TODO: implement unqualified imported module functions
-    // TODO: implement goto definition of modules that do not belong to the top
-    // level package.
     //
     pub fn goto_definition(
         &mut self,
@@ -165,13 +161,13 @@ where
             let (uri, line_numbers) = match location.module {
                 None => (params.text_document.uri, &line_numbers),
                 Some(name) => {
-                    let module = match this.compiler.get_source(name) {
-                        Some(module) => module,
-                        // TODO: support goto definition for functions defined in
-                        // different packages. Currently it is not possible as the
-                        // required LineNumbers and source file path information is
-                        // not stored in the module metadata.
-                        None => return Ok(None),
+                    let module = match (
+                        this.compiler.get_source(name),
+                        this.compiler.get_dependency_source(name),
+                    ) {
+                        (Some(module), _) => module,
+                        (_, Some(module)) => module,
+                        _ => return Ok(None),
                     };
                     let url = Url::parse(&format!("file:///{}", &module.path))
                         .expect("goto definition URL parse");

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -346,6 +346,42 @@ fn main() {
 }
 
 #[test]
+fn goto_definition_external_module_constants() {
+    let mut io = LanguageServerTestIO::new();
+    io.add_hex_package("my_dep");
+    _ = io.hex_dep_module("my_dep", "example_module", "pub const my_num = 1");
+
+    let code = "
+import example_module
+fn main() {
+  example_module.my_num
+}
+";
+
+    assert_eq!(
+        positioned_with_io_definition(code, Position::new(3, 20), &io),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\build\packages\my_dep\src\example_module.gleam"
+            } else {
+                "/build/packages/my_dep/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 10
+                },
+                end: Position {
+                    line: 0,
+                    character: 16
+                }
+            }
+        })
+    )
+}
+
+#[test]
 fn goto_definition_external_module_function_calls() {
     let mut io = LanguageServerTestIO::new();
     io.add_hex_package("my_dep");
@@ -375,6 +411,51 @@ fn main() {
                 end: Position {
                     line: 0,
                     character: 14
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_external_module_records() {
+    let mut io = LanguageServerTestIO::new();
+    io.add_hex_package("my_dep");
+    _ = io.hex_dep_module(
+        "my_dep",
+        "example_module",
+        "
+pub type Rec {
+  Var1(Int)
+  Var2(Int, Int)
+}
+",
+    );
+
+    let code = "
+import example_module
+fn main() {
+  example_module.Var1(1)
+}
+";
+
+    assert_eq!(
+        positioned_with_io_definition(code, Position::new(3, 20), &io),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\build\packages\my_dep\src\example_module.gleam"
+            } else {
+                "/build/packages/my_dep/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 2
+                },
+                end: Position {
+                    line: 2,
+                    character: 11
                 }
             }
         })


### PR DESCRIPTION
Closes #2655

Change takes the already existing output from compiling the dependencies and stores source data in lsp state. Then when looking for the source info for go to definition calls it just checks against both the original sources from the local module as well as the dependency sources.