### PR TITLE
Refactor: use pretty::join consistently

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -129,7 +129,7 @@ pub fn record_definition(name: &str, fields: &[(&str, Arc<Type>)]) -> String {
         docvec!(atom_string((*name).to_string()), " :: ", type_.group())
     });
     let fields = break_("", "")
-        .append(concat(Itertools::intersperse(fields, break_(",", ", "))))
+        .append(join(fields, break_(",", ", ")))
         .nest(INDENT)
         .append(break_("", ""))
         .group();
@@ -176,36 +176,24 @@ fn module_document<'a>(
         (false, false) => return Ok(header),
         (true, false) => "-export(["
             .to_doc()
-            .append(concat(Itertools::intersperse(
-                exports.into_iter(),
-                ", ".to_doc(),
-            )))
+            .append(join(exports, ", ".to_doc()))
             .append("]).")
             .append(lines(2)),
 
         (true, true) => "-export(["
             .to_doc()
-            .append(concat(Itertools::intersperse(
-                exports.into_iter(),
-                ", ".to_doc(),
-            )))
+            .append(join(exports, ", ".to_doc()))
             .append("]).")
             .append(line())
             .append("-export_type([")
             .to_doc()
-            .append(concat(Itertools::intersperse(
-                type_exports.into_iter(),
-                ", ".to_doc(),
-            )))
+            .append(join(type_exports, ", ".to_doc()))
             .append("]).")
             .append(lines(2)),
 
         (false, true) => "-export_type(["
             .to_doc()
-            .append(concat(Itertools::intersperse(
-                type_exports.into_iter(),
-                ", ".to_doc(),
-            )))
+            .append(join(type_exports, ", ".to_doc()))
             .append("]).")
             .append(lines(2)),
     };
@@ -213,16 +201,16 @@ fn module_document<'a>(
     let type_defs = if type_defs.is_empty() {
         nil()
     } else {
-        concat(Itertools::intersperse(type_defs.into_iter(), lines(2))).append(lines(2))
+        join(type_defs, lines(2)).append(lines(2))
     };
 
-    let statements = concat(Itertools::intersperse(
+    let statements = join(
         module
             .definitions
             .iter()
             .flat_map(|s| module_statement(s, &module.name, line_numbers)),
         lines(2),
-    ));
+    );
 
     Ok(header
         .append("-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).")
@@ -299,7 +287,7 @@ fn register_imports(
             let definition = if constructors.is_empty() {
                 let constructors =
                     std::iter::once("any()".to_doc()).chain(phantom_vars_constructor);
-                concat(Itertools::intersperse(constructors, break_(" |", " | ")))
+                join(constructors, break_(" |", " | "))
             } else {
                 let constructors = constructors
                     .iter()
@@ -314,14 +302,14 @@ fn register_imports(
                         }
                     })
                     .chain(phantom_vars_constructor);
-                concat(Itertools::intersperse(constructors, break_(" |", " | ")))
+                join(constructors, break_(" |", " | "))
             }
             .nest(INDENT);
             let type_printer = TypePrinter::new(module_name);
-            let params = concat(Itertools::intersperse(
+            let params = join(
                 typed_parameters.iter().map(|a| type_printer.print(a)),
                 ", ".to_doc(),
-            ));
+            );
             let doc = if *opaque { "-opaque " } else { "-type " }
                 .to_doc()
                 .append(Document::String(erl_safe_type_name(name.to_snake_case())))
@@ -416,10 +404,7 @@ where
     I: IntoIterator<Item = Document<'a>>,
 {
     break_("", "")
-        .append(concat(Itertools::intersperse(
-            args.into_iter(),
-            break_(",", ", "),
-        )))
+        .append(join(args, break_(",", ", ")))
         .nest(INDENT)
         .append(break_("", ""))
         .surround("(", ")")
@@ -507,7 +492,7 @@ fn string(value: &str) -> Document<'_> {
 }
 
 fn tuple<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
-    concat(Itertools::intersperse(elems.into_iter(), break_(",", ", ")))
+    join(elems, break_(",", ", "))
         .nest(INDENT)
         .surround("{", "}")
         .group()
@@ -559,7 +544,7 @@ fn string_concatenate_argument<'a>(value: &'a TypedExpr, env: &mut Env<'a>) -> D
 }
 
 fn bit_array<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
-    concat(Itertools::intersperse(elems.into_iter(), break_(",", ", ")))
+    join(elems, break_(",", ", "))
         .nest(INDENT)
         .surround("<<", ">>")
         .group()
@@ -928,10 +913,10 @@ fn expr_list<'a>(
     tail: &'a Option<Box<TypedExpr>>,
     env: &mut Env<'a>,
 ) -> Document<'a> {
-    let elements = concat(Itertools::intersperse(
+    let elements = join(
         elements.iter().map(|e| maybe_block_expr(e, env)),
         break_(",", ", "),
-    ));
+    );
     list(elements, tail.as_ref().map(|e| maybe_block_expr(e, env)))
 }
 
@@ -1014,13 +999,13 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
         Constant::String { value, .. } => string(value),
         Constant::Tuple { elements, .. } => tuple(elements.iter().map(|e| const_inline(e, env))),
 
-        Constant::List { elements, .. } => {
-            let elements = Itertools::intersperse(
-                elements.iter().map(|e| const_inline(e, env)),
-                break_(",", ", "),
-            );
-            concat(elements).nest(INDENT).surround("[", "]").group()
-        }
+        Constant::List { elements, .. } => join(
+            elements.iter().map(|e| const_inline(e, env)),
+            break_(",", ", "),
+        )
+        .nest(INDENT)
+        .surround("[", "]")
+        .group(),
 
         Constant::BitArray { segments, .. } => bit_array(
             segments
@@ -1080,7 +1065,7 @@ fn clause<'a>(clause: &'a TypedClause, env: &mut Env<'a>) -> Document<'a> {
     let initial_erlang_vars = env.erl_function_scope_vars.clone();
     let mut end_erlang_vars = im::HashMap::new();
 
-    let docs = Itertools::intersperse(
+    let doc = join(
         std::iter::once(pat)
             .chain(alternative_patterns)
             .map(|patterns| {
@@ -1108,7 +1093,6 @@ fn clause<'a>(clause: &'a TypedClause, env: &mut Env<'a>) -> Document<'a> {
         ";".to_doc().append(lines(2)),
     );
 
-    let doc = concat(docs);
     env.erl_function_scope_vars = end_erlang_vars;
     doc
 }
@@ -1239,7 +1223,7 @@ fn clause_guard<'a>(guard: &'a TypedClauseGuard, env: &mut Env<'a>) -> Document<
 }
 
 fn clauses<'a>(cs: &'a [TypedClause], env: &mut Env<'a>) -> Document<'a> {
-    concat(Itertools::intersperse(
+    join(
         cs.iter().map(|c| {
             let vars = env.current_scope_vars.clone();
             let erl = clause(c, env);
@@ -1247,7 +1231,7 @@ fn clauses<'a>(cs: &'a [TypedClause], env: &mut Env<'a>) -> Document<'a> {
             erl
         }),
         ";".to_doc().append(lines(2)),
-    ))
+    )
 }
 
 fn case<'a>(subjects: &'a [TypedExpr], cs: &'a [TypedClause], env: &mut Env<'a>) -> Document<'a> {
@@ -2001,10 +1985,7 @@ impl<'a> TypePrinter<'a> {
     }
 
     fn print_type_app(&self, module: &str, name: &str, args: &[Arc<Type>]) -> Document<'static> {
-        let args = concat(Itertools::intersperse(
-            args.iter().map(|a| self.print(a)),
-            ", ".to_doc(),
-        ));
+        let args = join(args.iter().map(|a| self.print(a)), ", ".to_doc());
         let name = Document::String(erl_safe_type_name(name.to_snake_case()));
         if self.current_module == module {
             docvec![name, "(", args, ")"]
@@ -2014,10 +1995,7 @@ impl<'a> TypePrinter<'a> {
     }
 
     fn print_fn(&self, args: &[Arc<Type>], retrn: &Type) -> Document<'static> {
-        let args = concat(Itertools::intersperse(
-            args.iter().map(|a| self.print(a)),
-            ", ".to_doc(),
-        ));
+        let args = join(args.iter().map(|a| self.print(a)), ", ".to_doc());
         let retrn = self.print(retrn);
         "fun(("
             .to_doc()

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -187,12 +187,12 @@ fn pattern_list<'a>(
     define_variables: bool,
     env: &mut Env<'a>,
 ) -> Document<'a> {
-    let elements = concat(Itertools::intersperse(
+    let elements = join(
         elements
             .iter()
             .map(|e| print(e, vars, define_variables, env)),
         break_(",", ", "),
-    ));
+    );
     let tail = tail.map(|tail| print(tail, vars, define_variables, env));
     list(elements, tail)
 }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -347,12 +347,12 @@ impl<'comments> Formatter<'comments> {
                         .iter()
                         .sorted_by(|a, b| a.name.cmp(&b.name))
                         .map(|e| e.to_doc());
-                    let unqualified = Itertools::intersperse(
+                    let unqualified = join(
                         unqualified_types.chain(unqualified_values),
                         flex_break(",", ", "),
                     );
                     let unqualified = break_("", "")
-                        .append(concat(unqualified))
+                        .append(unqualified)
                         .nest(INDENT)
                         .append(break_(",", ""))
                         .group();

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -283,12 +283,12 @@ impl<'a> Generator<'a> {
             return head.append("}");
         };
 
-        let parameters = concat(Itertools::intersperse(
+        let parameters = join(
             constructor.arguments.iter().enumerate().map(parameter),
             break_(",", ", "),
-        ));
+        );
 
-        let constructor_body = concat(Itertools::intersperse(
+        let constructor_body = join(
             constructor.arguments.iter().enumerate().map(|(i, arg)| {
                 let var = parameter((i, arg));
                 match &arg.label {
@@ -297,7 +297,7 @@ impl<'a> Generator<'a> {
                 }
             }),
             line(),
-        ));
+        );
 
         let class_body = docvec![
             line(),
@@ -604,10 +604,7 @@ where
     I: IntoIterator<Item = Document<'a>>,
 {
     break_("", "")
-        .append(concat(Itertools::intersperse(
-            args.into_iter(),
-            break_(",", ", "),
-        )))
+        .append(join(args, break_(",", ", ")))
         .nest(INDENT)
         .append(break_("", ""))
         .surround("(", ")")
@@ -625,7 +622,7 @@ fn wrap_object<'a>(
             None => key.to_doc(),
         }
     });
-    let fields = concat(Itertools::intersperse(fields, break_(",", ", ")));
+    let fields = join(fields, break_(",", ", "));
 
     if empty {
         "{}".to_doc()

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1068,7 +1068,7 @@ impl<'module> Generator<'module> {
 
     fn pattern_assignments_doc(assignments: Vec<Assignment<'_>>) -> Document<'_> {
         let assignments = assignments.into_iter().map(pattern::Assignment::into_doc);
-        concat(Itertools::intersperse(assignments, line()))
+        join(assignments, line())
     }
 
     fn pattern_take_assignments_doc<'a>(
@@ -1103,7 +1103,7 @@ impl<'module> Generator<'module> {
         };
 
         let checks_len = checks.len();
-        concat(Itertools::intersperse(
+        join(
             checks.into_iter().map(|check| {
                 if checks_len > 1 && check.may_require_wrapping() {
                     docvec!["(", check.into_doc(match_desired), ")"]
@@ -1112,7 +1112,7 @@ impl<'module> Generator<'module> {
                 }
             }),
             operator,
-        ))
+        )
         .group()
     }
 }
@@ -1397,13 +1397,13 @@ fn construct_record<'a>(
     arguments: impl IntoIterator<Item = Document<'a>>,
 ) -> Document<'a> {
     let mut any_arguments = false;
-    let arguments = concat(Itertools::intersperse(
+    let arguments = join(
         arguments.into_iter().map(|a| {
             any_arguments = true;
             a
         }),
         break_(",", ", "),
-    ));
+    );
     let arguments = docvec![break_("", ""), arguments].nest(INDENT);
     let name = if let Some(module) = module {
         docvec!["$", module, ".", name]

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use crate::{
     docvec,
     javascript::{JavaScriptCodegenTarget, INDENT},
-    pretty::{break_, concat, line, Document, Documentable},
+    pretty::{break_, concat, join, line, Document, Documentable},
 };
 
 /// A collection of JavaScript import statements from Gleam imports and from
@@ -51,10 +51,10 @@ impl<'a> Imports<'a> {
         if self.exports.is_empty() {
             imports
         } else {
-            let names = concat(Itertools::intersperse(
+            let names = join(
                 self.exports.into_iter().sorted().map(Document::String),
                 break_(",", ", "),
-            ));
+            );
             let names = docvec![
                 docvec![break_("", " "), names].nest(INDENT),
                 break_(",", " ")
@@ -113,7 +113,7 @@ impl<'a> Import<'a> {
             alias_imports
         } else {
             let members = self.unqualified.into_iter().map(Member::into_doc);
-            let members = concat(Itertools::intersperse(members, break_(",", ", ")));
+            let members = join(members, break_(",", ", "));
             let members = docvec![
                 docvec![break_("", " "), members].nest(INDENT),
                 break_(",", " ")

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -27,7 +27,7 @@ use ecow::EcoString;
 use itertools::Itertools;
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
-use super::{concat, import::Imports, line, lines, wrap_args, Output, INDENT};
+use super::{import::Imports, join, line, lines, wrap_args, Output, INDENT};
 
 /// When rendering a type variable to an TypeScript type spec we need all type
 /// variables with the same id to end up with the same name in the generated
@@ -122,10 +122,7 @@ fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
 ///
 fn tuple<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
     break_("", "")
-        .append(concat(Itertools::intersperse(
-            elems.into_iter(),
-            break_(",", ", "),
-        )))
+        .append(join(elems, break_(",", ", ")))
         .nest(INDENT)
         .append(break_("", ""))
         .surround("[", "]")
@@ -137,10 +134,7 @@ where
     I: IntoIterator<Item = Document<'a>>,
 {
     break_("", "")
-        .append(concat(Itertools::intersperse(
-            args.into_iter(),
-            break_(",", ", "),
-        )))
+        .append(join(args, break_(",", ", ")))
         .nest(INDENT)
         .append(break_("", ""))
         .surround("<", ">")
@@ -378,7 +372,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     x.arguments.iter().map(|a| &a.type_),
                 )
             });
-            concat(Itertools::intersperse(constructors, break_("| ", " | ")))
+            join(constructors, break_("| ", " | "))
         };
 
         definitions.push(Ok(docvec![
@@ -433,7 +427,7 @@ impl<'a> TypeScriptGenerator<'a> {
             line(),
             line(),
             // Then add each field to the class
-            concat(Itertools::intersperse(
+            join(
                 constructor.arguments.iter().enumerate().map(|(i, arg)| {
                     let name = arg
                         .label
@@ -448,7 +442,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     ]
                 }),
                 line(),
-            )),
+            ),
         ]
         .nest(INDENT);
 

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -4,7 +4,6 @@ use crate::{
     pretty::{nil, *},
 };
 use ecow::EcoString;
-use itertools::Itertools;
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -145,10 +144,10 @@ impl Printer {
             return nil();
         }
 
-        let args = concat(Itertools::intersperse(
+        let args = join(
             args.iter().map(|t| self.print(t).group()),
             break_(",", ", "),
-        ));
+        );
         break_("", "")
             .append(args)
             .nest(INDENT)


### PR DESCRIPTION
I noticed quite a few places doing `concat(Itertools::intersperse(docs, separator))`, which is what the [pretty::join()](https://github.com/gleam-lang/gleam/blob/0b1062543eb721893f6c9d8ad6ddb402d883c4e5/compiler-core/src/pretty.rs#L136) function does. 

Here I used the function for all those cases I could find. Remaining uses of `Itertools::intersperse` collect the result some other way than with `pretty::concat()`.