### PR TITLE
Fix generated files in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
+[attr]generated linguist-generated=true diff=generated
+
 # Generate Cap'n Proto code
-src/bindata_capnp.rs linguist-generated=true
+compiler-core/generated/schema_capnp.rs
+
+# Tests:
+test-package-compiler/src/generated_tests.rs generated


### PR DESCRIPTION
I think that `src/bindata_capnp.rs` is outdated and is replaced with `compiler-core/generated/schema_capnp.rs`.

I've reused our `generated` attribute from CPython: https://github.com/python/cpython/blob/b8d808ddd77f84de9f93adcc2aede2879eb5241e/.gitattributes#L66C1-L66C55

It is useful in a case that generated file are folded by default during reviews, you can still look through them, but noise is reduced.

I've also found one more generated file that is test-related.