### PR TITLE
Fix nested tuple dot access lexing, refs #1980

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@
   with no head and a spread tail.
 - The compiler will now raise a warning if you're pattern matching on tuple
   literals and suggest you use multiple subjects instead.
-- Fix a bug where JavaScript code generation would incorrectly parenthesise a
+- Fixed a bug where JavaScript code generation would incorrectly parenthesise a
   return statement.
-- Add support for the [Bun](https://bun.sh/) runtime when compiling to JavaScript by using `gleam run --target javascript --runtime bun`
+- Added support for the [Bun](https://bun.sh/) runtime when compiling to
+  JavaScript by using `gleam run --target javascript --runtime bun`
+- Fixed a bug where `tuple.0.1` was not recognised as a nested tuple access
+  expression
 
 ### Formatter
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
@@ -1,0 +1,130 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nlet tup = #(#(#(#(4))))\n{{{tup.0}.0}.0}.0\n"
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 1,
+                end: 24,
+            },
+            value: Tuple {
+                location: SrcSpan {
+                    start: 11,
+                    end: 24,
+                },
+                elems: [
+                    Tuple {
+                        location: SrcSpan {
+                            start: 13,
+                            end: 23,
+                        },
+                        elems: [
+                            Tuple {
+                                location: SrcSpan {
+                                    start: 15,
+                                    end: 22,
+                                },
+                                elems: [
+                                    Tuple {
+                                        location: SrcSpan {
+                                            start: 17,
+                                            end: 21,
+                                        },
+                                        elems: [
+                                            Int {
+                                                location: SrcSpan {
+                                                    start: 19,
+                                                    end: 20,
+                                                },
+                                                value: "4",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            pattern: Variable {
+                location: SrcSpan {
+                    start: 5,
+                    end: 8,
+                },
+                name: "tup",
+                type_: (),
+            },
+            kind: Let,
+            annotation: None,
+        },
+    ),
+    Expression(
+        TupleIndex {
+            location: SrcSpan {
+                start: 25,
+                end: 42,
+            },
+            index: 0,
+            tuple: Block {
+                location: SrcSpan {
+                    start: 25,
+                    end: 40,
+                },
+                statements: [
+                    Expression(
+                        TupleIndex {
+                            location: SrcSpan {
+                                start: 26,
+                                end: 39,
+                            },
+                            index: 0,
+                            tuple: Block {
+                                location: SrcSpan {
+                                    start: 26,
+                                    end: 37,
+                                },
+                                statements: [
+                                    Expression(
+                                        TupleIndex {
+                                            location: SrcSpan {
+                                                start: 27,
+                                                end: 36,
+                                            },
+                                            index: 0,
+                                            tuple: Block {
+                                                location: SrcSpan {
+                                                    start: 27,
+                                                    end: 34,
+                                                },
+                                                statements: [
+                                                    Expression(
+                                                        TupleIndex {
+                                                            location: SrcSpan {
+                                                                start: 28,
+                                                                end: 33,
+                                                            },
+                                                            index: 0,
+                                                            tuple: Var {
+                                                                location: SrcSpan {
+                                                                    start: 28,
+                                                                    end: 31,
+                                                                },
+                                                                name: "tup",
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        },
+                                    ),
+                                ],
+                            },
+                        },
+                    ),
+                ],
+            },
+        },
+    ),
+]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
@@ -1,0 +1,100 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nlet tup = #(#(#(#(4))))\ntup.0.0.0.0\n"
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 1,
+                end: 24,
+            },
+            value: Tuple {
+                location: SrcSpan {
+                    start: 11,
+                    end: 24,
+                },
+                elems: [
+                    Tuple {
+                        location: SrcSpan {
+                            start: 13,
+                            end: 23,
+                        },
+                        elems: [
+                            Tuple {
+                                location: SrcSpan {
+                                    start: 15,
+                                    end: 22,
+                                },
+                                elems: [
+                                    Tuple {
+                                        location: SrcSpan {
+                                            start: 17,
+                                            end: 21,
+                                        },
+                                        elems: [
+                                            Int {
+                                                location: SrcSpan {
+                                                    start: 19,
+                                                    end: 20,
+                                                },
+                                                value: "4",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            pattern: Variable {
+                location: SrcSpan {
+                    start: 5,
+                    end: 8,
+                },
+                name: "tup",
+                type_: (),
+            },
+            kind: Let,
+            annotation: None,
+        },
+    ),
+    Expression(
+        TupleIndex {
+            location: SrcSpan {
+                start: 25,
+                end: 36,
+            },
+            index: 0,
+            tuple: TupleIndex {
+                location: SrcSpan {
+                    start: 25,
+                    end: 34,
+                },
+                index: 0,
+                tuple: TupleIndex {
+                    location: SrcSpan {
+                        start: 25,
+                        end: 32,
+                    },
+                    index: 0,
+                    tuple: TupleIndex {
+                        location: SrcSpan {
+                            start: 25,
+                            end: 30,
+                        },
+                        index: 0,
+                        tuple: Var {
+                            location: SrcSpan {
+                                start: 25,
+                                end: 28,
+                            },
+                            name: "tup",
+                        },
+                    },
+                },
+            },
+        },
+    ),
+]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
@@ -1,0 +1,87 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nlet tup = #(#(5, 6))\n{tup.0}.1\n"
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 1,
+                end: 21,
+            },
+            value: Tuple {
+                location: SrcSpan {
+                    start: 11,
+                    end: 21,
+                },
+                elems: [
+                    Tuple {
+                        location: SrcSpan {
+                            start: 13,
+                            end: 20,
+                        },
+                        elems: [
+                            Int {
+                                location: SrcSpan {
+                                    start: 15,
+                                    end: 16,
+                                },
+                                value: "5",
+                            },
+                            Int {
+                                location: SrcSpan {
+                                    start: 18,
+                                    end: 19,
+                                },
+                                value: "6",
+                            },
+                        ],
+                    },
+                ],
+            },
+            pattern: Variable {
+                location: SrcSpan {
+                    start: 5,
+                    end: 8,
+                },
+                name: "tup",
+                type_: (),
+            },
+            kind: Let,
+            annotation: None,
+        },
+    ),
+    Expression(
+        TupleIndex {
+            location: SrcSpan {
+                start: 22,
+                end: 31,
+            },
+            index: 1,
+            tuple: Block {
+                location: SrcSpan {
+                    start: 22,
+                    end: 29,
+                },
+                statements: [
+                    Expression(
+                        TupleIndex {
+                            location: SrcSpan {
+                                start: 23,
+                                end: 28,
+                            },
+                            index: 0,
+                            tuple: Var {
+                                location: SrcSpan {
+                                    start: 23,
+                                    end: 26,
+                                },
+                                name: "tup",
+                            },
+                        },
+                    ),
+                ],
+            },
+        },
+    ),
+]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
@@ -1,0 +1,77 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nlet tup = #(#(5, 6))\ntup.0.1\n"
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 1,
+                end: 21,
+            },
+            value: Tuple {
+                location: SrcSpan {
+                    start: 11,
+                    end: 21,
+                },
+                elems: [
+                    Tuple {
+                        location: SrcSpan {
+                            start: 13,
+                            end: 20,
+                        },
+                        elems: [
+                            Int {
+                                location: SrcSpan {
+                                    start: 15,
+                                    end: 16,
+                                },
+                                value: "5",
+                            },
+                            Int {
+                                location: SrcSpan {
+                                    start: 18,
+                                    end: 19,
+                                },
+                                value: "6",
+                            },
+                        ],
+                    },
+                ],
+            },
+            pattern: Variable {
+                location: SrcSpan {
+                    start: 5,
+                    end: 8,
+                },
+                name: "tup",
+                type_: (),
+            },
+            kind: Let,
+            annotation: None,
+        },
+    ),
+    Expression(
+        TupleIndex {
+            location: SrcSpan {
+                start: 22,
+                end: 29,
+            },
+            index: 1,
+            tuple: TupleIndex {
+                location: SrcSpan {
+                    start: 22,
+                    end: 27,
+                },
+                index: 0,
+                tuple: Var {
+                    location: SrcSpan {
+                        start: 22,
+                        end: 25,
+                    },
+                    name: "tup",
+                },
+            },
+        },
+    ),
+]

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -767,16 +767,3 @@ tup.0.0.0.0
 "#
     );
 }
-
-#[test]
-fn struct_in_a_tuple() {
-    // https://github.com/gleam-lang/gleam/issues/1980
-    assert_parse!(
-        r#"
-pub fn main() {
-  let tup = #(Person("Nikita"),)
-  {tup.0}.name
-}
-"#
-    );
-}

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -724,3 +724,59 @@ pub fn main() -> Nil {
 "#
     );
 }
+
+// Tests for nested tuples and structs in tuples
+// https://github.com/gleam-lang/gleam/issues/1980
+
+#[test]
+fn nested_tuples() {
+    assert_parse!(
+        r#"
+let tup = #(#(5, 6))
+{tup.0}.1
+"#
+    );
+}
+
+#[test]
+fn nested_tuples_no_block() {
+    assert_parse!(
+        r#"
+let tup = #(#(5, 6))
+tup.0.1
+"#
+    );
+}
+
+#[test]
+fn deeply_nested_tuples() {
+    assert_parse!(
+        r#"
+let tup = #(#(#(#(4))))
+{{{tup.0}.0}.0}.0
+"#
+    );
+}
+
+#[test]
+fn deeply_nested_tuples_no_block() {
+    assert_parse!(
+        r#"
+let tup = #(#(#(#(4))))
+tup.0.0.0.0
+"#
+    );
+}
+
+#[test]
+fn struct_in_a_tuple() {
+    // https://github.com/gleam-lang/gleam/issues/1980
+    assert_parse!(
+        r#"
+pub fn main() {
+  let tup = #(Person("Nikita"),)
+  {tup.0}.name
+}
+"#
+    );
+}

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -47,6 +47,7 @@ pub fn main() {
       suite("string pattern matching", string_pattern_matching_tests()),
       suite("typescript file inclusion", typescript_file_included_tests()),
       suite("custom types mixed args match", mixed_arg_match_tests()),
+      suite("tuple access", tuple_access_tests()),
     ])
 
   ffi.halt(case stats.failures {
@@ -1516,6 +1517,86 @@ fn block_tests() {
           x
         },
         1,
+      )
+    }),
+  ]
+}
+
+type ContainsTuple {
+  ContainsTuple(data: #(Int, #(Int, Person)))
+}
+
+
+fn tuple_access_tests() {
+  [
+    // https://github.com/gleam-lang/gleam/issues/1980
+    "access regular tuple item"
+    |> example(fn() {
+      assert_equal(
+        {
+          let tup = #(3, 4, 5)
+          let x = tup.0
+          let y = tup.1
+          let z = tup.2
+          #(z, y, x)
+        },
+        #(5, 4, 3),
+      )
+    }),
+    "access nested tuple item"
+    |> example(fn() {
+      assert_equal(
+        {
+          let tup = #(#(4, 5), #(6, 7))
+          #(tup.0.1, tup.1.1, tup.1.0, tup.0.0)
+        },
+        #(5, 7, 6, 4),
+      )
+    }),
+    "access deeply nested tuple item"
+    |> example(fn() {
+      assert_equal(
+        {
+          let tup = #(#(5, #(6, 7, #(8))))
+          tup.0.1.2.0
+        },
+        8,
+      )
+    }),
+    "access nested struct in a tuple item"
+    |> example(fn() {
+      assert_equal(
+        {
+          let tup = #(
+            Person("Quinn", 27, "Canada"), 
+            Person("Nikita", 99, "Internet"),
+          )
+          tup.0.name
+        },
+        "Quinn",
+      )
+    }),
+    "access nested tuple in a struct"
+    |> example(fn() {
+      assert_equal(
+        {
+          let person = Person("Nikita", 99, "Internet")
+          let container = ContainsTuple(#(5, #(6, person)))
+          container.data.1.1.name
+        },
+        "Nikita",
+      )
+    }),
+    "access tuple, then struct, then tuple"
+    |> example(fn() {
+      assert_equal(
+        {
+          let person = Person("Nikita", 99, "Internet")
+          let container = ContainsTuple(#(5, #(6, person)))
+          let tup = #(container)
+          tup.0.data.0
+        },
+        5,
       )
     }),
   ]


### PR DESCRIPTION
Design:
- Lexer has now a special case, after `::Name` check that `::Dot` and `::Int` are not following the toke flow
- If they are, parse them as sequence of `::Dot` and `::Int` tokens, not `::Float` token
- Other this automatically start to work correctly 🎉 

Testing:
- I've added a couple of parsing tests for the direct comparision with `{}` and without blocks
- I've also added several runtime tests for this feature, since it is more fundamental :)

Please, share your feedback, since this is my first Gleam contribution and I might miss obvious things (I know Gleam for 1 week now 😆)

Closes https://github.com/gleam-lang/gleam/issues/1980