### PR TITLE
Annotate JavaScript runtime in `gleam run --help`

### DIFF
--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -188,6 +188,7 @@ enum Command {
         #[arg(short, long, ignore_case = true)]
         target: Option<Target>,
 
+        /// Optionally specify the JavaScript runtime: nodejs, deno, bun
         #[arg(long, ignore_case = true)]
         runtime: Option<Runtime>,
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -118,14 +118,14 @@ enum Command {
         warnings_as_errors: bool,
 
         /// The platform to target
-        #[arg(short, long, ignore_case = true)]
+        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
         target: Option<Target>,
     },
 
     /// Type check the project
     Check {
         /// The platform to target
-        #[arg(short, long, ignore_case = true)]
+        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
         target: Option<Target>,
     },
 
@@ -185,11 +185,11 @@ enum Command {
     #[command(trailing_var_arg = true)]
     Run {
         /// The platform to target
-        #[arg(short, long, ignore_case = true)]
+        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
         target: Option<Target>,
 
-        /// Optionally specify the JavaScript runtime: nodejs, deno, bun
-        #[arg(long, ignore_case = true)]
+        /// Specify the JavaScript runtime
+        #[arg(long, ignore_case = true, value_names = Runtime::VARIANTS)]
         runtime: Option<Runtime>,
 
         /// The module to run
@@ -203,10 +203,10 @@ enum Command {
     #[command(trailing_var_arg = true)]
     Test {
         /// The platform to target
-        #[arg(short, long, ignore_case = true)]
+        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
         target: Option<Target>,
 
-        #[arg(long, ignore_case = true)]
+        #[arg(long, ignore_case = true, value_names = Runtime::VARIANTS)]
         runtime: Option<Runtime>,
 
         arguments: Vec<String>,

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -110,6 +110,7 @@ use strum::VariantNames;
         .usage(styling::AnsiColor::Yellow.on_default())
         .literal(styling::AnsiColor::Green.on_default())
 )]
+
 enum Command {
     /// Build the project
     Build {
@@ -117,15 +118,13 @@ enum Command {
         #[arg(long)]
         warnings_as_errors: bool,
 
-        /// The platform to target
-        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
+        #[arg(short, long, ignore_case = true, help = target_doc())]
         target: Option<Target>,
     },
 
     /// Type check the project
     Check {
-        /// The platform to target
-        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
+        #[arg(short, long, ignore_case = true, help = target_doc())]
         target: Option<Target>,
     },
 
@@ -184,12 +183,10 @@ enum Command {
     /// Run the project
     #[command(trailing_var_arg = true)]
     Run {
-        /// The platform to target
-        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
+        #[arg(short, long, ignore_case = true, help = target_doc())]
         target: Option<Target>,
 
-        /// Specify the JavaScript runtime
-        #[arg(long, ignore_case = true, value_names = Runtime::VARIANTS)]
+        #[arg(long, ignore_case = true, help = runtime_doc())]
         runtime: Option<Runtime>,
 
         /// The module to run
@@ -202,11 +199,10 @@ enum Command {
     /// Run the project tests
     #[command(trailing_var_arg = true)]
     Test {
-        /// The platform to target
-        #[arg(short, long, ignore_case = true, value_names = Target::VARIANTS)]
+        #[arg(short, long, ignore_case = true, help = target_doc())]
         target: Option<Target>,
 
-        #[arg(long, ignore_case = true, value_names = Runtime::VARIANTS)]
+        #[arg(long, ignore_case = true, help = runtime_doc())]
         runtime: Option<Runtime>,
 
         arguments: Vec<String>,
@@ -248,6 +244,14 @@ enum Command {
     /// Export something useful from the Gleam project
     #[command(subcommand)]
     Export(ExportTarget),
+}
+
+fn target_doc() -> String {
+    format!("{:?} The platform to target", Target::VARIANTS)
+}
+
+fn runtime_doc() -> String {
+    format!("{:?} The JavaScript runtime to target", Runtime::VARIANTS)
 }
 
 #[derive(Subcommand, Debug, Clone)]


### PR DESCRIPTION
Currently, the javascript runtime selection is not documented when running `gleam run --help`. Change the help message to say
```
Usage: gleam run [OPTIONS] [ARGUMENTS]...

Arguments:
  [ARGUMENTS]...  

Options:
  -t, --target <TARGET>    The platform to target
      --runtime <RUNTIME>  Optionally specify the JavaScript runtime: nodejs, deno, bun
  -m, --module <MODULE>    The module to run
  -h, --help               Print help
```