### PR TITLE
Add aarch64-apple-darwin CI target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
             use-cross: false
             run-integration-tests: true
           - os: macos-14  # aarch64
+            toolchain: stable
             target: aarch64-apple-darwin
             use-cross: false
             run-integration-tests: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,13 +85,13 @@ jobs:
           otp-version: "25.1"
           elixir-version: "1.14.1"
           rebar3-version: "3"
-        if: ${{ matrix.os != 'macos-latest' }} # setup-beam does not support macOS
+        if: ${{ runner.os != 'macOS' }} # setup-beam does not support macOS
 
       - name: Install Erlang (macos)
         run: |
           brew install erlang rebar3 elixir
           mix local.hex --force
-        if: ${{ matrix.os == 'macos-latest' }} # setup-beam does not support macOS
+        if: ${{ runner.os == 'macOS' }} # setup-beam does not support macOS
 
       - name: Handle Rust dependencies caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,12 @@ jobs:
             target: aarch64-unknown-linux-musl
             use-cross: true
             run-integration-tests: false # Cannot run aarch64 binaries on x86_64
-          - os: macos-latest
+          - os: macos-12  # intel
             target: x86_64-apple-darwin
+            use-cross: false
+            run-integration-tests: true
+          - os: macos-14  # aarch64
+            target: aarch64-apple-darwin
             use-cross: false
             run-integration-tests: true
           - os: windows-latest
@@ -153,15 +157,15 @@ jobs:
         working-directory: ./test/external_only_javascript
         if: ${{ matrix.run-integration-tests }}
         env:
-          GLEAM_COMMAND: gleam 
-        
+          GLEAM_COMMAND: gleam
+
 
       - name: test/external_only_erlang
         run: ./test.sh
         working-directory: ./test/external_only_erlang
         if: ${{ matrix.run-integration-tests }}
         env:
-          GLEAM_COMMAND: gleam 
+          GLEAM_COMMAND: gleam
 
       - name: test/project_javascript
         run: |


### PR DESCRIPTION
GitHub now supports Apple M1 runners: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

So, I am changing `macos-latest` to be `macos-12`, since it is now just an alias for this version: https://github.com/gleam-lang/gleam/actions/runs/8331253881/job/22797719598#step:1:4

And I am adding this Tier2 Rust target. It should mostly work (until it does not as always).

But, keep in mind that this might slow the CI, for example, our jobs in CPython sometimes take hours to even start. And sometimes it is really fast: https://github.com/python/cpython/pull/116861

Refs https://github.com/gleam-lang/gleam/issues/1439