### PR TITLE
Fix formatting line breaks with `\r\n`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 - Fixed a bug where a record update's arguments would not be indented correctly.
 - Fixed a bug where function call arguments, tuple items and list items would be
   needlessly indented if preceded by a comment.
+- Fixed a bug where empty lines would be removed incorrectly with CRLF line
+  endings or trailing white space.
 
 ### Build tool
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -92,15 +92,11 @@ impl<'comments> Formatter<'comments> {
     fn any_comments(&self, limit: u32) -> bool {
         self.comments
             .first()
-            .map(|comment| comment.start < limit)
-            .unwrap_or(false)
+            .is_some_and(|comment| comment.start < limit)
     }
 
     fn any_empty_lines(&self, limit: u32) -> bool {
-        self.empty_lines
-            .first()
-            .map(|line| *line < limit)
-            .unwrap_or(false)
+        self.empty_lines.first().is_some_and(|line| *line < limit)
     }
 
     /// Pop comments that occur before a byte-index in the source, consuming

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -4465,6 +4465,127 @@ fn negation_block() {
 }
 
 #[test]
+fn empty_lines_work_with_trailing_space() {
+    let src = "pub fn main() {
+  let inc = fn(a) { a + 1 } 
+
+
+  pair.map_first(#(1, 2), inc)  
+  |> should.equal(#(2, 2)) 
+
+  // Comment
+
+  1  
+
+
+  // Comment 
+
+
+  2
+}
+";
+    let expected = "pub fn main() {
+  let inc = fn(a) { a + 1 }
+
+  pair.map_first(#(1, 2), inc)
+  |> should.equal(#(2, 2))
+
+  // Comment
+
+  1
+
+  // Comment 
+
+  2
+}
+";
+    assert_format!(expected); // Sanity check
+
+    assert_format_rewrite!(src, expected);
+}
+
+#[test]
+fn empty_lines_work_with_eol_normalisation() {
+    let src = "pub fn main() {
+  let inc = fn(a) { a + 1 }
+
+
+  pair.map_first(#(1, 2), inc)
+  |> should.equal(#(2, 2))
+
+  // Comment
+
+  1
+
+
+  // Comment
+
+
+  2
+}
+";
+    let expected = "pub fn main() {
+  let inc = fn(a) { a + 1 }
+
+  pair.map_first(#(1, 2), inc)
+  |> should.equal(#(2, 2))
+
+  // Comment
+
+  1
+
+  // Comment
+
+  2
+}
+";
+    assert_format!(expected); // Sanity check
+
+    assert_format_rewrite!(&src.replace('\n', "\r\n"), expected);
+    assert_format_rewrite!(&src.replace('\n', "\r"), expected);
+}
+
+#[test]
+fn empty_lines_work_with_trailing_space_and_eol_normalisation() {
+    let src = "pub fn main() {
+  let inc = fn(a) { a + 1 } 
+
+
+  pair.map_first(#(1, 2), inc)
+  |> should.equal(#(2, 2)) 
+
+  // Comment
+
+  1
+
+
+  // Comment
+
+
+  2
+}
+";
+    let expected = "pub fn main() {
+  let inc = fn(a) { a + 1 }
+
+  pair.map_first(#(1, 2), inc)
+  |> should.equal(#(2, 2))
+
+  // Comment
+
+  1
+
+  // Comment
+
+  2
+}
+";
+    assert_format!(expected); // Sanity check
+
+    assert_format_rewrite!(&src.replace('\n', "\r\n"), expected);
+    assert_format_rewrite!(&src.replace('\n', "\r"), expected);
+}
+#[test]
 fn single_empty_line_between_comments() {
     // empty line isn't added if it's not already present
     assert_format!(

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -93,7 +93,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         // Collapse \r\n into \n
-        while let Some((i, '\r')) = self.chr0 {
+        if let Some((i, '\r')) = self.chr0 {
             if let Some((_, '\n')) = self.chr1 {
                 // Transform windows EOL into \n
                 let _ = self.shift();


### PR DESCRIPTION
Attempt to fix #2753

I noticed the same happened with trailing space before the empty line. I think this was partially caused by https://github.com/gleam-lang/gleam/blob/2a459ff2c02a59ce32b989a40ce07d88e1d14bcd/compiler-core/src/format.rs#L704, which didn't find the further than expected empty line. But I might be wrong, I don't quite have the full picture where all the spaces and line breaks are handled.

I also added some tests for cases I bumped into with another attempt.

Adding tests for different EOL cases, I noticed that comments would retain the `\r` from `\r\n`. I fixed this by moving the reported position to the `\r` character.