### PR TITLE
fix(format): persists EOL sequence #2753

### DIFF
--- a/compiler-core/src/fix.rs
+++ b/compiler-core/src/fix.rs
@@ -1,3 +1,4 @@
+use crate::format::get_line_break_from_chars;
 use crate::{
     format::{Formatter, Intermediate},
     Error, Result,
@@ -19,10 +20,11 @@ pub fn parse_fix_and_format(src: &EcoString, path: &Utf8Path) -> Result<String> 
     // let module = some_fixer_module::Fixer::fix(module);
 
     // Format
+    let line_break = get_line_break_from_chars(src.chars());
     let mut buffer = String::new();
     Formatter::with_comments(&intermediate)
         .module(&module)
-        .pretty_print(80, &mut buffer)?;
+        .pretty_print(80, &mut buffer, line_break)?;
 
     Ok(buffer)
 }


### PR DESCRIPTION
Fixes #2753.

Tested this out and seems like it works, not sure about the direction that I took and if it makes sense for the project. If you think the new parameter to `format` and `pretty_print` makes sense, I can add any missing documentation and tests. Any feedback would be good.

## Video

https://github.com/gleam-lang/gleam/assets/48896572/84abb8b8-74a6-43bd-818c-53426ff5d89e

## More information

Also tested against [gleam-lang/example-todomvc](https://github.com/gleam-lang/example-todomvc) and [gleam-lang/example-echo-server](https://github.com/gleam-lang/example-echo-server).

Source code used in the video:
```gleam
import gleam/io

pub fn main() {
  io.println("hello, friend!")
}
```

Command being used:
```
cargo run --release format ../../gleam-dump/hello_world.gleam
```