### PR TITLE
Improve ci.yml and add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,6 +13,13 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
   CROSS_CONTAINER_UID: 0
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -61,7 +69,7 @@ jobs:
             run-integration-tests: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install musl-tools incl. musl-gcc
         uses: awalsh128/cache-apt-pkgs-action@v1
@@ -121,7 +129,7 @@ jobs:
           gleam test && cd src && gleam test && cd ..
           gleam docs build
         working-directory: ./test/project_erlang
-        if: ${{ matrix.os != 'windows-latest' && matrix.run-integration-tests }}
+        if: ${{ runner.os != 'Windows' && matrix.run-integration-tests }}
 
       - name: test/project_erlang (windows)
         run: |
@@ -130,21 +138,21 @@ jobs:
           gleam test && cd src && gleam test && cd ..
           gleam docs build
         working-directory: ./test/project_erlang_windows
-        if: ${{ matrix.os == 'windows-latest' && matrix.run-integration-tests }}
+        if: ${{ runner.os == 'Windows' && matrix.run-integration-tests }}
 
       - name: test/project_erlang export erlang-shipment (non-windows)
         run: |
           gleam export erlang-shipment
           ./build/erlang-shipment/entrypoint.sh run
         working-directory: ./test/project_erlang
-        if: ${{ matrix.os != 'windows-latest' && matrix.run-integration-tests }}
+        if: ${{ runner.os != 'Windows' && matrix.run-integration-tests }}
 
       - name: test/project_erlang export erlang-shipment (windows)
         run: |
           gleam export erlang-shipment
           .\build\erlang-shipment\entrypoint.ps1 run
         working-directory: ./test/project_erlang_windows
-        if: ${{ matrix.os == 'windows-latest' && matrix.run-integration-tests }}
+        if: ${{ runner.os == 'Windows' && matrix.run-integration-tests }}
 
       - name: test/project_erlang export package-interface
         run: |
@@ -225,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -235,9 +243,9 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install wasm-pack
         run: |
@@ -254,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -276,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -304,7 +312,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -332,7 +340,7 @@ jobs:
           command: build
 
       - name: Upload artifact (Ubuntu)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: gleam
           path: target/debug/gleam
@@ -343,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: Install Deno
         uses: denoland/setup-deno@v1
@@ -361,7 +369,7 @@ jobs:
           rebar3-version: "3"
 
       - name: Download Gleam binary from previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gleam
           path: ./test


### PR DESCRIPTION
Here's the full list of changes:
- `workflow_dispatch:` allows you to manually run actions from the admin panel: https://github.com/gleam-lang/gleam/actions/workflows/ci.yaml It is really useful sometimes, in other cases it just does nothing
- `permissions:` sets stricter security rules for this workflow. It should not be able to do anything. Upload / download of artifacts will continue to work: https://github.com/actions/upload-artifact/issues/197 `permissions:` can be set on individual jobs as well, if needed later
- `concurrency:` cancels previous jobs, when new commits are pushed to the CI. It helps to save extra resources and not to continue meaningless work
- I've changed `workflow.os` to `runner.os`, because the first is not really about the runner os, it is just the label we use
- `node-version:` is updated, because `16` is reaching its EOL, see https://nodejs.org/en/about/previous-releases `18` is still good 👍  
- I've also updated several actions' versions. No other changes here should be required
- I've also added `dependabot.yml` which is a nice tool to update deps, embeded into GitHub itself. It should not be very noisy and can help doing what I'm doing now :)

