### PR TITLE
Add `timeout-minutes` to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
   test:
     name: test
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -231,6 +232,7 @@ jobs:
 
   test-wasm:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -260,6 +262,7 @@ jobs:
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -282,6 +285,7 @@ jobs:
   validate-deps:
     name: validate-deps
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -310,6 +314,7 @@ jobs:
   lint-build:
     name: lint-build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -349,6 +354,7 @@ jobs:
     name: test-projects
     needs: lint-build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds `timeout-minutes:` to all CI jobs.
Docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes

Why does any project need that?
Because by default GitHub Actions has almost no timeouts, we had jobs that were running for almost a year. This is just pure resource waste, we should do better.

How do we define timeouts? There are two types of jobs:
- Based on the current metrics lint jobs take about a minute https://github.com/gleam-lang/gleam/actions/runs/8342174126/job/22829770221 So, `10 seconds` it is. It will allow some slowdown, but not a catastrophic one
- Test jobs are slower by definition, they have around 5 minutes right now https://github.com/gleam-lang/gleam/actions/runs/8342174126/job/22829772233 So, I've decided to cap them at 30 minutes