### PR TITLE
[WIP] Update LSP hover action to return labelled definition

### DIFF
--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -35,7 +35,7 @@ fn add_2(add adder:Int) {
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
-fn add_2(add adder:Int) -> Int
+pub fn add_2(add adder: Int) -> Int
 ```
 "
                 .to_string()
@@ -67,7 +67,7 @@ fn add_2(x) {
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
-fn add_2(x:Int) -> Int
+pub fn add_2(x: Int) -> Int
 ```
 "
                 .to_string()
@@ -458,7 +458,7 @@ fn append(x, y) {
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
-fn append(x:String, y:String) -> String
+pub fn append(x: String, y: String) -> String
 ```
  Exciting documentation
  Maybe even multiple lines

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -23,6 +23,38 @@ fn positioned_hover(src: &str, position: Position) -> Option<Hover> {
 }
 
 #[test]
+fn labelled_hover_function_definition() {
+    let code = "
+fn add_2(add adder:Int) {
+  adder + 2
+}
+";
+
+    assert_eq!(
+        positioned_hover(code, Position::new(1, 3)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam
+fn add_2(add adder:Int) -> Int
+```
+"
+                .to_string()
+            )),
+            range: Some(Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 23,
+                },
+            },),
+        })
+    );
+}
+
+#[test]
 fn hover_function_definition() {
     let code = "
 fn add_2(x) {
@@ -35,7 +67,7 @@ fn add_2(x) {
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
-fn(Int) -> Int
+fn add_2(x:Int) -> Int
 ```
 "
                 .to_string()
@@ -426,7 +458,7 @@ fn append(x, y) {
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
-fn(String, String) -> String
+fn append(x:String, y:String) -> String
 ```
  Exciting documentation
  Maybe even multiple lines

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -23,7 +23,7 @@ fn positioned_hover(src: &str, position: Position) -> Option<Hover> {
 }
 
 #[test]
-fn labelled_hover_function_definition() {
+fn hover_function_definition_with_label() {
     let code = "
 fn add_2(add adder:Int) {
   adder + 2


### PR DESCRIPTION
Relates to https://github.com/gleam-lang/gleam/issues/2653 

Updating the LSP hover action to return the full function head, as per the documentation. 

The planned format is as below
```
<fn-accessor-type> fn <function-name>(<label> <argument-name>: <type>, ..) -> <return-type> 
```
Eg:
For a function like below
```
fn greet(firstname name:String) { io.println("Hello " <> name) }
```
The generated string would be
```
fn greet(firstname name: String) -> Nil 
```

Current implementation uses pretty print and existing Fn Type enum. Since labels are not part of the type system, we are going ahead with simple string interpolation for now. 

P.S : This is the first time working with the codebase and such a big Rust repo, hence please feel free to suggest changes and improvements. 

P.P.S: I am trying to test it out in local hence kept the `[WIP]` tag. 