### PR TITLE
Fix a bug where tuple/call/list items would be needlessly indented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Fixed a bug where the formatter would move comments from the end of bounded
   expressions like lists, tuples, case expressions or function calls.
 - Fixed a bug where a record update's arguments would not be indented correctly.
+- Fixed a bug where function call arguments, tuple items and list items would be
+  needlessly indented if preceded by a comment.
 
 ### Build tool
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1044,7 +1044,14 @@ impl<'comments> Formatter<'comments> {
                 // make it easier to tell where one item ends and the other
                 // starts.
                 if elements.len() > 1 && (e.is_binop() || e.is_pipeline()) {
-                    self_.expr(e).group().nest(INDENT)
+                    // We pop the comments ourselves without relying on the default
+                    // `expression` way of commenting stuff. That's because we want to
+                    // avoid the comment block (and its newline) being indented by the
+                    // formatter. This way the comments gets added _after_ we increase
+                    // the nesting level.
+                    let comments = self_.pop_comments(e.start_byte_index());
+                    let doc = self_.expr(e).group().nest(INDENT);
+                    commented(doc, comments)
                 } else {
                     self_.expr(e).group()
                 }
@@ -1457,7 +1464,14 @@ impl<'comments> Formatter<'comments> {
             // make it easier to tell where one item ends and the other
             // starts.
             if arity > 1 && (arg.value.is_binop() || arg.value.is_pipeline()) {
-                self.expr(&arg.value).group().nest(INDENT)
+                // We pop the comments ourselves without relying on the default
+                // `expression` way of commenting stuff. That's because we want to
+                // avoid the comment block (and its newline) being indented by the
+                // formatter. This way the comments gets added _after_ we increase
+                // the nesting level.
+                let comments = self.pop_comments(arg.value.start_byte_index());
+                let doc = self.expr(&arg.value).group().nest(INDENT);
+                commented(doc, comments)
             } else {
                 self.expr(&arg.value).group()
             },
@@ -1650,7 +1664,14 @@ impl<'comments> Formatter<'comments> {
                 // make it easier to tell where one item ends and the other
                 // starts.
                 if list_size > 1 && (e.is_binop() || e.is_pipeline()) {
-                    self.expr(e).group().nest(INDENT)
+                    // We pop the comments ourselves without relying on the default
+                    // `expression` way of commenting stuff. That's because we want to
+                    // avoid the comment block (and its newline) being indented by the
+                    // formatter. This way the comments gets added _after_ we increase
+                    // the nesting level.
+                    let comments = self.pop_comments(e.start_byte_index());
+                    let doc = self.expr(e).group().nest(INDENT);
+                    commented(doc, comments)
                 } else {
                     self.expr(e).group()
                 }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5623,3 +5623,48 @@ fn comments_are_not_moved_out_of_function_calls() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2607
+#[test]
+fn function_arguments_after_comment_are_not_indented() {
+    assert_format!(
+        r#"pub fn main() {
+  wibble(
+    // Wobble
+    1 + 1,
+    "wibble",
+  )
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2607
+#[test]
+fn tuple_items_after_comment_are_not_indented() {
+    assert_format!(
+        r#"pub fn main() {
+  #(
+    // Wobble
+    1 + 1,
+    "wibble",
+  )
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2607
+#[test]
+fn list_items_after_comment_are_not_indented() {
+    assert_format!(
+        r#"pub fn main() {
+  [
+    // Wobble
+    1 + 1,
+    "wibble",
+  ]
+}
+"#
+    );
+}


### PR DESCRIPTION
This PR closes #2607 and closes #2611 