### PR TITLE
Fix `test_wasm` to actually run tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,13 +251,10 @@ jobs:
 
       - name: Install wasm-pack
         run: |
-          curl -L --output wasm-pack-init https://rustwasm.github.io/wasm-pack/installer/init.sh \
-          && chmod +x wasm-pack-init \
-          && ./wasm-pack-init \
-          && rm wasm-pack-init
+          curl -sSL https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
+
       - name: Run wasm tests
-        working-directory: ./compiler-wasm
-        run: wasm-pack test --node
+        run: wasm-pack test --node compiler-wasm
 
   rustfmt:
     name: rustfmt

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 gleam-core = { path = "../compiler-core" }
 console_error_panic_hook = "0.1.7"
 serde-wasm-bindgen = "0.6"
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.92", features = ["serde-serialize"] }
 tracing-wasm = "*"
 camino.workspace = true
 hexpm.workspace = true
@@ -24,4 +24,4 @@ termcolor.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.28"
+wasm-bindgen-test = "0.3.42"

--- a/compiler-wasm/src/tests.rs
+++ b/compiler-wasm/src/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 
-#[test]
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
 fn test_reset_filesystem() {
     reset_filesystem(0);
     assert_eq!(read_file_bytes(0, "hello"), None);
@@ -10,7 +12,7 @@ fn test_reset_filesystem() {
     assert_eq!(read_file_bytes(0, "hello"), None);
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_write_module() {
     reset_filesystem(0);
     assert_eq!(read_file_bytes(0, "/src/some/module.gleam"), None);
@@ -23,19 +25,19 @@ fn test_write_module() {
     assert_eq!(read_file_bytes(0, "/src/some/module.gleam"), None);
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_compile_package_bad_target() {
     reset_filesystem(0);
     assert!(compile_package(0, "ruby").is_err());
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_compile_package_empty() {
     reset_filesystem(0);
     assert!(compile_package(0, "javascript").is_ok());
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_compile_package_js() {
     reset_filesystem(0);
     write_module(0, "one/two", "pub const x = 1");
@@ -73,7 +75,7 @@ export function go() {
     );
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_warnings() {
     reset_filesystem(0);
     write_module(0, "one", "const x = 1");


### PR DESCRIPTION
Docs about `#[wasm_bindgen_test]`: https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/usage.html
Docs about `wasm-pack test`: https://rustwasm.github.io/wasm-pack/book/commands/test.html

I've also simplified the `wasm-pack` installation, we now don't have to use an intermediate file. We can just pipe the file into shell.