### PR TITLE
Fix exact package resolution for rc candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
   variable to any non-empty value.
 - Rust's Reqwest's `webpki-roots` are now used for TLS verification.
 - Update Deno config to allow passing `--location` runtime flag.
+- Fixed a bug with dependency resolution of exact versions of RC releases.
 
 ### Language Server
 

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -68,9 +68,9 @@ where
 // If the string would parse to an exact version then return the version
 fn parse_exact_version(ver: &str) -> Option<Version> {
     let version = ver.trim();
-    let is_digit = version.as_bytes().first();
+    let first_byte = version.as_bytes().first();
 
-    if version.starts_with("==") || is_digit.map_or(false, |v| v.is_ascii_digit()) {
+    if version.starts_with("==") || first_byte.map_or(false, |v| v.is_ascii_digit()) {
         let version = version.replace("==", "");
         let version = version.as_str().trim();
         if let Ok(v) = Version::parse(version) {

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -47,7 +47,7 @@ where
             version: root_version.clone(),
             outer_checksum: vec![],
             retirement_status: None,
-            requirements: requirements,
+            requirements,
             meta: (),
         }],
     };

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -72,7 +72,9 @@ fn parse_exact_version(ver: &str) -> Option<Version> {
         return None;
     }
 
-    if version.starts_with("==") || version.as_bytes().first().unwrap().is_ascii_digit() {
+    let is_digit = version.as_bytes().first();
+
+    if version.starts_with("==") || is_digit.map_or(false, |v| v.is_ascii_digit()) {
         let version = version.replace("==", "");
         let version = version.as_str().trim();
         if let Ok(v) = Version::parse(version) {

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -68,10 +68,6 @@ where
 // If the string would parse to an exact version then return the version
 fn parse_exact_version(ver: &str) -> Option<Version> {
     let version = ver.trim();
-    if version.is_empty() {
-        return None;
-    }
-
     let is_digit = version.as_bytes().first();
 
     if version.starts_with("==") || is_digit.map_or(false, |v| v.is_ascii_digit()) {


### PR DESCRIPTION
Closes #2630

Stores any versions that were set to exact releases and filters the available list if an exact release is found