### PR TITLE
Add vscode recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,6 @@
   "recommendations": [
     // Rust:
     "rust-lang.rust-analyzer",
-    // Debugging support:
-    "vadimcn.vscode-lldb",
 
     // Gleam:
     "Gleam.gleam",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  // @see https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions
+  "recommendations": [
+    // Rust:
+    "rust-lang.rust-analyzer",
+    // Debugging support:
+    "vadimcn.vscode-lldb",
+
+    // Gleam:
+    "Gleam.gleam",
+  ]
+}


### PR DESCRIPTION
This PR adds `.vscode/extensions.json` which contains a list of recommended extensions to install to get an easier time working on this project. As a new developer, it would be nice to have.

It includes: rust and gleam tools + a debugging backed (which is platform dependent and is different on Windows). But, I guess no one really uses Windows to develop Rust + Erlang tools, so it is fine? ¯\_(ツ)_/¯

Here's how it looks like inside the IDE: it is just a small section which suggests extensions, nothing more: 
<img width="1464" alt="Снимок экрана 2024-03-22 в 13 04 56" src="https://github.com/gleam-lang/gleam/assets/4660275/dec2b53f-893a-4e32-8096-800233bfb3ca">

Docs: https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions

Since there's no maintaince cost involved (or close to it), I guess that this can be considered a net-positive for the project: improving DX is a good thing.