### PR TITLE
Setup dependabot for Rust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ compiler-core/generated/schema_capnp.rs generated
 
 # Tests:
 test-package-compiler/src/generated_tests.rs generated
+
+# Lock files:
+Cargo.lock generated

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,27 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+
+# Rust:
+- package-ecosystem: "cargo"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "cargo"
+  directory: "/compiler-cli"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "cargo"
+  directory: "/compiler-core"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "cargo"
+  directory: "/compiler-wasm"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "cargo"
+  # Does not have any custom deps right now,
+  # but can add them in the future:
+  directory: "/test-package-compiler"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Adds `dependabot` support for Rust.
Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
See `cargo` section.

Possible risks:
- Noise, solution: increase the `interval` value, add `open-pull-requests-limit`
- Dependabot can have bugs specific to Rust and Cargo. Solution: patience :)

Closes #2803