### PR TITLE
Bump `pulldown-cmark` to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,14 +1621,21 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+checksum = "dce76ce678ffc8e5675b22aa1405de0b7037e2fdf8913fea40d1926c6fe1e6e7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "memchr",
+ "pulldown-cmark-escape",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
 
 [[package]]
 name = "quote"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -19,7 +19,7 @@ capnp = "0.14.3"
 # Template rendering
 askama = "0.12.0"
 # Markdown parsing
-pulldown-cmark = { version = "0.8.0", default-features = false }
+pulldown-cmark = { version = "0.10.0", default-features = false, features = ["html"] }
 # Non-empty vectors
 vec1 = "1.8.0"
 # XDG directory locations


### PR DESCRIPTION
Closes https://github.com/gleam-lang/gleam/pull/2812

It was failing with:

```
 error[E0433]: failed to resolve: could not find `html` in `pulldown_cmark`
   --> compiler-core/src/docs.rs:554:21
    |
554 |     pulldown_cmark::html::push_html(&mut s, p);
    |                     ^^^^ could not find `html` in `pulldown_cmark`
    |
note: found an item that was configured out
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pulldown-cmark-0.10.0/src/lib.rs:84:9
    |
84  | pub mod html;
    |         ^^^^
    = note: the item is gated behind the `html` feature

For more information about this error, try `rustc --explain E0433`.
```