### PR TITLE
Re-enable `unused_qualifications` in `compiler-cli/main.rs`

### DIFF
--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -29,8 +29,7 @@
     trivial_numeric_casts,
     nonstandard_style,
     unused_import_braces,
-    // TODO: re-enable this once the false positive bug is solved
-    // unused_qualifications,
+    unused_qualifications,
 )]
 #![deny(
     clippy::await_holding_lock,

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -29,7 +29,7 @@
     trivial_numeric_casts,
     nonstandard_style,
     unused_import_braces,
-    unused_qualifications,
+    unused_qualifications
 )]
 #![deny(
     clippy::await_holding_lock,


### PR DESCRIPTION
It seems to be fixed, introduced in https://github.com/gleam-lang/gleam/commit/673c8c941af97f0a062dafa05d0971c8fd2736fc