### PR TITLE
Rename `$prepend` to `listPrepend` on the JS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - Allow compilation of packages that require `"rebar"` using the rebar3 compiler.
 - A warning is now emitted when defining an opaque external type.
 - Improve error message when using incorrect quotes (`'`) to define a string
+- Fixed a bug where an imported module named `prepend` would conflict with the
+  `prepend` function imported from the prelude in the JavaScript target.
 
 ### Formatter
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -122,7 +122,7 @@ impl<'a> Generator<'a> {
         };
 
         if self.tracker.prepend_used {
-            self.register_prelude_usage(&mut imports, "prepend", Some("$prepend"));
+            self.register_prelude_usage(&mut imports, "prepend", Some("listPrepend"));
         };
 
         if self.tracker.custom_type_used {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1376,7 +1376,7 @@ where
 {
     elements.into_iter().rev().try_fold(tail, |tail, element| {
         let args = call_arguments([element, Ok(tail)])?;
-        Ok(docvec!["$prepend", args])
+        Ok(docvec!["listPrepend", args])
     })
 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
@@ -2,12 +2,11 @@
 source: compiler-core/src/javascript/tests/lists.rs
 expression: "\nfn go(x) {\n    []\n    [1]\n    [1, 2]\n    [1, 2, ..x]\n}\n"
 ---
-import { toList, prepend as $prepend } from "../gleam.mjs";
+import { toList, prepend as listPrepend } from "../gleam.mjs";
 
 function go(x) {
   toList([]);
   toList([1]);
   toList([1, 2]);
-  return $prepend(1, $prepend(2, x));
+  return listPrepend(1, listPrepend(2, x));
 }
-


### PR DESCRIPTION
Fixes #2823

Renames the `$prepend` alias for prelude's `prepend` to `listPrepend` instead. That way, it won't conflict with a Gleam module named `prepend`, and Gleam modules can't have uppercase characters, so the new name won't conflict with any Gleam modules (which are also imported with a dollar sign in front), variables (which also can't have uppercase characters) or types (which are in PascalCase, not camelCase).

Feel free to suggest an alternative solution, e.g. some name other than `listPrepend`. (Maybe `prependWith` could be better? Not sure.)