### PR TITLE
Fix spacing in invalid module name warning.

### DIFF
--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -154,8 +154,9 @@ impl Warning {
         match self {
             Warning::InvalidSource { path } => Diagnostic {
                 title: "Invalid module name".into(),
-                text: "Module names must begin with a lowercase letter and contain\
- only lowercase alphanumeric characters or underscores."
+                text: "\
+Module names must begin with a lowercase letter and contain
+only lowercase alphanumeric characters or underscores."
                     .into(),
                 level: diagnostic::Level::Warning,
                 location: None,


### PR DESCRIPTION
Trivial fix to the message attached to the compiler warning for invalid source file names.

Current (pre-patch) warning text is:
```
# NOTE: missing space in `containonly`
Module names must begin with a lowercase letter and containonly lowercase alphanumeric characters or underscores.
Hint: Rename `/Users/nashwan/Documents/Coding/Gleam/tour/src/01_basic_types.gleam` to be valid, or remove this file from the project source.
```

PS: I presume the intention is to have all of these compiler warnings **not** be too wide when printed out?

If so, note that the `Hint: Rename '{path}'` might still be a very long line depending on the problem `path` we're dealing with, like in the examplke above.

I'd be happy to make a separate patch which folds the warning/hint strings while printing them instead of having to rely on the formatting of multi-line string literals...