### PR TITLE
Let `ApiKeyCommand` use and prefer a long lived api key `HEXPM_API_KEY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@
   instead of relative.
 - The `gleam publish` command now asks for confirmation if the package repository
   URL doesn't return a successful status code.
+- `gleam publish` can now optionally use a Hex API key to authorise publishing
+  and retiring packages, set via the environment variable `HEXPM_API_KEY`.
 
 ### Language Server
 

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -37,18 +37,18 @@ pub trait ApiKeyCommand {
             &hostname,
             &username,
             &password,
-            &hex_config,
+            hex_config,
             &http,
         ))?;
 
         // Perform the API operation but don't exit early if it fails, we want to always
         // remove the API key
-        let result = self.with_api_key(runtime.handle(), &hex_config, &api_key);
+        let result = self.with_api_key(runtime.handle(), hex_config, &api_key);
 
         // Ensure to remove the API key
         runtime.block_on(gleam_core::hex::remove_api_key(
             &hostname,
-            &hex_config,
+            hex_config,
             &api_key,
             &http,
         ))?;

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -22,7 +22,7 @@ pub trait ApiKeyCommand {
 
     fn with_new_api_key(
         &mut self,
-        runtime: &tokio::runtime,
+        runtime: tokio::runtime::Runtime,
         hex_config: &hexpm::Config,
     ) -> Result<()> {
         let hostname = crate::publish::get_hostname();

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -9,8 +9,7 @@ const USER_PROMPT: &str = "https://hex.pm username";
 const USER_KEY: &str = "HEXPM_USER";
 const PASS_PROMPT: &str = "https://hex.pm password";
 const PASS_KEY: &str = "HEXPM_PASS";
-const API_KEY_PROMPT: &str = "https://hex.pm API key";
-const API_KEY_KEY: &str = "HEXPM_API_KEY";
+const API_KEY: &str = "HEXPM_API_KEY";
 
 /// A helper trait that handles the provisioning and destruction of a Hex API key.
 pub trait ApiKeyCommand {
@@ -21,73 +20,52 @@ pub trait ApiKeyCommand {
         api_key: &str,
     ) -> Result<()>;
 
+    fn with_new_api_key(
+        &mut self,
+        runtime: &tokio::runtime::Handle,
+        hex_config: &hexpm::Config,
+    ) -> Result<()> {
+        // Get login creds from user
+        let username = std::env::var(USER_KEY).or_else(|_| cli::ask(USER_PROMPT))?;
+        let password = std::env::var(PASS_KEY).or_else(|_| cli::ask_password(PASS_PROMPT))?;
+
+        // Get API key
+        let api_key = runtime.block_on(gleam_core::hex::create_api_key(
+            &hostname,
+            &username,
+            &password,
+            &hex_config,
+            &http,
+        ))?;
+
+        // Perform the API operation but don't exit early if it fails, we want to always
+        // remove the API key
+        let result = self.with_api_key(runtime.handle(), &hex_config, &api_key);
+
+        // Ensure to remove the API key
+        runtime.block_on(gleam_core::hex::remove_api_key(
+            &hostname,
+            &hex_config,
+            &api_key,
+            &http,
+        ))?;
+
+        result
+    }
+
     fn run(&mut self) -> Result<()> {
         let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
         let hostname = crate::publish::get_hostname();
         let hex_config = hexpm::Config::new();
         let http = HttpClient::new();
 
-        // Get login creds from user without prompting, to check
-        // if we're using username and password, or an API key.
-        let username = std::env::var(USER_KEY).unwrap_or("".into());
-        let password = std::env::var(PASS_KEY).unwrap_or("".into());
-        let api_key = std::env::var(API_KEY_KEY).unwrap_or("".into());
+        let api_key = std::env::var(API_KEY).unwrap_or_default().trim();
 
-        let insufficient_creds_in_env_var =
-            api_key.trim().is_empty() && (username.trim().is_empty() || password.trim().is_empty());
-
-        // Get login creds from user, prompting this time if
-        // insufficient creds could be sourced from the env vars.
-
-        // Prefer the API key, which is necessarily empty, so just ask for it.
-        let api_key = if insufficient_creds_in_env_var {
-            cli::ask_password(API_KEY_PROMPT)?
+        if api_key.is_empty() {
+            self.with_new_api_key(runtime.handle(), &hex_config)
         } else {
-            api_key
-        };
-        let no_api_key_supplied = api_key.trim().is_empty();
-
-        // If no creds were sourced from env vars or an API key was
-        // not entered, then we prompt for the username and password
-        let username = if insufficient_creds_in_env_var && no_api_key_supplied {
-            std::env::var(USER_KEY).or_else(|_| cli::ask(USER_PROMPT))?
-        } else {
-            username
-        };
-        let password = if insufficient_creds_in_env_var && no_api_key_supplied {
-            std::env::var(PASS_KEY).or_else(|_| cli::ask_password(PASS_PROMPT))?
-        } else {
-            password
-        };
-
-        let api_key = if no_api_key_supplied {
-            // Create and manage a short lived API key
-            runtime.block_on(gleam_core::hex::create_api_key(
-                &hostname,
-                &username,
-                &password,
-                &hex_config,
-                &http,
-            ))?
-        } else {
-            api_key
-        };
-
-        // Perform the API operation but don't exit early if it fails, we want to always
-        // check if we should remove the API key
-        let result = self.with_api_key(runtime.handle(), &hex_config, &api_key);
-
-        if no_api_key_supplied {
-            // Ensure to remove the API key
-            runtime.block_on(gleam_core::hex::remove_api_key(
-                &hostname,
-                &hex_config,
-                &api_key,
-                &http,
-            ))?;
+            self.with_api_key(runtime.handle(), &hex_config, &api_key)
         }
-
-        result
     }
 }
 

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -34,11 +34,7 @@ pub trait ApiKeyCommand {
 
         // Get API key
         let api_key = runtime.block_on(gleam_core::hex::create_api_key(
-            &hostname,
-            &username,
-            &password,
-            hex_config,
-            &http,
+            &hostname, &username, &password, hex_config, &http,
         ))?;
 
         // Perform the API operation but don't exit early if it fails, we want to always
@@ -47,10 +43,7 @@ pub trait ApiKeyCommand {
 
         // Ensure to remove the API key
         runtime.block_on(gleam_core::hex::remove_api_key(
-            &hostname,
-            hex_config,
-            &api_key,
-            &http,
+            &hostname, hex_config, &api_key, &http,
         ))?;
 
         result

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -25,6 +25,9 @@ pub trait ApiKeyCommand {
         runtime: &tokio::runtime::Handle,
         hex_config: &hexpm::Config,
     ) -> Result<()> {
+        let hostname = crate::publish::get_hostname();
+        let http = HttpClient::new();
+
         // Get login creds from user
         let username = std::env::var(USER_KEY).or_else(|_| cli::ask(USER_PROMPT))?;
         let password = std::env::var(PASS_KEY).or_else(|_| cli::ask_password(PASS_PROMPT))?;
@@ -55,9 +58,7 @@ pub trait ApiKeyCommand {
 
     fn run(&mut self) -> Result<()> {
         let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
-        let hostname = crate::publish::get_hostname();
         let hex_config = hexpm::Config::new();
-        let http = HttpClient::new();
 
         let api_key = std::env::var(API_KEY).unwrap_or_default().trim();
 

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -33,7 +33,8 @@ pub trait ApiKeyCommand {
         let password = std::env::var(PASS_KEY).unwrap_or("".into());
         let api_key = std::env::var(API_KEY_KEY).unwrap_or("".into());
 
-        let insufficient_creds_in_env_var = api_key.trim().is_empty() && (username.trim().is_empty() || password.trim().is_empty());
+        let insufficient_creds_in_env_var =
+            api_key.trim().is_empty() && (username.trim().is_empty() || password.trim().is_empty());
 
         // Get login creds from user, prompting this time if
         // insufficient creds could be sourced from the env vars.

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -22,7 +22,7 @@ pub trait ApiKeyCommand {
 
     fn with_new_api_key(
         &mut self,
-        runtime: tokio::runtime::Runtime,
+        runtime: &tokio::runtime::Runtime,
         hex_config: &hexpm::Config,
     ) -> Result<()> {
         let hostname = crate::publish::get_hostname();

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -60,7 +60,7 @@ pub trait ApiKeyCommand {
         let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
         let hex_config = hexpm::Config::new();
 
-        let api_key = std::env::var(API_KEY).unwrap_or_default().trim();
+        let api_key = std::env::var(API_KEY).unwrap_or_default().trim().to_owned();
 
         if api_key.is_empty() {
             self.with_new_api_key(&runtime, &hex_config)

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -22,7 +22,7 @@ pub trait ApiKeyCommand {
 
     fn with_new_api_key(
         &mut self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &tokio::runtime,
         hex_config: &hexpm::Config,
     ) -> Result<()> {
         let hostname = crate::publish::get_hostname();
@@ -63,7 +63,7 @@ pub trait ApiKeyCommand {
         let api_key = std::env::var(API_KEY).unwrap_or_default().trim();
 
         if api_key.is_empty() {
-            self.with_new_api_key(runtime.handle(), &hex_config)
+            self.with_new_api_key(&runtime, &hex_config)
         } else {
             self.with_api_key(runtime.handle(), &hex_config, &api_key)
         }


### PR DESCRIPTION
Addresses #2844 

Add a `HEXPM_API_KEY` which `ApiKeyCommand` will prefer, but will check if it's supplied or not and fall back to requesting the username and password, unless either the api key or username AND password are supplied via the env vars, in which case, it will prefer the api key. But if an API key isn't supplied to the prompt and a username and password are supplied, it will use those, and only prompt for them if no API key is given to the prompt for one if no credentials are supplied from env vars. Then wrap the creating and removing of the temporary key produced using the username and password with the check from whether or not a long lived api key was provided.