### PR TITLE
Fix issue with lsp not compiling on editor load

### DIFF
--- a/compiler-core/src/language_server/router.rs
+++ b/compiler-core/src/language_server/router.rs
@@ -59,7 +59,6 @@ where
         // If the path is the root of a known project then return it. Otherwise
         // find the nearest parent project.
         let path = if self.engines.contains_key(&path) {
-            tracing::info!(?path, "found engine for path");
             path
         } else {
             let Some(path) = find_gleam_project_parent(&self.io, &path) else {

--- a/compiler-core/src/language_server/router.rs
+++ b/compiler-core/src/language_server/router.rs
@@ -59,6 +59,7 @@ where
         // If the path is the root of a known project then return it. Otherwise
         // find the nearest parent project.
         let path = if self.engines.contains_key(&path) {
+            tracing::info!(?path, "found engine for path");
             path
         } else {
             let Some(path) = find_gleam_project_parent(&self.io, &path) else {
@@ -115,6 +116,12 @@ where
     let is_module = path.extension().map(|x| x == "gleam").unwrap_or(false);
     let mut directory = path.to_path_buf();
 
+    // If we are finding the gleam project of a directory then we want to check the directory itself
+    let is_directory = path.extension().is_none();
+    if is_directory {
+        directory.push("src");
+    }
+
     while let Some(root) = directory.parent() {
         // If there's no gleam.toml in the root then we continue to the next parent.
         if !io.is_file(&root.join("gleam.toml")) {
@@ -165,6 +172,16 @@ mod find_gleam_project_parent_tests {
         io.write(Utf8Path::new("/app/gleam.toml"), "").unwrap();
         assert_eq!(
             find_gleam_project_parent(&io, Utf8Path::new("/app/gleam.toml")),
+            Some(Utf8PathBuf::from("/app"))
+        );
+    }
+
+    #[test]
+    fn directory_with_gleam_toml() {
+        let io = InMemoryFileSystem::new();
+        io.write(Utf8Path::new("/app/gleam.toml"), "").unwrap();
+        assert_eq!(
+            find_gleam_project_parent(&io, Utf8Path::new("/app")),
             Some(Utf8PathBuf::from("/app"))
         );
     }


### PR DESCRIPTION
It looks like with the changes to https://github.com/gleam-lang/gleam/pull/2731 we only compile modules that have changed based on lsp messages for didOpen/didChange/didSave. However, on first lsp load/editor open (at least as tested with vs code) the very first call to compile_please would be caused by the initialization of the lsp itself (it was hard to tell exactly where but I assume it was the very first loop of the message `receive` not getting events in the first x milliseconds before the initial didOpen event). As such, the first call to compile_please would be https://github.com/gleam-lang/gleam/blob/main/compiler-core/src/language_server/server.rs#L347 which would get called with the root directory itself. This caused issues because `find_gleam_project_parent` would not recognized that the root directory was itself the "parent project". This change fixes this issue by checking the directory itself first if the passed in path is a directory