### PR TITLE
fixed goto for cached dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,21 +305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dca085c2c7d9d65ad749d450b19b551efaa8e3476a439bdca07aca8533097f3"
 
 [[package]]
-name = "capnp"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4bfb7088540597aa9a835f445dae750aa0792f84d253c6cd515940486e98e00"
-dependencies = [
- "embedded-io",
-]
-
-[[package]]
 name = "capnpc"
-version = "0.19.0"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ba30e0f08582d53c2f3710cf4bb65ff562614b1ba86906d7391adffe189ec"
+checksum = "bdc9f1dc84666d4ff007b1a16c8f97db80764a624625979be05d869bcff43aaa"
 dependencies = [
- "capnp 0.19.2",
+ "capnp",
 ]
 
 [[package]]
@@ -615,12 +606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,7 +875,7 @@ dependencies = [
  "bincode",
  "bytes",
  "camino",
- "capnp 0.14.11",
+ "capnp",
  "capnpc",
  "codespan-reporting",
  "debug-ignore",

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -19,7 +19,9 @@ capnp = "0.14.3"
 # Template rendering
 askama = "0.12.0"
 # Markdown parsing
-pulldown-cmark = { version = "0.10.0", default-features = false, features = ["html"] }
+pulldown-cmark = { version = "0.10.0", default-features = false, features = [
+  "html",
+] }
 # Non-empty vectors
 vec1 = "1.11.1"
 # XDG directory locations
@@ -68,7 +70,7 @@ tracing.workspace = true
 # Data (de)serialisation
 serde_derive = "1.0.130"
 # Cap'n Proto binary format codegen
-capnpc = "0.19.0"
+capnpc = "0.14.4"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -481,6 +481,14 @@ pub mod module {
     pub fn get_contains_todo(self) -> bool {
       self.reader.get_bool_field(0)
     }
+    #[inline]
+    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(7), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_line_numbers(&self) -> bool {
+      !self.reader.get_pointer_field(7).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -651,6 +659,22 @@ pub mod module {
     pub fn set_contains_todo(&mut self, value: bool)  {
       self.builder.set_bool_field(0, value);
     }
+    #[inline]
+    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(7), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_line_numbers(&mut self, value: crate::schema_capnp::line_numbers::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(7), value, false)
+    }
+    #[inline]
+    pub fn init_line_numbers(self, ) -> crate::schema_capnp::line_numbers::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(7), 0)
+    }
+    #[inline]
+    pub fn has_line_numbers(&self) -> bool {
+      !self.builder.get_pointer_field(7).is_null()
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -660,10 +684,13 @@ pub mod module {
     }
   }
   impl Pipeline  {
+    pub fn get_line_numbers(&self) -> crate::schema_capnp::line_numbers::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(7))
+    }
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 7 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 8 };
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
   }
 }
@@ -6220,5 +6247,154 @@ pub mod bit_array_segment_option {
       pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 1 };
       pub const TYPE_ID: u64 = 0xcf7d_fddd_a3be_0c5e;
     }
+  }
+}
+
+pub mod line_numbers {
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  #[derive(Clone, Copy)]
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+
+  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      Reader { reader,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Reader { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn get_line_starts(self) -> ::capnp::Result<::capnp::primitive_list::Reader<'a,u32>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_line_starts(&self) -> bool {
+      !self.reader.get_pointer_field(0).is_null()
+    }
+    #[inline]
+    pub fn get_length(self) -> u32 {
+      self.reader.get_data_field::<u32>(0)
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
+    #[inline]
+    fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
+  }
+  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      Builder { builder,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { .. *self }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.into_reader().total_size()
+    }
+    #[inline]
+    pub fn get_line_starts(self) -> ::capnp::Result<::capnp::primitive_list::Builder<'a,u32>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_line_starts(&mut self, value: ::capnp::primitive_list::Reader<'a,u32>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+    }
+    #[inline]
+    pub fn init_line_starts(self, size: u32) -> ::capnp::primitive_list::Builder<'a,u32> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
+    }
+    #[inline]
+    pub fn has_line_starts(&self) -> bool {
+      !self.builder.get_pointer_field(0).is_null()
+    }
+    #[inline]
+    pub fn get_length(self) -> u32 {
+      self.builder.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn set_length(&mut self, value: u32)  {
+      self.builder.set_data_field::<u32>(0, value);
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      Pipeline { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+  }
+  mod _private {
+    use capnp::private::layout;
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 1 };
+    pub const TYPE_ID: u64 = 0xebf6_0b4e_3e31_2165;
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -28,6 +28,7 @@ struct Module {
   typesConstructors @5 :List(Property(TypesVariantConstructors));
   unusedImports @6 :List(SrcSpan);
   containsTodo @7 :Bool;
+  lineNumbers @8 :LineNumbers;
 }
 
 struct TypesVariantConstructors {
@@ -239,4 +240,9 @@ struct BitArraySegmentOption {
       shortForm @18 :Bool;
     }
   }
+}
+
+struct LineNumbers {
+  lineStarts @0 :List(UInt32);
+  length @1 :UInt32;
 }

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -13,6 +13,7 @@ use crate::{
     build::{Origin, Target},
     call_graph::{into_dependency_order, CallGraphNode},
     dep_tree,
+    line_numbers::LineNumbers,
     type_::{
         self,
         environment::*,
@@ -122,6 +123,7 @@ pub fn infer_module<A>(
     warnings: &TypeWarningEmitter,
     direct_dependencies: &HashMap<EcoString, A>,
     target_support: TargetSupport,
+    line_numbers: LineNumbers,
 ) -> Result<TypedModule, Error> {
     let name = module.name.clone();
     let documentation = std::mem::take(&mut module.documentation);
@@ -275,6 +277,7 @@ pub fn infer_module<A>(
             package: package.clone(),
             unused_imports,
             contains_todo,
+            line_numbers,
         },
     })
 }

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::analyse::TargetSupport;
 use crate::build::Target;
+use crate::line_numbers::LineNumbers;
 use crate::type_::expression::Externals;
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME};
 use crate::{
@@ -28,6 +29,7 @@ fn compile_module(src: &str) -> TypedModule {
     // to have one place where we create all this required state for use in each
     // place.
     let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
+    let line_numbers = LineNumbers::new(src);
     crate::analyse::infer_module::<()>(
         Target::Erlang,
         &ids,
@@ -38,6 +40,7 @@ fn compile_module(src: &str) -> TypedModule {
         &TypeWarningEmitter::null(),
         &std::collections::HashMap::new(),
         TargetSupport::Enforced,
+        line_numbers,
     )
     .expect("should successfully infer")
 }

--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -135,6 +135,7 @@ where
             source_path: self.source_directory.join(format!("{}.gleam", name)),
             origin: self.origin,
             name,
+            line_numbers: meta.line_numbers,
         }
     }
 }

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{
     build::module_loader::SourceFingerprint,
     io::{memory::InMemoryFileSystem, FileSystemWriter},
+    line_numbers::LineNumbers,
 };
 use std::time::Duration;
 
@@ -157,11 +158,13 @@ fn write_cache(
     seconds: u64,
     codegen_performed: bool,
 ) {
+    let line_numbers = LineNumbers::new(source);
     let cache_metadata = CacheMetadata {
         mtime: SystemTime::UNIX_EPOCH + Duration::from_secs(seconds),
         codegen_performed,
         dependencies: vec![],
         fingerprint: SourceFingerprint::new(source),
+        line_numbers,
     };
     let path = Utf8Path::new(path);
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -1,4 +1,5 @@
 use crate::analyse::TargetSupport;
+use crate::line_numbers::{self, LineNumbers};
 use crate::type_::PRELUDE_MODULE_NAME;
 use crate::{
     ast::{SrcSpan, TypedModule, UntypedModule},
@@ -261,6 +262,7 @@ where
                 codegen_performed: self.perform_codegen,
                 dependencies: module.dependencies_list(),
                 fingerprint: SourceFingerprint::new(&module.code),
+                line_numbers: module.ast.type_info.line_numbers.clone(),
             };
             self.io.write_bytes(&path, &info.to_binary())?;
         }
@@ -420,6 +422,7 @@ fn analyse(
     {
         tracing::debug!(module = ?name, "Type checking");
 
+        let line_numbers = LineNumbers::new(&code);
         let ast = crate::analyse::infer_module(
             target,
             ids,
@@ -430,6 +433,7 @@ fn analyse(
             &TypeWarningEmitter::new(path.clone(), code.clone(), warnings.clone()),
             &direct_dependencies,
             target_support,
+            line_numbers,
         )
         .map_err(|error| Error::Type {
             path: path.clone(),
@@ -528,6 +532,7 @@ pub(crate) struct CachedModule {
     pub origin: Origin,
     pub dependencies: Vec<EcoString>,
     pub source_path: Utf8PathBuf,
+    pub line_numbers: LineNumbers,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -536,6 +541,7 @@ pub(crate) struct CacheMetadata {
     pub codegen_performed: bool,
     pub dependencies: Vec<EcoString>,
     pub fingerprint: SourceFingerprint,
+    pub line_numbers: LineNumbers,
 }
 
 impl CacheMetadata {

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -233,6 +233,14 @@ where
         Ok(modules)
     }
 
+    pub fn get_build_dir_for_module(&self, package: &str, module: &str) -> Utf8PathBuf {
+        self.paths
+            .build_packages_package(package)
+            .join("src")
+            .join(module)
+            .with_extension("gleam")
+    }
+
     fn write_prelude(&self) -> Result<()> {
         // Only the JavaScript target has a prelude to write.
         if !self.target().is_javascript() {

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -500,23 +500,6 @@ where
         self.compile_gleam_package(&config, false, package_root)
     }
 
-    fn load_cached_package(
-        &mut self,
-        build_dir: Utf8PathBuf,
-        package: &ManifestPackage,
-    ) -> Result<(), Error> {
-        for path in self.io.gleam_cache_files(&build_dir) {
-            let reader = BufReader::new(self.io.reader(&path)?);
-            let module = metadata::ModuleDecoder::new(self.ids.clone()).read(reader)?;
-            let _ = self
-                .importable_modules
-                .insert(module.name.clone(), module)
-                .ok_or(())
-                .expect_err("Metadata loaded for already loaded module");
-        }
-        Ok(())
-    }
-
     fn compile_gleam_package(
         &mut self,
         config: &PackageConfig,

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -44,6 +44,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
         let parsed = crate::parse::parse_module(dep_src).expect("dep syntax error");
         let mut ast = parsed.module;
         ast.name = dep_name.into();
+        let line_numbers = LineNumbers::new(dep_src);
         let dep = crate::analyse::infer_module::<()>(
             Target::Erlang,
             &ids,
@@ -54,6 +55,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
             &TypeWarningEmitter::null(),
             &std::collections::HashMap::new(),
             TargetSupport::NotEnforced,
+            line_numbers,
         )
         .expect("should successfully infer dep Erlang");
         let _ = modules.insert(dep_name.into(), dep.type_info);
@@ -62,6 +64,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
     let parsed = crate::parse::parse_module(src).expect("syntax error");
     let mut ast = parsed.module;
     ast.name = "my/mod".into();
+    let line_numbers = LineNumbers::new(src);
     let ast = crate::analyse::infer_module::<()>(
         Target::Erlang,
         &ids,
@@ -72,6 +75,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
         &TypeWarningEmitter::null(),
         &direct_dependencies,
         TargetSupport::NotEnforced,
+        line_numbers,
     )
     .expect("should successfully infer root Erlang");
     let line_numbers = LineNumbers::new(src);

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -98,6 +98,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
         let parsed = crate::parse::parse_module(dep_src).expect("dep syntax error");
         let mut ast = parsed.module;
         ast.name = (*dep_name).into();
+        let line_numbers = LineNumbers::new(dep_src);
         let dep = crate::analyse::infer_module::<()>(
             Target::JavaScript,
             &ids,
@@ -108,6 +109,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
             &TypeWarningEmitter::null(),
             &std::collections::HashMap::new(),
             TargetSupport::Enforced,
+            line_numbers,
         )
         .expect("should successfully infer");
         let _ = modules.insert((*dep_name).into(), dep.type_info);
@@ -117,6 +119,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
     let parsed = crate::parse::parse_module(src).expect("syntax error");
     let mut ast = parsed.module;
     ast.name = "my/mod".into();
+    let line_numbers = LineNumbers::new(src);
     crate::analyse::infer_module::<()>(
         Target::JavaScript,
         &ids,
@@ -127,6 +130,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
         &TypeWarningEmitter::null(),
         &direct_dependencies,
         TargetSupport::NotEnforced,
+        line_numbers,
     )
     .expect("should successfully infer")
 }

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -123,15 +123,11 @@ where
             let build_path = self
                 .project_compiler
                 .get_build_dir_for_module(&module.package, &module.name);
-            // Read the source
-            let code = self.project_compiler.io.read(&build_path);
-            if let Ok(code) = code {
-                // Create the source information
-                let path = build_path.as_os_str().to_string_lossy().to_string();
-                let line_numbers = LineNumbers::new(&code);
-                let source = ModuleSourceInformation { path, line_numbers };
-                _ = self.sources.insert(name.clone(), source);
-            }
+            // Create the source information
+            let path = build_path.as_os_str().to_string_lossy().to_string();
+            let line_numbers = module.line_numbers.clone();
+            let source = ModuleSourceInformation { path, line_numbers };
+            _ = self.sources.insert(name.clone(), source);
         }
 
         // Warnings from dependencies are not fixable by the programmer so

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -116,7 +116,7 @@ where
 
         // Since cached modules are not recompiled we need to manually add them
         for (name, module) in self.project_compiler.get_importable_modules() {
-            if self.sources.contains_key(name) {
+            if self.sources.contains_key(name) || name == "gleam" {
                 continue;
             }
             // Get the build path for the module

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -119,7 +119,6 @@ where
             if self.sources.contains_key(name) || name == "gleam" {
                 continue;
             }
-            tracing::info!("Loading source from cached module: {}", name);
             // Get the build path for the module
             let build_path = self
                 .project_compiler

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -119,12 +119,13 @@ where
             if self.sources.contains_key(name) || name == "gleam" {
                 continue;
             }
+            tracing::info!("Loading source from cached module: {}", name);
             // Get the build path for the module
             let build_path = self
                 .project_compiler
                 .get_build_dir_for_module(&module.package, &module.name);
             // Create the source information
-            let path = build_path.as_os_str().to_string_lossy().to_string();
+            let path = build_path.to_string();
             let line_numbers = module.line_numbers.clone();
             let source = ModuleSourceInformation { path, line_numbers };
             _ = self.sources.insert(name.clone(), source);

--- a/compiler-core/src/line_numbers.rs
+++ b/compiler-core/src/line_numbers.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct LineNumbers {
     line_starts: Vec<u32>,
     length: u32,

--- a/compiler-core/src/line_numbers.rs
+++ b/compiler-core/src/line_numbers.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct LineNumbers {
-    line_starts: Vec<u32>,
-    length: u32,
+    pub line_starts: Vec<u32>,
+    pub length: u32,
 }
 
 impl LineNumbers {

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -9,6 +9,7 @@ use crate::{
         TypedConstantBitArraySegment, TypedConstantBitArraySegmentOption,
     },
     build::Origin,
+    line_numbers::LineNumbers,
     schema_capnp::{self as schema, *},
     type_::{
         self, expression::Implementations, AccessorsMap, Deprecation, FieldMap, ModuleInterface,
@@ -78,6 +79,8 @@ impl ModuleDecoder {
             ),
             accessors: read_hashmap!(reader.get_accessors()?, self, accessors_map),
             unused_imports: read_vec!(reader.get_unused_imports()?, self, src_span),
+            // TODO: fixme
+            line_numbers: LineNumbers::new(""),
         })
     }
 

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -79,8 +79,7 @@ impl ModuleDecoder {
             ),
             accessors: read_hashmap!(reader.get_accessors()?, self, accessors_map),
             unused_imports: read_vec!(reader.get_unused_imports()?, self, src_span),
-            // TODO: fixme
-            line_numbers: LineNumbers::new(""),
+            line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
         })
     }
 
@@ -526,6 +525,17 @@ impl ModuleDecoder {
             index: reader.get_index() as u64,
             label: reader.get_label()?.into(),
             type_: self.type_(&reader.get_type()?)?,
+        })
+    }
+
+    fn line_starts(&mut self, i: &u32) -> Result<u32> {
+        Ok(*i)
+    }
+
+    fn line_numbers(&mut self, reader: &line_numbers::Reader<'_>) -> Result<LineNumbers> {
+        Ok(LineNumbers {
+            length: reader.get_length(),
+            line_starts: read_vec!(reader.get_line_starts()?, self, line_starts),
         })
     }
 }

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -46,9 +46,20 @@ impl<'a> ModuleEncoder<'a> {
         self.set_module_accessors(&mut module);
         self.set_module_types_constructors(&mut module);
         self.set_unused_imports(&mut module);
+        self.set_line_numbers(&mut module);
 
         capnp::serialize_packed::write_message(&mut buffer, &message).expect("capnp encode");
         Ok(buffer)
+    }
+
+    fn set_line_numbers(&mut self, module: &mut module::Builder<'_>) {
+        let mut line_numbers = module.reborrow().init_line_numbers();
+        line_numbers.set_length(self.data.line_numbers.length);
+        let line_starts =
+            line_numbers.init_line_starts(self.data.line_numbers.line_starts.len() as u32);
+        for (i, l) in self.data.line_numbers.line_starts.iter().enumerate() {
+            line_starts.reborrow().set(i as u32, *l);
+        }
     }
 
     fn set_unused_imports(&mut self, module: &mut module::Builder<'_>) {

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -8,6 +8,7 @@ use crate::{
         TypedConstantBitArraySegmentOption,
     },
     build::Origin,
+    line_numbers::LineNumbers,
     type_::{
         self, expression::Implementations, Deprecation, ModuleInterface, Type, TypeConstructor,
         TypeValueConstructor, TypeValueConstructorField, TypeVariantConstructors, ValueConstructor,
@@ -57,6 +58,7 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     }
 }
 
@@ -87,6 +89,7 @@ fn empty_module() {
         values: HashMap::new(),
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -114,6 +117,7 @@ fn module_with_private_type() {
         values: HashMap::new(),
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -133,6 +137,7 @@ fn module_with_unused_import() {
         ],
         accessors: HashMap::new(),
         values: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -160,6 +165,7 @@ fn module_with_app_type() {
         values: HashMap::new(),
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -187,6 +193,7 @@ fn module_with_fn_type() {
         values: HashMap::new(),
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -214,6 +221,7 @@ fn module_with_tuple_type() {
         values: HashMap::new(),
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -247,6 +255,7 @@ fn module_with_generic_type() {
             values: HashMap::new(),
             unused_imports: Vec::new(),
             accessors: HashMap::new(),
+            line_numbers: LineNumbers::new(""),
         }
     }
 
@@ -280,6 +289,7 @@ fn module_with_type_links() {
             values: HashMap::new(),
             unused_imports: Vec::new(),
             accessors: HashMap::new(),
+            line_numbers: LineNumbers::new(""),
         }
     }
 
@@ -308,6 +318,7 @@ fn module_type_to_constructors_mapping() {
         unused_imports: Default::default(),
         accessors: HashMap::new(),
         values: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -349,6 +360,7 @@ fn module_fn_value() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -391,6 +403,7 @@ fn deprecated_module_fn_value() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -431,6 +444,7 @@ fn private_module_fn_value() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -473,6 +487,7 @@ fn module_fn_value_regression() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -514,6 +529,7 @@ fn module_fn_value_with_field_map() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -554,6 +570,7 @@ fn record_value() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -597,6 +614,7 @@ fn record_value_with_field_map() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -658,6 +676,7 @@ fn accessors() {
             ),
         ]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -863,6 +882,7 @@ fn constant_var() {
             ),
         ]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1049,6 +1069,7 @@ fn deprecated_type() {
         values: HashMap::new(),
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1066,6 +1087,7 @@ fn contains_todo() {
         values: HashMap::new(),
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1106,6 +1128,7 @@ fn module_fn_value_with_external_implementations() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1147,6 +1170,7 @@ fn internal_module_fn() {
             },
         )]
         .into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1184,6 +1208,7 @@ fn type_variable_ids_in_constructors_are_shared() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [].into(),
+        line_numbers: LineNumbers::new(""),
     };
 
     let expected = HashMap::from([(

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -95,6 +95,27 @@ fn empty_module() {
 }
 
 #[test]
+fn with_line_numbers() {
+    let module = ModuleInterface {
+        contains_todo: false,
+        package: "some_package".into(),
+        origin: Origin::Src,
+        name: "one/two".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        values: HashMap::new(),
+        unused_imports: Vec::new(),
+        accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(
+            "const a = 1
+        const b = 2
+        const c = 3",
+        ),
+    };
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
 fn module_with_private_type() {
     let module = ModuleInterface {
         contains_todo: false,

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -8,6 +8,7 @@ use crate::{
     analyse::TargetSupport,
     build::{Module, Origin, Package, Target},
     config::{Docs, ErlangConfig, JavaScriptConfig, PackageConfig, Repository},
+    line_numbers::LineNumbers,
     type_::PRELUDE_MODULE_NAME,
     uid::UniqueIdGenerator,
     warning::TypeWarningEmitter,
@@ -70,6 +71,7 @@ pub fn compile_package(
         let parsed = crate::parse::parse_module(dep_src).expect("dep syntax error");
         let mut ast = parsed.module;
         ast.name = dep_name.into();
+        let line_numbers = LineNumbers::new(dep_src);
         let dep = crate::analyse::infer_module::<()>(
             Target::Erlang,
             &ids,
@@ -80,6 +82,7 @@ pub fn compile_package(
             &TypeWarningEmitter::null(),
             &std::collections::HashMap::new(),
             TargetSupport::Enforced,
+            line_numbers,
         )
         .expect("should successfully infer");
         let _ = modules.insert(dep_name.into(), dep.type_info);
@@ -103,6 +106,7 @@ pub fn compile_package(
         &TypeWarningEmitter::null(),
         &direct_dependencies,
         TargetSupport::Enforced,
+        LineNumbers::new(src),
     )
     .expect("should successfully infer");
 

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     bit_array,
     build::{Origin, Target},
+    line_numbers::LineNumbers,
     type_::expression::Implementations,
 };
 use error::*;
@@ -540,6 +541,7 @@ pub struct ModuleInterface {
     pub accessors: HashMap<EcoString, AccessorsMap>,
     pub unused_imports: Vec<SrcSpan>,
     pub contains_todo: bool,
+    pub line_numbers: LineNumbers,
 }
 
 /// Information on the constructors of a custom type.
@@ -605,7 +607,12 @@ pub struct TypeValueConstructorField {
 }
 
 impl ModuleInterface {
-    pub fn new(name: EcoString, origin: Origin, package: EcoString) -> Self {
+    pub fn new(
+        name: EcoString,
+        origin: Origin,
+        package: EcoString,
+        line_numbers: LineNumbers,
+    ) -> Self {
         Self {
             name,
             origin,
@@ -616,6 +623,7 @@ impl ModuleInterface {
             accessors: Default::default(),
             unused_imports: Default::default(),
             contains_todo: false,
+            line_numbers,
         }
     }
 

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -3,6 +3,7 @@ use strum::{EnumIter, IntoEnumIterator};
 use crate::{
     ast::{Publicity, SrcSpan},
     build::Origin,
+    line_numbers::LineNumbers,
     uid::UniqueIdGenerator,
 };
 
@@ -210,6 +211,8 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         accessors: HashMap::new(),
         unused_imports: Vec::new(),
         contains_todo: false,
+        // prelude doesn't have real src/line numbers
+        line_numbers: LineNumbers::new(""),
     };
 
     for t in PreludeType::iter() {

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -361,6 +361,7 @@ pub fn compile_module_with_target(
         let parsed = crate::parse::parse_module(module_src).expect("syntax error");
         let mut ast = parsed.module;
         ast.name = name.into();
+        let line_numbers = LineNumbers::new(module_src);
         let module = crate::analyse::infer_module::<()>(
             target,
             &ids,
@@ -371,6 +372,7 @@ pub fn compile_module_with_target(
             &warnings,
             &std::collections::HashMap::from_iter(vec![]),
             target_support,
+            line_numbers,
         )
         .expect("should successfully infer");
         let _ = modules.insert(name.into(), module.type_info);
@@ -392,6 +394,7 @@ pub fn compile_module_with_target(
         &warnings,
         &direct_dependencies,
         TargetSupport::Enforced,
+        LineNumbers::new(src),
     )
 }
 
@@ -582,6 +585,7 @@ fn infer_module_type_retention_test() {
         &TypeWarningEmitter::null(),
         &direct_dependencies,
         TargetSupport::Enforced,
+        LineNumbers::new(""),
     )
     .expect("Should infer OK");
 
@@ -645,6 +649,7 @@ fn infer_module_type_retention_test() {
             values: HashMap::new(),
             accessors: HashMap::new(),
             unused_imports: Vec::new(),
+            line_numbers: LineNumbers::new(""),
         }
     );
 }

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 9
 expression: "./cases/alias_unqualified_import"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<29 byte binary>
+<77 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -27,7 +26,7 @@ id(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<40 byte binary>
+<80 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -49,6 +48,3 @@ make() ->
                two]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 33
 expression: "./cases/erlang_app_generation"
 ---
 //// /out/lib/the_package/_gleam_artefacts/main.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<29 byte binary>
+<49 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).
@@ -27,6 +26,3 @@ expression: "./cases/erlang_app_generation"
     {modules, [main]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 45
 expression: "./cases/erlang_bug_752"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<29 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_bug_752"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<40 byte binary>
+<76 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -50,6 +49,3 @@ expression: "./cases/erlang_bug_752"
 
 //// /out/lib/the_package/include/two_Two.hrl
 -record(two, {thing :: one:one(integer())}).
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 57
 expression: "./cases/erlang_empty"
 ---
 //// /out/lib/the_package/_gleam_artefacts/empty.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<29 byte binary>
+<49 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.erl
 -module(empty).
@@ -21,6 +20,3 @@ expression: "./cases/erlang_empty"
     {modules, [empty]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 69
 expression: "./cases/erlang_escape_names"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<29 byte binary>
+<61 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_escape_names"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<40 byte binary>
+<128 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -58,6 +57,3 @@ unqualified_value() ->
                two]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 81
 expression: "./cases/erlang_import"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<40 byte binary>
+<80 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -25,7 +24,7 @@ unbox(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<29 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -47,6 +46,3 @@ unbox(X) ->
                two]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 93
 expression: "./cases/erlang_import_shadowing_prelude"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<29 byte binary>
+<61 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_import_shadowing_prelude"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<40 byte binary>
+<80 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -46,6 +45,3 @@ main() ->
                two]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 105
 expression: "./cases/erlang_nested"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<29 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
@@ -28,6 +27,3 @@ main() ->
     {modules, [one@two]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 117
 expression: "./cases/erlang_nested_qualified_constant"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<29 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
@@ -24,7 +23,7 @@ expression: "./cases/erlang_nested_qualified_constant"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<44 byte binary>
+<92 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -39,6 +38,3 @@ expression: "./cases/erlang_nested_qualified_constant"
                two]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 129
 expression: "./cases/hello_joe"
 ---
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.cache_meta
-<29 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.erl
 -module(hello_joe).
@@ -28,6 +27,3 @@ main() ->
     {modules, [hello_joe]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -6,7 +6,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<29 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -23,7 +23,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<40 byte binary>
+<112 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -70,6 +70,3 @@ warning: Unused private type
   │ ^ This private type is never used
 
 Hint: You can safely remove it.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<29 byte binary>
+<89 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -27,7 +27,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<40 byte binary>
+<316 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -94,6 +94,3 @@ aliased_fn_b() ->
 
 //// /out/lib/the_package/include/one_User.hrl
 -record(user, {name :: binary(), score :: integer()}).
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_external_fns"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<29 byte binary>
+<53 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -23,7 +23,7 @@ thing() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<51 byte binary>
+<303 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -84,6 +84,3 @@ the_consts() ->
                two]},
     {registered, []}
 ]}.
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.cache_meta
-<29 byte binary>
+<89 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.erl
 -module(one@one).
@@ -27,7 +27,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<59 byte binary>
+<475 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
@@ -123,6 +123,3 @@ aliased_fn_b() ->
 
 //// /out/lib/the_package/include/one@one_User.hrl
 -record(user, {name :: binary(), score :: integer()}).
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -6,7 +6,7 @@ expression: "./cases/javascript_d_ts"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello.cache_meta
-<29 byte binary>
+<73 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
 export * from "../prelude.d.mts";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 213
 expression: "./cases/javascript_empty"
 ---
 //// /out/lib/the_package/_gleam_artefacts/empty.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<29 byte binary>
+<49 byte binary>
 
 //// /out/lib/the_package/empty.mjs
 export {}
@@ -15,6 +14,3 @@ export {}
 
 //// /out/lib/the_package/gleam.mjs
 export * from "../prelude.mjs";
-
-
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -6,13 +6,13 @@ expression: "./cases/javascript_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<29 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<44 byte binary>
+<72 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
 export * from "../prelude.d.mts";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
@@ -1,13 +1,12 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 321
 expression: "./cases/variable_or_module"
 ---
 //// /out/lib/the_package/_gleam_artefacts/main.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<42 byte binary>
+<110 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).
@@ -28,7 +27,7 @@ record_field(Power) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.cache_meta
-<29 byte binary>
+<77 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.erl
 -module(power).
@@ -57,6 +56,3 @@ to_int(P) ->
 
 //// /out/lib/the_package/include/power_Power.hrl
 -record(power, {value :: integer()}).
-
-
-


### PR DESCRIPTION
Realized while debugging https://github.com/gleam-lang/gleam/pull/2860/files that the solution I wrote for https://github.com/gleam-lang/gleam/pull/2731 didn't actually work for non-clean builds. This adds a basic way to handle cached modules by reading the package src directly and constructing the missing source information. This seems to work well when I tested locally though there would maybe be a long term benefit to sticking this line number info in the cache itself