### PR TITLE
Fix bit arrays in guards not handling pattern variables in JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
   when the prefix had a Unicode codepoint escape sequence (`\u{...}`).
 - Improved error message for wrong patterns using constructors from other
   modules.
+- Fixed a bug on the JavaScript target where variables bound by patterns, if used
+  within a bit array literal inside a `case` clause's guard, would be used before they
+  were defined, leading to a runtime error when evaluating the `case` expression.
 
 ### Formatter
 

--- a/compiler-core/src/javascript/tests/case_clause_guards.rs
+++ b/compiler-core/src/javascript/tests/case_clause_guards.rs
@@ -29,6 +29,19 @@ fn rebound_var() {
 }
 
 #[test]
+fn bitarray_with_var() {
+    assert_js!(
+        r#"pub fn main() {
+  case 5 {
+    z if <<z>> == <<z>> -> Nil
+    _ -> Nil
+  }
+}
+"#,
+    )
+}
+
+#[test]
 fn operator_wrapping_right() {
     assert_js!(
         r#"pub fn main(xs, y: Bool, z: Bool) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__bitarray_with_var.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__bitarray_with_var.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/javascript/tests/case_clause_guards.rs
+expression: "pub fn main() {\n  case 5 {\n    z if <<z>> == <<z>> -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+import { isEqual, toBitArray } from "../gleam.mjs";
+
+export function main() {
+  let $ = 5;
+  if (isEqual(toBitArray([$]), toBitArray([$]))) {
+    let z = $;
+    return undefined;
+  } else {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/gleam/issues/2862

Explicitly handles bitarrays in guards, avoiding problems with pattern-bound variables being used (within the compiled condition) before they are defined (inside the compiled `if`'s body).

I used generics here to avoid having to duplicate the `bit_array` function for each type of `constant_expression`-like function. Feel free to suggest alternative implementations if desirable.