### PR TITLE
Improve messaging when failing to parse a series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fixed a bug on the JavaScript target where variables bound by patterns, if used
   within a bit array literal inside a `case` clause's guard, would be used before they
   were defined, leading to a runtime error when evaluating the `case` expression.
+- Improved error messages when failing to parse a series of things.
 
 ### Formatter
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -484,7 +484,8 @@ where
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elems =
                     Parser::series_of(self, &Parser::parse_expression, Some(&Token::Comma))?;
-                let (_, end) = self.expect_one(&Token::RightParen)?;
+                let (_, end) =
+                    self.expect_one_following_series(&Token::RightParen, "an expression".into())?;
                 UntypedExpr::Tuple {
                     location: SrcSpan { start, end },
                     elems,
@@ -574,7 +575,8 @@ where
                     },
                     Some(&Token::Comma),
                 )?;
-                let (_, end) = self.expect_one(&Token::GtGt)?;
+                let (_, end) =
+                    self.expect_one_following_series(&Token::GtGt, "a bit array segment".into())?;
                 UntypedExpr::BitArray {
                     location: SrcSpan { start, end },
                     segments,
@@ -617,9 +619,11 @@ where
                 self.advance();
                 let subjects =
                     Parser::series_of(self, &Parser::parse_expression, Some(&Token::Comma))?;
-                let _ = self.expect_one(&Token::LeftBrace)?;
+                let _ =
+                    self.expect_one_following_series(&Token::LeftBrace, "an expression".into())?;
                 let clauses = Parser::series_of(self, &Parser::parse_case_clause, None)?;
-                let (_, end) = self.expect_one(&Token::RightBrace)?;
+                let (_, end) =
+                    self.expect_one_following_series(&Token::RightBrace, "a case clause".into())?;
                 if subjects.is_empty() {
                     return parse_error(
                         ParseErrorType::ExpectedExpr,
@@ -811,7 +815,7 @@ where
             Parser::series_of(self, &Parser::parse_use_assignment, Some(&Token::Comma))?
         };
 
-        _ = self.expect_one(&Token::LArrow)?;
+        _ = self.expect_one_following_series(&Token::LArrow, "a use variable assignment".into())?;
         let call = self.expect_expression()?;
 
         Ok(Statement::Use(Use {
@@ -1102,7 +1106,8 @@ where
                 self.advance();
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elems = Parser::series_of(self, &Parser::parse_pattern, Some(&Token::Comma))?;
-                let (_, end) = self.expect_one(&Token::RightParen)?;
+                let (_, end) =
+                    self.expect_one_following_series(&Token::RightParen, "a pattern".into())?;
                 Pattern::Tuple {
                     location: SrcSpan { start, end },
                     elems,
@@ -1128,7 +1133,10 @@ where
                     },
                     Some(&Token::Comma),
                 )?;
-                let (_, end) = self.expect_one(&Token::GtGt)?;
+                let (_, end) = self.expect_one_following_series(
+                    &Token::GtGt,
+                    "a bit array segment pattern".into(),
+                )?;
                 Pattern::BitArray {
                     location: SrcSpan { start, end },
                     segments,
@@ -1147,7 +1155,8 @@ where
                 } else {
                     None
                 };
-                let (end, rsqb_e) = self.expect_one(&Token::RightSquare)?;
+                let (end, rsqb_e) =
+                    self.expect_one_following_series(&Token::RightSquare, "a pattern".into())?;
                 let tail = match tail {
                     // There is a tail and it has a Pattern::Var or Pattern::Discard
                     Some(Some(pat @ (Pattern::Variable { .. } | Pattern::Discard { .. }))) => {
@@ -1559,7 +1568,8 @@ where
             &|parser| Parser::parse_fn_param(parser, is_anon),
             Some(&Token::Comma),
         )?;
-        let (_, rpar_e) = self.expect_one(&Token::RightParen)?;
+        let (_, rpar_e) =
+            self.expect_one_following_series(&Token::RightParen, "a function parameter".into())?;
         let return_annotation = self.parse_type_annotation(&Token::RArrow)?;
 
         let (body, end, end_position) = match self.maybe_one(&Token::LeftBrace) {
@@ -1815,7 +1825,8 @@ where
                 // No separator
                 None,
             )?;
-            let (_, close_end) = self.expect_one(&Token::RightBrace)?;
+            let (_, close_end) = self
+                .expect_one_following_series(&Token::RightBrace, "a record constructor".into())?;
             (constructors, close_end)
         } else if let Some((eq_s, eq_e)) = self.maybe_one(&Token::Equal) {
             // Type Alias
@@ -1863,7 +1874,8 @@ where
         if self.maybe_one(&Token::LeftParen).is_some() {
             let args =
                 Parser::series_of(self, &|p| Ok(Parser::maybe_name(p)), Some(&Token::Comma))?;
-            let (_, par_e) = self.expect_one(&Token::RightParen)?;
+            let (_, par_e) =
+                self.expect_one_following_series(&Token::RightParen, "a name".into())?;
             let args2 = args.into_iter().map(|(_, a, _)| a).collect();
             Ok((start, upname, args2, par_e))
         } else {
@@ -1923,7 +1935,10 @@ where
                 },
                 Some(&Token::Comma),
             )?;
-            let (_, end) = self.expect_one(&Token::RightParen)?;
+            let (_, end) = self.expect_one_following_series(
+                &Token::RightParen,
+                "a constructor argument name".into(),
+            )?;
             Ok((args, end))
         } else {
             Ok((vec![], 0))
@@ -1980,7 +1995,7 @@ where
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let args =
                     Parser::series_of(self, &|x| Parser::parse_type(x), Some(&Token::Comma))?;
-                let _ = self.expect_one(&Token::RightParen)?;
+                let _ = self.expect_one_following_series(&Token::RightParen, "a type".into())?;
                 let (arr_s, arr_e) = self.expect_one(&Token::RArrow)?;
                 let retrn = self.parse_type()?;
                 if let Some(retrn) = retrn {
@@ -2298,7 +2313,8 @@ where
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elements =
                     Parser::series_of(self, &Parser::parse_const_value, Some(&Token::Comma))?;
-                let (_, end) = self.expect_one(&Token::RightParen)?;
+                let (_, end) = self
+                    .expect_one_following_series(&Token::RightParen, "a constant value".into())?;
                 Ok(Some(Constant::Tuple {
                     elements,
                     location: SrcSpan { start, end },
@@ -2309,7 +2325,8 @@ where
                 self.advance();
                 let elements =
                     Parser::series_of(self, &Parser::parse_const_value, Some(&Token::Comma))?;
-                let (_, end) = self.expect_one(&Token::RightSquare)?;
+                let (_, end) = self
+                    .expect_one_following_series(&Token::RightSquare, "a constant value".into())?;
                 Ok(Some(Constant::List {
                     elements,
                     location: SrcSpan { start, end },
@@ -2331,7 +2348,8 @@ where
                     },
                     Some(&Token::Comma),
                 )?;
-                let (_, end) = self.expect_one(&Token::GtGt)?;
+                let (_, end) =
+                    self.expect_one_following_series(&Token::GtGt, "a bit array segment".into())?;
                 Ok(Some(Constant::BitArray {
                     location: SrcSpan { start, end },
                     segments,
@@ -2419,7 +2437,10 @@ where
         if self.maybe_one(&Token::LeftParen).is_some() {
             let args =
                 Parser::series_of(self, &Parser::parse_const_record_arg, Some(&Token::Comma))?;
-            let (_, par_e) = self.expect_one(&Token::RightParen)?;
+            let (_, par_e) = self.expect_one_following_series(
+                &Token::RightParen,
+                "a constant record argument".into(),
+            )?;
             Ok(Some(Constant::Record {
                 location: SrcSpan { start, end: par_e },
                 module,
@@ -2660,6 +2681,19 @@ where
         match self.maybe_one(wanted) {
             Some((start, end)) => Ok((start, end)),
             None => self.next_tok_unexpected(vec![wanted.to_string().into()]),
+        }
+    }
+
+    // Expect a particular token after having parsed a series, advances the token stream
+    // Used for giving a clearer error message in cases where the series item is what failed to parse
+    fn expect_one_following_series(
+        &mut self,
+        wanted: &Token,
+        series: EcoString,
+    ) -> Result<(u32, u32), ParseError> {
+        match self.maybe_one(wanted) {
+            Some((start, end)) => Ok((start, end)),
+            None => self.next_tok_unexpected(vec![wanted.to_string().into(), series]),
         }
     }
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn main() {\n    let <<b1, pub>> = <<24, 3>>\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:15
+  │
+3 │     let <<b1, pub>> = <<24, 3>>
+  │               ^^^ I was not expecting this
+
+Expected one of: 
+">>"
+a bit array segment pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn main() {\n    let #(a, case, c) = #(1, 2, 3)\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:14
+  │
+3 │     let #(a, case, c) = #(1, 2, 3)
+  │              ^^^^ I was not expecting this
+
+Expected one of: 
+")"
+a pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn main() {\n    <<72, 101, 108, 108, 111, 44, 32, 74, 111, 101, const>>\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:53
+  │
+3 │     <<72, 101, 108, 108, 111, 44, 32, 74, 111, 101, const>>
+  │                                                     ^^^^^ I was not expecting this
+
+Expected one of: 
+">>"
+a bit array segment

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_case_pattern.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_case_pattern.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn main() {\n    case 1 {\n        -> -> 0\n    }\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:4:9
+  │
+4 │         -> -> 0
+  │         ^^ I was not expecting this
+
+Expected one of: 
+"}"
+a case clause

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn main() {\n    case 1, type {\n        _, _ -> 0\n    }\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:13
+  │
+3 │     case 1, type {
+  │             ^^^^ I was not expecting this
+
+Expected one of: 
+"{"
+an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_bit_array_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_bit_array_segment.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nconst a = <<1, 2, <->>\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:19
+  │
+2 │ const a = <<1, 2, <->>
+  │                   ^^ I was not expecting this
+
+Expected one of: 
+">>"
+a bit array segment

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_list.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_list.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nconst a = [1, 2, <-]\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:18
+  │
+2 │ const a = [1, 2, <-]
+  │                  ^^ I was not expecting this
+
+Expected one of: 
+"]"
+a constant value

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\ntype A {\n    A(String, Int)\n}\nconst a = A(\"a\", let)\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:5:18
+  │
+5 │ const a = A("a", let)
+  │                  ^^^ I was not expecting this
+
+Expected one of: 
+")"
+a constant record argument

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_tuple.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_tuple.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nconst a = #(1, 2, <-)\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:19
+  │
+2 │ const a = #(1, 2, <-)
+  │                   ^^ I was not expecting this
+
+Expected one of: 
+")"
+a constant value

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn f(g: fn(Int, 1) -> Int) -> Int {\n  g(0, 1)\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:17
+  │
+2 │ fn f(g: fn(Int, 1) -> Int) -> Int {
+  │                 ^ I was not expecting this
+
+Expected one of: 
+")"
+a type

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn main() {\n    #(1, 2, const)\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:13
+  │
+3 │     #(1, 2, const)
+  │             ^^^^^ I was not expecting this
+
+Expected one of: 
+")"
+an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\ntype A { \n    A(String)\n    type\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:4:5
+  │
+4 │     type
+  │     ^^^^ I was not expecting this
+
+Expected one of: 
+"}"
+a record constructor

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\ntype A { \n    A(type: String)\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:7
+  │
+3 │     A(type: String)
+  │       ^^^^ I was not expecting this
+
+Expected one of: 
+")"
+a constructor argument name

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\ntype A(a, type) { \n    A\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:11
+  │
+2 │ type A(a, type) { 
+  │           ^^^^ I was not expecting this
+
+Expected one of: 
+")"
+a name

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__use_invalid_assignments.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__use_invalid_assignments.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn main() {\n    use fn <- result.try(get_username())\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:9
+  │
+3 │     use fn <- result.try(get_username())
+  │         ^ I was expecting a pattern after this

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -855,3 +855,168 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn tuple_invalid_expr() {
+    assert_module_error!(
+        "
+fn main() {
+    #(1, 2, const)
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_invalid_segment() {
+    assert_module_error!(
+        "
+fn main() {
+    <<72, 101, 108, 108, 111, 44, 32, 74, 111, 101, const>>
+}
+"
+    );
+}
+
+#[test]
+fn case_invalid_expression() {
+    assert_module_error!(
+        "
+fn main() {
+    case 1, type {
+        _, _ -> 0
+    }
+}
+"
+    );
+}
+
+#[test]
+fn case_invalid_case_pattern() {
+    assert_module_error!(
+        "
+fn main() {
+    case 1 {
+        -> -> 0
+    }
+}
+"
+    );
+}
+
+#[test]
+fn use_invalid_assignments() {
+    assert_module_error!(
+        "
+fn main() {
+    use fn <- result.try(get_username())
+}
+"
+    );
+}
+
+#[test]
+fn assignment_pattern_invalid_tuple() {
+    assert_module_error!(
+        "
+fn main() {
+    let #(a, case, c) = #(1, 2, 3)
+}
+"
+    );
+}
+
+#[test]
+fn assignment_pattern_invalid_bit_segment() {
+    assert_module_error!(
+        "
+fn main() {
+    let <<b1, pub>> = <<24, 3>>
+}
+"
+    );
+}
+
+#[test]
+fn type_invalid_constructor() {
+    assert_module_error!(
+        "
+type A { 
+    A(String)
+    type
+}
+"
+    );
+}
+
+#[test]
+fn type_invalid_type_name() {
+    assert_module_error!(
+        "
+type A(a, type) { 
+    A
+}
+"
+    );
+}
+
+#[test]
+fn type_invalid_constructor_arg() {
+    assert_module_error!(
+        "
+type A { 
+    A(type: String)
+}
+"
+    );
+}
+
+#[test]
+fn function_type_invalid_param_type() {
+    assert_module_error!(
+        "
+fn f(g: fn(Int, 1) -> Int) -> Int {
+  g(0, 1)
+}
+"
+    );
+}
+
+#[test]
+fn const_invalid_tuple() {
+    assert_module_error!(
+        "
+const a = #(1, 2, <-)
+"
+    );
+}
+
+#[test]
+fn const_invalid_list() {
+    assert_module_error!(
+        "
+const a = [1, 2, <-]
+"
+    );
+}
+
+#[test]
+fn const_invalid_bit_array_segment() {
+    assert_module_error!(
+        "
+const a = <<1, 2, <->>
+"
+    );
+}
+
+#[test]
+fn const_invalid_record_constructor() {
+    assert_module_error!(
+        "
+type A {
+    A(String, Int)
+}
+const a = A(\"a\", let)
+"
+    );
+}


### PR DESCRIPTION
See #2826 for more details. In cases where the parser was expecting a series of things followed by a closing, we were only suggesting the closing. This pr adds the expected series as part of the error message.