### PR TITLE
Fix issue with using `const` value in BitArray size option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 - Improved error messages when failing to parse a series of things.
 - A warning is now raised for unused binary operations, records, record access
   and record updates.
+- Fixed a bug when using constant as the size option parameter
+  for `BitArray` caused unknown variable exception.
 
 ### Formatter
 

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -232,6 +232,11 @@ impl<'a> CallGraphBuilder<'a> {
             UntypedExpr::BitArray { segments, .. } => {
                 for segment in segments {
                     self.expression(&segment.value);
+                    for option in &segment.options {
+                        if let BitArrayOption::Size { value, .. } = option {
+                            self.expression(value);
+                        }
+                    }
                 }
             }
 

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -78,6 +78,18 @@ pub fn main() {
 }
 
 #[test]
+fn bit_array5() {
+    assert_erl!(
+        r#"const bit_size = 8
+pub fn main() {
+  let a = <<10:size(bit_size)>>
+  a
+}
+"#
+    );
+}
+
+#[test]
 fn bit_array_discard() {
     // https://github.com/gleam-lang/gleam/issues/704
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array5.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array5.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+assertion_line: 82
+expression: "const bit_size = 8\npub fn main() {\n  let a = <<10:size(bit_size)>>\n  a\n}\n"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> bitstring().
+main() ->
+    A = <<10:(lists:max([(8), 0]))>>,
+    A.


### PR DESCRIPTION
Issue https://github.com/gleam-lang/gleam/issues/2867.
As I research, right now value from BitArray size ignored - and this affect how dependency sorted in `gleam_core::call_graph::into_dependency_order`.