### PR TITLE
fix cached goto definition for local packages and refactor testing suite to be more consistent across lsp

### DIFF
--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -489,6 +489,14 @@ pub mod module {
     pub fn has_line_numbers(&self) -> bool {
       !self.reader.get_pointer_field(7).is_null()
     }
+    #[inline]
+    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(8), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_src_path(&self) -> bool {
+      !self.reader.get_pointer_field(8).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -675,6 +683,22 @@ pub mod module {
     pub fn has_line_numbers(&self) -> bool {
       !self.builder.get_pointer_field(7).is_null()
     }
+    #[inline]
+    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(8), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_src_path(&mut self, value: ::capnp::text::Reader<'_>)  {
+      self.builder.get_pointer_field(8).set_text(value);
+    }
+    #[inline]
+    pub fn init_src_path(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(8).init_text(size)
+    }
+    #[inline]
+    pub fn has_src_path(&self) -> bool {
+      !self.builder.get_pointer_field(8).is_null()
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -690,7 +714,7 @@ pub mod module {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 8 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 9 };
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -29,6 +29,7 @@ struct Module {
   unusedImports @6 :List(SrcSpan);
   containsTodo @7 :Bool;
   lineNumbers @8 :LineNumbers;
+  srcPath @9 :Text;
 }
 
 struct TypesVariantConstructors {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -124,6 +124,7 @@ pub fn infer_module<A>(
     direct_dependencies: &HashMap<EcoString, A>,
     target_support: TargetSupport,
     line_numbers: LineNumbers,
+    src_path: EcoString,
 ) -> Result<TypedModule, Error> {
     let name = module.name.clone();
     let documentation = std::mem::take(&mut module.documentation);
@@ -278,6 +279,7 @@ pub fn infer_module<A>(
             unused_imports,
             contains_todo,
             line_numbers,
+            src_path,
         },
     })
 }

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -41,6 +41,7 @@ fn compile_module(src: &str) -> TypedModule {
         &std::collections::HashMap::new(),
         TargetSupport::Enforced,
         line_numbers,
+        "".into(),
     )
     .expect("should successfully infer")
 }

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -434,6 +434,7 @@ fn analyse(
             &direct_dependencies,
             target_support,
             line_numbers,
+            path.as_str().into(),
         )
         .map_err(|error| Error::Type {
             path: path.clone(),

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -1,4 +1,4 @@
-use ecow::EcoString;
+use ecow::{eco_format, EcoString};
 
 use super::*;
 use crate::{
@@ -52,6 +52,7 @@ fn write_cache(fs: &InMemoryFileSystem, name: &str, seconds: u64, deps: Vec<EcoS
         unused_imports: Vec::new(),
         contains_todo: false,
         line_numbers: line_numbers.clone(),
+        src_path: eco_format!("/src/{}.gleam", name),
     };
     let path = Utf8Path::new("/artefact").join(format!("{name}.cache"));
     fs.write_bytes(

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -233,14 +233,6 @@ where
         Ok(modules)
     }
 
-    pub fn get_build_dir_for_module(&self, package: &str, module: &str) -> Utf8PathBuf {
-        self.paths
-            .build_packages_package(package)
-            .join("src")
-            .join(module)
-            .with_extension("gleam")
-    }
-
     fn write_prelude(&self) -> Result<()> {
         // Only the JavaScript target has a prelude to write.
         if !self.target().is_javascript() {

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -56,6 +56,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
             &std::collections::HashMap::new(),
             TargetSupport::NotEnforced,
             line_numbers,
+            "".into(),
         )
         .expect("should successfully infer dep Erlang");
         let _ = modules.insert(dep_name.into(), dep.type_info);
@@ -76,6 +77,7 @@ pub fn compile_test_project(src: &str, dep: Option<(&str, &str, &str)>) -> Strin
         &direct_dependencies,
         TargetSupport::NotEnforced,
         line_numbers,
+        "".into(),
     )
     .expect("should successfully infer root Erlang");
     let line_numbers = LineNumbers::new(src);

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -110,6 +110,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
             &std::collections::HashMap::new(),
             TargetSupport::Enforced,
             line_numbers,
+            "".into(),
         )
         .expect("should successfully infer");
         let _ = modules.insert((*dep_name).into(), dep.type_info);
@@ -131,6 +132,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
         &direct_dependencies,
         TargetSupport::NotEnforced,
         line_numbers,
+        "".into(),
     )
     .expect("should successfully infer")
 }

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -122,12 +122,8 @@ where
             if self.sources.contains_key(name) || name == "gleam" {
                 continue;
             }
-            // Get the build path for the module
-            let build_path = self
-                .project_compiler
-                .get_build_dir_for_module(&module.package, &module.name);
             // Create the source information
-            let path = build_path.to_string();
+            let path = module.src_path.to_string();
             let line_numbers = module.line_numbers.clone();
             let source = ModuleSourceInformation { path, line_numbers };
             _ = self.sources.insert(name.clone(), source);

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -2,24 +2,16 @@ use lsp_types::{Hover, HoverContents, HoverParams, MarkedString, Position, Range
 
 use super::*;
 
-fn positioned_with_io_hover(
-    src: &str,
-    position: Position,
-    io: &LanguageServerTestIO,
-) -> Option<Hover> {
-    let (mut engine, position_param) = positioned_with_io(src, position, io);
+fn hover<'a>(tester: TestRunner<'a>, position: Position) -> Option<Hover> {
+    tester.at(position, |engine, param, _| {
+        let params = HoverParams {
+            text_document_position_params: param,
+            work_done_progress_params: Default::default(),
+        };
+        let response = engine.hover(params);
 
-    let params = HoverParams {
-        text_document_position_params: position_param,
-        work_done_progress_params: Default::default(),
-    };
-    let response = engine.hover(params);
-
-    response.result.unwrap()
-}
-
-fn positioned_hover(src: &str, position: Position) -> Option<Hover> {
-    positioned_with_io_hover(src, position, &LanguageServerTestIO::new())
+        response.result.unwrap()
+    })
 }
 
 #[test]
@@ -31,7 +23,7 @@ fn add_2(x) {
 ";
 
     assert_eq!(
-        positioned_hover(code, Position::new(1, 3)),
+        hover(TestRunner::for_source(code), Position::new(1, 3)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -67,7 +59,7 @@ fn main() {
 ";
 
     assert_eq!(
-        positioned_hover(code, Position::new(6, 3)),
+        hover(TestRunner::for_source(code), Position::new(6, 3)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -109,7 +101,7 @@ pub fn main() {
 ";
 
     assert_eq!(
-        positioned_hover(code, Position::new(6, 3)),
+        hover(TestRunner::for_source(code), Position::new(6, 3)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -131,7 +123,7 @@ fn(Int) -> Int
         })
     );
     assert_eq!(
-        positioned_hover(code, Position::new(9, 7)),
+        hover(TestRunner::for_source(code), Position::new(9, 7)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -153,7 +145,7 @@ fn(Int) -> Int
         })
     );
     assert_eq!(
-        positioned_hover(code, Position::new(10, 7)),
+        hover(TestRunner::for_source(code), Position::new(10, 7)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -175,7 +167,7 @@ fn(Int) -> Int
         })
     );
     assert_eq!(
-        positioned_hover(code, Position::new(11, 7)),
+        hover(TestRunner::for_source(code), Position::new(11, 7)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -200,9 +192,6 @@ fn(Int) -> Int
 
 #[test]
 fn hover_imported_function() {
-    let io = LanguageServerTestIO::new();
-    _ = io.src_module("example_module", "pub fn my_fn() { Nil }");
-
     let code = "
 import example_module
 fn main() {
@@ -211,16 +200,16 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io_hover(code, Position::new(3, 19), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_module("example_module", "pub fn my_fn() { Nil }"),
+        Position::new(3, 19),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_imported_function() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "example_module", "pub fn my_fn() { Nil }");
-
     let code = "
 import example_module
 fn main() {
@@ -229,16 +218,16 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io_hover(code, Position::new(3, 19), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_hex_module("example_module", "pub fn my_fn() { Nil }"),
+        Position::new(3, 19),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_imported_unqualified_function() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "example_module", "pub fn my_fn() { Nil }");
-
     let code = "
 import example_module.{my_fn}
 fn main() {
@@ -247,16 +236,16 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io_hover(code, Position::new(3, 5), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_hex_module("example_module", "pub fn my_fn() { Nil }"),
+        Position::new(3, 5),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_imported_function_renamed_module() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "example_module", "pub fn my_fn() { Nil }");
-
     let code = "
 import example_module as renamed_module
 fn main() {
@@ -265,16 +254,16 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io_hover(code, Position::new(3, 22), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_hex_module("example_module", "pub fn my_fn() { Nil }"),
+        Position::new(3, 22),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_unqualified_imported_function_renamed_module() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "example_module", "pub fn my_fn() { Nil }");
-
     let code = "
 import example_module.{my_fn} as renamed_module
 fn main() {
@@ -283,20 +272,16 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io_hover(code, Position::new(3, 6), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_hex_module("example_module", "pub fn my_fn() { Nil }"),
+        Position::new(3, 6),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_imported_function_nested_module() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module(
-        "my_dep",
-        "my/nested/example_module",
-        "pub fn my_fn() { Nil }",
-    );
-
     // Example of HexDocs link with nested modules: https://hexdocs.pm/lustre/lustre/element/svg.html
     let code = "
 import my/nested/example_module
@@ -306,23 +291,17 @@ fn main() {
 ";
 
     // hovering over "my_fn"
-    let hover = positioned_with_io_hover(code, Position::new(3, 22), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code)
+            .add_hex_module("my/nested/example_module", "pub fn my_fn() { Nil }"),
+        Position::new(3, 22),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_imported_ffi_renamed_function() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module(
-        "my_dep",
-        "example_module",
-        r#"
-@external(erlang, "my_mod_ffi", "renamed_fn")
-pub fn my_fn() -> Nil
-"#,
-    );
-
     let code = r#"
 import example_module
 fn main() {
@@ -331,16 +310,22 @@ fn main() {
 "#;
 
     // hovering over "my_fn"
-    let hover = positioned_with_io_hover(code, Position::new(3, 22), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_hex_module(
+            "example_module",
+            r#"
+@external(erlang, "my_mod_ffi", "renamed_fn")
+pub fn my_fn() -> Nil
+"#,
+        ),
+        Position::new(3, 22),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_imported_constants() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "example_module", "pub const my_const = 42");
-
     let code = "
 import example_module
 fn main() {
@@ -349,16 +334,16 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io_hover(code, Position::new(3, 19), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_hex_module("example_module", "pub const my_const = 42"),
+        Position::new(3, 19),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_imported_unqualified_constants() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "example_module", "pub const my_const = 42");
-
     let code = "
 import example_module.{my_const}
 fn main() {
@@ -367,17 +352,16 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io_hover(code, Position::new(3, 5), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code).add_hex_module("example_module", "pub const my_const = 42"),
+        Position::new(3, 5),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_value_with_two_modules_same_name() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "a/example_module", "pub const my_const = 42");
-    _ = io.hex_dep_module("my_dep", "b/example_module", "pub const my_const = 42");
-
     let code = "
 import a/example_module as _
 import b/example_module
@@ -387,17 +371,18 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io_hover(code, Position::new(4, 22), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code)
+            .add_hex_module("a/example_module", "pub const my_const = 42")
+            .add_hex_module("b/example_module", "pub const my_const = 42"),
+        Position::new(4, 22),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
 #[test]
 fn hover_external_function_with_another_value_same_name() {
-    let mut io = LanguageServerTestIO::new();
-    io.add_hex_package("my_dep");
-    _ = io.hex_dep_module("my_dep", "a/example_module", "pub const my_const = 42");
-    _ = io.hex_dep_module("my_dep", "b/example_module", "pub const my_const = 42");
-
     let code = "
 import a/example_module.{my_const as discarded}
 import b/example_module.{my_const} as _
@@ -407,7 +392,13 @@ fn main() {
 ";
 
     // hovering over "my_const"
-    let hover = positioned_with_io_hover(code, Position::new(4, 8), &io).unwrap();
+    let hover = hover(
+        TestRunner::for_source(code)
+            .add_hex_module("a/example_module", "pub const my_const = 42")
+            .add_hex_module("b/example_module", "pub const my_const = 42"),
+        Position::new(4, 8),
+    )
+    .unwrap();
     insta::assert_debug_snapshot!(hover);
 }
 
@@ -422,7 +413,7 @@ fn append(x, y) {
 ";
 
     assert_eq!(
-        positioned_hover(code, Position::new(3, 3)),
+        hover(TestRunner::for_source(code), Position::new(3, 3)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -458,7 +449,7 @@ fn append(x, y) {
 ";
 
     assert_eq!(
-        positioned_hover(code, Position::new(3, 10)),
+        hover(TestRunner::for_source(code), Position::new(3, 10)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam\nString\n```".to_string()
@@ -487,7 +478,10 @@ fn append(x, y) {
 }
 ";
 
-    assert_eq!(positioned_hover(code, Position::new(4, 1)), None);
+    assert_eq!(
+        hover(TestRunner::for_source(code), Position::new(4, 1)),
+        None
+    );
 }
 
 #[test]
@@ -499,7 +493,7 @@ fn append(x, y) {
 ";
 
     assert_eq!(
-        positioned_hover(code, Position::new(2, 2)),
+        hover(TestRunner::for_source(code), Position::new(2, 2)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -531,7 +525,7 @@ const one = 1
 ";
 
     assert_eq!(
-        positioned_hover(code, Position::new(3, 6)),
+        hover(TestRunner::for_source(code), Position::new(3, 6)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam
@@ -573,7 +567,7 @@ fn do_stuff() {
 
     // hover over `a`
     assert_eq!(
-        positioned_hover(code, Position::new(8, 6)),
+        hover(TestRunner::for_source(code), Position::new(8, 6)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String("```gleam\nInt\n```".to_string())),
             range: Some(Range::new(Position::new(8, 6), Position::new(8, 7))),
@@ -582,7 +576,7 @@ fn do_stuff() {
 
     // hover over `b`
     assert_eq!(
-        positioned_hover(code, Position::new(8, 11)),
+        hover(TestRunner::for_source(code), Position::new(8, 11)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam\nfn(fn(Int) -> String) -> String\n```\n".to_string()
@@ -593,7 +587,7 @@ fn do_stuff() {
 
     // hover over `c`
     assert_eq!(
-        positioned_hover(code, Position::new(9, 2)),
+        hover(TestRunner::for_source(code), Position::new(9, 2)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
                 "```gleam\nString\n```\nA locally defined variable.".to_string()

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_function_with_another_value_same_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_function_with_another_value_same_name.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/b/example_module.html#my_const)",
+            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/example_module.html#my_const)",
+            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/example_module.html#my_fn)",
+            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/example_module.html#my_fn)",
+            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_nested_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_nested_module.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/my/nested/example_module.html#my_fn)",
+            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/my/nested/example_module.html#my_fn)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_renamed_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_renamed_module.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/example_module.html#my_fn)",
+            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_constants.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_constants.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/example_module.html#my_const)",
+            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_function.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/example_module.html#my_fn)",
+            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_unqualified_imported_function_renamed_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_unqualified_imported_function_renamed_module.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/example_module.html#my_fn)",
+            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
@@ -5,7 +5,7 @@ expression: hover
 Hover {
     contents: Scalar(
         String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/my_dep/b/example_module.html#my_const)",
+            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
         ),
     ),
     range: Some(

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -80,6 +80,7 @@ impl ModuleDecoder {
             accessors: read_hashmap!(reader.get_accessors()?, self, accessors_map),
             unused_imports: read_vec!(reader.get_unused_imports()?, self, src_span),
             line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
+            src_path: reader.get_src_path()?.into(),
         })
     }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -41,6 +41,7 @@ impl<'a> ModuleEncoder<'a> {
         module.set_name(&self.data.name);
         module.set_package(&self.data.package);
         module.set_contains_todo(self.data.contains_todo);
+        module.set_src_path(&self.data.src_path);
         self.set_module_types(&mut module);
         self.set_module_values(&mut module);
         self.set_module_accessors(&mut module);

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -59,6 +59,7 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     }
 }
 
@@ -90,6 +91,7 @@ fn empty_module() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -111,6 +113,7 @@ fn with_line_numbers() {
         const b = 2
         const c = 3",
         ),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -139,6 +142,7 @@ fn module_with_private_type() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -159,6 +163,7 @@ fn module_with_unused_import() {
         accessors: HashMap::new(),
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -187,6 +192,7 @@ fn module_with_app_type() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -215,6 +221,7 @@ fn module_with_fn_type() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -243,6 +250,7 @@ fn module_with_tuple_type() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -277,6 +285,7 @@ fn module_with_generic_type() {
             unused_imports: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
+            src_path: "some_path".into(),
         }
     }
 
@@ -311,6 +320,7 @@ fn module_with_type_links() {
             unused_imports: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
+            src_path: "some_path".into(),
         }
     }
 
@@ -340,6 +350,7 @@ fn module_type_to_constructors_mapping() {
         accessors: HashMap::new(),
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -382,6 +393,7 @@ fn module_fn_value() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -425,6 +437,7 @@ fn deprecated_module_fn_value() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -466,6 +479,7 @@ fn private_module_fn_value() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -509,6 +523,7 @@ fn module_fn_value_regression() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -551,6 +566,7 @@ fn module_fn_value_with_field_map() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -592,6 +608,7 @@ fn record_value() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -636,6 +653,7 @@ fn record_value_with_field_map() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -698,6 +716,7 @@ fn accessors() {
         ]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -904,6 +923,7 @@ fn constant_var() {
         ]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1091,6 +1111,7 @@ fn deprecated_type() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1109,6 +1130,7 @@ fn contains_todo() {
         unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1150,6 +1172,7 @@ fn module_fn_value_with_external_implementations() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1192,6 +1215,7 @@ fn internal_module_fn() {
         )]
         .into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1230,6 +1254,7 @@ fn type_variable_ids_in_constructors_are_shared() {
         accessors: HashMap::new(),
         values: [].into(),
         line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
     };
 
     let expected = HashMap::from([(

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -83,6 +83,7 @@ pub fn compile_package(
             &std::collections::HashMap::new(),
             TargetSupport::Enforced,
             line_numbers,
+            "".into(),
         )
         .expect("should successfully infer");
         let _ = modules.insert(dep_name.into(), dep.type_info);
@@ -107,6 +108,7 @@ pub fn compile_package(
         &direct_dependencies,
         TargetSupport::Enforced,
         LineNumbers::new(src),
+        "".into(),
     )
     .expect("should successfully infer");
 

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -549,6 +549,7 @@ pub struct ModuleInterface {
     pub unused_imports: Vec<SrcSpan>,
     pub contains_todo: bool,
     pub line_numbers: LineNumbers,
+    pub src_path: EcoString,
 }
 
 /// Information on the constructors of a custom type.
@@ -619,6 +620,7 @@ impl ModuleInterface {
         origin: Origin,
         package: EcoString,
         line_numbers: LineNumbers,
+        src_path: EcoString,
     ) -> Self {
         Self {
             name,
@@ -631,6 +633,7 @@ impl ModuleInterface {
             unused_imports: Default::default(),
             contains_todo: false,
             line_numbers,
+            src_path,
         }
     }
 

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -548,7 +548,9 @@ pub struct ModuleInterface {
     pub accessors: HashMap<EcoString, AccessorsMap>,
     pub unused_imports: Vec<SrcSpan>,
     pub contains_todo: bool,
+    /// Used for mapping to original source locations on disk
     pub line_numbers: LineNumbers,
+    /// Used for determining the source path of the module on disk
     pub src_path: EcoString,
 }
 

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -212,6 +212,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         unused_imports: Vec::new(),
         contains_todo: false,
         // prelude doesn't have real src/line numbers
+        src_path: "".into(),
         line_numbers: LineNumbers::new(""),
     };
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -373,6 +373,7 @@ pub fn compile_module_with_target(
             &std::collections::HashMap::from_iter(vec![]),
             target_support,
             line_numbers,
+            "".into(),
         )
         .expect("should successfully infer");
         let _ = modules.insert(name.into(), module.type_info);
@@ -395,6 +396,7 @@ pub fn compile_module_with_target(
         &direct_dependencies,
         TargetSupport::Enforced,
         LineNumbers::new(src),
+        "".into(),
     )
 }
 
@@ -586,6 +588,7 @@ fn infer_module_type_retention_test() {
         &direct_dependencies,
         TargetSupport::Enforced,
         LineNumbers::new(""),
+        "".into(),
     )
     .expect("Should infer OK");
 
@@ -650,6 +653,7 @@ fn infer_module_type_retention_test() {
             accessors: HashMap::new(),
             unused_imports: Vec::new(),
             line_numbers: LineNumbers::new(""),
+            src_path: "".into(),
         }
     );
 }


### PR DESCRIPTION
Another fix for the goto definitions (hopefully the last one for real this time). Realized when I did some further testing with a package with local dependencies that the source path was not being computed correctly. Opted to store the source path in the cache as well. While writing up new test cases to handle this I ended up cleaning up/combining the testing patterns for the lsp