### PR TITLE
Fix typo: autoatic -> automatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fixed a bug when using constant as the size option parameter
   for `BitArray` caused unknown variable exception.
 - Improved recommendations on error messages.
+- Improved error message for `BitArray` segment sizes.
 
 ### Formatter
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2195,7 +2195,7 @@ int, float, utf16 and utf32 types.")],
                         ),
                         bit_array::ErrorType::TypeDoesNotAllowSize { typ } => (
                             "Size cannot be specified here",
-                            vec![format!("Hint: {typ} segments have an autoatic size.")],
+                            vec![format!("Hint: {typ} segments have an automatic size.")],
                         ),
                         bit_array::ErrorType::TypeDoesNotAllowUnit { typ } => (
                             "Unit cannot be specified here",

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf16.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf16.snap
@@ -9,5 +9,5 @@ error: Invalid bit array segment
 1 │ let x = <<1:utf16-size(5)>> x
   │             ^^^^^ Size cannot be specified here
 
-Hint: utf16 segments have an autoatic size.
+Hint: utf16 segments have an automatic size.
 See: https://tour.gleam.run/data-types/bit-arrays/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf32.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf32.snap
@@ -9,5 +9,5 @@ error: Invalid bit array segment
 1 │ case <<1>> { <<1:utf32-size(5)>> -> a }
   │                  ^^^^^ Size cannot be specified here
 
-Hint: utf32 segments have an autoatic size.
+Hint: utf32 segments have an automatic size.
 See: https://tour.gleam.run/data-types/bit-arrays/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf8.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf8.snap
@@ -9,5 +9,5 @@ error: Invalid bit array segment
 1 │ let x = <<1:utf8-size(5)>> x
   │             ^^^^ Size cannot be specified here
 
-Hint: utf8 segments have an autoatic size.
+Hint: utf8 segments have an automatic size.
 See: https://tour.gleam.run/data-types/bit-arrays/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf16_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf16_2.snap
@@ -9,5 +9,5 @@ error: Invalid bit array segment
 1 │ let x = <<1:utf16_codepoint-size(5)>> x
   │             ^^^^^^^^^^^^^^^ Size cannot be specified here
 
-Hint: utf16_codepoint segments have an autoatic size.
+Hint: utf16_codepoint segments have an automatic size.
 See: https://tour.gleam.run/data-types/bit-arrays/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf32_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf32_2.snap
@@ -9,5 +9,5 @@ error: Invalid bit array segment
 1 │ case <<1>> { <<1:utf32_codepoint-size(5)>> -> a }
   │                  ^^^^^^^^^^^^^^^ Size cannot be specified here
 
-Hint: utf32_codepoint segments have an autoatic size.
+Hint: utf32_codepoint segments have an automatic size.
 See: https://tour.gleam.run/data-types/bit-arrays/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf8_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf8_2.snap
@@ -9,5 +9,5 @@ error: Invalid bit array segment
 1 │ let x = <<1:utf8_codepoint-size(5)>> x
   │             ^^^^^^^^^^^^^^ Size cannot be specified here
 
-Hint: utf8_codepoint segments have an autoatic size.
+Hint: utf8_codepoint segments have an automatic size.
 See: https://tour.gleam.run/data-types/bit-arrays/


### PR DESCRIPTION
<!-- Don't forget to update the CHANGELOG! -->
