### PR TITLE
Only autocomplete module or direct dep imports

### DIFF
--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -494,15 +494,20 @@ where
         start: lsp::Position,
         end: lsp::Position,
     ) -> Vec<lsp::CompletionItem> {
-        let direct_dep_packages: std::collections::HashSet<&EcoString> =
+        let mut direct_dep_packages: std::collections::HashSet<&EcoString> =
             std::collections::HashSet::from_iter(
+                self.compiler.project_compiler.config.dependencies.keys(),
+            );
+        if !current_module.origin.is_src() {
+            direct_dep_packages.extend(
                 self.compiler
                     .project_compiler
                     .config
-                    .dependencies
-                    .iter()
-                    .map(|(name, _)| name),
-            );
+                    .dev_dependencies
+                    .keys(),
+            )
+        }
+
         let already_imported: std::collections::HashSet<EcoString> =
             std::collections::HashSet::from_iter(current_module.dependencies_list());
         self.compiler

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -494,6 +494,15 @@ where
         start: lsp::Position,
         end: lsp::Position,
     ) -> Vec<lsp::CompletionItem> {
+        let direct_dep_packages: std::collections::HashSet<&EcoString> =
+            std::collections::HashSet::from_iter(
+                self.compiler
+                    .project_compiler
+                    .config
+                    .dependencies
+                    .iter()
+                    .map(|(name, _)| name),
+            );
         let already_imported: std::collections::HashSet<EcoString> =
             std::collections::HashSet::from_iter(current_module.dependencies_list());
         self.compiler
@@ -501,11 +510,13 @@ where
             .get_importable_modules()
             .iter()
             //
-            // You cannot import yourself
-            .filter(|(name, _)| *name != &current_module.name)
-            //
-            // You cannot import a module twice
-            .filter(|(name, _)| !already_imported.contains(*name))
+            // It is possible to import modules from dependencies of dependencies
+            // but it's not recommended so we don't include them in completions
+            .filter(|(_, module)| {
+                let is_root_or_prelude =
+                    module.package == self.root_package_name() || module.package == "";
+                is_root_or_prelude || direct_dep_packages.contains(&module.package)
+            })
             //
             // src/ cannot import test/
             .filter(|(_, module)| module.origin.is_src() || !current_module.origin.is_src())
@@ -513,6 +524,12 @@ where
             // It is possible to import internal modules from other packages,
             // but it's not recommended so we don't include them in completions
             .filter(|(_, module)| module.package == self.root_package_name() || !module.is_internal)
+            //
+            // You cannot import a module twice
+            .filter(|(name, _)| !already_imported.contains(*name))
+            //
+            // You cannot import yourself
+            .filter(|(name, _)| *name != &current_module.name)
             //
             // Everything else we suggest as a completion
             .map(|(name, _)| lsp::CompletionItem {

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -519,7 +519,7 @@ where
             // but it's not recommended so we don't include them in completions
             .filter(|(_, module)| {
                 let is_root_or_prelude =
-                    module.package == self.root_package_name() || module.package == "";
+                    module.package == self.root_package_name() || module.package.is_empty();
                 is_root_or_prelude || direct_dep_packages.contains(&module.package)
             })
             //

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -499,6 +499,7 @@ where
                 self.compiler.project_compiler.config.dependencies.keys(),
             );
         if !current_module.origin.is_src() {
+            // In tests we can import direct dev dependencies
             direct_dep_packages.extend(
                 self.compiler
                     .project_compiler

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1153,12 +1153,10 @@ pub fn main() {
 }";
     let dep = "";
 
-    let position = Position::new(0, 10);
     let mut io = LanguageServerTestIO::new();
     let _ = io.hex_dep_module("indirect_package", "indirect_module", "");
-    let mut engine = TestProject::for_source(code)
-        .add_hex_module("example_module", dep)
-        .build_engine(&mut io);
+    let test_project = TestProject::for_source(code).add_hex_module("example_module", dep);
+    let mut engine = test_project.build_engine(&mut io);
 
     // Manually add an indirect dependency to the project
     let compiler = &mut engine.compiler.project_compiler;
@@ -1186,16 +1184,8 @@ pub fn main() {
     let response = engine.compile_please();
     assert!(response.result.is_ok());
 
-    let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
-        r"\\?\C:\src\app.gleam"
-    } else {
-        "/src/app.gleam"
-    });
-
-    let url = Url::from_file_path(path).unwrap();
-
-    let position_param =
-        TextDocumentPositionParams::new(TextDocumentIdentifier::new(url), position);
+    let position = Position::new(0, 10);
+    let position_param = test_project.build_path(position);
 
     let response = engine.completion(position_param, code.into());
 

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1224,18 +1224,13 @@ pub fn main() {
 }";
     let dep = "";
 
-    let (mut engine, position_param) = TestProject::for_source(code)
-        .add_hex_module("example_module", dep)
-        .add_dev_hex_module("indirect_module", "")
-        .positioned_with_io(Position::new(0, 10));
-
-    let response = engine.completion(position_param, code.into());
-
-    let mut completions = response.result.unwrap().unwrap_or_default();
-    completions.sort_by(|a, b| a.label.cmp(&b.label));
-
     assert_eq!(
-        completions,
+        completion(
+            TestProject::for_source(code)
+                .add_hex_module("example_module", dep)
+                .add_dev_hex_module("indirect_module", ""),
+            Position::new(0, 10)
+        ),
         vec![CompletionItem {
             label: "example_module".into(),
             kind: Some(CompletionItemKind::MODULE),

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -459,10 +459,11 @@ impl<'a> TestProject<'a> {
             add_package_from_manifest(&mut engine, toml_path, package.clone());
         }
 
-        let dev_dep_toml_path = engine.paths.build_packages_package_config("indirect_hex");
+        // Add an indirect dependency manifest
+        let toml_path = engine.paths.build_packages_package_config("indirect_hex");
         write_toml_from_manifest(
             &mut engine,
-            dev_dep_toml_path,
+            toml_path,
             ManifestPackage {
                 name: "indirect_hex".into(),
                 source: ManifestPackageSource::Hex {
@@ -472,10 +473,12 @@ impl<'a> TestProject<'a> {
                 ..Default::default()
             },
         );
-        let dev_dep_toml_path = engine.paths.build_packages_package_config("dev_hex");
+
+        // Add a dev dependency
+        let toml_path = engine.paths.build_packages_package_config("dev_hex");
         add_dev_package_from_manifest(
             &mut engine,
-            dev_dep_toml_path,
+            toml_path,
             ManifestPackage {
                 name: "dev_hex".into(),
                 source: ManifestPackageSource::Hex {

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -410,6 +410,34 @@ impl<'a> TestProject<'a> {
         engine
     }
 
+    pub fn build_path(&self, position: Position) -> TextDocumentPositionParams {
+        let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
+            r"\\?\C:\src\app.gleam"
+        } else {
+            "/src/app.gleam"
+        });
+
+        let url = Url::from_file_path(path).unwrap();
+
+        TextDocumentPositionParams::new(TextDocumentIdentifier::new(url), position)
+    }
+
+    pub fn build_test_path(
+        &self,
+        position: Position,
+        test_name: &str,
+    ) -> TextDocumentPositionParams {
+        let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
+            format!(r"\\?\C:\test\{}.gleam", test_name)
+        } else {
+            format!("/test/{}.gleam", test_name)
+        });
+
+        let url = Url::from_file_path(path).unwrap();
+
+        TextDocumentPositionParams::new(TextDocumentIdentifier::new(url), position)
+    }
+
     pub fn positioned_with_io(
         &self,
         position: Position,
@@ -426,18 +454,9 @@ impl<'a> TestProject<'a> {
         let response = engine.compile_please();
         assert!(response.result.is_ok());
 
-        let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
-            r"\\?\C:\src\app.gleam"
-        } else {
-            "/src/app.gleam"
-        });
+        let param = self.build_path(position);
 
-        let url = Url::from_file_path(path).unwrap();
-
-        (
-            engine,
-            TextDocumentPositionParams::new(TextDocumentIdentifier::new(url), position),
-        )
+        (engine, param)
     }
 
     pub fn positioned_with_io_in_test(
@@ -457,18 +476,9 @@ impl<'a> TestProject<'a> {
         let response = engine.compile_please();
         assert!(response.result.is_ok());
 
-        let path = Utf8PathBuf::from(if cfg!(target_family = "windows") {
-            format!(r"\\?\C:\test\{}.gleam", test_name)
-        } else {
-            format!("/test/{}.gleam", test_name)
-        });
+        let param = self.build_test_path(position, test_name);
 
-        let url = Url::from_file_path(path).unwrap();
-
-        (
-            engine,
-            TextDocumentPositionParams::new(TextDocumentIdentifier::new(url), position),
-        )
+        (engine, param)
     }
 
     pub fn at<T>(


### PR DESCRIPTION
Closes #2902

Checks the package config to get the list of direct dep packages and filters out any packages that are not part of a direct dep, the root package, or the prelude. For tests it also includes the list of direct dev deps.

Also swaps the order of the filters so that the ones that are likely to remove the most packages (roughly) go first 