### PR TITLE
show better error message when manifest.toml is corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Build tool
+
+- A helpful error message is now shown if the `manifest.toml` file has been
+  edited to be invalid in some way.
+  ```
+  error: Corrupt manifest.toml
+
+  The `manifest.toml` file is corrupt.
+
+  Hint: Please fun `gleam update` to fix it.
+  ```
+
 ### Compiler
 
 - The compiler will now raise a warning for `let assert` assignments where the

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -259,6 +259,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
 
     #[error("Publishing packages to reserve names is not permitted")]
     HexPackageSquatting,
+
+    #[error("Corrupt manifest.toml")]
+    CorruptManifest,
 }
 
 impl Error {
@@ -3147,6 +3150,13 @@ but you are using v{gleam_version}.",
                 level: Level::Error,
                 location: None,
                 hint: None,
+            },
+            Error::CorruptManifest => Diagnostic {
+                title: "Corrupt manifest.toml".into(),
+                text: "The `manifest.toml` file is corrupt.".into(),
+                level: Level::Error,
+                location: None,
+                hint: Some("Please run `gleam update` to fix it.".into()),
             },
         }
     }


### PR DESCRIPTION
Steps to recreate the bug.

make a new project 
`gleam new hellogleam`

add some dependency, eg: `glexer` 
`gleam add glexer`

the `gleam.toml` should be looking like this
```toml
name = "hellogleam"
version = "1.0.0"

# Fill out these fields if you intend to generate HTML documentation or publish
# your project to the Hex package manager.
#
# description = ""
# licences = ["Apache-2.0"]
# repository = { type = "github", user = "username", repo = "project" }
# links = [{ title = "Website", href = "https://gleam.run" }]
#
# For a full reference of all the available options, you can have a look at
# https://gleam.run/writing-gleam/gleam-toml/.

[dependencies]
gleam_stdlib = ">= 0.36.0 and < 1.0.0"
glexer = ">= 0.7.0 and < 1.0.0"

[dev-dependencies]
gleeunit = ">= 1.0.0 and < 2.0.0"
```

the `manifest.toml` should be looking like this

```toml
# This file was generated by Gleam
# You typically do not need to edit this file

packages = [
  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
  { name = "glexer", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "4484942A465482A0A100936E1E5F12314DB4B5AC0D87575A7B9E9062090B96BE" },
]

[requirements]
gleam_stdlib = { version = ">= 0.36.0 and < 1.0.0" }
gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
glexer = { version = ">= 0.7.0 and < 1.0.0"}
```

Now, delete the `gleam_stdlib` package in the manifest

```toml
# This file was generated by Gleam
# You typically do not need to edit this file

packages = [
  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
  { name = "glexer", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "4484942A465482A0A100936E1E5F12314DB4B5AC0D87575A7B9E9062090B96BE" },
]

[requirements]
gleam_stdlib = { version = ">= 0.36.0 and < 1.0.0" }
gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
glexer = { version = ">= 0.7.0 and < 1.0.0"}
```

run `gleam add glexer`