### PR TITLE
initial implementation of goto types and separating annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,10 @@
   removed if it would otherwise be left blank.
   ([Milco Kats](https://github.com/katsmil))
 
+- Hover for type annotations is now separate from the thing being annotated ([Ameen Radwan](https://github.com/Acepie))
+
+- Go to definition now works for direct type annotations ([Ameen Radwan](https://github.com/Acepie))
+
 ### Bug Fixes
 
 - Fixed [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145) by

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -1283,6 +1283,14 @@ pub mod type_constructor {
     pub fn has_origin(&self) -> bool {
       !self.reader.get_pointer_field(4).is_null()
     }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.reader.get_pointer_field(5).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -1421,6 +1429,22 @@ pub mod type_constructor {
     pub fn has_origin(&self) -> bool {
       !self.builder.get_pointer_field(4).is_null()
     }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_documentation(&mut self, value: ::capnp::text::Reader<'_>)  {
+      self.builder.get_pointer_field(5).set_text(value);
+    }
+    #[inline]
+    pub fn init_documentation(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(5).init_text(size)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.builder.get_pointer_field(5).is_null()
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -1439,7 +1463,7 @@ pub mod type_constructor {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
     pub const TYPE_ID: u64 = 0xb1fb_6d62_e00b_6d7a;
   }
 }

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -1275,6 +1275,14 @@ pub mod type_constructor {
     pub fn has_deprecated(&self) -> bool {
       !self.reader.get_pointer_field(3).is_null()
     }
+    #[inline]
+    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_origin(&self) -> bool {
+      !self.reader.get_pointer_field(4).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -1397,6 +1405,22 @@ pub mod type_constructor {
     pub fn has_deprecated(&self) -> bool {
       !self.builder.get_pointer_field(3).is_null()
     }
+    #[inline]
+    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_origin(&mut self, value: crate::schema_capnp::src_span::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+    }
+    #[inline]
+    pub fn init_origin(self, ) -> crate::schema_capnp::src_span::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), 0)
+    }
+    #[inline]
+    pub fn has_origin(&self) -> bool {
+      !self.builder.get_pointer_field(4).is_null()
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -1409,10 +1433,13 @@ pub mod type_constructor {
     pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
       ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
     }
+    pub fn get_origin(&self) -> crate::schema_capnp::src_span::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(4))
+    }
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 4 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 5 };
     pub const TYPE_ID: u64 = 0xb1fb_6d62_e00b_6d7a;
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -57,6 +57,7 @@ struct TypeConstructor {
   publicity @3 :Publicity;
   deprecated @4 :Text;
   origin @5 :SrcSpan;
+  documentation @6 :Text;
 }
 
 struct AccessorsMap {

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -56,6 +56,7 @@ struct TypeConstructor {
   module @2 :Text;
   publicity @3 :Publicity;
   deprecated @4 :Text;
+  origin @5 :SrcSpan;
 }
 
 struct AccessorsMap {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -369,7 +369,7 @@ fn register_type_alias(
         type_ast: resolved_type,
         deprecation,
         type_: _,
-        documentation: _,
+        documentation,
     } = t;
 
     // A type alias must not have the same name as any other type in the module.
@@ -392,6 +392,7 @@ fn register_type_alias(
             typ,
             deprecation: deprecation.clone(),
             publicity: *publicity,
+            documentation: documentation.clone(),
         },
     )?;
 
@@ -425,6 +426,7 @@ fn register_types_from_custom_type<'a>(
         deprecation,
         opaque,
         constructors,
+        documentation,
         ..
     } = t;
     assert_unique_type_name(names, name, *location)?;
@@ -461,6 +463,7 @@ fn register_types_from_custom_type<'a>(
             parameters,
             publicity,
             typ,
+            documentation: documentation.clone(),
         },
     )?;
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -632,13 +632,12 @@ impl TypedDefinition {
                     .constructors
                     .iter()
                     .find(|constructor| constructor.location.contains(byte_index))
-                    .map(|constructor| {
+                    .and_then(|constructor| {
                         constructor
                             .arguments
                             .iter()
                             .find(|arg| arg.location.contains(byte_index))
                     })
-                    .flatten()
                     .filter(|arg| arg.location.contains(byte_index))
                     .map(|arg| Some(Located::Annotation(&arg.ast, &arg.type_)))
                 {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -372,7 +372,7 @@ impl TypeAst {
 
                     None
                 })
-                .or(Some(Located::Annotation(self, type_))),
+                .or(Some(Located::Annotation(self.location(), type_))),
             TypeAst::Constructor(TypeAstConstructor { arguments, .. }) => type_
                 .constructor_types()
                 .and_then(|arg_types| {
@@ -386,7 +386,7 @@ impl TypeAst {
 
                     None
                 })
-                .or(Some(Located::Annotation(self, type_))),
+                .or(Some(Located::Annotation(self.location(), type_))),
             TypeAst::Tuple(TypeAstTuple { elems, .. }) => type_
                 .tuple_types()
                 .and_then(|elem_types| {
@@ -400,8 +400,8 @@ impl TypeAst {
 
                     None
                 })
-                .or(Some(Located::Annotation(self, type_))),
-            TypeAst::Var(_) | TypeAst::Hole(_) => Some(Located::Annotation(self, type_)),
+                .or(Some(Located::Annotation(self.location(), type_))),
+            TypeAst::Var(_) | TypeAst::Hole(_) => Some(Located::Annotation(self.location(), type_)),
         }
     }
 }

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -315,7 +315,7 @@ impl<'a> Located<'a> {
                 }),
             type_::Type::Var { type_, .. } => type_
                 .borrow()
-                .nested_type()
+                .inner_type()
                 .and_then(|v| self.type_location(importable_modules, v)),
             _ => None,
         }

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -296,7 +296,7 @@ pub enum Located<'a> {
     ModuleStatement(&'a TypedDefinition),
     FunctionBody(&'a TypedFunction),
     Arg(&'a TypedArg),
-    Annotation(&'a TypeAst, &'a type_::Type),
+    Annotation(&'a TypeAst, std::sync::Arc<type_::Type>),
 }
 
 impl<'a> Located<'a> {
@@ -314,14 +314,14 @@ impl<'a> Located<'a> {
                 span: statement.location(),
             }),
             Self::Arg(_) => None,
-            Self::Annotation(_, type_) => match type_ {
+            Self::Annotation(_, type_) => match type_.as_ref() {
                 // For type annotations, we need to look up the type location
                 // From the module interface.
                 type_::Type::Named { name, module, .. } => importable_modules
                     .get(module)
                     .and_then(|i| i.types.get(name))
                     .map(|t| DefinitionLocation {
-                        module: Some(module),
+                        module: Some(&module),
                         span: t.origin,
                     }),
                 _ => None,

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -300,30 +300,9 @@ pub enum Located<'a> {
 }
 
 impl<'a> Located<'a> {
-    fn type_location(
-        &self,
-        importable_modules: &'a im::HashMap<EcoString, type_::ModuleInterface>,
-        type_: std::sync::Arc<type_::Type>,
-    ) -> Option<DefinitionLocation<'_>> {
-        match type_.as_ref() {
-            type_::Type::Named { name, module, .. } => importable_modules
-                .get(module)
-                .and_then(|i| i.types.get(name))
-                .map(|t| DefinitionLocation {
-                    module: Some(&t.module),
-                    span: t.origin,
-                }),
-            type_::Type::Var { type_, .. } => type_
-                .borrow()
-                .inner_type()
-                .and_then(|v| self.type_location(importable_modules, v)),
-            _ => None,
-        }
-    }
-
     pub fn definition_location(
         &self,
-        importable_modules: &'a im::HashMap<EcoString, type_::ModuleInterface>,
+        type_constructor: Option<&'a type_::TypeConstructor>,
     ) -> Option<DefinitionLocation<'_>> {
         match self {
             Self::Pattern(pattern) => pattern.definition_location(),
@@ -335,7 +314,18 @@ impl<'a> Located<'a> {
                 span: statement.location(),
             }),
             Self::Arg(_) => None,
-            Self::Annotation(_, type_) => self.type_location(importable_modules, type_.clone()),
+            Self::Annotation(_, type_) => type_constructor.map(|t| DefinitionLocation {
+                module: Some(&t.module),
+                span: t.origin,
+            }),
+        }
+    }
+
+    /// Returns the type an annotation is pointing to. Returns `None` if not an annotation
+    pub fn annotation_type(&self) -> Option<std::sync::Arc<type_::Type>> {
+        match self {
+            Self::Annotation(_, type_) => Some(type_.clone()),
+            _ => None,
         }
     }
 }

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -319,8 +319,7 @@ impl<'a> Located<'a> {
                 // From the module interface.
                 type_::Type::Named { name, module, .. } => importable_modules
                     .get(module)
-                    .map(|i| i.types.get(name))
-                    .flatten()
+                    .and_then(|i| i.types.get(name))
                     .map(|t| DefinitionLocation {
                         module: Some(module),
                         span: t.origin,

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -109,6 +109,12 @@ where
         // Store the compiled dependency module information
         for module in &compiled_dependencies {
             let path = module.input_path.as_os_str().to_string_lossy().to_string();
+            // strip canonicalised windows prefix
+            #[cfg(target_family = "windows")]
+            let path = path
+                .strip_prefix(r"\\?\")
+                .map(|s| s.to_string())
+                .unwrap_or(path);
             let line_numbers = LineNumbers::new(&module.code);
             let source = ModuleSourceInformation { path, line_numbers };
             _ = self.sources.insert(module.name.clone(), source);
@@ -124,6 +130,12 @@ where
             }
             // Create the source information
             let path = module.src_path.to_string();
+            // strip canonicalised windows prefix
+            #[cfg(target_family = "windows")]
+            let path = path
+                .strip_prefix(r"\\?\")
+                .map(|s| s.to_string())
+                .unwrap_or(path);
             let line_numbers = module.line_numbers.clone();
             let source = ModuleSourceInformation { path, line_numbers };
             _ = self.sources.insert(name.clone(), source);

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -302,7 +302,7 @@ where
                 Located::Arg(arg) => Some(hover_for_function_argument(arg, lines)),
                 Located::FunctionBody(_) => None,
                 Located::Annotation(annotation, type_) => {
-                    Some(hover_for_annotation(annotation, type_, lines))
+                    Some(hover_for_annotation(annotation, &type_, lines))
                 }
             })
         })

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1455,3 +1455,66 @@ pub fn main() {
         },]
     );
 }
+
+#[test]
+fn completions_for_a_function_arg_annotation() {
+    let code = "
+pub fn wibble(
+  _: String,
+) -> Nil {
+  Nil
+}
+";
+
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(2, 11)),
+        prelude_type_completions(),
+    );
+}
+
+#[test]
+fn completions_for_a_function_return_annotation() {
+    let code = "
+pub fn wibble(
+  _: String,
+) -> Nil {
+  Nil
+}
+";
+
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(3, 7)),
+        prelude_type_completions(),
+    );
+}
+
+#[test]
+fn completions_for_a_var_annotation() {
+    let code = "
+pub fn main() {
+  let wibble: Int = 7
+}
+";
+
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(2, 16)),
+        prelude_type_completions(),
+    );
+}
+
+#[test]
+fn completions_for_a_const_annotation() {
+    let code = "
+
+const wibble: Int = 7
+
+pub fn main() {
+  let wibble: Int = 7
+}
+";
+
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(2, 16)),
+        prelude_type_completions(),
+    );
+}

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -711,6 +711,48 @@ fn make_var() -> example_module.Rec {
 }
 
 #[test]
+fn goto_definition_type_in_path_dep() {
+    let dep = "
+pub type Rec {
+  Var1(Int)
+  Var2(Int, Int)
+}
+";
+
+    let code = "
+import example_module
+fn make_var() -> example_module.Rec {
+  example_module.Var1(1)
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_dep_module("example_module", dep),
+            Position::new(2, 33)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\dep\src\example_module.gleam"
+            } else {
+                "/dep/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0
+                },
+                end: Position {
+                    line: 1,
+                    character: 12
+                }
+            }
+        })
+    )
+}
+
+#[test]
 fn goto_definition_deep_type_in_module() {
     let hex_src = "
 pub type Wobble {

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -596,3 +596,96 @@ fn do_stuff() {
         })
     );
 }
+
+#[test]
+fn hover_function_arg_annotation() {
+    let code = "
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x: String, y: String) -> String {
+  x <> y
+}
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(3, 17)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nString\n```".to_string()
+            )),
+            range: Some(Range::new(Position::new(3, 13), Position::new(3, 19))),
+        })
+    );
+}
+
+#[test]
+fn hover_function_return_annotation() {
+    let code = "
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x: String, y: String) -> String {
+  x <> y
+}
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(3, 39)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nString\n```".to_string()
+            )),
+            range: Some(Range::new(Position::new(3, 35), Position::new(3, 41))),
+        })
+    );
+}
+
+#[test]
+fn hover_module_constant_annotation() {
+    let code = "
+/// Exciting documentation
+/// Maybe even multiple lines
+const one: Int = 1
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(3, 13)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String("```gleam\nInt\n```".to_string())),
+            range: Some(Range::new(Position::new(3, 11), Position::new(3, 14))),
+        })
+    );
+}
+
+#[test]
+fn hover_type_constructor_annotation() {
+    let code = "
+type Wibble {
+    Wibble(arg: String)
+}
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(2, 20)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nString\n```".to_string()
+            )),
+            range: Some(Range::new(Position::new(2, 16), Position::new(2, 22))),
+        })
+    );
+}
+
+#[test]
+fn hover_type_alias_annotation() {
+    let code = "
+type Wibble = Int
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(1, 15)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String("```gleam\nInt\n```".to_string())),
+            range: Some(Range::new(Position::new(1, 14), Position::new(1, 17))),
+        })
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -611,7 +611,7 @@ fn append(x: String, y: String) -> String {
         hover(TestProject::for_source(code), Position::new(3, 17)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
-                "```gleam\nString\n```".to_string()
+                "```gleam\nString\n```\n".to_string()
             )),
             range: Some(Range::new(Position::new(3, 13), Position::new(3, 19))),
         })
@@ -632,7 +632,7 @@ fn append(x: String, y: String) -> String {
         hover(TestProject::for_source(code), Position::new(3, 39)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
-                "```gleam\nString\n```".to_string()
+                "```gleam\nString\n```\n".to_string()
             )),
             range: Some(Range::new(Position::new(3, 35), Position::new(3, 41))),
         })
@@ -650,7 +650,9 @@ const one: Int = 1
     assert_eq!(
         hover(TestProject::for_source(code), Position::new(3, 13)),
         Some(Hover {
-            contents: HoverContents::Scalar(MarkedString::String("```gleam\nInt\n```".to_string())),
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nInt\n```\n".to_string()
+            )),
             range: Some(Range::new(Position::new(3, 11), Position::new(3, 14))),
         })
     );
@@ -668,7 +670,7 @@ type Wibble {
         hover(TestProject::for_source(code), Position::new(2, 20)),
         Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
-                "```gleam\nString\n```".to_string()
+                "```gleam\nString\n```\n".to_string()
             )),
             range: Some(Range::new(Position::new(2, 16), Position::new(2, 22))),
         })
@@ -684,7 +686,9 @@ type Wibble = Int
     assert_eq!(
         hover(TestProject::for_source(code), Position::new(1, 15)),
         Some(Hover {
-            contents: HoverContents::Scalar(MarkedString::String("```gleam\nInt\n```".to_string())),
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nInt\n```\n".to_string()
+            )),
             range: Some(Range::new(Position::new(1, 14), Position::new(1, 17))),
         })
     );
@@ -702,8 +706,36 @@ fn wibble() {
     assert_eq!(
         hover(TestProject::for_source(code), Position::new(2, 18)),
         Some(Hover {
-            contents: HoverContents::Scalar(MarkedString::String("```gleam\nInt\n```".to_string())),
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nInt\n```\n".to_string()
+            )),
             range: Some(Range::new(Position::new(2, 16), Position::new(2, 19))),
+        })
+    );
+}
+
+#[test]
+fn hover_function_arg_annotation_with_documentation() {
+    let code = "
+/// Exciting documentation
+/// Maybe even multiple lines
+type Wibble {
+    Wibble(arg: String)
+}
+
+fn identity(x: Wibble) -> Wibble {
+  x
+}
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(7, 20)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nWibble\n```\n Exciting documentation\n Maybe even multiple lines\n"
+                    .to_string()
+            )),
+            range: Some(Range::new(Position::new(7, 15), Position::new(7, 21))),
         })
     );
 }

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -689,3 +689,21 @@ type Wibble = Int
         })
     );
 }
+
+#[test]
+fn hover_assignment_annotation() {
+    let code = "
+fn wibble() {
+    let wobble: Int = 7
+    wobble
+}
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(2, 18)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String("```gleam\nInt\n```".to_string())),
+            range: Some(Range::new(Position::new(2, 16), Position::new(2, 19))),
+        })
+    );
+}

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -530,7 +530,7 @@ impl<'a> TestProject<'a> {
         _ = io.src_module("app", self.src);
 
         let response = engine.compile_please();
-        assert!(response.result.is_ok());
+        response.result.expect("failed to compile");
 
         let param = self.build_path(position);
 

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -98,7 +98,7 @@ impl ModuleDecoder {
         };
         Ok(TypeConstructor {
             publicity: self.publicity(reader.get_publicity()?),
-            origin: Default::default(),
+            origin: self.src_span(&reader.get_origin()?)?,
             module: reader.get_module()?.into(),
             parameters: read_vec!(reader.get_parameters()?, self, type_),
             typ: type_,

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -103,6 +103,7 @@ impl ModuleDecoder {
             parameters: read_vec!(reader.get_parameters()?, self, type_),
             typ: type_,
             deprecation,
+            documentation: self.optional_string(reader.get_documentation()?),
         })
     }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -182,6 +182,13 @@ impl<'a> ModuleEncoder<'a> {
             &constructor.parameters,
         );
         self.build_src_span(builder.reborrow().init_origin(), constructor.origin);
+        builder.set_documentation(
+            constructor
+                .documentation
+                .as_ref()
+                .map(EcoString::as_str)
+                .unwrap_or_default(),
+        );
     }
 
     fn build_type_value_constructor(

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -181,6 +181,7 @@ impl<'a> ModuleEncoder<'a> {
                 .init_parameters(constructor.parameters.len() as u32),
             &constructor.parameters,
         );
+        self.build_src_span(builder.reborrow().init_origin(), constructor.origin);
     }
 
     fn build_type_value_constructor(

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -329,7 +329,44 @@ fn module_with_type_links() {
                     module: "a".into(),
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
-                    documentation: Some("documentation".into()),
+                    documentation: None,
+                },
+            )]
+            .into(),
+            types_value_constructors: HashMap::new(),
+            values: HashMap::new(),
+            unused_imports: Vec::new(),
+            accessors: HashMap::new(),
+            line_numbers: LineNumbers::new(""),
+            src_path: "some_path".into(),
+        }
+    }
+
+    assert_eq!(roundtrip(&make(linked_type)), make(type_));
+}
+
+#[test]
+fn module_with_type_documentation() {
+    let linked_type = type_::link(type_::int());
+    let type_ = type_::int();
+
+    fn make(type_: Arc<Type>) -> ModuleInterface {
+        ModuleInterface {
+            is_internal: false,
+            contains_todo: false,
+            package: "some_package".into(),
+            origin: Origin::Src,
+            name: "a".into(),
+            types: [(
+                "SomeType".into(),
+                TypeConstructor {
+                    typ: type_,
+                    publicity: Publicity::Public,
+                    origin: Default::default(),
+                    module: "a".into(),
+                    parameters: vec![],
+                    deprecation: Deprecation::NotDeprecated,
+                    documentation: Some("type documentation".into()),
                 },
             )]
             .into(),

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -346,7 +346,7 @@ fn module_with_type_links() {
 }
 
 #[test]
-fn module_with_type_documentation() {
+fn module_with_type_constructor_documentation() {
     let linked_type = type_::link(type_::int());
     let type_ = type_::int();
 
@@ -367,6 +367,46 @@ fn module_with_type_documentation() {
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
                     documentation: Some("type documentation".into()),
+                },
+            )]
+            .into(),
+            types_value_constructors: HashMap::new(),
+            values: HashMap::new(),
+            unused_imports: Vec::new(),
+            accessors: HashMap::new(),
+            line_numbers: LineNumbers::new(""),
+            src_path: "some_path".into(),
+        }
+    }
+
+    assert_eq!(roundtrip(&make(linked_type)), make(type_));
+}
+
+#[test]
+fn module_with_type_constructor_origin() {
+    let linked_type = type_::link(type_::int());
+    let type_ = type_::int();
+
+    fn make(type_: Arc<Type>) -> ModuleInterface {
+        ModuleInterface {
+            is_internal: false,
+            contains_todo: false,
+            package: "some_package".into(),
+            origin: Origin::Src,
+            name: "a".into(),
+            types: [(
+                "SomeType".into(),
+                TypeConstructor {
+                    typ: type_,
+                    publicity: Publicity::Public,
+                    origin: SrcSpan {
+                        start: 535,
+                        end: 543,
+                    },
+                    module: "a".into(),
+                    parameters: vec![],
+                    deprecation: Deprecation::NotDeprecated,
+                    documentation: None,
                 },
             )]
             .into(),

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -140,6 +140,7 @@ fn module_with_private_type() {
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
+                documentation: None,
             },
         )]
         .into(),
@@ -192,6 +193,7 @@ fn module_with_app_type() {
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
+                documentation: None,
             },
         )]
         .into(),
@@ -222,6 +224,7 @@ fn module_with_fn_type() {
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
+                documentation: None,
             },
         )]
         .into(),
@@ -252,6 +255,7 @@ fn module_with_tuple_type() {
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
+                documentation: None,
             },
         )]
         .into(),
@@ -288,6 +292,7 @@ fn module_with_generic_type() {
                     module: "the/module".into(),
                     parameters: vec![t1, t2],
                     deprecation: Deprecation::NotDeprecated,
+                    documentation: None,
                 },
             )]
             .into(),
@@ -324,6 +329,7 @@ fn module_with_type_links() {
                     module: "a".into(),
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
+                    documentation: Some("documentation".into()),
                 },
             )]
             .into(),
@@ -1142,6 +1148,7 @@ fn deprecated_type() {
                 deprecation: Deprecation::Deprecated {
                     message: "oh no".into(),
                 },
+                documentation: None,
             },
         )]
         .into(),

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1896,13 +1896,16 @@ where
                         let _ = Parser::next_tok(p);
                         let doc = p.take_documentation(start);
                         match Parser::parse_type(p)? {
-                            Some(type_ast) => Ok(Some(RecordConstructorArg {
-                                label: Some(name),
-                                ast: type_ast,
-                                location: SrcSpan { start, end },
-                                type_: (),
-                                doc,
-                            })),
+                            Some(type_ast) => {
+                                let end = type_ast.location().end;
+                                Ok(Some(RecordConstructorArg {
+                                    label: Some(name),
+                                    ast: type_ast,
+                                    location: SrcSpan { start, end },
+                                    type_: (),
+                                    doc,
+                                }))
+                            }
                             None => {
                                 parse_error(ParseErrorType::ExpectedType, SrcSpan { start, end })
                             }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -152,15 +152,6 @@ impl Type {
         }
     }
 
-    /// Gets the inner type following any var links. Returns a pointer to self
-    /// if the type is not a var.
-    pub fn inner_type(&self) -> Option<Arc<Self>> {
-        match self {
-            Self::Var { type_, .. } => type_.borrow().inner_type(),
-            _ => Some(Arc::new(self.clone())),
-        }
-    }
-
     pub fn is_nil(&self) -> bool {
         match self {
             Self::Named { module, name, .. } if "Nil" == name && is_prelude_module(module) => true,
@@ -879,13 +870,6 @@ impl TypeVar {
     pub fn named_type_name(&self) -> Option<(EcoString, EcoString)> {
         match self {
             Self::Link { type_ } => type_.named_type_name(),
-            Self::Unbound { .. } | Self::Generic { .. } => None,
-        }
-    }
-
-    pub fn inner_type(&self) -> Option<Arc<Type>> {
-        match self {
-            Self::Link { type_ } => type_.inner_type(),
             Self::Unbound { .. } | Self::Generic { .. } => None,
         }
     }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -899,6 +899,7 @@ pub struct TypeConstructor {
     pub parameters: Vec<Arc<Type>>,
     pub typ: Arc<Type>,
     pub deprecation: Deprecation,
+    pub documentation: Option<EcoString>,
 }
 impl TypeConstructor {
     pub(crate) fn with_location(mut self, location: SrcSpan) -> Self {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -134,6 +134,28 @@ impl Type {
         }
     }
 
+    pub fn tuple_types(&self) -> Option<Vec<Arc<Self>>> {
+        match self {
+            Self::Tuple { elems } => Some(elems.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn constructor_types(&self) -> Option<Vec<Arc<Self>>> {
+        match self {
+            Self::Named { args, .. } => Some(args.clone()),
+            Self::Var { type_, .. } => type_.borrow().constructor_types(),
+            _ => None,
+        }
+    }
+
+    pub fn nested_type(&self) -> Option<Arc<Self>> {
+        match self {
+            Self::Var { type_, .. } => type_.borrow().nested_type(),
+            _ => Some(Arc::new(self.clone())),
+        }
+    }
+
     pub fn is_nil(&self) -> bool {
         match self {
             Self::Named { module, name, .. } if "Nil" == name && is_prelude_module(module) => true,
@@ -793,6 +815,13 @@ impl TypeVar {
         }
     }
 
+    pub fn constructor_types(&self) -> Option<Vec<Arc<Type>>> {
+        match self {
+            Self::Link { type_ } => type_.constructor_types(),
+            Self::Unbound { .. } | Self::Generic { .. } => None,
+        }
+    }
+
     pub fn is_result(&self) -> bool {
         match self {
             Self::Link { type_ } => type_.is_result(),
@@ -845,6 +874,13 @@ impl TypeVar {
     pub fn named_type_name(&self) -> Option<(EcoString, EcoString)> {
         match self {
             Self::Link { type_ } => type_.named_type_name(),
+            Self::Unbound { .. } | Self::Generic { .. } => None,
+        }
+    }
+
+    pub fn nested_type(&self) -> Option<Arc<Type>> {
+        match self {
+            Self::Link { type_ } => type_.nested_type(),
             Self::Unbound { .. } | Self::Generic { .. } => None,
         }
     }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -134,6 +134,7 @@ impl Type {
         }
     }
 
+    /// Gets the types inside of a tuple. Returns `None` if the type is not a tuple.
     pub fn tuple_types(&self) -> Option<Vec<Arc<Self>>> {
         match self {
             Self::Tuple { elems } => Some(elems.clone()),
@@ -141,6 +142,8 @@ impl Type {
         }
     }
 
+    /// Gets the argument types for a type constructor. Returns `None` if the type
+    /// does not lead to a type constructor.
     pub fn constructor_types(&self) -> Option<Vec<Arc<Self>>> {
         match self {
             Self::Named { args, .. } => Some(args.clone()),
@@ -149,9 +152,11 @@ impl Type {
         }
     }
 
-    pub fn nested_type(&self) -> Option<Arc<Self>> {
+    /// Gets the inner type following any var links. Returns a pointer to self
+    /// if the type is not a var.
+    pub fn inner_type(&self) -> Option<Arc<Self>> {
         match self {
-            Self::Var { type_, .. } => type_.borrow().nested_type(),
+            Self::Var { type_, .. } => type_.borrow().inner_type(),
             _ => Some(Arc::new(self.clone())),
         }
     }
@@ -878,9 +883,9 @@ impl TypeVar {
         }
     }
 
-    pub fn nested_type(&self) -> Option<Arc<Type>> {
+    pub fn inner_type(&self) -> Option<Arc<Type>> {
         match self {
-            Self::Link { type_ } => type_.nested_type(),
+            Self::Link { type_ } => type_.inner_type(),
             Self::Unbound { .. } | Self::Generic { .. } => None,
         }
     }

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -228,6 +228,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     module: PRELUDE_MODULE_NAME.into(),
                     publicity: Publicity::Public,
                     deprecation: NotDeprecated,
+                    documentation: None,
                 };
                 let _ = prelude.types.insert(BIT_ARRAY.into(), v.clone());
             }
@@ -290,6 +291,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
             }
@@ -304,6 +306,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
             }
@@ -318,6 +321,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
             }
@@ -333,6 +337,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
             }
@@ -363,6 +368,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
                 let _ = prelude.types_value_constructors.insert(
@@ -391,6 +397,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
                 let _ = prelude.types_value_constructors.insert(
@@ -461,6 +468,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
             }
@@ -475,6 +483,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
+                        documentation: None,
                     },
                 );
             }


### PR DESCRIPTION
<!-- Don't forget to update the CHANGELOG! -->
An initial implementation for making annotations distinct from the thing being annotated. Currently in most places where the user hovers over an annotation it either doesn't work or hovers the larger object being annotated (function head, constant, custom type). This change is the first part of separating that out and allowing for operations on the located annotation. Currently that means hovering will display the type itself, completions will always be type completions (this seems to be exactly the same as current in all cases), and goto definition now will go to where the type is declared. There are a couple known gaps here but overall its still an improvement so want to start with this and get feedback

Known things to improve:

- Type aliases seem to be stored in the ast directly as the type being aliased meaning that hover/goto will use the underlying type
- ~Hovering over a type won't show documentation~
- ~Because of how locations/labels for CustomType constructor args are implemented hovering over the arg label will be treated as hovering over the annotation~
  -  ~This is probably fixable but honestly I kinda like it so wanna get thoughts~