### PR TITLE
Add test to make sure comments are not moved out of const lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@
 
 ### Language Server
 
+- Update messages from the client are now batched to avoid doing excess
+  compilation work in the language server, improving performance. This makes a
+  large difference in low power machines where the language server could
+  struggle to keep up with the edits from the client.
 - The `Compiling Gleam` message is no longer emitted each time code is compiled.
   This is to reduce noise in editors that show this message prominently such as
   Neovim.

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5905,3 +5905,19 @@ fn comments_inside_binop_chain() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2911
+#[test]
+fn comments_are_not_moved_out_of_const_lists() {
+    assert_format!(
+        r#"pub fn main() {
+  let x = [
+    // A comment!
+    1, 2, 3,
+    // Another comment!!
+    4, 5,
+  ]
+}
+"#
+    );
+}


### PR DESCRIPTION
This PR closes #2911
No fix was needed as that's already what the formatter does, but I added a test to make sure we don't break this.
<!-- Don't forget to update the CHANGELOG! -->
