### PR TITLE
Fix formatting of pipes and binops in comma separated lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@
   blank lines and converting them to `\n`.
 - The formatter can now format groups of imports alphabetically.
 - Fixed a bug where comments would be moved out of an empty list.
+- Fixed a bug where pipes and binary operations in function calls would be
+  nested more than necessary.
+- Improved formatting of comments in binary operation chains.
 
 ### Build tool
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -3732,8 +3732,8 @@ fn commented_binop() {
     assert_format!(
         "fn main() {
   1
-  + // hello
-  2
+  // hello
+  + 2
 }
 "
     );
@@ -3742,10 +3742,10 @@ fn commented_binop() {
         "fn main() {
   // one
   1
-  + // two
-  2
-  + // three
-  3
+  // two
+  + 2
+  // three
+  + 3
 }
 "
     );
@@ -5817,6 +5817,90 @@ fn empty_lists_with_comment_inside_are_indented_properly() {
       // Nothing here as well!
     ],
   )
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2890
+#[test]
+fn piped_blocks_are_not_needlessly_indented() {
+    assert_format!(
+        r#"pub fn main() {
+  #(
+    1,
+    {
+      "long enough to need to wrap. blah blah blah blah blah blah blah blah blah"
+    }
+      |> foo,
+    3,
+  )
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2890
+#[test]
+fn piped_lists_are_not_needlessly_indented() {
+    assert_format!(
+        r#"pub fn main() {
+  fun(
+    [
+      ["wibble wobble", "wibble", "wobble"],
+      ["long enough to go over", "line limit"],
+    ]
+      |> list.concat,
+    todo,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn comments_inside_nested_pipe_chain() {
+    assert_format!(
+        r#"pub fn main() {
+  fun(
+    thing
+      // A comment
+      |> wibble
+      // Another comment
+      |> wobble,
+    thing,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn comments_inside_nested_binop_chain() {
+    assert_format!(
+        r#"pub fn main() {
+  fun(
+    thing
+      // A comment
+      <> wibble
+      // Another comment
+      <> wobble,
+    thing,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn comments_inside_binop_chain() {
+    assert_format!(
+        r#"pub fn main() {
+  thing
+  // A comment
+  <> wibble
+  // Another comment
+  <> wobble
 }
 "#
     );


### PR DESCRIPTION
This PR closes #2890
I've also improved the formatting of comments inside chains of binary operations to make consistent with what pipes do
<!-- Don't forget to update the CHANGELOG! -->
