### PR TITLE
One-line pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,31 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Pipes can now be placed on a single line if they are short enough:
+
+  ```gleam
+  [1, 2, 3] |> list.map(int.to_string) |> string.join(with: "\n")
+  ```
+
+  In addition you can also force the formatter to break a pipe on multiple lines
+  by manually breaking it. This:
+
+  ```gleam
+  [1, 2, 3]
+  // By putting a newline here I'm telling the formatter to split the pipeline
+  |> list.map(int.to_string) |> string.join(with: "\n")
+  ```
+
+  Will turn into this:
+
+  ```gleam
+  [1, 2, 3]
+  |> list.map(int.to_string)
+  |> string.join(with: "\n")
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Language Server
 
 - The code action to remove unused imports now removes the entire line is

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -89,7 +89,7 @@ impl<'comments> Formatter<'comments> {
             doc_comments: &extra.doc_comments,
             module_comments: &extra.module_comments,
             empty_lines: extra.empty_lines,
-            new_lines: &extra.new_lines,
+            new_lines: extra.new_lines,
         }
     }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use ecow::EcoString;
 use itertools::Itertools;
-use std::{collections::BTreeSet, sync::Arc};
+use std::{cmp::Ordering, sync::Arc};
 use vec1::Vec1;
 
 use crate::type_::Deprecation;
@@ -41,7 +41,7 @@ pub(crate) struct Intermediate<'a> {
     doc_comments: Vec<Comment<'a>>,
     module_comments: Vec<Comment<'a>>,
     empty_lines: &'a [u32],
-    new_lines: &'a BTreeSet<u32>,
+    new_lines: &'a [u32],
 }
 
 impl<'a> Intermediate<'a> {
@@ -75,7 +75,7 @@ pub struct Formatter<'a> {
     doc_comments: &'a [Comment<'a>],
     module_comments: &'a [Comment<'a>],
     empty_lines: &'a [u32],
-    new_lines: Option<&'a BTreeSet<u32>>,
+    new_lines: &'a [u32],
 }
 
 impl<'comments> Formatter<'comments> {
@@ -89,7 +89,7 @@ impl<'comments> Formatter<'comments> {
             doc_comments: &extra.doc_comments,
             module_comments: &extra.module_comments,
             empty_lines: extra.empty_lines,
-            new_lines: Some(extra.new_lines),
+            new_lines: &extra.new_lines,
         }
     }
 
@@ -1346,20 +1346,24 @@ impl<'comments> Formatter<'comments> {
         let first = self.expr(first).group();
         docs.push(self.operator_side(first, 5, first_precedence));
 
-        let try_to_keep_on_one_line = if let Some(new_lines) = self.new_lines {
-            let pipeline_start = expressions.first().location().start;
-            let pipeline_end = expressions.last().location().end;
-            // If there's any newline between the pipeline start and end
-            // then we want to force the pipeline to be split on multiple lines.
-            new_lines
-                .range(pipeline_start..pipeline_end)
-                .next()
-                .is_none()
-        } else {
-            // If we are not keeping track of newlines in the source code then
-            // we split the pipeline by default.
-            false
-        };
+        let pipeline_start = expressions.first().location().start;
+        let pipeline_end = expressions.last().location().end;
+        let try_to_keep_on_one_line = self
+            .new_lines
+            .binary_search_by(|newline| {
+                if *newline <= pipeline_start {
+                    Ordering::Less
+                } else if *newline >= pipeline_end {
+                    Ordering::Greater
+                } else {
+                    // If the newline is in between the pipe start and end
+                    // then we've found it!
+                    Ordering::Equal
+                }
+            })
+            // If we couldn't find any newline between the start and end of
+            // the pipeline then we will try and keep it on a single line.
+            .is_err();
 
         for expr in expressions.iter().skip(1) {
             let comments = self.pop_comments(expr.location().start);

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -28,11 +28,11 @@ macro_rules! assert_format {
 
 #[macro_export]
 macro_rules! assert_format_rewrite {
-    ($src:expr, $output:expr  $(,)?) => {
+    ($src:expr, $expected:expr  $(,)?) => {
         let mut writer = String::new();
         $crate::format::pretty(&mut writer, &$src.into(), camino::Utf8Path::new("<stdin>"))
             .unwrap();
-        assert_eq!(writer, $output);
+        assert_eq!(writer, $expected);
     };
 }
 
@@ -4581,9 +4581,9 @@ fn empty_lines_work_with_trailing_space_and_eol_normalisation() {
   2
 }
 ";
-    assert_format!(expected); // Sanity check
+    assert_format!(expected); // check the expected value is well formatted.
 
-    assert_format_rewrite!(&src.replace('\n', "\r\n"), expected);
+    assert_format_rewrite!(src.replace('\n', "\r\n"), expected);
     assert_format_rewrite!(&src.replace('\n', "\r"), expected);
 }
 #[test]

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -4500,7 +4500,9 @@ fn empty_lines_work_with_trailing_space() {
   2
 }
 ";
-    assert_format!(expected); // Sanity check
+    // We first make extra sure we've not messed up the expected output and
+    // check it's well formatted.
+    assert_format!(expected);
 
     assert_format_rewrite!(src, expected);
 }
@@ -4540,7 +4542,10 @@ fn empty_lines_work_with_eol_normalisation() {
   2
 }
 ";
-    assert_format!(expected); // Sanity check
+
+    // We first make extra sure we've not messed up the expected output and
+    // check it's well formatted.
+    assert_format!(expected);
 
     assert_format_rewrite!(&src.replace('\n', "\r\n"), expected);
     assert_format_rewrite!(&src.replace('\n', "\r"), expected);
@@ -4581,7 +4586,10 @@ fn empty_lines_work_with_trailing_space_and_eol_normalisation() {
   2
 }
 ";
-    assert_format!(expected); // check the expected value is well formatted.
+
+    // We first make extra sure we've not messed up the expected output and
+    // check it's well formatted.
+    assert_format!(expected);
 
     assert_format_rewrite!(src.replace('\n', "\r\n"), expected);
     assert_format_rewrite!(&src.replace('\n', "\r"), expected);

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -11,6 +11,7 @@ mod external_types;
 mod function;
 mod guards;
 mod imports;
+mod pipeline;
 mod record_update;
 mod tuple;
 mod use_;

--- a/compiler-core/src/format/tests/pipeline.rs
+++ b/compiler-core/src/format/tests/pipeline.rs
@@ -36,3 +36,20 @@ pub fn multi_line_pipeline_is_split_no_matter_the_length() {
 "#
     );
 }
+
+#[test]
+pub fn adding_a_newline_to_a_pipeline_splits_all() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  wibble |> wobble
+  |> wabble
+}
+"#,
+        r#"pub fn main() {
+  wibble
+  |> wobble
+  |> wabble
+}
+"#,
+    );
+}

--- a/compiler-core/src/format/tests/pipeline.rs
+++ b/compiler-core/src/format/tests/pipeline.rs
@@ -20,7 +20,7 @@ pub fn single_line_pipeline_longer_than_line_limit_gets_split() {
 pub fn single_line_pipeline_shorter_than_line_limit_is_kept_on_a_single_line() {
     assert_format!(
         r#"pub fn main() {
-  wibble |> wobble
+  wibble(1) |> wobble
 }
 "#
     );
@@ -30,7 +30,7 @@ pub fn single_line_pipeline_shorter_than_line_limit_is_kept_on_a_single_line() {
 pub fn multi_line_pipeline_is_split_no_matter_the_length() {
     assert_format!(
         r#"pub fn main() {
-  wibble
+  wibble(1)
   |> wobble
 }
 "#

--- a/compiler-core/src/format/tests/pipeline.rs
+++ b/compiler-core/src/format/tests/pipeline.rs
@@ -1,0 +1,38 @@
+use crate::{assert_format, assert_format_rewrite};
+
+#[test]
+pub fn single_line_pipeline_longer_than_line_limit_gets_split() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  wibble |> wobble |> loooooooooooooooooooooooooooooooooooooooooooong_function_name
+}
+"#,
+        r#"pub fn main() {
+  wibble
+  |> wobble
+  |> loooooooooooooooooooooooooooooooooooooooooooong_function_name
+}
+"#,
+    );
+}
+
+#[test]
+pub fn single_line_pipeline_shorter_than_line_limit_is_kept_on_a_single_line() {
+    assert_format!(
+        r#"pub fn main() {
+  wibble |> wobble
+}
+"#
+    );
+}
+
+#[test]
+pub fn multi_line_pipeline_is_split_no_matter_the_length() {
+    assert_format!(
+        r#"pub fn main() {
+  wibble
+  |> wobble
+}
+"#
+    );
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2892,7 +2892,7 @@ where
                     self.extra.module_comments.push(SrcSpan { start, end });
                 }
                 Some(Ok((start, Token::NewLine, _))) => {
-                    let _ = self.extra.new_lines.insert(start);
+                    let _ = self.extra.new_lines.push(start);
                 }
 
                 // die on lex error

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2891,6 +2891,9 @@ where
                 Some(Ok((start, Token::CommentModule, end))) => {
                     self.extra.module_comments.push(SrcSpan { start, end });
                 }
+                Some(Ok((start, Token::NewLine, _))) => {
+                    let _ = self.extra.new_lines.insert(start);
+                }
 
                 // die on lex error
                 Some(Err(err)) => {
@@ -3442,7 +3445,8 @@ fn is_reserved_word(tok: Token) -> bool {
         | Token::EndOfFile
         | Token::CommentNormal
         | Token::CommentModule
-        | Token::EmptyLine => false,
+        | Token::EmptyLine
+        | Token::NewLine => false,
     }
 }
 

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use ecow::EcoString;
 
 use crate::ast::SrcSpan;
@@ -10,7 +8,7 @@ pub struct ModuleExtra {
     pub doc_comments: Vec<SrcSpan>,
     pub comments: Vec<SrcSpan>,
     pub empty_lines: Vec<u32>,
-    pub new_lines: BTreeSet<u32>,
+    pub new_lines: Vec<u32>,
 }
 
 impl ModuleExtra {

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use ecow::EcoString;
 
 use crate::ast::SrcSpan;
@@ -8,6 +10,7 @@ pub struct ModuleExtra {
     pub doc_comments: Vec<SrcSpan>,
     pub comments: Vec<SrcSpan>,
     pub empty_lines: Vec<u32>,
+    pub new_lines: BTreeSet<u32>,
 }
 
 impl ModuleExtra {

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -437,9 +437,15 @@ where
                 // Add one, so the empty line does not overlap with previous token's end
                 let tok_start = self.get_pos() + 1;
 
+                // We want to emit newline tokens
+                if c == '\n' {
+                    self.emit((tok_start, Token::NewLine, tok_start));
+                }
+
                 let mut newlines = 0;
                 while let Some('\n' | ' ' | '\t' | '\x0C') = self.chr0 {
                     if self.next_char() == Some('\n') {
+                        self.emit((self.get_pos(), Token::NewLine, self.get_pos()));
                         newlines += 1;
                     }
                 }

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -432,26 +432,11 @@ where
                 self.eat_single_char(Token::Hash);
             }
             '\n' | ' ' | '\t' | '\x0C' => {
-                // Skip whitespaces and consume empty lines
-
-                // Add one, so the empty line does not overlap with previous token's end
-                let tok_start = self.get_pos() + 1;
-
-                // We want to emit newline tokens
+                let tok_start = self.get_pos();
+                let _ = self.next_char();
+                let tok_end = self.get_pos();
                 if c == '\n' {
-                    self.emit((tok_start, Token::NewLine, tok_start));
-                }
-
-                let mut newlines = 0;
-                while let Some('\n' | ' ' | '\t' | '\x0C') = self.chr0 {
-                    if self.next_char() == Some('\n') {
-                        self.emit((self.get_pos(), Token::NewLine, self.get_pos()));
-                        newlines += 1;
-                    }
-                }
-                if newlines > 1 {
-                    let tok_end = self.get_pos();
-                    self.emit((tok_start, Token::EmptyLine, tok_end));
+                    self.emit((tok_start, Token::NewLine, tok_end));
                 }
             }
             c => {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -58,6 +58,6 @@ Parsed {
         doc_comments: [],
         comments: [],
         empty_lines: [],
-        new_lines: {},
+        new_lines: [],
     },
 }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 646
 expression: "import wibble.{type Wobble, Wobble, type Wabble}"
 ---
 Parsed {
@@ -59,5 +58,6 @@ Parsed {
         doc_comments: [],
         comments: [],
         empty_lines: [],
+        new_lines: {},
     },
 }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/parse/tests.rs
-expression: "\ntype A(a, type) { \n    A\n}\n"
+expression: "\ntype A(a, type) {\n    A\n}\n"
 ---
 error: Syntax error
   ┌─ /src/parse/error.gleam:2:11
   │
-2 │ type A(a, type) { 
+2 │ type A(a, type) {
   │           ^^^^ I was not expecting this
 
 Expected one of: 

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -2,8 +2,11 @@ use crate::ast::SrcSpan;
 use crate::parse::error::{
     InvalidUnicodeEscapeError, LexicalError, LexicalErrorType, ParseError, ParseErrorType,
 };
+use crate::parse::lexer::make_tokenizer;
+use crate::parse::token::Token;
 use camino::Utf8PathBuf;
 
+use itertools::Itertools;
 use pretty_assertions::assert_eq;
 
 macro_rules! assert_error {
@@ -941,7 +944,7 @@ fn main() {
 fn type_invalid_constructor() {
     assert_module_error!(
         "
-type A { 
+type A {
     A(String)
     type
 }
@@ -953,7 +956,7 @@ type A {
 fn type_invalid_type_name() {
     assert_module_error!(
         "
-type A(a, type) { 
+type A(a, type) {
     A
 }
 "
@@ -964,7 +967,7 @@ type A(a, type) {
 fn type_invalid_constructor_arg() {
     assert_module_error!(
         "
-type A { 
+type A {
     A(type: String)
 }
 "
@@ -1018,5 +1021,19 @@ type A {
 }
 const a = A(\"a\", let)
 "
+    );
+}
+
+#[test]
+fn newline_tokens() {
+    assert_eq!(
+        make_tokenizer("1\n\n2\n").collect_vec(),
+        [
+            Ok((0, Token::Int { value: "1".into() }, 1)),
+            Ok((1, Token::NewLine, 2)),
+            Ok((2, Token::NewLine, 3)),
+            Ok((3, Token::Int { value: "2".into() }, 4)),
+            Ok((4, Token::NewLine, 5))
+        ]
     );
 }

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -63,6 +63,7 @@ pub enum Token {
     CommentNormal,
     CommentModule,
     EmptyLine,
+    NewLine,
     // Keywords (alphabetically):
     As,
     Assert,
@@ -140,6 +141,7 @@ impl fmt::Display for Token {
             Token::Echo => "echo",
             Token::Else => "else",
             Token::EmptyLine => "EMPTYLINE",
+            Token::NewLine => "NEWLINE",
             Token::EndOfFile => "EOF",
             Token::Equal => "=",
             Token::EqualEqual => "==",

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -62,7 +62,6 @@ pub enum Token {
     // Extra
     CommentNormal,
     CommentModule,
-    EmptyLine,
     NewLine,
     // Keywords (alphabetically):
     As,
@@ -140,7 +139,6 @@ impl fmt::Display for Token {
             Token::DotDot => "..",
             Token::Echo => "echo",
             Token::Else => "else",
-            Token::EmptyLine => "EMPTYLINE",
             Token::NewLine => "NEWLINE",
             Token::EndOfFile => "EOF",
             Token::Equal => "=",


### PR DESCRIPTION
<!-- Don't forget to update the CHANGELOG! -->
This PR closes #1622 

Before going further with the implementation and adding more tests I'd love to get some feedback on the implementation, specifically on the data structure choice. The big picture idea is:
- Add a new `NewLine` token
- Keep track of all new lines like we do with empty lines, comments, etc.
- When we're in a pipe we want to see if there's any new line between its start and end
  - If that's the case then the programmer wants the newline to be split on multiple lines
  - Otherwise, we try and fit it on a single line and split it only if it goes beyond the 80 chars limit

On the data structure choice:
- I went with a `BTreeSet` because it looks like to be the best to check if a value (the newline) exists between a range (pipe start and end positions). If I used an array like empty lines, every time we run into a pipe we would have to walk through the array to find it
- I'm also considering using an array (just like empty lines, comments etc) and implementing a kind of binary search on that one, taking advantage of the fact that the positions would already be sorted in increasing order

What do you think would be best @lpil? I quite like how simple the implementation is in this PR thanks to the `BTreeSet`


Having this kind of data structure and keeping track of newlines would also allow us to extend this behaviour to other stuff in the future (function arguments, list items, etc. like it was suggested in #1117)

---

EDIT: In the end we decided to go for the array of newlines and implement a binary search!