### PR TITLE
Fix formatting of empty bit arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - Fixed a bug on the JavaScript target where variables named `debugger`, which
   is a JavaScript keyword, were not being renamed, leading to runtime errors.
 
+### Formatter
+
+- Fixed a bug where comments would be moved out of an empty bit array.
+- Fixed a bug where the formatter could add a trailing comma inside empty
+  bit arrays, generating invalid syntax.
+
+
 ## v1.1.0-rc1 - 2024-04-08
 
 ### Compiler

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -401,7 +401,7 @@ impl<'comments> Formatter<'comments> {
                 let segment_docs = segments
                     .iter()
                     .map(|s| bit_array_segment(s, |e| self.const_expr(e)))
-                    .collect::<Vec<_>>();
+                    .collect_vec();
 
                 self.bit_array(
                     segment_docs,
@@ -848,7 +848,7 @@ impl<'comments> Formatter<'comments> {
                 let segment_docs = segments
                     .iter()
                     .map(|s| bit_array_segment(s, |e| self.bit_array_segment_expr(e)))
-                    .collect::<Vec<_>>();
+                    .collect_vec();
 
                 self.bit_array(
                     segment_docs,
@@ -1789,7 +1789,7 @@ impl<'comments> Formatter<'comments> {
                 let segment_docs = segments
                     .iter()
                     .map(|s| bit_array_segment(s, |e| self.pattern(e)))
-                    .collect::<Vec<_>>();
+                    .collect_vec();
 
                 self.bit_array(segment_docs, false, location)
             }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2213,6 +2213,11 @@ fn bit_array<'a>(
     segments: impl IntoIterator<Item = Document<'a>>,
     is_simple: bool,
 ) -> Document<'a> {
+    let mut segments = segments.into_iter().peekable();
+    if segments.peek().is_none() {
+        // Avoid adding illegal comma in empty bit array
+        return "<<>>".to_doc();
+    }
     let comma = if is_simple {
         flex_break(",", ", ")
     } else {

--- a/compiler-core/src/format/tests/bit_array.rs
+++ b/compiler-core/src/format/tests/bit_array.rs
@@ -41,6 +41,18 @@ fn long() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/2932
+#[test]
+fn tight_empty() {
+    assert_format!(
+        "fn main() {
+  let some_really_really_really_really_really_really_really_long_variable_name_to_force_wrapping = <<>>
+  some_really_really_really_really_really_really_really_long_variable_name_to_force_wrapping
+}
+"
+    );
+}
+
 #[test]
 fn concise_wrapping_of_simple_bit_arrays() {
     assert_format!(

--- a/compiler-core/src/format/tests/bit_array.rs
+++ b/compiler-core/src/format/tests/bit_array.rs
@@ -54,6 +54,59 @@ fn tight_empty() {
 }
 
 #[test]
+fn comments_are_not_moved_out_of_empty_bit_array() {
+    assert_format!(
+        r#"pub fn main() {
+  // This is an empty bit array!
+  <<
+    // Nothing here...
+  >>
+}
+"#
+    );
+}
+
+#[test]
+fn empty_bit_arrays_with_comment_inside_are_indented_properly() {
+    assert_format!(
+        r#"pub fn main() {
+  fun(
+    <<
+      // Nothing here...
+    >>,
+    wibble_wobble_wibble_wobble_wibble_wobble_wibble_wobble,
+    <<
+      // Nothing here as well!
+    >>,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn comments_inside_non_empty_bit_arrays_are_not_moved() {
+    assert_format!(
+        r#"pub fn main() {
+  fun(
+    <<
+      // One is below me.
+      1, 2,
+      // Three is below me.
+      3,
+    >>,
+    wibble_wobble_wibble_wobble_wibble_wobble_wibble_wobble,
+    <<
+      // Three is below me.
+      3,
+    >>,
+  )
+}
+"#
+    );
+}
+
+#[test]
 fn concise_wrapping_of_simple_bit_arrays() {
     assert_format!(
         "pub fn main() {

--- a/compiler-core/src/javascript/tests/lists.rs
+++ b/compiler-core/src/javascript/tests/lists.rs
@@ -100,6 +100,7 @@ fn go(xs) {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/2904
 #[test]
 fn tight_empty_list() {
     assert_js!(


### PR DESCRIPTION
<!-- Don't forget to update the CHANGELOG! -->

1. Made it so empty bit arrays are not broken by the formatter into `<<\n,\n>>`, but kept as `<<>>`, to avoid generating invalid syntax. Fixes #2932
2. Extended https://github.com/gleam-lang/gleam/pull/2923 to also apply to bit arrays, such that comments inside empty bit arrays are not moved outside them. This required a small refactor as we needed a mutable reference to `self` where we previously had no `self`.
3. Added a missing comment in a test I added in a previous PR. I think the reference to the appropriate issue, as is done for other tests, should be there as it is helpful for future readers.