### PR TITLE
Oh dear debugger... fixed on JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Compiler
+
+- Fixed a bug on the JavaScript target where variables named `debugger`, which
+  is a JavaScript keyword, were not being renamed, leading to runtime errors.
+
 ## v1.1.0-rc1 - 2024-04-08
 
 ### Compiler

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -675,7 +675,7 @@ fn is_usable_js_identifier(word: &str) -> bool {
             | "class"
             | "const"
             | "continue"
-            | "deoh dear"
+            | "debugger"
             | "default"
             | "delete"
             | "do"

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -665,7 +665,7 @@ fn try_wrap_object<'a>(items: impl IntoIterator<Item = (Document<'a>, Output<'a>
 fn is_usable_js_identifier(word: &str) -> bool {
     !matches!(
         word,
-        // Keywords and reserved works
+        // Keywords and reserved words
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
         "await"
             | "arguments"

--- a/compiler-core/src/javascript/tests/assignments.rs
+++ b/compiler-core/src/javascript/tests/assignments.rs
@@ -184,3 +184,16 @@ pub fn main() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2931
+#[test]
+fn keyword_assignment() {
+    assert_js!(
+        r#"
+pub fn main() {
+  let class = 10
+  let debugger = 50
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__keyword_assignment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__keyword_assignment.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/assignments.rs
+expression: "\npub fn main() {\n  let class = 10\n  let debugger = 50\n}\n"
+---
+export function main() {
+  let class$ = 10;
+  let debugger$ = 50;
+  return debugger$;
+}


### PR DESCRIPTION
<!-- Don't forget to update the CHANGELOG! -->
Fixes #2931

- Variables named `deoh dear` are no longer escaped (they are awesome and deserve peace)
- Variables named `debugger` are now escaped
-