### PR TITLE
Use std::io::IsTerminal instead of atty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Compiler
+
+- Fix [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145) by
+  using Rust's `std::io::IsTerminal` instead of the `atty` library.
+
 ## v1.1.0 - 2024-04-16
 
 ### Formatter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,17 +169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,7 +822,6 @@ name = "gleam"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "atty",
  "base16",
  "bytes",
  "camino",
@@ -1002,15 +990,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1495,7 +1474,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -14,8 +14,6 @@ ctrlc = { version = "3.2.1", features = ["termination"] }
 clap = { version = "4.5.4", features = ["derive"] }
 # Recursively traversing directories
 ignore = "0.4.22"
-# Check for tty
-atty = "0.2.14"
 # Allow user to type in sensitive information without showing it in the shell
 rpassword = "5.0.1"
 # Async runtime

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -4,7 +4,7 @@ use gleam_core::{
 };
 use hexpm::version::Version;
 use std::{
-    io::Write,
+    io::{IsTerminal, Write},
     time::{Duration, Instant},
 };
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
@@ -195,7 +195,7 @@ fn colour_forced() -> bool {
 fn color_choice() -> ColorChoice {
     if colour_forced() {
         termcolor::ColorChoice::Always
-    } else if atty::is(atty::Stream::Stderr) {
+    } else if std::io::stderr().is_terminal() {
         termcolor::ColorChoice::Auto
     } else {
         termcolor::ColorChoice::Never


### PR DESCRIPTION
See: https://rustsec.org/advisories/RUSTSEC-2021-0145
Fixes: #2935 