### PR TITLE
Revert internal warning and build tool complaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@
 - Fixed a bug where comments would be moved out of an empty bit array.
 - Fixed a bug where the formatter could add a trailing comma inside empty
   bit arrays, generating invalid syntax.
+- Revert the warning about internal types being exposed in a package's public
+  API.
 
+### Build tool
+
+- Revert the change that would make the build tool refuse to publish a package
+  that exposes an internal type in its public API.
 
 ## v1.1.0-rc1 - 2024-04-08
 

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -275,19 +275,26 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &PackageConfig) -> Result<
         return Err(Error::CannotPublishTodo { unfinished });
     }
 
+    // TODO: This is commented out until we figure out a better way to
+    //       deal with reexports of internal types.
+    //       As things stand it would break both Lustre and Mist.
+    //       You can see the thread starting around here for more
+    //       context: https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
+    //
+    //
     // If any of the modules in the package contain a leaked internal type then
     // refuse to publish as the package is not yet finished.
-    let unfinished = built
-        .root_package
-        .modules
-        .iter()
-        .filter(|module| module.ast.type_info.leaks_internal_types)
-        .map(|module| module.name.clone())
-        .sorted()
-        .collect_vec();
-    if !unfinished.is_empty() {
-        return Err(Error::CannotPublishLeakedInternalType { unfinished });
-    }
+    // let unfinished = built
+    //     .root_package
+    //     .modules
+    //     .iter()
+    //     .filter(|module| module.ast.type_info.leaks_internal_types)
+    //     .map(|module| module.name.clone())
+    //     .sorted()
+    //     .collect_vec();
+    // if !unfinished.is_empty() {
+    //     return Err(Error::CannotPublishLeakedInternalType { unfinished });
+    // }
 
     // Collect all the files we want to include in the tarball
     let generated_files = match target {

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -275,26 +275,10 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &PackageConfig) -> Result<
         return Err(Error::CannotPublishTodo { unfinished });
     }
 
-    // TODO: This is commented out until we figure out a better way to
-    //       deal with reexports of internal types.
-    //       As things stand it would break both Lustre and Mist.
-    //       You can see the thread starting around here for more
-    //       context: https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
-    //
-    //
-    // If any of the modules in the package contain a leaked internal type then
+    // TODO: If any of the modules in the package contain a leaked internal type then
     // refuse to publish as the package is not yet finished.
-    // let unfinished = built
-    //     .root_package
-    //     .modules
-    //     .iter()
-    //     .filter(|module| module.ast.type_info.leaks_internal_types)
-    //     .map(|module| module.name.clone())
-    //     .sorted()
-    //     .collect_vec();
-    // if !unfinished.is_empty() {
-    //     return Err(Error::CannotPublishLeakedInternalType { unfinished });
-    // }
+    // We need to move aliases in to the type system first.
+    // context: https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
 
     // Collect all the files we want to include in the tarball
     let generated_files = match target {

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -501,10 +501,6 @@ pub mod module {
     pub fn get_is_internal(self) -> bool {
       self.reader.get_bool_field(1)
     }
-    #[inline]
-    pub fn get_leaks_internal_types(self) -> bool {
-      self.reader.get_bool_field(2)
-    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -714,14 +710,6 @@ pub mod module {
     #[inline]
     pub fn set_is_internal(&mut self, value: bool)  {
       self.builder.set_bool_field(1, value);
-    }
-    #[inline]
-    pub fn get_leaks_internal_types(self) -> bool {
-      self.builder.get_bool_field(2)
-    }
-    #[inline]
-    pub fn set_leaks_internal_types(&mut self, value: bool)  {
-      self.builder.set_bool_field(2, value);
     }
   }
 

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -31,7 +31,6 @@ struct Module {
   lineNumbers @8 :LineNumbers;
   srcPath @9 :Text;
   isInternal @10 :Bool;
-  leaksInternalTypes @11 :Bool;
 }
 
 struct TypesVariantConstructors {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -252,8 +252,6 @@ pub fn infer_module<A>(
     env.accessors
         .retain(|_, accessors| accessors.publicity.is_importable());
 
-    let mut leaked_internal_type_encountered = false;
-
     // Ensure no exported values have private types in their type signature
     for value in env.module_values.values() {
         if value.publicity.is_private() {
@@ -275,19 +273,6 @@ pub fn infer_module<A>(
         // module ourselves, the type wouldn't actually be publicly exposed.
         if package_config.is_internal_module(name.as_str()) {
             continue;
-        }
-        if let Some(_leaked) = value.type_.find_internal_type() {
-            leaked_internal_type_encountered = true;
-            // TODO: This is commented out until we figure out a better way to
-            //       deal with reexports of internal types.
-            //       As things stand it would break both Lustre and Mist.
-            //       You can see the thread starting around here for more
-            //       context: https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
-            //
-            // env.warnings.emit(type_::Warning::InternalTypeLeak {
-            //     location: value.variant.definition_location(),
-            //     leaked,
-            // })
         }
     }
 
@@ -317,7 +302,6 @@ pub fn infer_module<A>(
             is_internal,
             unused_imports,
             contains_todo,
-            leaks_internal_types: leaked_internal_type_encountered,
             line_numbers,
             src_path,
         },

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -276,12 +276,18 @@ pub fn infer_module<A>(
         if package_config.is_internal_module(name.as_str()) {
             continue;
         }
-        if let Some(leaked) = value.type_.find_internal_type() {
+        if let Some(_leaked) = value.type_.find_internal_type() {
             leaked_internal_type_encountered = true;
-            env.warnings.emit(type_::Warning::InternalTypeLeak {
-                location: value.variant.definition_location(),
-                leaked,
-            })
+            // TODO: This is commented out until we figure out a better way to
+            //       deal with reexports of internal types.
+            //       As things stand it would break both Lustre and Mist.
+            //       You can see the thread starting around here for more
+            //       context: https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
+            //
+            // env.warnings.emit(type_::Warning::InternalTypeLeak {
+            //     location: value.variant.definition_location(),
+            //     leaked,
+            // })
         }
     }
 

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -51,7 +51,6 @@ fn write_cache(fs: &InMemoryFileSystem, name: &str, seconds: u64, deps: Vec<EcoS
         accessors: Default::default(),
         unused_imports: Vec::new(),
         contains_todo: false,
-        leaks_internal_types: false,
         line_numbers: line_numbers.clone(),
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -70,7 +70,6 @@ impl ModuleDecoder {
             package: reader.get_package()?.into(),
             is_internal: reader.get_is_internal(),
             contains_todo: reader.get_contains_todo(),
-            leaks_internal_types: reader.get_leaks_internal_types(),
             origin: Origin::Src,
             values: read_hashmap!(reader.get_values()?, self, value_constructor),
             types: read_hashmap!(reader.get_types()?, self, type_constructor),

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -42,7 +42,6 @@ impl<'a> ModuleEncoder<'a> {
         module.set_package(&self.data.package);
         module.set_contains_todo(self.data.contains_todo);
         module.set_src_path(self.data.src_path.as_str());
-        module.set_leaks_internal_types(self.data.leaks_internal_types);
         module.set_is_internal(self.data.is_internal);
         self.set_module_types(&mut module);
         self.set_module_values(&mut module);

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -32,7 +32,6 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
     ModuleInterface {
         is_internal: true,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -87,7 +86,6 @@ fn empty_module() {
     let module = ModuleInterface {
         is_internal: true,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "one/two".into(),
@@ -107,7 +105,6 @@ fn with_line_numbers() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "one/two".into(),
@@ -131,7 +128,6 @@ fn module_with_private_type() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b".into(),
@@ -162,7 +158,6 @@ fn module_with_unused_import() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -185,7 +180,6 @@ fn module_with_app_type() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b".into(),
@@ -216,7 +210,6 @@ fn module_with_fn_type() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b".into(),
@@ -247,7 +240,6 @@ fn module_with_tuple_type() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b".into(),
@@ -284,7 +276,6 @@ fn module_with_generic_type() {
         ModuleInterface {
             is_internal: false,
             contains_todo: false,
-            leaks_internal_types: false,
             package: "some_package".into(),
             origin: Origin::Src,
             name: "a/b".into(),
@@ -321,7 +312,6 @@ fn module_with_type_links() {
         ModuleInterface {
             is_internal: false,
             contains_todo: false,
-            leaks_internal_types: false,
             package: "some_package".into(),
             origin: Origin::Src,
             name: "a".into(),
@@ -354,7 +344,6 @@ fn module_type_to_constructors_mapping() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -385,7 +374,6 @@ fn module_fn_value() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -431,7 +419,6 @@ fn deprecated_module_fn_value() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -479,7 +466,6 @@ fn private_module_fn_value() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -527,7 +513,6 @@ fn module_fn_value_regression() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b/c".into(),
@@ -574,7 +559,6 @@ fn module_fn_value_with_field_map() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -623,7 +607,6 @@ fn record_value() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -667,7 +650,6 @@ fn record_value_with_field_map() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -712,7 +694,6 @@ fn accessors() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -927,7 +908,6 @@ fn constant_var() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a".into(),
@@ -1148,7 +1128,6 @@ fn deprecated_type() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b".into(),
@@ -1181,28 +1160,6 @@ fn contains_todo() {
     let module = ModuleInterface {
         contains_todo: true,
         //             ^^^^ It does, it does!
-        leaks_internal_types: false,
-        is_internal: false,
-        package: "some_package".into(),
-        origin: Origin::Src,
-        name: "a/b".into(),
-        types: [].into(),
-        types_value_constructors: HashMap::new(),
-        values: HashMap::new(),
-        unused_imports: Vec::new(),
-        accessors: HashMap::new(),
-        line_numbers: LineNumbers::new(""),
-        src_path: "some_path".into(),
-    };
-    assert_eq!(roundtrip(&module), module);
-}
-
-#[test]
-fn leaks_internal_types() {
-    let module = ModuleInterface {
-        contains_todo: false,
-        leaks_internal_types: true,
-        //                    ^^^^ It does, it does!
         is_internal: false,
         package: "some_package".into(),
         origin: Origin::Src,
@@ -1223,7 +1180,6 @@ fn module_fn_value_with_external_implementations() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b/c".into(),
@@ -1270,7 +1226,6 @@ fn internal_module_fn() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b/c".into(),
@@ -1318,7 +1273,6 @@ fn type_variable_ids_in_constructors_are_shared() {
     let module = ModuleInterface {
         is_internal: false,
         contains_todo: false,
-        leaks_internal_types: false,
         package: "some_package".into(),
         origin: Origin::Src,
         name: "a/b/c".into(),

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -570,7 +570,6 @@ pub struct ModuleInterface {
     pub accessors: HashMap<EcoString, AccessorsMap>,
     pub unused_imports: Vec<SrcSpan>,
     pub contains_todo: bool,
-    pub leaks_internal_types: bool,
     /// Used for mapping to original source locations on disk
     pub line_numbers: LineNumbers,
     /// Used for determining the source path of the module on disk
@@ -661,7 +660,6 @@ impl ModuleInterface {
             accessors: Default::default(),
             unused_imports: Default::default(),
             contains_todo: false,
-            leaks_internal_types: false,
             is_internal: false,
             line_numbers,
             src_path,

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -211,7 +211,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         accessors: HashMap::new(),
         unused_imports: Vec::new(),
         contains_todo: false,
-        leaks_internal_types: false,
         is_internal: false,
         // prelude doesn't have real src
         src_path: "".into(),

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -633,7 +633,6 @@ fn infer_module_type_retention_test() {
         module.type_info,
         ModuleInterface {
             contains_todo: false,
-            leaks_internal_types: false,
             origin: Origin::Src,
             package: "thepackage".into(),
             name: "ok".into(),

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1361,6 +1361,14 @@ pub fn main() {
     );
 }
 
+/*
+
+TODO: These tests are commented out until we figure out a better way to deal
+      with reexports of internal types and reintroduce the warning.
+      As things stand it would break both Lustre and Mist.
+      You can see the thread starting around here for more context:
+      https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
+
 #[test]
 fn internal_type_in_public_function_return() {
     assert_warning!(
@@ -1457,3 +1465,5 @@ pub type Wobble {
 }"
     );
 }
+
+*/


### PR DESCRIPTION
These pesky gleamlins not putting everything in a single file smh

Jokes aside, we want to revert these changes as it would break both Lustre and Mist (see #2938) and That's Not Good.
These could be added back once we have a better story for reexports of private/internal types but it looks like something for another Gleam version!

