### PR TITLE
Fix a bug where the first pattern of a case expression would be nested more than necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Unreleased
+
+## Formatter
+
+- Fixed a bug where the first subject of a case expression clause would be
+  indented more than necessary.
+
 ## v1.1.0-rc3 - 2024-04-12
 
 ### Formatter

--- a/compiler-core/src/format/tests/cases.rs
+++ b/compiler-core/src/format/tests/cases.rs
@@ -89,3 +89,19 @@ fn multiple_patterns_and_alternative_patterns_mixed_together() {
 "#
     );
 }
+
+#[test]
+fn case_pattern_split_on_multiple_lines_is_not_needlessly_nested() {
+    assert_format!(
+        r#"pub fn main() {
+  case thing {
+    CannotSaveNewSnapshot(
+      reason: reason,
+      title: title,
+      destination: destination,
+    ) -> todo
+  }
+}
+"#
+    );
+}


### PR DESCRIPTION
This PR closes #2940
