### PR TITLE
Module type inference supports returning multiple errors and pipes multiple errors to outputs properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 - Empty case expressions are no longer parse errors and will instead be
   exhaustiveness errors. ([Race Williams](https://github.com/raquentin))
 
+- Initial support for type analysis returning multiple errors. ([Ameen Radwan](https://github.com/Acepie))
+
 ### Formatter
 
 - Redundant alias names for imported modules are now removed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring 0.17.8",

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -1,4 +1,4 @@
-use crate::analyse::TargetSupport;
+use crate::analyse::{infer_module, InferenceResult, TargetSupport};
 use crate::line_numbers::{self, LineNumbers};
 use crate::type_::PRELUDE_MODULE_NAME;
 use crate::{
@@ -423,7 +423,7 @@ fn analyse(
         tracing::debug!(module = ?name, "Type checking");
 
         let line_numbers = LineNumbers::new(&code);
-        let ast = crate::analyse::infer_module(
+        let InferenceResult { ast, errors } = infer_module(
             target,
             ids,
             ast,
@@ -435,12 +435,28 @@ fn analyse(
             line_numbers,
             package_config,
             path.clone(),
-        )
-        .map_err(|error| Error::Type {
-            path: path.clone(),
-            src: code.clone(),
-            error,
-        })?;
+        );
+
+        if let Ok(error) = vec1::Vec1::try_from_vec(errors) {
+            return Err(Error::Type {
+                path: path.clone(),
+                src: code.clone(),
+                error,
+            });
+        }
+
+        // TODO: Once we are guaranteed to get an AST back we should change this
+        // so that instead of returning immediately we bubble up and
+        // do the error check prior to code generation.
+        let ast = match ast {
+            Some(ast) => ast,
+            None => {
+                // This should never happen, but if it does then we should immediately error
+                return Err(Error::TypeNotGenerated {
+                    module: name.clone(),
+                });
+            }
+        };
 
         // Register the types from this module so they can be imported into
         // other modules.

--- a/compiler-core/src/diagnostic.rs
+++ b/compiler-core/src/diagnostic.rs
@@ -109,10 +109,4 @@ impl Diagnostic {
             .set_color(&ColorSpec::new())
             .expect("write_title_reset");
     }
-
-    pub fn pretty_string(&self) -> String {
-        let mut nocolor = Buffer::no_color();
-        self.write(&mut nocolor);
-        String::from_utf8(nocolor.into_inner()).expect("Error printing produced invalid utf8")
-    }
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -63,9 +63,6 @@ pub enum Error {
         error: Vec1<crate::type_::Error>,
     },
 
-    #[error("type checking module {module} produced no results")]
-    TypeNotGenerated { module: Name },
-
     #[error("unknown import {import}")]
     UnknownImport {
         import: EcoString,
@@ -2744,18 +2741,6 @@ Rename or remove one of them.",
             }
                 })
                 .collect_vec(),
-
-            Error::TypeNotGenerated { module } => {
-                let text =
-                    format!("A problem was encountered when type checking the module `{module}`. This is due to a bug in the compiler.");
-                vec![Diagnostic {
-                    title: "Failed to typecheck a module".into(),
-                    text,
-                    hint: None,
-                    location: None,
-                    level: Level::Error,
-                }]
-            }
 
             Error::Parse { path, src, error } => {
                 let (label, extra) = error.details();

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -543,6 +543,69 @@ pub enum Warning {
 }
 
 impl Error {
+    // Location where the error started
+    pub fn start_location(&self) -> u32 {
+        match self {
+            Error::SrcImportingTest { location, .. }
+            | Error::BitArraySegmentError { location, .. }
+            | Error::UnknownVariable { location, .. }
+            | Error::UnknownType { location, .. }
+            | Error::UnknownModule { location, .. }
+            | Error::UnknownModuleType { location, .. }
+            | Error::UnknownModuleValue { location, .. }
+            | Error::UnknownModuleField { location, .. }
+            | Error::NotFn { location, .. }
+            | Error::UnknownRecordField { location, .. }
+            | Error::IncorrectArity { location, .. }
+            | Error::UpdateMultiConstructorType { location, .. }
+            | Error::UnnecessarySpreadOperator { location, .. }
+            | Error::IncorrectTypeArity { location, .. }
+            | Error::CouldNotUnify { location, .. }
+            | Error::RecursiveType { location, .. }
+            | Error::DuplicateName {
+                location_a: location,
+                ..
+            }
+            | Error::DuplicateImport { location, .. }
+            | Error::DuplicateTypeName { location, .. }
+            | Error::DuplicateArgument { location, .. }
+            | Error::DuplicateField { location, .. }
+            | Error::PrivateTypeLeak { location, .. }
+            | Error::UnexpectedLabelledArg { location, .. }
+            | Error::PositionalArgumentAfterLabelled { location, .. }
+            | Error::IncorrectNumClausePatterns { location, .. }
+            | Error::NonLocalClauseGuardVariable { location, .. }
+            | Error::ExtraVarInAlternativePattern { location, .. }
+            | Error::MissingVarInAlternativePattern { location, .. }
+            | Error::DuplicateVarInPattern { location, .. }
+            | Error::OutOfBoundsTupleIndex { location, .. }
+            | Error::NotATuple { location, .. }
+            | Error::NotATupleUnbound { location, .. }
+            | Error::RecordAccessUnknownType { location, .. }
+            | Error::RecordUpdateInvalidConstructor { location, .. }
+            | Error::UnexpectedTypeHole { location, .. }
+            | Error::NotExhaustivePatternMatch { location, .. }
+            | Error::ArgumentNameAlreadyUsed { location, .. }
+            | Error::UnlabelledAfterlabelled { location, .. }
+            | Error::RecursiveTypeAlias { location, .. }
+            | Error::ExternalMissingAnnotation { location, .. }
+            | Error::NoImplementation { location, .. }
+            | Error::UnsupportedExpressionTarget { location, .. }
+            | Error::InvalidExternalJavascriptModule { location, .. }
+            | Error::InvalidExternalJavascriptFunction { location, .. }
+            | Error::InexhaustiveCaseExpression { location, .. }
+            | Error::InexhaustiveLetAssignment { location, .. }
+            | Error::UnusedTypeAliasParameter { location, .. }
+            | Error::DuplicateTypeParameter { location, .. }
+            | Error::UnsupportedPublicFunctionTarget { location, .. } => location.start,
+            Error::UnknownLabels { unknown, .. } => {
+                unknown.iter().map(|(_, s)| s.start).min().unwrap_or(0)
+            }
+            Error::ReservedModuleName { .. } => 0,
+            Error::KeywordInModuleName { .. } => 0,
+        }
+    }
+
     pub fn with_unify_error_situation(mut self, new_situation: UnifyErrorSituation) -> Self {
         match self {
             Error::CouldNotUnify {

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -413,7 +413,7 @@ pub fn compile_module_with_opts(
     ast.name = module_name.into();
     let mut config = crate::config::PackageConfig::default();
     config.name = "thepackage".into();
-    let crate::analyse::InferenceResult { ast, errors } = crate::analyse::infer_module(
+    let inference_result = crate::analyse::infer_module(
         target,
         &ids,
         ast,
@@ -427,10 +427,9 @@ pub fn compile_module_with_opts(
         "".into(),
     );
 
-    match ast {
-        Some(_) if !errors.is_empty() => Err(errors),
-        None => Err(errors),
-        Some(ast) => Ok(ast),
+    match inference_result {
+        Ok(ast) => Ok(ast),
+        Err(crate::analyse::InferenceFailure { errors, .. }) => Err(errors.to_vec()),
     }
 }
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -133,7 +133,7 @@ macro_rules! assert_error {
         let error = $crate::error::Error::Type {
             src: $src.into(),
             path: camino::Utf8PathBuf::from("/src/one/two.gleam"),
-            error,
+            error: vec1::vec1![error],
         };
         let output = error.pretty_string();
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
@@ -344,7 +344,7 @@ pub fn compile_module(
     src: &str,
     warnings: Option<Arc<dyn WarningEmitterIO>>,
     dep: Vec<DependencyModule<'_>>,
-) -> Result<TypedModule, crate::type_::Error> {
+) -> Result<TypedModule, Vec<crate::type_::Error>> {
     compile_module_with_opts(
         module_name,
         src,
@@ -362,7 +362,7 @@ pub fn compile_module_with_opts(
     dep: Vec<DependencyModule<'_>>,
     target: Target,
     target_support: TargetSupport,
-) -> Result<TypedModule, crate::type_::Error> {
+) -> Result<TypedModule, Vec<crate::type_::Error>> {
     let ids = UniqueIdGenerator::new();
     let mut modules = im::HashMap::new();
     let warnings = TypeWarningEmitter::new(
@@ -413,7 +413,7 @@ pub fn compile_module_with_opts(
     ast.name = module_name.into();
     let mut config = crate::config::PackageConfig::default();
     config.name = "thepackage".into();
-    crate::analyse::infer_module(
+    let crate::analyse::InferenceResult { ast, errors } = crate::analyse::infer_module(
         target,
         &ids,
         ast,
@@ -425,7 +425,13 @@ pub fn compile_module_with_opts(
         LineNumbers::new(src),
         &config,
         "".into(),
-    )
+    );
+
+    match ast {
+        Some(_) if !errors.is_empty() => Err(errors),
+        None => Err(errors),
+        Some(ast) => Ok(ast),
+    }
 }
 
 pub fn module_error(src: &str, deps: Vec<DependencyModule<'_>>) -> String {
@@ -449,7 +455,7 @@ pub fn module_error_with_target(
     let error = Error::Type {
         src: src.into(),
         path: Utf8PathBuf::from("/src/one/two.gleam"),
-        error,
+        error: Vec1::try_from_vec(error).expect("should have at least one error"),
     };
     error.pretty_string()
 }

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1763,3 +1763,26 @@ fn list() {
 fn mismatched_list_tail() {
     assert_error!("[\"foo\", ..[1, 2]]");
 }
+
+#[test]
+fn leak_multiple_private_types() {
+    assert_module_error!(
+        "
+        type Private {
+            Private
+        }
+
+        pub fn ret_private() -> Private {
+            Private
+        }
+
+        pub fn ret_private2() -> Private {
+            Private
+        }
+
+        pub fn main() {
+            ret_private()
+        }
+        "
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__leak_multiple_private_types.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__leak_multiple_private_types.snap
@@ -1,0 +1,39 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n        type Private {\n            Private\n        }\n\n        pub fn ret_private() -> Private {\n            Private\n        }\n\n        pub fn ret_private2() -> Private {\n            Private\n        }\n\n        pub fn main() {\n            ret_private()\n        }\n        "
+---
+error: Private type used in public interface
+  ┌─ /src/one/two.gleam:6:9
+  │
+6 │         pub fn ret_private() -> Private {
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following type is private, but is being used by this public export.
+
+    Private
+
+Private types can only be used within the module that defines them.
+
+error: Private type used in public interface
+   ┌─ /src/one/two.gleam:10:9
+   │
+10 │         pub fn ret_private2() -> Private {
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following type is private, but is being used by this public export.
+
+    Private
+
+Private types can only be used within the module that defines them.
+
+error: Private type used in public interface
+   ┌─ /src/one/two.gleam:14:9
+   │
+14 │         pub fn main() {
+   │         ^^^^^^^^^^^^^
+
+The following type is private, but is being used by this public export.
+
+    Private
+
+Private types can only be used within the module that defines them.


### PR DESCRIPTION
<!-- Don't forget to update the CHANGELOG! -->
Closes #2951

Used leaking of private types as an example to show the multiple errors but we can remove that bit if we'd rather handle it all at once. The core of the change is just changing the return type on infer_modules and changing the error type for type errors to have a list of errors instead of a single error. The majority of the lines changed are formatting in the errors since we now have an error that produces multiple diagnostics

<img width="1512" alt="Screenshot 2024-04-11 at 6 55 51 AM" src="https://github.com/gleam-lang/gleam/assets/5996838/75c02a98-886a-4a75-a795-4d2fc2811ec0">
<img width="1190" alt="Screenshot 2024-04-11 at 6 56 18 AM" src="https://github.com/gleam-lang/gleam/assets/5996838/6813bd09-9920-46c3-83c9-a88efcc147d0">
