### PR TITLE
Fix generated `mod` property in erlang application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Compiler
 
-- Fix [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145) by
+- Fixed [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145) by
   using Rust's `std::io::IsTerminal` instead of the `atty` library.
+- Fixed the generated `mod` property in the Erlang application file when using
+  the `application_start_module` property in `gleam.toml`
 
 ## v1.1.0 - 2024-04-16
 

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -102,7 +102,7 @@ impl<'a> ErlangApp<'a> {
             .erlang
             .application_start_module
             .as_ref()
-            .map(|module| tuple("mod", &format!("'{}'", module.replace("/", "@"))))
+            .map(|module| tuple("mod", &format!("{{'{}', []}}", module.replace("/", "@"))))
             .unwrap_or_default();
 
         let modules = modules

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
@@ -14,7 +14,7 @@ expression: "./cases/erlang_app_generation"
 
 //// /out/lib/the_package/ebin/my_erlang_application.app
 {application, my_erlang_application, [
-    {mod, 'my_erlang_application_sup'},
+    {mod, {'my_erlang_application_sup', []}},
     {vsn, "0.1.0"},
     {applications, [gleam_otp,
                     gleam_stdlib,


### PR DESCRIPTION
The generated output was just `{mod, 'my_module'}`.  But I'm pretty sure
this needs to include the arguments as well?  This PR updates it to
produce: `{mod, {'my_module', []}}`.  In my local testing, this worked
as expected.

<!-- Don't forget to update the CHANGELOG! -->
