### PR TITLE
(POC) Transitive dependency overriding

### DIFF
--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -399,7 +399,12 @@ fn analyse(
     target_support: TargetSupport,
 ) -> Result<Vec<Module>, Error> {
     let mut modules = Vec::with_capacity(parsed_modules.len() + 1);
-    let direct_dependencies = package_config.dependencies_for(mode).expect("Package deps");
+    // We don't have to use the root config patch here,
+    // as we only use the dependencies' names, not their
+    // versions, when analysing.
+    let direct_dependencies = package_config
+        .dependencies_for(mode, &Default::default())
+        .expect("Package deps");
 
     // Insert the prelude
     // DUPE: preludeinsertion

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -347,6 +347,7 @@ fn locked_no_changes() {
     .into();
     let manifest = Manifest {
         requirements: config.all_dependencies(&config.patch).unwrap(),
+        patch: HashMap::new(),
         packages: vec![
             manifest_package("prod1", "1.1.0", &[]),
             manifest_package("prod2", "1.2.0", &[]),
@@ -372,7 +373,8 @@ fn locked_some_removed() {
     config.dependencies = [("prod1".into(), Requirement::hex("~> 1.0"))].into();
     config.dev_dependencies = [("dev2".into(), Requirement::hex("~> 2.0"))].into();
     let manifest = Manifest {
-        requirements: config.all_dependencies(&config.patch).unwrap(),
+        requirements: config.all_dependencies(&Default::default()).unwrap(),
+        patch: HashMap::new(),
         packages: vec![
             manifest_package("prod1", "1.1.0", &[]),
             manifest_package("prod2", "1.2.0", &[]), // Not in config
@@ -413,6 +415,7 @@ fn locked_some_changed() {
             ("dev2".into(), Requirement::hex("~> 2.0")),
         ]
         .into(),
+        patch: HashMap::new(),
         packages: vec![
             manifest_package("prod1", "1.1.0", &[]),
             manifest_package("prod2", "1.2.0", &[]),
@@ -447,6 +450,7 @@ fn locked_nested_are_removed_too() {
             ("2".into(), Requirement::hex("~> 1.0")),
         ]
         .into(),
+        patch: HashMap::new(),
         packages: vec![
             manifest_package("1", "1.1.0", &["1.1", "1.2"]),
             manifest_package("1.1", "1.1.0", &["1.1.1", "1.1.2"]),
@@ -499,6 +503,7 @@ fn locked_unlock_new() {
             ("2".into(), Requirement::hex("~> 1.0")),
         ]
         .into(),
+        patch: HashMap::new(),
         packages: vec![
             manifest_package("1", "1.1.0", &["3"]),
             manifest_package("2", "1.1.0", &["3"]),

--- a/compiler-core/src/language_server/tests/mod.rs
+++ b/compiler-core/src/language_server/tests/mod.rs
@@ -61,6 +61,7 @@ impl LanguageServerTestIO {
             paths: ProjectPaths::at_filesystem_root(),
             manifest: Manifest {
                 requirements: HashMap::new(),
+                patch: HashMap::new(),
                 packages: vec![],
             },
         }

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -153,6 +153,7 @@ fn package_from_module(module: Module) -> Package {
             documentation: Docs { pages: vec![] },
             dependencies: std::collections::HashMap::new(),
             dev_dependencies: std::collections::HashMap::new(),
+            patch: std::collections::HashMap::new(),
             repository: Repository::default(),
             links: vec![],
             erlang: ErlangConfig::default(),


### PR DESCRIPTION
<!-- Don't forget to update the CHANGELOG! -->
Proof of concept for #2899. Basically implements most of the hard parts; this PR should be easy to adjust based on the result of the discussion there.

## Current design

Adds a new `[patch]` section to `gleam.toml`, which works exactly like `[dependencies]`, except that any package in the root project's `[patch]` will override any transitive dependencies to that package. For example, consider this `gleam.toml` in the `test1` project:

```toml
[dependencies]
gleam_stdlib = ">= 0.34.0 and < 2.0.0"
test2 = { path = "../test2" }

[dev-dependencies]
gleeunit = ">= 1.0.0 and < 2.0.0"

[patch]
test2 = { path = "../test3" }
simplifile = "1.6.0"
filepath = { path = "../filepath" }
```

If we assume that `test3` depends on `simplifile` 1.7.0, what will happen here is that:

1. `test1` will depend on `test3` instead of `test2` (for now assuming the package at `test3` is also named `test2`).
2. `test2` will depend on simplifile 1.6.0 instead of 1.7.0, even if incompatible (the error is silenced).
3. `simplifile` 1.6.0 (depended on by test2) will now depend on filepath at `../filepath` instead of the Hex version it usually depends on (1.0.0).

This `[patch]` section is added to the `manifest.toml` to ensure the manifest updates when the `[patch]` changes.

## Current implementation

1. On `compiler-core`, most changes occur in `dependency`. There, we have a check for version incompatibilities; it is simply skipped when the package is patched by the root config. Additionally, when working with pubgrub's traits for dependency resolving, we ensure we filter packages' versions according to the root config patch, and also update the fetched packages' dependencies accordingly so pubgrub doesn't get confused. We also, of course, add the `patch` section to `PackageConfig`, and also require specifying a `patch` to access a config's dependencies.
2. On `compiler-cli`, most changes are in `dependencies`. Here, we had to refactor providing local and Git packages into a `PackageProvider` struct containing `provide_*_package` as methods instead of top-level functions. This was necessary as the `PackageFetcher` now stores the PackageProvider in a RefCell, such that, if a Hex package depends on a package which was patched to point to a local or Git package instead of a Hex package, the PackageProvider is invoked to provide that package instead of fetching from Hex (or get it from cache if the package was already provided before - hence the need for RefCell, so we can update the cache, which is also later reused to add those local packages to the manifest). Additionally, in the `provide_*_package` methods, we update each package's dependencies according to the root config's patch during traversal of dependencies. Finally, in the appropriate location within `compiler-cli`, we also ensure the manifest is updated when the patch section changes.

## TODO

I will wait for further discussion before progressing on this PR, so here's more or less what still needs to be done.

- [ ] Decide on the final design (via discussion at the relevant issue)
- [ ] Add support for overriding a package with another package, even if it has a different name (could be separate PR)
- [ ] Add unit tests
- [ ] Update CHANGELOG