### PR TITLE
Remove redundant as names from imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Empty case expressions are no longer parse errors and will instead be
 exhaustiveness errors, resulting in a better error message that shows what the
 missing patterns are. ([Race Williams](https://github.com/raquentin))
 
+### Formatter
+
+Now the formatter removes redundant alias names from imported modules.
+([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 #### Bug Fixes
 
 Fixed [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145) by
@@ -15,4 +20,5 @@ using Rust's `std::io::IsTerminal` instead of the `atty` library.
 ([Pi-Cla](https://github.com/Pi-Cla))
 
 Fixed the generated `mod` property in the Erlang application file when using the
-`application_start_module` property in `gleam.toml`. ([Alex Manning](https://github.com/rawhat))
+`application_start_module` property in `gleam.toml`.
+([Alex Manning](https://github.com/rawhat))

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -362,7 +362,7 @@ impl<'comments> Formatter<'comments> {
                     // used anyways we won't render it. For example:
                     // ```gleam
                     // import gleam/int as int
-                    //                  ^^^^^^ this is redundand and removed
+                    //                  ^^^^^^ this is redundant and removed
                     // ```
                     (Some(module_name), Some((AssignName::Variable(name), _)))
                         if &module_name == name =>

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -354,12 +354,25 @@ impl<'comments> Formatter<'comments> {
                         .group();
                     ".{".to_doc().append(unqualified).append("}")
                 };
+
                 let doc = docvec!["import ", module.as_str(), second];
-                match as_name {
-                    Some((AssignName::Variable(name) | AssignName::Discard(name), _)) => {
+                let default_module_access_name = module.split('/').last().map(EcoString::from);
+                match (default_module_access_name, as_name) {
+                    // If the `as name` is the same as the module name that would be
+                    // used anyways we won't render it. For example:
+                    // ```gleam
+                    // import gleam/int as int
+                    //                  ^^^^^^ this is redundand and removed
+                    // ```
+                    (Some(module_name), Some((AssignName::Variable(name), _)))
+                        if &module_name == name =>
+                    {
+                        doc
+                    }
+                    (_, None) => doc,
+                    (_, Some((AssignName::Variable(name) | AssignName::Discard(name), _))) => {
                         doc.append(" as ").append(name)
                     }
-                    None => doc,
                 }
             }
 

--- a/compiler-core/src/format/tests/imports.rs
+++ b/compiler-core/src/format/tests/imports.rs
@@ -25,6 +25,12 @@ fn discarded_import_with_unqualified() {
 }
 
 #[test]
+fn redundant_as_name_is_removed() {
+    assert_format_rewrite!("import wibble/wobble as wobble", "import wibble/wobble\n");
+    assert_format_rewrite!("import wibble as wibble", "import wibble\n");
+}
+
+#[test]
 fn imports_are_sorted_alphabetically() {
     assert_format_rewrite!(
         "import c import a/a import a/c import b import a/ab import a",


### PR DESCRIPTION
As suggested by @jfmengels the formatter could remove redundant as names in imports:
```gleam
import gleam/int as int
//               ^^^^^^ Redundant and removed by the formatter
```