### PR TITLE
Fix variable escaping in constants on JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Empty case expressions are no longer parse errors and will instead be
   exhaustiveness errors. ([Race Williams](https://github.com/raquentin))
 
+- Fixed variables in constant expressions not being escaped correctly when
+  exporting to JavaScript. ([PgBiel](https://github.com/PgBiel))
+
 ### Formatter
 
 - Redundant alias names for imported modules are now removed.

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1286,8 +1286,13 @@ pub(crate) fn constant_expression<'a>(
 
         Constant::Var { name, module, .. } => Ok({
             match module {
-                None => name.to_doc(),
-                Some(module) => docvec!["$", module, ".", name],
+                None => maybe_escape_identifier_doc(name),
+                Some(module) => {
+                    // JS keywords can be accessed here, but we must escape anyway
+                    // as we escape when exporting such names in the first place,
+                    // and the imported name has to match the exported name.
+                    docvec!["$", module, ".", maybe_escape_identifier_doc(name)]
+                }
             }
         }),
     }

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1230,7 +1230,7 @@ pub(crate) fn guard_constant_expression<'a>(
             .iter()
             .find(|assignment| assignment.name == name)
             .map(|assignment| assignment.subject.clone().append(assignment.path.clone()))
-            .unwrap_or_else(|| name.to_doc())),
+            .unwrap_or_else(|| maybe_escape_identifier_doc(name))),
 
         expression => constant_expression(tracker, expression),
     }

--- a/compiler-core/src/javascript/tests/assignments.rs
+++ b/compiler-core/src/javascript/tests/assignments.rs
@@ -197,3 +197,14 @@ pub fn main() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3004
+#[test]
+fn escaped_variables_in_constants() {
+    assert_js!(
+        r#"
+pub const class = 5
+pub const something = class
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/case_clause_guards.rs
+++ b/compiler-core/src/javascript/tests/case_clause_guards.rs
@@ -41,6 +41,30 @@ fn bitarray_with_var() {
     )
 }
 
+// https://github.com/gleam-lang/gleam/issues/3004
+#[test]
+fn keyword_var() {
+    assert_js!(
+        r#"
+pub const function = 5
+pub const do = 10
+pub fn main() {
+  let class = 5
+  let while = 10
+  let var = 7
+  case var {
+    _ if class == while -> True
+    _ if [class] == [5] -> True
+    function if #(function) == #(5) -> False
+    _ if do == function -> True
+    while if while > 5 -> False
+    class -> False
+  }
+}
+"#,
+    );
+}
+
 #[test]
 fn operator_wrapping_right() {
     assert_js!(

--- a/compiler-core/src/javascript/tests/modules.rs
+++ b/compiler-core/src/javascript/tests/modules.rs
@@ -177,3 +177,35 @@ pub fn nasa_go() { go() }
 "#
     );
 }
+
+#[test]
+fn import_with_keyword() {
+    assert_js!(
+        (
+            CURRENT_PACKAGE,
+            "rocket_ship",
+            r#"
+pub const class = 1
+pub const in = 2
+"#
+        ),
+        r#"
+import rocket_ship.{class, in as while}
+pub fn main() {
+  #(class, while)
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/3004
+#[test]
+fn constant_module_access_with_keyword() {
+    assert_js!(
+        (CURRENT_PACKAGE, "rocket_ship", r#"pub const class = 1"#),
+        r#"
+import rocket_ship
+pub const variable = rocket_ship.class
+"#,
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__escaped_variables_in_constants.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__escaped_variables_in_constants.snap
@@ -1,0 +1,7 @@
+---
+source: compiler-core/src/javascript/tests/assignments.rs
+expression: "\npub const class = 5\npub const something = class\n"
+---
+export const class$ = 5;
+
+export const something = class$;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__keyword_var.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__keyword_var.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/case_clause_guards.rs
+expression: "\npub const function = 5\npub const do = 10\npub fn main() {\n  let class = 5\n  let while = 10\n  let var = 7\n  case var {\n    _ if class == while -> True\n    _ if [class] == [5] -> True\n    function if #(function) == #(5) -> False\n    _ if do == function -> True\n    while if while > 5 -> False\n    class -> False\n  }\n}\n"
+---
+import { toList, isEqual } from "../gleam.mjs";
+
+export const function$ = 5;
+
+export const do$ = 10;
+
+export function main() {
+  let class$ = 5;
+  let while$ = 10;
+  let var$ = 7;
+  if (class$ === while$) {
+    return true;
+  } else if (isEqual(toList([class$]), toList([5]))) {
+    return true;
+  } else if (isEqual([var$], [5])) {
+    let function$1 = var$;
+    return false;
+  } else if (10 === 5) {
+    return true;
+  } else if (var$ > 5) {
+    let while$1 = var$;
+    return false;
+  } else {
+    let class$1 = var$;
+    return false;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__constant_module_access_with_keyword.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__constant_module_access_with_keyword.snap
@@ -1,0 +1,7 @@
+---
+source: compiler-core/src/javascript/tests/modules.rs
+expression: "\nimport rocket_ship\npub const variable = rocket_ship.class\n"
+---
+import * as $rocket_ship from "../rocket_ship.mjs";
+
+export const variable = $rocket_ship.class$;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__import_with_keyword.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__import_with_keyword.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/javascript/tests/modules.rs
+expression: "\nimport rocket_ship.{class, in as while}\npub fn main() {\n  #(class, while)\n}\n"
+---
+import * as $rocket_ship from "../rocket_ship.mjs";
+import { class$, in$ as while$ } from "../rocket_ship.mjs";
+
+export function main() {
+  return [class$, while$];
+}


### PR DESCRIPTION
Fixes #3004

1. Fixes escaping of variable names in constant expressions
2. Fixes escaping of accessed module members in constant expressions
3. Fixes escaping of variable names in constant expressions in case clause guards
4. Added an extra test related to imports for good measure