### PR TITLE
fix panic when unused import is first character of file

### DIFF
--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -747,15 +747,15 @@ fn code_action_unused_imports(
     for unused in unused {
         let SrcSpan { start, end } = *unused;
 
-        // If removing an unused alias, don't backspace
-        // Otherwise, adjust the start position by 1 to ensure the entire line is deleted with the import.
-        let adjusted_start = if delete_line(unused, &line_numbers) {
-            start - 1
+        // If removing an unused alias or at the beginning of the file, don't backspace
+        // Otherwise, adjust the end position by 1 to ensure the entire line is deleted with the import.
+        let adjusted_end = if delete_line(unused, &line_numbers) {
+            end + 1
         } else {
-            start
+            end
         };
 
-        let range = src_span_to_lsp_range(SrcSpan::new(adjusted_start, end), &line_numbers);
+        let range = src_span_to_lsp_range(SrcSpan::new(start, adjusted_end), &line_numbers);
         // Keep track of whether any unused import has is where the cursor is
         hovered = hovered || overlaps(params.range, range);
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -121,6 +121,24 @@ pub fn main() {
 }
 
 #[test]
+fn test_remove_unused_start_of_file() {
+    let code = "import option
+import result
+
+pub fn main() {
+  result.is_ok
+}
+";
+    let expected = "import result
+
+pub fn main() {
+  result.is_ok
+}
+";
+    assert_eq!(remove_unused_action(code, 2), expected.to_string())
+}
+
+#[test]
 fn test_remove_unused_alias() {
     let code = "
 // test


### PR DESCRIPTION
Currently on main the lsp crashes if there is an unused import as the first character of the file because `start - 1` would be negative and `start` is a u32