### PR TITLE
Improve error message if importing type using the value import syntax or vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,28 @@
 
 - Initial support for type analysis returning multiple errors. ([Ameen Radwan](https://github.com/Acepie))
 
+- Improve error message if importing type using the value import syntax or vice versa. ([Pi-Cla](https://github.com/Pi-Cla/))
+
+```
+error: Unknown module field
+  ┌─ /src/one/two.gleam:1:19
+  │
+1 │ import gleam/foo.{Bar}
+  │                   ^^^ Did you mean `type Bar`?
+
+`Bar` is only a type, it cannot be imported as a value.
+```
+
+```
+error: Unknown module type
+  ┌─ /src/one/two.gleam:1:19
+  │
+1 │ import gleam/foo.{type Baz}
+  │                   ^^^^^^^^ Did you mean `Baz`?
+
+`Baz` is only a value, it cannot be imported as a type.
+```
+
 ### Formatter
 
 - Redundant alias names for imported modules are now removed.

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -78,6 +78,9 @@ impl<'a> Importer<'a> {
                 name: import.name.clone(),
                 module_name: module.name.clone(),
                 type_constructors: module.public_type_names(),
+                imported_type_as_value: module
+                    .get_public_value(&import.name)
+                    .map_or_else(|| false, |_| true),
             })?
             .clone()
             .with_location(import.location);
@@ -121,6 +124,9 @@ impl<'a> Importer<'a> {
                     name: import_name.clone(),
                     module_name: module.name.clone(),
                     value_constructors: module.public_value_names(),
+                    imported_value_as_type: module
+                        .get_public_type(import_name)
+                        .map_or_else(|| false, |_| true),
                 });
             }
         };

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1912,8 +1912,13 @@ Private types can only be used within the module that defines them.",
                     name,
                     module_name,
                     type_constructors,
+                    imported_type_as_value
                 } => {
-                    let text = format!("The module `{module_name}` does not have a `{name}` type.",);
+                    let text = if *imported_type_as_value {
+                        format!("`{name}` is only a value, it cannot be imported as a type.")
+                    } else {
+                        format!("The module `{module_name}` does not have a `{name}` type.")
+                    };
                     Diagnostic {
                         title: "Unknown module type".into(),
                         text,
@@ -1921,7 +1926,11 @@ Private types can only be used within the module that defines them.",
                         level: Level::Error,
                         location: Some(Location {
                             label: Label {
-                                text: did_you_mean(name, type_constructors),
+                                text: if *imported_type_as_value {
+                                    Some(format!("Did you mean `{name}`?"))
+                                } else {
+                                    did_you_mean(name, type_constructors)
+                                },
                                 span: *location,
                             },
                             path: path.clone(),
@@ -1936,8 +1945,13 @@ Private types can only be used within the module that defines them.",
                     name,
                     module_name,
                     value_constructors,
+                    imported_value_as_type,
                 } => {
-                    let text = format!("The module `{module_name}` does not have a `{name}` value.",);
+                    let text = if *imported_value_as_type {
+                        format!("`{name}` is only a type, it cannot be imported as a value.")
+                    } else {
+                        format!("The module `{module_name}` does not have a `{name}` value.")
+                    };
                     Diagnostic {
                         title: "Unknown module field".into(),
                         text,
@@ -1945,7 +1959,11 @@ Private types can only be used within the module that defines them.",
                         level: Level::Error,
                         location: Some(Location {
                             label: Label {
-                                text: did_you_mean(name, value_constructors),
+                                text: if *imported_value_as_type {
+                                    Some(format!("Did you mean `type {name}`?"))
+                                } else {
+                                    did_you_mean(name, value_constructors)
+                                },
                                 span: *location,
                             },
                             path: path.clone(),

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -334,6 +334,7 @@ impl<'a> Environment<'a> {
                         name: name.clone(),
                         module_name: module.name.clone(),
                         type_constructors: module.public_type_names(),
+                        imported_type_as_value: false,
                     })
             }
         }?;
@@ -380,6 +381,7 @@ impl<'a> Environment<'a> {
                         name: name.clone(),
                         module_name: module.name.clone(),
                         type_constructors: module.public_type_names(),
+                        imported_type_as_value: false,
                     }
                 })
             }
@@ -416,6 +418,7 @@ impl<'a> Environment<'a> {
                         name: name.clone(),
                         module_name: module.name.clone(),
                         value_constructors: module.public_value_names(),
+                        imported_value_as_type: false,
                     }
                 })
             }

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -69,6 +69,7 @@ pub enum Error {
         name: EcoString,
         module_name: EcoString,
         type_constructors: Vec<EcoString>,
+        imported_type_as_value: bool,
     },
 
     UnknownModuleValue {
@@ -76,6 +77,7 @@ pub enum Error {
         name: EcoString,
         module_name: EcoString,
         value_constructors: Vec<EcoString>,
+        imported_value_as_type: bool,
     },
 
     UnknownModuleField {
@@ -659,6 +661,7 @@ pub enum UnknownValueConstructorError {
         name: EcoString,
         module_name: EcoString,
         value_constructors: Vec<EcoString>,
+        imported_value_as_type: bool,
     },
 }
 
@@ -691,11 +694,13 @@ pub fn convert_get_value_constructor_error(
             name,
             module_name,
             value_constructors,
+            imported_value_as_type,
         } => Error::UnknownModuleValue {
             location,
             name,
             module_name,
             value_constructors,
+            imported_value_as_type,
         },
     }
 }
@@ -722,6 +727,7 @@ pub enum UnknownTypeConstructorError {
         name: EcoString,
         module_name: EcoString,
         type_constructors: Vec<EcoString>,
+        imported_type_as_value: bool,
     },
 }
 
@@ -749,11 +755,13 @@ pub fn convert_get_type_constructor_error(
             name,
             module_name,
             type_constructors,
+            imported_type_as_value,
         } => Error::UnknownModuleType {
             location: *location,
             name,
             module_name,
             type_constructors,
+            imported_type_as_value,
         },
     }
 }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1627,6 +1627,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         },
                         module_name: module.name.clone(),
                         value_constructors: module.public_value_names(),
+                        imported_value_as_type: false,
                     })?;
 
             // Emit a warning if the value being used is deprecated.
@@ -1958,6 +1959,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         module_name: module_name.clone(),
                         name: name.clone(),
                         value_constructors: module.public_value_names(),
+                        imported_value_as_type: false,
                     })?
             }
         };

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1708,6 +1708,32 @@ pub fn main(_x: two.Thing) {
 }
 
 #[test]
+fn value_imported_as_type() {
+    assert_with_module_error!(
+        (
+            "gleam/foo",
+            "pub type Bar {
+               Baz
+             }"
+        ),
+        "import gleam/foo.{type Baz}"
+    );
+}
+
+#[test]
+fn type_imported_as_value() {
+    assert_with_module_error!(
+        (
+            "gleam/foo",
+            "pub type Bar {
+               Baz
+             }"
+        ),
+        "import gleam/foo.{Bar}"
+    );
+}
+
+#[test]
 fn duplicate_module_function_arguments() {
     assert_module_error!(
         "

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "import gleam/foo.{Bar}"
+---
+error: Unknown module field
+  ┌─ /src/one/two.gleam:1:19
+  │
+1 │ import gleam/foo.{Bar}
+  │                   ^^^ Did you mean `type Bar`?
+
+`Bar` is only a type, it cannot be imported as a value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__value_imported_as_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__value_imported_as_type.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "import gleam/foo.{type Baz}"
+---
+error: Unknown module type
+  ┌─ /src/one/two.gleam:1:19
+  │
+1 │ import gleam/foo.{type Baz}
+  │                   ^^^^^^^^ Did you mean `Baz`?
+
+`Baz` is only a value, it cannot be imported as a type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/imports.rs
-assertion_line: 213
 expression: "import one.{One, type One}\n\npub fn main() -> One {\n  todo\n}\n"
 ---
 error: Unknown module field
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{One, type One}
-  │             ^^^
+  │             ^^^ Did you mean `type One`?
 
-The module `one` does not have a `One` value.
-
+`One` is only a type, it cannot be imported as a value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructo.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/imports.rs
-assertion_line: 175
 expression: "import one.{Two}\n\npub fn main() {\n  Two\n}"
 ---
 error: Unknown module field
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{Two}
-  │             ^^^
+  │             ^^^ Did you mean `type Two`?
 
-The module `one` does not have a `Two` value.
-
+`Two` is only a type, it cannot be imported as a value.


### PR DESCRIPTION
Resolves #2576
Now they look like this:
```
error: Unknown module field
  ┌─ /src/one/two.gleam:1:19
  │
1 │ import gleam/foo.{Bar}
  │                   ^^^ Did you mean `type Bar`?
`Bar` is only a type, it cannot be imported as a value.
```

```
error: Unknown module type
  ┌─ /src/one/two.gleam:1:19
  │
1 │ import gleam/foo.{type Baz}
  │                   ^^^^^^^^ Did you mean `Baz`?
`Baz` is only a value, it cannot be imported as a type.
```