### PR TITLE
[Help Wanted] Ensure _ pattern marks all rows beneath it as redundant

### DIFF
--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -844,6 +844,41 @@ pub fn main(x) {
     );
 }
 
+//https://github.com/gleam-lang/gleam/issues/2651
+#[test]
+fn redundant_3() {
+    assert_warning!(
+        r#"
+pub fn main(x) {
+case x {
+59 -> "gleew"
+14 -> "glabber"
+1 -> ""
+_ -> "glooper"
+2 -> ""
+3 -> "glen"
+4 -> "glew"
+}
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_4() {
+    assert_warning!(
+        r#"
+pub fn main(x) {
+case x {
+"P" -> 4
+_ -> 3
+"geeper!" -> 5
+}
+}
+"#
+    );
+}
+
 #[test]
 fn let_1() {
     assert_module_error!(

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_3.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\npub fn main(x) {\ncase x {\n59 -> \"gleew\"\n14 -> \"glabber\"\n1 -> \"\"\n_ -> \"glooper\"\n2 -> \"\"\n3 -> \"glen\"\n4 -> \"glew\"\n}\n}\n"
+---
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:8:1
+  │
+8 │ 2 -> ""
+  │ ^^^^^^^
+
+This case clause cannot be reached as a previous clause matches
+the same values.
+
+Hint: It can be safely removed.
+
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:9:1
+  │
+9 │ 3 -> "glen"
+  │ ^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches
+the same values.
+
+Hint: It can be safely removed.
+
+warning: Unreachable case clause
+   ┌─ /src/warning/wrn.gleam:10:1
+   │
+10 │ 4 -> "glew"
+   │ ^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches
+the same values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_4.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\npub fn main(x) {\ncase x {\n\"P\" -> 4\n_ -> 3\n\"geeper!\" -> 5\n}\n}\n"
+---
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:6:1
+  │
+6 │ "geeper!" -> 5
+  │ ^^^^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches
+the same values.
+
+Hint: It can be safely removed.


### PR DESCRIPTION
We did not have thorough enough tests as pointed out in #2651 so none of our existing tests placed the `_` pattern anywhere but on the first or last row. Hence me repurposing an if statement that only checked the first row into a for loop checking every row

Also to get the fancy Github thing saying this PR will close an issue:
Resolves #2651 woohoo