### PR TITLE
fix off by 1 in completion range from lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,6 @@
 
 - Fixed a typo when attempting to publish a package with non-Hex dependencies
   ([inoas](https://github.com/inoas))
+
+- Fixed import completions not appearing in some editors due to range being
+  longer than line. ([Ameen Radwan](https://github.com/Acepie))

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -482,7 +482,7 @@ where
         let start = line_num.line_and_column_number(start_of_line);
         let end = line_num.line_and_column_number(end_of_line - 1);
         let start = lsp::Position::new(start.line - 1, start.column + 6);
-        let end = lsp::Position::new(end.line - 1, end.column);
+        let end = lsp::Position::new(end.line - 1, end.column - 1);
         let completions = self.complete_modules_for_import(module, start, end);
 
         Some(Ok(Some(completions)))

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -963,7 +963,7 @@ pub fn main() {
                     },
                     end: Position {
                         line: 0,
-                        character: 11
+                        character: 10
                     }
                 },
                 new_text: "gleam".into()
@@ -1041,7 +1041,7 @@ pub fn test_helper() {
                         },
                         end: Position {
                             line: 0,
-                            character: 13
+                            character: 12
                         }
                     },
                     new_text: "app".into()
@@ -1059,7 +1059,7 @@ pub fn test_helper() {
                         },
                         end: Position {
                             line: 0,
-                            character: 13
+                            character: 12
                         }
                     },
                     new_text: "test_helper".into()
@@ -1099,7 +1099,7 @@ pub fn main() { 1 }
                     },
                     end: Position {
                         line: 0,
-                        character: 13
+                        character: 12
                     }
                 },
                 new_text: "dep".into()
@@ -1134,7 +1134,7 @@ pub fn main() {
                     },
                     end: Position {
                         line: 0,
-                        character: 13
+                        character: 12
                     }
                 },
                 new_text: "example_module".into()
@@ -1171,7 +1171,7 @@ pub fn main() {
                     },
                     end: Position {
                         line: 0,
-                        character: 13
+                        character: 12
                     }
                 },
                 new_text: "example_module".into()
@@ -1208,7 +1208,7 @@ pub fn main() {
                     },
                     end: Position {
                         line: 0,
-                        character: 13
+                        character: 12
                     }
                 },
                 new_text: "example_module".into()
@@ -1258,7 +1258,7 @@ pub fn main() {
                         },
                         end: Position {
                             line: 0,
-                            character: 13
+                            character: 12
                         }
                     },
                     new_text: "app".into()
@@ -1276,7 +1276,7 @@ pub fn main() {
                         },
                         end: Position {
                             line: 0,
-                            character: 13
+                            character: 12
                         }
                     },
                     new_text: "example_module".into()
@@ -1294,7 +1294,7 @@ pub fn main() {
                         },
                         end: Position {
                             line: 0,
-                            character: 13
+                            character: 12
                         }
                     },
                     new_text: "indirect_module".into()
@@ -1337,7 +1337,7 @@ pub fn main() { 1 }
                     },
                     end: Position {
                         line: 3,
-                        character: 13
+                        character: 12
                     }
                 },
                 new_text: "example_module".into()
@@ -1372,7 +1372,7 @@ pub fn main() {
                     },
                     end: Position {
                         line: 0,
-                        character: 13
+                        character: 12
                     }
                 },
                 new_text: "dep".into()
@@ -1407,7 +1407,7 @@ pub fn main() {
                     },
                     end: Position {
                         line: 0,
-                        character: 14
+                        character: 13
                     }
                 },
                 new_text: "dep".into()
@@ -1446,7 +1446,7 @@ pub fn main() {
                     },
                     end: Position {
                         line: 0,
-                        character: 13
+                        character: 12
                     }
                 },
                 new_text: internal_name.clone(),


### PR DESCRIPTION
Import completions were not appearing in Zed. It turns out there was an off by 1 bug in the end range that the lsp was emitting for the completion. Other editors just clip that range to the end of the line but zed https://github.com/zed-industries/zed/blob/e1791b7dd0ff1948d3d302674fda2f659974c0b3/crates/project/src/lsp_command.rs#L1513 throws an exception if the end is past the line and doesn't show the completion. Fixing the off by 1 bug causes the completions to appear again