### PR TITLE
Add Never type to Prelude (WIP on warning for expressions after a function with return type Never)

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1971,6 +1971,7 @@ impl<'a> TypePrinter<'a> {
 
     fn print_prelude_type(&self, name: &str, args: &[Arc<Type>]) -> Document<'static> {
         match name {
+            "Never" => "never".to_doc(),
             "Nil" => "nil".to_doc(),
             "Int" | "UtfCodepoint" => "integer()".to_doc(),
             "String" => "binary()".to_doc(),

--- a/compiler-core/src/erlang/tests/functions.rs
+++ b/compiler-core/src/erlang/tests/functions.rs
@@ -69,6 +69,21 @@ pub fn main() {
 }
 
 #[test]
+fn never_function_called() {
+    assert_erl!(
+        r#"
+pub fn main() {
+  bottom()
+}
+
+pub fn bottom() -> Never {
+  bottom()
+}
+"#
+    );
+}
+
+#[test]
 fn nested_imported_function_called() {
     assert_erl!(
         ("package", "some/other", "pub fn wibble() { Nil }"),

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__never_function_called.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__never_function_called.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/erlang/tests/functions.rs
+expression: "\npub fn main() {\n  bottom()\n}\n\npub fn bottom() -> Never {\n  bottom()\n}\n"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([bottom/0, main/0]).
+
+-spec bottom() -> never.
+bottom() ->
+    bottom().
+
+-spec main() -> never.
+main() ->
+    bottom().

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -34,6 +34,21 @@ pub fn take_two(x: Int) -> Int {
 }
 
 #[test]
+fn calling_never_function() {
+    assert_js!(
+        r#"
+pub fn main() {
+  bottom()
+}
+
+pub fn bottom() -> Never {
+  bottom()
+}
+"#,
+    );
+}
+
+#[test]
 fn function_formatting() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__calling_never_function.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__calling_never_function.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\npub fn main() {\n  bottom()\n}\n\npub fn bottom() -> Never {\n  bottom()\n}\n"
+---
+export function bottom() {
+  while (true) {
+    
+  }
+}
+
+export function main() {
+  return bottom();
+}

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -63,6 +63,13 @@ fn prelude_type_completions() -> Vec<CompletionItem> {
             ..Default::default()
         },
         CompletionItem {
+            label: "Never".into(),
+            kind: Some(CompletionItemKind::CLASS),
+            detail: Some("Type".into()),
+            documentation: None,
+            ..Default::default()
+        },
+        CompletionItem {
             label: "Nil".into(),
             kind: Some(CompletionItemKind::CLASS),
             detail: Some("Type".into()),

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -160,6 +160,16 @@ impl Type {
         }
     }
 
+    pub fn is_never(&self) -> bool {
+        match self {
+            Self::Named { module, name, .. } if "Never" == name && is_prelude_module(module) => {
+                true
+            }
+            Self::Var { type_ } => type_.borrow().is_never(),
+            _ => false,
+        }
+    }
+
     pub fn is_bit_array(&self) -> bool {
         match self {
             Self::Named { module, name, .. } if "BitArray" == name && is_prelude_module(module) => {
@@ -835,6 +845,13 @@ impl TypeVar {
     pub fn is_nil(&self) -> bool {
         match self {
             Self::Link { type_ } => type_.is_nil(),
+            Self::Unbound { .. } | Self::Generic { .. } => false,
+        }
+    }
+
+    pub fn is_never(&self) -> bool {
+        match self {
+            Self::Link { type_ } => type_.is_never(),
             Self::Unbound { .. } | Self::Generic { .. } => false,
         }
     }

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -534,6 +534,12 @@ pub enum Warning {
     RedundantAssertAssignment {
         location: SrcSpan,
     },
+
+    /// If an expression occurs after a function returning the Never type then it is guarenteed
+    /// to never be executed (since the function above it will never return)
+    ExpressionAfterNever {
+        location: SrcSpan,
+    },
 }
 
 impl Error {

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -19,6 +19,7 @@ const BOOL: &str = "Bool";
 const FLOAT: &str = "Float";
 const INT: &str = "Int";
 const LIST: &str = "List";
+const NEVER: &str = "Never";
 const NIL: &str = "Nil";
 const RESULT: &str = "Result";
 const STRING: &str = "String";
@@ -38,6 +39,7 @@ pub enum PreludeType {
     Float,
     Int,
     List,
+    Never,
     Nil,
     Result,
     String,
@@ -52,6 +54,7 @@ impl PreludeType {
             PreludeType::Float => FLOAT,
             PreludeType::Int => INT,
             PreludeType::List => LIST,
+            PreludeType::Never => NEVER,
             PreludeType::Nil => NIL,
             PreludeType::Result => RESULT,
             PreludeType::String => STRING,
@@ -95,6 +98,16 @@ pub fn string() -> Arc<Type> {
         args: vec![],
         publicity: Publicity::Public,
         name: STRING.into(),
+        module: PRELUDE_MODULE_NAME.into(),
+        package: PRELUDE_PACKAGE_NAME.into(),
+    })
+}
+
+pub fn never() -> Arc<Type> {
+    Arc::new(Type::Named {
+        args: vec![],
+        publicity: Publicity::Public,
+        name: NEVER.into(),
         module: PRELUDE_MODULE_NAME.into(),
         package: PRELUDE_PACKAGE_NAME.into(),
     })
@@ -334,6 +347,21 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         origin: Default::default(),
                         parameters: vec![list_parameter.clone()],
                         typ: list(list_parameter),
+                        module: PRELUDE_MODULE_NAME.into(),
+                        publicity: Publicity::Public,
+                        deprecation: NotDeprecated,
+                        documentation: None,
+                    },
+                );
+            }
+
+            PreludeType::Never => {
+                let _ = prelude.types.insert(
+                    NEVER.into(),
+                    TypeConstructor {
+                        origin: Default::default(),
+                        parameters: vec![],
+                        typ: never(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1756,6 +1756,17 @@ fn(x, x) {
 }
 
 #[test]
+fn try_to_construct_never() {
+    assert_error!(
+        "
+fn() {
+  Never
+}
+"
+    );
+}
+
+#[test]
 fn negate_boolean_as_integer() {
     assert_error!(
         "

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__try_to_construct_never.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__try_to_construct_never.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nfn() {\n  Never\n}\n"
+---
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:3
+  │
+3 │   Never
+  │   ^^^^^
+
+`Never` is a type, it cannot be used as a value.

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -700,6 +700,22 @@ hidden from the package's documentation.",
                         extra_labels: vec![],
                     }),
                 },
+                type_::Warning::ExpressionAfterNever { location } => Diagnostic {
+                    title: "Expression after never".into(),
+                    text: "This expression is redundant since it comes after a function with the `Never` return type."
+                        .into(),
+                    hint: None,
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        label: diagnostic::Label {
+                            text: Some("You can remove this".into()),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
             },
         }
     }


### PR DESCRIPTION
As discussed in #3044 it would be neat to add a type to the Prelude which could represent functions which never return.

The `Never` type can not be constructed because if it could be constructed then someone could write a function which does return at some point with it.
For example we don't want this to be possible:
```gleam
fn go_forever() -> Never {
    // oh no it actually does stop!
    Never
}
```


WIP on figuring out where to add in the Warning for expressions coming after a function/expression of type `Never`.