### PR TITLE
Added goto definition support for imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,9 +162,11 @@
   removed if it would otherwise be left blank.
   ([Milco Kats](https://github.com/katsmil))
 
-- Hover for type annotations is now separate from the thing being annotated ([Ameen Radwan](https://github.com/Acepie))
+- Hover for type annotations is now separate from the thing being annotated. ([Ameen Radwan](https://github.com/Acepie))
 
-- Go to definition now works for direct type annotations ([Ameen Radwan](https://github.com/Acepie))
+- Go to definition now works for direct type annotations. ([Ameen Radwan](https://github.com/Acepie))
+
+- Go to definition now works for import statements. ([Ameen Radwan](https://github.com/Acepie))
 
 ### Bug Fixes
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -738,8 +738,36 @@ impl TypedDefinition {
                 }
             }
 
-            Definition::Import(_) => {
+            Definition::Import(import) => {
                 if self.location().contains(byte_index) {
+                    if let Some(unqualified) = import
+                        .unqualified_values
+                        .iter()
+                        .find(|i| i.location.contains(byte_index))
+                    {
+                        return Some(Located::UnqualifiedImport(
+                            crate::build::UnqualifiedImport {
+                                name: unqualified.name.clone(),
+                                module: import.module.clone(),
+                                is_type: false,
+                            },
+                        ));
+                    }
+
+                    if let Some(unqualified) = import
+                        .unqualified_types
+                        .iter()
+                        .find(|i| i.location.contains(byte_index))
+                    {
+                        return Some(Located::UnqualifiedImport(
+                            crate::build::UnqualifiedImport {
+                                name: unqualified.name.clone(),
+                                module: import.module.clone(),
+                                is_type: true,
+                            },
+                        ));
+                    }
+
                     Some(Located::ModuleStatement(self))
                 } else {
                     None

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -226,6 +226,8 @@ where
                     None
                 }
 
+                Located::UnqualifiedImport(_) => None,
+
                 Located::Arg(_) => None,
 
                 Located::Annotation(_, _) => Some(this.completion_types(module)),
@@ -288,6 +290,7 @@ where
                     Some(hover_for_module_constant(constant, lines))
                 }
                 Located::ModuleStatement(_) => None,
+                Located::UnqualifiedImport(_) => None,
                 Located::Pattern(pattern) => Some(hover_for_pattern(pattern, lines)),
                 Located::Expression(expression) => {
                     let module = this.module_for_uri(&params.text_document.uri);

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -800,3 +800,213 @@ fn make_var() -> example_module.Wabble(example_module.Wibble(example_module.Wobb
         })
     )
 }
+
+#[test]
+fn goto_definition_import() {
+    let code = "
+import example_module
+fn main() {
+  example_module.my_num
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_module("example_module", "pub const my_num = 1"),
+            Position::new(1, 13)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0
+                },
+                end: Position {
+                    line: 0,
+                    character: 0
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_import_aliased() {
+    let code = "
+import example_module as example
+fn main() {
+  example.my_num
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_module("example_module", "pub const my_num = 1"),
+            Position::new(1, 29)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0
+                },
+                end: Position {
+                    line: 0,
+                    character: 0
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_import_unqualified_value() {
+    let code = "
+import example_module.{my_num}
+fn main() {
+  my_num
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_module("example_module", "pub const my_num = 1"),
+            Position::new(1, 26)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 10
+                },
+                end: Position {
+                    line: 0,
+                    character: 16
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_import_unqualified_value_with_as() {
+    let code = "
+import example_module.{my_num as num}
+fn main() {
+  num
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_module("example_module", "pub const my_num = 1"),
+            Position::new(1, 35)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 10
+                },
+                end: Position {
+                    line: 0,
+                    character: 16
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_import_unqualified_type() {
+    let code = "
+import example_module.{type MyType}
+fn main() -> MyType {
+  0
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_module("example_module", "pub type MyType = Int"),
+            Position::new(1, 33)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0
+                },
+                end: Position {
+                    line: 0,
+                    character: 21
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn goto_definition_import_unqualified_type_with_as() {
+    let code = "
+import example_module.{type MyType as Wibble}
+fn main() -> Wibble {
+  0
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_module("example_module", "pub type MyType = Int"),
+            Position::new(1, 42)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\example_module.gleam"
+            } else {
+                "/src/example_module.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0
+                },
+                end: Position {
+                    line: 0,
+                    character: 21
+                }
+            }
+        })
+    )
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2176,8 +2176,9 @@ where
                         as_name: None,
                     };
                     if self.maybe_one(&Token::As).is_some() {
-                        let (_, as_name, _) = self.expect_name()?;
+                        let (_, as_name, end) = self.expect_name()?;
                         import.as_name = Some(as_name);
+                        import.location.end = end;
                     }
                     imports.values.push(import)
                 }
@@ -2191,8 +2192,9 @@ where
                         as_name: None,
                     };
                     if self.maybe_one(&Token::As).is_some() {
-                        let (_, as_name, _) = self.expect_upname()?;
+                        let (_, as_name, end) = self.expect_upname()?;
                         import.as_name = Some(as_name);
+                        import.location.end = end;
                     }
                     imports.values.push(import)
                 }
@@ -2207,8 +2209,9 @@ where
                         as_name: None,
                     };
                     if self.maybe_one(&Token::As).is_some() {
-                        let (_, as_name, _) = self.expect_upname()?;
+                        let (_, as_name, end) = self.expect_upname()?;
                         import.as_name = Some(as_name);
+                        import.location.end = end;
                     }
                     imports.types.push(import)
                 }


### PR DESCRIPTION
For qualified import statements it just goes to the top of the file. For unqualified import statements it goes to the definition of the actual type/value. This also sets up unqualified imports as a separate `Located` in the lsp which should help with making implementing hover relatively easy (didn't wanna put it in this pr but will probably have one up for hover after this)