### PR TITLE
ci: add wasm target to release

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -214,3 +214,58 @@ jobs:
             org.opencontainers.image.source=https://github.com/gleam-lang/gleam
             org.opencontainers.image.version=nightly-${{ matrix.base-image }}
             org.opencontainers.image.licenses=Apache-2.0
+
+  build-nightly-wasm:
+    name: build-nightly-wasm
+    runs-on: ubuntu-latest
+      #needs: [ nightly-last-run ]
+      #if: ${{ github.repository_owner == 'gleam-lang' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Build wasm
+        run: wasm-pack build --release --target web compiler-wasm
+
+      - name: Build wasm archive
+        run: |
+          VERSION="nightly"
+          DAY=$(date +"%y%m%d")
+          ARCHIVE="gleam-$VERSION-browser.tar.gz"
+
+          tar -C compiler-wasm/pkg/ -czvf $ARCHIVE .
+          openssl dgst -r -sha256 -out "$ARCHIVE".sha256 "$ARCHIVE"
+          openssl dgst -r -sha512 -out "$ARCHIVE".sha512 "$ARCHIVE"
+
+          echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
+          echo "DAY=$DAY" >> $GITHUB_ENV
+
+      - name: Upload x86_64-unknown-linux-musl artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gleam
+          path: target/${{ matrix.target }}/release/gleam
+          overwrite: true
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+
+      - name: Upload wasm release archive
+        shell: bash
+        run: |
+          gh release upload nightly --clobber \
+            "${{ env.ASSET }}" \
+            "${{ env.ASSET }}.sha256" \
+            "${{ env.ASSET }}.sha512"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -233,7 +233,7 @@ jobs:
           override: true
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: curl -sSL https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
 
       - name: Build wasm
         run: wasm-pack build --release --target web compiler-wasm
@@ -250,14 +250,6 @@ jobs:
 
           echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
           echo "DAY=$DAY" >> $GITHUB_ENV
-
-      - name: Upload x86_64-unknown-linux-musl artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: gleam
-          path: target/${{ matrix.target }}/release/gleam
-          overwrite: true
-        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
 
       - name: Upload wasm release archive
         shell: bash


### PR DESCRIPTION
a very slow follow-up to #2433 ^^;

I've added a test/example implementation for the nightly release, should be alright to add roughly the same thing to the release.yaml.

Just wanted to get a clarification on direction generally. If i'm correct it's better to split this out into it's own job as it doesn't fix into the matrix nicely due to the change in build process but if you have recommendations, preferences, whatever, let me know, happy to fit the implementation as required.

example of the build can be found here: 
https://github.com/bgwdotdev/gleam/actions/runs/8869952879/job/24351188803 

with the associated files here:
https://github.com/bgwdotdev/gleam/releases/tag/nightly