### PR TITLE
LSP: code action to remove redundant tuple in case subject

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -4,6 +4,7 @@ mod untyped;
 
 #[cfg(test)]
 mod tests;
+pub mod visit;
 
 pub use self::typed::TypedExpr;
 pub use self::untyped::{UntypedExpr, Use};

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -17,6 +17,7 @@ use crate::type_::expression::Implementations;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -1319,6 +1320,16 @@ impl SrcSpan {
 
     pub fn contains(&self, byte_index: u32) -> bool {
         byte_index >= self.start && byte_index < self.end
+    }
+
+    pub fn cmp_byte_index(&self, byte_index: u32) -> Ordering {
+        if byte_index < self.start {
+            Ordering::Less
+        } else if self.end <= byte_index {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
     }
 }
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1320,6 +1320,10 @@ impl SrcSpan {
     pub fn contains(&self, byte_index: u32) -> bool {
         byte_index >= self.start && byte_index < self.end
     }
+
+    pub fn contains_span(&self, other: Self) -> bool {
+        self.start <= other.start && other.end <= self.end
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1320,10 +1320,6 @@ impl SrcSpan {
     pub fn contains(&self, byte_index: u32) -> bool {
         byte_index >= self.start && byte_index < self.end
     }
-
-    pub fn contains_span(&self, other: Self) -> bool {
-        self.start <= other.start && other.end <= self.end
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -721,7 +721,7 @@ pub fn visit_use<'a, V>(v: &mut V, use_: &'a Use)
 where
     V: Visit<'a> + ?Sized,
 {
-    { /* TODO */ }
+    /* TODO */
 }
 
 pub fn visit_typed_call_arg<'a, V>(v: &mut V, arg: &'a TypedCallArg)

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -11,13 +11,26 @@ use ecow::EcoString;
 use crate::type_::Type;
 
 use super::{
-    BinOp, BitArrayOption, SrcSpan, Statement, TypeAst, TypedArg, TypedClause, TypedExpr,
-    TypedExprBitArraySegment, TypedRecordUpdateArg, TypedStatement, Use,
+    BinOp, BitArrayOption, Definition, SrcSpan, Statement, TypeAst, TypedArg, TypedClause,
+    TypedDefinition, TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule,
+    TypedRecordUpdateArg, TypedStatement, Use,
 };
 
 pub trait Visit<'a> {
-    fn visit_typed_expr(&mut self, node: &'a TypedExpr) {
-        visit_typed_expr(self, node);
+    fn visit_typed_module(&mut self, module: &'a TypedModule) {
+        visit_typed_module(self, module);
+    }
+
+    fn visit_typed_definition(&mut self, def: &'a TypedDefinition) {
+        visit_typed_definition(self, def);
+    }
+
+    fn visit_typed_function(&mut self, fun: &'a TypedFunction) {
+        visit_typed_function(self, fun);
+    }
+
+    fn visit_typed_expr(&mut self, expr: &'a TypedExpr) {
+        visit_typed_expr(self, expr);
     }
 
     fn visit_typed_expr_int(
@@ -255,6 +268,35 @@ pub trait Visit<'a> {
 
     fn visit_typed_bit_array_option(&mut self, option: &'a BitArrayOption<TypedExpr>) {
         visit_typed_bit_array_option(self, option);
+    }
+}
+
+pub fn visit_typed_module<'a, V>(v: &mut V, module: &'a TypedModule)
+where
+    V: Visit<'a> + ?Sized,
+{
+    for def in &module.definitions {
+        v.visit_typed_definition(def);
+    }
+}
+pub fn visit_typed_definition<'a, V>(v: &mut V, def: &'a TypedDefinition)
+where
+    V: Visit<'a> + ?Sized,
+{
+    match def {
+        Definition::Function(fun) => v.visit_typed_function(fun),
+        Definition::TypeAlias(type_alias) => todo!(),
+        Definition::CustomType(custom_type) => todo!(),
+        Definition::Import(import) => todo!(),
+        Definition::ModuleConstant(module_constant) => todo!(),
+    }
+}
+pub fn visit_typed_function<'a, V>(v: &mut V, fun: &'a TypedFunction)
+where
+    V: Visit<'a> + ?Sized,
+{
+    for stmt in &fun.body {
+        v.visit_typed_statement(stmt);
     }
 }
 
@@ -675,7 +717,7 @@ pub fn visit_use<'a, V>(v: &mut V, use_: &'a Use)
 where
     V: Visit<'a> + ?Sized,
 {
-    todo!("v.visit_untyped_expr(use_.call)")
+    todo!()
 }
 
 pub fn visit_typed_call_arg<'a, V>(v: &mut V, arg: &'a TypedCallArg)

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -11,8 +11,8 @@ use ecow::EcoString;
 use crate::type_::Type;
 
 use super::{
-    BinOp, SrcSpan, TypeAst, TypedArg, TypedClause, TypedExpr, TypedExprBitArraySegment,
-    TypedRecordUpdateArg, TypedStatement,
+    BinOp, SrcSpan, Statement, TypeAst, TypedArg, TypedClause, TypedExpr, TypedExprBitArraySegment,
+    TypedRecordUpdateArg, TypedStatement, Use,
 };
 
 pub trait Visit<'a> {
@@ -224,6 +224,18 @@ pub trait Visit<'a> {
     fn visit_typed_expr_negate_int(&self, location: &'a SrcSpan, value: &'a TypedExpr) {
         visit_typed_expr_negate_int(self, location, value)
     }
+
+    fn visit_typed_statement(&self, stmt: &'a TypedStatement) {
+        visit_typed_statement(self, stmt);
+    }
+
+    fn visit_typed_assignment(&self, assignment: &'a TypedAssignment) {
+        visit_typed_assignment(self, assignment);
+    }
+
+    fn visit_use(&self, use_: &'a Use) {
+        visit_use(self, use_);
+    }
 }
 
 pub fn visit_typed_expr<'a, V>(v: &V, node: &'a TypedExpr)
@@ -389,7 +401,7 @@ where
     V: Visit<'a> + ?Sized,
 {
     for stmt in statements {
-        todo!()
+        v.visit_typed_statement(stmt);
     }
 }
 
@@ -402,7 +414,7 @@ pub fn visit_typed_expr_pipeline<'a, V>(
     V: Visit<'a> + ?Sized,
 {
     for assignment in assignments {
-        todo!();
+        v.visit_typed_assignment(assignment);
     }
 
     v.visit_typed_expr(finally);
@@ -430,7 +442,7 @@ pub fn visit_typed_expr_fn<'a, V>(
     V: Visit<'a> + ?Sized,
 {
     for stmt in body {
-        todo!()
+        v.visit_typed_statement(stmt);
     }
 }
 
@@ -616,4 +628,29 @@ where
     V: Visit<'a> + ?Sized,
 {
     v.visit_typed_expr(value);
+}
+
+pub fn visit_typed_statement<'a, V>(v: &V, stmt: &'a TypedStatement)
+where
+    V: Visit<'a> + ?Sized,
+{
+    match stmt {
+        Statement::Expression(expr) => v.visit_typed_expr(expr),
+        Statement::Assignment(assignment) => v.visit_typed_assignment(assignment),
+        Statement::Use(use_) => v.visit_use(use_),
+    }
+}
+
+pub fn visit_typed_assignment<'a, V>(v: &V, assignment: &'a TypedAssignment)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(&assignment.value);
+}
+
+pub fn visit_use<'a, V>(v: &V, use_: &'a Use)
+where
+    V: Visit<'a> + ?Sized,
+{
+    todo!("v.visit_untyped_expr(use_.call)")
 }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -1,5 +1,3 @@
-#![allow(unused_variables)]
-
 use crate::{
     ast::TypedAssignment,
     type_::{ModuleValueConstructor, TypedCallArg, ValueConstructor},
@@ -283,16 +281,17 @@ where
         v.visit_typed_definition(def);
     }
 }
+
 pub fn visit_typed_definition<'a, V>(v: &mut V, def: &'a TypedDefinition)
 where
     V: Visit<'a> + ?Sized,
 {
     match def {
         Definition::Function(fun) => v.visit_typed_function(fun),
-        Definition::TypeAlias(type_alias) => { /* TODO */ }
-        Definition::CustomType(custom_type) => { /* TODO */ }
-        Definition::Import(import) => { /* TODO */ }
-        Definition::ModuleConstant(module_constant) => { /* TODO */ }
+        Definition::TypeAlias(_type_alias) => { /* TODO */ }
+        Definition::CustomType(_custom_type) => { /* TODO */ }
+        Definition::Import(_import) => { /* TODO */ }
+        Definition::ModuleConstant(_module_constant) => { /* TODO */ }
     }
 }
 pub fn visit_typed_function<'a, V>(v: &mut V, fun: &'a TypedFunction)
@@ -433,30 +432,30 @@ where
 }
 
 pub fn visit_typed_expr_int<'a, V>(
-    v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    value: &'a EcoString,
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _value: &'a EcoString,
 ) where
     V: Visit<'a> + ?Sized,
 {
 }
 
 pub fn visit_typed_expr_float<'a, V>(
-    v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    value: &'a EcoString,
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _value: &'a EcoString,
 ) where
     V: Visit<'a> + ?Sized,
 {
 }
 
 pub fn visit_typed_expr_string<'a, V>(
-    v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    value: &'a EcoString,
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _value: &'a EcoString,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -464,7 +463,7 @@ pub fn visit_typed_expr_string<'a, V>(
 
 pub fn visit_typed_expr_block<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
+    _location: &'a SrcSpan,
     statements: &'a [TypedStatement],
 ) where
     V: Visit<'a> + ?Sized,
@@ -476,7 +475,7 @@ pub fn visit_typed_expr_block<'a, V>(
 
 pub fn visit_typed_expr_pipeline<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
+    _location: &'a SrcSpan,
     assignments: &'a [TypedAssignment],
     finally: &'a TypedExpr,
 ) where
@@ -490,23 +489,24 @@ pub fn visit_typed_expr_pipeline<'a, V>(
 }
 
 pub fn visit_typed_expr_var<'a, V>(
-    v: &mut V,
-    location: &'a SrcSpan,
-    constructor: &'a ValueConstructor,
-    name: &'a EcoString,
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _constructor: &'a ValueConstructor,
+    _name: &'a EcoString,
 ) where
     V: Visit<'a> + ?Sized,
 {
+    /* TODO */
 }
 
 pub fn visit_typed_expr_fn<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    is_capture: &'a bool,
-    args: &'a [TypedArg],
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _is_capture: &'a bool,
+    _args: &'a [TypedArg],
     body: &'a [TypedStatement],
-    return_annotation: &'a Option<TypeAst>,
+    _return_annotation: &'a Option<TypeAst>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -517,8 +517,8 @@ pub fn visit_typed_expr_fn<'a, V>(
 
 pub fn visit_typed_expr_list<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
     elements: &'a [TypedExpr],
     tail: &'a Option<Box<TypedExpr>>,
 ) where
@@ -535,8 +535,8 @@ pub fn visit_typed_expr_list<'a, V>(
 
 pub fn visit_typed_expr_call<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
     fun: &'a TypedExpr,
     args: &'a [TypedCallArg],
 ) where
@@ -550,9 +550,9 @@ pub fn visit_typed_expr_call<'a, V>(
 
 pub fn visit_typed_expr_bin_op<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    name: &'a BinOp,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _name: &'a BinOp,
     left: &'a TypedExpr,
     right: &'a TypedExpr,
 ) where
@@ -564,8 +564,8 @@ pub fn visit_typed_expr_bin_op<'a, V>(
 
 pub fn visit_typed_expr_case<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
     subjects: &'a [TypedExpr],
     clauses: &'a [TypedClause],
 ) where
@@ -582,10 +582,10 @@ pub fn visit_typed_expr_case<'a, V>(
 
 pub fn visit_typed_expr_record_access<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    label: &'a EcoString,
-    index: &'a u64,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _label: &'a EcoString,
+    _index: &'a u64,
     record: &'a TypedExpr,
 ) where
     V: Visit<'a> + ?Sized,
@@ -594,22 +594,23 @@ pub fn visit_typed_expr_record_access<'a, V>(
 }
 
 pub fn visit_typed_expr_module_select<'a, V>(
-    v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    label: &'a EcoString,
-    module_name: &'a EcoString,
-    module_alias: &'a EcoString,
-    constructor: &'a ModuleValueConstructor,
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _label: &'a EcoString,
+    _module_name: &'a EcoString,
+    _module_alias: &'a EcoString,
+    _constructor: &'a ModuleValueConstructor,
 ) where
     V: Visit<'a> + ?Sized,
 {
+    /* TODO */
 }
 
 pub fn visit_typed_expr_tuple<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
     elems: &'a [TypedExpr],
 ) where
     V: Visit<'a> + ?Sized,
@@ -621,9 +622,9 @@ pub fn visit_typed_expr_tuple<'a, V>(
 
 pub fn visit_typed_expr_tuple_index<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
-    index: &'a u64,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
+    _index: &'a u64,
     tuple: &'a TypedExpr,
 ) where
     V: Visit<'a> + ?Sized,
@@ -633,9 +634,9 @@ pub fn visit_typed_expr_tuple_index<'a, V>(
 
 pub fn visit_typed_expr_todo<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
+    _location: &'a SrcSpan,
     message: &'a Option<Box<TypedExpr>>,
-    type_: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -646,9 +647,9 @@ pub fn visit_typed_expr_todo<'a, V>(
 
 pub fn visit_typed_expr_panic<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
+    _location: &'a SrcSpan,
     message: &'a Option<Box<TypedExpr>>,
-    type_: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -659,8 +660,8 @@ pub fn visit_typed_expr_panic<'a, V>(
 
 pub fn visit_typed_expr_bit_array<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
     segments: &'a [TypedExprBitArraySegment],
 ) where
     V: Visit<'a> + ?Sized,
@@ -672,8 +673,8 @@ pub fn visit_typed_expr_bit_array<'a, V>(
 
 pub fn visit_typed_expr_record_update<'a, V>(
     v: &mut V,
-    location: &'a SrcSpan,
-    typ: &'a Arc<Type>,
+    _location: &'a SrcSpan,
+    _typ: &'a Arc<Type>,
     spread: &'a TypedExpr,
     args: &'a [TypedRecordUpdateArg],
 ) where
@@ -685,14 +686,14 @@ pub fn visit_typed_expr_record_update<'a, V>(
     }
 }
 
-pub fn visit_typed_expr_negate_bool<'a, V>(v: &mut V, location: &'a SrcSpan, value: &'a TypedExpr)
+pub fn visit_typed_expr_negate_bool<'a, V>(v: &mut V, _location: &'a SrcSpan, value: &'a TypedExpr)
 where
     V: Visit<'a> + ?Sized,
 {
     v.visit_typed_expr(value);
 }
 
-pub fn visit_typed_expr_negate_int<'a, V>(v: &mut V, location: &'a SrcSpan, value: &'a TypedExpr)
+pub fn visit_typed_expr_negate_int<'a, V>(v: &mut V, _location: &'a SrcSpan, value: &'a TypedExpr)
 where
     V: Visit<'a> + ?Sized,
 {
@@ -717,7 +718,7 @@ where
     v.visit_typed_expr(&assignment.value);
 }
 
-pub fn visit_use<'a, V>(v: &mut V, use_: &'a Use)
+pub fn visit_use<'a, V>(_v: &mut V, _use_: &'a Use)
 where
     V: Visit<'a> + ?Sized,
 {
@@ -755,31 +756,34 @@ where
     v.visit_typed_expr(&arg.value);
 }
 
-pub fn visit_typed_bit_array_option<'a, V>(v: &mut V, option: &'a BitArrayOption<TypedExpr>)
+pub fn visit_typed_bit_array_option<'a, V>(_v: &mut V, option: &'a BitArrayOption<TypedExpr>)
 where
     V: Visit<'a> + ?Sized,
 {
     match option {
-        BitArrayOption::Bytes { location } => { /* TODO */ }
-        BitArrayOption::Int { location } => { /* TODO */ }
-        BitArrayOption::Float { location } => { /* TODO */ }
-        BitArrayOption::Bits { location } => { /* TODO */ }
-        BitArrayOption::Utf8 { location } => { /* TODO */ }
-        BitArrayOption::Utf16 { location } => { /* TODO */ }
-        BitArrayOption::Utf32 { location } => { /* TODO */ }
-        BitArrayOption::Utf8Codepoint { location } => { /* TODO */ }
-        BitArrayOption::Utf16Codepoint { location } => { /* TODO */ }
-        BitArrayOption::Utf32Codepoint { location } => { /* TODO */ }
-        BitArrayOption::Signed { location } => { /* TODO */ }
-        BitArrayOption::Unsigned { location } => { /* TODO */ }
-        BitArrayOption::Big { location } => { /* TODO */ }
-        BitArrayOption::Little { location } => { /* TODO */ }
-        BitArrayOption::Native { location } => { /* TODO */ }
+        BitArrayOption::Bytes { location: _ } => { /* TODO */ }
+        BitArrayOption::Int { location: _ } => { /* TODO */ }
+        BitArrayOption::Float { location: _ } => { /* TODO */ }
+        BitArrayOption::Bits { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf8 { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf16 { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf32 { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf8Codepoint { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf16Codepoint { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf32Codepoint { location: _ } => { /* TODO */ }
+        BitArrayOption::Signed { location: _ } => { /* TODO */ }
+        BitArrayOption::Unsigned { location: _ } => { /* TODO */ }
+        BitArrayOption::Big { location: _ } => { /* TODO */ }
+        BitArrayOption::Little { location: _ } => { /* TODO */ }
+        BitArrayOption::Native { location: _ } => { /* TODO */ }
         BitArrayOption::Size {
-            location,
-            value,
-            short_form,
-        } => v.visit_typed_expr(value),
-        BitArrayOption::Unit { location, value } => { /* TODO */ }
+            location: _,
+            value: _,
+            short_form: _,
+        } => { /* TODO */ }
+        BitArrayOption::Unit {
+            location: _,
+            value: _,
+        } => { /* TODO */ }
     }
 }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -1,7 +1,44 @@
-use crate::{
-    ast::TypedAssignment,
-    type_::{ModuleValueConstructor, TypedCallArg, ValueConstructor},
-};
+//! AST traversal routines, referenced from [`syn::visit`](https://docs.rs/syn/latest/syn/visit/index.html)
+//!
+//! Each method of the [`Visit`] trait can be overriden to customize the
+//! behaviour when visiting the corresponding type of AST node. By default,
+//! every method recursively visits the substructure of the node by using the
+//! right visitor method.
+//!
+//! # Example
+//!
+//! Suppose we would like to collect all function names in a module,
+//! we can do the following:
+//!
+//! ```no_run
+//! use gleam_core::ast::{TypedFunction, visit::{self, Visit}};
+//!
+//! struct FnCollector<'ast> {
+//!     functions: Vec<&'ast TypedFunction>
+//! }
+//!
+//! impl<'ast> Visit<'ast> for FnCollector<'ast> {
+//!     fn visit_typed_function(&mut self, fun: &'ast TypedFunction) {
+//!         self.functions.push(fun);
+//!
+//!         // Use the default behaviour to visit any nested functions
+//!         visit::visit_typed_function(self, fun);
+//!     }
+//! }
+//!
+//! fn print_all_module_functions() {
+//!     let module = todo!("module");
+//!     let mut fn_collector = FnCollector { functions: vec![] };
+//!
+//!     // This will walk the AST and collect all functions
+//!     fn_collector.visit_typed_module(module);
+//!
+//!     // Print the collected functions
+//!     println!("{:#?}", fn_collector.functions);
+//! }
+//! ```
+
+use crate::type_::{ModuleValueConstructor, TypedCallArg, ValueConstructor};
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -9,8 +46,8 @@ use ecow::EcoString;
 use crate::type_::Type;
 
 use super::{
-    BinOp, BitArrayOption, Definition, SrcSpan, Statement, TypeAst, TypedArg, TypedClause,
-    TypedDefinition, TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule,
+    BinOp, BitArrayOption, Definition, SrcSpan, Statement, TypeAst, TypedArg, TypedAssignment,
+    TypedClause, TypedDefinition, TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule,
     TypedRecordUpdateArg, TypedStatement, Use,
 };
 

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -16,80 +16,84 @@ use super::{
     TypedRecordUpdateArg, TypedStatement, Use,
 };
 
-pub trait Visit<'a> {
-    fn visit_typed_module(&mut self, module: &'a TypedModule) {
+pub trait Visit<'ast> {
+    fn visit_typed_module(&mut self, module: &'ast TypedModule) {
         visit_typed_module(self, module);
     }
 
-    fn visit_typed_definition(&mut self, def: &'a TypedDefinition) {
+    fn visit_typed_definition(&mut self, def: &'ast TypedDefinition) {
         visit_typed_definition(self, def);
     }
 
-    fn visit_typed_function(&mut self, fun: &'a TypedFunction) {
+    fn visit_typed_function(&mut self, fun: &'ast TypedFunction) {
         visit_typed_function(self, fun);
     }
 
-    fn visit_typed_expr(&mut self, expr: &'a TypedExpr) {
+    fn visit_typed_expr(&mut self, expr: &'ast TypedExpr) {
         visit_typed_expr(self, expr);
     }
 
     fn visit_typed_expr_int(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        value: &'a EcoString,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        value: &'ast EcoString,
     ) {
         visit_typed_expr_int(self, location, typ, value);
     }
 
     fn visit_typed_expr_float(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        value: &'a EcoString,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        value: &'ast EcoString,
     ) {
         visit_typed_expr_float(self, location, typ, value);
     }
 
     fn visit_typed_expr_string(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        value: &'a EcoString,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        value: &'ast EcoString,
     ) {
         visit_typed_expr_string(self, location, typ, value);
     }
 
-    fn visit_typed_expr_block(&mut self, location: &'a SrcSpan, statements: &'a [TypedStatement]) {
+    fn visit_typed_expr_block(
+        &mut self,
+        location: &'ast SrcSpan,
+        statements: &'ast [TypedStatement],
+    ) {
         visit_typed_expr_block(self, location, statements);
     }
 
     fn visit_typed_expr_pipeline(
         &mut self,
-        location: &'a SrcSpan,
-        assignments: &'a [TypedAssignment],
-        finally: &'a TypedExpr,
+        location: &'ast SrcSpan,
+        assignments: &'ast [TypedAssignment],
+        finally: &'ast TypedExpr,
     ) {
         visit_typed_expr_pipeline(self, location, assignments, finally);
     }
 
     fn visit_typed_expr_var(
         &mut self,
-        location: &'a SrcSpan,
-        constructor: &'a ValueConstructor,
-        name: &'a EcoString,
+        location: &'ast SrcSpan,
+        constructor: &'ast ValueConstructor,
+        name: &'ast EcoString,
     ) {
         visit_typed_expr_var(self, location, constructor, name);
     }
 
     fn visit_typed_expr_fn(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        is_capture: &'a bool,
-        args: &'a [TypedArg],
-        body: &'a [TypedStatement],
-        return_annotation: &'a Option<TypeAst>,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        is_capture: &'ast bool,
+        args: &'ast [TypedArg],
+        body: &'ast [TypedStatement],
+        return_annotation: &'ast Option<TypeAst>,
     ) {
         visit_typed_expr_fn(
             self,
@@ -104,64 +108,64 @@ pub trait Visit<'a> {
 
     fn visit_typed_expr_list(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        elements: &'a [TypedExpr],
-        tail: &'a Option<Box<TypedExpr>>,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        elements: &'ast [TypedExpr],
+        tail: &'ast Option<Box<TypedExpr>>,
     ) {
         visit_typed_expr_list(self, location, typ, elements, tail);
     }
 
     fn visit_typed_expr_call(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        fun: &'a TypedExpr,
-        args: &'a [TypedCallArg],
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        fun: &'ast TypedExpr,
+        args: &'ast [TypedCallArg],
     ) {
         visit_typed_expr_call(self, location, typ, fun, args);
     }
 
     fn visit_typed_expr_bin_op(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        name: &'a BinOp,
-        left: &'a TypedExpr,
-        right: &'a TypedExpr,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        name: &'ast BinOp,
+        left: &'ast TypedExpr,
+        right: &'ast TypedExpr,
     ) {
         visit_typed_expr_bin_op(self, location, typ, name, left, right);
     }
 
     fn visit_typed_expr_case(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        subjects: &'a [TypedExpr],
-        clauses: &'a [TypedClause],
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        subjects: &'ast [TypedExpr],
+        clauses: &'ast [TypedClause],
     ) {
         visit_typed_expr_case(self, location, typ, subjects, clauses);
     }
 
     fn visit_typed_expr_record_access(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        label: &'a EcoString,
-        index: &'a u64,
-        record: &'a TypedExpr,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        label: &'ast EcoString,
+        index: &'ast u64,
+        record: &'ast TypedExpr,
     ) {
         visit_typed_expr_record_access(self, location, typ, label, index, record);
     }
 
     fn visit_typed_expr_module_select(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        label: &'a EcoString,
-        module_name: &'a EcoString,
-        module_alias: &'a EcoString,
-        constructor: &'a ModuleValueConstructor,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        label: &'ast EcoString,
+        module_name: &'ast EcoString,
+        module_alias: &'ast EcoString,
+        constructor: &'ast ModuleValueConstructor,
     ) {
         visit_typed_expr_module_select(
             self,
@@ -176,97 +180,97 @@ pub trait Visit<'a> {
 
     fn visit_typed_expr_tuple(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        elems: &'a [TypedExpr],
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        elems: &'ast [TypedExpr],
     ) {
         visit_typed_expr_tuple(self, location, typ, elems);
     }
 
     fn visit_typed_expr_tuple_index(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        index: &'a u64,
-        tuple: &'a TypedExpr,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        index: &'ast u64,
+        tuple: &'ast TypedExpr,
     ) {
         visit_typed_expr_tuple_index(self, location, typ, index, tuple);
     }
 
     fn visit_typed_expr_todo(
         &mut self,
-        location: &'a SrcSpan,
-        message: &'a Option<Box<TypedExpr>>,
-        type_: &'a Arc<Type>,
+        location: &'ast SrcSpan,
+        message: &'ast Option<Box<TypedExpr>>,
+        type_: &'ast Arc<Type>,
     ) {
         visit_typed_expr_todo(self, location, message, type_);
     }
 
     fn visit_typed_expr_panic(
         &mut self,
-        location: &'a SrcSpan,
-        message: &'a Option<Box<TypedExpr>>,
-        type_: &'a Arc<Type>,
+        location: &'ast SrcSpan,
+        message: &'ast Option<Box<TypedExpr>>,
+        type_: &'ast Arc<Type>,
     ) {
         visit_typed_expr_panic(self, location, message, type_);
     }
 
     fn visit_typed_expr_bit_array(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        segments: &'a [TypedExprBitArraySegment],
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        segments: &'ast [TypedExprBitArraySegment],
     ) {
         visit_typed_expr_bit_array(self, location, typ, segments);
     }
 
     fn visit_typed_expr_record_update(
         &mut self,
-        location: &'a SrcSpan,
-        typ: &'a Arc<Type>,
-        spread: &'a TypedExpr,
-        args: &'a [TypedRecordUpdateArg],
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        spread: &'ast TypedExpr,
+        args: &'ast [TypedRecordUpdateArg],
     ) {
         visit_typed_expr_record_update(self, location, typ, spread, args);
     }
 
-    fn visit_typed_expr_negate_bool(&mut self, location: &'a SrcSpan, value: &'a TypedExpr) {
+    fn visit_typed_expr_negate_bool(&mut self, location: &'ast SrcSpan, value: &'ast TypedExpr) {
         visit_typed_expr_negate_bool(self, location, value);
     }
 
-    fn visit_typed_expr_negate_int(&mut self, location: &'a SrcSpan, value: &'a TypedExpr) {
+    fn visit_typed_expr_negate_int(&mut self, location: &'ast SrcSpan, value: &'ast TypedExpr) {
         visit_typed_expr_negate_int(self, location, value)
     }
 
-    fn visit_typed_statement(&mut self, stmt: &'a TypedStatement) {
+    fn visit_typed_statement(&mut self, stmt: &'ast TypedStatement) {
         visit_typed_statement(self, stmt);
     }
 
-    fn visit_typed_assignment(&mut self, assignment: &'a TypedAssignment) {
+    fn visit_typed_assignment(&mut self, assignment: &'ast TypedAssignment) {
         visit_typed_assignment(self, assignment);
     }
 
-    fn visit_use(&mut self, use_: &'a Use) {
+    fn visit_use(&mut self, use_: &'ast Use) {
         visit_use(self, use_);
     }
 
-    fn visit_typed_call_arg(&mut self, arg: &'a TypedCallArg) {
+    fn visit_typed_call_arg(&mut self, arg: &'ast TypedCallArg) {
         visit_typed_call_arg(self, arg);
     }
 
-    fn visit_typed_clause(&mut self, clause: &'a TypedClause) {
+    fn visit_typed_clause(&mut self, clause: &'ast TypedClause) {
         visit_typed_clause(self, clause);
     }
 
-    fn visit_typed_expr_bit_array_segment(&mut self, segment: &'a TypedExprBitArraySegment) {
+    fn visit_typed_expr_bit_array_segment(&mut self, segment: &'ast TypedExprBitArraySegment) {
         visit_typed_expr_bit_array_segment(self, segment);
     }
 
-    fn visit_typed_record_update_arg(&mut self, arg: &'a TypedRecordUpdateArg) {
+    fn visit_typed_record_update_arg(&mut self, arg: &'ast TypedRecordUpdateArg) {
         visit_typed_record_update_arg(self, arg);
     }
 
-    fn visit_typed_bit_array_option(&mut self, option: &'a BitArrayOption<TypedExpr>) {
+    fn visit_typed_bit_array_option(&mut self, option: &'ast BitArrayOption<TypedExpr>) {
         visit_typed_bit_array_option(self, option);
     }
 }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -1,0 +1,619 @@
+#![allow(unused_variables)]
+
+use crate::{
+    ast::TypedAssignment,
+    type_::{ModuleValueConstructor, TypedCallArg, ValueConstructor},
+};
+use std::sync::Arc;
+
+use ecow::EcoString;
+
+use crate::type_::Type;
+
+use super::{
+    BinOp, SrcSpan, TypeAst, TypedArg, TypedClause, TypedExpr, TypedExprBitArraySegment,
+    TypedRecordUpdateArg, TypedStatement,
+};
+
+pub trait Visit<'a> {
+    fn visit_typed_expr(&self, node: &'a TypedExpr) {
+        visit_typed_expr(self, node);
+    }
+
+    fn visit_typed_expr_int(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        value: &'a EcoString,
+    ) {
+        visit_typed_expr_int(self, location, typ, value);
+    }
+
+    fn visit_typed_expr_float(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        value: &'a EcoString,
+    ) {
+        visit_typed_expr_float(self, location, typ, value);
+    }
+
+    fn visit_typed_expr_string(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        value: &'a EcoString,
+    ) {
+        visit_typed_expr_string(self, location, typ, value);
+    }
+
+    fn visit_typed_expr_block(&self, location: &'a SrcSpan, statements: &'a [TypedStatement]) {
+        visit_typed_expr_block(self, location, statements);
+    }
+
+    fn visit_typed_expr_pipeline(
+        &self,
+        location: &'a SrcSpan,
+        assignments: &'a [TypedAssignment],
+        finally: &'a TypedExpr,
+    ) {
+        visit_typed_expr_pipeline(self, location, assignments, finally);
+    }
+
+    fn visit_typed_expr_var(
+        &self,
+        location: &'a SrcSpan,
+        constructor: &'a ValueConstructor,
+        name: &'a EcoString,
+    ) {
+        visit_typed_expr_var(self, location, constructor, name);
+    }
+
+    fn visit_typed_expr_fn(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        is_capture: &'a bool,
+        args: &'a [TypedArg],
+        body: &'a [TypedStatement],
+        return_annotation: &'a Option<TypeAst>,
+    ) {
+        visit_typed_expr_fn(
+            self,
+            location,
+            typ,
+            is_capture,
+            args,
+            body,
+            return_annotation,
+        );
+    }
+
+    fn visit_typed_expr_list(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        elements: &'a [TypedExpr],
+        tail: &'a Option<Box<TypedExpr>>,
+    ) {
+        visit_typed_expr_list(self, location, typ, elements, tail);
+    }
+
+    fn visit_typed_expr_call(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        fun: &'a TypedExpr,
+        args: &'a [TypedCallArg],
+    ) {
+        visit_typed_expr_call(self, location, typ, fun, args);
+    }
+
+    fn visit_typed_expr_bin_op(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        name: &'a BinOp,
+        left: &'a TypedExpr,
+        right: &'a TypedExpr,
+    ) {
+        visit_typed_expr_bin_op(self, location, typ, name, left, right);
+    }
+
+    fn visit_typed_expr_case(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        subjects: &'a [TypedExpr],
+        clauses: &'a [TypedClause],
+    ) {
+        visit_typed_expr_case(self, location, typ, subjects, clauses);
+    }
+
+    fn visit_typed_expr_record_access(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        label: &'a EcoString,
+        index: &'a u64,
+        record: &'a TypedExpr,
+    ) {
+        visit_typed_expr_record_access(self, location, typ, label, index, record);
+    }
+
+    fn visit_typed_expr_module_select(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        label: &'a EcoString,
+        module_name: &'a EcoString,
+        module_alias: &'a EcoString,
+        constructor: &'a ModuleValueConstructor,
+    ) {
+        visit_typed_expr_module_select(
+            self,
+            location,
+            typ,
+            label,
+            module_name,
+            module_alias,
+            constructor,
+        );
+    }
+
+    fn visit_typed_expr_tuple(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        elems: &'a [TypedExpr],
+    ) {
+        visit_typed_expr_tuple(self, location, typ, elems);
+    }
+
+    fn visit_typed_expr_tuple_index(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        index: &'a u64,
+        tuple: &'a TypedExpr,
+    ) {
+        visit_typed_expr_tuple_index(self, location, typ, index, tuple);
+    }
+
+    fn visit_typed_expr_todo(
+        &self,
+        location: &'a SrcSpan,
+        message: &'a Option<Box<TypedExpr>>,
+        type_: &'a Arc<Type>,
+    ) {
+        visit_typed_expr_todo(self, location, message, type_);
+    }
+
+    fn visit_typed_expr_panic(
+        &self,
+        location: &'a SrcSpan,
+        message: &'a Option<Box<TypedExpr>>,
+        type_: &'a Arc<Type>,
+    ) {
+        visit_typed_expr_panic(self, location, message, type_);
+    }
+
+    fn visit_typed_expr_bit_array(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        segments: &'a [TypedExprBitArraySegment],
+    ) {
+        visit_typed_expr_bit_array(self, location, typ, segments);
+    }
+
+    fn visit_typed_expr_record_update(
+        &self,
+        location: &'a SrcSpan,
+        typ: &'a Arc<Type>,
+        spread: &'a TypedExpr,
+        args: &'a [TypedRecordUpdateArg],
+    ) {
+        visit_typed_expr_record_update(self, location, typ, spread, args);
+    }
+
+    fn visit_typed_expr_negate_bool(&self, location: &'a SrcSpan, value: &'a TypedExpr) {
+        visit_typed_expr_negate_bool(self, location, value);
+    }
+
+    fn visit_typed_expr_negate_int(&self, location: &'a SrcSpan, value: &'a TypedExpr) {
+        visit_typed_expr_negate_int(self, location, value)
+    }
+}
+
+pub fn visit_typed_expr<'a, V>(v: &V, node: &'a TypedExpr)
+where
+    V: Visit<'a> + ?Sized,
+{
+    match node {
+        TypedExpr::Int {
+            location,
+            typ,
+            value,
+        } => v.visit_typed_expr_int(location, typ, value),
+        TypedExpr::Float {
+            location,
+            typ,
+            value,
+        } => v.visit_typed_expr_float(location, typ, value),
+        TypedExpr::String {
+            location,
+            typ,
+            value,
+        } => v.visit_typed_expr_string(location, typ, value),
+        TypedExpr::Block {
+            location,
+            statements,
+        } => v.visit_typed_expr_block(location, statements),
+        TypedExpr::Pipeline {
+            location,
+            assignments,
+            finally,
+        } => v.visit_typed_expr_pipeline(location, assignments, finally),
+        TypedExpr::Var {
+            location,
+            constructor,
+            name,
+        } => v.visit_typed_expr_var(location, constructor, name),
+        TypedExpr::Fn {
+            location,
+            typ,
+            is_capture,
+            args,
+            body,
+            return_annotation,
+        } => v.visit_typed_expr_fn(location, typ, is_capture, args, body, return_annotation),
+        TypedExpr::List {
+            location,
+            typ,
+            elements,
+            tail,
+        } => v.visit_typed_expr_list(location, typ, elements, tail),
+        TypedExpr::Call {
+            location,
+            typ,
+            fun,
+            args,
+        } => v.visit_typed_expr_call(location, typ, fun, args),
+        TypedExpr::BinOp {
+            location,
+            typ,
+            name,
+            left,
+            right,
+        } => v.visit_typed_expr_bin_op(location, typ, name, left, right),
+        TypedExpr::Case {
+            location,
+            typ,
+            subjects,
+            clauses,
+        } => v.visit_typed_expr_case(location, typ, subjects, clauses),
+        TypedExpr::RecordAccess {
+            location,
+            typ,
+            label,
+            index,
+            record,
+        } => v.visit_typed_expr_record_access(location, typ, label, index, record),
+        TypedExpr::ModuleSelect {
+            location,
+            typ,
+            label,
+            module_name,
+            module_alias,
+            constructor,
+        } => v.visit_typed_expr_module_select(
+            location,
+            typ,
+            label,
+            module_name,
+            module_alias,
+            constructor,
+        ),
+        TypedExpr::Tuple {
+            location,
+            typ,
+            elems,
+        } => v.visit_typed_expr_tuple(location, typ, elems),
+        TypedExpr::TupleIndex {
+            location,
+            typ,
+            index,
+            tuple,
+        } => v.visit_typed_expr_tuple_index(location, typ, index, tuple),
+        TypedExpr::Todo {
+            location,
+            message,
+            type_,
+        } => v.visit_typed_expr_todo(location, message, type_),
+        TypedExpr::Panic {
+            location,
+            message,
+            type_,
+        } => v.visit_typed_expr_panic(location, message, type_),
+        TypedExpr::BitArray {
+            location,
+            typ,
+            segments,
+        } => v.visit_typed_expr_bit_array(location, typ, segments),
+        TypedExpr::RecordUpdate {
+            location,
+            typ,
+            spread,
+            args,
+        } => v.visit_typed_expr_record_update(location, typ, spread, args),
+        TypedExpr::NegateBool { location, value } => {
+            v.visit_typed_expr_negate_bool(location, value)
+        }
+        TypedExpr::NegateInt { location, value } => v.visit_typed_expr_negate_int(location, value),
+    }
+}
+
+pub fn visit_typed_expr_int<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    value: &'a EcoString,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_expr_float<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    value: &'a EcoString,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_expr_string<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    value: &'a EcoString,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_expr_block<'a, V>(v: &V, location: &'a SrcSpan, statements: &'a [TypedStatement])
+where
+    V: Visit<'a> + ?Sized,
+{
+    for stmt in statements {
+        todo!()
+    }
+}
+
+pub fn visit_typed_expr_pipeline<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    assignments: &'a [TypedAssignment],
+    finally: &'a TypedExpr,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for assignment in assignments {
+        todo!();
+    }
+
+    v.visit_typed_expr(finally);
+}
+
+pub fn visit_typed_expr_var<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    constructor: &'a ValueConstructor,
+    name: &'a EcoString,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_expr_fn<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    is_capture: &'a bool,
+    args: &'a [TypedArg],
+    body: &'a [TypedStatement],
+    return_annotation: &'a Option<TypeAst>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for stmt in body {
+        todo!()
+    }
+}
+
+pub fn visit_typed_expr_list<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    elements: &'a [TypedExpr],
+    tail: &'a Option<Box<TypedExpr>>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for element in elements {
+        v.visit_typed_expr(element);
+    }
+
+    if let Some(tail) = tail {
+        v.visit_typed_expr(tail);
+    }
+}
+
+pub fn visit_typed_expr_call<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    fun: &'a TypedExpr,
+    args: &'a [TypedCallArg],
+) where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(fun);
+    for arg in args {
+        todo!()
+    }
+}
+
+pub fn visit_typed_expr_bin_op<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    name: &'a BinOp,
+    left: &'a TypedExpr,
+    right: &'a TypedExpr,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(left);
+    v.visit_typed_expr(right);
+}
+
+pub fn visit_typed_expr_case<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    subjects: &'a [TypedExpr],
+    clauses: &'a [TypedClause],
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for subject in subjects {
+        v.visit_typed_expr(subject);
+    }
+
+    for clause in clauses {
+        todo!()
+    }
+}
+
+pub fn visit_typed_expr_record_access<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    label: &'a EcoString,
+    index: &'a u64,
+    record: &'a TypedExpr,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(record);
+}
+
+pub fn visit_typed_expr_module_select<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    label: &'a EcoString,
+    module_name: &'a EcoString,
+    module_alias: &'a EcoString,
+    constructor: &'a ModuleValueConstructor,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_expr_tuple<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    elems: &'a [TypedExpr],
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for elem in elems {
+        v.visit_typed_expr(elem);
+    }
+}
+
+pub fn visit_typed_expr_tuple_index<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    index: &'a u64,
+    tuple: &'a TypedExpr,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(tuple);
+}
+
+pub fn visit_typed_expr_todo<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    message: &'a Option<Box<TypedExpr>>,
+    type_: &'a Arc<Type>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    if let Some(message) = message {
+        v.visit_typed_expr(message);
+    }
+}
+
+pub fn visit_typed_expr_panic<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    message: &'a Option<Box<TypedExpr>>,
+    type_: &'a Arc<Type>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    if let Some(message) = message {
+        v.visit_typed_expr(message);
+    }
+}
+
+pub fn visit_typed_expr_bit_array<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    segments: &'a [TypedExprBitArraySegment],
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for segment in segments {
+        todo!()
+    }
+}
+
+pub fn visit_typed_expr_record_update<'a, V>(
+    v: &V,
+    location: &'a SrcSpan,
+    typ: &'a Arc<Type>,
+    spread: &'a TypedExpr,
+    args: &'a [TypedRecordUpdateArg],
+) where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(spread);
+    for arg in args {
+        todo!()
+    }
+}
+
+pub fn visit_typed_expr_negate_bool<'a, V>(v: &V, location: &'a SrcSpan, value: &'a TypedExpr)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(value);
+}
+
+pub fn visit_typed_expr_negate_int<'a, V>(v: &V, location: &'a SrcSpan, value: &'a TypedExpr)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(value);
+}

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -16,12 +16,12 @@ use super::{
 };
 
 pub trait Visit<'a> {
-    fn visit_typed_expr(&self, node: &'a TypedExpr) {
+    fn visit_typed_expr(&mut self, node: &'a TypedExpr) {
         visit_typed_expr(self, node);
     }
 
     fn visit_typed_expr_int(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         value: &'a EcoString,
@@ -30,7 +30,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_float(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         value: &'a EcoString,
@@ -39,7 +39,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_string(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         value: &'a EcoString,
@@ -47,12 +47,12 @@ pub trait Visit<'a> {
         visit_typed_expr_string(self, location, typ, value);
     }
 
-    fn visit_typed_expr_block(&self, location: &'a SrcSpan, statements: &'a [TypedStatement]) {
+    fn visit_typed_expr_block(&mut self, location: &'a SrcSpan, statements: &'a [TypedStatement]) {
         visit_typed_expr_block(self, location, statements);
     }
 
     fn visit_typed_expr_pipeline(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         assignments: &'a [TypedAssignment],
         finally: &'a TypedExpr,
@@ -61,7 +61,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_var(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         constructor: &'a ValueConstructor,
         name: &'a EcoString,
@@ -70,7 +70,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_fn(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         is_capture: &'a bool,
@@ -90,7 +90,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_list(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         elements: &'a [TypedExpr],
@@ -100,7 +100,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_call(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         fun: &'a TypedExpr,
@@ -110,7 +110,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_bin_op(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         name: &'a BinOp,
@@ -121,7 +121,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_case(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         subjects: &'a [TypedExpr],
@@ -131,7 +131,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_record_access(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         label: &'a EcoString,
@@ -142,7 +142,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_module_select(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         label: &'a EcoString,
@@ -162,7 +162,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_tuple(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         elems: &'a [TypedExpr],
@@ -171,7 +171,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_tuple_index(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         index: &'a u64,
@@ -181,7 +181,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_todo(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         message: &'a Option<Box<TypedExpr>>,
         type_: &'a Arc<Type>,
@@ -190,7 +190,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_panic(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         message: &'a Option<Box<TypedExpr>>,
         type_: &'a Arc<Type>,
@@ -199,7 +199,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_bit_array(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         segments: &'a [TypedExprBitArraySegment],
@@ -208,7 +208,7 @@ pub trait Visit<'a> {
     }
 
     fn visit_typed_expr_record_update(
-        &self,
+        &mut self,
         location: &'a SrcSpan,
         typ: &'a Arc<Type>,
         spread: &'a TypedExpr,
@@ -217,28 +217,28 @@ pub trait Visit<'a> {
         visit_typed_expr_record_update(self, location, typ, spread, args);
     }
 
-    fn visit_typed_expr_negate_bool(&self, location: &'a SrcSpan, value: &'a TypedExpr) {
+    fn visit_typed_expr_negate_bool(&mut self, location: &'a SrcSpan, value: &'a TypedExpr) {
         visit_typed_expr_negate_bool(self, location, value);
     }
 
-    fn visit_typed_expr_negate_int(&self, location: &'a SrcSpan, value: &'a TypedExpr) {
+    fn visit_typed_expr_negate_int(&mut self, location: &'a SrcSpan, value: &'a TypedExpr) {
         visit_typed_expr_negate_int(self, location, value)
     }
 
-    fn visit_typed_statement(&self, stmt: &'a TypedStatement) {
+    fn visit_typed_statement(&mut self, stmt: &'a TypedStatement) {
         visit_typed_statement(self, stmt);
     }
 
-    fn visit_typed_assignment(&self, assignment: &'a TypedAssignment) {
+    fn visit_typed_assignment(&mut self, assignment: &'a TypedAssignment) {
         visit_typed_assignment(self, assignment);
     }
 
-    fn visit_use(&self, use_: &'a Use) {
+    fn visit_use(&mut self, use_: &'a Use) {
         visit_use(self, use_);
     }
 }
 
-pub fn visit_typed_expr<'a, V>(v: &V, node: &'a TypedExpr)
+pub fn visit_typed_expr<'a, V>(v: &mut V, node: &'a TypedExpr)
 where
     V: Visit<'a> + ?Sized,
 {
@@ -367,7 +367,7 @@ where
 }
 
 pub fn visit_typed_expr_int<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     value: &'a EcoString,
@@ -377,7 +377,7 @@ pub fn visit_typed_expr_int<'a, V>(
 }
 
 pub fn visit_typed_expr_float<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     value: &'a EcoString,
@@ -387,7 +387,7 @@ pub fn visit_typed_expr_float<'a, V>(
 }
 
 pub fn visit_typed_expr_string<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     value: &'a EcoString,
@@ -396,8 +396,11 @@ pub fn visit_typed_expr_string<'a, V>(
 {
 }
 
-pub fn visit_typed_expr_block<'a, V>(v: &V, location: &'a SrcSpan, statements: &'a [TypedStatement])
-where
+pub fn visit_typed_expr_block<'a, V>(
+    v: &mut V,
+    location: &'a SrcSpan,
+    statements: &'a [TypedStatement],
+) where
     V: Visit<'a> + ?Sized,
 {
     for stmt in statements {
@@ -406,7 +409,7 @@ where
 }
 
 pub fn visit_typed_expr_pipeline<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     assignments: &'a [TypedAssignment],
     finally: &'a TypedExpr,
@@ -421,7 +424,7 @@ pub fn visit_typed_expr_pipeline<'a, V>(
 }
 
 pub fn visit_typed_expr_var<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     constructor: &'a ValueConstructor,
     name: &'a EcoString,
@@ -431,7 +434,7 @@ pub fn visit_typed_expr_var<'a, V>(
 }
 
 pub fn visit_typed_expr_fn<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     is_capture: &'a bool,
@@ -447,7 +450,7 @@ pub fn visit_typed_expr_fn<'a, V>(
 }
 
 pub fn visit_typed_expr_list<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     elements: &'a [TypedExpr],
@@ -465,7 +468,7 @@ pub fn visit_typed_expr_list<'a, V>(
 }
 
 pub fn visit_typed_expr_call<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     fun: &'a TypedExpr,
@@ -480,7 +483,7 @@ pub fn visit_typed_expr_call<'a, V>(
 }
 
 pub fn visit_typed_expr_bin_op<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     name: &'a BinOp,
@@ -494,7 +497,7 @@ pub fn visit_typed_expr_bin_op<'a, V>(
 }
 
 pub fn visit_typed_expr_case<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     subjects: &'a [TypedExpr],
@@ -512,7 +515,7 @@ pub fn visit_typed_expr_case<'a, V>(
 }
 
 pub fn visit_typed_expr_record_access<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     label: &'a EcoString,
@@ -525,7 +528,7 @@ pub fn visit_typed_expr_record_access<'a, V>(
 }
 
 pub fn visit_typed_expr_module_select<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     label: &'a EcoString,
@@ -538,7 +541,7 @@ pub fn visit_typed_expr_module_select<'a, V>(
 }
 
 pub fn visit_typed_expr_tuple<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     elems: &'a [TypedExpr],
@@ -551,7 +554,7 @@ pub fn visit_typed_expr_tuple<'a, V>(
 }
 
 pub fn visit_typed_expr_tuple_index<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     index: &'a u64,
@@ -563,7 +566,7 @@ pub fn visit_typed_expr_tuple_index<'a, V>(
 }
 
 pub fn visit_typed_expr_todo<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     message: &'a Option<Box<TypedExpr>>,
     type_: &'a Arc<Type>,
@@ -576,7 +579,7 @@ pub fn visit_typed_expr_todo<'a, V>(
 }
 
 pub fn visit_typed_expr_panic<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     message: &'a Option<Box<TypedExpr>>,
     type_: &'a Arc<Type>,
@@ -589,7 +592,7 @@ pub fn visit_typed_expr_panic<'a, V>(
 }
 
 pub fn visit_typed_expr_bit_array<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     segments: &'a [TypedExprBitArraySegment],
@@ -602,7 +605,7 @@ pub fn visit_typed_expr_bit_array<'a, V>(
 }
 
 pub fn visit_typed_expr_record_update<'a, V>(
-    v: &V,
+    v: &mut V,
     location: &'a SrcSpan,
     typ: &'a Arc<Type>,
     spread: &'a TypedExpr,
@@ -616,21 +619,21 @@ pub fn visit_typed_expr_record_update<'a, V>(
     }
 }
 
-pub fn visit_typed_expr_negate_bool<'a, V>(v: &V, location: &'a SrcSpan, value: &'a TypedExpr)
+pub fn visit_typed_expr_negate_bool<'a, V>(v: &mut V, location: &'a SrcSpan, value: &'a TypedExpr)
 where
     V: Visit<'a> + ?Sized,
 {
     v.visit_typed_expr(value);
 }
 
-pub fn visit_typed_expr_negate_int<'a, V>(v: &V, location: &'a SrcSpan, value: &'a TypedExpr)
+pub fn visit_typed_expr_negate_int<'a, V>(v: &mut V, location: &'a SrcSpan, value: &'a TypedExpr)
 where
     V: Visit<'a> + ?Sized,
 {
     v.visit_typed_expr(value);
 }
 
-pub fn visit_typed_statement<'a, V>(v: &V, stmt: &'a TypedStatement)
+pub fn visit_typed_statement<'a, V>(v: &mut V, stmt: &'a TypedStatement)
 where
     V: Visit<'a> + ?Sized,
 {
@@ -641,14 +644,14 @@ where
     }
 }
 
-pub fn visit_typed_assignment<'a, V>(v: &V, assignment: &'a TypedAssignment)
+pub fn visit_typed_assignment<'a, V>(v: &mut V, assignment: &'a TypedAssignment)
 where
     V: Visit<'a> + ?Sized,
 {
     v.visit_typed_expr(&assignment.value);
 }
 
-pub fn visit_use<'a, V>(v: &V, use_: &'a Use)
+pub fn visit_use<'a, V>(v: &mut V, use_: &'a Use)
 where
     V: Visit<'a> + ?Sized,
 {

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -289,10 +289,10 @@ where
 {
     match def {
         Definition::Function(fun) => v.visit_typed_function(fun),
-        Definition::TypeAlias(type_alias) => todo!(),
-        Definition::CustomType(custom_type) => todo!(),
-        Definition::Import(import) => todo!(),
-        Definition::ModuleConstant(module_constant) => todo!(),
+        Definition::TypeAlias(type_alias) => { /* TODO */ }
+        Definition::CustomType(custom_type) => { /* TODO */ }
+        Definition::Import(import) => { /* TODO */ }
+        Definition::ModuleConstant(module_constant) => { /* TODO */ }
     }
 }
 pub fn visit_typed_function<'a, V>(v: &mut V, fun: &'a TypedFunction)
@@ -721,7 +721,7 @@ pub fn visit_use<'a, V>(v: &mut V, use_: &'a Use)
 where
     V: Visit<'a> + ?Sized,
 {
-    todo!()
+    { /* TODO */ }
 }
 
 pub fn visit_typed_call_arg<'a, V>(v: &mut V, arg: &'a TypedCallArg)
@@ -760,26 +760,26 @@ where
     V: Visit<'a> + ?Sized,
 {
     match option {
-        BitArrayOption::Bytes { location } => todo!(),
-        BitArrayOption::Int { location } => todo!(),
-        BitArrayOption::Float { location } => todo!(),
-        BitArrayOption::Bits { location } => todo!(),
-        BitArrayOption::Utf8 { location } => todo!(),
-        BitArrayOption::Utf16 { location } => todo!(),
-        BitArrayOption::Utf32 { location } => todo!(),
-        BitArrayOption::Utf8Codepoint { location } => todo!(),
-        BitArrayOption::Utf16Codepoint { location } => todo!(),
-        BitArrayOption::Utf32Codepoint { location } => todo!(),
-        BitArrayOption::Signed { location } => todo!(),
-        BitArrayOption::Unsigned { location } => todo!(),
-        BitArrayOption::Big { location } => todo!(),
-        BitArrayOption::Little { location } => todo!(),
-        BitArrayOption::Native { location } => todo!(),
+        BitArrayOption::Bytes { location } => { /* TODO */ }
+        BitArrayOption::Int { location } => { /* TODO */ }
+        BitArrayOption::Float { location } => { /* TODO */ }
+        BitArrayOption::Bits { location } => { /* TODO */ }
+        BitArrayOption::Utf8 { location } => { /* TODO */ }
+        BitArrayOption::Utf16 { location } => { /* TODO */ }
+        BitArrayOption::Utf32 { location } => { /* TODO */ }
+        BitArrayOption::Utf8Codepoint { location } => { /* TODO */ }
+        BitArrayOption::Utf16Codepoint { location } => { /* TODO */ }
+        BitArrayOption::Utf32Codepoint { location } => { /* TODO */ }
+        BitArrayOption::Signed { location } => { /* TODO */ }
+        BitArrayOption::Unsigned { location } => { /* TODO */ }
+        BitArrayOption::Big { location } => { /* TODO */ }
+        BitArrayOption::Little { location } => { /* TODO */ }
+        BitArrayOption::Native { location } => { /* TODO */ }
         BitArrayOption::Size {
             location,
             value,
             short_form,
         } => v.visit_typed_expr(value),
-        BitArrayOption::Unit { location, value } => todo!(),
+        BitArrayOption::Unit { location, value } => { /* TODO */ }
     }
 }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -793,7 +793,7 @@ where
     v.visit_typed_expr(&arg.value);
 }
 
-pub fn visit_typed_bit_array_option<'a, V>(_v: &mut V, option: &'a BitArrayOption<TypedExpr>)
+pub fn visit_typed_bit_array_option<'a, V>(v: &mut V, option: &'a BitArrayOption<TypedExpr>)
 where
     V: Visit<'a> + ?Sized,
 {
@@ -815,9 +815,11 @@ where
         BitArrayOption::Native { location: _ } => { /* TODO */ }
         BitArrayOption::Size {
             location: _,
-            value: _,
+            value,
             short_form: _,
-        } => { /* TODO */ }
+        } => {
+            v.visit_typed_expr(value);
+        }
         BitArrayOption::Unit {
             location: _,
             value: _,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -11,8 +11,8 @@ use ecow::EcoString;
 use crate::type_::Type;
 
 use super::{
-    BinOp, SrcSpan, Statement, TypeAst, TypedArg, TypedClause, TypedExpr, TypedExprBitArraySegment,
-    TypedRecordUpdateArg, TypedStatement, Use,
+    BinOp, BitArrayOption, SrcSpan, Statement, TypeAst, TypedArg, TypedClause, TypedExpr,
+    TypedExprBitArraySegment, TypedRecordUpdateArg, TypedStatement, Use,
 };
 
 pub trait Visit<'a> {
@@ -235,6 +235,26 @@ pub trait Visit<'a> {
 
     fn visit_use(&mut self, use_: &'a Use) {
         visit_use(self, use_);
+    }
+
+    fn visit_typed_call_arg(&mut self, arg: &'a TypedCallArg) {
+        visit_typed_call_arg(self, arg);
+    }
+
+    fn visit_typed_clause(&mut self, clause: &'a TypedClause) {
+        visit_typed_clause(self, clause);
+    }
+
+    fn visit_typed_expr_bit_array_segment(&mut self, segment: &'a TypedExprBitArraySegment) {
+        visit_typed_expr_bit_array_segment(self, segment);
+    }
+
+    fn visit_typed_record_update_arg(&mut self, arg: &'a TypedRecordUpdateArg) {
+        visit_typed_record_update_arg(self, arg);
+    }
+
+    fn visit_typed_bit_array_option(&mut self, option: &'a BitArrayOption<TypedExpr>) {
+        visit_typed_bit_array_option(self, option);
     }
 }
 
@@ -478,7 +498,7 @@ pub fn visit_typed_expr_call<'a, V>(
 {
     v.visit_typed_expr(fun);
     for arg in args {
-        todo!()
+        v.visit_typed_call_arg(arg);
     }
 }
 
@@ -510,7 +530,7 @@ pub fn visit_typed_expr_case<'a, V>(
     }
 
     for clause in clauses {
-        todo!()
+        v.visit_typed_clause(clause);
     }
 }
 
@@ -600,7 +620,7 @@ pub fn visit_typed_expr_bit_array<'a, V>(
     V: Visit<'a> + ?Sized,
 {
     for segment in segments {
-        todo!()
+        v.visit_typed_expr_bit_array_segment(segment);
     }
 }
 
@@ -615,7 +635,7 @@ pub fn visit_typed_expr_record_update<'a, V>(
 {
     v.visit_typed_expr(spread);
     for arg in args {
-        todo!()
+        v.visit_typed_record_update_arg(arg);
     }
 }
 
@@ -656,4 +676,64 @@ where
     V: Visit<'a> + ?Sized,
 {
     todo!("v.visit_untyped_expr(use_.call)")
+}
+
+pub fn visit_typed_call_arg<'a, V>(v: &mut V, arg: &'a TypedCallArg)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(&arg.value);
+}
+
+pub fn visit_typed_clause<'a, V>(v: &mut V, clause: &'a TypedClause)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(&clause.then);
+}
+
+pub fn visit_typed_expr_bit_array_segment<'a, V>(v: &mut V, segment: &'a TypedExprBitArraySegment)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(&segment.value);
+    for option in &segment.options {
+        v.visit_typed_bit_array_option(option);
+    }
+}
+
+pub fn visit_typed_record_update_arg<'a, V>(v: &mut V, arg: &'a TypedRecordUpdateArg)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(&arg.value);
+}
+
+pub fn visit_typed_bit_array_option<'a, V>(v: &mut V, option: &'a BitArrayOption<TypedExpr>)
+where
+    V: Visit<'a> + ?Sized,
+{
+    match option {
+        BitArrayOption::Bytes { location } => todo!(),
+        BitArrayOption::Int { location } => todo!(),
+        BitArrayOption::Float { location } => todo!(),
+        BitArrayOption::Bits { location } => todo!(),
+        BitArrayOption::Utf8 { location } => todo!(),
+        BitArrayOption::Utf16 { location } => todo!(),
+        BitArrayOption::Utf32 { location } => todo!(),
+        BitArrayOption::Utf8Codepoint { location } => todo!(),
+        BitArrayOption::Utf16Codepoint { location } => todo!(),
+        BitArrayOption::Utf32Codepoint { location } => todo!(),
+        BitArrayOption::Signed { location } => todo!(),
+        BitArrayOption::Unsigned { location } => todo!(),
+        BitArrayOption::Big { location } => todo!(),
+        BitArrayOption::Little { location } => todo!(),
+        BitArrayOption::Native { location } => todo!(),
+        BitArrayOption::Size {
+            location,
+            value,
+            short_form,
+        } => v.visit_typed_expr(value),
+        BitArrayOption::Unit { location, value } => todo!(),
+    }
 }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -105,7 +105,8 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
             // Delete `(`
             let (lparen_offset, _) = code
                 .match_indices('(')
-                .find(|(i, _)| !self.extra.contains(*i as u32))
+                // Ignore in comments
+                .find(|(i, _)| !self.extra.contains(location.start + *i as u32))
                 .expect("`(` not found in tuple");
 
             self.edits.push(TextEdit {
@@ -131,7 +132,8 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
 
                 if let Some((trailing_comma_offset, _)) = code
                     .rmatch_indices(',')
-                    .find(|(i, _)| !self.extra.contains(*i as u32))
+                    // Ignore in comments
+                    .find(|(i, _)| !self.extra.contains(last_elem_span.end + *i as u32))
                 {
                     self.edits.push(TextEdit {
                         range: src_span_to_lsp_range(

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -174,20 +174,17 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
     }
 
     pub fn code_actions(mut self) -> Vec<CodeAction> {
-        let uri = &self.params.text_document.uri;
-        let mut actions = vec![];
-
         self.visit_typed_module(self.module);
-
         if !self.hovered {
             return vec![];
         }
 
         self.edits.sort_by_key(|edit| edit.range.start);
 
+        let mut actions = vec![];
         CodeActionBuilder::new("Remove redundant tuple")
-            .kind(CodeActionKind::QUICKFIX)
-            .changes(uri.clone(), self.edits)
+            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .changes(self.params.text_document.uri.clone(), self.edits)
             .preferred(true)
             .push_to(&mut actions);
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1,4 +1,17 @@
-use lsp_types::{CodeAction, Url};
+use std::sync::Arc;
+
+use ecow::EcoString;
+use lsp_types::{CodeAction, CodeActionKind, CodeActionParams, TextEdit, Url};
+
+use crate::{
+    ast::{self, visit::Visit as _, SrcSpan},
+    build,
+    line_numbers::LineNumbers,
+    parse::extra::ModuleExtra,
+    type_::Type,
+};
+
+use super::{engine::overlaps, src_span_to_lsp_range};
 
 #[derive(Debug)]
 pub struct CodeActionBuilder {
@@ -21,12 +34,12 @@ impl CodeActionBuilder {
         }
     }
 
-    pub fn kind(mut self, kind: lsp_types::CodeActionKind) -> Self {
+    pub fn kind(mut self, kind: CodeActionKind) -> Self {
         self.action.kind = Some(kind);
         self
     }
 
-    pub fn changes(mut self, uri: Url, edits: Vec<lsp_types::TextEdit>) -> Self {
+    pub fn changes(mut self, uri: Url, edits: Vec<TextEdit>) -> Self {
         let mut edit = self.action.edit.take().unwrap_or_default();
         let mut changes = edit.changes.take().unwrap_or_default();
         _ = changes.insert(uri, edits);
@@ -43,5 +56,141 @@ impl CodeActionBuilder {
 
     pub fn push_to(self, actions: &mut Vec<CodeAction>) {
         actions.push(self.action);
+    }
+}
+
+pub struct RedundantTupleInCaseSubject<'a> {
+    line_numbers: LineNumbers,
+    code: &'a EcoString,
+    extra: &'a ModuleExtra,
+    params: &'a CodeActionParams,
+    module: &'a ast::TypedModule,
+    edits: Vec<TextEdit>,
+    hovered: bool,
+}
+
+impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
+    fn visit_typed_expr_case(
+        &mut self,
+        location: &'ast SrcSpan,
+        typ: &'ast Arc<Type>,
+        subjects: &'ast [ast::TypedExpr],
+        clauses: &'ast [ast::TypedClause],
+    ) {
+        for subject in subjects {
+            let ast::TypedExpr::Tuple {
+                location, elems, ..
+            } = subject
+            else {
+                continue;
+            };
+
+            let range = src_span_to_lsp_range(*location, &self.line_numbers);
+            self.hovered = self.hovered || overlaps(self.params.range, range);
+
+            let code = self
+                .code
+                .get(location.start as usize..location.end as usize)
+                .expect("valid span");
+
+            // Delete `#`
+            self.edits.push(TextEdit {
+                range: src_span_to_lsp_range(
+                    SrcSpan::new(location.start, location.start + 1),
+                    &self.line_numbers,
+                ),
+                new_text: "".to_string(),
+            });
+
+            // Delete `(`
+            let (lparen_offset, _) = code
+                .match_indices('(')
+                .find(|(i, _)| !self.extra.contains(*i as u32))
+                .expect("`(` not found in tuple");
+
+            self.edits.push(TextEdit {
+                range: src_span_to_lsp_range(
+                    SrcSpan::new(
+                        location.start + lparen_offset as u32,
+                        location.start + lparen_offset as u32 + 1,
+                    ),
+                    &self.line_numbers,
+                ),
+                new_text: "".to_string(),
+            });
+
+            // Delete trailing `,` (if applicable)
+            if let Some(last_elem) = elems.last() {
+                let last_elem_span = last_elem.location();
+
+                // Get the code after the last element until the tuple's `)`
+                let code = self
+                    .code
+                    .get(last_elem_span.end as usize..location.end as usize)
+                    .expect("valid span");
+
+                if let Some((trailing_comma_offset, _)) = code
+                    .rmatch_indices(',')
+                    .find(|(i, _)| !self.extra.contains(*i as u32))
+                {
+                    self.edits.push(TextEdit {
+                        range: src_span_to_lsp_range(
+                            SrcSpan::new(
+                                last_elem_span.end + trailing_comma_offset as u32,
+                                last_elem_span.end + trailing_comma_offset as u32 + 1,
+                            ),
+                            &self.line_numbers,
+                        ),
+                        new_text: "".to_string(),
+                    });
+                }
+            }
+
+            // Delete )
+            self.edits.push(TextEdit {
+                range: src_span_to_lsp_range(
+                    SrcSpan::new(location.end - 1, location.end),
+                    &self.line_numbers,
+                ),
+                new_text: "".to_string(),
+            });
+        }
+
+        ast::visit::visit_typed_expr_case(self, location, typ, subjects, clauses)
+    }
+}
+
+impl<'a> RedundantTupleInCaseSubject<'a> {
+    pub fn new(module: &'a build::Module, params: &'a CodeActionParams) -> Self {
+        Self {
+            line_numbers: LineNumbers::new(&module.code),
+            code: &module.code,
+            extra: &module.extra,
+            params,
+            module: &module.ast,
+            edits: vec![],
+            hovered: false,
+        }
+    }
+
+    pub fn code_actions(mut self) -> Vec<CodeAction> {
+        let uri = &self.params.text_document.uri;
+        let mut actions = vec![];
+
+        self.visit_typed_module(self.module);
+
+        if !self.hovered {
+            return vec![];
+        }
+
+        self.edits.sort_by_key(|edit| edit.range.start);
+
+        CodeActionBuilder::new("Remove redundant tuple")
+            .kind(CodeActionKind::QUICKFIX)
+            .changes(uri.clone(), self.edits)
+            .preferred(true)
+            .push_to(&mut actions);
+
+        actions
     }
 }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -208,7 +208,7 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
         let (lparen_offset, _) = tuple_code
             .match_indices('(')
             // Ignore in comments
-            .find(|(i, _)| !self.extra.contains(location.start + *i as u32))
+            .find(|(i, _)| !self.extra.is_within_comment(location.start + *i as u32))
             .expect("`(` not found in tuple");
 
         edits.push(TextEdit {
@@ -233,7 +233,11 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
             if let Some((trailing_comma_offset, _)) = code_after_last_elem
                 .rmatch_indices(',')
                 // Ignore in comments
-                .find(|(i, _)| !self.extra.contains(last_elem_location.end + *i as u32))
+                .find(|(i, _)| {
+                    !self
+                        .extra
+                        .is_within_comment(last_elem_location.end + *i as u32)
+                })
             {
                 edits.push(TextEdit {
                     range: src_span_to_lsp_range(

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -184,7 +184,7 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
         self.edits.sort_by_key(|edit| edit.range.start);
 
         let mut actions = vec![];
-        CodeActionBuilder::new("Remove redundant tuple in case subject")
+        CodeActionBuilder::new("Remove redundant tuples")
             .kind(CodeActionKind::REFACTOR_REWRITE)
             .changes(self.params.text_document.uri.clone(), self.edits)
             .preferred(true)

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -182,7 +182,7 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
         self.edits.sort_by_key(|edit| edit.range.start);
 
         let mut actions = vec![];
-        CodeActionBuilder::new("Remove redundant tuple")
+        CodeActionBuilder::new("Remove redundant tuple in case subject")
             .kind(CodeActionKind::REFACTOR_REWRITE)
             .changes(self.params.text_document.uri.clone(), self.edits)
             .preferred(true)

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::{
         Arg, Definition, Import, ModuleConstant, Publicity, SrcSpan, TypedDefinition, TypedExpr,
-        TypedFunction, TypedPattern,
+        TypedFunction, TypedModule, TypedPattern,
     },
     build::{type_constructor_from_modules, Located, Module, UnqualifiedImport},
     config::PackageConfig,
@@ -25,7 +25,8 @@ use std::sync::Arc;
 use strum::IntoEnumIterator;
 
 use super::{
-    code_action::CodeActionBuilder, src_span_to_lsp_range, DownloadDependencies, MakeLocker,
+    code_action::{CodeActionBuilder, RedundantTupleInCaseSubject},
+    src_span_to_lsp_range, DownloadDependencies, MakeLocker,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -248,6 +249,7 @@ where
             };
 
             code_action_unused_imports(module, &params, &mut actions);
+            actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
 
             Ok(if actions.is_empty() {
                 None
@@ -810,7 +812,7 @@ fn hover_for_imported_value(
 }
 
 // Returns true if any part of either range overlaps with the other.
-fn overlaps(a: lsp_types::Range, b: lsp_types::Range) -> bool {
+pub fn overlaps(a: lsp_types::Range, b: lsp_types::Range) -> bool {
     within(a.start, b) || within(a.end, b) || within(b.start, a) || within(b.end, a)
 }
 
@@ -911,7 +913,7 @@ fn format_hexdocs_link_section(package_name: &str, module_name: &str, name: &str
 fn get_hexdocs_link_section(
     module_name: &str,
     name: &str,
-    ast: &crate::ast::TypedModule,
+    ast: &TypedModule,
     hex_deps: &std::collections::HashSet<EcoString>,
 ) -> Option<String> {
     let package_name = ast.definitions.iter().find_map(|def| match def {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -175,7 +175,7 @@ pub fn main() {
 }
 
 #[test]
-fn test_remove_redundant_tuple_in_case_simple() {
+fn test_remove_redundant_tuple_in_case_subject_simple() {
     let code = "
 pub fn main() {
   case #() { a -> 0 }
@@ -189,6 +189,26 @@ pub fn main() {
   case  { a -> 0 }
   case 1 { a -> 0 }
   case 1, 2 { a -> 0 }
+}
+";
+
+    assert_eq!(
+        apply_first_code_action_with_title(code, 7, REMOVE_REDUNDANT_TUPLE_IN_CASE_SUBJECT_TITLE),
+        expected
+    );
+}
+
+#[test]
+fn test_remove_redundant_tuple_in_case_subject_nested() {
+    let code = "
+pub fn main() {
+  case #(case #(0) { a -> 0 }) { b -> 0 }
+}
+";
+
+    let expected = "
+pub fn main() {
+  case case 0 { a -> 0 } { b -> 0 }
 }
 ";
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -51,7 +51,7 @@ fn engine_response(src: &str, line: u32) -> engine::Response<Option<Vec<lsp_type
 }
 
 const REMOVE_UNUSED_IMPORTS_TITLE: &str = "Remove unused imports";
-const REMOVE_REDUNDANT_TUPLE_IN_CASE_SUBJECT_TITLE: &str = "Remove redundant tuple in case subject";
+const REMOVE_REDUNDANT_TUPLES: &str = "Remove redundant tuples";
 
 fn apply_first_code_action_with_title(src: &str, line: u32, title: &str) -> String {
     let response = engine_response(src, line)
@@ -193,7 +193,7 @@ pub fn main() {
 ";
 
     assert_eq!(
-        apply_first_code_action_with_title(code, 7, REMOVE_REDUNDANT_TUPLE_IN_CASE_SUBJECT_TITLE),
+        apply_first_code_action_with_title(code, 7, REMOVE_REDUNDANT_TUPLES),
         expected
     );
 }
@@ -213,7 +213,7 @@ pub fn main() {
 ";
 
     assert_eq!(
-        apply_first_code_action_with_title(code, 7, REMOVE_REDUNDANT_TUPLE_IN_CASE_SUBJECT_TITLE),
+        apply_first_code_action_with_title(code, 7, REMOVE_REDUNDANT_TUPLES),
         expected
     );
 }
@@ -241,8 +241,7 @@ pub fn main() {
 }
 ";
 
-    let result =
-        apply_first_code_action_with_title(code, 20, REMOVE_REDUNDANT_TUPLE_IN_CASE_SUBJECT_TITLE);
+    let result = apply_first_code_action_with_title(code, 20, REMOVE_REDUNDANT_TUPLES);
 
     insta::assert_snapshot!(result);
 }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -51,7 +51,7 @@ fn engine_response(src: &str, line: u32) -> engine::Response<Option<Vec<lsp_type
 }
 
 const REMOVE_UNUSED_IMPORTS_TITLE: &str = "Remove unused imports";
-const REMOVE_REDUNDANT_TUPLE_IN_CASE_SUBJECT_TITLE: &str = "Remove redundant tuple";
+const REMOVE_REDUNDANT_TUPLE_IN_CASE_SUBJECT_TITLE: &str = "Remove redundant tuple in case subject";
 
 fn apply_first_code_action_with_title(src: &str, line: u32, title: &str) -> String {
     let response = engine_response(src, line)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: result
+---
+pub fn main() {
+  case
+    
+      // first comment
+      1,
+      // second comment
+      2,
+      3 // third comment before comma
+
+      
+
+      // fourth comment after comma
+
+    
+  {
+    a -> 0
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
@@ -17,6 +17,17 @@ pub fn main() {
 
     
   {
-    a -> 0
+    
+      // first comment
+      a,
+      // second comment
+      b,
+      c // third comment before comma
+
+      
+
+      // fourth comment after comma
+
+     -> 0
   }
 }

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -16,16 +16,18 @@ impl ModuleExtra {
         Default::default()
     }
 
-    pub fn contains(&self, offset: u32) -> bool {
-        self.module_comments
-            .iter()
-            .any(|span| span.contains(offset))
-            || self.doc_comments.iter().any(|span| span.contains(offset))
-            || self.comments.iter().any(|span| span.contains(offset))
+    pub fn is_within_comment(&self, byte_index: u32) -> bool {
+        self.comments
+            .binary_search_by(|span| span.cmp_byte_index(byte_index))
+            .is_ok()
             || self
-                .empty_lines
-                .iter()
-                .any(|&empty_line_offset| empty_line_offset == offset)
+                .doc_comments
+                .binary_search_by(|span| span.cmp_byte_index(byte_index))
+                .is_ok()
+            || self
+                .module_comments
+                .binary_search_by(|span| span.cmp_byte_index(byte_index))
+                .is_ok()
     }
 }
 

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -15,6 +15,18 @@ impl ModuleExtra {
     pub fn new() -> Self {
         Default::default()
     }
+
+    pub fn contains(&self, offset: u32) -> bool {
+        self.module_comments
+            .iter()
+            .any(|span| span.contains(offset))
+            || self.doc_comments.iter().any(|span| span.contains(offset))
+            || self.comments.iter().any(|span| span.contains(offset))
+            || self
+                .empty_lines
+                .iter()
+                .any(|&empty_line_offset| empty_line_offset == offset)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
Closes #2982

Supports batch removal.

Also adds a basic visitor pattern to walk the typed AST.