### PR TITLE
Convert String Segments in Bit Arrays to \x form for Erlang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,3 +309,5 @@
 - Fixed a bug where having utf8 symbols in `gleam.toml`'s description value
   would result in an HTTP 500 error when running `gleam publish`.
   ([inoas](https://github.com/inoas))
+- Unicode `\u{}` syntax in bit_array string segments now produce valid Erlang
+  unicode characters ([Pi-Cla](https://github.com/Pi-Cla))

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -602,7 +602,7 @@ fn expr_segment<'a>(
         // Skip the normal <<value/utf8>> surrounds and set the string literal flag
         TypedExpr::String { value, .. } => {
             value_is_a_string_literal = true;
-            value.to_doc().surround("\"", "\"")
+            string_inner(value).surround("\"", "\"")
         }
 
         // As normal

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -128,3 +128,25 @@ fn bit_array_declare_and_use_var() {
 }"#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3050
+#[test]
+fn unicode_bit_array_1() {
+    assert_erl!(
+        r#"
+    pub fn main() {
+        let emoji = "\u{1F600}"
+        let arr = <<emoji:utf8>>
+}"#
+    );
+}
+
+#[test]
+fn unicode_bit_array_2() {
+    assert_erl!(
+        r#"
+    pub fn main() {
+        let arr = <<"\u{1F600}":utf8>>
+}"#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_1.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\n    pub fn main() {\n        let emoji = \"\\u{1F600}\"\n        let arr = <<emoji:utf8>>\n}"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> bitstring().
+main() ->
+    Emoji = <<"\x{1F600}"/utf8>>,
+    Arr = <<Emoji/binary>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_2.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\n    pub fn main() {\n        let arr = <<\"\\u{1F600}\":utf8>>\n}"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> bitstring().
+main() ->
+    Arr = <<"\x{1F600}"/utf8>>.

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -937,6 +937,8 @@ fn bit_array_target_tests() -> List(Test) {
     |> example(fn() {
       assert_equal(True, <<63, 128, 0, 0>> == <<1.0:float-32>>)
     }),
+    "<<\"😀\":utf8>> == <<\"\u{1F600}\":utf8>>"
+    |> example(fn() { assert_equal(True, <<"😀":utf8>> == <<"\u{1F600}":utf8>>) }),
   ]
 }
 


### PR DESCRIPTION
Fixes #3050