### PR TITLE
LSP hover on unqualified support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,8 @@
 
 - Go to definition now works for import statements. ([Ameen Radwan](https://github.com/Acepie))
 
+- Hover now works for unqualified imports. ([Ameen Radwan](https://github.com/Acepie))
+
 ### Bug Fixes
 
 - Fixed [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145) by

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -750,6 +750,7 @@ impl TypedDefinition {
                                 name: &unqualified.name,
                                 module: &import.module,
                                 is_type: false,
+                                location: &unqualified.location,
                             },
                         ));
                     }
@@ -764,6 +765,7 @@ impl TypedDefinition {
                                 name: &unqualified.name,
                                 module: &import.module,
                                 is_type: true,
+                                location: &unqualified.location,
                             },
                         ));
                     }

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -293,6 +293,7 @@ pub struct UnqualifiedImport<'a> {
     pub name: &'a EcoString,
     pub module: &'a EcoString,
     pub is_type: bool,
+    pub location: &'a SrcSpan,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -341,6 +342,7 @@ impl<'a> Located<'a> {
                 module,
                 name,
                 is_type,
+                ..
             }) => importable_modules.get(*module).and_then(|m| {
                 if *is_type {
                     m.types.get(*name).map(|t| DefinitionLocation {

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -739,3 +739,95 @@ fn identity(x: Wibble) -> Wibble {
         })
     );
 }
+
+#[test]
+fn hover_import_unqualified_value() {
+    let code = "
+import example_module.{my_num}
+fn main() {
+  my_num
+}
+";
+
+    assert_eq!(
+        hover(
+            TestProject::for_source(code).add_module(
+                "example_module",
+                "
+/// Exciting documentation
+/// Maybe even multiple lines
+pub const my_num = 1"
+            ),
+            Position::new(1, 26)
+        ),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines\n"
+                    .to_string()
+            )),
+            range: Some(Range::new(Position::new(1, 23), Position::new(1, 29))),
+        })
+    )
+}
+
+#[test]
+fn hover_import_unqualified_value_from_hex() {
+    let code = "
+import example_module.{my_num}
+fn main() {
+  my_num
+}
+";
+
+    assert_eq!(
+        hover(
+            TestProject::for_source(code).add_hex_module(
+                "example_module",
+                "
+/// Exciting documentation
+/// Maybe even multiple lines
+pub const my_num = 1"
+            ),
+            Position::new(1, 26)
+        ),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_num)"
+                    .to_string()
+            )),
+            range: Some(Range::new(Position::new(1, 23), Position::new(1, 29))),
+        })
+    )
+}
+
+#[test]
+fn hover_import_unqualified_type() {
+    let code = "
+import example_module.{type MyType, MyType}
+fn main() -> MyType {
+  MyType
+}
+";
+
+    assert_eq!(
+        hover(
+            TestProject::for_source(code).add_module(
+                "example_module",
+                "
+/// Exciting documentation
+/// Maybe even multiple lines
+pub type MyType {
+    MyType
+}"
+            ),
+            Position::new(1, 33)
+        ),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nMyType\n```\n Exciting documentation\n Maybe even multiple lines\n"
+                    .to_string()
+            )),
+            range: Some(Range::new(Position::new(1, 23), Position::new(1, 34))),
+        })
+    )
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2176,8 +2176,9 @@ where
                         as_name: None,
                     };
                     if self.maybe_one(&Token::As).is_some() {
-                        let (_, as_name, _) = self.expect_name()?;
+                        let (_, as_name, end) = self.expect_name()?;
                         import.as_name = Some(as_name);
+                        import.location.end = end;
                     }
                     imports.values.push(import)
                 }
@@ -2191,8 +2192,9 @@ where
                         as_name: None,
                     };
                     if self.maybe_one(&Token::As).is_some() {
-                        let (_, as_name, _) = self.expect_upname()?;
+                        let (_, as_name, end) = self.expect_upname()?;
                         import.as_name = Some(as_name);
+                        import.location.end = end;
                     }
                     imports.values.push(import)
                 }
@@ -2207,8 +2209,9 @@ where
                         as_name: None,
                     };
                     if self.maybe_one(&Token::As).is_some() {
-                        let (_, as_name, _) = self.expect_upname()?;
+                        let (_, as_name, end) = self.expect_upname()?;
                         import.as_name = Some(as_name);
+                        import.location.end = end;
                     }
                     imports.types.push(import)
                 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as.snap
@@ -6,7 +6,7 @@ error: Duplicate type definition
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{type One as MyOne, type One as MyOne}
-  │             ^^^^^^^^           ^^^^^^^^ Redefined here
+  │             ^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^ Redefined here
   │             │                   
   │             First defined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as_multiline.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as_multiline.snap
@@ -6,9 +6,9 @@ error: Duplicate type definition
   ┌─ /src/one/two.gleam:2:11
   │
 2 │           type One as MyOne,
-  │           ^^^^^^^^ First defined here
+  │           ^^^^^^^^^^^^^^^^^ First defined here
 3 │           type One as MyOne
-  │           ^^^^^^^^ Redefined here
+  │           ^^^^^^^^^^^^^^^^^ Redefined here
 
 The type `MyOne` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.


### PR DESCRIPTION
Hovering over an unqualified import for an type shows the same hover as using the type as an annotation. Hovering over an unqualified import for a value has the same behavior as hovering over the value as an expression. This is true for both the unqualified name as well as the as name