### PR TITLE
Add gleam hex revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@
 
   Hint: Rename this module and try again.
   ```
+- New subcommand `gleam hex revert` added. ([Pi-Cla](https://github.com/Pi-Cla))
+  * You can specify the options like this: `gleam hex revert --package gling --version 1.2.3`
+  * A new package can be reverted or updated within 24 hours of it's initial publish,
+  a new version of an existing package can be reverted or updated within one hour.
+  * You could already update packages even before this release by running: `gleam publish` again.
 
 ### Compiler
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -365,6 +365,20 @@ enum Hex {
     /// - HEXPM_PASS: (optional) The Hex password to authenticate with.
     #[command(verbatim_doc_comment)]
     Unretire { package: String, version: String },
+
+    /// Revert a release from Hex
+    ///
+    /// This command uses this environment variables:
+    ///
+    /// - HEXPM_USER: (optional) The Hex username to authenticate with.
+    /// - HEXPM_PASS: (optional) The Hex password to authenticate with.
+    Revert {
+        #[arg(long)]
+        package: Option<String>,
+
+        #[arg(long)]
+        version: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -469,6 +483,8 @@ fn main() {
         Command::Hex(Hex::Unretire { package, version }) => {
             hex::UnretireCommand::new(package, version).run()
         }
+
+        Command::Hex(Hex::Revert { package, version }) => hex::revertcommand(package, version),
 
         Command::Add { packages, dev } => add::command(packages, dev),
 

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -5,8 +5,8 @@ use gleam_core::{
     build::{Codegen, Mode, Options, Package, Target},
     config::{PackageConfig, SpdxLicense},
     docs::DocContext,
-    hex, paths,
-    paths::ProjectPaths,
+    hex,
+    paths::{self, ProjectPaths},
     requirement::Requirement,
     Error, Result,
 };


### PR DESCRIPTION
A new package can be reverted or updated within 24 hours of it's initial publish, a new version of an existing package can be reverted or updated within one hour.

Resolves #3019