### PR TITLE
Don't move comments outside of record constructor #3018

### DIFF
--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2309,9 +2309,13 @@ impl<'comments> Formatter<'comments> {
         let comments = self.pop_comments(location.end);
         let closing_parens = match printed_comments(comments, false) {
             None => docvec!(break_(",", ""), ")"),
-            Some(comment) => {
-                docvec!(break_(",", "").nest(INDENT), comment.nest(INDENT), line(), ")").force_break()
-            }
+            Some(comment) => docvec!(
+                break_(",", "").nest(INDENT),
+                comment.nest(INDENT),
+                line(),
+                ")"
+            )
+            .force_break(),
         };
 
         "(".to_doc().append(args_doc).append(closing_parens).group()

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1481,11 +1481,10 @@ impl<'comments> Formatter<'comments> {
         let doc = if constructor.arguments.is_empty() {
             constructor.name.as_str().to_doc()
         } else {
-            constructor
-                .name
-                .as_str()
-                .to_doc()
-                .append(wrap_args(constructor.arguments.iter().map(
+            let args = constructor
+                .arguments
+                .iter()
+                .map(
                     |RecordConstructorArg {
                          label,
                          ast,
@@ -1503,7 +1502,13 @@ impl<'comments> Formatter<'comments> {
                             arg_comments,
                         )
                     },
-                )))
+                )
+                .collect::<Vec<Document<'a>>>();
+            constructor
+                .name
+                .as_str()
+                .to_doc()
+                .append(self.wrap_function_call_args(args, &constructor.location))
                 .group()
         };
 
@@ -2305,7 +2310,7 @@ impl<'comments> Formatter<'comments> {
         let closing_parens = match printed_comments(comments, false) {
             None => docvec!(break_(",", ""), ")"),
             Some(comment) => {
-                docvec!(break_(",", "").nest(INDENT), comment, line(), ")").force_break()
+                docvec!(break_(",", "").nest(INDENT), comment.nest(INDENT), line(), ")").force_break()
             }
         };
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5960,7 +5960,7 @@ pub const wibble = 1
 }
 
 #[test]
-fn comments_inside_contant_list() {
+fn comments_inside_constant_list() {
     assert_format!(
         r#"const wibble = [
   // A comment
@@ -5974,7 +5974,7 @@ fn comments_inside_contant_list() {
 }
 
 #[test]
-fn comments_inside_contant_empty_list() {
+fn comments_inside_constant_empty_list() {
     assert_format!(
         r#"const wibble = [
   // A comment
@@ -5984,7 +5984,7 @@ fn comments_inside_contant_empty_list() {
 }
 
 #[test]
-fn comments_inside_contant_tuple() {
+fn comments_inside_constant_tuple() {
     assert_format!(
         r#"const wibble = #(
   // A comment
@@ -5999,7 +5999,7 @@ fn comments_inside_contant_tuple() {
 }
 
 #[test]
-fn comments_inside_contant_empty_tuple() {
+fn comments_inside_constant_empty_tuple() {
     assert_format!(
         r#"const wibble = #(
   // A comment

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5960,6 +5960,34 @@ pub const wibble = 1
 }
 
 #[test]
+fn comments_inside_type_constructor() {
+    assert_format!(
+        r#"type Select {
+  Select(
+    // comment: String,
+    // modifier: String,
+    // with: String,
+    select: String,
+    distinct: String,
+    from: String,
+    join: String,
+    where: String,
+    group_by: String,
+    having: String,
+    // window: String,
+    order: String,
+    limit: String,
+    offset: String,
+    union: String,
+    // stuff
+    // epilog: String,
+  )
+}
+"#
+    );
+}
+
+#[test]
 fn comments_inside_constant_list() {
     assert_format!(
         r#"const wibble = [
@@ -6031,6 +6059,23 @@ fn comments_at_the_end_of_anonymous_function() {
     // another final comment
     // at the end of the block
   }
+}
+"#
+    );
+}
+
+#[test]
+fn comments_at_the_end_of_function_call() {
+    assert_format!(
+        r#"pub fn main() {
+  wibble(
+    wobble,
+    wubble,
+    wabble,
+    // One
+    // Two
+    // Three
+  )
 }
 "#
     );


### PR DESCRIPTION
I believe this fixes #3018: Now type constructors are formatted correctly, like so:

```gleam
type Select {
  Select(
    // comment: String,
    // modifier: String,
    // with: String,
    select: String,
    distinct: String,
    from: String,
    join: String,
    where: String,
    group_by: String,
    having: String,
    // window: String,
    order: String,
    limit: String,
    offset: String,
    union: String,
    // epilog: String,
  )
}
```

instead of the last comment being moved out of the parens:

```gleam
    offset: String,
    union: String,
  )
  // epilog: String,
}
```


(I'd been trying to figure this out for about a week and only just now saw that, in the meantime, @Axot017 [expressed interest](https://github.com/gleam-lang/gleam/issues/3018#issuecomment-2091554180) in solving this ticket too. I hope it's ok to post this PR!)