### PR TITLE
Fix formatting of trailing comments in arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,53 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Comments appearing after arguments are not longer moved to different place.
+  You can now write all of those:
+
+  ```gleam
+  type Record {
+    Record(
+      field: String,
+      // comment_line_1: String,
+      // comment_line_2: String,
+    )
+  }
+  ```
+
+  ```gleam
+  pub fn main() {
+    fn(
+      a,
+      // A comment 2
+    ) {
+      1
+    }
+  }
+  ```
+
+  ```gleam
+  fn main() {
+    let triple = Triple(1, 2, 3)
+    let Triple(
+      a,
+      ..,
+      // comment
+    ) = triple
+    a
+  }
+  ```
+
+  ```gleam
+  type Record {
+    Record(
+      // comment_line_1: String,
+      // comment_line_2: String,
+    )
+  }
+  ```
+
+  ([Mateusz Ledwoń](https://github.com/Axot017))
+
 ### Language Server
 
 - The code action to remove unused imports now removes the entire line is

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -531,7 +531,7 @@ fn function<'a>(
             text_documentation: text_documentation(doc),
             signature: print(
                 formatter
-                    .docs_fn_signature(Publicity::Public, name, args, ret.clone())
+                    .docs_fn_signature(Publicity::Public, name, args, ret.clone(), location)
                     .group(),
             ),
             source_url: source_links.url(*location),
@@ -667,7 +667,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
             name,
             definition: print(
                 formatter
-                    .type_alias(Publicity::Public, name, args, typ, deprecation)
+                    .type_alias(Publicity::Public, name, args, typ, deprecation, location)
                     .group(),
             ),
             documentation: markdown_documentation(doc),

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6035,3 +6035,77 @@ fn comments_at_the_end_of_anonymous_function() {
 "#
     );
 }
+
+#[test]
+fn comments_in_anonymous_function_args() {
+    assert_format!(
+        r#"pub fn main() {
+  fn(
+    // A comment 1
+    // A comment 2
+  ) {
+    1
+  }
+}
+"#
+    );
+    assert_format!(
+        r#"pub fn main() {
+  fn(
+    // A comment 1
+    a,
+    // A comment 2
+  ) {
+    1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn comments_after_last_argument_of_record_constructor() {
+    assert_format!(
+        r#"type Record {
+  Record(
+    field: String,
+    // comment_line_1: String,
+    // comment_line_2: String,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn only_comments_in_record_constructor() {
+    assert_format!(
+        r#"type Record {
+  Record(
+    // comment_line_1: String,
+    // comment_line_2: String,
+  )
+}
+"#
+    );
+}
+#[test]
+fn comment_after_spread_operator() {
+    assert_format!(
+        "type Triple {
+  Triple(a: Int, b: Int, c: Int)
+}
+
+fn main() {
+  let triple = Triple(1, 2, 3)
+  let Triple(
+    really_really_long_variable_name_a,
+    c: really_really_long_variable_name_c,
+    ..,
+    // comment
+  ) = triple
+  really_really_long_variable_name_c
+}
+"
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/gleam/issues/3018 and related issues. (After investigation it turned out that this bug occurs in every place where wrap_args was used so I fixed all of them)