### PR TITLE
Add hint to use --replace flag when not explicitly replacing a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,20 @@
   a new version of an existing package can be reverted or updated within one hour.
   * You could already update packages even before this release by running: `gleam publish` again.
 
+- When the user tries to replace a release without the `--replace` flag
+  the error message now mentions the lack of a `--replace` flag.
+  ([Pi-Cla](https://github.com/Pi-Cla))
+
+  ```
+  error: Version already published
+
+  Version v1.0.0 has already been published.
+  This release has been recently published so you can replace it
+  or you can publish it using a different version number
+
+  Hint: Please add the --replace flag if you want to replace the release.
+  ```
+
 ### Compiler
 
 - The compiler will now raise a warning for `let assert` assignments where the

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -193,6 +193,7 @@ impl ApiKeyCommand for PublishCommand {
 
         runtime.block_on(hex::publish_package(
             std::mem::take(&mut self.package_tarball),
+            self.config.version.to_string(),
             api_key,
             hex_config,
             self.replace,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -270,6 +270,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
 
     #[error("The Gleam module {path} would overwrite the Erlang module {name}")]
     GleamModuleWouldOverwriteStandardErlangModule { name: EcoString, path: Utf8PathBuf },
+
+    #[error("Version already published")]
+    HexPublishReplaceRequired { version: String },
 }
 
 impl Error {
@@ -3364,6 +3367,16 @@ causing confusing errors and crashes.
                 level: Level::Error,
                 location: None,
                 hint: Some("Rename this module and try again.".into()),
+            }],
+
+            Error::HexPublishReplaceRequired { version } => vec![Diagnostic {
+                title: "Version already published".into(),
+                text: wrap_format!("Version v{version} has already been published.
+This release has been recently published so you can replace it \
+or you can publish it using a different version number"),
+                level: Level::Error,
+                location: None,
+                hint: Some("Please add the --replace flag if you want to replace the release.".into()),
             }],
         }
     }

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -2,7 +2,7 @@ use camino::Utf8Path;
 use debug_ignore::DebugIgnore;
 use flate2::read::GzDecoder;
 use futures::future;
-use hexpm::version::Version;
+use hexpm::{version::Version, ApiError};
 use tar::Archive;
 
 use crate::{
@@ -29,6 +29,7 @@ fn key_name(hostname: &str) -> String {
 
 pub async fn publish_package<Http: HttpClient>(
     release_tarball: Vec<u8>,
+    version: String,
     api_key: &str,
     config: &hexpm::Config,
     replace: bool,
@@ -37,7 +38,10 @@ pub async fn publish_package<Http: HttpClient>(
     tracing::info!("Publishing package, replace: {}", replace);
     let request = hexpm::publish_package_request(release_tarball, api_key, config, replace);
     let response = http.send(request).await?;
-    hexpm::publish_package_response(response).map_err(Error::hex)
+    hexpm::publish_package_response(response).map_err(|e| match e {
+        ApiError::NotReplacing => Error::HexPublishReplaceRequired { version },
+        err => Error::hex(err),
+    })
 }
 
 #[derive(Debug, strum::EnumString, strum::VariantNames, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Resolves #2271