### PR TITLE
Try to compile time error when trying to make non byte aligned array on js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,24 @@
   reserved word in Erlang/OTP 27.
   ([Jake Barszcz](https://github.com/barszcz))
 
+- Non byte aligned arrays that use literals for size are now marked as an
+  Unsupported feature for Javascript since they would already cause
+  a runtime error on Javascript.
+
+  This means if you compile specifically for Javascript you will now recieve this error:
+
+  ```
+  error: Unsupported feature for compilation target
+    ┌─ /src/test/gleam_test.gleam:6:5
+    │
+  6 │   <<1:size(5)>>
+    │     ^^^^^^^^^
+
+  Non byte aligned array is not supported for JavaScript compilation.
+  ```
+
+  Else any functions which rely on this will not be compiled into Javascript.
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -129,6 +129,17 @@ fn bit_array_declare_and_use_var() {
     );
 }
 
+#[test]
+fn negative_size() {
+    assert_erl!(
+        r#"
+pub fn main() {
+  <<1:size(-1)>>
+}
+"#,
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/3050
 #[test]
 fn unicode_bit_array_1() {

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__negative_size.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__negative_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\npub fn main() {\n  <<1:size(-1)>>\n}\n"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> bitstring().
+main() ->
+    <<1:0>>.

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -60,7 +60,7 @@ fn sized() {
     assert_js!(
         r#"
 fn go() {
-  <<256:4>>
+  <<256:64>>
 }
 "#,
     );
@@ -71,7 +71,7 @@ fn explicit_sized() {
     assert_js!(
         r#"
 fn go() {
-  <<256:size(4)>>
+  <<256:size(64)>>
 }
 "#,
     );
@@ -295,4 +295,46 @@ fn as_module_const() {
           >>
         "#
     )
+}
+
+// https://github.com/gleam-lang/gleam/issues/1591
+#[test]
+fn not_byte_aligned() {
+    assert_js!(
+        r#"
+fn thing() {
+  4
+}
+
+fn go() {
+  <<256:4>>
+}
+"#,
+    );
+}
+
+#[test]
+fn not_byte_aligned_explicit_sized() {
+    assert_js!(
+        r#"
+fn go() {
+  <<256:size(4)>>
+}
+"#,
+    );
+}
+
+// This test would ideally also result in go() being deleted like the previous tests
+// but we can not know for sure what the value of a variable is going to be
+// so right now go() is not deleted.
+#[test]
+fn not_byte_aligned_variable() {
+    assert_js!(
+        r#"
+fn go() {
+  let x = 4
+  <<256:size(x)>>
+}
+"#,
+    );
 }

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -297,6 +297,17 @@ fn as_module_const() {
     )
 }
 
+#[test]
+fn negative_size() {
+    assert_js!(
+        r#"
+fn go() {
+  <<1:size(-1)>>
+}
+"#,
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/1591
 #[test]
 fn not_byte_aligned() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn go() {\n  <<1:size(-1)>>\n}\n"
+---
+import { toBitArray, sizedInt } from "../gleam.mjs";
+
+function go() {
+  return toBitArray([sizedInt(1, -1)]);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn thing() {\n  4\n}\n\nfn go() {\n  <<256:4>>\n}\n"
+---
+import { toBitArray } from "../gleam.mjs";
+
+function thing() {
+  return 4;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned_explicit_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned_explicit_sized.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn go() {\n  <<256:size(4)>>\n}\n"
+---
+import { toBitArray } from "../gleam.mjs";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned_variable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned_variable.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:size(64)>>\n}\n"
+expression: "\nfn go() {\n  let x = 4\n  <<256:size(x)>>\n}\n"
 ---
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([sizedInt(256, 64)]);
+  let x = 4;
+  return toBitArray([sizedInt(256, x)]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:4>>\n}\n"
+expression: "\nfn go() {\n  <<256:64>>\n}\n"
 ---
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([sizedInt(256, 4)]);
+  return toBitArray([sizedInt(256, 64)]);
 }


### PR DESCRIPTION
Try to detect when someone tries to make a non byte aligned array on Javascript. This compile time error still fails to trigger if the size value is a variable though. So we still need the runtime error in the Javascript template too.

Fixes #1591