### PR TITLE
Change 'field' to 'label' in TypeError::DuplicateField definition

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1378,9 +1378,9 @@ Names in a Gleam module must be unique so one will need to be renamed."
 
                 TypeError::DuplicateField { location, label } => {
                     let text =
-                        format!("The field `{label}` has already been defined. Rename this field.");
+                        format!("The label `{label}` has already been defined. Rename this label.");
                     Diagnostic {
-                        title: "Duplicate field".into(),
+                        title: "Duplicate label".into(),
                         text,
                         hint: None,
                         level: Level::Error,


### PR DESCRIPTION
According to https://github.com/gleam-lang/gleam/issues/3122 there's an error message incorrectly identifying a "label" as a "field". This PR changes the error message to say "label" as shown below:

Before

``The field `a` has already been defined.``

After

``The label `a` has already been defined.``
