### PR TITLE
fix formatting when comment is before first statement in anonymous function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fixed a bug where the formatter would incorrectly move comments at the start of an anonymous function to the end of the arguments. ([Ameen Radwan](https://github.com/Acepie))
+
 ## v1.2.0-rc1 - 2024-05-23
 
 ### Build tool

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -31,11 +31,11 @@ pub enum UntypedExpr {
 
     // TODO: create new variant for captures specifically
     Fn {
-        /// The location from the start of the `fn` keyword to the end of the head before the opening bracket
-        head_location: SrcSpan,
         /// For anonymous functions, this is the location of the entire function including the end of the body.
         /// For named functions, this is the location of the function head.
         location: SrcSpan,
+        /// The byte location of the end of the function head before the opening bracket
+        end_of_head_byte_index: u32,
         is_capture: bool,
         arguments: Vec<Arg<()>>,
         body: Vec1<UntypedStatement>,

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -31,6 +31,10 @@ pub enum UntypedExpr {
 
     // TODO: create new variant for captures specifically
     Fn {
+        /// The location from the start of the `fn` keyword to the end of the head before the opening bracket
+        head_location: SrcSpan,
+        /// For anonymous functions, this is the location of the entire function including the end of the body.
+        /// For named functions, this is the location of the function head.
         location: SrcSpan,
         is_capture: bool,
         arguments: Vec<Arg<()>>,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -249,12 +249,20 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             } => self.fold_block(location, statements),
 
             UntypedExpr::Fn {
+                head_location,
                 location,
                 is_capture,
                 arguments,
                 body,
                 return_annotation,
-            } => self.fold_fn(location, is_capture, arguments, body, return_annotation),
+            } => self.fold_fn(
+                head_location,
+                location,
+                is_capture,
+                arguments,
+                body,
+                return_annotation,
+            ),
 
             UntypedExpr::List {
                 location,
@@ -361,6 +369,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             }
 
             UntypedExpr::Fn {
+                head_location,
                 location,
                 is_capture,
                 arguments,
@@ -371,6 +380,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 let return_annotation = return_annotation.map(|t| self.fold_type(t));
                 let body = body.mapped(|s| self.fold_statement(s));
                 UntypedExpr::Fn {
+                    head_location,
                     location,
                     is_capture,
                     arguments,
@@ -653,6 +663,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
     fn fold_fn(
         &mut self,
+        head_location: SrcSpan,
         location: SrcSpan,
         is_capture: bool,
         arguments: Vec<UntypedArg>,
@@ -660,6 +671,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         return_annotation: Option<TypeAst>,
     ) -> UntypedExpr {
         UntypedExpr::Fn {
+            head_location,
             location,
             is_capture,
             arguments,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -249,15 +249,15 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             } => self.fold_block(location, statements),
 
             UntypedExpr::Fn {
-                head_location,
                 location,
+                end_of_head_byte_index,
                 is_capture,
                 arguments,
                 body,
                 return_annotation,
             } => self.fold_fn(
-                head_location,
                 location,
+                end_of_head_byte_index,
                 is_capture,
                 arguments,
                 body,
@@ -369,8 +369,8 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             }
 
             UntypedExpr::Fn {
-                head_location,
                 location,
+                end_of_head_byte_index,
                 is_capture,
                 arguments,
                 body,
@@ -380,8 +380,8 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 let return_annotation = return_annotation.map(|t| self.fold_type(t));
                 let body = body.mapped(|s| self.fold_statement(s));
                 UntypedExpr::Fn {
-                    head_location,
                     location,
+                    end_of_head_byte_index,
                     is_capture,
                     arguments,
                     body,
@@ -663,16 +663,16 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
     fn fold_fn(
         &mut self,
-        head_location: SrcSpan,
         location: SrcSpan,
+        end_of_head_byte_index: u32,
         is_capture: bool,
         arguments: Vec<UntypedArg>,
         body: Vec1<UntypedStatement>,
         return_annotation: Option<TypeAst>,
     ) -> UntypedExpr {
         UntypedExpr::Fn {
-            head_location,
             location,
+            end_of_head_byte_index,
             is_capture,
             arguments,
             body,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -788,10 +788,11 @@ impl<'comments> Formatter<'comments> {
         return_annotation: Option<&'a TypeAst>,
         body: &'a Vec1<UntypedStatement>,
         location: &SrcSpan,
+        head_location: &SrcSpan,
     ) -> Document<'a> {
         let args_docs = args.iter().map(|e| self.fn_arg(e)).collect_vec();
         let args = self
-            .wrap_args(args_docs, body.first().location().start)
+            .wrap_args(args_docs, head_location.end)
             .group()
             .next_break_fits(NextBreakFitsMode::Disabled);
         //   ^^^ We add this so that when an expression function is passed as
@@ -931,8 +932,15 @@ impl<'comments> Formatter<'comments> {
                 arguments: args,
                 body,
                 location,
+                head_location,
                 ..
-            } => self.expr_fn(args, return_annotation.as_ref(), body, location),
+            } => self.expr_fn(
+                args,
+                return_annotation.as_ref(),
+                body,
+                location,
+                head_location,
+            ),
 
             UntypedExpr::List {
                 elements,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -788,11 +788,11 @@ impl<'comments> Formatter<'comments> {
         return_annotation: Option<&'a TypeAst>,
         body: &'a Vec1<UntypedStatement>,
         location: &SrcSpan,
-        head_location: &SrcSpan,
+        end_of_head_byte_index: &u32,
     ) -> Document<'a> {
         let args_docs = args.iter().map(|e| self.fn_arg(e)).collect_vec();
         let args = self
-            .wrap_args(args_docs, head_location.end)
+            .wrap_args(args_docs, *end_of_head_byte_index)
             .group()
             .next_break_fits(NextBreakFitsMode::Disabled);
         //   ^^^ We add this so that when an expression function is passed as
@@ -932,14 +932,14 @@ impl<'comments> Formatter<'comments> {
                 arguments: args,
                 body,
                 location,
-                head_location,
+                end_of_head_byte_index,
                 ..
             } => self.expr_fn(
                 args,
                 return_annotation.as_ref(),
                 body,
                 location,
-                head_location,
+                end_of_head_byte_index,
             ),
 
             UntypedExpr::List {

--- a/compiler-core/src/format/tests/function.rs
+++ b/compiler-core/src/format/tests/function.rs
@@ -262,3 +262,57 @@ fn expr_function_as_last_argument() {
 "#
     );
 }
+
+#[test]
+fn comment_at_start_of_inline_function_body() {
+    assert_format!(
+        r#"pub fn main() {
+  let add = fn(x: Int, y: Int) {
+    // This is a comment
+    x + y
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn comment_at_start_of_top_level_function_body() {
+    assert_format!(
+        r#"pub fn add(x: Int, y: Int) {
+  // This is a comment
+  x + y
+}
+"#
+    );
+}
+
+#[test]
+fn comment_at_end_of_inline_function_args() {
+    assert_format!(
+        r#"pub fn main() {
+  let add = fn(
+    x: Int,
+    y: Int,
+    // This is a comment
+  ) {
+    x + y
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn comment_middle_of_inline_function_body() {
+    assert_format!(
+        r#"pub fn main() {
+  let add = fn(x: Int, y: Int, z: Int) {
+    let a = x + y
+    // This is a comment
+    a + z
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -594,6 +594,7 @@ where
                         end_position,
                         ..
                     })) => UntypedExpr::Fn {
+                        head_location: location,
                         location: SrcSpan::new(location.start, end_position),
                         is_capture: false,
                         arguments: args,
@@ -1584,7 +1585,7 @@ where
                 let end = return_annotation
                     .as_ref()
                     .map(|l| l.location().end)
-                    .unwrap_or_else(|| if is_anon { rbr_e } else { rpar_e });
+                    .unwrap_or(rpar_e);
                 let body = match some_body {
                     None => vec1![Statement::Expression(UntypedExpr::Todo {
                         kind: TodoKind::EmptyFunction,
@@ -3545,6 +3546,7 @@ pub fn make_call(
 
         // An anon function using the capture syntax run(_, 1, 2)
         1 => Ok(UntypedExpr::Fn {
+            head_location: call.location(),
             location: call.location(),
             is_capture: true,
             arguments: vec![Arg {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -594,8 +594,8 @@ where
                         end_position,
                         ..
                     })) => UntypedExpr::Fn {
-                        head_location: location,
                         location: SrcSpan::new(location.start, end_position),
+                        end_of_head_byte_index: location.end,
                         is_capture: false,
                         arguments: args,
                         body,
@@ -3546,8 +3546,8 @@ pub fn make_call(
 
         // An anon function using the capture syntax run(_, 1, 2)
         1 => Ok(UntypedExpr::Fn {
-            head_location: call.location(),
             location: call.location(),
+            end_of_head_byte_index: call.location().end,
             is_capture: true,
             arguments: vec![Arg {
                 location: SrcSpan { start: 0, end: 0 },

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -608,6 +608,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // callback to the use's call function.
         let callback = UntypedExpr::Fn {
             arguments: assignments.function_arguments,
+            head_location: SrcSpan::new(first.start, sequence_location.end),
             location: SrcSpan::new(first.start, sequence_location.end),
             return_annotation: None,
             is_capture: false,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -608,8 +608,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // callback to the use's call function.
         let callback = UntypedExpr::Fn {
             arguments: assignments.function_arguments,
-            head_location: SrcSpan::new(first.start, sequence_location.end),
             location: SrcSpan::new(first.start, sequence_location.end),
+            end_of_head_byte_index: sequence_location.end,
             return_annotation: None,
             is_capture: false,
             body: statements,


### PR DESCRIPTION
Closes #3109

The root cause of the issue here is that https://github.com/gleam-lang/gleam/commit/2d56b6a2554c1023f15e432eda5f16831d54c1e2#diff-6e737fd16c3877b93866d0f63709896f2f7b2f1afa64a6543a8344f99f7ebe96R2383 with this change the arg wrapping is dependent on a passed in location to determine when to stop looking for comments but in the AST for functions we use locations inconsistently between top level function definitions and anonymous function definitions. In top level functions, the location refers to only the function head and so https://github.com/gleam-lang/gleam/blob/main/compiler-core/src/format.rs#L753 points to the exact opening bracket of the body. On the other hand for anonymous functions, the location actually include the whole function meaning that the ast does not know where the real location of the body opening bracket is. Instead the current implementation looks at the start of the first statement https://github.com/gleam-lang/gleam/blob/main/compiler-core/src/format.rs#L794 hence the issue.

To solve the issue I added a new field to the AST that would consistently be the location of the head. For top level functions it would be exactly the same as the location whereas for anonymous functions the behavior would match top level.