### PR TITLE
Better error message for triple equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,20 @@
     │                  ^^^^^^^ Functions can only be called within other functions
   ```
 
+- The compiler will now provide more helpful error messages when triple equals
+  are used instead of double equals. ([Rabin Gaire](https://github.com/rabingaire))
+
+  ```
+  error: Syntax error
+    ┌─ /src/parse/error.gleam:4:37
+    │
+  4 │   [1,2,3] |> list.filter(fn (a) { a === 3 })
+    │                                     ^^^ Did you mean `==`?
+
+  Gleam uses `==` to check for equality between two values.
+  See: https://tour.gleam.run/basics/equality
+  ```
+
 ### Formatter
 
 - Redundant alias names for imported modules are now removed.

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -29,6 +29,7 @@ pub enum LexicalErrorType {
     BadName { name: String },
     BadDiscardName { name: String },
     BadUpname { name: String },
+    InvalidTripleEqual,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -372,6 +373,13 @@ impl LexicalError {
             LexicalErrorType::InvalidUnicodeEscape(InvalidUnicodeEscapeError::InvalidCodepoint) => {
                 ("Invalid Unicode codepoint", vec![])
             }
+            LexicalErrorType::InvalidTripleEqual => (
+                "Did you mean `==`?",
+                vec![
+                    "Gleam uses `==` to check for equality between two values.".into(),
+                    "See: https://tour.gleam.run/basics/equality".into(),
+                ],
+            ),
         }
     }
 }

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -191,6 +191,15 @@ where
                     Some('=') => {
                         let _ = self.next_char();
                         let tok_end = self.get_pos();
+                        if let Some('=') = self.chr0 {
+                            return Err(LexicalError {
+                                error: LexicalErrorType::InvalidTripleEqual,
+                                location: SrcSpan {
+                                    start: tok_start,
+                                    end: tok_end + 1,
+                                },
+                            });
+                        };
                         self.emit((tok_start, Token::EqualEqual, tok_end));
                     }
                     _ => {

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -358,6 +358,36 @@ fn name2() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/3125
+#[test]
+fn triple_equals() {
+    assert_error!(
+        "let bar:Int = 32
+        bar === 42",
+        ParseError {
+            error: ParseErrorType::LexError {
+                error: LexicalError {
+                    error: LexicalErrorType::InvalidTripleEqual,
+                    location: SrcSpan { start: 29, end: 32 },
+                }
+            },
+            location: SrcSpan { start: 29, end: 32 },
+        }
+    );
+}
+
+#[test]
+fn triple_equals_with_whitespace() {
+    assert_error!(
+        "let bar:Int = 32
+        bar ==     = 42",
+        ParseError {
+            error: ParseErrorType::NoLetBinding,
+            location: SrcSpan { start: 36, end: 37 },
+        }
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/1231
 #[test]
 fn pointless_spread() {


### PR DESCRIPTION
fix: #3125

This is the new error message after the fix:
```
error: Syntax error
  ┌─ /Users/rabingaire/Desktop/test_app/src/test_app.gleam:4:37
  │
4 │   [1,2,3] |> list.filter(fn (a) { a === 3 }) 
  │                                     ^^^ Did you mean `==`?

Gleam uses `==` to check for equality between two values.
See: https://tour.gleam.run/basics/equality
```