### PR TITLE
LSP: ignore completion in comments

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -17,7 +17,6 @@ use crate::type_::expression::Implementations;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
-use std::cmp::Ordering;
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -1329,16 +1328,6 @@ impl SrcSpan {
 
     pub fn contains(&self, byte_index: u32) -> bool {
         byte_index >= self.start && byte_index < self.end
-    }
-
-    pub fn cmp_byte_index(&self, byte_index: u32) -> Ordering {
-        if byte_index < self.start {
-            Ordering::Less
-        } else if self.end <= byte_index {
-            Ordering::Greater
-        } else {
-            Ordering::Equal
-        }
     }
 }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -18,7 +18,7 @@ use camino::Utf8PathBuf;
 use ecow::EcoString;
 use lsp::CodeAction;
 use lsp_types::{self as lsp, Hover, HoverContents, MarkedString, Url};
-use std::{cmp::Ordering, sync::Arc};
+use std::sync::Arc;
 
 use super::{
     code_action::{CodeActionBuilder, RedundantTupleInCaseSubject},
@@ -203,40 +203,8 @@ where
                 .module_line_numbers
                 .byte_index(params.position.line, params.position.character);
 
-            // Use binary search to find if the byte_index is
-            // in the range [span.start, span.end]
-            //
-            // Do note that the end is inclusive, because we would like to
-            // detect if the cursor is right after the comment
-            // (when we are typing/insert mode in Vim)
-            let comment_cmp = |span: &SrcSpan| {
-                if byte_index < span.start {
-                    Ordering::Less
-                } else if span.end < byte_index {
-                    // inclusive end
-                    Ordering::Greater
-                } else {
-                    Ordering::Equal
-                }
-            };
-
             // If in comment context, do not provide completions
-            //
-            // We cannot simply use `module.extra.is_within_comment` as it
-            // cannot detect if we are currently typing/inserting text at the
-            // end of the comment
-            if module.extra.comments.binary_search_by(comment_cmp).is_ok()
-                || module
-                    .extra
-                    .doc_comments
-                    .binary_search_by(comment_cmp)
-                    .is_ok()
-                || module
-                    .extra
-                    .module_comments
-                    .binary_search_by(comment_cmp)
-                    .is_ok()
-            {
+            if module.extra.is_within_comment(byte_index) {
                 return Ok(None);
             }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -203,6 +203,17 @@ where
                 .module_line_numbers
                 .byte_index(params.position.line, params.position.character);
 
+            // Do not suggest in comments
+            if module.extra.is_within_comment(byte_index)
+                || (byte_index > 0
+                    && module
+                        .extra
+                        // Cursor is at the end of the comment
+                        .is_within_comment(byte_index - 1))
+            {
+                return Ok(None);
+            }
+
             let Some(found) = module.find_node(byte_index) else {
                 return Ok(None);
             };

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1147,7 +1147,26 @@ pub fn main() {
 }
 
 #[test]
-fn ignore_completions_in_comments() {
+fn ignore_completions_in_empty_comment() {
+    // Reproducing issue #2161
+    let code = "
+pub fn main() {
+  case 0 {
+    //
+    _ -> 1
+  }
+}
+";
+
+    // End of the comment (right after the last `/`)
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(3, 6)),
+        vec![],
+    );
+}
+
+#[test]
+fn ignore_completions_in_middle_of_comment() {
     // Reproducing issue #2161
     let code = "
 pub fn main() {
@@ -1158,13 +1177,26 @@ pub fn main() {
 }
 ";
 
-    // Inside the comment span
+    // At `c`
     assert_eq!(
         completion(TestProject::for_source(code), Position::new(3, 7)),
         vec![],
     );
+}
 
-    // End of the comment
+#[test]
+fn ignore_completions_in_end_of_comment() {
+    // Reproducing issue #2161
+    let code = "
+pub fn main() {
+  case 0 {
+    // comment
+    _ -> 1
+  }
+}
+";
+
+    // End of the comment (after `t`)
     assert_eq!(
         completion(TestProject::for_source(code), Position::new(3, 14)),
         vec![],

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1145,3 +1145,28 @@ pub fn main() {
         Position::new(2, 16)
     ),);
 }
+
+#[test]
+fn ignore_completions_in_comments() {
+    // Reproducing issue #2161
+    let code = "
+pub fn main() {
+  case 0 {
+    // comment
+    _ -> 1
+  }
+}
+";
+
+    // Inside the comment span
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(3, 7)),
+        vec![],
+    );
+
+    // End of the comment
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(3, 14)),
+        vec![],
+    );
+}


### PR DESCRIPTION
Closes #2161 

Simply check if the current cursor is in a comment context by comparing comment spans (from Module's extras).