### PR TITLE
Do not leak crate-private type SourceFingerprint

### DIFF
--- a/compiler-core/src/language_server/router.rs
+++ b/compiler-core/src/language_server/router.rs
@@ -26,7 +26,7 @@ use super::feedback::FeedbackBookKeeper;
 /// file using the nearest parent `gleam.toml` file.
 ///
 #[derive(Debug)]
-pub struct Router<IO, Reporter> {
+pub(crate) struct Router<IO, Reporter> {
     io: FileSystemProxy<IO>,
     engines: HashMap<Utf8PathBuf, Project<IO, Reporter>>,
     progress_reporter: Reporter,
@@ -183,11 +183,11 @@ where
 }
 
 #[derive(Debug)]
-pub struct Project<A, B> {
+pub(crate) struct Project<A, B> {
     pub engine: LanguageServerEngine<A, B>,
     pub feedback: FeedbackBookKeeper,
     pub gleam_toml_modification_time: SystemTime,
-    pub(crate) gleam_toml_fingerprint: SourceFingerprint,
+    pub gleam_toml_fingerprint: SourceFingerprint,
 }
 
 #[cfg(test)]

--- a/compiler-core/src/language_server/router.rs
+++ b/compiler-core/src/language_server/router.rs
@@ -187,7 +187,7 @@ pub struct Project<A, B> {
     pub engine: LanguageServerEngine<A, B>,
     pub feedback: FeedbackBookKeeper,
     pub gleam_toml_modification_time: SystemTime,
-    pub gleam_toml_fingerprint: SourceFingerprint,
+    pub(crate) gleam_toml_fingerprint: SourceFingerprint,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Compiling on rustc 1.71.1 currently triggers a compile-time error:

```
error[E0446]: crate-private type `SourceFingerprint` in public interface
   --> compiler-core/src/language_server/router.rs:190:5
    |
190 |     pub gleam_toml_fingerprint: SourceFingerprint,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
    |
   ::: compiler-core/src/build.rs:415:1
    |
415 | pub(crate) struct SourceFingerprint(u64);
    | ----------------------------------- `SourceFingerprint` declared as crate-private

For more information about this error, try `rustc --explain E0446`.
```

This pr implements the staightforward fix, marking gleam_toml_fingerprint crate-private.