### PR TITLE
Update opener dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,9 +1496,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opener"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9901cb49d7fc923b256db329ee26ffed69130bf05d74b9efdd1875c92d6af01"
+checksum = "f8df34be653210fbe9ffaff41d3b92721c56ce82dfee58ee684f9afb5e3a90c0"
 dependencies = [
  "bstr",
  "dbus",


### PR DESCRIPTION
Version 0.7.1 of opener no longer pulls in the dbus dependency unless the "reveal" feature is explicitly added.

See https://github.com/Seeker14491/opener/pull/31 for additional context