### PR TITLE
Module loader ignores previously matching cache if there have been recent changes in LSP mode

### DIFF
--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -57,7 +57,7 @@ pub fn command(options: CompilePackage) -> Result<()> {
             &mut type_manifests,
             &mut defined_modules,
             &mut StaleTracker::default(),
-            &HashSet::new(),
+            &mut HashSet::new(),
             &NullTelemetry,
         )
         .into_result()

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -16,7 +16,7 @@ use gleam_core::{
     warning::WarningEmitter,
     Error, Result,
 };
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 pub fn command(options: CompilePackage) -> Result<()> {
     let ids = UniqueIdGenerator::new();
@@ -57,6 +57,7 @@ pub fn command(options: CompilePackage) -> Result<()> {
             &mut type_manifests,
             &mut defined_modules,
             &mut StaleTracker::default(),
+            &HashSet::new(),
             &NullTelemetry,
         )
         .into_result()

--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -73,6 +73,11 @@ where
             if meta.fingerprint != SourceFingerprint::new(&source_module.code) {
                 tracing::debug!(?name, "cache_stale");
                 return Ok(Input::New(source_module));
+            } else if self.mode == Mode::Lsp {
+                // Since the lsp can have valid but incorrect intermediate code states between
+                // successful compilations, we need to invalidate the cache even if the fingerprint matches
+                tracing::debug!(?name, "cache_stale for lsp");
+                return Ok(Input::New(source_module));
             }
         }
 

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -86,6 +86,27 @@ fn cache_present_and_stale_but_source_is_the_same() {
 }
 
 #[test]
+fn cache_present_and_stale_source_is_the_same_lsp_mode() {
+    let name = "package".into();
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
+    let fs = InMemoryFileSystem::new();
+    let warnings = WarningEmitter::null();
+    let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
+    loader.mode = Mode::Lsp;
+
+    // The mtime of the source is newer than that of the cache
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 2);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
+
+    let result = loader
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
+        .unwrap();
+
+    assert!(result.is_new());
+}
+
+#[test]
 fn cache_present_without_codegen_when_required() {
     let name = "package".into();
     let src = Utf8Path::new("/src");

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -13,7 +13,8 @@ fn no_cache_present() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
 
     fs.write(&Utf8Path::new("/src/main.gleam"), "const x = 1")
         .unwrap();
@@ -32,7 +33,8 @@ fn cache_present_and_fresh() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
 
     // The mtime of the source is older than that of the cache
     write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 0);
@@ -52,7 +54,8 @@ fn cache_present_and_stale() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
 
     // The mtime of the source is newer than that of the cache
     write_src(&fs, TEST_SOURCE_2, "/src/main.gleam", 2);
@@ -72,7 +75,8 @@ fn cache_present_and_stale_but_source_is_the_same() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
 
     // The mtime of the source is newer than that of the cache
     write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 2);
@@ -92,7 +96,31 @@ fn cache_present_and_stale_source_is_the_same_lsp_mode() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let mut loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
+    loader.mode = Mode::Lsp;
+
+    // The mtime of the source is newer than that of the cache
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 2);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
+
+    let result = loader
+        .load(Utf8Path::new("/src/main.gleam").to_path_buf())
+        .unwrap();
+
+    assert!(result.is_cached());
+}
+
+#[test]
+fn cache_present_and_stale_source_is_the_same_lsp_mode_and_invalidated() {
+    let name = "package".into();
+    let src = Utf8Path::new("/src");
+    let artefact = Utf8Path::new("/artefact");
+    let fs = InMemoryFileSystem::new();
+    let warnings = WarningEmitter::null();
+    let mut incomplete_modules = HashSet::new();
+    let _ = incomplete_modules.insert("main".into());
+    let mut loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
     loader.mode = Mode::Lsp;
 
     // The mtime of the source is newer than that of the cache
@@ -113,7 +141,8 @@ fn cache_present_without_codegen_when_required() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let mut loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
     loader.codegen = CodegenRequired::Yes;
 
     // The mtime of the cache is newer than that of the source
@@ -134,7 +163,8 @@ fn cache_present_with_codegen_when_required() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let mut loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
     loader.codegen = CodegenRequired::Yes;
 
     // The mtime of the cache is newer than that of the source
@@ -155,7 +185,8 @@ fn cache_present_without_codegen_when_not_required() {
     let artefact = Utf8Path::new("/artefact");
     let fs = InMemoryFileSystem::new();
     let warnings = WarningEmitter::null();
-    let mut loader = make_loader(&warnings, &name, &fs, src, artefact);
+    let incomplete_modules = HashSet::new();
+    let mut loader = make_loader(&warnings, &name, &fs, src, artefact, &incomplete_modules);
     loader.codegen = CodegenRequired::No;
 
     // The mtime of the cache is newer than that of the source
@@ -203,6 +234,7 @@ fn make_loader<'a>(
     fs: &InMemoryFileSystem,
     src: &'a Utf8Path,
     artefact: &'a Utf8Path,
+    incomplete_modules: &'a HashSet<EcoString>,
 ) -> ModuleLoader<'a, InMemoryFileSystem> {
     ModuleLoader {
         warnings,
@@ -214,5 +246,6 @@ fn make_loader<'a>(
         source_directory: &src,
         artefact_directory: &artefact,
         origin: Origin::Src,
+        incomplete_modules,
     }
 }

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -92,7 +92,7 @@ where
         existing_modules: &mut im::HashMap<EcoString, type_::ModuleInterface>,
         already_defined_modules: &mut im::HashMap<EcoString, Utf8PathBuf>,
         stale_modules: &mut StaleTracker,
-        incomplete_modules: &HashSet<EcoString>,
+        incomplete_modules: &mut HashSet<EcoString>,
         telemetry: &dyn Telemetry,
     ) -> Outcome<Vec<Module>, Error> {
         let span = tracing::info_span!("compile", package = %self.config.name.as_str());
@@ -153,6 +153,7 @@ where
             existing_modules,
             warnings,
             self.target_support,
+            incomplete_modules,
         );
         let modules = match outcome {
             Outcome::Ok(modules) => modules,
@@ -415,6 +416,7 @@ fn analyse(
     module_types: &mut im::HashMap<EcoString, type_::ModuleInterface>,
     warnings: &WarningEmitter,
     target_support: TargetSupport,
+    incomplete_modules: &mut HashSet<EcoString>,
 ) -> Outcome<Vec<Module>, Error> {
     let mut modules = Vec::with_capacity(parsed_modules.len() + 1);
     let direct_dependencies = package_config.dependencies_for(mode).expect("Package deps");
@@ -456,6 +458,8 @@ fn analyse(
 
         match analysis {
             Outcome::Ok(ast) => {
+                // Module has compiled successfully. Make sure it isn't marked as incomplete.
+                let _ = incomplete_modules.remove(&name.clone());
                 // Register the types from this module so they can be imported into
                 // other modules.
                 let _ = module_types.insert(name.clone(), ast.type_info.clone());
@@ -479,6 +483,8 @@ fn analyse(
                     src: code.clone(),
                     errors,
                 };
+                // Mark as incomplete so that this module isn't reloaded from cache.
+                let _ = incomplete_modules.insert(name.clone());
                 // Register the partially type checked module data so that it can be
                 // used in the language server.
                 modules.push(Module {

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -92,6 +92,7 @@ where
         existing_modules: &mut im::HashMap<EcoString, type_::ModuleInterface>,
         already_defined_modules: &mut im::HashMap<EcoString, Utf8PathBuf>,
         stale_modules: &mut StaleTracker,
+        incomplete_modules: &HashSet<EcoString>,
         telemetry: &dyn Telemetry,
     ) -> Outcome<Vec<Module>, Error> {
         let span = tracing::info_span!("compile", package = %self.config.name.as_str());
@@ -120,6 +121,7 @@ where
             &self.config.name,
             stale_modules,
             already_defined_modules,
+            incomplete_modules,
         );
         let loaded = match loader.run() {
             Ok(loaded) => loaded,

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -60,6 +60,7 @@ pub struct PackageLoader<'a, IO> {
     target: Target,
     stale_modules: &'a mut StaleTracker,
     already_defined_modules: &'a mut im::HashMap<EcoString, Utf8PathBuf>,
+    incomplete_modules: &'a HashSet<EcoString>,
 }
 
 impl<'a, IO> PackageLoader<'a, IO>
@@ -78,6 +79,7 @@ where
         package_name: &'a EcoString,
         stale_modules: &'a mut StaleTracker,
         already_defined_modules: &'a mut im::HashMap<EcoString, Utf8PathBuf>,
+        incomplete_modules: &'a HashSet<EcoString>,
     ) -> Self {
         Self {
             io,
@@ -91,6 +93,7 @@ where
             artefact_directory,
             stale_modules,
             already_defined_modules,
+            incomplete_modules,
         }
     }
 
@@ -198,6 +201,7 @@ where
             artefact_directory: self.artefact_directory,
             source_directory: &src,
             origin: Origin::Src,
+            incomplete_modules: self.incomplete_modules,
         };
 
         // Src

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -80,6 +80,7 @@ fn run_loader(fs: InMemoryFileSystem, root: &Utf8Path, artefact: &Utf8Path) -> L
         target: Target::JavaScript,
         stale_modules: &mut StaleTracker::default(),
         already_defined_modules: &mut defined,
+        incomplete_modules: &mut HashSet::new(),
     };
     let loaded = loader.run().unwrap();
 

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -566,31 +566,14 @@ where
         };
 
         // Compile project to Erlang or JavaScript source code
-        let outcome = compiler.compile(
+        compiler.compile(
             &mut self.warnings,
             &mut self.importable_modules,
             &mut self.defined_modules,
             &mut self.stale_modules,
-            &self.incomplete_modules,
+            &mut self.incomplete_modules,
             self.telemetry.as_ref(),
-        );
-        let outcome = match outcome {
-            Outcome::Ok(modules) => {
-                // On successful compilation we remove the module from the incomplete set
-                modules.iter().for_each(|m| {
-                    let _ = self.incomplete_modules.remove(&m.name);
-                });
-                Outcome::Ok(modules)
-            }
-            Outcome::PartialFailure(modules, errors) => {
-                // On partial compilation failure we add all the module to the incomplete set
-                self.incomplete_modules
-                    .extend(modules.iter().map(|m| m.name.clone()));
-                Outcome::PartialFailure(modules, errors)
-            }
-            Outcome::TotalFailure(_) => outcome,
-        };
-        outcome
+        )
     }
 }
 

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{collections::HashSet, time::SystemTime};
 
 use crate::{
     build::{Mode, NullTelemetry, PackageCompiler, StaleTracker, TargetCodegenConfiguration},
@@ -58,6 +58,7 @@ fn compile_with_markdown_pages(
             &mut type_manifests,
             &mut defined_modules,
             &mut StaleTracker::default(),
+            &mut HashSet::new(),
             &NullTelemetry,
         )
         .unwrap();

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -209,7 +209,7 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
             &mut type_manifests,
             &mut defined_modules,
             &mut StaleTracker::default(),
-            &HashSet::new(),
+            &mut HashSet::new(),
             &NullTelemetry,
         )
         .into_result()

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -16,7 +16,7 @@ use gleam_core::{
 };
 use hexpm::version::Version;
 use im::HashMap;
-use std::{cell::RefCell, sync::Arc};
+use std::{cell::RefCell, collections::HashSet, sync::Arc};
 use wasm_filesystem::WasmFileSystem;
 
 use wasm_bindgen::prelude::*;
@@ -209,6 +209,7 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
             &mut type_manifests,
             &mut defined_modules,
             &mut StaleTracker::default(),
+            &HashSet::new(),
             &NullTelemetry,
         )
         .into_result()

--- a/test-package-compiler/src/lib.rs
+++ b/test-package-compiler/src/lib.rs
@@ -73,7 +73,7 @@ pub fn prepare(path: &str) -> String {
         &mut modules,
         &mut im::HashMap::new(),
         &mut StaleTracker::default(),
-        &HashSet::new(),
+        &mut HashSet::new(),
         &NullTelemetry,
     );
     match result {

--- a/test-package-compiler/src/lib.rs
+++ b/test-package-compiler/src/lib.rs
@@ -18,7 +18,11 @@ use gleam_core::{
 };
 use itertools::Itertools;
 use regex::Regex;
-use std::{collections::HashMap, fmt::Write, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write,
+    sync::Arc,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -69,6 +73,7 @@ pub fn prepare(path: &str) -> String {
         &mut modules,
         &mut im::HashMap::new(),
         &mut StaleTracker::default(),
+        &HashSet::new(),
         &NullTelemetry,
     );
     match result {


### PR DESCRIPTION
Closes #3172

In LSP mode the last cached build is not necessarily the last version of the module that was loaded by the LSP so if there have been source changes we ignore the cache even if the source matches the last successful cached version