### PR TITLE
fixed end location of tuple annotations

### DIFF
--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -634,6 +634,27 @@ fn append(x: String, y: String) -> String {
 }
 
 #[test]
+fn hover_function_return_annotation_with_tuple() {
+    let code = "
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x: String, y: String) -> #(String, String) {
+  #(x, y)
+}
+";
+
+    assert_eq!(
+        hover(TestProject::for_source(code), Position::new(3, 39)),
+        Some(Hover {
+            contents: HoverContents::Scalar(MarkedString::String(
+                "```gleam\nString\n```\n".to_string()
+            )),
+            range: Some(Range::new(Position::new(3, 37), Position::new(3, 43))),
+        })
+    );
+}
+
+#[test]
 fn hover_module_constant_annotation() {
     let code = "
 /// Exciting documentation

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1985,11 +1985,11 @@ where
             }
 
             // Tuple
-            Some((start, Token::Hash, end)) => {
+            Some((start, Token::Hash, _)) => {
                 self.advance();
                 let _ = self.expect_one(&Token::LeftParen)?;
                 let elems = self.parse_types()?;
-                let _ = self.expect_one(&Token::RightParen)?;
+                let (_, end) = self.expect_one(&Token::RightParen)?;
                 Ok(Some(TypeAst::Tuple(TypeAstTuple {
                     location: SrcSpan { start, end },
                     elems,

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__alias_direct_cycle.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__alias_direct_cycle.snap
@@ -6,7 +6,7 @@ error: Type cycle
   ┌─ /src/one/two.gleam:2:1
   │
 2 │ type A = #(A, A)
-  │ ^^^^^^^^^^
+  │ ^^^^^^^^^^^^^^^^
 
 This type alias is defined in terms of itself.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__duplicate_variable_error_does_not_stop_analysis.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__duplicate_variable_error_does_not_stop_analysis.snap
@@ -7,7 +7,7 @@ error: Duplicate type parameter
   │  
 2 │ ╭ type Two(a, a) =
 3 │ │   #(a, a)
-  │ ╰───^
+  │ ╰─────────^
 
 This definition has multiple type parameters named `a`.
 Rename or remove one of them.


### PR DESCRIPTION
Closes #3176 

The end location for a tuple type was previously set to the end of the opening left paren instead of the closing right paren. This meant that hovering inside a tuple type was not properly being captured but hovering on the opening paren was.
