### PR TITLE
RC - fix  wrong warning for redundant matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   in a pipeline.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would raise a warning for matching on a literal
+  value if the case expression is used just for its guards.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.2.0-rc1 - 2024-05-23
 
 ### Build tool

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warnings_for_matches_on_literal_values_that_are_not_like_an_if_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warnings_for_matches_on_literal_values_that_are_not_like_an_if_1.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n    pub fn main() {\n        case True {\n          _ -> 1\n        }\n    }\n        "
+---
+warning: Match on a literal value
+  ┌─ /src/warning/wrn.gleam:3:14
+  │
+3 │         case True {
+  │              ^^^^ There's no need to pattern match on this value
+
+Matching on a literal value is redundant since you can already tell which
+branch is going to match with this value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warnings_for_matches_on_literal_values_that_are_not_like_an_if_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warnings_for_matches_on_literal_values_that_are_not_like_an_if_2.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n    pub fn main() {\n        case True {\n          True -> 1\n          _ -> 2\n        }\n    }\n        "
+---
+warning: Match on a literal value
+  ┌─ /src/warning/wrn.gleam:3:14
+  │
+3 │         case True {
+  │              ^^^^ There's no need to pattern match on this value
+
+Matching on a literal value is redundant since you can already tell which
+branch is going to match with this value.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1957,3 +1957,58 @@ fn unreachable_code_analysis_treats_anonymous_functions_independently_3() {
         "#
     );
 }
+
+#[test]
+fn no_warnings_for_matches_used_like_ifs() {
+    assert_no_warnings!(
+        r#"
+    pub fn main() {
+        case True {
+          _ if True -> 1
+          _ -> 2
+        }
+    }
+        "#
+    );
+}
+
+#[test]
+fn no_warnings_for_matches_used_like_ifs_2() {
+    assert_no_warnings!(
+        r#"
+    pub fn main() {
+        case 1 {
+          _ if True -> 1
+          _ -> 2
+        }
+    }
+        "#
+    );
+}
+
+#[test]
+fn warnings_for_matches_on_literal_values_that_are_not_like_an_if_1() {
+    assert_warning!(
+        r#"
+    pub fn main() {
+        case True {
+          _ -> 1
+        }
+    }
+        "#
+    );
+}
+
+#[test]
+fn warnings_for_matches_on_literal_values_that_are_not_like_an_if_2() {
+    assert_warning!(
+        r#"
+    pub fn main() {
+        case True {
+          True -> 1
+          _ -> 2
+        }
+    }
+        "#
+    );
+}


### PR DESCRIPTION
This PR fixes a bug in the RC where the compiler would raise a warning for matches on literal values that are used just for their guards. Something like this will no longer raise a warning:

```gleam
case True {
  _ if condition -> todo
  _ if other -> todo
  _ -> todo
}
```