### PR TITLE
Add failing test for trailing comment in bit arrays

### DIFF
--- a/compiler-core/src/format/tests/bit_array.rs
+++ b/compiler-core/src/format/tests/bit_array.rs
@@ -99,6 +99,7 @@ fn comments_inside_non_empty_bit_arrays_are_not_moved() {
     <<
       // Three is below me.
       3,
+      // Trailing comment is kept inside bit array.
     >>,
   )
 }

--- a/compiler-core/src/format/tests/bit_array.rs
+++ b/compiler-core/src/format/tests/bit_array.rs
@@ -99,8 +99,22 @@ fn comments_inside_non_empty_bit_arrays_are_not_moved() {
     <<
       // Three is below me.
       3,
-      // Trailing comment is kept inside bit array.
     >>,
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn trailing_comments_inside_non_empty_bit_arrays_are_not_moved() {
+    assert_format!(
+        r#"pub fn main() {
+  fun(
+    <<
+      1, 2,
+      // One and two are above me.
+    >>
   )
 }
 "#


### PR DESCRIPTION
In my use case, commenting out a trailing value moved it out of the bit array which was very confusing. 