### PR TITLE
Fix list append error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Bug Fixes
 
+- Fixed a bug where the compiler would output a confusing error message when
+  trying to use the spread syntax to append to a list.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ## v1.2.1 - 2024-05-30
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -505,7 +505,6 @@ where
                 if let Some(location) = self.maybe_one(&Token::DotDot) {
                     dot_dot_location = Some(location);
                     tail = self.parse_expression()?.map(Box::new);
-
                     if self.maybe_one(&Token::Comma).is_some() {
                         // See if there's a list of items after the tail,
                         // like `[..wibble, wobble, wabble]`
@@ -532,7 +531,10 @@ where
                     }
                     _ => {}
                 }
-                if tail.is_some() && elements.is_empty() {
+                if tail.is_some()
+                    && elements.is_empty()
+                    && elements_after_tail.as_ref().map_or(true, |e| e.is_empty())
+                {
                     return parse_error(
                         ParseErrorType::ListSpreadWithoutElements,
                         SrcSpan { start, end },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__list_spread_as_first_item_followed_by_other_items.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__list_spread_as_first_item_followed_by_other_items.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\npub fn main() -> Nil {\n  let xs = [1, 2, 3]\n  [..xs, 3 + 3, 4]\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:4:4
+  │
+4 │   [..xs, 3 + 3, 4]
+  │    ^^^^ I wasn't expecting elements after this spread
+
+A spread can only be used to prepend elements to lists like this: `[first, ..rest]`.
+
+Hint: If you need to append elements to a list you can use `list.append`.
+See: https://hexdocs.pm/gleam_stdlib/gleam/list.html#append

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -791,6 +791,18 @@ pub fn main() -> Nil {
     );
 }
 
+#[test]
+fn list_spread_as_first_item_followed_by_other_items() {
+    assert_module_error!(
+        r#"
+pub fn main() -> Nil {
+  let xs = [1, 2, 3]
+  [..xs, 3 + 3, 4]
+}
+"#
+    );
+}
+
 // Tests for nested tuples and structs in tuples
 // https://github.com/gleam-lang/gleam/issues/1980
 


### PR DESCRIPTION
This PR fixes a bug where the compiler would output a confusing error message if a spread was used to append to a list like this: `[..xs, 1]`. The error would complain about the spread being useless instead of saying it can't be used to append to a list