### PR TITLE
Add `maybe` as a reserved word for Erlang compile target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
   anonymous function passed as an argument.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would generate invalid Erlang code when
+  declaring an identifier named `Maybe`/`maybe` and compiling against
+  Erlang/OTP 27, where `maybe` is now a reserved word.
+  ([Jake Barszcz](https://github.com/barszcz))
+
 ## v1.2.1 - 2024-05-30
 
 ### Bug Fixes

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1763,6 +1763,7 @@ pub fn is_erlang_reserved_word(name: &str) -> bool {
             | "if"
             | "of"
             | "case"
+            | "maybe"
     )
 }
 

--- a/compiler-core/src/erlang/tests/reserved.rs
+++ b/compiler-core/src/erlang/tests/reserved.rs
@@ -28,6 +28,7 @@ pub type End { TestEnd }
 pub type Fun { TestFun }
 pub type If { TestIf }
 pub type Let { TestLet }
+pub type Maybe { TestMaybe }
 pub type Not { TestNot }
 pub type Of { TestOf }
 pub type Or { TestOr }

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__reserved__escape_erlang_reserved_keywords_in_type_names.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__reserved__escape_erlang_reserved_keywords_in_type_names.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/erlang/tests/reserved.rs
-expression: "pub type After { TestAfter }\npub type And { TestAnd }\npub type Andalso { TestAndAlso }\npub type Band { TestBAnd }\npub type Begin { TestBegin }\npub type Bnot { TestBNot }\npub type Bor { TestBOr }\npub type Bsl { TestBsl }\npub type Bsr { TestBsr }\npub type Bxor { TestBXor }\npub type Case { TestCase }\npub type Catch { TestCatch }\npub type Cond { TestCond }\npub type Div { TestDiv }\npub type End { TestEnd }\npub type Fun { TestFun }\npub type If { TestIf }\npub type Let { TestLet }\npub type Not { TestNot }\npub type Of { TestOf }\npub type Or { TestOr }\npub type Orelse { TestOrElse }\npub type Query { TestQuery }\npub type Receive { TestReceive }\npub type Rem { TestRem }\npub type Try { TestTry }\npub type When { TestWhen }\npub type Xor { TestXor }"
+expression: "pub type After { TestAfter }\npub type And { TestAnd }\npub type Andalso { TestAndAlso }\npub type Band { TestBAnd }\npub type Begin { TestBegin }\npub type Bnot { TestBNot }\npub type Bor { TestBOr }\npub type Bsl { TestBsl }\npub type Bsr { TestBsr }\npub type Bxor { TestBXor }\npub type Case { TestCase }\npub type Catch { TestCatch }\npub type Cond { TestCond }\npub type Div { TestDiv }\npub type End { TestEnd }\npub type Fun { TestFun }\npub type If { TestIf }\npub type Let { TestLet }\npub type Maybe { TestMaybe }\npub type Not { TestNot }\npub type Of { TestOf }\npub type Or { TestOr }\npub type Orelse { TestOrElse }\npub type Query { TestQuery }\npub type Receive { TestReceive }\npub type Rem { TestRem }\npub type Try { TestTry }\npub type When { TestWhen }\npub type Xor { TestXor }"
 ---
 -module(my@mod).
 -compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
 
--export_type(['after'/0, 'and'/0, 'andalso'/0, 'band'/0, 'begin'/0, 'bnot'/0, 'bor'/0, 'bsl'/0, 'bsr'/0, 'bxor'/0, 'case'/0, 'catch'/0, 'cond'/0, 'div'/0, 'end'/0, 'fun'/0, 'if'/0, 'let'/0, 'not'/0, 'of'/0, 'or'/0, 'orelse'/0, 'query'/0, 'receive'/0, 'rem'/0, 'try'/0, 'when'/0, 'xor'/0]).
+-export_type(['after'/0, 'and'/0, 'andalso'/0, 'band'/0, 'begin'/0, 'bnot'/0, 'bor'/0, 'bsl'/0, 'bsr'/0, 'bxor'/0, 'case'/0, 'catch'/0, 'cond'/0, 'div'/0, 'end'/0, 'fun'/0, 'if'/0, 'let'/0, 'maybe'/0, 'not'/0, 'of'/0, 'or'/0, 'orelse'/0, 'query'/0, 'receive'/0, 'rem'/0, 'try'/0, 'when'/0, 'xor'/0]).
 
 -type 'after'() :: test_after.
 
@@ -42,6 +42,8 @@ expression: "pub type After { TestAfter }\npub type And { TestAnd }\npub type An
 -type 'if'() :: test_if.
 
 -type 'let'() :: test_let.
+
+-type 'maybe'() :: test_maybe.
 
 -type 'not'() :: test_not.
 


### PR DESCRIPTION
`maybe` is reserved as of Erlang/OTP 27.
See https://www.erlang.org/doc/system/expressions.html#maybe for more info.

Let me know if there are any other tests I should add? I'm not super familiar with Rust, but this seemed like a simple enough change.

Closes https://github.com/gleam-lang/gleam/issues/3233,