### PR TITLE
Enable remove redundant tuple action with catch all patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@
 
 ### Language Server
 
+- The language server will now suggest the "Remove redundant tuple" action even
+  if the case expression contains some catch all patterns:
+
+  ```
+  case #(a, b) {
+    #(1, 2) -> todo
+    _ -> todo
+  }
+  ```
+
+  Becomes:
+
+  ```
+  case a, b {
+    1, 2 -> todo
+    _, _ -> todo
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug Fixes
 
 - Fixed a bug where the compiler would output a confusing error message when

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -267,12 +267,12 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
         edits
     }
 
-    fn discard_tuple_items(&self, location: SrcSpan, len: usize) -> TextEdit {
+    fn discard_tuple_items(&self, discard_location: SrcSpan, tuple_items: usize) -> TextEdit {
         // Replace the old discard with multiple discard, one for each of the
         // tuple items.
         TextEdit {
-            range: src_span_to_lsp_range(location, &self.line_numbers),
-            new_text: itertools::intersperse(iter::repeat("_").take(len), ", ").collect(),
+            range: src_span_to_lsp_range(discard_location, &self.line_numbers),
+            new_text: itertools::intersperse(iter::repeat("_").take(tuple_items), ", ").collect(),
         }
     }
 }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -91,13 +91,13 @@ fn apply_code_edit(
             panic!("Unknown url {}", change_url)
         }
         for edit in change {
-            let start = line_numbers.byte_index(edit.range.start.line, edit.range.start.character)
-                as i32
-                - offset;
-            let end = line_numbers.byte_index(edit.range.end.line, edit.range.end.character) as i32
-                - offset;
+            let start =
+                line_numbers.byte_index(edit.range.start.line, edit.range.start.character) - offset;
+            let end =
+                line_numbers.byte_index(edit.range.end.line, edit.range.end.character) - offset;
             let range = (start as usize)..(end as usize);
-            offset += end - start - edit.new_text.len() as i32;
+            offset += end - start;
+            offset -= edit.new_text.len() as u32;
             result.replace_range(range, &edit.new_text);
         }
     }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_redundant_tuple_with_catch_all_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_redundant_tuple_with_catch_all_pattern.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(code, 4, REMOVE_REDUNDANT_TUPLES)"
+---
+pub fn main() {
+  case 1, 2, 3, 4 {
+    2, 2, 2, 2 -> 0
+    1, 2, _, _ -> 0
+    _, _, 1, 2 -> 0
+    _, _, _, _ -> 1
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_with_catch_all_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_with_catch_all_pattern.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(code, 4, REMOVE_REDUNDANT_TUPLES)"
+---
+pub fn main() {
+  case 1, 2 {
+    1, 2 -> 0
+    _, _ -> 1
+  }
+}


### PR DESCRIPTION
Previously the LSP wouldn't suggest the "Remove redundant tuple" action in a case match that had a catch all ignored pattern. Now it is enable for those cases as well:
```gleam
case #(a, b, c) {
  #(1, 2, 3) -> todo
  _ -> todo
}
```
Becomes:
```gleam
case a, b, c {
  1, 2, 3 -> todo
  _, _, _ -> todo
}
```