### PR TITLE
fix excessive `gleam.mjs` generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   anonymous function passed as an argument.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would unnecessarily generate `gleam.mjs`,
+  confusing build tools like Vite
+  ([Ofek Doitch](https://github.com/ofekd))
+
 ## v1.2.1 - 2024-05-30
 
 ### Bug Fixes

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -186,7 +186,13 @@ impl<'a> JavaScript<'a> {
             }
             self.js_module(writer, module, &js_name)?
         }
-        self.write_prelude(writer)?;
+
+        // This check skips unnecessary `gleam.mjs` writes which confuse
+        // watchers and HMR build tools
+        if !modules.is_empty() {
+            self.write_prelude(writer)?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
This patch fixes excessive generation by checking if `modules` is empty.

Two other possible solutions have been ruled out:

- Checking for file existence may result in not updating outdated files
- Comparing contents is slow

closes #3178