### PR TITLE
Fix bug with redundant capture warning

### DIFF
--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2064,3 +2064,16 @@ fn redundant_function_capture_in_pipe_4() {
 "
     );
 }
+
+#[test]
+fn redundant_function_capture_in_pipe_5() {
+    assert_no_warnings!(
+        "
+  pub fn wibble(_, _) { 1 }
+
+  pub fn main() {
+    1 |> wibble(2, _)
+  }
+"
+    );
+}


### PR DESCRIPTION
This PR fixes a bug I didn't notice in a PR that got recently fixed. Now the compiler won't complain about _all_ function holes but only those that are truly redundant