### PR TITLE
Implement code action to ignore unused Result value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Added a code action to add `let _ = ` to an unused result value.
+  ([Leah Ulmschneider](https://github.com/leah-u))
+
 ### Bug Fixes
 
 - Fixed a bug where the compiler would output a confusing error message when

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use strum::IntoEnumIterator;
 
 use super::{
-    code_action::{CodeActionBuilder, RedundantTupleInCaseSubject},
+    code_action::{CodeActionBuilder, RedundantTupleInCaseSubject, UnusedResultValue},
     src_span_to_lsp_range, DownloadDependencies, MakeLocker,
 };
 
@@ -258,6 +258,7 @@ where
 
             code_action_unused_imports(module, &params, &mut actions);
             actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
+            actions.extend(UnusedResultValue::new(module, &params).code_actions());
 
             Ok(if actions.is_empty() {
                 None

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__assign_unused_result.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__assign_unused_result.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(code, 2, ASSIGN_UNUSED_RESULT)"
+---
+pub fn main() {
+    let _ = Ok(0)
+    Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__assign_unused_result_in_block.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__assign_unused_result_in_block.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(code, 3, ASSIGN_UNUSED_RESULT)"
+---
+pub fn main() {
+    {
+        let _ = Ok(0)
+        Nil
+    }
+    Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__assign_unused_result_only_first_action.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__assign_unused_result_only_first_action.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(code, 2, ASSIGN_UNUSED_RESULT)"
+---
+pub fn main() {
+    let _ = Ok(0)
+    Ok(0)
+    Nil
+}


### PR DESCRIPTION
Closes #2960

My first contribution, please be gentle :3

I had to undo the changes from commit [64924b9](https://github.com/gleam-lang/gleam/commit/64924b949856253603300b47151d37d45d1c5fe7) as my tests would otherwise panic with an integer underflow. I'm not really sure why it was necessary in the first place, maybe @giacomocavalieri can help?