### PR TITLE
Fix compiler crash when defining duplicate types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
   anonymous function passed as an argument.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would crash when a type was defined with
+  the same name as an imported type.
+  ([Gears](https://github.com/gearsdatapacks))
+
 ## v1.2.1 - 2024-05-30
 
 ### Bug Fixes

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -289,6 +289,22 @@ impl<'a> Environment<'a> {
         }
     }
 
+    pub fn assert_unique_type_name(
+        &mut self,
+        name: &EcoString,
+        location: SrcSpan,
+    ) -> Result<(), Error> {
+        match self.module_types.get(name) {
+            None => Ok(()),
+            Some(prelude_type) if is_prelude_module(&prelude_type.module) => Ok(()),
+            Some(previous) => Err(Error::DuplicateTypeName {
+                name: name.clone(),
+                location,
+                previous_location: previous.origin,
+            }),
+        }
+    }
+
     /// Map a type to constructors in the current scope.
     ///
     pub fn insert_type_to_constructors(

--- a/compiler-core/src/type_/tests/custom_types.rs
+++ b/compiler-core/src/type_/tests/custom_types.rs
@@ -1,4 +1,4 @@
-use crate::{assert_module_error, assert_module_infer, assert_warning};
+use crate::{assert_module_error, assert_module_infer, assert_warning, assert_with_module_error};
 
 // https://github.com/gleam-lang/gleam/issues/2215
 #[test]
@@ -59,3 +59,13 @@ type Three(a, a) {
 "#
     );
 }
+
+#[test]
+fn conflict_with_import() {
+    // We cannot declare a type with the same name as an imported type
+    assert_with_module_error!(
+        ("foo", "pub type A { B }"),
+        "import foo.{type A} type A { C }",
+    );
+}
+

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/type_/tests/custom_types.rs
+expression: "import foo.{type A} type A { C }"
+---
+error: Duplicate type definition
+  ┌─ /src/one/two.gleam:1:13
+  │
+1 │ import foo.{type A} type A { C }
+  │             ^^^^^^  ^^^^^^ Redefined here
+  │             │        
+  │             First defined here
+
+The type `A` has been defined multiple times.
+Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/type_/tests/type_alias.rs
+expression: "import foo.{type Bar} type Bar = Int"
+---
+error: Duplicate type definition
+  ┌─ /src/one/two.gleam:1:13
+  │
+1 │ import foo.{type Bar} type Bar = Int
+  │             ^^^^^^^^  ^^^^^^^^^^^^^^ Redefined here
+  │             │          
+  │             First defined here
+
+The type `Bar` has been defined multiple times.
+Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/type_alias.rs
+++ b/compiler-core/src/type_/tests/type_alias.rs
@@ -1,4 +1,4 @@
-use crate::{assert_infer_with_module, assert_module_error, assert_module_infer};
+use crate::{assert_infer_with_module, assert_module_error, assert_module_infer, assert_with_module_error};
 
 #[test]
 fn alias_dep() {
@@ -135,5 +135,15 @@ fn example(a: X) {
   todo
 }
 "#
+    );
+}
+
+
+#[test]
+fn conflict_with_import() {
+    // We cannot declare a type with the same name as an imported type
+    assert_with_module_error!(
+        ("foo", "pub type Bar = String"),
+        "import foo.{type Bar} type Bar = Int",
     );
 }


### PR DESCRIPTION
This is a possible solution to #3209, which moves the duplicate name check into `Environment`, meaning it has access to the imported types as well as locally defined types.

Also, should I add a test for this? If so, where is the best place to put that?

Closes #3209