### PR TITLE
Revert "fix excessive `gleam.mjs` generation"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,6 @@
   anonymous function passed as an argument.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- Fixed a bug where the compiler would unnecessarily generate `gleam.mjs`,
-  confusing build tools like Vite
-  ([Ofek Doitch](https://github.com/ofekd))
-
 ## v1.2.1 - 2024-05-30
 
 ### Bug Fixes

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -186,13 +186,7 @@ impl<'a> JavaScript<'a> {
             }
             self.js_module(writer, module, &js_name)?
         }
-
-        // This check skips unnecessary `gleam.mjs` writes which confuse
-        // watchers and HMR build tools
-        if !modules.is_empty() {
-            self.write_prelude(writer)?;
-        }
-
+        self.write_prelude(writer)?;
         Ok(())
     }
 


### PR DESCRIPTION
Reverts gleam-lang/gleam#3238

Hi @ofekd, I've had to revert this as it fails to write the prelude when there's no modules, and it still updates the prelude when no modules have changed. Sorry, I should have caught these in the original review.