### PR TITLE
Surface diagnostic errors for import cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@
 - Compiler now supports arithmetic operations in guards.
   ([Danielle Maywood](https://github.com/DanielleMaywood))
 
+- Import cycles now show the location where the import occur.
+  ([Ameen Radwan](https://github.com/Acepie))
+
 ### Formatter
 
 ### Language Server
@@ -124,11 +127,13 @@
 
 - LSP can now suggest completions for values and types from importable modules
   and adds the import to the top of the file.
-  ([Ameen Radwan](https://github.com/Acepie)
+  ([Ameen Radwan](https://github.com/Acepie))
 
-- LSP completions now use the "text_edit" language server API resulting in
-  better/more accurate insertions.
-  ([Ameen Radwan](https://github.com/Acepie)
+- Diagnostics with extra labels now show the diagnostic in all locations including across multiple files.
+  ([Ameen Radwan](https://github.com/Acepie))
+
+- LSP completions now use the "text_edit" language server API resulting in better/more accurate insertions.
+  ([Ameen Radwan](https://github.com/Acepie))
 
 ### Bug Fixes
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1399,7 +1399,7 @@ impl TypedClauseGuard {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct SrcSpan {
     pub start: u32,
     pub end: u32,

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -281,13 +281,6 @@ impl Module {
             }
         }
     }
-
-    pub(crate) fn dependencies_list(&self) -> Vec<EcoString> {
-        self.dependencies
-            .iter()
-            .map(|(name, _)| name.clone())
-            .collect()
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -279,7 +279,7 @@ where
             let info = CacheMetadata {
                 mtime: module.mtime,
                 codegen_performed: self.perform_codegen,
-                dependencies: module.dependencies_list(),
+                dependencies: module.dependencies.clone(),
                 fingerprint: SourceFingerprint::new(&module.code),
                 line_numbers: module.ast.type_info.line_numbers.clone(),
             };
@@ -557,7 +557,7 @@ impl Input {
     pub fn dependencies(&self) -> Vec<EcoString> {
         match self {
             Input::New(m) => m.dependencies.iter().map(|(n, _)| n.clone()).collect(),
-            Input::Cached(m) => m.dependencies.clone(),
+            Input::Cached(m) => m.dependencies.iter().map(|(n, _)| n.clone()).collect(),
         }
     }
 
@@ -582,7 +582,7 @@ impl Input {
 pub(crate) struct CachedModule {
     pub name: EcoString,
     pub origin: Origin,
-    pub dependencies: Vec<EcoString>,
+    pub dependencies: Vec<(EcoString, SrcSpan)>,
     pub source_path: Utf8PathBuf,
     pub line_numbers: LineNumbers,
 }
@@ -591,7 +591,7 @@ pub(crate) struct CachedModule {
 pub(crate) struct CacheMetadata {
     pub mtime: SystemTime,
     pub codegen_performed: bool,
-    pub dependencies: Vec<EcoString>,
+    pub dependencies: Vec<(EcoString, SrcSpan)>,
     pub fingerprint: SourceFingerprint,
     pub line_numbers: LineNumbers,
 }

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -15,6 +15,7 @@ use itertools::Itertools;
 use vec1::Vec1;
 
 use crate::{
+    ast::SrcSpan,
     build::{module_loader::ModuleLoader, package_compiler::module_name, Module, Origin},
     config::PackageConfig,
     dep_tree,
@@ -120,7 +121,7 @@ where
             .sorted_by(|(a, _), (b, _)| a.cmp(b))
             .collect();
         let sequence = dep_tree::toposort_deps(deps)
-            .map_err(|e| convert_deps_tree_error(e, dep_location_map))?;
+            .map_err(|e| self.convert_deps_tree_error(e, dep_location_map))?;
 
         // Now that we have loaded sources and caches we check to see if any of
         // the caches need to be invalidated because their dependencies have
@@ -271,6 +272,63 @@ where
             mtime,
             self.warnings.clone(),
         )
+    }
+
+    fn convert_deps_tree_error(
+        &self,
+        e: dep_tree::Error,
+        dep_location_map: HashMap<EcoString, &Input>,
+    ) -> Error {
+        match e {
+            dep_tree::Error::Cycle(modules) => {
+                let modules = modules
+                    .iter()
+                    .enumerate()
+                    .map(|(i, module)| {
+                        // cycles are in order of reference so get next in list or loop back to first
+                        let ind = if i == modules.len() - 1 { 0 } else { i + 1 };
+                        let next = modules.get(ind).expect("next module must exist");
+                        let input = dep_location_map.get(module).expect("dependency must exist");
+                        let location = match input {
+                            Input::New(module) => {
+                                let (_, location) = module
+                                    .dependencies
+                                    .iter()
+                                    .find(|d| &d.0 == next)
+                                    .expect("import must exist for there to be a cycle");
+                                ImportCycleLocationDetails {
+                                    location: *location,
+                                    path: module.path.clone(),
+                                    src: module.code.clone(),
+                                }
+                            }
+                            Input::Cached(cached_module) => {
+                                let (_, location) = cached_module
+                                    .dependencies
+                                    .iter()
+                                    .find(|d| &d.0 == next)
+                                    .expect("import must exist for there to be a cycle");
+                                let src = self
+                                    .io
+                                    .read(&cached_module.source_path)
+                                    .expect("failed to read source")
+                                    .into();
+                                ImportCycleLocationDetails {
+                                    location: *location,
+                                    path: cached_module.source_path.clone(),
+                                    src,
+                                }
+                            }
+                        };
+                        (module.clone(), location)
+                    })
+                    .collect_vec();
+                Error::ImportCycle {
+                    modules: Vec1::try_from(modules)
+                        .expect("at least 1 module must exist in cycle"),
+                }
+            }
+        }
     }
 }
 
@@ -1554,39 +1612,6 @@ fn ensure_gleam_module_does_not_overwrite_standard_erlang_module(input: &Input) 
         path: input.path.to_owned(),
     })
 }
-
-fn convert_deps_tree_error(
-    e: dep_tree::Error,
-    dep_location_map: HashMap<EcoString, &Input>,
-) -> Error {
-    match e {
-        dep_tree::Error::Cycle(modules) => {
-            let mut locations = vec![];
-            for (i, module) in modules.iter().enumerate() {
-                // cycles are in order of reference so get next in list or loop back to first
-                let ind = if i == modules.len() - 1 { 0 } else { i + 1 };
-                let next = modules.get(ind).expect("next module must exist");
-                // HACK: for cached modules we do not have the location of the import
-                if let Some(Input::New(module)) = dep_location_map.get(module) {
-                    if let Some((_, location)) = module.dependencies.iter().find(|d| &d.0 == next) {
-                        locations.push(ImportCycleLocationDetails {
-                            location: *location,
-                            path: module.path.clone(),
-                            src: module.code.clone(),
-                        });
-                    }
-                }
-            }
-            tracing::info!(?locations);
-            Error::ImportCycle {
-                modules,
-                locations: Vec1::try_from(locations)
-                    .expect("at least 2 modules must exist in cycle"),
-            }
-        }
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct StaleTracker(HashSet<EcoString>);
 
@@ -1595,8 +1620,8 @@ impl StaleTracker {
         _ = self.0.insert(name);
     }
 
-    fn includes_any(&self, names: &[EcoString]) -> bool {
-        names.iter().any(|n| self.0.contains(n.as_str()))
+    fn includes_any(&self, names: &[(EcoString, SrcSpan)]) -> bool {
+        names.iter().any(|n| self.0.contains(n.0.as_str()))
     }
 
     pub fn empty(&mut self) {

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -28,7 +28,13 @@ fn write_src(fs: &InMemoryFileSystem, path: &str, seconds: u64, src: &str) {
     fs.set_modification_time(&path, SystemTime::UNIX_EPOCH + Duration::from_secs(seconds));
 }
 
-fn write_cache(fs: &InMemoryFileSystem, name: &str, seconds: u64, deps: Vec<EcoString>, src: &str) {
+fn write_cache(
+    fs: &InMemoryFileSystem,
+    name: &str,
+    seconds: u64,
+    deps: Vec<(EcoString, SrcSpan)>,
+    src: &str,
+) {
     let line_numbers = line_numbers::LineNumbers::new(src);
     let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(seconds);
     let cache_metadata = CacheMetadata {
@@ -190,7 +196,13 @@ fn module_is_stale_if_deps_are_stale() {
 
     // Cache is fresh but dep is stale
     write_src(&fs, "/src/two.gleam", 1, "import one");
-    write_cache(&fs, "two", 2, vec![EcoString::from("one")], "import one");
+    write_cache(
+        &fs,
+        "two",
+        2,
+        vec![(EcoString::from("one"), SrcSpan { start: 0, end: 0 })],
+        "import one",
+    );
 
     // Cache is fresh
     write_src(&fs, "/src/three.gleam", 1, TEST_SOURCE_1);

--- a/compiler-core/src/diagnostic.rs
+++ b/compiler-core/src/diagnostic.rs
@@ -36,9 +36,8 @@ impl Label {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExtraLocation {
-    pub src: Option<EcoString>,
-    pub path: Option<Utf8PathBuf>,
+pub struct ExtraLabel {
+    pub src_info: Option<(EcoString, Utf8PathBuf)>,
     pub label: Label,
 }
 
@@ -47,7 +46,7 @@ pub struct Location {
     pub src: EcoString,
     pub path: Utf8PathBuf,
     pub label: Label,
-    pub extra_labels: Vec<ExtraLocation>,
+    pub extra_labels: Vec<ExtraLabel>,
 }
 
 // TODO: split this into locationed diagnostics and locationless diagnostics
@@ -92,15 +91,10 @@ impl Diagnostic {
             .extra_labels
             .iter()
             .map(|l| {
-                let location_path = if let Some(p) = &l.path {
-                    p.as_str()
+                let (location_src, location_path) = if let Some(info) = &l.src_info {
+                    (info.0.as_str(), info.1.as_str())
                 } else {
-                    main_location_path
-                };
-                let location_src = if let Some(s) = &l.src {
-                    s.as_str()
-                } else {
-                    main_location_src
+                    (main_location_src, main_location_path)
                 };
                 match file_map.get(location_path) {
                     None => {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::build::{Outcome, Runtime, Target};
-use crate::diagnostic::{Diagnostic, ExtraLocation, Label, Location};
+use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
 use crate::type_::error::RecordVariants;
 use crate::type_::error::{MissingAnnotation, UnknownTypeHint};
 use crate::type_::{error::PatternMatchKind, FieldAccessUsage};
@@ -1250,10 +1250,9 @@ modules cannot import them. Perhaps move the `{test_module}` module to the src d
                         }
                     });
                     let label = labels.next().expect("Unknown labels first label");
-                    let extra_labels = labels.map(|label| ExtraLocation {
-                      path: None,
-                      src: None,
-                      label,
+                    let extra_labels = labels.map(|label| ExtraLabel {
+                        src_info: None,
+                        label,
                     }).collect();
                     let text = if valid.is_empty() {
                         "This constructor does not accept any labelled arguments.".into()
@@ -1348,9 +1347,8 @@ Names in a Gleam module must be unique so one will need to be renamed."
                             },
                             path: path.clone(),
                             src: src.clone(),
-                            extra_labels: vec![ExtraLocation {
-                              path: None,
-                              src: None,
+                            extra_labels: vec![ExtraLabel {
+                              src_info: None,
                               label: Label {
                                   text: Some("First imported here".into()),
                                   span: *previous_location,
@@ -1387,9 +1385,8 @@ Names in a Gleam module must be unique so one will need to be renamed."
                             },
                             path: path.clone(),
                             src: src.clone(),
-                            extra_labels: vec![ExtraLocation {
-                              path: None,
-                              src: None,
+                            extra_labels: vec![ExtraLabel {
+                              src_info: None,
                               label: Label {
                                 text: Some("First defined here".into()),
                                 span: *first_location,
@@ -1421,9 +1418,8 @@ Names in a Gleam module must be unique so one will need to be renamed."
                             },
                             path: path.clone(),
                             src: src.clone(),
-                            extra_labels: vec![ExtraLocation {
-                              path: None,
-                              src: None,
+                            extra_labels: vec![ExtraLabel {
+                              src_info: None,
                               label: Label {
                                 text: Some("First defined here".into()),
                                 span: *previous_location,
@@ -2943,9 +2939,8 @@ See: https://tour.gleam.run/advanced-features/use/");
                             },
                             path: path.clone(),
                             src: src.clone(),
-                            extra_labels: vec![ExtraLocation {
-                              path: None,
-                              src: None,
+                            extra_labels: vec![ExtraLabel {
+                              src_info: None,
                               label: Label {
                                   text: Some(format!("Expected {expected}, got {given}")),
                                   span: *pattern_location
@@ -2990,13 +2985,12 @@ See: https://tour.gleam.run/advanced-features/use/");
 
             Error::ImportCycle { modules } => {
                 let first_location = &modules.first().1;
-                let rest_locations = modules.iter().skip(1).map(|(_, l)| ExtraLocation {
+                let rest_locations = modules.iter().skip(1).map(|(_, l)| ExtraLabel {
                     label: Label {
                         text: Some("Imported here".into()),
                         span: l.location
                     },
-                    path: Some(l.path.clone()),
-                    src: Some(l.src.clone()),
+                    src_info: Some((l.src.clone(), l.path.clone())),
                 }).collect_vec();
                 let mut text = "The import statements for these modules form a cycle:
 "

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -276,7 +276,9 @@ where
         }
 
         let already_imported: std::collections::HashSet<EcoString> =
-            std::collections::HashSet::from_iter(self.module.dependencies_list());
+            std::collections::HashSet::from_iter(
+                self.module.dependencies.iter().map(|d| d.0.clone()),
+            );
         self.compiler
             .project_compiler
             .get_importable_modules()

--- a/compiler-core/src/language_server/feedback.rs
+++ b/compiler-core/src/language_server/feedback.rs
@@ -123,15 +123,29 @@ impl FeedbackBookKeeper {
         self.unset_errors(&mut feedback);
 
         for diagnostic in diagnostics {
-            match diagnostic.location.as_ref().map(|l| l.path.clone()) {
-                Some(path) => {
-                    _ = self.files_with_errors.insert(path.clone());
-                    feedback.append_diagnostic(path, diagnostic);
-                }
+            if let Some(l) = &diagnostic.location {
+                _ = self.files_with_errors.insert(l.path.clone());
+                feedback.append_diagnostic(l.path.clone(), diagnostic.clone());
 
-                None => {
-                    feedback.append_message(diagnostic);
+                for extra in &l.extra_labels {
+                    _ = self.files_with_errors.insert(extra.path.clone());
+                    feedback.append_diagnostic(
+                        extra.path.clone(),
+                        Diagnostic {
+                            text: format!(""),
+                            hint: None,
+                            location: Some(crate::diagnostic::Location {
+                                label: extra.label.clone(),
+                                path: extra.path.clone(),
+                                src: extra.src.clone(),
+                                extra_labels: vec![],
+                            }),
+                            ..diagnostic.clone()
+                        },
+                    );
                 }
+            } else {
+                feedback.append_message(diagnostic);
             }
         }
 

--- a/compiler-core/src/language_server/feedback.rs
+++ b/compiler-core/src/language_server/feedback.rs
@@ -123,29 +123,15 @@ impl FeedbackBookKeeper {
         self.unset_errors(&mut feedback);
 
         for diagnostic in diagnostics {
-            if let Some(l) = &diagnostic.location {
-                _ = self.files_with_errors.insert(l.path.clone());
-                feedback.append_diagnostic(l.path.clone(), diagnostic.clone());
-
-                for extra in &l.extra_labels {
-                    _ = self.files_with_errors.insert(extra.path.clone());
-                    feedback.append_diagnostic(
-                        extra.path.clone(),
-                        Diagnostic {
-                            text: format!(""),
-                            hint: None,
-                            location: Some(crate::diagnostic::Location {
-                                label: extra.label.clone(),
-                                path: extra.path.clone(),
-                                src: extra.src.clone(),
-                                extra_labels: vec![],
-                            }),
-                            ..diagnostic.clone()
-                        },
-                    );
+            match diagnostic.location.as_ref().map(|l| l.path.clone()) {
+                Some(path) => {
+                    _ = self.files_with_errors.insert(path.clone());
+                    feedback.append_diagnostic(path, diagnostic);
                 }
-            } else {
-                feedback.append_message(diagnostic);
+
+                None => {
+                    feedback.append_message(diagnostic);
+                }
             }
         }
 

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -464,13 +464,8 @@ fn diagnostic_to_lsp(diagnostic: Diagnostic) -> Vec<lsp::Diagnostic> {
         .iter()
         .map(|extra| {
             let message = extra.label.text.clone().unwrap_or_default();
-            let location = if let Some(path) = &extra.path {
-                let line_numbers = LineNumbers::new(
-                    &extra
-                        .src
-                        .clone()
-                        .expect("different path must have source attached"),
-                );
+            let location = if let Some((src, path)) = &extra.src_info {
+                let line_numbers = LineNumbers::new(src);
                 lsp::Location {
                     uri: path_to_uri(path.clone()),
                     range: src_span_to_lsp_range(extra.label.span, &line_numbers),

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use debug_ignore::DebugIgnore;
+use itertools::Itertools;
 use lsp_types::{
     self as lsp, HoverProviderCapability, InitializeParams, Position, PublishDiagnosticsParams,
     Range, TextEdit, Url,
@@ -455,15 +456,47 @@ fn diagnostic_to_lsp(diagnostic: Diagnostic) -> Vec<lsp::Diagnostic> {
         .location
         .expect("Diagnostic given to LSP without location");
     let line_numbers = LineNumbers::new(&location.src);
+    let path = path_to_uri(location.path);
+    let range = src_span_to_lsp_range(location.label.span, &line_numbers);
+
+    let related_info = location
+        .extra_labels
+        .iter()
+        .map(|extra| {
+            let message = extra.label.text.clone().unwrap_or_default();
+            let location = if let Some(path) = &extra.path {
+                let line_numbers = LineNumbers::new(
+                    &extra
+                        .src
+                        .clone()
+                        .expect("different path must have source attached"),
+                );
+                lsp::Location {
+                    uri: path_to_uri(path.clone()),
+                    range: src_span_to_lsp_range(extra.label.span, &line_numbers),
+                }
+            } else {
+                lsp::Location {
+                    uri: path.clone(),
+                    range: src_span_to_lsp_range(extra.label.span, &line_numbers),
+                }
+            };
+            lsp::DiagnosticRelatedInformation { location, message }
+        })
+        .collect_vec();
 
     let main = lsp::Diagnostic {
-        range: src_span_to_lsp_range(location.label.span, &line_numbers),
+        range,
         severity: Some(severity),
         code: None,
         code_description: None,
         source: None,
         message: text,
-        related_information: None,
+        related_information: if related_info.is_empty() {
+            None
+        } else {
+            Some(related_info)
+        },
         tags: None,
         data: None,
     };

--- a/test-package-compiler/cases/import_cycle_multi/gleam.toml
+++ b/test-package-compiler/cases/import_cycle_multi/gleam.toml
@@ -1,0 +1,3 @@
+name = "importy"
+version = "0.1.0"
+target = "erlang"

--- a/test-package-compiler/cases/import_cycle_multi/src/one.gleam
+++ b/test-package-compiler/cases/import_cycle_multi/src/one.gleam
@@ -1,0 +1,1 @@
+import two

--- a/test-package-compiler/cases/import_cycle_multi/src/two.gleam
+++ b/test-package-compiler/cases/import_cycle_multi/src/two.gleam
@@ -1,0 +1,1 @@
+import one

--- a/test-package-compiler/src/generated_tests.rs
+++ b/test-package-compiler/src/generated_tests.rs
@@ -147,6 +147,18 @@ fn import_cycle() {
 
 #[rustfmt::skip]
 #[test]
+fn import_cycle_multi() {
+    let output =
+        crate::prepare("./cases/import_cycle_multi");
+    insta::assert_snapshot!(
+        "import_cycle_multi",
+        output,
+        "./cases/import_cycle_multi"
+    );
+}
+
+#[rustfmt::skip]
+#[test]
 fn import_shadowed_name_warning() {
     let output =
         crate::prepare("./cases/import_shadowed_name_warning");

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
@@ -26,7 +26,7 @@ id(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<80 byte binary>
+<88 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
@@ -23,7 +23,7 @@ expression: "./cases/erlang_bug_752"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<76 byte binary>
+<84 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
@@ -23,7 +23,7 @@ expression: "./cases/erlang_escape_names"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<128 byte binary>
+<136 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<80 byte binary>
+<88 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
@@ -23,7 +23,7 @@ expression: "./cases/erlang_import_shadowing_prelude"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<80 byte binary>
+<88 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
@@ -23,7 +23,7 @@ expression: "./cases/erlang_nested_qualified_constant"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<92 byte binary>
+<100 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle.snap
@@ -6,7 +6,7 @@ error: Import cycle
   ┌─ src/one.gleam:1:1
   │
 1 │ import one
-  │ ^
+  │ ^ Imported here
 
 The import statements for these modules form a cycle:
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle_multi.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle_multi.snap
@@ -6,12 +6,12 @@ error: Import cycle
   ┌─ src/two.gleam:1:1
   │
 1 │ import one
-  │ ^
+  │ ^ Imported here
   │
   ┌─ src/one.gleam:1:1
   │
 1 │ import two
-  │ ^
+  │ ^ Imported here
 
 The import statements for these modules form a cycle:
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle_multi.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle_multi.snap
@@ -1,16 +1,23 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-expression: "./cases/import_cycle"
+expression: "./cases/import_cycle_multi"
 ---
 error: Import cycle
-  ┌─ src/one.gleam:1:1
+  ┌─ src/two.gleam:1:1
   │
 1 │ import one
+  │ ^
+  │
+  ┌─ src/one.gleam:1:1
+  │
+1 │ import two
   │ ^
 
 The import statements for these modules form a cycle:
 
     ┌─────┐
+    │     two
+    │     ↓
     │     one
     └─────┘
 Gleam doesn't support dependency cycles like these, please break the

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -23,7 +23,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<112 byte binary>
+<120 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
@@ -27,7 +27,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<316 byte binary>
+<324 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
@@ -23,7 +23,7 @@ thing() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<303 byte binary>
+<319 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
@@ -27,7 +27,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<475 byte binary>
+<491 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -12,7 +12,7 @@ expression: "./cases/javascript_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<72 byte binary>
+<80 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
 export * from "../prelude.d.mts";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
@@ -6,7 +6,7 @@ expression: "./cases/variable_or_module"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<110 byte binary>
+<118 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).


### PR DESCRIPTION
Closes #3274 

Looks up the import location within the module when a cycle error occurs and adds the location to the error. In addition, in order to make this change render, there were updates to the lsp feedback and diagnostic mechanisms to allow for cross file feedback and the rendering of extra labels.