### PR TITLE
Update content width of built docs to avoid horizontal scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
   the same name as an imported type.
   ([Gears](https://github.com/gearsdatapacks))
 
+- Fixed a bug where a horizontal scrollbar would appear on code blocks in built
+  documentation when they contained lines 79 or 80 characters long.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.2.1 - 2024-05-30
 
 ### Bug Fixes

--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -124,7 +124,7 @@
   --accent: var(--pink);
 
   /* Sizes */
-  --content-width: 750px;
+  --content-width: 772px;
   --header-height: 60px;
   --hash-offset: calc(var(--header-height) * 1.67);
   --sidebar-width: 240px;


### PR DESCRIPTION
Fixes #3276.

The actual required value to avoid scrolling in my testing on macOS was 771px, but I haven't tested on Windows or Linux. I rounded up to 772px, but could consider rounding up further to be more on the safe side.