### PR TITLE
Fix #3288

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@
   aliasing it and then using it in a constant expression would generate invalid
   JavaScript.
   ([Louis Pilfold](https://github.com/lpil))
+  
+- Fixed a bug where the compiler would crash because types weren't registered if
+  they referenced a non-existent type.
+  ([Gears](https://github.com/gearsdatapacks))
 
 ## v1.2.1 - 2024-05-30
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -844,7 +844,13 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 constructor.arguments.iter().enumerate()
             {
                 // Build a type from the annotation AST
-                let t = hydrator.type_from_ast(ast, environment)?;
+                let t = match hydrator.type_from_ast(ast, environment) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        self.errors.push(e);
+                        continue;
+                    }
+                };
 
                 fields.push(TypeValueConstructorField { type_: t.clone() });
 

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -966,3 +966,23 @@ pub fn main(x: something) {
 "#
     );
 }
+
+#[test]
+fn reference_absent_type() {
+    // This test is here because this code previously caused the compiler
+    // to crash, and we want to make sure that it doesn't break again
+    assert_module_error!(
+        "
+type Foo {
+    Bar(Int)
+    Baz(Qux)
+}
+
+pub fn main(foo) {
+    case foo {
+        Bar(x) -> x
+    }
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__reference_absent_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__reference_absent_type.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\ntype Foo {\n    Bar(Int)\n    Baz(Qux)\n}\n\npub fn main(foo) {\n    case foo {\n        Bar(x) -> x\n    }\n}\n"
+---
+error: Unknown type
+  ┌─ /src/one/two.gleam:4:9
+  │
+4 │     Baz(Qux)
+  │         ^^^
+
+The type `Qux` is not defined or imported in this module.
+
+error: Private type used in public interface
+  ┌─ /src/one/two.gleam:7:1
+  │
+7 │ pub fn main(foo) {
+  │ ^^^^^^^^^^^^^^^^
+
+The following type is private, but is being used by this public export.
+
+    Foo
+
+Private types can only be used within the module that defines them.
+
+error: Inexhaustive patterns
+   ┌─ /src/one/two.gleam:8:5
+   │  
+ 8 │ ╭     case foo {
+ 9 │ │         Bar(x) -> x
+10 │ │     }
+   │ ╰─────^
+
+This case expression does not have a pattern for all possible values.
+If it is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    Baz


### PR DESCRIPTION
Fixes #3288 
This just makes the analyser more fault tolerant for custom types that reference other types that don't exist, and still registers the custom type in that case.