### PR TITLE
[LSP] Add parentheses to functions

### DIFF
--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -653,10 +653,14 @@ fn value_completion(
     value: &crate::type_::ValueConstructor,
     insert_range: Range,
 ) -> CompletionItem {
-    let label = match module_qualifier {
+    let mut label = match module_qualifier {
         Some(module) => format!("{module}.{name}"),
         None => name.to_string(),
     };
+    // Append "()" if the value is a function.
+    if let ValueConstructorVariant::ModuleFn { .. } = value.variant {
+        label.push_str("()");
+    }
 
     let type_ = Printer::new().pretty_print(&value.type_, 0);
 

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -19,7 +19,7 @@ fn completion_at_default_position(tester: TestProject<'_>) -> Vec<CompletionItem
     let tester = TestProject { src, ..tester };
     completion(tester, Position::new(1, 0))
         .into_iter()
-        .filter(|c| c.label != "typing_in_here")
+        .filter(|c| c.label != "typing_in_here()")
         .collect_vec()
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import.snap
@@ -44,7 +44,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
         tags: None,
     },
     CompletionItem {
-        label: "myfun",
+        label: "myfun()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -80,7 +80,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
                             character: 12,
                         },
                     },
-                    new_text: "myfun",
+                    new_text: "myfun()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
@@ -4,7 +4,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
 ---
 [
     CompletionItem {
-        label: "myfun",
+        label: "myfun()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
                             character: 18,
                         },
                     },
-                    new_text: "myfun",
+                    new_text: "myfun()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
@@ -44,7 +44,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
         tags: None,
     },
     CompletionItem {
-        label: "myfun",
+        label: "myfun()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -80,7 +80,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
                             character: 0,
                         },
                     },
-                    new_text: "myfun",
+                    new_text: "myfun()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
 ---
 [
     CompletionItem {
-        label: "dep.wobble",
+        label: "dep.wobble()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "dep.wobble",
+                    new_text: "dep.wobble()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
 ---
 [
     CompletionItem {
-        label: "dep.wobble",
+        label: "dep.wobble()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "dep.wobble",
+                    new_text: "dep.wobble()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
 ---
 [
     CompletionItem {
-        label: "dep.wobble",
+        label: "dep.wobble()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "dep.wobble",
+                    new_text: "dep.wobble()",
                 },
             ),
         ),
@@ -67,7 +67,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         tags: None,
     },
     CompletionItem {
-        label: "dep2.wobble",
+        label: "dep2.wobble()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -103,7 +103,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "dep2.wobble",
+                    new_text: "dep2.wobble()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_module_function.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
 ---
 [
     CompletionItem {
-        label: "dep.wobble",
+        label: "dep.wobble()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "dep.wobble",
+                    new_text: "dep.wobble()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_module_function.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
 ---
 [
     CompletionItem {
-        label: "dep.wobble",
+        label: "dep.wobble()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "dep.wobble",
+                    new_text: "dep.wobble()",
                 },
             ),
         ),
@@ -51,7 +51,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         tags: None,
     },
     CompletionItem {
-        label: "wobble",
+        label: "wobble()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -87,7 +87,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "wobble",
+                    new_text: "wobble()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
@@ -98,7 +98,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
         tags: None,
     },
     CompletionItem {
-        label: "dep.main",
+        label: "dep.main()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -134,7 +134,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
                             character: 0,
                         },
                     },
-                    new_text: "dep.main",
+                    new_text: "dep.main()",
                 },
             ),
         ),
@@ -145,7 +145,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
         tags: None,
     },
     CompletionItem {
-        label: "dep.random_float",
+        label: "dep.random_float()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -181,7 +181,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
                             character: 0,
                         },
                     },
-                    new_text: "dep.random_float",
+                    new_text: "dep.random_float()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
@@ -98,7 +98,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         tags: None,
     },
     CompletionItem {
-        label: "main",
+        label: "main()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -134,7 +134,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
                             character: 0,
                         },
                     },
-                    new_text: "main",
+                    new_text: "main()",
                 },
             ),
         ),
@@ -145,7 +145,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         tags: None,
     },
     CompletionItem {
-        label: "random_float",
+        label: "random_float()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -181,7 +181,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
                             character: 0,
                         },
                     },
-                    new_text: "random_float",
+                    new_text: "random_float()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
 ---
 [
     CompletionItem {
-        label: "main",
+        label: "main()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
                             character: 0,
                         },
                     },
-                    new_text: "main",
+                    new_text: "main()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function_with_documentation.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
 ---
 [
     CompletionItem {
-        label: "main",
+        label: "main()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -47,7 +47,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
                             character: 0,
                         },
                     },
-                    new_text: "main",
+                    new_text: "main()",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_function.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
 ---
 [
     CompletionItem {
-        label: "private",
+        label: "private()",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -40,7 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "private",
+                    new_text: "private()",
                 },
             ),
         ),


### PR DESCRIPTION
<img width="889" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/2d470031-24b3-4cbe-958d-31cdb4125583">

This is how Rust works. And I believe it also speeds up coding.
<img width="584" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/6f6eefd0-8a1e-4863-a91b-4adb542dcf55">
