### PR TITLE
Add Information About Found Token in UnexpectedToken Error Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,24 @@
 - Import cycles now show the location where the import occur.
   ([Ameen Radwan](https://github.com/Acepie))
 
+- Error messages resulting from unexpected tokens now include information on
+  the found token's type. This updated message explains how the lexer handled
+  the token, so as to guide the user towards providing correct syntax.
+
+  Following is an example, where the error message indicates that the name of
+  the provided field conflicts with a keyword:
+
+  ```
+  3 │     A(type: String)
+    │       ^^^^ I was not expecting this
+
+  Found the keyword `type`, expected one of:
+  `)`
+  a constructor argument name
+  ```
+
+  ([Rahul D. Ghosal](https://github.com/rdghosal))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2813,7 +2813,7 @@ where
                 Token::UpName { .. } => {
                     parse_error(ParseErrorType::IncorrectName, SrcSpan { start, end })
                 }
-                _ if is_reserved_word(tok) => parse_error(
+                _ if tok.is_reserved_word() => parse_error(
                     ParseErrorType::UnexpectedReservedWord,
                     SrcSpan { start, end },
                 ),
@@ -3543,90 +3543,6 @@ fn parse_error<T>(error: ParseErrorType, location: SrcSpan) -> Result<T, ParseEr
 //
 // Misc Helpers
 //
-
-/// Returns whether the given token is a reserved word.
-///
-/// Useful for checking if a user tried to enter a reserved word as a name.
-fn is_reserved_word(tok: Token) -> bool {
-    match tok {
-        Token::As
-        | Token::Assert
-        | Token::Case
-        | Token::Const
-        | Token::Fn
-        | Token::If
-        | Token::Import
-        | Token::Let
-        | Token::Opaque
-        | Token::Pub
-        | Token::Todo
-        | Token::Type
-        | Token::Use
-        | Token::Auto
-        | Token::Delegate
-        | Token::Derive
-        | Token::Echo
-        | Token::Else
-        | Token::Implement
-        | Token::Macro
-        | Token::Panic
-        | Token::Test => true,
-
-        Token::Name { .. }
-        | Token::UpName { .. }
-        | Token::DiscardName { .. }
-        | Token::Int { .. }
-        | Token::Float { .. }
-        | Token::String { .. }
-        | Token::CommentDoc { .. }
-        | Token::LeftParen
-        | Token::RightParen
-        | Token::LeftSquare
-        | Token::RightSquare
-        | Token::LeftBrace
-        | Token::RightBrace
-        | Token::Plus
-        | Token::Minus
-        | Token::Star
-        | Token::Slash
-        | Token::Less
-        | Token::Greater
-        | Token::LessEqual
-        | Token::GreaterEqual
-        | Token::Percent
-        | Token::PlusDot
-        | Token::MinusDot
-        | Token::StarDot
-        | Token::SlashDot
-        | Token::LessDot
-        | Token::GreaterDot
-        | Token::LessEqualDot
-        | Token::GreaterEqualDot
-        | Token::LtGt
-        | Token::Colon
-        | Token::Comma
-        | Token::Hash
-        | Token::Bang
-        | Token::Equal
-        | Token::EqualEqual
-        | Token::NotEqual
-        | Token::Vbar
-        | Token::VbarVbar
-        | Token::AmperAmper
-        | Token::LtLt
-        | Token::GtGt
-        | Token::Pipe
-        | Token::Dot
-        | Token::RArrow
-        | Token::LArrow
-        | Token::DotDot
-        | Token::At
-        | Token::EndOfFile
-        | Token::CommentNormal
-        | Token::CommentModule
-        | Token::NewLine => false,
-    }
-}
 
 // Parsing a function call into the appropriate structure
 #[derive(Debug)]

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -241,12 +241,12 @@ where
         parse_result: Result<A, ParseError>,
     ) -> Result<A, ParseError> {
         let parse_result = self.ensure_no_errors(parse_result)?;
-        if let Some((start, found, end)) = self.next_tok() {
+        if let Some((start, token, end)) = self.next_tok() {
             // there are still more tokens
             let expected = vec!["An import, const, type, or function.".into()];
             return parse_error(
                 ParseErrorType::UnexpectedToken {
-                    found,
+                    token,
                     expected,
                     hint: None,
                 },
@@ -2477,9 +2477,9 @@ where
                             })),
                         }
                     }
-                    Some((start, found, end)) => parse_error(
+                    Some((start, token, end)) => parse_error(
                         ParseErrorType::UnexpectedToken {
-                            found,
+                            token,
                             expected: vec!["UpName".into(), "Name".into()],
                             hint: None,
                         },
@@ -2970,9 +2970,9 @@ where
     fn next_tok_unexpected<A>(&mut self, expected: Vec<EcoString>) -> Result<A, ParseError> {
         match self.next_tok() {
             None => parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 }),
-            Some((start, found, end)) => parse_error(
+            Some((start, token, end)) => parse_error(
                 ParseErrorType::UnexpectedToken {
-                    found,
+                    token,
                     expected,
                     hint: None,
                 },
@@ -3579,9 +3579,8 @@ pub fn make_call(
                 if name != "_" {
                     return parse_error(
                         ParseErrorType::UnexpectedToken {
-                            found: Token::Name { name },
+                            token: Token::Name { name },
                             expected: vec!["An expression".into(), "An underscore".into()],
-
                             hint: None,
                         },
                         location,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -73,7 +73,7 @@ use crate::warning::{DeprecatedSyntaxWarning, WarningEmitter};
 use crate::Warning;
 use camino::Utf8PathBuf;
 use ecow::EcoString;
-use error::{LexicalError, ParseError, ParseErrorType, UnexpectedTokenInfo};
+use error::{LexicalError, ParseError, ParseErrorType, ParserErrorCause};
 use lexer::{LexResult, Spanned};
 use std::cmp::Ordering;
 use std::collections::VecDeque;
@@ -246,10 +246,7 @@ where
             let expected = vec!["An import, const, type, or function.".into()];
             return parse_error(
                 ParseErrorType::UnexpectedToken {
-                    found: UnexpectedTokenInfo {
-                        display: tok.to_string(),
-                        is_keyword: is_reserved_word(tok),
-                    },
+                    found: ParserErrorCause::Token(tok),
                     expected,
                     hint: None,
                 },
@@ -2482,10 +2479,7 @@ where
                     }
                     Some((start, tok, end)) => parse_error(
                         ParseErrorType::UnexpectedToken {
-                            found: UnexpectedTokenInfo {
-                                display: tok.to_string(),
-                                is_keyword: is_reserved_word(tok),
-                            },
+                            found: ParserErrorCause::Token(tok),
                             expected: vec!["UpName".into(), "Name".into()],
                             hint: None,
                         },
@@ -2978,10 +2972,7 @@ where
             None => parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 }),
             Some((start, tok, end)) => parse_error(
                 ParseErrorType::UnexpectedToken {
-                    found: UnexpectedTokenInfo {
-                        display: tok.to_string(),
-                        is_keyword: is_reserved_word(tok),
-                    },
+                    found: ParserErrorCause::Token(tok),
                     expected,
                     hint: None,
                 },
@@ -3672,10 +3663,7 @@ pub fn make_call(
                 if name != "_" {
                     return parse_error(
                         ParseErrorType::UnexpectedToken {
-                            found: UnexpectedTokenInfo {
-                                display: name.into(),
-                                is_keyword: false,
-                            },
+                            found: ParserErrorCause::Descriptor("a name".into()),
                             expected: vec!["An expression".into(), "An underscore".into()],
 
                             hint: None,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -73,7 +73,7 @@ use crate::warning::{DeprecatedSyntaxWarning, WarningEmitter};
 use crate::Warning;
 use camino::Utf8PathBuf;
 use ecow::EcoString;
-use error::{LexicalError, ParseError, ParseErrorType};
+use error::{LexicalError, ParseError, ParseErrorType, UnexpectedTokenInfo};
 use lexer::{LexResult, Spanned};
 use std::cmp::Ordering;
 use std::collections::VecDeque;
@@ -246,7 +246,10 @@ where
             let expected = vec!["An import, const, type, or function.".into()];
             return parse_error(
                 ParseErrorType::UnexpectedToken {
-                    found: format_found_token(tok),
+                    found: UnexpectedTokenInfo {
+                        display: tok.to_string(),
+                        is_keyword: is_reserved_word(tok),
+                    },
                     expected,
                     hint: None,
                 },
@@ -2479,7 +2482,10 @@ where
                     }
                     Some((start, tok, end)) => parse_error(
                         ParseErrorType::UnexpectedToken {
-                            found: format_found_token(tok),
+                            found: UnexpectedTokenInfo {
+                                display: tok.to_string(),
+                                is_keyword: is_reserved_word(tok),
+                            },
                             expected: vec!["UpName".into(), "Name".into()],
                             hint: None,
                         },
@@ -2972,7 +2978,10 @@ where
             None => parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 }),
             Some((start, tok, end)) => parse_error(
                 ParseErrorType::UnexpectedToken {
-                    found: format_found_token(tok),
+                    found: UnexpectedTokenInfo {
+                        display: tok.to_string(),
+                        is_keyword: is_reserved_word(tok),
+                    },
                     expected,
                     hint: None,
                 },
@@ -3628,19 +3637,6 @@ fn is_reserved_word(tok: Token) -> bool {
     }
 }
 
-/// Formats a token into a debug-style string and specifies whether
-/// the token is a reserved word (i.e., keyword).
-fn format_found_token(tok: Token) -> String {
-    let base = tok.to_string();
-    if is_reserved_word(tok) {
-        format!("{base} (a keyword)")
-    }
-    else {
-        format!("{base}")
-    }
-}
-
-
 // Parsing a function call into the appropriate structure
 #[derive(Debug)]
 pub enum ParserArg {
@@ -3676,7 +3672,10 @@ pub fn make_call(
                 if name != "_" {
                     return parse_error(
                         ParseErrorType::UnexpectedToken {
-                            found: format!("{name:?}"),
+                            found: UnexpectedTokenInfo {
+                                display: name.into(),
+                                is_keyword: false,
+                            },
                             expected: vec!["An expression".into(), "An underscore".into()],
 
                             hint: None,

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -189,19 +189,19 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 vec!["Please remove the argument label.".into()],
             ),
             ParseErrorType::UnexpectedToken {
-                found,
+                token,
                 expected,
                 hint,
             } => {
-                let found = match found {
+                let found = match token {
                     Token::Int { .. } => "an Int".to_string(),
                     Token::Float { .. } => "a Float".to_string(),
                     Token::String { .. } => "a String".to_string(),
                     Token::CommentDoc { .. } => "a comment".to_string(),
                     Token::DiscardName { .. } => "a discard name".to_string(),
                     Token::Name { .. } | Token::UpName { .. } => "a name".to_string(),
-                    _ if found.is_reserved_word() => format!("the keyword {}", found),
-                    _ => found.to_string(),
+                    _ if token.is_reserved_word() => format!("the keyword {}", token),
+                    _ => token.to_string(),
                 };
 
                 let messages = std::iter::once(format!("Found {found}, expected one of: "))
@@ -306,7 +306,7 @@ pub enum ParseErrorType {
     UnexpectedEof,
     UnexpectedReservedWord, // reserved word used when a name was expected
     UnexpectedToken {
-        found: Token,
+        token: Token,
         expected: Vec<EcoString>,
         hint: Option<EcoString>,
     },

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -1,5 +1,6 @@
 use crate::ast::SrcSpan;
 use crate::error::wrap;
+use std::fmt;
 use ecow::EcoString;
 use heck::{ToSnakeCase, ToUpperCamelCase};
 
@@ -7,6 +8,12 @@ use heck::{ToSnakeCase, ToUpperCamelCase};
 pub struct LexicalError {
     pub error: LexicalErrorType,
     pub location: SrcSpan,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct UnexpectedTokenInfo {
+    pub display: String,
+    pub is_keyword: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -290,7 +297,7 @@ pub enum ParseErrorType {
     UnexpectedEof,
     UnexpectedReservedWord, // reserved word used when a name was expected
     UnexpectedToken {
-        found: String,
+        found: UnexpectedTokenInfo,
         expected: Vec<EcoString>,
         hint: Option<EcoString>,
     },
@@ -395,6 +402,18 @@ impl LexicalError {
                     "See: https://tour.gleam.run/basics/equality".into(),
                 ],
             ),
+        }
+    }
+}
+
+impl fmt::Display for UnexpectedTokenInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let base = self.display.replace("\"", "");
+        if self.is_keyword {
+            write!(f, "the keyword `{}`", base)
+        }
+        else {
+            write!(f, "\"{}\"", base)
         }
     }
 }

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -200,8 +200,14 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 hint,
             } => {
                 let found = match found {
-                    ParserErrorCause::Token(tok) => tok.to_string(),
                     ParserErrorCause::Descriptor(desc) => desc.to_string(),
+                    ParserErrorCause::Token(tok) => {
+                        let display = tok.to_string();
+                        match tok.is_reserved_word() {
+                            true => format!("the keyword `{}`", display.replace("\"", "")),
+                            false => display
+                        }
+                    },
                 };
 
                 let messages = std::iter::once(format!("Found {found}, expected one of: "))

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -205,9 +205,9 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                         let display = tok.to_string();
                         match tok.is_reserved_word() {
                             true => format!("the keyword `{}`", display.replace("\"", "")),
-                            false => display
+                            false => display,
                         }
-                    },
+                    }
                 };
 
                 let messages = std::iter::once(format!("Found {found}, expected one of: "))

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -200,7 +200,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                     Token::CommentDoc { .. } => "a comment".to_string(),
                     Token::DiscardName { .. } => "a discard name".to_string(),
                     Token::Name { .. } | Token::UpName { .. } => "a name".to_string(),
-                    _ if found.is_reserved_word() => format!("the keyword {}", found.to_string()),
+                    _ if found.is_reserved_word() => format!("the keyword {}", found),
                     _ => found.to_string(),
                 };
 

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -10,12 +10,6 @@ pub struct LexicalError {
     pub location: SrcSpan,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum ParserErrorCause {
-    Token(Token),
-    Descriptor(EcoString),
-}
-
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InvalidUnicodeEscapeError {
     MissingOpeningBrace,          // Expected '{'
@@ -200,14 +194,14 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 hint,
             } => {
                 let found = match found {
-                    ParserErrorCause::Descriptor(desc) => desc.to_string(),
-                    ParserErrorCause::Token(tok) => {
-                        let display = tok.to_string();
-                        match tok.is_reserved_word() {
-                            true => format!("the keyword {}", display),
-                            false => display,
-                        }
-                    }
+                    Token::Int { .. } => "an Int".to_string(),
+                    Token::Float { .. } => "a Float".to_string(),
+                    Token::String { .. } => "a String".to_string(),
+                    Token::CommentDoc { .. } => "a comment".to_string(),
+                    Token::DiscardName { .. } => "a discard name".to_string(),
+                    Token::Name { .. } | Token::UpName { .. } => "a name".to_string(),
+                    _ if found.is_reserved_word() => format!("the keyword {}", found.to_string()),
+                    _ => found.to_string(),
                 };
 
                 let messages = std::iter::once(format!("Found {found}, expected one of: "))
@@ -312,7 +306,7 @@ pub enum ParseErrorType {
     UnexpectedEof,
     UnexpectedReservedWord, // reserved word used when a name was expected
     UnexpectedToken {
-        found: ParserErrorCause,
+        found: Token,
         expected: Vec<EcoString>,
         hint: Option<EcoString>,
     },

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -1,8 +1,8 @@
 use crate::ast::SrcSpan;
 use crate::error::wrap;
-use std::fmt;
 use ecow::EcoString;
 use heck::{ToSnakeCase, ToUpperCamelCase};
+use std::fmt;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LexicalError {
@@ -411,8 +411,7 @@ impl fmt::Display for UnexpectedTokenInfo {
         let base = self.display.replace("\"", "");
         if self.is_keyword {
             write!(f, "the keyword `{}`", base)
-        }
-        else {
+        } else {
             write!(f, "\"{}\"", base)
         }
     }

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -187,8 +187,8 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 "Argument labels are not allowed for anonymous functions",
                 vec!["Please remove the argument label.".into()],
             ),
-            ParseErrorType::UnexpectedToken { expected, hint } => {
-                let messages = std::iter::once("Expected one of: ".to_string())
+            ParseErrorType::UnexpectedToken { found, expected, hint } => {
+                let messages = std::iter::once(format!("Found {}, expected one of: ", found))
                     .chain(expected.iter().map(|s| s.to_string()));
 
                 let messages = match hint {
@@ -290,6 +290,7 @@ pub enum ParseErrorType {
     UnexpectedEof,
     UnexpectedReservedWord, // reserved word used when a name was expected
     UnexpectedToken {
+        found: String,
         expected: Vec<EcoString>,
         hint: Option<EcoString>,
     },

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -204,7 +204,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                     ParserErrorCause::Token(tok) => {
                         let display = tok.to_string();
                         match tok.is_reserved_word() {
-                            true => format!("the keyword `{}`", display.replace("\"", "")),
+                            true => format!("the keyword {}", display),
                             false => display,
                         }
                     }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     let <<b1, pub>> = <<24, 3>>
   │               ^^^ I was not expecting this
 
-Found "pub" (a keyword), expected one of: 
+Found the keyword `pub`, expected one of: 
 ">>"
 a bit array segment pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     let <<b1, pub>> = <<24, 3>>
   │               ^^^ I was not expecting this
 
-Expected one of: 
+Found "pub" (a keyword), expected one of: 
 ">>"
 a bit array segment pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_bit_segment.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │               ^^^ I was not expecting this
 
 Found the keyword `pub`, expected one of: 
-">>"
+`>>`
 a bit array segment pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     let #(a, case, c) = #(1, 2, 3)
   │              ^^^^ I was not expecting this
 
-Expected one of: 
+Found "case" (a keyword), expected one of: 
 ")"
 a pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     let #(a, case, c) = #(1, 2, 3)
   │              ^^^^ I was not expecting this
 
-Found "case" (a keyword), expected one of: 
+Found the keyword `case`, expected one of: 
 ")"
 a pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__assignment_pattern_invalid_tuple.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │              ^^^^ I was not expecting this
 
 Found the keyword `case`, expected one of: 
-")"
+`)`
 a pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     <<72, 101, 108, 108, 111, 44, 32, 74, 111, 101, const>>
   │                                                     ^^^^^ I was not expecting this
 
-Found "const" (a keyword), expected one of: 
+Found the keyword `const`, expected one of: 
 ">>"
 a bit array segment

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │                                                     ^^^^^ I was not expecting this
 
 Found the keyword `const`, expected one of: 
-">>"
+`>>`
 a bit array segment

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bit_array_invalid_segment.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     <<72, 101, 108, 108, 111, 44, 32, 74, 111, 101, const>>
   │                                                     ^^^^^ I was not expecting this
 
-Expected one of: 
+Found "const" (a keyword), expected one of: 
 ">>"
 a bit array segment

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__capture_with_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__capture_with_name.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │   add(_name, 1)
   │       ^^^^^ I was not expecting this
 
-Expected one of: 
+Found "_name", expected one of: 
 An expression
 An underscore

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__capture_with_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__capture_with_name.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │   add(_name, 1)
   │       ^^^^^ I was not expecting this
 
-Found "_name", expected one of: 
+Found a name, expected one of: 
 An expression
 An underscore

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_case_pattern.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_case_pattern.snap
@@ -8,6 +8,6 @@ error: Syntax error
 4 │         -> -> 0
   │         ^^ I was not expecting this
 
-Found "->", expected one of: 
-"}"
+Found `->`, expected one of: 
+`}`
 a case clause

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_case_pattern.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_case_pattern.snap
@@ -8,6 +8,6 @@ error: Syntax error
 4 │         -> -> 0
   │         ^^ I was not expecting this
 
-Expected one of: 
+Found "->", expected one of: 
 "}"
 a case clause

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     case 1, type {
   │             ^^^^ I was not expecting this
 
-Found "type" (a keyword), expected one of: 
+Found the keyword `type`, expected one of: 
 "{"
 an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     case 1, type {
   │             ^^^^ I was not expecting this
 
-Expected one of: 
+Found "type" (a keyword), expected one of: 
 "{"
 an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │             ^^^^ I was not expecting this
 
 Found the keyword `type`, expected one of: 
-"{"
+`{`
 an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_bit_array_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_bit_array_segment.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ const a = <<1, 2, <->>
   │                   ^^ I was not expecting this
 
-Expected one of: 
+Found "<-", expected one of: 
 ">>"
 a bit array segment

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_bit_array_segment.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_bit_array_segment.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ const a = <<1, 2, <->>
   │                   ^^ I was not expecting this
 
-Found "<-", expected one of: 
-">>"
+Found `<-`, expected one of: 
+`>>`
 a bit array segment

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_list.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_list.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ const a = [1, 2, <-]
   │                  ^^ I was not expecting this
 
-Found "<-", expected one of: 
-"]"
+Found `<-`, expected one of: 
+`]`
 a constant value

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_list.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_list.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ const a = [1, 2, <-]
   │                  ^^ I was not expecting this
 
-Expected one of: 
+Found "<-", expected one of: 
 "]"
 a constant value

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
@@ -8,6 +8,6 @@ error: Syntax error
 5 │ const a = A("a", let)
   │                  ^^^ I was not expecting this
 
-Expected one of: 
+Found "let" (a keyword), expected one of: 
 ")"
 a constant record argument

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │                  ^^^ I was not expecting this
 
 Found the keyword `let`, expected one of: 
-")"
+`)`
 a constant record argument

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_record_constructor.snap
@@ -8,6 +8,6 @@ error: Syntax error
 5 │ const a = A("a", let)
   │                  ^^^ I was not expecting this
 
-Found "let" (a keyword), expected one of: 
+Found the keyword `let`, expected one of: 
 ")"
 a constant record argument

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_tuple.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_tuple.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ const a = #(1, 2, <-)
   │                   ^^ I was not expecting this
 
-Found "<-", expected one of: 
-")"
+Found `<-`, expected one of: 
+`)`
 a constant value

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_tuple.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_invalid_tuple.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ const a = #(1, 2, <-)
   │                   ^^ I was not expecting this
 
-Expected one of: 
+Found "<-", expected one of: 
 ")"
 a constant value

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_invalid_signature.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_invalid_signature.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ fn f(a, "b") -> String {
   │         ^^^ I was not expecting this
 
-Found "b", expected one of: 
-")"
+Found `b`, expected one of: 
+`)`
 a function parameter

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_invalid_signature.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_invalid_signature.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ fn f(a, "b") -> String {
   │         ^^^ I was not expecting this
 
-Found `b`, expected one of: 
+Found a String, expected one of: 
 `)`
 a function parameter

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_invalid_signature.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_invalid_signature.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nfn f(a, \"b\") -> String {\n    a <> b\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:9
+  │
+2 │ fn f(a, "b") -> String {
+  │         ^^^ I was not expecting this
+
+Found "b", expected one of: 
+")"
+a function parameter

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ fn f(g: fn(Int, 1) -> Int) -> Int {
   │                 ^ I was not expecting this
 
-Found "1", expected one of: 
-")"
+Found `1`, expected one of: 
+`)`
 a type

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ fn f(g: fn(Int, 1) -> Int) -> Int {
   │                 ^ I was not expecting this
 
-Found `1`, expected one of: 
+Found an Int, expected one of: 
 `)`
 a type

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_type_invalid_param_type.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ fn f(g: fn(Int, 1) -> Int) -> Int {
   │                 ^ I was not expecting this
 
-Expected one of: 
+Found "1", expected one of: 
 ")"
 a type

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     #(1, 2, const)
   │             ^^^^^ I was not expecting this
 
-Expected one of: 
+Found "const" (a keyword), expected one of: 
 ")"
 an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     #(1, 2, const)
   │             ^^^^^ I was not expecting this
 
-Found "const" (a keyword), expected one of: 
+Found the keyword `const`, expected one of: 
 ")"
 an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__tuple_invalid_expr.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │             ^^^^^ I was not expecting this
 
 Found the keyword `const`, expected one of: 
-")"
+`)`
 an expression

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │     ^^^^ I was not expecting this
 
 Found the keyword `type`, expected one of: 
-"}"
+`}`
 a record constructor

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
@@ -8,6 +8,6 @@ error: Syntax error
 4 │     type
   │     ^^^^ I was not expecting this
 
-Expected one of: 
+Found "type" (a keyword), expected one of: 
 "}"
 a record constructor

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor.snap
@@ -8,6 +8,6 @@ error: Syntax error
 4 │     type
   │     ^^^^ I was not expecting this
 
-Found "type" (a keyword), expected one of: 
+Found the keyword `type`, expected one of: 
 "}"
 a record constructor

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     A(type: String)
   │       ^^^^ I was not expecting this
 
-Found "type" (a keyword), expected one of: 
+Found the keyword `type`, expected one of: 
 ")"
 a constructor argument name

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │       ^^^^ I was not expecting this
 
 Found the keyword `type`, expected one of: 
-")"
+`)`
 a constructor argument name

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_constructor_arg.snap
@@ -8,6 +8,6 @@ error: Syntax error
 3 │     A(type: String)
   │       ^^^^ I was not expecting this
 
-Expected one of: 
+Found "type" (a keyword), expected one of: 
 ")"
 a constructor argument name

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_record.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_record.snap
@@ -8,6 +8,6 @@ error: Syntax error
 5 │     3
   │     ^ I was not expecting this
 
-Found "3", expected one of: 
-"}"
+Found `3`, expected one of: 
+`}`
 a record constructor

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_record.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_record.snap
@@ -8,6 +8,6 @@ error: Syntax error
 5 │     3
   │     ^ I was not expecting this
 
-Found `3`, expected one of: 
+Found an Int, expected one of: 
 `}`
 a record constructor

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_record.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_record.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\ntype A {\n    One\n    Two\n    3\n}\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:5:5
+  │
+5 │     3
+  │     ^ I was not expecting this
+
+Found "3", expected one of: 
+"}"
+a record constructor

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ type A(a, type) {
   │           ^^^^ I was not expecting this
 
-Found "type" (a keyword), expected one of: 
+Found the keyword `type`, expected one of: 
 ")"
 a name

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
@@ -9,5 +9,5 @@ error: Syntax error
   │           ^^^^ I was not expecting this
 
 Found the keyword `type`, expected one of: 
-")"
+`)`
 a name

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__type_invalid_type_name.snap
@@ -8,6 +8,6 @@ error: Syntax error
 2 │ type A(a, type) {
   │           ^^^^ I was not expecting this
 
-Expected one of: 
+Found "type" (a keyword), expected one of: 
 ")"
 a name

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1059,6 +1059,19 @@ type A {
 }
 
 #[test]
+fn type_invalid_record() {
+    assert_module_error!(
+        "
+type A {
+    One
+    Two
+    3
+}
+"
+    );
+}
+
+#[test]
 fn function_type_invalid_param_type() {
     assert_module_error!(
         "
@@ -1066,6 +1079,17 @@ fn f(g: fn(Int, 1) -> Int) -> Int {
   g(0, 1)
 }
 "
+    );
+}
+
+#[test]
+fn function_invalid_signature() {
+    assert_module_error!(
+        r#"
+fn f(a, "b") -> String {
+    a <> b
+}
+"#
     );
 }
 

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -113,6 +113,87 @@ impl Token {
             _ => None,
         }
     }
+
+    pub fn is_reserved_word(&self) -> bool {
+        match self {
+            Token::As
+            | Token::Assert
+            | Token::Case
+            | Token::Const
+            | Token::Fn
+            | Token::If
+            | Token::Import
+            | Token::Let
+            | Token::Opaque
+            | Token::Pub
+            | Token::Todo
+            | Token::Type
+            | Token::Use
+            | Token::Auto
+            | Token::Delegate
+            | Token::Derive
+            | Token::Echo
+            | Token::Else
+            | Token::Implement
+            | Token::Macro
+            | Token::Panic
+            | Token::Test => true,
+
+            Token::Name { .. }
+            | Token::UpName { .. }
+            | Token::DiscardName { .. }
+            | Token::Int { .. }
+            | Token::Float { .. }
+            | Token::String { .. }
+            | Token::CommentDoc { .. }
+            | Token::LeftParen
+            | Token::RightParen
+            | Token::LeftSquare
+            | Token::RightSquare
+            | Token::LeftBrace
+            | Token::RightBrace
+            | Token::Plus
+            | Token::Minus
+            | Token::Star
+            | Token::Slash
+            | Token::Less
+            | Token::Greater
+            | Token::LessEqual
+            | Token::GreaterEqual
+            | Token::Percent
+            | Token::PlusDot
+            | Token::MinusDot
+            | Token::StarDot
+            | Token::SlashDot
+            | Token::LessDot
+            | Token::GreaterDot
+            | Token::LessEqualDot
+            | Token::GreaterEqualDot
+            | Token::LtGt
+            | Token::Colon
+            | Token::Comma
+            | Token::Hash
+            | Token::Bang
+            | Token::Equal
+            | Token::EqualEqual
+            | Token::NotEqual
+            | Token::Vbar
+            | Token::VbarVbar
+            | Token::AmperAmper
+            | Token::LtLt
+            | Token::GtGt
+            | Token::Pipe
+            | Token::Dot
+            | Token::RArrow
+            | Token::LArrow
+            | Token::DotDot
+            | Token::At
+            | Token::EndOfFile
+            | Token::CommentNormal
+            | Token::CommentModule
+            | Token::NewLine => false,
+        }
+    }
 }
 
 impl fmt::Display for Token {

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -275,6 +275,6 @@ impl fmt::Display for Token {
             Token::Vbar => "|",
             Token::VbarVbar => "||",
         };
-        write!(f, "\"{s}\"")
+        write!(f, "`{s}`")
     }
 }


### PR DESCRIPTION
Addresses #3286.

This commit introduces:
- A `found` member to `ParserErrorType::UnexpectedToken` of type struct `UnexpectedTokenInfo`
- An impl of std::fmt::Display in `UnexpectedTokenInfo` that specifies whether the unexpected token is a reserved word (i.e., keyword).

This commit changes:
- The `details` of `ParserErrorType::UnexpectedToken` to read `"I was not expecting this. Found {.found}, expected..."`
- In the case of a keyword, `details` of `ParserErrorType::UnexpectedToken` read as `"I was not expecting this. Found the keyword {.found}, expected..."` (see updated snapshots).


Would appreciate any and all feedback.
Thanks!