### PR TITLE
fix excessive `gleam.mjs` generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@
   statements in a function when there is an error in a previous one.
   ([Ameen Radwan](https://github.com/Acepie))
 
+- Fixed a bug where the compiler would unnecessarily generate `gleam.mjs`,
+  confusing build tools like Vite.
+  ([Ofek Doitch](https://github.com/ofekd))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -181,6 +181,10 @@ impl FileSystemWriter for ProjectIO {
     fn write_bytes(&self, path: &Utf8Path, content: &[u8]) -> Result<(), Error> {
         write_bytes(path, content)
     }
+
+    fn exists(&self, path: &Utf8Path) -> bool {
+        path.exists()
+    }
 }
 
 impl CommandExecutor for ProjectIO {

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -236,6 +236,7 @@ pub trait FileSystemWriter {
     fn hardlink(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn delete_file(&self, path: &Utf8Path) -> Result<(), Error>;
+    fn exists(&self, path: &Utf8Path) -> bool;
 }
 
 #[derive(Debug)]

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -127,6 +127,10 @@ impl FileSystemWriter for InMemoryFileSystem {
             .insert(path.to_path_buf(), file);
         Ok(())
     }
+
+    fn exists(&self, path: &Utf8Path) -> bool {
+        self.files.deref().borrow().contains_key(path)
+    }
 }
 
 impl FileSystemReader for InMemoryFileSystem {

--- a/compiler-core/src/language_server/files.rs
+++ b/compiler-core/src/language_server/files.rs
@@ -93,6 +93,10 @@ where
     fn delete_file(&self, path: &Utf8Path) -> Result<()> {
         self.io.delete_file(path)
     }
+
+    fn exists(&self, path: &Utf8Path) -> bool {
+        self.io.exists(path)
+    }
 }
 
 impl<IO> FileSystemReader for FileSystemProxy<IO>

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -198,6 +198,10 @@ impl FileSystemWriter for LanguageServerTestIO {
     fn write_bytes(&self, path: &Utf8Path, content: &[u8]) -> Result<(), crate::Error> {
         self.io.write_bytes(path, content)
     }
+
+    fn exists(&self, path: &Utf8Path) -> bool {
+        self.io.exists(path)
+    }
 }
 
 impl DownloadDependencies for LanguageServerTestIO {

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -70,6 +70,10 @@ impl FileSystemWriter for WasmFileSystem {
         tracing::trace!("write_bytes {:?}", path);
         self.imfs.write_bytes(path, content)
     }
+
+    fn exists(&self, path: &Utf8Path) -> bool {
+        self.imfs.exists(path)
+    }
 }
 
 impl FileSystemReader for WasmFileSystem {


### PR DESCRIPTION
This patch fixes excessive generation by checking for file existence.

An earlier attempt (#3238) had done this by checking for empty `modules`, noting in its commit message that file existence checks will cause old `gleam.mjs` to never be updated when a new version is available. I have since learned that that was incorrect, as new versions of `gleam` delete `build` folders created by previous versions.

closes #3178