### PR TITLE
LSP Code Action: Convert `let assert` into a case expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,13 @@
 
   ([Gears](https://github.com/gearsdatapacks))
 
+## v1.3.2 - 2024-07-11
+
+### Language Server
+
+- The language server no longer shows completions when inside a literal string.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug Fixes
 
 - Fixed a bug where the compiler would report errors for duplicate `@external`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@
 - The language server no longer shows completions when inside a literal string.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- LSP can now suggest a code action to convert `let assert Ok` into a case expression:
+- LSP can now suggest a code action to convert `let assert` into a case expression:
 
   ```
   let assert Ok(foo) = bar()
@@ -127,7 +127,7 @@
   ```
   let foo = case bar() {
     Ok(foo) -> foo
-    Error(e) -> panic as "value was not ok"
+    _ -> panic
   }
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,14 +119,14 @@
 - LSP can now suggest a code action to convert `let assert` into a case expression:
 
   ```
-  let assert Ok(foo) = bar()
+  let assert Ok(value) = get_result()
   ```
 
   Becomes:
 
   ```
-  let foo = case bar() {
-    Ok(foo) -> foo
+  let value = case get_result() {
+    Ok(value) -> value
     _ -> panic
   }
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
   For example, provided a User type:
 
-  ```
+  ```gleam
   pub type User {
     name: String
   }
@@ -84,14 +84,30 @@
 - The language server now suggests a code a action to rename variables, types and
   functions when they don't match the Gleam naming requirements:
 
-  ```
+  ```gleam
   let myNumber = 10
   ```
 
   Becomes:
 
-  ```
+  ```gleam
   let my_number = 10
+  ```
+
+- The language server can now suggest a code action to convert `let assert` into
+  a case expression:
+
+  ```gleam
+  let assert Ok(value) = get_result()
+  ```
+
+  Becomes:
+
+  ```gleam
+  let value = case get_result() {
+    Ok(value) -> value
+    _ -> panic
+  }
   ```
 
   ([Gears](https://github.com/gearsdatapacks))
@@ -108,30 +124,6 @@
 
 - Fixed a bug where a private type could be leaked from an internal module.
   ([Ameen Radwan](https://github.com/Acepie))
-
-## v1.3.2 - 2024-07-11
-
-### Language Server
-
-- The language server no longer shows completions when inside a literal string.
-  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
-
-- LSP can now suggest a code action to convert `let assert` into a case expression:
-
-  ```
-  let assert Ok(value) = get_result()
-  ```
-
-  Becomes:
-
-  ```
-  let value = case get_result() {
-    Ok(value) -> value
-    _ -> panic
-  }
-  ```
-
-  ([Gears](https://github.com/gearsdatapacks))
 
 ## v1.3.2 - 2024-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,23 @@
 - The language server no longer shows completions when inside a literal string.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- LSP can now suggest a code action to convert `let assert Ok` into a case expression:
+
+  ```
+  let assert Ok(foo) = bar()
+  ```
+
+  Becomes:
+
+  ```
+  let foo = case bar() {
+    Ok(foo) -> foo
+    Error(e) -> panic as "value was not ok"
+  }
+  ```
+
+  ([Gears](https://github.com/gearsdatapacks))
+
 ### Bug Fixes
 
 - Fixed a bug where the compiler would report errors for duplicate `@external`

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1718,7 +1718,9 @@ impl AssignName {
 impl<A> Pattern<A> {
     pub fn location(&self) -> SrcSpan {
         match self {
-            Pattern::Assign { pattern, .. } => pattern.location(),
+            Pattern::Assign {
+                pattern, location, ..
+            } => SrcSpan::new(pattern.location().start, location.end),
             Pattern::Int { location, .. }
             | Pattern::Variable { location, .. }
             | Pattern::VarUsage { location, .. }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -388,7 +388,7 @@ pub trait Visit<'ast> {
         arguments: &'ast Vec<CallArg<TypedPattern>>,
         module: &'ast Option<EcoString>,
         constructor: &'ast Inferred<PatternConstructor>,
-        with_spread: &'ast bool,
+        spread: &'ast Option<SrcSpan>,
         type_: &'ast Arc<Type>,
     ) {
         visit_typed_pattern_constructor(
@@ -398,7 +398,7 @@ pub trait Visit<'ast> {
             arguments,
             module,
             constructor,
-            with_spread,
+            spread,
             type_,
         );
     }
@@ -1003,7 +1003,7 @@ where
             arguments,
             module,
             constructor,
-            with_spread,
+            spread,
             type_,
         } => v.visit_typed_pattern_constructor(
             location,
@@ -1011,7 +1011,7 @@ where
             arguments,
             module,
             constructor,
-            with_spread,
+            spread,
             type_,
         ),
         Pattern::Tuple { location, elems } => v.visit_typed_pattern_tuple(location, elems),
@@ -1122,7 +1122,7 @@ pub fn visit_typed_pattern_constructor<'a, V>(
     arguments: &'a Vec<CallArg<TypedPattern>>,
     _module: &'a Option<EcoString>,
     _constructor: &'a Inferred<PatternConstructor>,
-    _with_spread: &'a bool,
+    _spread: &'a Option<SrcSpan>,
     _type: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -38,7 +38,10 @@
 //! }
 //! ```
 
-use crate::type_::{ModuleValueConstructor, TypedCallArg, ValueConstructor};
+use crate::{
+    analyse::Inferred,
+    type_::{ModuleValueConstructor, PatternConstructor, TypedCallArg, ValueConstructor},
+};
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -46,9 +49,10 @@ use ecow::EcoString;
 use crate::type_::Type;
 
 use super::{
-    BinOp, BitArrayOption, Definition, SrcSpan, Statement, TypeAst, TypedArg, TypedAssignment,
-    TypedClause, TypedDefinition, TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule,
-    TypedRecordUpdateArg, TypedStatement, Use,
+    AssignName, BinOp, BitArrayOption, BitArraySegment, CallArg, Definition, Pattern, SrcSpan,
+    Statement, TypeAst, TypedArg, TypedAssignment, TypedClause, TypedDefinition, TypedExpr,
+    TypedExprBitArraySegment, TypedFunction, TypedModule, TypedPattern, TypedRecordUpdateArg,
+    TypedStatement, Use,
 };
 
 pub trait Visit<'ast> {
@@ -312,6 +316,128 @@ pub trait Visit<'ast> {
     fn visit_typed_bit_array_option(&mut self, option: &'ast BitArrayOption<TypedExpr>) {
         visit_typed_bit_array_option(self, option);
     }
+
+    fn visit_typed_pattern(&mut self, pattern: &'ast TypedPattern) {
+        visit_typed_pattern(self, pattern);
+    }
+
+    fn visit_typed_pattern_int(&mut self, location: &'ast SrcSpan, value: &'ast EcoString) {
+        visit_typed_pattern_int(self, location, value);
+    }
+
+    fn visit_typed_pattern_float(&mut self, location: &'ast SrcSpan, value: &'ast EcoString) {
+        visit_typed_pattern_float(self, location, value);
+    }
+
+    fn visit_typed_pattern_string(&mut self, location: &'ast SrcSpan, value: &'ast EcoString) {
+        visit_typed_pattern_string(self, location, value);
+    }
+
+    fn visit_typed_pattern_variable(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        type_: &'ast Arc<Type>,
+    ) {
+        visit_typed_pattern_variable(self, location, name, type_);
+    }
+
+    fn visit_typed_pattern_var_usage(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        constructor: &'ast Option<ValueConstructor>,
+        type_: &'ast Arc<Type>,
+    ) {
+        visit_typed_pattern_var_usage(self, location, name, constructor, type_);
+    }
+
+    fn visit_typed_pattern_assign(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        pattern: &'ast TypedPattern,
+    ) {
+        visit_typed_pattern_assign(self, location, name, pattern);
+    }
+
+    fn visit_typed_pattern_discard(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        type_: &'ast Arc<Type>,
+    ) {
+        visit_typed_pattern_discard(self, location, name, type_)
+    }
+
+    fn visit_typed_pattern_list(
+        &mut self,
+        location: &'ast SrcSpan,
+        elements: &'ast Vec<TypedPattern>,
+        tail: &'ast Option<Box<TypedPattern>>,
+        type_: &'ast Arc<Type>,
+    ) {
+        visit_typed_pattern_list(self, location, elements, tail, type_);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn visit_typed_pattern_constructor(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        arguments: &'ast Vec<CallArg<TypedPattern>>,
+        module: &'ast Option<EcoString>,
+        constructor: &'ast Inferred<PatternConstructor>,
+        with_spread: &'ast bool,
+        type_: &'ast Arc<Type>,
+    ) {
+        visit_typed_pattern_constructor(
+            self,
+            location,
+            name,
+            arguments,
+            module,
+            constructor,
+            with_spread,
+            type_,
+        );
+    }
+
+    fn visit_typed_pattern_tuple(
+        &mut self,
+        location: &'ast SrcSpan,
+        elems: &'ast Vec<TypedPattern>,
+    ) {
+        visit_typed_pattern_tuple(self, location, elems);
+    }
+
+    fn visit_typed_pattern_bit_array(
+        &mut self,
+        location: &'ast SrcSpan,
+        segments: &'ast Vec<BitArraySegment<TypedPattern, Arc<Type>>>,
+    ) {
+        visit_typed_pattern_bit_array(self, location, segments);
+    }
+
+    fn visit_typed_pattern_string_prefix(
+        &mut self,
+        location: &'ast SrcSpan,
+        left_location: &'ast SrcSpan,
+        left_side_assignment: &'ast Option<(EcoString, SrcSpan)>,
+        right_location: &'ast SrcSpan,
+        left_side_string: &'ast EcoString,
+        right_side_assignment: &'ast AssignName,
+    ) {
+        visit_typed_pattern_string_prefix(
+            self,
+            location,
+            left_location,
+            left_side_assignment,
+            right_location,
+            left_side_string,
+            right_side_assignment,
+        );
+    }
 }
 
 pub fn visit_typed_module<'a, V>(v: &mut V, module: &'a TypedModule)
@@ -329,7 +455,7 @@ where
 {
     match def {
         Definition::Function(fun) => v.visit_typed_function(fun),
-        Definition::TypeAlias(_type_alias) => { /* TODO */ }
+        Definition::TypeAlias(_typealias) => { /* TODO */ }
         Definition::CustomType(_custom_type) => { /* TODO */ }
         Definition::Import(_import) => { /* TODO */ }
         Definition::ModuleConstant(_module_constant) => { /* TODO */ }
@@ -678,7 +804,7 @@ pub fn visit_typed_expr_todo<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
     message: &'a Option<Box<TypedExpr>>,
-    _type_: &'a Arc<Type>,
+    _type: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -691,7 +817,7 @@ pub fn visit_typed_expr_panic<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
     message: &'a Option<Box<TypedExpr>>,
-    _type_: &'a Arc<Type>,
+    _type: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -758,6 +884,7 @@ where
     V: Visit<'a> + ?Sized,
 {
     v.visit_typed_expr(&assignment.value);
+    v.visit_typed_pattern(&assignment.pattern);
 }
 
 pub fn visit_use<'a, V>(_v: &mut V, _use_: &'a Use)
@@ -778,6 +905,9 @@ pub fn visit_typed_clause<'a, V>(v: &mut V, clause: &'a TypedClause)
 where
     V: Visit<'a> + ?Sized,
 {
+    for pattern in clause.pattern.iter() {
+        v.visit_typed_pattern(pattern);
+    }
     v.visit_typed_expr(&clause.then);
 }
 
@@ -830,6 +960,213 @@ where
             value: _,
         } => { /* TODO */ }
     }
+}
+
+pub fn visit_typed_pattern<'a, V>(v: &mut V, pattern: &'a TypedPattern)
+where
+    V: Visit<'a> + ?Sized,
+{
+    match pattern {
+        Pattern::Int { location, value } => v.visit_typed_pattern_int(location, value),
+        Pattern::Float { location, value } => v.visit_typed_pattern_float(location, value),
+        Pattern::String { location, value } => v.visit_typed_pattern_string(location, value),
+        Pattern::Variable {
+            location,
+            name,
+            type_,
+        } => v.visit_typed_pattern_variable(location, name, type_),
+        Pattern::VarUsage {
+            location,
+            name,
+            constructor,
+            type_,
+        } => v.visit_typed_pattern_var_usage(location, name, constructor, type_),
+        Pattern::Assign {
+            location,
+            name,
+            pattern,
+        } => v.visit_typed_pattern_assign(location, name, pattern),
+        Pattern::Discard {
+            location,
+            name,
+            type_,
+        } => v.visit_typed_pattern_discard(location, name, type_),
+        Pattern::List {
+            location,
+            elements,
+            tail,
+            type_,
+        } => v.visit_typed_pattern_list(location, elements, tail, type_),
+        Pattern::Constructor {
+            location,
+            name,
+            arguments,
+            module,
+            constructor,
+            with_spread,
+            type_,
+        } => v.visit_typed_pattern_constructor(
+            location,
+            name,
+            arguments,
+            module,
+            constructor,
+            with_spread,
+            type_,
+        ),
+        Pattern::Tuple { location, elems } => v.visit_typed_pattern_tuple(location, elems),
+        Pattern::BitArray { location, segments } => {
+            v.visit_typed_pattern_bit_array(location, segments)
+        }
+        Pattern::StringPrefix {
+            location,
+            left_location,
+            left_side_assignment,
+            right_location,
+            left_side_string,
+            right_side_assignment,
+        } => v.visit_typed_pattern_string_prefix(
+            location,
+            left_location,
+            left_side_assignment,
+            right_location,
+            left_side_string,
+            right_side_assignment,
+        ),
+        Pattern::Invalid { location, type_ } => v.visit_typed_expr_invalid(location, type_),
+    }
+}
+
+fn visit_typed_pattern_int<'a, V>(_v: &mut V, _location: &'a SrcSpan, _value: &'a EcoString)
+where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_pattern_float<'a, V>(_v: &mut V, _location: &'a SrcSpan, _value: &'a EcoString)
+where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_pattern_string<'a, V>(_v: &mut V, _location: &'a SrcSpan, _value: &'a EcoString)
+where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_pattern_variable<'a, V>(
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _name: &'a EcoString,
+    _type: &'a Arc<Type>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_pattern_var_usage<'a, V>(
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _name: &'a EcoString,
+    _constructor: &'a Option<ValueConstructor>,
+    _type: &'a Arc<Type>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_pattern_assign<'a, V>(
+    v: &mut V,
+    _location: &'a SrcSpan,
+    _name: &'a EcoString,
+    pattern: &'a TypedPattern,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_pattern(pattern);
+}
+
+pub fn visit_typed_pattern_discard<'a, V>(
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _name: &'a EcoString,
+    _type: &'a Arc<Type>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_pattern_list<'a, V>(
+    v: &mut V,
+    _location: &'a SrcSpan,
+    elements: &'a Vec<TypedPattern>,
+    tail: &'a Option<Box<TypedPattern>>,
+    _type: &'a Arc<Type>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for element in elements {
+        v.visit_typed_pattern(element);
+    }
+    if let Some(tail) = tail {
+        v.visit_typed_pattern(tail);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn visit_typed_pattern_constructor<'a, V>(
+    v: &mut V,
+    _location: &'a SrcSpan,
+    _name: &'a EcoString,
+    arguments: &'a Vec<CallArg<TypedPattern>>,
+    _module: &'a Option<EcoString>,
+    _constructor: &'a Inferred<PatternConstructor>,
+    _with_spread: &'a bool,
+    _type: &'a Arc<Type>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for argument in arguments {
+        v.visit_typed_pattern(&argument.value);
+    }
+}
+
+pub fn visit_typed_pattern_tuple<'a, V>(
+    v: &mut V,
+    _location: &'a SrcSpan,
+    elems: &'a Vec<TypedPattern>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for elem in elems {
+        v.visit_typed_pattern(elem);
+    }
+}
+
+pub fn visit_typed_pattern_bit_array<'a, V>(
+    v: &mut V,
+    _location: &'a SrcSpan,
+    segments: &'a Vec<BitArraySegment<TypedPattern, Arc<Type>>>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    for segment in segments {
+        v.visit_typed_pattern(&segment.value);
+    }
+}
+
+pub fn visit_typed_pattern_string_prefix<'a, V>(
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _left_location: &'a SrcSpan,
+    _left_side_assignment: &'a Option<(EcoString, SrcSpan)>,
+    _right_location: &'a SrcSpan,
+    _left_side_string: &'a EcoString,
+    _right_side_assignment: &'a AssignName,
+) where
+    V: Visit<'a> + ?Sized,
+{
 }
 
 pub fn visit_typed_expr_invalid<'a, V>(_v: &mut V, _location: &'a SrcSpan, _typ: &'a Arc<Type>)

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -324,7 +324,7 @@ impl<'ast> ast::visit::Visit<'ast> for LetAssertToCase<'_> {
         let variables = std::mem::take(&mut self.pattern_variables);
 
         let assigned = match variables.len() {
-            0 => "",
+            0 => "_",
             1 => variables.first().expect("Variables is length one"),
             _ => &format!("#({})", variables.join(", ")),
         };
@@ -333,11 +333,11 @@ impl<'ast> ast::visit::Visit<'ast> for LetAssertToCase<'_> {
             range,
             new_text: format!(
                 "let {assigned} = case {expr} {{
-{indent}  {pattern} -> {assigned}
+{indent}  {pattern} -> {value}
 {indent}  _ -> panic
 {indent}}}",
                 // "_" isn't a valid expression, so we just return Nil from the case expression
-                assigned = if assigned == "_" { "Nil" } else { assigned }
+                value = if assigned == "_" { "Nil" } else { assigned }
             ),
         };
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -22,7 +22,7 @@ use lsp_types::{self as lsp, Hover, HoverContents, MarkedString, Url};
 use std::sync::Arc;
 
 use super::{
-    code_action::{AssertResultToCase, CodeActionBuilder, RedundantTupleInCaseSubject},
+    code_action::{CodeActionBuilder, LetAssertToCase, RedundantTupleInCaseSubject},
     completer::Completer,
     src_span_to_lsp_range, DownloadDependencies, MakeLocker,
 };
@@ -273,6 +273,7 @@ where
             code_action_unused_imports(module, &params, &mut actions);
             code_action_fix_names(module, &params, &mut actions);
             actions.extend(AssertResultToCase::new(module, &params).code_actions());
+            actions.extend(LetAssertToCase::new(module, &params).code_actions());
             actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
 
             Ok(if actions.is_empty() {

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -22,7 +22,7 @@ use lsp_types::{self as lsp, Hover, HoverContents, MarkedString, Url};
 use std::sync::Arc;
 
 use super::{
-    code_action::{CodeActionBuilder, RedundantTupleInCaseSubject},
+    code_action::{AssertResultToCase, CodeActionBuilder, RedundantTupleInCaseSubject},
     completer::Completer,
     src_span_to_lsp_range, DownloadDependencies, MakeLocker,
 };
@@ -272,6 +272,7 @@ where
 
             code_action_unused_imports(module, &params, &mut actions);
             code_action_fix_names(module, &params, &mut actions);
+            actions.extend(AssertResultToCase::new(module, &params).code_actions());
             actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
 
             Ok(if actions.is_empty() {

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -272,7 +272,6 @@ where
 
             code_action_unused_imports(module, &params, &mut actions);
             code_action_fix_names(module, &params, &mut actions);
-            actions.extend(AssertResultToCase::new(module, &params).code_actions());
             actions.extend(LetAssertToCase::new(module, &params).code_actions());
             actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -717,6 +717,38 @@ fn test_convert_let_assert_string_prefix_pattern_alias_to_case() {
     ));
 }
 
+#[test]
+fn test_convert_inner_let_assert_to_case() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        r#"pub fn main() {
+    let assert [wibble] = {
+        let assert Ok(wobble) = {
+            Ok(1)
+        }
+        [wobble]
+    }
+}"#,
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_outer_let_assert_to_case() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        r#"pub fn main() {
+    let assert [wibble] = {
+        let assert Ok(wobble) = {
+            Ok(1)
+        }
+        [wobble]
+    }
+}"#,
+        1,
+        CONVERT_TO_CASE
+    ));
+}
+
 /* TODO: implement qualified unused location
 #[test]
 fn test_remove_unused_qualified_action() {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -595,22 +595,113 @@ fn test_convert_assert_result_to_case() {
 pub fn main() {
   let assert Ok(foo) = Ok(1)
 }
-";
-
-    insta::assert_snapshot!(apply_first_code_action_with_title(code, 2, CONVERT_TO_CASE));
+",
+        2,
+        CONVERT_TO_CASE
+    ));
 }
 
 #[test]
-fn test_convert_assert_result_to_case_indented() {
-    let code = "
+fn test_convert_let_assert_to_case_indented() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
 pub fn main() {
   {
     let assert Ok(foo) = Ok(1)
   }
 }
-";
+",
+        3,
+        CONVERT_TO_CASE
+    ));
+}
 
-    insta::assert_snapshot!(apply_first_code_action_with_title(code, 3, CONVERT_TO_CASE));
+#[test]
+fn test_convert_let_assert_to_case_multi_variables() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
+pub fn main() {
+  let assert [var1, var2, _var3, var4] = [1, 2, 3, 4]
+}
+",
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_let_assert_to_case_no_variables() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
+pub fn main() {
+  let assert [_elem] = [6]
+}
+",
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_let_assert_alias_to_case() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
+pub fn main() {
+  let assert 10 as ten = 10
+}
+",
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_let_assert_tuple_to_case() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
+pub fn main() {
+   let assert #(first, 10, third) = #(5, 10, 15)
+}
+",
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_let_assert_bit_array_to_case() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
+pub fn main() {
+  let assert <<bits1, bits2>> = <<73, 98>>
+}
+",
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_let_assert_string_prefix_to_case() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        r#"
+pub fn main() {
+  let assert "_" <> thing = "_Hello"
+}"#,
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_let_assert_string_prefix_pattern_alias_to_case() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        r#"pub fn main() {
+    let assert "123" as one_two_three <> rest = "123456"
+}"#,
+        1,
+        CONVERT_TO_CASE
+    ));
 }
 
 /* TODO: implement qualified unused location

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -593,7 +593,7 @@ fn rename_invalid_case_variable_discard() {
 fn test_convert_assert_result_to_case() {
     let code = "
 pub fn main() {
-  let assert Ok(foo) = Ok(1)
+  let assert Ok(value) = Ok(1)
 }
 ",
         2,
@@ -607,7 +607,7 @@ fn test_convert_let_assert_to_case_indented() {
         "
 pub fn main() {
   {
-    let assert Ok(foo) = Ok(1)
+    let assert Ok(value) = Ok(1)
   }
 }
 ",
@@ -630,11 +630,24 @@ pub fn main() {
 }
 
 #[test]
-fn test_convert_let_assert_to_case_no_variables() {
+fn test_convert_let_assert_to_case_discard() {
     insta::assert_snapshot!(apply_first_code_action_with_title(
         "
 pub fn main() {
   let assert [_elem] = [6]
+}
+",
+        2,
+        CONVERT_TO_CASE
+    ));
+}
+
+#[test]
+fn test_convert_let_assert_to_case_no_variables() {
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
+pub fn main() {
+  let assert [] = []
 }
 ",
         2,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -590,8 +590,10 @@ fn rename_invalid_case_variable_discard() {
     ));
 }
 
+#[test]
 fn test_convert_assert_result_to_case() {
-    let code = "
+    insta::assert_snapshot!(apply_first_code_action_with_title(
+        "
 pub fn main() {
   let assert Ok(value) = Ok(1)
 }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -52,6 +52,7 @@ fn engine_response(src: &str, line: u32) -> engine::Response<Option<Vec<lsp_type
 
 const REMOVE_UNUSED_IMPORTS: &str = "Remove unused imports";
 const REMOVE_REDUNDANT_TUPLES: &str = "Remove redundant tuples";
+const CONVERT_TO_CASE: &str = "Convert to case";
 
 fn apply_first_code_action_with_title(src: &str, line: u32, title: &str) -> String {
     let response = engine_response(src, line)
@@ -587,6 +588,29 @@ fn rename_invalid_case_variable_discard() {
 }",
         1
     ));
+}
+
+fn test_convert_assert_result_to_case() {
+    let code = "
+pub fn main() {
+  let assert Ok(foo) = Ok(1)
+}
+";
+
+    insta::assert_snapshot!(apply_first_code_action_with_title(code, 2, CONVERT_TO_CASE));
+}
+
+#[test]
+fn test_convert_assert_result_to_case_indented() {
+    let code = "
+pub fn main() {
+  {
+    let assert Ok(foo) = Ok(1)
+  }
+}
+";
+
+    insta::assert_snapshot!(apply_first_code_action_with_title(code, 3, CONVERT_TO_CASE));
 }
 
 /* TODO: implement qualified unused location

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(code, 2, CONVERT_TO_CASE)"
+assertion_line: 595
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert Ok(value) = Ok(1)\n}\n\",\n    2, CONVERT_TO_CASE)"
 ---
 pub fn main() {
-  let foo = case Ok(1) {
-    Ok(foo) -> foo
+  let value = case Ok(1) {
+    Ok(value) -> value
     _ -> panic
   }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(code, 2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let foo = case Ok(1) {
+    Ok(foo) -> foo
+    Error(e) -> panic as "Expected Ok value"
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case_indented.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case_indented.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(code, 3, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  {
+    let foo = case Ok(1) {
+      Ok(foo) -> foo
+      Error(e) -> panic as "Expected Ok value"
+    }
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_inner_let_assert_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_inner_let_assert_to_case.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let assert [wibble] = {\n        let assert Ok(wobble) = {\n            Ok(1)\n        }\n        [wobble]\n    }\n}\"#,\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+    let assert [wibble] = {
+        let wobble = case {
+            Ok(1)
+        } {
+          Ok(wobble) -> wobble
+          _ -> panic
+        }
+        [wobble]
+    }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_alias_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_alias_to_case.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert 10 as ten = 10\n}\n\",\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let ten = case 10 {
+    10 as ten -> ten
+    _ -> panic
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_bit_array_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_bit_array_to_case.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert <<bits1, bits2>> = <<73, 98>>\n}\n\",\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let #(bits1, bits2) = case <<73, 98>> {
+    <<bits1, bits2>> -> #(bits1, bits2)
+    _ -> panic
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_pattern_alias_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_pattern_alias_to_case.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let assert \"123\" as one_two_three <> rest = \"123456\"\n}\"#,\n    1, CONVERT_TO_CASE)"
+---
+pub fn main() {
+    let #(one_two_three, rest) = case "123456" {
+      "123" as one_two_three <> rest -> #(one_two_three, rest)
+      _ -> panic
+    }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_to_case.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(r#\"\npub fn main() {\n  let assert \"_\" <> thing = \"_Hello\"\n}\"#,\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let thing = case "_Hello" {
+    "_" <> thing -> thing
+    _ -> panic
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(code, 2, CONVERT_TO_CASE)"
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert Ok(foo) = Ok(1)\n}\n\",\n    2, CONVERT_TO_CASE)"
 ---
 pub fn main() {
   let foo = case Ok(1) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case.snap
@@ -1,10 +1,10 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert Ok(foo) = Ok(1)\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert Ok(value) = Ok(1)\n}\n\",\n    2, CONVERT_TO_CASE)"
 ---
 pub fn main() {
-  let foo = case Ok(1) {
-    Ok(foo) -> foo
+  let value = case Ok(1) {
+    Ok(value) -> value
     _ -> panic
   }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_discard.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [_elem] = [6]\n}\n\",\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let _ = case [6] {
+    [_elem] -> Nil
+    _ -> panic
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_indented.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_indented.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(code, 3, CONVERT_TO_CASE)"
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  {\n    let assert Ok(foo) = Ok(1)\n  }\n}\n\",\n    3, CONVERT_TO_CASE)"
 ---
 pub fn main() {
   {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_indented.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_indented.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  {\n    let assert Ok(foo) = Ok(1)\n  }\n}\n\",\n    3, CONVERT_TO_CASE)"
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  {\n    let assert Ok(value) = Ok(1)\n  }\n}\n\",\n    3, CONVERT_TO_CASE)"
 ---
 pub fn main() {
   {
-    let foo = case Ok(1) {
-      Ok(foo) -> foo
+    let value = case Ok(1) {
+      Ok(value) -> value
       _ -> panic
     }
   }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_multi_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_multi_variables.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [var1, var2, _var3, var4] = [1, 2, 3, 4]\n}\n\",\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let #(var1, var2, var4) = case [1, 2, 3, 4] {
+    [var1, var2, _var3, var4] -> #(var1, var2, var4)
+    _ -> panic
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [_elem] = [6]\n}\n\",\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let _ = case [6] {
+    [_elem] -> Nil
+    _ -> panic
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no_variables.snap
@@ -1,10 +1,10 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [_elem] = [6]\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [] = []\n}\n\",\n    2, CONVERT_TO_CASE)"
 ---
 pub fn main() {
-  let  = case [6] {
-    [_elem] -> 
+  let _ = case [] {
+    [] -> Nil
     _ -> panic
   }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no_variables.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [_elem] = [6]\n}\n\",\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+  let  = case [6] {
+    [_elem] -> 
+    _ -> panic
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_tuple_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_tuple_to_case.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(\"\npub fn main() {\n   let assert #(first, 10, third) = #(5, 10, 15)\n}\n\",\n    2, CONVERT_TO_CASE)"
+---
+pub fn main() {
+   let #(first, third) = case #(5, 10, 15) {
+     #(first, 10, third) -> #(first, third)
+     _ -> panic
+   }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_outer_let_assert_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_outer_let_assert_to_case.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let assert [wibble] = {\n        let assert Ok(wobble) = {\n            Ok(1)\n        }\n        [wobble]\n    }\n}\"#,\n    1, CONVERT_TO_CASE)"
+---
+pub fn main() {
+    let wibble = case {
+        let assert Ok(wobble) = {
+            Ok(1)
+        }
+        [wobble]
+    } {
+      [wibble] -> wibble
+      _ -> panic
+    }
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1292,7 +1292,7 @@ where
                 }
 
                 Pattern::List {
-                    location: SrcSpan { start, end },
+                    location: SrcSpan { start, end: rsqb_e },
                     elements,
                     tail: tail.map(Box::new),
                     type_: (),

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case20.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case20.snap
@@ -6,7 +6,7 @@ error: Type mismatch
   ┌─ /src/one/two.gleam:1:18
   │
 1 │ case [1] { [x] | [] as x -> 1 }
-  │                  ^
+  │                  ^^
 
 Expected type:
 


### PR DESCRIPTION
Closes #2958 
Implements a code action which converts:
```gleam
let assert Ok(value) = get_result()
```
into:
```gleam
let value = case get_result() {
  Ok(value) -> value
  _ -> panic
}
```