### PR TITLE
Handle Version Specifiers at Package Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
   exist as a dependency in the project.
   ([Changfeng Lou](https://github.com/hnlcf))
 
+- `gleam add` now takes an optional package version specifier,
+  separated by a `@`, that resolves as follows:
+
+  ```shell
+  gleam add lustre@1.2.3 # "1.2.3"
+  gleam add lustre@1.2   # ">= 1.2.0 and < 2.0.0"
+  gleam add lustre@1     # ">= 1.0.0 and < 2.0.0"
+  gleam add lustre       # ">= 0.0.0"
+  ```
+
+  ([Rahul D. Ghosal](https://github.com/rdghosal))
+
 ### Compiler
 
 - The compiler now emits a warning for redundant function captures in a

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -151,7 +151,9 @@ fn get_hexpm_version(package: &str) -> Result<Requirement> {
                 3 => Ok(Requirement::hex(version)),
                 n_parts => Err(Error::InvalidVersionFormat {
                     input: version.to_string(),
-                    error: format!("Expected up to 3 version numbers in specifier (MAJOR.MINOR.PATH), found {n_parts}"),
+                    error: format!(
+                        "Expected up to 3 numbers in version specifier (MAJOR.MINOR.PATCH), found {n_parts}"
+                    ),
                 }),
             }
         }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -118,7 +118,7 @@ pub fn update() -> Result<()> {
     Ok(())
 }
 
-fn get_hexpm_version(package: &str) -> Result<Requirement> {
+fn parse_hex_requirement(package: &str) -> Result<Requirement> {
     match package.find('@') {
         Some(pos) => {
             // Using the major version specifier, calculate the maximum
@@ -166,8 +166,8 @@ fn get_hexpm_version(package: &str) -> Result<Requirement> {
 #[test]
 fn hex_from_package_specifier() {
     // Bad versions.
-    assert!(get_hexpm_version("package_1@1.2.3.4").is_err());
-    assert!(get_hexpm_version("package_2@not_a_version").is_err());
+    assert!(parse_hex_requirement("package_1@1.2.3.4").is_err());
+    assert!(parse_hex_requirement("package_2@not_a_version").is_err());
 
     // Good versions.
     let packages = vec![
@@ -178,7 +178,7 @@ fn hex_from_package_specifier() {
     ];
 
     for (provided, expected) in packages {
-        let version = get_hexpm_version(&provided).unwrap();
+        let version = parse_hex_requirement(&provided).unwrap();
         match &version {
             Requirement::Hex { version: v } => {
                 assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {}", v);
@@ -219,7 +219,7 @@ pub fn download<Telem: Telemetry>(
     // Insert the new packages to add, if it exists
     if let Some((packages, dev)) = new_package {
         for package in packages {
-            let version = get_hexpm_version(&package)?;
+            let version = parse_hex_requirement(&package)?;
             let _ = if dev {
                 config.dev_dependencies.insert(package.into(), version)
             } else {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -163,11 +163,16 @@ fn get_hexpm_version(package: &str) -> Result<Requirement> {
 
 #[test]
 fn hex_from_package_specifier() {
+    // Bad versions.
+    assert!(get_hexpm_version("package_1@1.2.3.4").is_err());
+    assert!(get_hexpm_version("package_2@not_a_version").is_err());
+
+    // Good versions.
     let packages = vec![
-        ("package_1", ">= 0.0.0"),
-        ("package_1@1", ">= 1.0.0 and < 2.0.0"),
-        ("package_1@1.2", ">= 1.2.0 and < 2.0.0"),
-        ("package_3@1.2.3", "1.2.3"),
+        ("package_3", ">= 0.0.0"),
+        ("package_4@1", ">= 1.0.0 and < 2.0.0"),
+        ("package_5@1.2", ">= 1.2.0 and < 2.0.0"),
+        ("package_6@1.2.3", "1.2.3"),
     ];
 
     for (provided, expected) in packages {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -164,29 +164,69 @@ fn parse_hex_requirement(package: &str) -> Result<Requirement> {
 }
 
 #[test]
-fn hex_from_package_specifier() {
-    // Bad versions.
-    assert!(parse_hex_requirement("package_1@1.2.3.4").is_err());
-    assert!(parse_hex_requirement("package_2@not_a_version").is_err());
+fn parse_hex_requirement_invalid_semver() {
+    assert!(parse_hex_requirement("some_package@1.2.3.4").is_err());
+}
 
-    // Good versions.
-    let packages = vec![
-        ("package_3", ">= 0.0.0"),
-        ("package_4@1", ">= 1.0.0 and < 2.0.0"),
-        ("package_5@1.2", ">= 1.2.0 and < 2.0.0"),
-        ("package_6@1.2.3", "1.2.3"),
-    ];
+#[test]
+fn parse_hex_requirement_non_numeric_version() {
+    assert!(parse_hex_requirement("some_package@not_a_version").is_err());
+}
 
-    for (provided, expected) in packages {
-        let version = parse_hex_requirement(&provided).unwrap();
-        match &version {
-            Requirement::Hex { version: v } => {
-                assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {}", v);
-            }
-            _ => assert!(false, "failed hexpm version parse: {}", provided),
+#[test]
+fn parse_hex_requirement_default() {
+    let provided = "some_package";
+    let expected = ">= 0.0.0";
+    let version = parse_hex_requirement(&provided).unwrap();
+    match &version {
+        Requirement::Hex { version: v } => {
+            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {}", v);
         }
-        assert_eq!(version, Requirement::hex(expected))
+        _ => assert!(false, "failed hexpm version parse: {}", provided),
     }
+    assert_eq!(version, Requirement::hex(expected))
+}
+
+#[test]
+fn parse_hex_requirement_major_only() {
+    let provided = "some_package@1";
+    let expected = ">= 1.0.0 and < 2.0.0";
+    let version = parse_hex_requirement(&provided).unwrap();
+    match &version {
+        Requirement::Hex { version: v } => {
+            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {}", v);
+        }
+        _ => assert!(false, "failed hexpm version parse: {}", provided),
+    }
+    assert_eq!(version, Requirement::hex(expected))
+}
+
+#[test]
+fn parse_hex_requirement_major_and_minor() {
+    let provided = "some_package@1.2";
+    let expected = ">= 1.2.0 and < 2.0.0";
+    let version = parse_hex_requirement(&provided).unwrap();
+    match &version {
+        Requirement::Hex { version: v } => {
+            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {}", v);
+        }
+        _ => assert!(false, "failed hexpm version parse: {}", provided),
+    }
+    assert_eq!(version, Requirement::hex(expected))
+}
+
+#[test]
+fn parse_hex_requirement_major_minor_and_patch() {
+    let provided = "some_package@1.2.3";
+    let expected = "1.2.3";
+    let version = parse_hex_requirement(&provided).unwrap();
+    match &version {
+        Requirement::Hex { version: v } => {
+            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {}", v);
+        }
+        _ => assert!(false, "failed hexpm version parse: {}", provided),
+    }
+    assert_eq!(version, Requirement::hex(expected))
 }
 
 pub fn download<Telem: Telemetry>(

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -118,35 +118,60 @@ pub fn update() -> Result<()> {
     Ok(())
 }
 
-fn get_hexpm_version(package: &str) -> Requirement {
-    match package.find(|c: char| !(c.is_alphanumeric() || c == '_')) {
+fn get_hexpm_version(package: &str) -> Result<Requirement> {
+    match package.find('@') {
         Some(pos) => {
-            // Consume whatever delimiter separates the package name and
-            // version.
-            let version = &package[pos..];
+            // Using the major version specifier, calculate the maximum
+            // allowable version (i.e., the next major version).
+            let version = &package[pos + 1..];
+            let parts = version.split(".").collect::<Vec<_>>();
+            let major = parts[0]
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidVersionFormat {
+                    input: version.to_string(),
+                    error: "Failed to parse semantic major version as integer".to_string(),
+                })?;
+            let max_ver = [&(major + 1).to_string(), "0", "0"].join(".");
 
-            // Normalize the version to include MAJOR.MINOR.PATCH.
-            match version.matches('.').count() {
-                0 => Requirement::hex(&[version, "0", "0"].join(".")),
-                1 => Requirement::hex(&[version, "0"].join(".")),
-                _ => Requirement::hex(version),
+            // Pad the provided version specifier with zeros and create Hex
+            // version.
+            match parts.len() {
+                1 => {
+                    let min_ver = [&parts[0], "0", "0"].join(".");
+                    Ok(Requirement::hex(
+                        &[">=", &min_ver, "and", "<", &max_ver].join(" "),
+                    ))
+                }
+                2 => {
+                    let min_ver = [&parts[0], &parts[1], "0"].join(".");
+                    Ok(Requirement::hex(
+                        &[">=", &min_ver, "and", "<", &max_ver].join(" "),
+                    ))
+                }
+                3 => Ok(Requirement::hex(version)),
+                n_parts => Err(Error::InvalidVersionFormat {
+                    input: version.to_string(),
+                    error: format!("Expected up to 3 version numbers in specifier (MAJOR.MINOR.PATH), found {n_parts}"),
+                }),
             }
         }
 
-        None => Requirement::hex(">= 0.0.0"),
+        // Default to the latest version available.
+        None => Ok(Requirement::hex(">= 0.0.0")),
     }
 }
 
 #[test]
-fn package_spec_to_hex() {
+fn hex_from_package_specifier() {
     let packages = vec![
-        ("package_1==1", "==1.0.0"),
-        ("package_2>=1.0", ">=1.0.0"),
-        ("package_3~>1.0.0", "~>1.0.0"),
+        ("package_1", ">= 0.0.0"),
+        ("package_1@1", ">= 1.0.0 and < 2.0.0"),
+        ("package_1@1.2", ">= 1.2.0 and < 2.0.0"),
+        ("package_3@1.2.3", "1.2.3"),
     ];
 
     for (provided, expected) in packages {
-        let version = get_hexpm_version(&provided);
+        let version = get_hexpm_version(&provided).unwrap();
         match &version {
             Requirement::Hex { version: v } => {
                 assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {}", v);
@@ -187,7 +212,7 @@ pub fn download<Telem: Telemetry>(
     // Insert the new packages to add, if it exists
     if let Some((packages, dev)) = new_package {
         for package in packages {
-            let version = get_hexpm_version(&package);
+            let version = get_hexpm_version(&package)?;
             let _ = if dev {
                 config.dev_dependencies.insert(package.into(), version)
             } else {


### PR DESCRIPTION
Addresses #3262.

### Adds:
- A helper to parse an optionally provided version specifier that is applied at package download.
- Unit tests to validate whether the specifier is PubGrub-compliant.

### Notes:
The solution here deviates from the original suggestion, in terms of what delimiters are expected as follows:

- Suggested:
```bash
$ gleam add my_package@1.0.0
```

- Implemented:
```bash
$ gleam add my_package==1.0.0
```

I chose this implementation as an enhancement to the original proposal that allows the user to provide a more flexible version specifier (e.g., `<~ 1.0.0`, `<= 1.0.0`).


Needless to say, this PR is open to feedback, and the implementation here can also be made to align with the original suggestion.
Careful review of the testing methodology would especially be appreciated.

Thank you!
