### PR TITLE
LSP: Show fn/value signature instead of a module name

### DIFF
--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import.snap
@@ -49,7 +49,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "dep",
+                    "fn() -> Int",
                 ),
             },
         ),
@@ -96,7 +96,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "dep",
+                    "String",
                 ),
             },
         ),
@@ -143,7 +143,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "dep",
+                    "String",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
@@ -9,7 +9,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "dep",
+                    "fn() -> Int",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
@@ -49,7 +49,7 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "dep",
+                    "fn() -> Int",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "dep",
+                    "fn() -> Nil",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "a/b/dep",
+                    "fn() -> Nil",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "dep",
+                    "fn() -> Nil",
                 ),
             },
         ),
@@ -72,7 +72,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Nil",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_module_function.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Nil",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_enum.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_enum.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),
@@ -56,7 +56,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_record.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn(Int) -> Box",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_module_function.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Nil",
                 ),
             },
         ),
@@ -56,7 +56,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Nil",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_enum.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_enum.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),
@@ -56,7 +56,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),
@@ -103,7 +103,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_record.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn(Int) -> Box",
                 ),
             },
         ),
@@ -56,7 +56,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn(Int) -> Box",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Foo",
                 ),
             },
         ),
@@ -56,7 +56,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Int",
                 ),
             },
         ),
@@ -103,7 +103,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Int",
                 ),
             },
         ),
@@ -150,7 +150,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Float",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Foo",
                 ),
             },
         ),
@@ -56,7 +56,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Int",
                 ),
             },
         ),
@@ -103,7 +103,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Int",
                 ),
             },
         ),
@@ -150,7 +150,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Float",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),
@@ -56,7 +56,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum_with_documentation.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),
@@ -63,7 +63,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Direction",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Int",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function_with_documentation.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Int",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn(Int, Int, Float) -> Box",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record_with_documentation.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn(Int, Int, Float) -> Box",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__opaque_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__opaque_type.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Wibble",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_function.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "fn() -> Int",
                 ),
             },
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_type.snap
@@ -9,7 +9,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
             CompletionItemLabelDetails {
                 detail: None,
                 description: Some(
-                    "app",
+                    "Wibble",
                 ),
             },
         ),


### PR DESCRIPTION
RFC: What do you think about this proposal?

**Motivation:** I want to see the function or value signatures when autocompleting, it allows quickly understand what function does and what does it return.  The module name can be deduced by the prefix before ".".


| Before | After |
|--------|--------|
| <img width="572" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/40cac882-f8d8-4373-96f1-662e67c11833"> | <img width="572" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/62e3b51b-e576-4ba7-832c-8c0c5fea45c6"> | 

| Before | After |
|--------|--------|
| <img width="554" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/51ab7bb2-30af-4419-a6cf-7553595fd70a"> |  <img width="558" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/b769bfbe-0cca-484c-b1b1-9a7f9dd11030"> | 

| Before | After |
|--------|--------|
| <img width="625" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/519a6019-037a-4f15-a1a5-149a79f60090"> | <img width="619" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/0885a2d2-c51b-4f1a-8eca-24f3bb17b763">| 

