### PR TITLE
LSP: Add extra new line after 1st import autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@
   being attempted.
   ([Ameen Radwan](https://github.com/Acepie))
 
+- The language server will now insert a blank line before the first statement
+  when inserting a new import and there are no other imports at the top of the
+  module.
+  ([Zhomart Mukhamejanov](https://github.com/Zhomart))
+
 ### Bug Fixes
 
 - Functions, types and constructors named `module_info` are now escaped

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -646,7 +646,12 @@ where
     // 2nd element in the pair is true if the first definition is an import statement.
     fn first_import_in_module(&'a self) -> (Position, bool) {
         // As "self.module.ast.definitions"  could be sorted, let's find the actual first definition by position.
-        let first_definition = self.module.ast.definitions.iter().min_by(|a, b| a.location().start.cmp(&b.location().start));
+        let first_definition = self
+            .module
+            .ast
+            .definitions
+            .iter()
+            .min_by(|a, b| a.location().start.cmp(&b.location().start));
         let import = first_definition.and_then(get_import);
         let import_start = import.map_or(0, |i| i.location.start);
         let import_line = self.module_line_numbers.line_number(import_start);

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -645,7 +645,9 @@ where
     // If the 1st definition is not an import statement, then it returns the 1st line.
     // 2nd element in the pair is true if the first definition is an import statement.
     fn first_import_in_module(&'a self) -> (Position, bool) {
-        let import = self.module.ast.definitions.first().and_then(get_import);
+        // As "self.module.ast.definitions"  could be sorted, let's find the actual first definition by position.
+        let first_definition = self.module.ast.definitions.iter().min_by(|a, b| a.location().start.cmp(&b.location().start));
+        let import = first_definition.and_then(get_import);
         let import_start = import.map_or(0, |i| i.location.start);
         let import_line = self.module_line_numbers.line_number(import_start);
         (Position::new(import_line - 1, 0), import.is_some())

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -216,7 +216,9 @@ fn importable_adds_extra_new_line_if_import_exists_below_other_definitions() {
     let code = "\nimport dep2\n"; // "code" goes after "fn typing_in_here() {}".
 
     assert_debug_snapshot!(completion_with_prefix(
-        TestProject::for_source(code).add_module("dep", dep).add_module("dep2", ""),
+        TestProject::for_source(code)
+            .add_module("dep", dep)
+            .add_module("dep2", ""),
         prefix
     ));
 }
@@ -228,7 +230,9 @@ fn importable_does_not_add_extra_new_line_if_imports_exist() {
     let code = "";
 
     assert_debug_snapshot!(completion_with_prefix(
-        TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
+        TestProject::for_source(code)
+            .add_module("dep", dep)
+            .add_module("foo", ""),
         prefix
     ));
 }
@@ -240,7 +244,9 @@ fn importable_does_not_add_extra_new_line_if_newline_exists() {
     let code = "";
 
     assert_debug_snapshot!(completion_with_prefix(
-        TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
+        TestProject::for_source(code)
+            .add_module("dep", dep)
+            .add_module("foo", ""),
         prefix
     ));
 }

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -213,10 +213,10 @@ fn importable_adds_extra_new_line_if_no_imports() {
 fn importable_adds_extra_new_line_if_import_exists_below_other_definitions() {
     let dep = "pub fn wobble() {\nNil\n}";
     let prefix = "";
-    let code = "\nimport foo\n";
+    let code = "\nimport dep2\n"; // "code" goes after "fn typing_in_here() {}".
 
     assert_debug_snapshot!(completion_with_prefix(
-        TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
+        TestProject::for_source(code).add_module("dep", dep).add_module("dep2", ""),
         prefix
     ));
 }

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -15,9 +15,18 @@ fn completion(tester: TestProject<'_>, position: Position) -> Vec<CompletionItem
 }
 
 fn completion_at_default_position(tester: TestProject<'_>) -> Vec<CompletionItem> {
-    let src = &format!("fn typing_in_here() {{\n  0\n}}\n {}", tester.src);
+    completion_with_prefix(tester, "")
+}
+
+fn completion_with_prefix(tester: TestProject<'_>, prefix: &str) -> Vec<CompletionItem> {
+    let src = &format!("{}fn typing_in_here() {{\n  0\n}}\n {}", prefix, tester.src);
     let tester = TestProject { src, ..tester };
-    completion(tester, Position::new(1, 0))
+    // Put the cursor inside the "typing_in_here" fn body.
+    let line = 1 + prefix.lines().count();
+    println!("line: {}", line);
+    println!("code:\n{}", src);
+    println!("code at line: {}", src.lines().nth(line).unwrap());
+    completion(tester, Position::new(line as u32, 0))
         .into_iter()
         .filter(|c| c.label != "typing_in_here")
         .collect_vec()
@@ -189,6 +198,42 @@ pub fn wobble() {
     assert_debug_snapshot!(completion_at_default_position(
         TestProject::for_source(code).add_module("a/b/dep", dep)
     ),);
+}
+
+#[test]
+fn importable_adds_extra_new_line_if_no_imports() {
+    let dep = "pub fn wobble() {\nNil\n}";
+    let code = "";
+    let prefix = "";
+
+    assert_debug_snapshot!(completion_with_prefix(
+        TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
+        prefix
+    ));
+}
+
+#[test]
+fn importable_does_not_add_extra_new_line_if_imports_exist() {
+    let dep = "pub fn wobble() {\nNil\n}";
+    let code = "";
+    let prefix = "import foo\n\n";
+
+    assert_debug_snapshot!(completion_with_prefix(
+        TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
+        prefix
+    ));
+}
+
+#[test]
+fn importable_does_not_add_extra_new_line_if_newline_exists() {
+    let dep = "pub fn wobble() {\nNil\n}";
+    let code = "";
+    let prefix = "\n";
+
+    assert_debug_snapshot!(completion_with_prefix(
+        TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
+        prefix
+    ));
 }
 
 #[test]

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -23,9 +23,6 @@ fn completion_with_prefix(tester: TestProject<'_>, prefix: &str) -> Vec<Completi
     let tester = TestProject { src, ..tester };
     // Put the cursor inside the "typing_in_here" fn body.
     let line = 1 + prefix.lines().count();
-    println!("line: {}", line);
-    println!("code:\n{}", src);
-    println!("code at line: {}", src.lines().nth(line).unwrap());
     completion(tester, Position::new(line as u32, 0))
         .into_iter()
         .filter(|c| c.label != "typing_in_here")
@@ -203,8 +200,20 @@ pub fn wobble() {
 #[test]
 fn importable_adds_extra_new_line_if_no_imports() {
     let dep = "pub fn wobble() {\nNil\n}";
-    let code = "";
     let prefix = "";
+    let code = "";
+
+    assert_debug_snapshot!(completion_with_prefix(
+        TestProject::for_source(code).add_module("dep", dep),
+        prefix
+    ));
+}
+
+#[test]
+fn importable_adds_extra_new_line_if_import_exists_below_other_definitions() {
+    let dep = "pub fn wobble() {\nNil\n}";
+    let prefix = "";
+    let code = "\nimport foo\n";
 
     assert_debug_snapshot!(completion_with_prefix(
         TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
@@ -215,8 +224,8 @@ fn importable_adds_extra_new_line_if_no_imports() {
 #[test]
 fn importable_does_not_add_extra_new_line_if_imports_exist() {
     let dep = "pub fn wobble() {\nNil\n}";
-    let code = "";
     let prefix = "import foo\n\n";
+    let code = "";
 
     assert_debug_snapshot!(completion_with_prefix(
         TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),
@@ -227,8 +236,8 @@ fn importable_does_not_add_extra_new_line_if_imports_exist() {
 #[test]
 fn importable_does_not_add_extra_new_line_if_newline_exists() {
     let dep = "pub fn wobble() {\nNil\n}";
-    let code = "";
     let prefix = "\n";
+    let code = "";
 
     assert_debug_snapshot!(completion_with_prefix(
         TestProject::for_source(code).add_module("dep", dep).add_module("foo", ""),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_adds_extra_new_line_if_import_exists_below_other_definitions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_adds_extra_new_line_if_import_exists_below_other_definitions.snap
@@ -1,0 +1,69 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "completion_with_prefix(TestProject::for_source(code).add_module(\"dep\",\n            dep).add_module(\"foo\", \"\"), prefix)"
+---
+[
+    CompletionItem {
+        label: "dep.wobble",
+        label_details: Some(
+            CompletionItemLabelDetails {
+                detail: None,
+                description: Some(
+                    "dep",
+                ),
+            },
+        ),
+        kind: Some(
+            Function,
+        ),
+        detail: Some(
+            "fn() -> Nil",
+        ),
+        documentation: None,
+        deprecated: None,
+        preselect: None,
+        sort_text: None,
+        filter_text: None,
+        insert_text: None,
+        insert_text_format: None,
+        insert_text_mode: None,
+        text_edit: Some(
+            Edit(
+                TextEdit {
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 0,
+                        },
+                    },
+                    new_text: "dep.wobble",
+                },
+            ),
+        ),
+        additional_text_edits: Some(
+            [
+                TextEdit {
+                    range: Range {
+                        start: Position {
+                            line: 4,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 4,
+                            character: 0,
+                        },
+                    },
+                    new_text: "import dep\n",
+                },
+            ],
+        ),
+        command: None,
+        commit_characters: None,
+        data: None,
+        tags: None,
+    },
+]

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_adds_extra_new_line_if_import_exists_below_other_definitions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_adds_extra_new_line_if_import_exists_below_other_definitions.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "completion_with_prefix(TestProject::for_source(code).add_module(\"dep\",\n            dep).add_module(\"foo\", \"\"), prefix)"
+expression: "completion_with_prefix(TestProject::for_source(code).add_module(\"dep\",\n            dep).add_module(\"dep2\", \"\"), prefix)"
 ---
 [
     CompletionItem {
@@ -49,15 +49,15 @@ expression: "completion_with_prefix(TestProject::for_source(code).add_module(\"d
                 TextEdit {
                     range: Range {
                         start: Position {
-                            line: 4,
+                            line: 0,
                             character: 0,
                         },
                         end: Position {
-                            line: 4,
+                            line: 0,
                             character: 0,
                         },
                     },
-                    new_text: "import dep\n",
+                    new_text: "import dep\n\n",
                 },
             ],
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_adds_extra_new_line_if_no_imports.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_adds_extra_new_line_if_no_imports.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "completion_at_default_position(TestProject::for_source(code).add_module(\"dep\",\n        dep))"
+expression: "completion_with_prefix(TestProject::for_source(code).add_module(\"dep\",\n            dep).add_module(\"foo\", \"\"), prefix)"
 ---
 [
     CompletionItem {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_does_not_add_extra_new_line_if_imports_exist.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_does_not_add_extra_new_line_if_imports_exist.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "completion_at_default_position(TestProject::for_source(code).add_module(\"dep\",\n        dep))"
+expression: "completion_with_prefix(TestProject::for_source(code).add_module(\"dep\",\n            dep).add_module(\"foo\", \"\"), prefix)"
 ---
 [
     CompletionItem {
@@ -32,11 +32,11 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                 TextEdit {
                     range: Range {
                         start: Position {
-                            line: 1,
+                            line: 3,
                             character: 0,
                         },
                         end: Position {
-                            line: 1,
+                            line: 3,
                             character: 0,
                         },
                     },
@@ -57,7 +57,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "import dep\n\n",
+                    new_text: "import dep\n",
                 },
             ],
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_does_not_add_extra_new_line_if_newline_exists.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_does_not_add_extra_new_line_if_newline_exists.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "completion_at_default_position(TestProject::for_source(code).add_module(\"dep\",\n        dep))"
+expression: "completion_with_prefix(TestProject::for_source(code).add_module(\"dep\",\n            dep).add_module(\"foo\", \"\"), prefix)"
 ---
 [
     CompletionItem {
@@ -32,11 +32,11 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                 TextEdit {
                     range: Range {
                         start: Position {
-                            line: 1,
+                            line: 2,
                             character: 0,
                         },
                         end: Position {
-                            line: 1,
+                            line: 2,
                             character: 0,
                         },
                     },
@@ -57,7 +57,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "import dep\n\n",
+                    new_text: "import dep\n",
                 },
             ],
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
@@ -57,7 +57,7 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                             character: 0,
                         },
                     },
-                    new_text: "import a/b/dep\n",
+                    new_text: "import a/b/dep\n\n",
                 },
             ],
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
@@ -49,15 +49,15 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
                 TextEdit {
                     range: Range {
                         start: Position {
-                            line: 7,
+                            line: 0,
                             character: 0,
                         },
                         end: Position {
-                            line: 7,
+                            line: 0,
                             character: 0,
                         },
                     },
-                    new_text: "import dep\n",
+                    new_text: "import dep\n\n",
                 },
             ],
         ),


### PR DESCRIPTION
Not sure what happened to this PR: https://github.com/gleam-lang/gleam/pull/3277

But here's a fix for https://github.com/gleam-lang/gleam/issues/3271

Changes:

1. Use the 1st definition instead of the 1st import
2. Add extra newline after the import if the 1st definition is not import

Demo (update Jul 13):

![2024-07-13 at 18 30 15 - Azure Cuckoo](https://github.com/user-attachments/assets/013b272c-355e-48f0-899f-7ca9024d20c0)

