### PR TITLE
Arithmetic guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@
   to JavaScript.
   ([Ofek Doitch](https://github.com/ofekd))
 
+- Compiler now supports arithmetic operations in guards.
+  ([Danielle Maywood](https://github.com/DanielleMaywood))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1183,6 +1183,60 @@ pub enum ClauseGuard<Type, RecordTag> {
         right: Box<Self>,
     },
 
+    AddInt {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    AddFloat {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    SubInt {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    SubFloat {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    MultInt {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    MultFloat {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    DivInt {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    DivFloat {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
+    RemainderInt {
+        location: SrcSpan,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+
     Or {
         location: SrcSpan,
         left: Box<Self>,
@@ -1251,6 +1305,15 @@ impl<A, B> ClauseGuard<A, B> {
             | ClauseGuard::GtFloat { location, .. }
             | ClauseGuard::GtEqFloat { location, .. }
             | ClauseGuard::LtFloat { location, .. }
+            | ClauseGuard::AddInt { location, .. }
+            | ClauseGuard::AddFloat { location, .. }
+            | ClauseGuard::SubInt { location, .. }
+            | ClauseGuard::SubFloat { location, .. }
+            | ClauseGuard::MultInt { location, .. }
+            | ClauseGuard::MultFloat { location, .. }
+            | ClauseGuard::DivInt { location, .. }
+            | ClauseGuard::DivFloat { location, .. }
+            | ClauseGuard::RemainderInt { location, .. }
             | ClauseGuard::FieldAccess { location, .. }
             | ClauseGuard::LtEqFloat { location, .. }
             | ClauseGuard::ModuleSelect { location, .. } => *location,
@@ -1279,6 +1342,15 @@ impl<A, B> ClauseGuard<A, B> {
             ClauseGuard::GtEqFloat { .. } => Some(BinOp::GtEqFloat),
             ClauseGuard::LtFloat { .. } => Some(BinOp::LtFloat),
             ClauseGuard::LtEqFloat { .. } => Some(BinOp::LtEqFloat),
+            ClauseGuard::AddInt { .. } => Some(BinOp::AddInt),
+            ClauseGuard::AddFloat { .. } => Some(BinOp::AddFloat),
+            ClauseGuard::SubInt { .. } => Some(BinOp::SubInt),
+            ClauseGuard::SubFloat { .. } => Some(BinOp::SubFloat),
+            ClauseGuard::MultInt { .. } => Some(BinOp::MultInt),
+            ClauseGuard::MultFloat { .. } => Some(BinOp::MultFloat),
+            ClauseGuard::DivInt { .. } => Some(BinOp::DivInt),
+            ClauseGuard::DivFloat { .. } => Some(BinOp::DivFloat),
+            ClauseGuard::RemainderInt { .. } => Some(BinOp::RemainderInt),
 
             ClauseGuard::Constant(_)
             | ClauseGuard::Var { .. }
@@ -1298,6 +1370,17 @@ impl TypedClauseGuard {
             ClauseGuard::FieldAccess { type_, .. } => type_.clone(),
             ClauseGuard::ModuleSelect { type_, .. } => type_.clone(),
             ClauseGuard::Constant(constant) => constant.type_(),
+
+            ClauseGuard::AddInt { .. }
+            | ClauseGuard::SubInt { .. }
+            | ClauseGuard::MultInt { .. }
+            | ClauseGuard::DivInt { .. }
+            | ClauseGuard::RemainderInt { .. } => type_::int(),
+
+            ClauseGuard::AddFloat { .. }
+            | ClauseGuard::SubFloat { .. }
+            | ClauseGuard::MultFloat { .. }
+            | ClauseGuard::DivFloat { .. } => type_::float(),
 
             ClauseGuard::Or { .. }
             | ClauseGuard::Not { .. }

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -391,6 +391,15 @@ impl<'a> CallGraphBuilder<'a> {
             | ClauseGuard::GtEqFloat { left, right, .. }
             | ClauseGuard::LtFloat { left, right, .. }
             | ClauseGuard::LtEqFloat { left, right, .. }
+            | ClauseGuard::AddInt { left, right, .. }
+            | ClauseGuard::AddFloat { left, right, .. }
+            | ClauseGuard::SubInt { left, right, .. }
+            | ClauseGuard::SubFloat { left, right, .. }
+            | ClauseGuard::MultInt { left, right, .. }
+            | ClauseGuard::MultFloat { left, right, .. }
+            | ClauseGuard::DivInt { left, right, .. }
+            | ClauseGuard::DivFloat { left, right, .. }
+            | ClauseGuard::RemainderInt { left, right, .. }
             | ClauseGuard::Or { left, right, .. }
             | ClauseGuard::And { left, right, .. } => {
                 self.guard(left);

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1212,6 +1212,42 @@ fn bare_clause_guard<'a>(guard: &'a TypedClauseGuard, env: &mut Env<'a>) -> Docu
             .append(" =< ")
             .append(clause_guard(right, env)),
 
+        ClauseGuard::AddInt { left, right, .. } => clause_guard(left, env)
+            .append(" + ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::AddFloat { left, right, .. } => clause_guard(left, env)
+            .append(" + ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::SubInt { left, right, .. } => clause_guard(left, env)
+            .append(" - ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::SubFloat { left, right, .. } => clause_guard(left, env)
+            .append(" - ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::MultInt { left, right, .. } => clause_guard(left, env)
+            .append(" * ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::MultFloat { left, right, .. } => clause_guard(left, env)
+            .append(" * ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::DivInt { left, right, .. } => clause_guard(left, env)
+            .append(" div ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::DivFloat { left, right, .. } => clause_guard(left, env)
+            .append(" / ")
+            .append(clause_guard(right, env)),
+
+        ClauseGuard::RemainderInt { left, right, .. } => clause_guard(left, env)
+            .append(" rem ")
+            .append(clause_guard(right, env)),
+
         // Only local variables are supported and the typer ensures that all
         // ClauseGuard::Vars are local variables
         ClauseGuard::Var { name, .. } => env.local_var_name(name),
@@ -1254,7 +1290,16 @@ fn clause_guard<'a>(guard: &'a TypedClauseGuard, env: &mut Env<'a>) -> Document<
         | ClauseGuard::GtFloat { .. }
         | ClauseGuard::GtEqFloat { .. }
         | ClauseGuard::LtFloat { .. }
-        | ClauseGuard::LtEqFloat { .. } => "("
+        | ClauseGuard::LtEqFloat { .. }
+        | ClauseGuard::AddInt { .. }
+        | ClauseGuard::AddFloat { .. }
+        | ClauseGuard::SubInt { .. }
+        | ClauseGuard::SubFloat { .. }
+        | ClauseGuard::MultInt { .. }
+        | ClauseGuard::MultFloat { .. }
+        | ClauseGuard::DivInt { .. }
+        | ClauseGuard::DivFloat { .. }
+        | ClauseGuard::RemainderInt { .. } => "("
             .to_doc()
             .append(bare_clause_guard(guard, env))
             .append(")"),

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2189,6 +2189,33 @@ impl<'comments> Formatter<'comments> {
             ClauseGuard::LtEqFloat { left, right, .. } => {
                 self.clause_guard_bin_op(&BinOp::LtEqFloat, left, right)
             }
+            ClauseGuard::AddInt { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::AddInt, left, right)
+            }
+            ClauseGuard::AddFloat { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::AddFloat, left, right)
+            }
+            ClauseGuard::SubInt { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::SubInt, left, right)
+            }
+            ClauseGuard::SubFloat { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::SubFloat, left, right)
+            }
+            ClauseGuard::MultInt { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::MultInt, left, right)
+            }
+            ClauseGuard::MultFloat { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::MultFloat, left, right)
+            }
+            ClauseGuard::DivInt { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::DivInt, left, right)
+            }
+            ClauseGuard::DivFloat { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::DivFloat, left, right)
+            }
+            ClauseGuard::RemainderInt { left, right, .. } => {
+                self.clause_guard_bin_op(&BinOp::RemainderInt, left, right)
+            }
 
             ClauseGuard::Var { name, .. } => name.to_doc(),
 

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -183,6 +183,15 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
             | ClauseGuard::GtEqFloat { .. }
             | ClauseGuard::LtFloat { .. }
             | ClauseGuard::LtEqFloat { .. }
+            | ClauseGuard::AddInt { .. }
+            | ClauseGuard::AddFloat { .. }
+            | ClauseGuard::SubInt { .. }
+            | ClauseGuard::SubFloat { .. }
+            | ClauseGuard::MultInt { .. }
+            | ClauseGuard::MultFloat { .. }
+            | ClauseGuard::DivInt { .. }
+            | ClauseGuard::DivFloat { .. }
+            | ClauseGuard::RemainderInt { .. }
             | ClauseGuard::Or { .. }
             | ClauseGuard::And { .. }
             | ClauseGuard::ModuleSelect { .. } => Ok(docvec!("(", self.guard(guard)?, ")")),
@@ -241,6 +250,37 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
                 docvec!(left, " <= ", right)
+            }
+
+            ClauseGuard::AddFloat { left, right, .. } | ClauseGuard::AddInt { left, right, .. } => {
+                let left = self.wrapped_guard(left)?;
+                let right = self.wrapped_guard(right)?;
+                docvec!(left, " + ", right)
+            }
+
+            ClauseGuard::SubFloat { left, right, .. } | ClauseGuard::SubInt { left, right, .. } => {
+                let left = self.wrapped_guard(left)?;
+                let right = self.wrapped_guard(right)?;
+                docvec!(left, " - ", right)
+            }
+
+            ClauseGuard::MultFloat { left, right, .. }
+            | ClauseGuard::MultInt { left, right, .. } => {
+                let left = self.wrapped_guard(left)?;
+                let right = self.wrapped_guard(right)?;
+                docvec!(left, " * ", right)
+            }
+
+            ClauseGuard::DivFloat { left, right, .. } | ClauseGuard::DivInt { left, right, .. } => {
+                let left = self.wrapped_guard(left)?;
+                let right = self.wrapped_guard(right)?;
+                docvec!(left, " / ", right)
+            }
+
+            ClauseGuard::RemainderInt { left, right, .. } => {
+                let left = self.wrapped_guard(left)?;
+                let right = self.wrapped_guard(right)?;
+                docvec!(left, " % ", right)
             }
 
             ClauseGuard::Or { left, right, .. } => {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3425,6 +3425,60 @@ fn clause_guard_reduction(
             right,
         },
 
+        Token::Plus => ClauseGuard::AddInt {
+            location,
+            left,
+            right,
+        },
+
+        Token::PlusDot => ClauseGuard::AddFloat {
+            location,
+            left,
+            right,
+        },
+
+        Token::Minus => ClauseGuard::SubInt {
+            location,
+            left,
+            right,
+        },
+
+        Token::MinusDot => ClauseGuard::SubFloat {
+            location,
+            left,
+            right,
+        },
+
+        Token::Star => ClauseGuard::MultInt {
+            location,
+            left,
+            right,
+        },
+
+        Token::StarDot => ClauseGuard::MultFloat {
+            location,
+            left,
+            right,
+        },
+
+        Token::Slash => ClauseGuard::DivInt {
+            location,
+            left,
+            right,
+        },
+
+        Token::SlashDot => ClauseGuard::DivFloat {
+            location,
+            left,
+            right,
+        },
+
+        Token::Percent => ClauseGuard::RemainderInt {
+            location,
+            left,
+            right,
+        },
+
         _ => panic!("Token could not be converted to Guard Op."),
     }
 }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
@@ -1,0 +1,103 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
+---
+[
+    Expression(
+        Case {
+            location: SrcSpan {
+                start: 1,
+                end: 45,
+            },
+            subjects: [
+                Int {
+                    location: SrcSpan {
+                        start: 6,
+                        end: 7,
+                    },
+                    value: "2",
+                },
+                Int {
+                    location: SrcSpan {
+                        start: 9,
+                        end: 10,
+                    },
+                    value: "3",
+                },
+            ],
+            clauses: [
+                Clause {
+                    location: SrcSpan {
+                        start: 17,
+                        end: 43,
+                    },
+                    pattern: [
+                        Variable {
+                            location: SrcSpan {
+                                start: 17,
+                                end: 18,
+                            },
+                            name: "x",
+                            type_: (),
+                        },
+                        Variable {
+                            location: SrcSpan {
+                                start: 20,
+                                end: 21,
+                            },
+                            name: "y",
+                            type_: (),
+                        },
+                    ],
+                    alternative_patterns: [],
+                    guard: Some(
+                        Equals {
+                            location: SrcSpan {
+                                start: 25,
+                                end: 35,
+                            },
+                            left: AddInt {
+                                location: SrcSpan {
+                                    start: 25,
+                                    end: 30,
+                                },
+                                left: Var {
+                                    location: SrcSpan {
+                                        start: 25,
+                                        end: 26,
+                                    },
+                                    type_: (),
+                                    name: "x",
+                                },
+                                right: Var {
+                                    location: SrcSpan {
+                                        start: 29,
+                                        end: 30,
+                                    },
+                                    type_: (),
+                                    name: "y",
+                                },
+                            },
+                            right: Constant(
+                                Int {
+                                    location: SrcSpan {
+                                        start: 34,
+                                        end: 35,
+                                    },
+                                    value: "1",
+                                },
+                            ),
+                        },
+                    ),
+                    then: Var {
+                        location: SrcSpan {
+                            start: 39,
+                            end: 43,
+                        },
+                        name: "True",
+                    },
+                },
+            ],
+        },
+    ),
+]

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1121,3 +1121,14 @@ fn newline_tokens() {
         ]
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/1756
+#[test]
+fn arithmetic_in_guards() {
+    assert_parse!(
+        "
+case 2, 3 {
+    x, y if x + y == 1 -> True
+}"
+    );
+}

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -106,6 +106,10 @@ impl Token {
             | Self::GreaterEqualDot
             | Self::GreaterDot => Some(4),
 
+            Self::Plus | Self::PlusDot | Self::Minus | Self::MinusDot => Some(5),
+
+            Self::Star | Self::StarDot | Self::Slash | Self::SlashDot | Self::Percent => Some(6),
+
             _ => None,
         }
     }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1747,6 +1747,172 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 })
             }
 
+            ClauseGuard::AddInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(int(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::AddInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::AddFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(float(), left.type_())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(float(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::AddFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::SubInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(int(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::SubInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::SubFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(float(), left.type_())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(float(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::SubFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::MultInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(int(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::MultInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::MultFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(float(), left.type_())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(float(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::MultFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::DivInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(int(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::DivInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::DivFloat {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(float(), left.type_())
+                    .map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(float(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::DivFloat {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
+            ClauseGuard::RemainderInt {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                let left = self.infer_clause_guard(*left)?;
+                unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
+                let right = self.infer_clause_guard(*right)?;
+                unify(int(), right.type_())
+                    .map_err(|e| convert_unify_error(e, right.location()))?;
+                Ok(ClauseGuard::RemainderInt {
+                    location,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                })
+            }
+
             ClauseGuard::Constant(constant) => {
                 Ok(ClauseGuard::Constant(self.infer_const(&None, constant)))
             }

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -657,6 +657,55 @@ fn clause_guard_tests() -> List(Test) {
         _ -> 1
       })
     }),
+    "1 + 1 == 2"
+    |> example(fn() {
+      assert_equal(0, case Nil {
+        _ if 1 + 1 == 2 -> 0
+        _ -> 1
+      })
+    }),
+    "47 % 5 == 2"
+    |> example(fn() {
+      assert_equal(0, case Nil {
+        _ if 47 % 5 == 2 -> 0
+        _ -> 1
+      })
+    }),
+    "3 * 5 == 15"
+    |> example(fn() {
+      assert_equal(0, case Nil {
+        _ if 3 * 5 == 15 -> 0
+        _ -> 1
+      })
+    }),
+    "3 * 5 + 1 == 16"
+    |> example(fn() {
+      assert_equal(0, case Nil {
+        _ if 3 * 5 + 1 == 16 -> 0
+        _ -> 1
+      })
+    }),
+    "1 + 3 * 5 == 16"
+    |> example(fn() {
+      assert_equal(0, case Nil {
+        _ if 1 + 3 * 5 == 16 -> 0
+        _ -> 1
+      })
+    }),
+    "1 - 15 / 5 == -2"
+    |> example(fn() {
+      assert_equal(0, case Nil {
+        _ if 1 - 15 / 5 == -2 -> 0
+        _ -> 1
+      })
+    }),
+    "15 / 5 - 1 == 2"
+    |> example(fn() {
+      assert_equal(0, case Nil {
+        _ if 15 / 5 - 1 == 2 -> 0
+        _ -> 1
+      })
+    }),
     "#(True, False).0"
     |> example(fn() {
       assert_equal(0, case Nil {
@@ -1570,7 +1619,7 @@ fn tuple_access_tests() {
       assert_equal(
         {
           let tup = #(
-            Person("Quinn", 27, "Canada"), 
+            Person("Quinn", 27, "Canada"),
             Person("Nikita", 99, "Internet"),
           )
           tup.0.name


### PR DESCRIPTION
Closes #1756

This adds support for `+`, `+.`, `-`, `-.`, `*`, `*.`, `/`, `/.` and `%` operators in guards.

If there are more tests required I'm happy to add more!