### PR TITLE
Mark module alias access in pattern as 'used'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,10 @@
   matching on strings with an `as` pattern.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would warn that a module alias was unused when
+  it was only used in case patterns.
+  ([Michael Jones](https://github.com/michaeljones))
+
 ## v1.2.1 - 2024-05-30
 
 ### Bug Fixes

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -428,6 +428,7 @@ impl<'a> Environment<'a> {
                     }
                 })?;
                 let _ = self.unused_modules.remove(module_name);
+                let _ = self.unused_module_aliases.remove(module_name);
                 module.get_public_value(name).ok_or_else(|| {
                     UnknownValueConstructorError::ModuleValue {
                         name: name.clone(),

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -348,14 +348,6 @@ fn unused_imported_module_with_alias_and_unqualified_name_no_warnings_test() {
 }
 
 #[test]
-fn unused_imported_module_with_alias_no_warning_on_used_in_case_test() {
-    assert_no_warnings!(
-        ("thepackage", "gleam/foo", "pub type Foo { Foo(Int) }"),
-        "import gleam/foo as f\npub fn baz(a) { case a { f.Foo(int) -> { int } }  }",
-    );
-}
-
-#[test]
 fn unused_imported_module_no_warning_on_used_function_test() {
     assert_no_warnings!(
         ("thepackage", "gleam/foo", "pub fn bar() { 1 }"),
@@ -384,6 +376,15 @@ fn unused_imported_module_no_warning_on_used_unqualified_type_test() {
     assert_no_warnings!(
         ("thepackage", "gleam/foo", "pub type Foo = Int"),
         "import gleam/foo.{type Foo} pub fn baz(a: Foo) { a }",
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/3313
+#[test]
+fn imported_module_with_alias_no_warning_when_only_used_in_case_test() {
+    assert_no_warnings!(
+        ("thepackage", "gleam/foo", "pub type Foo { Foo(Int) }"),
+        "import gleam/foo as f\npub fn baz(a) { case a { f.Foo(int) -> { int } }  }",
     );
 }
 

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -348,6 +348,14 @@ fn unused_imported_module_with_alias_and_unqualified_name_no_warnings_test() {
 }
 
 #[test]
+fn unused_imported_module_with_alias_no_warning_on_used_in_case_test() {
+    assert_no_warnings!(
+        ("thepackage", "gleam/foo", "pub type Foo { Foo(Int) }"),
+        "import gleam/foo as f\npub fn baz(a) { case a { f.Foo(int) -> { int } }  }",
+    );
+}
+
+#[test]
 fn unused_imported_module_no_warning_on_used_function_test() {
     assert_no_warnings!(
         ("thepackage", "gleam/foo", "pub fn bar() { 1 }"),


### PR DESCRIPTION
This is an attempt to fix: https://github.com/gleam-lang/gleam/issues/3313

I don't have any experience with the code base. This is an educated guess based on grepping and fixing the added test.