### PR TITLE
Fix invalid erlang when shadowing the bit pattern's size variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 ### Bug Fixes
 
+- Fixed a bug in the compiler where shadowing a sized value in a bit pattern
+  would cause invalid erlang code to be generated.
+  ([Antonio Iaccarino](https://github.com/eingin))
+
 - Fixed a bug where the formatter would not format strings with big grapheme
   clusters properly.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use ecow::eco_format;
 
 use crate::analyse::Inferred;
@@ -194,39 +196,41 @@ fn pattern_segment<'a>(
     env: &mut Env<'a>,
     guards: &mut Vec<Document<'a>>,
 ) -> Document<'a> {
-    let mut pattern_is_a_string_literal = false;
-    let mut pattern_is_a_discard = false;
-    let document = match value {
-        // Skip the normal <<value/utf8>> surrounds
-        Pattern::String { value, .. } => {
-            pattern_is_a_string_literal = true;
-            value.to_doc().surround("\"", "\"")
-        }
+    let pattern_is_a_string_literal = matches!(value, Pattern::String { .. });
+    let pattern_is_a_discard = matches!(value, Pattern::Discard { .. });
 
-        // As normal
-        Pattern::Discard { .. } => {
-            pattern_is_a_discard = true;
-            print(value, vars, define_variables, env, guards)
-        }
-        Pattern::Variable { .. } | Pattern::Int { .. } | Pattern::Float { .. } => {
-            print(value, vars, define_variables, env, guards)
-        }
+    let vars = RefCell::new(vars);
+    let guards = RefCell::new(guards);
 
-        // No other pattern variants are allowed in pattern bit array segments
+    let create_document = |env: &mut Env<'a>| match value {
+        Pattern::String { value, .. } => value.to_doc().surround("\"", "\""),
+        Pattern::Discard { .. }
+        | Pattern::Variable { .. }
+        | Pattern::Int { .. }
+        | Pattern::Float { .. } => print(
+            value,
+            &mut vars.borrow_mut(),
+            define_variables,
+            env,
+            &mut guards.borrow_mut(),
+        ),
         _ => panic!("Pattern segment match not recognised"),
     };
 
     let size = |value: &'a TypedPattern, env: &mut Env<'a>| {
-        Some(
-            ":".to_doc()
-                .append(print(value, vars, define_variables, env, guards)),
-        )
+        Some(":".to_doc().append(print(
+            value,
+            &mut vars.borrow_mut(),
+            define_variables,
+            env,
+            &mut guards.borrow_mut(),
+        )))
     };
 
     let unit = |value: &'a u8| Some(eco_format!("unit:{value}").to_doc());
 
     bit_array_segment(
-        document,
+        create_document,
         options,
         size,
         unit,

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__bit_pattern_shadowing.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__bit_pattern_shadowing.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/erlang/tests.rs
+expression: "\npub fn main() {\n  let code = <<\"hello world\":utf8>>\n  let pre = 1\n  case code {\n    <<pre:bytes-size(pre), _:bytes>> -> pre\n    _ -> panic\n  }\n}        "
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-file("/root/project/test/my/mod.gleam", 2).
+-spec main() -> bitstring().
+main() ->
+    Code = <<"hello world"/utf8>>,
+    Pre = 1,
+    case Code of
+        <<Pre@1:Pre/binary, _/binary>> ->
+            Pre@1;
+
+        _ ->
+            erlang:error(#{gleam_error => panic,
+                    message => <<"`panic` expression evaluated."/utf8>>,
+                    module => <<"my/mod"/utf8>>,
+                    function => <<"main"/utf8>>,
+                    line => 7})
+    end.

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -943,3 +943,19 @@ fn windows_file_escaping_bug() {
     let output = compile_test_project(src, path, None);
     insta::assert_snapshot!(insta::internals::AutoName, output, src);
 }
+
+// https://github.com/gleam-lang/gleam/issues/3315
+#[test]
+fn bit_pattern_shadowing() {
+    assert_erl!(
+        "
+pub fn main() {
+  let code = <<\"hello world\":utf8>>
+  let pre = 1
+  case code {
+    <<pre:bytes-size(pre), _:bytes>> -> pre
+    _ -> panic
+  }
+}        "
+    );
+}


### PR DESCRIPTION
This closes #3315

When using the `size(x)` option on a bit array pattern. If the size option is passed a variable, and that variable is shadowed by the pattern segment the compiler will use the new shadowed name. This happens since the the usage of the already defined variable comes after the definition of the pattern's variable. It will therefore cause the compiler to use the new shadowed name instead of the intended previous name.

```gleam
let pre = 1
..
<<pre:bytes-size(pre), _:bytes>>
```
This currently creates
```erlang
<<Pre@1:Pre@1/binary, _/binary>>
```

To fix this I have moved the creation of the erlang output for the size portion before the value part. This will ensure that the previous variable name is used.
