### PR TITLE
Fixed spelling mistake in function get_module_inferface -> get_module_interface

### DIFF
--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -183,7 +183,7 @@ where
         }
     }
 
-    pub fn get_module_inferface(&self, name: &str) -> Option<&ModuleInterface> {
+    pub fn get_module_interface(&self, name: &str) -> Option<&ModuleInterface> {
         self.project_compiler.get_importable_modules().get(name)
     }
 }

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -162,7 +162,7 @@ where
             // Find the module that is being imported from
             let importing_module_name = src.get(6..dot_index)?.trim();
             let importing_module: &ModuleInterface =
-                self.compiler.get_module_inferface(importing_module_name)?;
+                self.compiler.get_module_interface(importing_module_name)?;
 
             Some(Ok(Some(
                 self.unqualified_completions_from_module(importing_module),
@@ -368,7 +368,7 @@ where
         for import in self.module.ast.definitions.iter().filter_map(get_import) {
             // The module may not be known of yet if it has not previously
             // compiled yet in this editor session.
-            let Some(module) = self.compiler.get_module_inferface(&import.module) else {
+            let Some(module) = self.compiler.get_module_interface(&import.module) else {
                 continue;
             };
 
@@ -481,7 +481,7 @@ where
         for import in self.module.ast.definitions.iter().filter_map(get_import) {
             // The module may not be known of yet if it has not previously
             // compiled yet in this editor session.
-            let Some(module) = self.compiler.get_module_inferface(&import.module) else {
+            let Some(module) = self.compiler.get_module_interface(&import.module) else {
                 continue;
             };
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -234,7 +234,7 @@ where
                 // we should try to provide completions for unqualified values
                 Located::ModuleStatement(Definition::Import(import)) => this
                     .compiler
-                    .get_module_inferface(import.module.as_str())
+                    .get_module_interface(import.module.as_str())
                     .map(|importing_module| {
                         completer.unqualified_completions_from_module(importing_module)
                     }),
@@ -316,7 +316,7 @@ where
                     location,
                 }) => this
                     .compiler
-                    .get_module_inferface(module.as_str())
+                    .get_module_interface(module.as_str())
                     .and_then(|module| {
                         if is_type {
                             module.types.get(name).map(|t| {


### PR DESCRIPTION
Addresses #3341.

This commit changes:

Fixed a spelling mistake of the function `get_module_inferface` in `compiler-core/src/language_server/compiler.rs` and everywhere it is referenced.