### PR TITLE
Update to macos-12 in release-nightly and release

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -69,7 +69,7 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false
-          - os: macos-11
+          - os: macos-12
             target: aarch64-apple-darwin
             use-cross: false
           - os: windows-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false
-          - os: macos-11
+          - os: macos-12
             target: aarch64-apple-darwin
             use-cross: false
           - os: windows-latest


### PR DESCRIPTION
macos-11 was deprecated 2 days ago leaving the nightly release job hanging with no error message lol.

mentioned in 2 places, apparently:
- https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/
- https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job