### PR TITLE
Left align opaque flag on types in the documentation generator

### DIFF
--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -540,7 +540,8 @@ body.drawer-open .label-closed {
   border-width: 1px;
   border-color: var(--fg-shade-2);
   font-size: 0.9em;
-  margin-left: 8px;
+  margin-left: 12px;
+  margin-right: auto;
   float: right;
 }
 


### PR DESCRIPTION
Closes #3340

This left aligns the `Opaque` flag on types

With opaque flag:
<img width="609" alt="Screenshot 2024-07-02 at 9 00 18 AM" src="https://github.com/gleam-lang/gleam/assets/39470600/b3aef9ff-98bf-43ce-9ed5-e2f9e4a23623">

Without opaque flag:
<img width="620" alt="Screenshot 2024-07-02 at 9 52 27 AM" src="https://github.com/gleam-lang/gleam/assets/39470600/11bc4ec4-206d-4010-ac40-ed912db0f7a5">

Without source link, with opaque flag:
<img width="600" alt="Screenshot 2024-07-02 at 8 59 39 AM" src="https://github.com/gleam-lang/gleam/assets/39470600/505f9d88-1f60-478a-9c9b-719fa3f3fb0b">
