### PR TITLE
Turn LS tests into snapshot tests

### DIFF
--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -136,6 +136,11 @@ fn show_hover(code: &str, range: Range, pointer: Position) -> String {
 
 #[macro_export]
 macro_rules! assert_hover {
+    ($code:literal, $pointer:expr $(,)?) => {
+        let project = TestProject::for_source($code);
+        assert_hover!(project, $pointer);
+    };
+
     ($project:expr, $pointer:expr $(,)?) => {
         let src = $project.src;
         let position = $pointer.find_position(src);
@@ -151,18 +156,20 @@ macro_rules! assert_hover {
 
 #[test]
 fn hover_function_definition() {
-    let code = "
+    assert_hover!(
+        "
 fn add_2(x) {
   x + 2
 }
-";
-    let project = TestProject::for_source(code);
-    assert_hover!(project, find_position_of("add_2"));
+",
+        find_position_of("add_2")
+    );
 }
 
 #[test]
 fn hover_local_function() {
-    let code = "
+    assert_hover!(
+        "
 fn my_fn() {
   Nil
 }
@@ -170,10 +177,7 @@ fn my_fn() {
 fn main() {
   my_fn
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("my_fn").under_char('y').nth_occurrence(2)
     );
 }
@@ -181,7 +185,8 @@ fn main() {
 // https://github.com/gleam-lang/gleam/issues/2654
 #[test]
 fn hover_local_function_in_pipe() {
-    let code = "
+    assert_hover!(
+        "
 fn add1(num: Int) -> Int {
   num + 1
 }
@@ -194,10 +199,7 @@ pub fn main() {
   |> add1
   |> add1
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("add1")
             .with_char_offset(1)
             .nth_occurrence(2)
@@ -207,7 +209,8 @@ pub fn main() {
 // https://github.com/gleam-lang/gleam/issues/2654
 #[test]
 fn hover_local_function_in_pipe_1() {
-    let code = "
+    assert_hover!(
+        "
 fn add1(num: Int) -> Int {
   num + 1
 }
@@ -220,10 +223,7 @@ pub fn main() {
   |> add1
   |> add1
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("add1")
             .with_char_offset(2)
             .nth_occurrence(3)
@@ -233,7 +233,8 @@ pub fn main() {
 // https://github.com/gleam-lang/gleam/issues/2654
 #[test]
 fn hover_local_function_in_pipe_2() {
-    let code = "
+    assert_hover!(
+        "
 fn add1(num: Int) -> Int {
   num + 1
 }
@@ -246,10 +247,7 @@ pub fn main() {
   |> add1
   |> add1
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("add1")
             .with_char_offset(2)
             .nth_occurrence(4)
@@ -259,7 +257,8 @@ pub fn main() {
 // https://github.com/gleam-lang/gleam/issues/2654
 #[test]
 fn hover_local_function_in_pipe_3() {
-    let code = "
+    assert_hover!(
+        "
 fn add1(num: Int) -> Int {
   num + 1
 }
@@ -272,10 +271,7 @@ pub fn main() {
   |> add1
   |> add1
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("add1")
             .with_char_offset(2)
             .nth_occurrence(5)
@@ -466,29 +462,28 @@ fn main() {
 
 #[test]
 fn hover_function_definition_with_docs() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 fn append(x, y) {
   x <> y
 }
-";
-
-    assert_hover!(TestProject::for_source(code), find_position_of("append"));
+",
+        find_position_of("append")
+    );
 }
 
 #[test]
 fn hover_function_argument() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 fn append(x, y) {
   x <> y
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("append(x, y)").under_char('x')
     );
 }
@@ -511,32 +506,32 @@ fn append(x, y) {
 
 #[test]
 fn hover_expressions_in_function_body() {
-    let code = "
+    assert_hover!(
+        "
 fn append(x, y) {
   x <> y
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("x").nth_occurrence(2)
     );
 }
 
 #[test]
 fn hover_module_constant() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 const one = 1
-";
-
-    assert_hover!(TestProject::for_source(code), find_position_of("one"));
+",
+        find_position_of("one")
+    );
 }
 
 #[test]
 fn hover_variable_in_use_expression() {
-    let code = "
+    assert_hover!(
+        "
 fn b(fun: fn(Int) -> String) {
   fun(42)
 }
@@ -547,17 +542,15 @@ fn do_stuff() {
   use a <- b
   c
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("use a").under_last_char()
     );
 }
 
 #[test]
 fn hover_variable_in_use_expression_1() {
-    let code = "
+    assert_hover!(
+        "
 fn b(fun: fn(Int) -> String) {
   fun(42)
 }
@@ -568,17 +561,15 @@ fn do_stuff() {
   use a <- b
   c
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("b").nth_occurrence(2)
     );
 }
 
 #[test]
 fn hover_variable_in_use_expression_2() {
-    let code = "
+    assert_hover!(
+        "
 fn b(fun: fn(Int) -> String) {
   fun(42)
 }
@@ -589,120 +580,99 @@ fn do_stuff() {
   use a <- b
   c
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("c").nth_occurrence(2)
     );
 }
 
 #[test]
 fn hover_function_arg_annotation_2() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 fn append(x: String, y: String) -> String {
   x <> y
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("String").under_char('n')
     );
 }
 
 #[test]
 fn hover_function_return_annotation() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 fn append(x: String, y: String) -> String {
   x <> y
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("String").under_char('n').nth_occurrence(3)
     );
 }
 
 #[test]
 fn hover_function_return_annotation_with_tuple() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 fn append(x: String, y: String) -> #(String, String) {
   #(x, y)
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("String").under_char('r').nth_occurrence(3)
     );
 }
 
 #[test]
 fn hover_module_constant_annotation() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 const one: Int = 1
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("Int").under_last_char()
     );
 }
 
 #[test]
 fn hover_type_constructor_annotation() {
-    let code = "
+    assert_hover!(
+        "
 type Wibble {
     Wibble(arg: String)
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("String").under_char('n')
     );
 }
 
 #[test]
 fn hover_type_alias_annotation() {
-    let code = "
-type Wibble = Int
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
-        find_position_of("Int").under_char('n')
-    );
+    assert_hover!("type Wibble = Int", find_position_of("Int").under_char('n'));
 }
 
 #[test]
 fn hover_assignment_annotation() {
-    let code = "
+    assert_hover!(
+        "
 fn wibble() {
     let wobble: Int = 7
     wobble
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("Int").under_last_char()
     );
 }
 
 #[test]
 fn hover_function_arg_annotation_with_documentation() {
-    let code = "
+    assert_hover!(
+        "
 /// Exciting documentation
 /// Maybe even multiple lines
 type Wibble {
@@ -712,10 +682,7 @@ type Wibble {
 fn identity(x: Wibble) -> Wibble {
   x
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("Wibble")
             .under_last_char()
             .nth_occurrence(3)
@@ -780,7 +747,7 @@ fn main() -> MyType {
 /// Exciting documentation
 /// Maybe even multiple lines
 pub type MyType {
-    MyType
+  MyType
 }"
         ),
         find_position_of("MyType").under_last_char()
@@ -789,20 +756,19 @@ pub type MyType {
 
 #[test]
 fn hover_works_even_for_invalid_code() {
-    let code = "
+    assert_hover!(
+        "
 fn invalid() { 1 + Nil }
 fn valid() { Nil }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("fn valid").under_char('v')
     );
 }
 
 #[test]
 fn hover_for_pattern_spread_ignoring_all_fields() {
-    let code = "
+    assert_hover!(
+        "
 pub type Model {
   Model(
     Int,
@@ -817,14 +783,15 @@ pub fn main() {
     Model(..) -> todo
   }
 }
-";
-
-    assert_hover!(TestProject::for_source(code), find_position_of(".."));
+",
+        find_position_of("..")
+    );
 }
 
 #[test]
 fn hover_for_pattern_spread_ignoring_some_fields() {
-    let code = "
+    assert_hover!(
+        "
 pub type Model {
   Model(
     Int,
@@ -839,17 +806,15 @@ pub fn main() {
     Model(_, label1: _, ..) -> todo
   }
 }
-";
-
-    assert_hover!(
-        TestProject::for_source(code),
+",
         find_position_of("..").under_last_char()
     );
 }
 
 #[test]
 fn hover_for_pattern_spread_ignoring_all_positional_fields() {
-    let code = "
+    assert_hover!(
+        "
 pub type Model {
   Model(
     Int,
@@ -864,7 +829,7 @@ pub fn main() {
     Model(_, _, _, ..) -> todo
   }
 }
-";
-
-    assert_hover!(TestProject::for_source(code), find_position_of(".."));
+",
+        find_position_of("..")
+    );
 }

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -68,7 +68,7 @@ impl PositionFinder {
         let byte_index = src
             .match_indices(value)
             .nth(nth_occurrence - 1)
-            .expect("no match for pointer")
+            .expect("no match for position")
             .0;
 
         byte_index_to_position(src, byte_index + offset)
@@ -99,7 +99,7 @@ fn byte_index_to_position(src: &str, byte_index: usize) -> Position {
     Position::new(line, col)
 }
 
-fn show_hover(code: &str, range: Range, pointer: Position) -> String {
+fn show_hover(code: &str, range: Range, position: Position) -> String {
     let Range { start, end } = range;
 
     // When we display the over range the end character is always excluded!
@@ -111,11 +111,11 @@ fn show_hover(code: &str, range: Range, pointer: Position) -> String {
         let mut underline_empty = true;
 
         for (column_number, _) in line.chars().enumerate() {
-            let position = Position::new(line_number as u32, column_number as u32);
-            if position == pointer {
+            let current_position = Position::new(line_number as u32, column_number as u32);
+            if current_position == position {
                 underline_empty = false;
                 underline.push('↑');
-            } else if start.le(&position) && position.lt(&end) {
+            } else if start.le(&current_position) && current_position.lt(&end) {
                 underline_empty = false;
                 underline.push('▔');
             } else {
@@ -136,14 +136,14 @@ fn show_hover(code: &str, range: Range, pointer: Position) -> String {
 
 #[macro_export]
 macro_rules! assert_hover {
-    ($code:literal, $pointer:expr $(,)?) => {
+    ($code:literal, $position:expr $(,)?) => {
         let project = TestProject::for_source($code);
-        assert_hover!(project, $pointer);
+        assert_hover!(project, $position);
     };
 
-    ($project:expr, $pointer:expr $(,)?) => {
+    ($project:expr, $position:expr $(,)?) => {
         let src = $project.src;
-        let position = $pointer.find_position(src);
+        let position = $position.find_position(src);
         let result = hover($project, position).expect("no hover produced");
         let pretty_hover = show_hover(src, result.range.expect("hover with no range"), position);
         let output = format!(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_redundant_tuple_with_catch_all_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_redundant_tuple_with_catch_all_pattern.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(code, 4, REMOVE_REDUNDANT_TUPLES)"
+expression: "\npub fn main() {\n  case #(1, 2), #(3, 4) {\n    #(2, 2), #(2, 2) -> 0\n    #(1, 2), _ -> 0\n    _, #(1, 2) -> 0\n    _, _ -> 1\n  }\n}\n"
 ---
 pub fn main() {
   case 1, 2, 3, 4 {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: result
+expression: "\npub fn main() {\n  case\n    #(\n      // first comment\n      1,\n      // second comment\n      2,\n      3 // third comment before comma\n\n      ,\n\n      // fourth comment after comma\n\n    )\n  {\n    #(\n      // first comment\n      a,\n      // second comment\n      b,\n      c // third comment before comma\n\n      ,\n\n      // fourth comment after comma\n\n    ) -> 0\n  }\n}\n"
 ---
 pub fn main() {
   case

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_nested.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_nested.snap
@@ -1,0 +1,7 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  case #(case #(0) { #(a) -> 0 }) { #(b) -> 0 }\n}\n"
+---
+pub fn main() {
+  case case 0 { a -> 0 } { b -> 0 }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_only_safe_remove.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_only_safe_remove.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  case #(0), #(1) {\n    #(1), #(b) -> 0\n    a, #(0) -> 1 // The first of this clause is not a tuple\n    #(a), #(b) -> 2\n  }\n}\n"
+---
+pub fn main() {
+  case #(0), 1 {
+    #(1), b -> 0
+    a, 0 -> 1 // The first of this clause is not a tuple
+    #(a), b -> 2
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_simple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_simple.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  case #(1) { #(a) -> 0 }\n  case #(1, 2) { #(a, b) -> 0 }\n}\n"
+---
+pub fn main() {
+  case 1 { a -> 0 }
+  case 1, 2 { a, b -> 0 }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_with_catch_all_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_with_catch_all_pattern.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(code, 4, REMOVE_REDUNDANT_TUPLES)"
+expression: "\npub fn main() {\n  case #(1, 2) {\n    #(1, 2) -> 0\n    _ -> 1\n  }\n}\n"
 ---
 pub fn main() {
   case 1, 2 {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_alias.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\n// test\nimport result.{is_ok} as res\nimport option\n\npub fn main() {\n  is_ok\n}\n"
+---
+// test
+import result.{is_ok} 
+
+pub fn main() {
+  is_ok
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_simple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_simple.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\n// test\nimport // comment\n  list as lispy\nimport result\nimport option\n\npub fn main() {\n  result.is_ok\n}\n"
+---
+// test
+import result
+
+pub fn main() {
+  result.is_ok
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_start_of_file.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_start_of_file.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "import option\nimport result\n\npub fn main() {\n  result.is_ok\n}\n"
+---
+import result
+
+pub fn main() {
+  result.is_ok
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_assignment_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_assignment_annotation.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn wibble() {\n    let wobble: Int = 7\n    wobble\n}\n"
+---
+fn wibble() {
+    let wobble: Int = 7
+                ▔▔↑    
+    wobble
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_expressions_in_function_body.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_expressions_in_function_body.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn append(x, y) {\n  x <> y\n}\n"
+---
+fn append(x, y) {
+  x <> y
+  ↑     
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```\nA locally defined variable.",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_function_with_another_value_same_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_function_with_another_value_same_name.snap
@@ -1,23 +1,18 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport a/example_module.{my_const as discarded}\nimport b/example_module.{my_const} as _\nfn main() {\n    my_const\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 4,
-                character: 4,
-            },
-            end: Position {
-                line: 4,
-                character: 12,
-            },
-        },
-    ),
+import a/example_module.{my_const as discarded}
+import b/example_module.{my_const} as _
+fn main() {
+    my_const
+    ▔▔▔▔↑▔▔▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport example_module\nfn main() {\n  example_module.my_const\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 16,
-            },
-            end: Position {
-                line: 3,
-                character: 25,
-            },
-        },
-    ),
+import example_module
+fn main() {
+  example_module.my_const
+                ▔▔▔↑▔▔▔▔▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport example_module\nfn main() {\n    example_module.my_fn\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 18,
-            },
-            end: Position {
-                line: 3,
-                character: 24,
-            },
-        },
-    ),
+import example_module
+fn main() {
+    example_module.my_fn
+                  ▔▔▔▔↑▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport example_module\nfn main() {\n  example_module.my_fn\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 16,
-            },
-            end: Position {
-                line: 3,
-                character: 22,
-            },
-        },
-    ),
+import example_module
+fn main() {
+  example_module.my_fn
+                ▔▔▔↑▔▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_nested_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_nested_module.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport my/nested/example_module\nfn main() {\n    example_module.my_fn\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/my/nested/example_module.html#my_fn)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 18,
-            },
-            end: Position {
-                line: 3,
-                character: 24,
-            },
-        },
-    ),
+import my/nested/example_module
+fn main() {
+    example_module.my_fn
+                  ▔▔▔▔↑▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/my/nested/example_module.html#my_fn)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_renamed_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_renamed_module.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport example_module as renamed_module\nfn main() {\n    renamed_module.my_fn\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 18,
-            },
-            end: Position {
-                line: 3,
-                character: 24,
-            },
-        },
-    ),
+import example_module as renamed_module
+fn main() {
+    renamed_module.my_fn
+                  ▔▔▔▔↑▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_constants.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_constants.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport example_module.{my_const}\nfn main() {\n  my_const\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 2,
-            },
-            end: Position {
-                line: 3,
-                character: 10,
-            },
-        },
-    ),
+import example_module.{my_const}
+fn main() {
+  my_const
+  ▔▔▔↑▔▔▔▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_unqualified_function.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport example_module.{my_fn}\nfn main() {\n  my_fn\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 2,
-            },
-            end: Position {
-                line: 3,
-                character: 7,
-            },
-        },
-    ),
+import example_module.{my_fn}
+fn main() {
+  my_fn
+  ▔▔▔↑▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_unqualified_imported_function_renamed_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_unqualified_imported_function_renamed_module.snap
@@ -1,23 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport example_module.{my_fn} as renamed_module\nfn main() {\n    my_fn\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 3,
-                character: 4,
-            },
-            end: Position {
-                line: 3,
-                character: 9,
-            },
-        },
-    ),
+import example_module.{my_fn} as renamed_module
+fn main() {
+    my_fn
+    ▔▔↑▔▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Nil\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
@@ -1,23 +1,18 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: hover
+expression: "\nimport a/example_module as _\nimport b/example_module\nfn main() {\n    example_module.my_const\n}\n"
 ---
-Hover {
-    contents: Scalar(
-        String(
-            "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
-        ),
-    ),
-    range: Some(
-        Range {
-            start: Position {
-                line: 4,
-                character: 18,
-            },
-            end: Position {
-                line: 4,
-                character: 27,
-            },
-        },
-    ),
+import a/example_module as _
+import b/example_module
+fn main() {
+    example_module.my_const
+                  ▔▔▔▔↑▔▔▔▔
 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_spread_ignoring_all_fields.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_spread_ignoring_all_fields.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub type Model {\n  Model(\n    Int,\n    Float,\n    label1: Int,\n    label2: String,\n  )\n}\n\npub fn main() {\n  case todo {\n    Model(..) -> todo\n  }\n}\n"
+---
+pub type Model {
+  Model(
+    Int,
+    Float,
+    label1: Int,
+    label2: String,
+  )
+}
+
+pub fn main() {
+  case todo {
+    Model(..) -> todo
+          ↑▔         
+  }
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "Unused positional fields:\n- `Int`\n- `Float`\n\nUnused labelled fields:\n- `label1: Int`\n- `label2: String`",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_spread_ignoring_all_positional_fields.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_spread_ignoring_all_positional_fields.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub type Model {\n  Model(\n    Int,\n    Float,\n    label1: Int,\n    label2: String,\n  )\n}\n\npub fn main() {\n  case todo {\n    Model(_, _, _, ..) -> todo\n  }\n}\n"
+---
+pub type Model {
+  Model(
+    Int,
+    Float,
+    label1: Int,
+    label2: String,
+  )
+}
+
+pub fn main() {
+  case todo {
+    Model(_, _, _, ..) -> todo
+                   ↑▔         
+  }
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "Unused labelled fields:\n- `label2: String`",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_spread_ignoring_some_fields.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_spread_ignoring_some_fields.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub type Model {\n  Model(\n    Int,\n    Float,\n    label1: Int,\n    label2: String,\n  )\n}\n\npub fn main() {\n  case todo {\n    Model(_, label1: _, ..) -> todo\n  }\n}\n"
+---
+pub type Model {
+  Model(
+    Int,
+    Float,
+    label1: Int,
+    label2: String,
+  )
+}
+
+pub fn main() {
+  case todo {
+    Model(_, label1: _, ..) -> todo
+                        ▔↑         
+  }
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "Unused positional fields:\n- `Float`\n\nUnused labelled fields:\n- `label2: String`",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_2.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\nfn append(x: String, y: String) -> String {\n  x <> y\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x: String, y: String) -> String {
+             ▔▔▔▔↑▔                        
+  x <> y
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_with_documentation.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\ntype Wibble {\n    Wibble(arg: String)\n}\n\nfn identity(x: Wibble) -> Wibble {\n  x\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+type Wibble {
+    Wibble(arg: String)
+}
+
+fn identity(x: Wibble) -> Wibble {
+               ▔▔▔▔▔↑             
+  x
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nWibble\n```\n Exciting documentation\n Maybe even multiple lines\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_argument.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_argument.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\nfn append(x, y) {\n  x <> y\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x, y) {
+          ↑      
+  x <> y
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_definition.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn add_2(x) {\n  x + 2\n}\n"
+---
+fn add_2(x) {
+▔▔▔↑▔▔▔▔▔▔▔  
+  x + 2
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int) -> Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_definition_with_docs.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_definition_with_docs.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\nfn append(x, y) {\n  x <> y\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x, y) {
+▔▔▔↑▔▔▔▔▔▔▔▔▔▔▔  
+  x <> y
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(String, String) -> String\n```\n Exciting documentation\n Maybe even multiple lines\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\nfn append(x: String, y: String) -> String {\n  x <> y\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x: String, y: String) -> String {
+                                   ▔▔▔▔↑▔  
+  x <> y
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation_with_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation_with_tuple.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\nfn append(x: String, y: String) -> #(String, String) {\n  #(x, y)\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+fn append(x: String, y: String) -> #(String, String) {
+                                     ▔▔↑▔▔▔           
+  #(x, y)
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_type.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport example_module.{type MyType, MyType}\nfn main() -> MyType {\n  MyType\n}\n"
+---
+import example_module.{type MyType, MyType}
+                       ▔▔▔▔▔▔▔▔▔▔↑         
+fn main() -> MyType {
+  MyType
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nMyType\n```\n Exciting documentation\n Maybe even multiple lines\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_value.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_value.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport example_module.{my_num}\nfn main() {\n  my_num\n}\n"
+---
+import example_module.{my_num}
+                       ▔▔▔↑▔▔ 
+fn main() {
+  my_num
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_value_from_hex.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_value_from_hex.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport example_module.{my_num}\nfn main() {\n  my_num\n}\n"
+---
+import example_module.{my_num}
+                       ▔▔▔↑▔▔ 
+fn main() {
+  my_num
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_num)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function.snap
@@ -1,11 +1,14 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: "\nimport example_module\nfn main() {\n  example_module.my_fn\n}\n"
+expression: "\nfn my_fn() {\n  Nil\n}\n\nfn main() {\n  my_fn\n}\n"
 ---
-import example_module
+fn my_fn() {
+  Nil
+}
+
 fn main() {
-  example_module.my_fn
-                ▔▔▔↑▔▔
+  my_fn
+  ▔↑▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn add1(num: Int) -> Int {\n  num + 1\n}\n\npub fn main() {\n  add1(1)\n\n  1\n  |> add1\n  |> add1\n  |> add1\n}\n"
+---
+fn add1(num: Int) -> Int {
+  num + 1
+}
+
+pub fn main() {
+  add1(1)
+  ▔↑▔▔   
+
+  1
+  |> add1
+  |> add1
+  |> add1
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int) -> Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe_1.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe_1.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn add1(num: Int) -> Int {\n  num + 1\n}\n\npub fn main() {\n  add1(1)\n\n  1\n  |> add1\n  |> add1\n  |> add1\n}\n"
+---
+fn add1(num: Int) -> Int {
+  num + 1
+}
+
+pub fn main() {
+  add1(1)
+
+  1
+  |> add1
+     ▔▔↑▔
+  |> add1
+  |> add1
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int) -> Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe_2.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn add1(num: Int) -> Int {\n  num + 1\n}\n\npub fn main() {\n  add1(1)\n\n  1\n  |> add1\n  |> add1\n  |> add1\n}\n"
+---
+fn add1(num: Int) -> Int {
+  num + 1
+}
+
+pub fn main() {
+  add1(1)
+
+  1
+  |> add1
+  |> add1
+     ▔▔↑▔
+  |> add1
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int) -> Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe_3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_local_function_in_pipe_3.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn add1(num: Int) -> Int {\n  num + 1\n}\n\npub fn main() {\n  add1(1)\n\n  1\n  |> add1\n  |> add1\n  |> add1\n}\n"
+---
+fn add1(num: Int) -> Int {
+  num + 1
+}
+
+pub fn main() {
+  add1(1)
+
+  1
+  |> add1
+  |> add1
+  |> add1
+     ▔▔↑▔
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int) -> Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\nconst one = 1\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+const one = 1
+      ↑▔▔    
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant_annotation.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\nconst one: Int = 1\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+const one: Int = 1
+           ▔▔↑    
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_alias_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_alias_annotation.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype Wibble = Int\n"
+---
+type Wibble = Int
+              ▔↑▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_constructor_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_constructor_annotation.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype Wibble {\n    Wibble(arg: String)\n}\n"
+---
+type Wibble {
+    Wibble(arg: String)
+                ▔▔▔▔↑▔ 
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_variable_in_use_expression.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_variable_in_use_expression.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn b(fun: fn(Int) -> String) {\n  fun(42)\n}\n\nfn do_stuff() {\n  let c = \"done\"\n\n  use a <- b\n  c\n}\n"
+---
+fn b(fun: fn(Int) -> String) {
+  fun(42)
+}
+
+fn do_stuff() {
+  let c = "done"
+
+  use a <- b
+      ↑     
+  c
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_variable_in_use_expression_1.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_variable_in_use_expression_1.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn b(fun: fn(Int) -> String) {\n  fun(42)\n}\n\nfn do_stuff() {\n  let c = \"done\"\n\n  use a <- b\n  c\n}\n"
+---
+fn b(fun: fn(Int) -> String) {
+  fun(42)
+}
+
+fn do_stuff() {
+  let c = "done"
+
+  use a <- b
+           ↑
+  c
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(fn(Int) -> String) -> String\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_variable_in_use_expression_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_variable_in_use_expression_2.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn b(fun: fn(Int) -> String) {\n  fun(42)\n}\n\nfn do_stuff() {\n  let c = \"done\"\n\n  use a <- b\n  c\n}\n"
+---
+fn b(fun: fn(Int) -> String) {
+  fun(42)
+}
+
+fn do_stuff() {
+  let c = "done"
+
+  use a <- b
+  c
+  ↑
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```\nA locally defined variable.",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_works_even_for_invalid_code.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_works_even_for_invalid_code.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn invalid() { 1 + Nil }\nfn valid() { Nil }\n"
+---
+fn invalid() { 1 + Nil }
+fn valid() { Nil }
+▔▔▔↑▔▔▔▔▔▔        
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Nil\n```\n",
+    ),
+)


### PR DESCRIPTION
This PR replaces most of the old LS tests (especially the hover ones) with snapshot tests.

A huge time saver is that in a hover test you'll no longer have to guess if the highlighted span is correct, since it will be shown directly in the source code; previously one would have to manually write down the expected highlighted span.

Another nice thing is now there is a handy dsl to write hover tests and avoid hard coding positions, for example:
```rs
let code = "fn wibble() { todo }"
assert_hover!(..., Position::new(0, 4))
assert_hover!(..., find_position_of("wibble").under_char('i'))
```

![Screenshot 2024-07-03 alle 13 31 18](https://github.com/gleam-lang/gleam/assets/20598369/3dbeb116-739e-4a03-8f6c-effc8069d432)
