### PR TITLE
De-foo-ify code

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -460,9 +460,9 @@ impl Publicity {
 ///
 /// ```gleam
 /// // Public function
-/// pub fn bar() -> String { ... }
+/// pub fn wobble() -> String { ... }
 /// // Private function
-/// fn foo(x: Int) -> Int { ... }
+/// fn wibble(x: Int) -> Int { ... }
 /// ```
 pub struct Function<T, Expr> {
     pub location: SrcSpan,

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -175,13 +175,13 @@ fn internal_definitions_are_not_included() {
         "app.gleam",
         r#"
 @internal
-pub const foo = 1
+pub const wibble = 1
 
 @internal
-pub type Foo = Int
+pub type Wibble = Int
 
 @internal
-pub type Bar { Bar }
+pub type Wobble { Wobble }
 
 @internal
 pub fn one() { 1 }

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -107,13 +107,13 @@ fn print<'a>(
 
             match left_side_assignment {
                 Some((left_name, _)) => {
-                    // "foo" as prefix <> rest
-                    //       ^^^^^^^^^ In case the left prefix of the pattern matching is given an alias
-                    //                 we bind it to a local variable so that it can be correctly
-                    //                 referenced inside the case branch.
+                    // "wibble" as prefix <> rest
+                    //             ^^^^^^^^^ In case the left prefix of the pattern matching is given an alias
+                    //                       we bind it to a local variable so that it can be correctly
+                    //                       referenced inside the case branch.
                     //
-                    // <<Prefix:3/binary, Rest/binary>> when Prefix =:= <<"foo">>
-                    //   ^^^^^^^^                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+                    // <<Prefix:3/binary, Rest/binary>> when Prefix =:= <<"wibble">>
+                    //   ^^^^^^^^                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     //   since erlang's binary pattern matching doesn't allow direct string assignment
                     //   to variables within the pattern, we first match the expected prefix length in
                     //   bytes, then use a guard clause to verify the content.

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -2627,7 +2627,7 @@ fn pattern_discard() {
 
     assert_format!(
         r#"fn main() {
-  let _foo = 1
+  let _wibble = 1
   Nil
 }
 "#
@@ -2851,10 +2851,10 @@ fn expr_case() {
         r#"fn main() {
   case bool {
     True -> {
-      "Foo"
+      "Wibble"
       |> io.println
 
-      "Bar"
+      "Wobble"
       |> io.println
 
       Nil
@@ -4598,9 +4598,9 @@ fn empty_lines_work_with_trailing_space_and_eol_normalisation() {
 fn single_empty_line_between_comments() {
     // empty line isn't added if it's not already present
     assert_format!(
-        "pub fn foo() {
-  // foo
-  // bar
+        "pub fn wibble() {
+  // wibble
+  // wobble
   123
 }
 "
@@ -4611,10 +4611,10 @@ fn single_empty_line_between_comments() {
 fn single_empty_line_between_comments1() {
     // single empty line between comments/statement preserved
     assert_format!(
-        "pub fn foo() {
-  // foo
+        "pub fn wibble() {
+  // wibble
 
-  // bar
+  // wobble
 
   123
 }
@@ -4626,20 +4626,20 @@ fn single_empty_line_between_comments1() {
 fn single_empty_line_between_comments2() {
     // multiple consecutive empty lines condensed into one
     assert_format_rewrite!(
-        "pub fn foo() {
-  // foo
+        "pub fn wibble() {
+  // wibble
 
 
-  // bar
+  // wobble
 
 
   123
 }
 ",
-        "pub fn foo() {
-  // foo
+        "pub fn wibble() {
+  // wibble
 
-  // bar
+  // wobble
 
   123
 }
@@ -4651,9 +4651,9 @@ fn single_empty_line_between_comments2() {
 fn single_empty_line_between_comments3() {
     // freestanding comments keep empty lines
     assert_format!(
-        "// foo
+        "// wibble
 
-// bar
+// wobble
 "
     );
 }
@@ -4662,14 +4662,14 @@ fn single_empty_line_between_comments3() {
 fn single_empty_line_between_comments4() {
     // freestanding comments condense consecutive empty lines
     assert_format_rewrite!(
-        "// foo
+        "// wibble
 
 
-// bar
+// wobble
 ",
-        "// foo
+        "// wibble
 
-// bar
+// wobble
 ",
     );
 }
@@ -4678,8 +4678,8 @@ fn single_empty_line_between_comments4() {
 #[test]
 fn no_newline_before_comments() {
     assert_format!(
-        "// foo
-// bar
+        "// wibble
+// wobble
 "
     );
 }
@@ -4785,9 +4785,9 @@ fn do_not_remove_required_braces_case_guard() {
 
     assert_format!(
         "fn main() {
-  let foo = True
-  case foo {
-    foo if True != { 1 == 2 } -> Nil
+  let wibble = True
+  case wibble {
+    wibble if True != { 1 == 2 } -> Nil
     _ -> Nil
   }
 }
@@ -4796,10 +4796,10 @@ fn do_not_remove_required_braces_case_guard() {
 
     assert_format!(
         "fn main() {
-  let foo = True
-  let bar = False
-  case foo {
-    foo if True != { 1 == { bar == foo } } -> Nil
+  let wibble = True
+  let wobble = False
+  case wibble {
+    wibble if True != { 1 == { wobble == wibble } } -> Nil
     _ -> Nil
   }
 }
@@ -4808,9 +4808,9 @@ fn do_not_remove_required_braces_case_guard() {
 
     assert_format!(
         "fn main() {
-  let foo = #(10, [0])
-  case foo {
-    foo if True && { foo.0 == 10 || foo.0 == 1 } -> Nil
+  let wibble = #(10, [0])
+  case wibble {
+    wibble if True && { wibble.0 == 10 || wibble.0 == 1 } -> Nil
     _ -> Nil
   }
 }
@@ -4851,17 +4851,17 @@ fn remove_braces_case_guard() {
 fn remove_braces_case_guard_2() {
     assert_format_rewrite!(
         "fn main() {
-  let foo = #(10, [0])
-  case foo {
-    foo if True && { foo.0 == 10 } -> Nil
+  let wibble = #(10, [0])
+  case wibble {
+    wibble if True && { wibble.0 == 10 } -> Nil
     _ -> Nil
   }
 }
 ",
         "fn main() {
-  let foo = #(10, [0])
-  case foo {
-    foo if True && foo.0 == 10 -> Nil
+  let wibble = #(10, [0])
+  case wibble {
+    wibble if True && wibble.0 == 10 -> Nil
     _ -> Nil
   }
 }
@@ -5550,7 +5550,7 @@ fn function_call_close_to_line_limit() {
 fn multiline_string_are_not_broken_with_string_concatenation_if_they_fit() {
     assert_format!(
         r#"pub fn main() {
-  "pub fn foo(" <> arg <> ") ->" <> type_ <> "{
+  "pub fn wibble(" <> arg <> ") ->" <> type_ <> "{
     body
 }"
 }
@@ -5581,13 +5581,13 @@ fn nesting_goes_back_to_normal_after_multiline_string() {
 fn multiline_string_get_broken_on_newlines_as_function_arguments() {
     assert_format!(
         r#"pub fn main() {
-  foo(
-    bar,
-    "bar
-  asd
-       baz",
-    foo,
-    bar,
+  wibble(
+    wobble,
+    "wobble
+  wibble
+       wobble",
+    wibble,
+    wobble,
   )
 }
 "#
@@ -5598,11 +5598,11 @@ fn multiline_string_get_broken_on_newlines_as_function_arguments() {
 fn pipeline_used_as_function_arguments_gets_nested() {
     assert_format!(
         r#"pub fn main() {
-  foo(
+  wibble(
     a_variable_with_a_long_name
       |> another_variable_with_a_long_name
       |> yet_another_variable_with_a_long_name,
-    bar,
+    wobble,
   )
 }
 "#
@@ -5613,7 +5613,7 @@ fn pipeline_used_as_function_arguments_gets_nested() {
 fn pipeline_used_as_function_arguments_is_not_nested_if_it_is_the_only_argument() {
     assert_format!(
         r#"pub fn main() {
-  foo(
+  wibble(
     a_variable_with_a_long_name
     |> another_variable_with_a_long_name
     |> yet_another_variable_with_a_long_name,
@@ -5628,7 +5628,7 @@ fn pipeline_inside_list_gets_nested() {
     assert_format!(
         r#"pub fn main() {
   [
-    foo,
+    wibble,
     a_variable_with_a_long_name
       |> another_variable_with_a_long_name
       |> yet_another_variable_with_a_long_name,
@@ -5657,7 +5657,7 @@ fn pipeline_inside_tuple_gets_nested() {
     assert_format!(
         r#"pub fn main() {
   #(
-    foo,
+    wibble,
     a_variable_with_a_long_name
       |> another_variable_with_a_long_name
       |> yet_another_variable_with_a_long_name,
@@ -5841,7 +5841,7 @@ fn piped_blocks_are_not_needlessly_indented() {
     {
       "long enough to need to wrap. blah blah blah blah blah blah blah blah blah"
     }
-      |> foo,
+      |> wibble,
     3,
   )
 }

--- a/compiler-core/src/format/tests/binary_operators.rs
+++ b/compiler-core/src/format/tests/binary_operators.rs
@@ -25,12 +25,12 @@ pub fn long_comparison_chain() {
   && trying_other_comparisons < with_ints
   || trying_other_comparisons <= with_ints
   && trying_other_comparisons >= with_ints
-  || and_now_an_equality_check == with_a_function(foo, bar)
+  || and_now_an_equality_check == with_a_function(wibble, wobble)
   && trying_other_comparisons >. with_floats
-  || trying_other_comparisons <. with_floats(baz)
+  || trying_other_comparisons <. with_floats(wobble)
   && trying_other_comparisons <=. with_floats
-  || trying_other_comparisons(foo, bar) >=. with_floats
-  && foo <> bar
+  || trying_other_comparisons(wibble, wobble) >=. with_floats
+  && wibble <> wobble
 }
 "#
     );
@@ -42,7 +42,7 @@ pub fn long_chain_mixing_operators() {
         r#"pub fn main() {
   variable + variable - variable * variable / variable
   == variable * variable / variable - variable + variable
-  || foo * bar > 11
+  || wibble * wobble > 11
 }
 "#
     );
@@ -51,7 +51,7 @@ pub fn long_chain_mixing_operators() {
         r#"pub fn main() {
   variable +. variable -. variable *. variable /. variable
   == variable *. variable /. variable -. variable +. variable
-  || foo *. bar >=. 11
+  || wibble *. wobble >=. 11
 }
 "#
     );
@@ -120,7 +120,7 @@ fn labelled_field_with_binary_operators_are_not_broken_if_they_can_fit() {
 
     assert_format!(
         r#"pub fn main() {
-  Ok(foo(
+  Ok(wibble(
     name: names.name,
     text: text,
     code: code,
@@ -134,7 +134,7 @@ fn labelled_field_with_binary_operators_are_not_broken_if_they_can_fit() {
 
     assert_format!(
         r#"pub fn main() {
-  Ok(foo(
+  Ok(wibble(
     name: names.name,
     text: text,
     code: code,
@@ -155,8 +155,8 @@ fn math_binops_kept_on_a_single_line_in_pipes() {
     assert_format!(
         r#"pub fn main() {
   1 + 2 * 3 / 4 - 5
-  |> foo
-  |> bar
+  |> wibble
+  |> wobble
 }
 "#
     );
@@ -164,8 +164,8 @@ fn math_binops_kept_on_a_single_line_in_pipes() {
     assert_format!(
         r#"pub fn main() {
   1 +. 2 *. 3 /. 4 -. 5
-  |> foo
-  |> bar
+  |> wibble
+  |> wobble
 }
 "#
     );
@@ -175,11 +175,11 @@ fn math_binops_kept_on_a_single_line_in_pipes() {
 fn binop_used_as_function_arguments_gets_nested() {
     assert_format!(
         r#"pub fn main() {
-  foo(
+  wibble(
     a_variable_with_a_long_name
       <> another_variable_with_a_long_name
       <> yet_another_variable_with_a_long_name,
-    bar,
+    wobble,
   )
 }
 "#
@@ -190,7 +190,7 @@ fn binop_used_as_function_arguments_gets_nested() {
 fn binop_is_not_nested_if_the_only_argument() {
     assert_format!(
         r#"pub fn main() {
-  foo(
+  wibble(
     a_variable_with_a_long_name
     <> another_variable_with_a_long_name
     <> yet_another_variable_with_a_long_name,
@@ -205,7 +205,7 @@ fn binop_inside_list_gets_nested() {
     assert_format!(
         r#"pub fn main() {
   [
-    foo,
+    wibble,
     a_variable_with_a_long_name
       <> another_variable_with_a_long_name
       <> yet_another_variable_with_a_long_name,
@@ -234,7 +234,7 @@ fn binop_inside_tuple_gets_nested() {
     assert_format!(
         r#"pub fn main() {
   #(
-    foo,
+    wibble,
     a_variable_with_a_long_name
       <> another_variable_with_a_long_name
       <> yet_another_variable_with_a_long_name,

--- a/compiler-core/src/format/tests/blocks.rs
+++ b/compiler-core/src/format/tests/blocks.rs
@@ -74,8 +74,8 @@ fn last_comments_are_not_moved_out_of_blocks() {
 
     assert_format!(
         r#"fn main() {
-  case foo {
-    bar -> {
+  case wibble {
+    wobble -> {
       1
       // Hope I can stay inside this clause
     }

--- a/compiler-core/src/format/tests/function.rs
+++ b/compiler-core/src/format/tests/function.rs
@@ -73,9 +73,9 @@ fn anonymous_function_with_multi_line_long_breakable_body_as_final_function_argu
     assert_format!(
         r#"pub fn main() {
   some_function(123, 456, fn(x) {
-    call_to_other_function(a, b, c, d, e, f, g, case foo {
-      Bar -> 1
-      Baz -> 2
+    call_to_other_function(a, b, c, d, e, f, g, case wibble {
+      Wibble -> 1
+      Wobble -> 2
     })
   })
 }
@@ -166,7 +166,7 @@ fn nested_breakable_lists_in_function_calls() {
     assert_format!(
         r#"pub fn main() {
   html([attribute("lang", "en")], [
-    head([attribute("foo", "bar")], [
+    head([attribute("wibble", "wobble")], [
       title([], [text("Hello this is some HTML")]),
     ]),
     body([], [h1([], [text("Hello, world!")])]),
@@ -181,7 +181,7 @@ fn nested_breakable_tuples_in_function_calls() {
     assert_format!(
         r#"pub fn main() {
   html(#(attribute("lang", "en")), #(
-    head(#(attribute("foo", "bar")), #(
+    head(#(attribute("wibble", "wobble")), #(
       title(#(), #(text("Hello this is some HTML"))),
       body(#(), #(text("Hello this is some HTML"))),
     )),

--- a/compiler-core/src/format/tests/tuple.rs
+++ b/compiler-core/src/format/tests/tuple.rs
@@ -56,7 +56,7 @@ fn tuple_with_last_splittable_arg() {
 #[test]
 fn constant_long_list_of_tuples() {
     assert_format!(
-        r#"const foo = [
+        r#"const wibble = [
   #(1, 2), #(3, 4), #(5, 6), #(7, 8), #(9, 10), #(11, 12), #(1, 2), #(3, 4),
   #(5, 6), #(7, 8), #(9, 10), #(11, 12),
 ]

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -448,13 +448,13 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                     self.pop();
                 }
                 if let Some((left, _)) = left_side_assignment {
-                    // "foo" as prefix <> rest
-                    //       ^^^^^^^^^ In case the left prefix of the pattern matching is given an
-                    //                 alias we bind it to a local variable so that it can be
-                    //                 correctly referenced inside the case branch.
-                    // let prefix = "foo";
-                    // ^^^^^^^^^^^^^^^^^^^ we're adding this assignment inside the if clause
-                    //                     the case branch gets translated into.
+                    // "wibble" as prefix <> rest
+                    //          ^^^^^^^^^ In case the left prefix of the pattern matching is given an
+                    //                    alias we bind it to a local variable so that it can be
+                    //                    correctly referenced inside the case branch.
+                    // let prefix = "wibble";
+                    // ^^^^^^^^^^^^^^^^^^^^^ we're adding this assignment inside the if clause
+                    //                       the case branch gets translated into.
                     self.push_assignment(expression::string(left_side_string), left);
                 }
                 Ok(())

--- a/compiler-core/src/javascript/tests/assignments.rs
+++ b/compiler-core/src/javascript/tests/assignments.rs
@@ -37,19 +37,19 @@ fn variable_renaming() {
     assert_js!(
         r#"
 
-fn go(x, foo) {
+fn go(x, wibble) {
   let a = 1
-  foo(a)
+  wibble(a)
   let a = 2
-  foo(a)
+  wibble(a)
   let assert #(a, 3) = x
   let b = a
-  foo(b)
+  wibble(b)
   let c = {
     let a = a
     #(a, b)
   }
-  foo(a)
+  wibble(a)
   // make sure arguments are counted in initial state
   let x = c
   x
@@ -97,10 +97,10 @@ fn rebound_argument() {
 #[test]
 fn rebound_function() {
     assert_js!(
-        r#"pub fn x() { 
+        r#"pub fn x() {
   Nil
 }
-        
+
 pub fn main() {
   let x = False
   x
@@ -112,10 +112,10 @@ pub fn main() {
 #[test]
 fn rebound_function_and_arg() {
     assert_js!(
-        r#"pub fn x() { 
+        r#"pub fn x() {
   Nil
 }
-        
+
 pub fn main(x) {
   let x = False
   x
@@ -153,7 +153,7 @@ fn module_const_var() {
     assert_js!(
         r#"
 pub const int = 42
-pub const int_alias = int 
+pub const int_alias = int
 pub fn use_int_alias() { int_alias }
 
 pub const compound: #(Int, Int) = #(int, int_alias)
@@ -167,7 +167,7 @@ fn module_const_var1() {
     assert_ts_def!(
         r#"
 pub const int = 42
-pub const int_alias = int 
+pub const int_alias = int
 pub const compound: #(Int, Int) = #(int, int_alias)
 "#
     );

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -370,9 +370,9 @@ pub fn version(n) {
 #[test]
 fn pipe_shadow_import() {
     assert_js!(
-        (CURRENT_PACKAGE, "foo", "pub fn println(x: String) {  }"),
+        (CURRENT_PACKAGE, "wibble", "pub fn println(x: String) {  }"),
         r#"
-        import foo.{println}
+        import wibble.{println}
         pub fn main() {
           let println =
             "oh dear"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_renaming.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_renaming.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-expression: "\n\nfn go(x, foo) {\n  let a = 1\n  foo(a)\n  let a = 2\n  foo(a)\n  let assert #(a, 3) = x\n  let b = a\n  foo(b)\n  let c = {\n    let a = a\n    #(a, b)\n  }\n  foo(a)\n  // make sure arguments are counted in initial state\n  let x = c\n  x\n}\n"
+expression: "\n\nfn go(x, wibble) {\n  let a = 1\n  wibble(a)\n  let a = 2\n  wibble(a)\n  let assert #(a, 3) = x\n  let b = a\n  wibble(b)\n  let c = {\n    let a = a\n    #(a, b)\n  }\n  wibble(a)\n  // make sure arguments are counted in initial state\n  let x = c\n  x\n}\n"
 ---
 import { makeError } from "../gleam.mjs";
 
-function go(x, foo) {
+function go(x, wibble) {
   let a = 1;
-  foo(a);
+  wibble(a);
   let a$1 = 2;
-  foo(a$1);
+  wibble(a$1);
   if (x[1] !== 3) {
     throw makeError(
       "assignment_no_match",
@@ -21,12 +21,12 @@ function go(x, foo) {
   }
   let a$2 = x[0];
   let b = a$2;
-  foo(b);
+  wibble(b);
   let c = (() => {
     let a$3 = a$2;
     return [a$3, b];
   })();
-  foo(a$2);
+  wibble(a$2);
   let x$1 = c;
   return x$1;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__pipe_shadow_import.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__pipe_shadow_import.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/functions.rs
-expression: "\n        import foo.{println}\n        pub fn main() {\n          let println =\n            \"oh dear\"\n            |> println\n          println\n        }"
+expression: "\n        import wibble.{println}\n        pub fn main() {\n          let println =\n            \"oh dear\"\n            |> println\n          println\n        }"
 ---
-import * as $foo from "../foo.mjs";
-import { println } from "../foo.mjs";
+import * as $wibble from "../wibble.mjs";
+import { println } from "../wibble.mjs";
 
 export function main() {
   let println$1 = (() => {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/src/javascript/tests/strings.rs
-expression: "\npub fn go(x) {\n  case \"Θ foo bar\" {\n    \"Θ\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"🫥 is neutral dotted\" {\n    \"🫥\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"🇺🇸 is a cluster\" {\n    \"🇺🇸\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"\\\" is a an escaped quote\" {\n    \"\\\"\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"\\\\ is a an escaped backslash\" {\n    \"\\\\\" <> rest -> rest\n    _ -> \"\"\n  }\n}\n"
+expression: "\npub fn go(x) {\n  case \"Θ wibble wobble\" {\n    \"Θ\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"🫥 is neutral dotted\" {\n    \"🫥\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"🇺🇸 is a cluster\" {\n    \"🇺🇸\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"\\\" is a an escaped quote\" {\n    \"\\\"\" <> rest -> rest\n    _ -> \"\"\n  }\n  case \"\\\\ is a an escaped backslash\" {\n    \"\\\\\" <> rest -> rest\n    _ -> \"\"\n  }\n}\n"
 ---
 export function go(x) {
-  let $ = "Θ foo bar";
+  let $ = "Θ wibble wobble";
   if ($.startsWith("Θ")) {
     let rest = $.slice(1);
     rest

--- a/compiler-core/src/javascript/tests/strings.rs
+++ b/compiler-core/src/javascript/tests/strings.rs
@@ -125,7 +125,7 @@ fn string_prefix_utf16() {
     assert_js!(
         r#"
 pub fn go(x) {
-  case "Θ foo bar" {
+  case "Θ wibble wobble" {
     "Θ" <> rest -> rest
     _ -> ""
   }

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -670,8 +670,8 @@ fn internal_values_from_root_package_are_in_the_completions() {
 @external(erlang, "rand", "uniform")
 @internal pub fn random_float() -> Float
 @internal pub fn main() { 0 }
-@internal pub type Foo { Bar }
-@internal pub const foo = 1
+@internal pub type Wibble { Wobble }
+@internal pub const wibble = 1
 "#;
 
     assert_debug_snapshot!(completion_at_default_position(
@@ -705,8 +705,8 @@ fn internal_values_from_the_same_module_are_in_the_completions() {
 @external(erlang, "rand", "uniform")
 @internal pub fn random_float() -> Float
 @internal pub fn main() { 0 }
-@internal pub type Foo { Bar }
-@internal pub const foo = 1
+@internal pub type Wibble { Wobble }
+@internal pub const wibble = 1
 "#;
 
     assert_debug_snapshot!(completion_at_default_position(TestProject::for_source(
@@ -719,7 +719,7 @@ fn internal_types_from_the_same_module_are_in_the_completions() {
     let code = "
 @internal pub type Alias = Result(Int, String)
 @internal pub type AnotherType {
-  Bar
+  Wibble
 }
 ";
 
@@ -756,8 +756,8 @@ fn internal_values_from_a_dependency_are_ignored() {
 @external(erlang, "rand", "uniform")
 @internal pub fn random_float() -> Float
 @internal pub fn main() { 0 }
-@internal pub type Foo { Bar }
-@internal pub const foo = 1
+@internal pub type Wibble { Wobble }
+@internal pub const wibble = 1
 "#;
 
     assert_debug_snapshot!(completion_at_default_position(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
 ---
 [
     CompletionItem {
-        label: "dep.Bar",
+        label: "dep.Wobble",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -17,7 +17,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
             EnumMember,
         ),
         detail: Some(
-            "Foo",
+            "Wibble",
         ),
         documentation: None,
         deprecated: None,
@@ -40,54 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
                             character: 0,
                         },
                     },
-                    new_text: "dep.Bar",
-                },
-            ),
-        ),
-        additional_text_edits: None,
-        command: None,
-        commit_characters: None,
-        data: None,
-        tags: None,
-    },
-    CompletionItem {
-        label: "dep.foo",
-        label_details: Some(
-            CompletionItemLabelDetails {
-                detail: None,
-                description: Some(
-                    "app",
-                ),
-            },
-        ),
-        kind: Some(
-            Constant,
-        ),
-        detail: Some(
-            "Int",
-        ),
-        documentation: None,
-        deprecated: None,
-        preselect: None,
-        sort_text: None,
-        filter_text: None,
-        insert_text: None,
-        insert_text_format: None,
-        insert_text_mode: None,
-        text_edit: Some(
-            Edit(
-                TextEdit {
-                    range: Range {
-                        start: Position {
-                            line: 1,
-                            character: 0,
-                        },
-                        end: Position {
-                            line: 1,
-                            character: 0,
-                        },
-                    },
-                    new_text: "dep.foo",
+                    new_text: "dep.Wobble",
                 },
             ),
         ),
@@ -182,6 +135,53 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
                         },
                     },
                     new_text: "dep.random_float",
+                },
+            ),
+        ),
+        additional_text_edits: None,
+        command: None,
+        commit_characters: None,
+        data: None,
+        tags: None,
+    },
+    CompletionItem {
+        label: "dep.wibble",
+        label_details: Some(
+            CompletionItemLabelDetails {
+                detail: None,
+                description: Some(
+                    "app",
+                ),
+            },
+        ),
+        kind: Some(
+            Constant,
+        ),
+        detail: Some(
+            "Int",
+        ),
+        documentation: None,
+        deprecated: None,
+        preselect: None,
+        sort_text: None,
+        filter_text: None,
+        insert_text: None,
+        insert_text_format: None,
+        insert_text_mode: None,
+        text_edit: Some(
+            Edit(
+                TextEdit {
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 0,
+                        },
+                    },
+                    new_text: "dep.wibble",
                 },
             ),
         ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
@@ -4,7 +4,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
 ---
 [
     CompletionItem {
-        label: "Bar",
+        label: "Wobble",
         label_details: Some(
             CompletionItemLabelDetails {
                 detail: None,
@@ -17,7 +17,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
             EnumMember,
         ),
         detail: Some(
-            "Foo",
+            "Wibble",
         ),
         documentation: None,
         deprecated: None,
@@ -40,54 +40,7 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
                             character: 0,
                         },
                     },
-                    new_text: "Bar",
-                },
-            ),
-        ),
-        additional_text_edits: None,
-        command: None,
-        commit_characters: None,
-        data: None,
-        tags: None,
-    },
-    CompletionItem {
-        label: "foo",
-        label_details: Some(
-            CompletionItemLabelDetails {
-                detail: None,
-                description: Some(
-                    "app",
-                ),
-            },
-        ),
-        kind: Some(
-            Constant,
-        ),
-        detail: Some(
-            "Int",
-        ),
-        documentation: None,
-        deprecated: None,
-        preselect: None,
-        sort_text: None,
-        filter_text: None,
-        insert_text: None,
-        insert_text_format: None,
-        insert_text_mode: None,
-        text_edit: Some(
-            Edit(
-                TextEdit {
-                    range: Range {
-                        start: Position {
-                            line: 1,
-                            character: 0,
-                        },
-                        end: Position {
-                            line: 1,
-                            character: 0,
-                        },
-                    },
-                    new_text: "foo",
+                    new_text: "Wobble",
                 },
             ),
         ),
@@ -182,6 +135,53 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
                         },
                     },
                     new_text: "random_float",
+                },
+            ),
+        ),
+        additional_text_edits: None,
+        command: None,
+        commit_characters: None,
+        data: None,
+        tags: None,
+    },
+    CompletionItem {
+        label: "wibble",
+        label_details: Some(
+            CompletionItemLabelDetails {
+                detail: None,
+                description: Some(
+                    "app",
+                ),
+            },
+        ),
+        kind: Some(
+            Constant,
+        ),
+        detail: Some(
+            "Int",
+        ),
+        documentation: None,
+        deprecated: None,
+        preselect: None,
+        sort_text: None,
+        filter_text: None,
+        insert_text: None,
+        insert_text_format: None,
+        insert_text_mode: None,
+        text_edit: Some(
+            Edit(
+                TextEdit {
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 0,
+                        },
+                    },
+                    new_text: "wibble",
                 },
             ),
         ),

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -162,7 +162,7 @@ pub struct ImplementationsInterface {
     /// Consider the following function:
     ///
     /// ```gleam
-    /// @external(erlang, "foo", "bar")
+    /// @external(erlang, "wibble", "wobble")
     /// pub fn a_random_number() -> Int {
     ///   4
     ///   // This is a default implementation.
@@ -205,7 +205,7 @@ pub struct ImplementationsInterface {
     /// Let's have a look at an example:
     ///
     /// ```gleam
-    /// @external(javascript, "foo", "bar")
+    /// @external(javascript, "wibble", "wobble")
     /// pub fn javascript_only() -> Int
     /// ```
     ///
@@ -308,8 +308,8 @@ pub enum TypeInterface {
     },
     /// A type variable.
     /// ```gleam
-    /// pub fn foo(value: a) -> a {}
-    /// //                ^ This is a type variable.
+    /// pub fn wibble(value: a) -> a {}
+    /// //                   ^ This is a type variable.
     /// ```
     Variable { id: u64 },
     /// A custom named type.
@@ -613,7 +613,7 @@ fn from_type_helper(type_: &Type, id_map: &mut IdMap) -> TypeInterface {
 /// After type inference the ids associated with type variables can be quite
 /// high and are not the best to produce a human/machine readable output.
 ///
-/// Imagine a function like this one: `pub fn foo(item: a, rest: b) -> c`
+/// Imagine a function like this one: `pub fn wibble(item: a, rest: b) -> c`
 /// What we want here is for type variables to have increasing ids starting from
 /// 0: `a` with id `0`, `b` with id `1` and `c` with id `2`.
 ///

--- a/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__type_definition.snap
+++ b/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__type_definition.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/package_interface/tests.rs
-expression: "\n/// Wibble's documentation\npub type Wibble(a, b) {\n  Wob\n  Baz\n}\n"
+expression: "\n/// Wibble's documentation\npub type Wibble(a, b) {\n  Wibble\n  Wobble\n}\n"
 ---
 {
   "name": "my_package",
@@ -18,12 +18,12 @@ expression: "\n/// Wibble's documentation\npub type Wibble(a, b) {\n  Wob\n  Baz
           "constructors": [
             {
               "documentation": null,
-              "name": "Wob",
+              "name": "Wibble",
               "parameters": []
             },
             {
               "documentation": null,
-              "name": "Baz",
+              "name": "Wobble",
               "parameters": []
             }
           ]

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -201,8 +201,8 @@ pub fn internal_definitions_are_not_included() {
         "
 @internal pub const float = 1.1
 @internal pub fn main() {}
-@internal pub type Foo
-@internal pub type Bar = Int
+@internal pub type Wibble
+@internal pub type Wobble = Int
 "
     );
 }
@@ -223,8 +223,8 @@ pub fn type_definition() {
         "
 /// Wibble's documentation
 pub type Wibble(a, b) {
-  Wob
-  Baz
+  Wibble
+  Wobble
 }
 "
     )

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_eq_after_binding_snapshot_1.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_eq_after_binding_snapshot_1.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/src/parse/tests.rs
-expression: let foo
+expression: let wibble
 ---
 error: Syntax error
   ┌─ /src/parse/error.gleam:1:5
   │
-1 │ let foo
-  │     ^^^ I was expecting a '=' after this
+1 │ let wibble
+  │     ^^^^^^ I was expecting a '=' after this

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_eq_after_binding_snapshot_2.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_eq_after_binding_snapshot_2.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/src/parse/tests.rs
-expression: "let foo\n        foo = 4"
+expression: "let wibble\n        wibble = 4"
 ---
 error: Syntax error
   ┌─ /src/parse/error.gleam:1:5
   │
-1 │ let foo
-  │     ^^^ I was expecting a '=' after this
+1 │ let wibble
+  │     ^^^^^^ I was expecting a '=' after this

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_1.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_1.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/parse/tests.rs
-expression: foo = 4
+expression: wibble = 4
 ---
 error: Syntax error
-  ┌─ /src/parse/error.gleam:1:5
+  ┌─ /src/parse/error.gleam:1:8
   │
-1 │ foo = 4
-  │     ^ There must be a 'let' to bind variable to value
+1 │ wibble = 4
+  │        ^ There must be a 'let' to bind variable to value
 
 Hint: Use let for binding.
 See: https://tour.gleam.run/basics/assignments/

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_2.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_2.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/parse/tests.rs
-expression: "foo:Int = 4"
+expression: "wibble:Int = 4"
 ---
 error: Syntax error
-  ┌─ /src/parse/error.gleam:1:4
+  ┌─ /src/parse/error.gleam:1:7
   │
-1 │ foo:Int = 4
-  │    ^ There must be a 'let' to bind variable to value
+1 │ wibble:Int = 4
+  │       ^ There must be a 'let' to bind variable to value
 
 Hint: Use let for binding.
 See: https://tour.gleam.run/basics/assignments/

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_3.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__no_let_binding_snapshot_3.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/parse/tests.rs
-expression: "let bar:Int = 32\n        bar = 42"
+expression: "let wobble:Int = 32\n        wobble = 42"
 ---
 error: Syntax error
-  ┌─ /src/parse/error.gleam:2:13
+  ┌─ /src/parse/error.gleam:2:16
   │
-2 │         bar = 42
-  │             ^ There must be a 'let' to bind variable to value
+2 │         wobble = 42
+  │                ^ There must be a 'let' to bind variable to value
 
 Hint: Use let for binding.
 See: https://tour.gleam.run/basics/assignments/

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -370,16 +370,16 @@ fn name2() {
 #[test]
 fn triple_equals() {
     assert_error!(
-        "let bar:Int = 32
-        bar === 42",
+        "let wobble:Int = 32
+        wobble === 42",
         ParseError {
             error: ParseErrorType::LexError {
                 error: LexicalError {
                     error: LexicalErrorType::InvalidTripleEqual,
-                    location: SrcSpan { start: 29, end: 32 },
+                    location: SrcSpan { start: 35, end: 38 },
                 }
             },
-            location: SrcSpan { start: 29, end: 32 },
+            location: SrcSpan { start: 35, end: 38 },
         }
     );
 }
@@ -387,11 +387,11 @@ fn triple_equals() {
 #[test]
 fn triple_equals_with_whitespace() {
     assert_error!(
-        "let bar:Int = 32
-        bar ==     = 42",
+        "let wobble:Int = 32
+        wobble ==     = 42",
         ParseError {
             error: ParseErrorType::NoLetBinding,
-            location: SrcSpan { start: 36, end: 37 },
+            location: SrcSpan { start: 42, end: 43 },
         }
     );
 }
@@ -437,9 +437,9 @@ fn anonymous_function_labeled_arguments() {
 #[test]
 fn no_let_binding() {
     assert_error!(
-        "foo = 32",
+        "wibble = 32",
         ParseError {
-            location: SrcSpan { start: 4, end: 5 },
+            location: SrcSpan { start: 7, end: 8 },
             error: ParseErrorType::NoLetBinding
         }
     );
@@ -448,9 +448,9 @@ fn no_let_binding() {
 #[test]
 fn no_let_binding1() {
     assert_error!(
-        "foo:Int = 32",
+        "wibble:Int = 32",
         ParseError {
-            location: SrcSpan { start: 3, end: 4 },
+            location: SrcSpan { start: 6, end: 7 },
             error: ParseErrorType::NoLetBinding
         }
     );
@@ -459,10 +459,10 @@ fn no_let_binding1() {
 #[test]
 fn no_let_binding2() {
     assert_error!(
-        "let bar:Int = 32
-        bar = 42",
+        "let wobble:Int = 32
+        wobble = 42",
         ParseError {
-            location: SrcSpan { start: 29, end: 30 },
+            location: SrcSpan { start: 35, end: 36 },
             error: ParseErrorType::NoLetBinding
         }
     );
@@ -482,9 +482,9 @@ fn no_let_binding3() {
 #[test]
 fn no_eq_after_binding() {
     assert_error!(
-        "let foo",
+        "let wibble",
         ParseError {
-            location: SrcSpan { start: 4, end: 7 },
+            location: SrcSpan { start: 4, end: 10 },
             error: ParseErrorType::ExpectedEqual
         }
     );
@@ -493,10 +493,10 @@ fn no_eq_after_binding() {
 #[test]
 fn no_eq_after_binding1() {
     assert_error!(
-        "let foo
-        foo = 4",
+        "let wibble
+        wibble = 4",
         ParseError {
-            location: SrcSpan { start: 4, end: 7 },
+            location: SrcSpan { start: 4, end: 10 },
             error: ParseErrorType::ExpectedEqual
         }
     );
@@ -504,31 +504,31 @@ fn no_eq_after_binding1() {
 
 #[test]
 fn no_let_binding_snapshot_1() {
-    assert_error!("foo = 4");
+    assert_error!("wibble = 4");
 }
 
 #[test]
 fn no_let_binding_snapshot_2() {
-    assert_error!("foo:Int = 4");
+    assert_error!("wibble:Int = 4");
 }
 
 #[test]
 fn no_let_binding_snapshot_3() {
     assert_error!(
-        "let bar:Int = 32
-        bar = 42"
+        "let wobble:Int = 32
+        wobble = 42"
     );
 }
 
 #[test]
 fn no_eq_after_binding_snapshot_1() {
-    assert_error!("let foo");
+    assert_error!("let wibble");
 }
 #[test]
 fn no_eq_after_binding_snapshot_2() {
     assert_error!(
-        "let foo
-        foo = 4"
+        "let wibble
+        wibble = 4"
     );
 }
 

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -228,9 +228,9 @@ pub enum NestMode {
     /// to exactly the specified value.
     ///
     /// `doc.nest(2).set_nesting(0)`
-    /// "foo
-    /// bar    <- no indentation is added!
-    /// baz"
+    /// "wibble
+    /// wobble    <- no indentation is added!
+    /// wubble"
     Set,
 }
 

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -293,25 +293,28 @@ fn empty_documents() {
 
     // strings
     assert!("".to_doc().is_empty());
-    assert!(!"foo".to_doc().is_empty());
+    assert!(!"wibble".to_doc().is_empty());
     assert!(!" ".to_doc().is_empty());
     assert!(!"\n".to_doc().is_empty());
 
     // containers
     assert!("".to_doc().nest(2).is_empty());
-    assert!(!"foo".to_doc().nest(2).is_empty());
+    assert!(!"wibble".to_doc().nest(2).is_empty());
     assert!("".to_doc().group().is_empty());
-    assert!(!"foo".to_doc().group().is_empty());
+    assert!(!"wibble".to_doc().group().is_empty());
     assert!(break_("", "").is_empty());
-    assert!(!break_("foo", "foo").is_empty());
-    assert!(!break_("foo\nbar", "foo bar").is_empty());
+    assert!(!break_("wibble", "wibble").is_empty());
+    assert!(!break_("wibble\nwobble", "wibble wobble").is_empty());
     assert!("".to_doc().append("".to_doc()).is_empty());
-    assert!(!"foo".to_doc().append("".to_doc()).is_empty());
-    assert!(!"".to_doc().append("foo".to_doc()).is_empty());
+    assert!(!"wibble".to_doc().append("".to_doc()).is_empty());
+    assert!(!"".to_doc().append("wibble".to_doc()).is_empty());
 }
 
 #[test]
 fn set_nesting() {
-    let doc = Vec(vec!["foo".to_doc(), break_("", " "), "bar".to_doc()]).group();
-    assert_eq!("foo\nbar", doc.set_nesting(0).nest(2).to_pretty_string(1));
+    let doc = Vec(vec!["wibble".to_doc(), break_("", " "), "wobble".to_doc()]).group();
+    assert_eq!(
+        "wibble\nwobble",
+        doc.set_nesting(0).nest(2).to_pretty_string(1)
+    );
 }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -27,8 +27,8 @@ pub struct Implementations {
     /// Imagine this scenario:
     ///
     /// ```gleam
-    /// @external(javascript, "foo", "bar")
-    /// @external(erlang, "foo", "bar")
+    /// @external(javascript, "wibble", "wobble")
+    /// @external(erlang, "wibble", "wobble")
     /// pub fn func() -> Int
     /// ```
     ///
@@ -122,7 +122,7 @@ impl Implementations {
         //
         // For example:
         // ```gleam
-        // @external(erlang, "foo", "bar")
+        // @external(erlang, "wibble", "wobble")
         // pub fn erlang_only_with_pure_gleam_default() -> Int {
         //   1 + 1
         // }

--- a/compiler-core/src/type_/tests/custom_types.rs
+++ b/compiler-core/src/type_/tests/custom_types.rs
@@ -64,7 +64,7 @@ type Three(a, a) {
 fn conflict_with_import() {
     // We cannot declare a type with the same name as an imported type
     assert_with_module_error!(
-        ("foo", "pub type A { B }"),
-        "import foo.{type A} type A { C }",
+        ("wibble", "pub type A { B }"),
+        "import wibble.{type A} type A { C }",
     );
 }

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -666,7 +666,7 @@ pub fn x() { id(1, 1.0) }"
 fn module_could_not_unify4() {
     assert_module_error!(
         "
-fn bar() -> Int {
+fn wobble() -> Int {
     5
 }
 
@@ -675,7 +675,7 @@ fn run(one: fn() -> String) {
 }
 
 fn demo() {
-    run(bar)
+    run(wobble)
 }"
     );
 }
@@ -684,7 +684,7 @@ fn demo() {
 fn module_could_not_unify5() {
     assert_module_error!(
         "
-fn bar(x: Int) -> Int {
+fn wobble(x: Int) -> Int {
     x * 5
 }
 
@@ -693,7 +693,7 @@ fn run(one: fn(String) -> Int) {
 }
 
 fn demo() {
-    run(bar)
+    run(wobble)
 }"
     );
 }
@@ -1045,16 +1045,16 @@ fn duplicate() { 2 }"
 #[test]
 fn duplicate_const_const() {
     assert_module_error!(
-        "const foo = 1
-const foo = 2"
+        "const wibble = 1
+const wibble = 2"
     );
 }
 
 #[test]
 fn duplicate_fn_fn() {
     assert_module_error!(
-        "fn foo() { 1 }
-fn foo() { 2 }"
+        "fn wibble() { 1 }
+fn wibble() { 2 }"
     );
 }
 
@@ -1063,9 +1063,9 @@ fn duplicate_extfn_extfn() {
     assert_module_error!(
         r#"
 @external(erlang, "module1", "function1")
-fn foo() -> Float
+fn wibble() -> Float
 @external(erlang, "module2", "function2")
-fn foo() -> Float
+fn wibble() -> Float
 "#
     );
 }
@@ -1075,19 +1075,19 @@ fn duplicate_extfn_fn() {
     assert_module_error!(
         "
 @external(erlang, \"module1\", \"function1\")
-fn foo() -> Float
+fn wibble() -> Float
 
-fn foo() { 2 }"
+fn wibble() { 2 }"
     );
 }
 
 #[test]
 fn duplicate_fn_extfn() {
     assert_module_error!(
-        "fn foo() { 1 }
+        "fn wibble() { 1 }
 
 @external(erlang, \"module2\", \"function2\")
-fn foo() -> Float
+fn wibble() -> Float
 "
     );
 }
@@ -1095,10 +1095,10 @@ fn foo() -> Float
 #[test]
 fn duplicate_const_extfn() {
     assert_module_error!(
-        "const foo = 1
+        "const wibble = 1
 
 @external(erlang, \"module2\", \"function2\")
-fn foo() -> Float
+fn wibble() -> Float
 "
     );
 }
@@ -1108,25 +1108,25 @@ fn duplicate_extfn_const() {
     assert_module_error!(
         "
 @external(erlang, \"module1\", \"function1\")
-fn foo() -> Float
+fn wibble() -> Float
 
-const foo = 2"
+const wibble = 2"
     );
 }
 
 #[test]
 fn duplicate_const_fn() {
     assert_module_error!(
-        "const foo = 1
-fn foo() { 2 }"
+        "const wibble = 1
+fn wibble() { 2 }"
     );
 }
 
 #[test]
 fn duplicate_fn_const() {
     assert_module_error!(
-        "fn foo() { 1 }
-const foo = 2"
+        "fn wibble() { 1 }
+const wibble = 2"
     );
 }
 
@@ -1264,9 +1264,9 @@ fn wrong_type_var() {
     // A unification error should show the type var as named by user
     // See https://github.com/gleam-lang/gleam/issues/1256
     assert_module_error!(
-        r#"fn foo(x: String) { x }
+        r#"fn wibble(x: String) { x }
 fn multi_result(x: some_name) {
-  foo(x)
+  wibble(x)
 }"#
     );
 }
@@ -1275,9 +1275,9 @@ fn multi_result(x: some_name) {
 fn wrong_type_arg() {
     assert_module_error!(
         r#"
-fn foo(x: List(Int)) { x }
+fn wibble(x: List(Int)) { x }
 fn main(y: List(something)) {
-  foo(y)
+  wibble(y)
 }"#
     );
 }
@@ -1522,10 +1522,10 @@ fn negate_string() {
 #[test]
 fn ambiguous_type_error() {
     assert_with_module_error!(
-        ("foo", "pub type Thing { Thing }"),
-        "import foo pub type Thing { Thing }
+        ("wibble", "pub type Thing { Thing }"),
+        "import wibble pub type Thing { Thing }
         pub fn main() {
-            [Thing] == [foo.Thing]
+            [Thing] == [wibble.Thing]
         }",
     );
 }
@@ -1533,13 +1533,13 @@ fn ambiguous_type_error() {
 #[test]
 fn ambiguous_import_error_no_unqualified() {
     assert_with_module_error!(
-        ("foo/sub", "pub fn bar() { 1 }"),
-        ("foo2/sub", "pub fn bar() { 1 }"),
+        ("wibble/sub", "pub fn wobble() { 1 }"),
+        ("wibble2/sub", "pub fn wobble() { 1 }"),
         "
-        import foo/sub
-        import foo2/sub
+        import wibble/sub
+        import wibble2/sub
         pub fn main() {
-            sub.bar()
+            sub.wobble()
         }
         ",
     );
@@ -1548,13 +1548,13 @@ fn ambiguous_import_error_no_unqualified() {
 #[test]
 fn ambiguous_import_error_with_unqualified() {
     assert_with_module_error!(
-        ("foo/sub", "pub fn bar() { 1 }"),
-        ("foo2/sub", "pub fn bar() { 1 }"),
+        ("wibble/sub", "pub fn wobble() { 1 }"),
+        ("wibble2/sub", "pub fn wobble() { 1 }"),
         "
-        import foo/sub
-        import foo2/sub.{bar}
+        import wibble/sub
+        import wibble2/sub.{wobble}
         pub fn main() {
-            sub.bar()
+            sub.wobble()
         }
         ",
     );
@@ -1564,16 +1564,16 @@ fn ambiguous_import_error_with_unqualified() {
 fn same_imports_multiple_times() {
     assert_with_module_error!(
         (
-            "gleam/foo",
+            "gleam/wibble",
             "
-            pub fn bar() { 1 }
+            pub fn wobble() { 1 }
             pub fn zoo() { 1 }
             "
         ),
         "
-        import gleam/foo.{bar}
-        import gleam/foo.{zoo}
-        pub fn go() { bar() + zoo() }
+        import gleam/wibble.{wobble}
+        import gleam/wibble.{zoo}
+        pub fn go() { wobble() + zoo() }
         "
     );
 }
@@ -1804,12 +1804,12 @@ pub fn main(_x: two.Thing) {
 fn value_imported_as_type() {
     assert_with_module_error!(
         (
-            "gleam/foo",
-            "pub type Bar {
-               Baz
+            "gleam/wibble",
+            "pub type Wibble {
+               Wobble
              }"
         ),
-        "import gleam/foo.{type Baz}"
+        "import gleam/wibble.{type Wobble}"
     );
 }
 
@@ -1817,12 +1817,12 @@ fn value_imported_as_type() {
 fn type_imported_as_value() {
     assert_with_module_error!(
         (
-            "gleam/foo",
-            "pub type Bar {
-               Baz
+            "gleam/wibble",
+            "pub type Wibble {
+               Wobble
              }"
         ),
-        "import gleam/foo.{Bar}"
+        "import gleam/wibble.{Wibble}"
     );
 }
 
@@ -1880,7 +1880,7 @@ fn list() {
 
 #[test]
 fn mismatched_list_tail() {
-    assert_error!("[\"foo\", ..[1, 2]]");
+    assert_error!("[\"wibble\", ..[1, 2]]");
 }
 
 #[test]

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -929,7 +929,7 @@ pub type Returned(a) {
   Returned(List(a))
 }
 
-fn foo(user: Returned(#())) -> Int {
+fn wibble(user: Returned(#())) -> Int {
   let Returned([#()]) = user
   1
 }
@@ -973,14 +973,14 @@ fn reference_absent_type() {
     // to crash, and we want to make sure that it doesn't break again
     assert_module_error!(
         "
-type Foo {
-    Bar(Int)
-    Baz(Qux)
+type Wibble {
+    One(Int)
+    Two(Absent)
 }
 
-pub fn main(foo) {
-    case foo {
-        Bar(x) -> x
+pub fn main(wibble) {
+    case wibble {
+        One(x) -> x
     }
 }
 "

--- a/compiler-core/src/type_/tests/imports.rs
+++ b/compiler-core/src/type_/tests/imports.rs
@@ -281,10 +281,10 @@ fn deprecated_type_import_conflict_two_modules() {
 #[test]
 fn imported_constructor_instead_of_type() {
     assert_with_module_error!(
-        ("module", "pub type Foo { Foo }"),
-        "import module.{Foo}
+        ("module", "pub type Wibble { Wibble }"),
+        "import module.{Wibble}
 
-pub fn main(x: Foo) {
+pub fn main(x: Wibble) {
   todo
 }",
     );

--- a/compiler-core/src/type_/tests/pretty.rs
+++ b/compiler-core/src/type_/tests/pretty.rs
@@ -15,7 +15,7 @@ fn print(type_: Arc<Type>) -> String {
 fn custom_bool() -> Arc<Type> {
     Arc::new(Type::Named {
         publicity: Publicity::Public,
-        package: "foo".into(),
+        package: "wibble".into(),
         module: "one/two".into(),
         name: "Bool".into(),
         args: vec![],

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/custom_types.rs
-expression: "import foo.{type A} type A { C }"
+expression: "import wibble.{type A} type A { C }"
 ---
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:1:13
+  ┌─ /src/one/two.gleam:1:16
   │
-1 │ import foo.{type A} type A { C }
-  │             ^^^^^^  ^^^^^^ Redefined here
-  │             │        
-  │             First defined here
+1 │ import wibble.{type A} type A { C }
+  │                ^^^^^^  ^^^^^^ Redefined here
+  │                │        
+  │                First defined here
 
 The type `A` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\n        import foo/sub\n        import foo2/sub\n        pub fn main() {\n            sub.bar()\n        }\n        "
+expression: "\n        import wibble/sub\n        import wibble2/sub\n        pub fn main() {\n            sub.wobble()\n        }\n        "
 ---
 error: Duplicate import
   ┌─ /src/one/two.gleam:2:9
   │
-2 │         import foo/sub
-  │         ^^^^^^^^^^^^^^ First imported here
-3 │         import foo2/sub
-  │         ^^^^^^^^^^^^^^^ Reimported here
+2 │         import wibble/sub
+  │         ^^^^^^^^^^^^^^^^^ First imported here
+3 │         import wibble2/sub
+  │         ^^^^^^^^^^^^^^^^^^ Reimported here
 
 `sub` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\n        import foo/sub\n        import foo2/sub.{bar}\n        pub fn main() {\n            sub.bar()\n        }\n        "
+expression: "\n        import wibble/sub\n        import wibble2/sub.{wobble}\n        pub fn main() {\n            sub.wobble()\n        }\n        "
 ---
 error: Duplicate import
   ┌─ /src/one/two.gleam:2:9
   │
-2 │         import foo/sub
-  │         ^^^^^^^^^^^^^^ First imported here
-3 │         import foo2/sub.{bar}
-  │         ^^^^^^^^^^^^^^^^^^^^^ Reimported here
+2 │         import wibble/sub
+  │         ^^^^^^^^^^^^^^^^^ First imported here
+3 │         import wibble2/sub.{wobble}
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
 `sub` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_type_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_type_error.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "import foo pub type Thing { Thing }\n        pub fn main() {\n            [Thing] == [foo.Thing]\n        }"
+expression: "import wibble pub type Thing { Thing }\n        pub fn main() {\n            [Thing] == [wibble.Thing]\n        }"
 ---
 error: Type mismatch
   ┌─ /src/one/two.gleam:3:24
   │
-3 │             [Thing] == [foo.Thing]
-  │                        ^^^^^^^^^^^
+3 │             [Thing] == [wibble.Thing]
+  │                        ^^^^^^^^^^^^^^
 
 Expected type:
 
@@ -14,4 +14,4 @@ Expected type:
 
 Found type:
 
-    List(foo.Thing)
+    List(wibble.Thing)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_const.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "const foo = 1\nconst foo = 2"
+expression: "const wibble = 1\nconst wibble = 2"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:1:7
   │
-1 │ const foo = 1
-  │       ^^^ First defined here
-2 │ const foo = 2
-  │       ^^^ Redefined here
+1 │ const wibble = 1
+  │       ^^^^^^ First defined here
+2 │ const wibble = 2
+  │       ^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_extfn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_extfn.snap
@@ -1,15 +1,15 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "const foo = 1\n\n@external(erlang, \"module2\", \"function2\")\nfn foo() -> Float\n"
+expression: "const wibble = 1\n\n@external(erlang, \"module2\", \"function2\")\nfn wibble() -> Float\n"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:1:7
   │
-1 │ const foo = 1
-  │       ^^^ First defined here
+1 │ const wibble = 1
+  │       ^^^^^^ First defined here
   ·
-4 │ fn foo() -> Float
-  │ ^^^^^^^^ Redefined here
+4 │ fn wibble() -> Float
+  │ ^^^^^^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_fn.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "const foo = 1\nfn foo() { 2 }"
+expression: "const wibble = 1\nfn wibble() { 2 }"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:1:7
   │
-1 │ const foo = 1
-  │       ^^^ First defined here
-2 │ fn foo() { 2 }
-  │ ^^^^^^^^ Redefined here
+1 │ const wibble = 1
+  │       ^^^^^^ First defined here
+2 │ fn wibble() { 2 }
+  │ ^^^^^^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_const.snap
@@ -1,15 +1,15 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\n@external(erlang, \"module1\", \"function1\")\nfn foo() -> Float\n\nconst foo = 2"
+expression: "\n@external(erlang, \"module1\", \"function1\")\nfn wibble() -> Float\n\nconst wibble = 2"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:3:1
   │
-3 │ fn foo() -> Float
-  │ ^^^^^^^^ First defined here
+3 │ fn wibble() -> Float
+  │ ^^^^^^^^^^^ First defined here
 4 │ 
-5 │ const foo = 2
-  │       ^^^ Redefined here
+5 │ const wibble = 2
+  │       ^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_extfn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_extfn.snap
@@ -1,15 +1,15 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\n@external(erlang, \"module1\", \"function1\")\nfn foo() -> Float\n@external(erlang, \"module2\", \"function2\")\nfn foo() -> Float\n"
+expression: "\n@external(erlang, \"module1\", \"function1\")\nfn wibble() -> Float\n@external(erlang, \"module2\", \"function2\")\nfn wibble() -> Float\n"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:3:1
   │
-3 │ fn foo() -> Float
-  │ ^^^^^^^^ First defined here
+3 │ fn wibble() -> Float
+  │ ^^^^^^^^^^^ First defined here
 4 │ @external(erlang, "module2", "function2")
-5 │ fn foo() -> Float
-  │ ^^^^^^^^ Redefined here
+5 │ fn wibble() -> Float
+  │ ^^^^^^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_fn.snap
@@ -1,15 +1,15 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\n@external(erlang, \"module1\", \"function1\")\nfn foo() -> Float\n\nfn foo() { 2 }"
+expression: "\n@external(erlang, \"module1\", \"function1\")\nfn wibble() -> Float\n\nfn wibble() { 2 }"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:3:1
   │
-3 │ fn foo() -> Float
-  │ ^^^^^^^^ First defined here
+3 │ fn wibble() -> Float
+  │ ^^^^^^^^^^^ First defined here
 4 │ 
-5 │ fn foo() { 2 }
-  │ ^^^^^^^^ Redefined here
+5 │ fn wibble() { 2 }
+  │ ^^^^^^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_const.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "fn foo() { 1 }\nconst foo = 2"
+expression: "fn wibble() { 1 }\nconst wibble = 2"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:1:1
   │
-1 │ fn foo() { 1 }
-  │ ^^^^^^^^ First defined here
-2 │ const foo = 2
-  │       ^^^ Redefined here
+1 │ fn wibble() { 1 }
+  │ ^^^^^^^^^^^ First defined here
+2 │ const wibble = 2
+  │       ^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_extfn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_extfn.snap
@@ -1,15 +1,15 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "fn foo() { 1 }\n\n@external(erlang, \"module2\", \"function2\")\nfn foo() -> Float\n"
+expression: "fn wibble() { 1 }\n\n@external(erlang, \"module2\", \"function2\")\nfn wibble() -> Float\n"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:1:1
   │
-1 │ fn foo() { 1 }
-  │ ^^^^^^^^ First defined here
+1 │ fn wibble() { 1 }
+  │ ^^^^^^^^^^^ First defined here
   ·
-4 │ fn foo() -> Float
-  │ ^^^^^^^^ Redefined here
+4 │ fn wibble() -> Float
+  │ ^^^^^^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_fn.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "fn foo() { 1 }\nfn foo() { 2 }"
+expression: "fn wibble() { 1 }\nfn wibble() { 2 }"
 ---
 error: Duplicate definition
   ┌─ /src/one/two.gleam:1:1
   │
-1 │ fn foo() { 1 }
-  │ ^^^^^^^^ First defined here
-2 │ fn foo() { 2 }
-  │ ^^^^^^^^ Redefined here
+1 │ fn wibble() { 1 }
+  │ ^^^^^^^^^^^ First defined here
+2 │ fn wibble() { 2 }
+  │ ^^^^^^^^^^^ Redefined here
 
-`foo` has been defined multiple times.
+`wibble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__mismatched_list_tail.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__mismatched_list_tail.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "[\"foo\", ..[1, 2]]"
+expression: "[\"wibble\", ..[1, 2]]"
 ---
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:11
+  ┌─ /src/one/two.gleam:1:14
   │
-1 │ ["foo", ..[1, 2]]
-  │           ^^^^^^
+1 │ ["wibble", ..[1, 2]]
+  │              ^^^^^^
 
 All elements in a list must have the same type, but the elements of
 this list don't match the type of the elements being prepended to it.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_could_not_unify4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_could_not_unify4.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\nfn bar() -> Int {\n    5\n}\n\nfn run(one: fn() -> String) {\n    one()\n}\n\nfn demo() {\n    run(bar)\n}"
+expression: "\nfn wobble() -> Int {\n    5\n}\n\nfn run(one: fn() -> String) {\n    one()\n}\n\nfn demo() {\n    run(wobble)\n}"
 ---
 error: Type mismatch
    ┌─ /src/one/two.gleam:11:9
    │
-11 │     run(bar)
-   │         ^^^
+11 │     run(wobble)
+   │         ^^^^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_could_not_unify5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_could_not_unify5.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\nfn bar(x: Int) -> Int {\n    x * 5\n}\n\nfn run(one: fn(String) -> Int) {\n    one(\"one.\")\n}\n\nfn demo() {\n    run(bar)\n}"
+expression: "\nfn wobble(x: Int) -> Int {\n    x * 5\n}\n\nfn run(one: fn(String) -> Int) {\n    one(\"one.\")\n}\n\nfn demo() {\n    run(wobble)\n}"
 ---
 error: Type mismatch
    ┌─ /src/one/two.gleam:11:9
    │
-11 │     run(bar)
-   │         ^^^
+11 │     run(wobble)
+   │         ^^^^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -1,22 +1,22 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\n        import gleam/foo.{bar}\n        import gleam/foo.{zoo}\n        pub fn go() { bar() + zoo() }\n        "
+expression: "\n        import gleam/wibble.{wobble}\n        import gleam/wibble.{zoo}\n        pub fn go() { wobble() + zoo() }\n        "
 ---
 error: Duplicate import
   ┌─ /src/one/two.gleam:2:9
   │
-2 │         import gleam/foo.{bar}
-  │         ^^^^^^^^^^^^^^^^^^^^^^ First imported here
-3 │         import gleam/foo.{zoo}
-  │         ^^^^^^^^^^^^^^^^^^^^^^ Reimported here
+2 │         import gleam/wibble.{wobble}
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ First imported here
+3 │         import gleam/wibble.{zoo}
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
-`foo` has been imported multiple times.
+`wibble` has been imported multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.
 
 error: Unknown variable
-  ┌─ /src/one/two.gleam:4:31
+  ┌─ /src/one/two.gleam:4:34
   │
-4 │         pub fn go() { bar() + zoo() }
-  │                               ^^^
+4 │         pub fn go() { wobble() + zoo() }
+  │                                  ^^^
 
 The name `zoo` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "import gleam/foo.{Bar}"
+expression: "import gleam/wibble.{Wibble}"
 ---
 error: Unknown module field
-  ┌─ /src/one/two.gleam:1:19
+  ┌─ /src/one/two.gleam:1:22
   │
-1 │ import gleam/foo.{Bar}
-  │                   ^^^ Did you mean `type Bar`?
+1 │ import gleam/wibble.{Wibble}
+  │                      ^^^^^^ Did you mean `type Wibble`?
 
-`Bar` is only a type, it cannot be imported as a value.
+`Wibble` is only a type, it cannot be imported as a value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__value_imported_as_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__value_imported_as_type.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "import gleam/foo.{type Baz}"
+expression: "import gleam/wibble.{type Wobble}"
 ---
 error: Unknown module type
-  ┌─ /src/one/two.gleam:1:19
+  ┌─ /src/one/two.gleam:1:22
   │
-1 │ import gleam/foo.{type Baz}
-  │                   ^^^^^^^^ Did you mean `Baz`?
+1 │ import gleam/wibble.{type Wobble}
+  │                      ^^^^^^^^^^^ Did you mean `Wobble`?
 
-`Baz` is only a value, it cannot be imported as a type.
+`Wobble` is only a value, it cannot be imported as a type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__wrong_type_arg.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__wrong_type_arg.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\nfn foo(x: List(Int)) { x }\nfn main(y: List(something)) {\n  foo(y)\n}"
+expression: "\nfn wibble(x: List(Int)) { x }\nfn main(y: List(something)) {\n  wibble(y)\n}"
 ---
 error: Type mismatch
-  ┌─ /src/one/two.gleam:4:7
+  ┌─ /src/one/two.gleam:4:10
   │
-4 │   foo(y)
-  │       ^
+4 │   wibble(y)
+  │          ^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__wrong_type_var.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__wrong_type_var.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "fn foo(x: String) { x }\nfn multi_result(x: some_name) {\n  foo(x)\n}"
+expression: "fn wibble(x: String) { x }\nfn multi_result(x: some_name) {\n  wibble(x)\n}"
 ---
 error: Type mismatch
-  ┌─ /src/one/two.gleam:3:7
+  ┌─ /src/one/two.gleam:3:10
   │
-3 │   foo(x)
-  │       ^
+3 │   wibble(x)
+  │          ^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__reference_absent_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__reference_absent_type.snap
@@ -1,32 +1,32 @@
 ---
 source: compiler-core/src/type_/tests/exhaustiveness.rs
-expression: "\ntype Foo {\n    Bar(Int)\n    Baz(Qux)\n}\n\npub fn main(foo) {\n    case foo {\n        Bar(x) -> x\n    }\n}\n"
+expression: "\ntype Wibble {\n    One(Int)\n    Two(Absent)\n}\n\npub fn main(wibble) {\n    case wibble {\n        One(x) -> x\n    }\n}\n"
 ---
 error: Unknown type
   ┌─ /src/one/two.gleam:4:9
   │
-4 │     Baz(Qux)
-  │         ^^^
+4 │     Two(Absent)
+  │         ^^^^^^
 
-The type `Qux` is not defined or imported in this module.
+The type `Absent` is not defined or imported in this module.
 
 error: Private type used in public interface
   ┌─ /src/one/two.gleam:7:1
   │
-7 │ pub fn main(foo) {
-  │ ^^^^^^^^^^^^^^^^
+7 │ pub fn main(wibble) {
+  │ ^^^^^^^^^^^^^^^^^^^
 
 The following type is private, but is being used by this public export.
 
-    Foo
+    Wibble
 
 Private types can only be used within the module that defines them.
 
 error: Inexhaustive patterns
    ┌─ /src/one/two.gleam:8:5
    │  
- 8 │ ╭     case foo {
- 9 │ │         Bar(x) -> x
+ 8 │ ╭     case wibble {
+ 9 │ │         One(x) -> x
 10 │ │     }
    │ ╰─────^
 
@@ -35,4 +35,4 @@ If it is run on one of the values without a pattern then it will crash.
 
 The missing patterns are:
 
-    Baz
+    Two

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__imported_constructor_instead_of_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__imported_constructor_instead_of_type.snap
@@ -1,13 +1,13 @@
 ---
 source: compiler-core/src/type_/tests/imports.rs
-expression: "import module.{Foo}\n\npub fn main(x: Foo) {\n  todo\n}"
+expression: "import module.{Wibble}\n\npub fn main(x: Wibble) {\n  todo\n}"
 ---
 error: Unknown type
   ┌─ /src/one/two.gleam:3:16
   │
-3 │ pub fn main(x: Foo) {
-  │                ^^^
+3 │ pub fn main(x: Wibble) {
+  │                ^^^^^^
 
-The type `Foo` is not defined or imported in this module.
-There is a value in scope with the name `Foo`, but no type in scope with
+The type `Wibble` is not defined or imported in this module.
+There is a value in scope with the name `Wibble`, but no type in scope with
 that name.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
@@ -1,14 +1,14 @@
 ---
 source: compiler-core/src/type_/tests/type_alias.rs
-expression: "import foo.{type Bar} type Bar = Int"
+expression: "import wibble.{type Wobble} type Wobble = Int"
 ---
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:1:13
+  ┌─ /src/one/two.gleam:1:16
   │
-1 │ import foo.{type Bar} type Bar = Int
-  │             ^^^^^^^^  ^^^^^^^^^^^^^^ Redefined here
-  │             │          
-  │             First defined here
+1 │ import wibble.{type Wobble} type Wobble = Int
+  │                ^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^ Redefined here
+  │                │             
+  │                First defined here
 
-The type `Bar` has been defined multiple times.
+The type `Wobble` has been defined multiple times.
 Names in a Gleam module must be unique so one will need to be renamed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_func_warning_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_func_warning_test.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "pub fn main() { foo() }\npub fn foo() { }\n"
+expression: "pub fn main() { wibble() }\npub fn wibble() { }\n"
 ---
 warning: Unimplemented function
   ┌─ /src/warning/wrn.gleam:2:1
   │
-2 │ pub fn foo() { }
-  │ ^^^^^^^^^^^^ This code is incomplete
+2 │ pub fn wibble() { }
+  │ ^^^^^^^^^^^^^^^ This code is incomplete
 
 This code will crash if it is run. Be sure to finish it before
 running your program.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__result_discard_warning_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__result_discard_warning_test.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\npub fn foo() { Ok(5) }\npub fn main() {\n  foo()\n  5\n}"
+expression: "\npub fn wibble() { Ok(5) }\npub fn main() {\n  wibble()\n  5\n}"
 ---
 warning: Unused result value
   ┌─ /src/warning/wrn.gleam:4:3
   │
-4 │   foo()
-  │   ^^^^^ The Result value created here is unused
+4 │   wibble()
+  │   ^^^^^^^^ The Result value created here is unused
 
 Hint: If you are sure you don't need it you can assign it to `_`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_for_duplicate_module_no_warning_for_alias_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_for_duplicate_module_no_warning_for_alias_test.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\n            import a/foo\n            import b/foo as bar\n            const one = foo.one\n        "
+expression: "\n            import a/wibble\n            import b/wibble as wobble\n            const one = wibble.one\n        "
 ---
 warning: Unused private constant
   ┌─ /src/warning/wrn.gleam:4:19
   │
-4 │             const one = foo.one
+4 │             const one = wibble.one
   │                   ^^^ This private constant is never used
 
 Hint: You can safely remove it.
@@ -13,7 +13,7 @@ Hint: You can safely remove it.
 warning: Unused imported module
   ┌─ /src/warning/wrn.gleam:3:13
   │
-3 │             import b/foo as bar
-  │             ^^^^^^^^^^^^^^^^^^^ This imported module is never used
+3 │             import b/wibble as wobble
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_warning_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_warning_test.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\n            import gleam/foo.{one} as bar\n            const one = one\n        "
+expression: "\n            import gleam/wibble.{one} as wobble\n            const one = one\n        "
 ---
 warning: Unused private constant
   ┌─ /src/warning/wrn.gleam:3:19
@@ -11,11 +11,11 @@ warning: Unused private constant
 Hint: You can safely remove it.
 
 warning: Unused imported module alias
-  ┌─ /src/warning/wrn.gleam:2:36
+  ┌─ /src/warning/wrn.gleam:2:39
   │
-2 │             import gleam/foo.{one} as bar
-  │                                    ^^^^^^ This alias is never used
+2 │             import gleam/wibble.{one} as wobble
+  │                                       ^^^^^^^^^ This alias is never used
 
 Hint: You can safely remove it.
 
-    import gleam/foo as _
+    import gleam/wibble as _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_warnings_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_warnings_test.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: import gleam/foo
+expression: import gleam/wibble
 ---
 warning: Unused imported module
   ┌─ /src/warning/wrn.gleam:1:1
   │
-1 │ import gleam/foo
-  │ ^^^^^^^^^^^^^^^^ This imported module is never used
+1 │ import gleam/wibble
+  │ ^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_with_alias_warnings_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_with_alias_warnings_test.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: import gleam/foo as bar
+expression: import gleam/wibble as wobble
 ---
 warning: Unused imported module
   ┌─ /src/warning/wrn.gleam:1:1
   │
-1 │ import gleam/foo as bar
-  │ ^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
+1 │ import gleam/wibble as wobble
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_wuth_alias_warning_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_wuth_alias_warning_test.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: import gleam/foo as bar
+expression: import gleam/wibble as wobble
 ---
 warning: Unused imported module
   ┌─ /src/warning/wrn.gleam:1:1
   │
-1 │ import gleam/foo as bar
-  │ ^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
+1 │ import gleam/wibble as wobble
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_variable_never_used_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__warning_variable_never_used_test.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\npub fn foo() { Ok(5) }\npub fn main() { let five = foo() }"
+expression: "\npub fn wibble() { Ok(5) }\npub fn main() { let five = wibble() }"
 ---
 warning: Unused variable
   ┌─ /src/warning/wrn.gleam:3:21
   │
-3 │ pub fn main() { let five = foo() }
+3 │ pub fn main() { let five = wibble() }
   │                     ^^^^ This variable is never used
 
 Hint: You can ignore it with an underscore: `_five`.

--- a/compiler-core/src/type_/tests/target_implementations.rs
+++ b/compiler-core/src/type_/tests/target_implementations.rs
@@ -72,7 +72,7 @@ pub fn pure_gleam_2() { pure_gleam_1() * 2 }
 pub fn erlang_only_function() {
     assert_targets!(
         r#"
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 pub fn erlang_only_1() -> Int
 
 pub fn erlang_only_2() { erlang_only_1() * 2 }
@@ -106,8 +106,8 @@ pub fn erlang_only_2() { erlang_only_1() * 2 }
 pub fn externals_only_function() {
     assert_targets!(
         r#"
-@external(erlang, "foo", "bar")
-@external(javascript, "foo", "bar")
+@external(erlang, "wibble", "wobble")
+@external(javascript, "wibble", "wobble")
 pub fn all_externals_1() -> Int
 
 pub fn all_externals_2() { all_externals_1() * 2 }
@@ -141,10 +141,10 @@ pub fn all_externals_2() { all_externals_1() * 2 }
 pub fn externals_with_pure_gleam_body() {
     assert_targets!(
         r#"
-@external(javascript, "foo", "bar")
+@external(javascript, "wibble", "wobble")
 pub fn javascript_external_and_pure_body() -> Int { 1 + 1 }
 
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 pub fn erlang_external_and_pure_body() -> Int { 1 + 1 }
 
 pub fn pure_gleam() {
@@ -190,10 +190,10 @@ pub fn pure_gleam() {
 pub fn erlang_external_with_javascript_body() {
     assert_targets!(
         r#"
-@external(javascript, "foo", "bar")
+@external(javascript, "wibble", "wobble")
 fn javascript_only() -> Int
 
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 pub fn erlang_external_and_javascript_body() -> Int { javascript_only() }
 
 pub fn all_externals() -> Int { erlang_external_and_javascript_body() }
@@ -237,10 +237,10 @@ pub fn all_externals() -> Int { erlang_external_and_javascript_body() }
 pub fn javascript_external_with_erlang_body() {
     assert_targets!(
         r#"
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 pub fn erlang_only() -> Int
 
-@external(javascript, "foo", "bar")
+@external(javascript, "wibble", "wobble")
 pub fn javascript_external_and_erlang_body() -> Int { erlang_only() }
 
 pub fn all_externals() -> Int { javascript_external_and_erlang_body() }
@@ -284,10 +284,10 @@ pub fn all_externals() -> Int { javascript_external_and_erlang_body() }
 pub fn function_with_no_valid_implementations() {
     assert_module_error!(
         r#"
-@external(javascript, "foo", "bar")
+@external(javascript, "wibble", "wobble")
 fn javascript_only() -> Int
 
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 fn erlang_only() -> Int
 
 pub fn main() {
@@ -301,11 +301,11 @@ pub fn main() {
 #[test]
 pub fn invalid_both_and_one_called_from_erlang() {
     let src = r#"
-@external(erlang, "foo", "bar")
-@external(javascript, "foo", "bar")
+@external(erlang, "wibble", "wobble")
+@external(javascript, "wibble", "wobble")
 fn both_external() -> Int
 
-@external(javascript, "foo", "bar")
+@external(javascript, "wibble", "wobble")
 fn javascript_only() -> Int
 
 pub fn no_valid_erlang_impl() {
@@ -327,11 +327,11 @@ pub fn no_valid_erlang_impl() {
 #[test]
 pub fn invalid_both_and_one_called_from_javascript() {
     let src = r#"
-@external(erlang, "foo", "bar")
-@external(javascript, "foo", "bar")
+@external(erlang, "wibble", "wobble")
+@external(javascript, "wibble", "wobble")
 fn both_external() -> Int
 
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 fn erlang_only() -> Int
 
 pub fn no_valid_javascript_impl() {
@@ -353,11 +353,11 @@ pub fn no_valid_javascript_impl() {
 #[test]
 pub fn invalid_both_and_one_called_from_erlang_flipped() {
     let src = r#"
-@external(erlang, "foo", "bar")
-@external(javascript, "foo", "bar")
+@external(erlang, "wibble", "wobble")
+@external(javascript, "wibble", "wobble")
 fn both_external() -> Int
 
-@external(javascript, "foo", "bar")
+@external(javascript, "wibble", "wobble")
 fn javascript_only() -> Int
 
 pub fn no_valid_erlang_impl() {
@@ -379,11 +379,11 @@ pub fn no_valid_erlang_impl() {
 #[test]
 pub fn invalid_both_and_one_called_from_javascript_flipped() {
     let src = r#"
-@external(erlang, "foo", "bar")
-@external(javascript, "foo", "bar")
+@external(erlang, "wibble", "wobble")
+@external(javascript, "wibble", "wobble")
 fn both_external() -> Int
 
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 fn erlang_only() -> Int
 
 pub fn no_valid_javascript_impl() {
@@ -405,7 +405,7 @@ pub fn no_valid_javascript_impl() {
 #[test]
 pub fn invalid_erlang_with_external() {
     let src = r#"
-@external(javascript, "foo", "bar")
+@external(javascript, "wibble", "wobble")
 fn javascript_only() -> Int
 
 @external(javascript, "one", "two")
@@ -427,7 +427,7 @@ pub fn no_valid_erlang_impl() {
 #[test]
 pub fn invalid_javascript_with_external() {
     let src = r#"
-@external(erlang, "foo", "bar")
+@external(erlang, "wibble", "wobble")
 fn erlang_only() -> Int
 
 @external(erlang, "one", "two")

--- a/compiler-core/src/type_/tests/type_alias.rs
+++ b/compiler-core/src/type_/tests/type_alias.rs
@@ -144,7 +144,7 @@ fn example(a: X) {
 fn conflict_with_import() {
     // We cannot declare a type with the same name as an imported type
     assert_with_module_error!(
-        ("foo", "pub type Bar = String"),
-        "import foo.{type Bar} type Bar = Int",
+        ("wibble", "pub type Wobble = String"),
+        "import wibble.{type Wobble} type Wobble = Int",
     );
 }

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -38,8 +38,8 @@ fn todo_with_known_type() {
 #[test]
 fn empty_func_warning_test() {
     assert_warning!(
-        "pub fn main() { foo() }
-pub fn foo() { }
+        "pub fn main() { wibble() }
+pub fn wibble() { }
 "
     );
 }
@@ -48,8 +48,8 @@ pub fn foo() { }
 fn warning_variable_never_used_test() {
     assert_warning!(
         "
-pub fn foo() { Ok(5) }
-pub fn main() { let five = foo() }"
+pub fn wibble() { Ok(5) }
+pub fn main() { let five = wibble() }"
     );
 }
 
@@ -71,9 +71,9 @@ fn result_discard_warning_test() {
     // Implicitly discarded Results emit warnings
     assert_warning!(
         "
-pub fn foo() { Ok(5) }
+pub fn wibble() { Ok(5) }
 pub fn main() {
-  foo()
+  wibble()
   5
 }"
     );
@@ -84,8 +84,8 @@ fn result_discard_warning_test2() {
     // Explicitly discarded Results do not emit warnings
     assert_no_warnings!(
         "
-pub fn foo() { Ok(5) }
-pub fn main() { let _ = foo() 5 }",
+pub fn wibble() { Ok(5) }
+pub fn main() { let _ = wibble() 5 }",
     );
 }
 
@@ -319,14 +319,17 @@ fn used_destructure() {
 
 #[test]
 fn unused_imported_module_warnings_test() {
-    assert_warning!(("gleam/foo", "pub fn bar() { 1 }"), "import gleam/foo");
+    assert_warning!(
+        ("gleam/wibble", "pub fn wobble() { 1 }"),
+        "import gleam/wibble"
+    );
 }
 
 #[test]
 fn unused_imported_module_with_alias_warnings_test() {
     assert_warning!(
-        ("gleam/foo", "pub fn bar() { 1 }"),
-        "import gleam/foo as bar"
+        ("gleam/wibble", "pub fn wobble() { 1 }"),
+        "import gleam/wibble as wobble"
     );
 }
 
@@ -343,39 +346,39 @@ fn unused_imported_module_with_alias_and_unqualified_name_warnings_test() {
 fn unused_imported_module_with_alias_and_unqualified_name_no_warnings_test() {
     assert_warning!(
         ("package", "gleam/one", "pub fn two() { 1 }"),
-        "import gleam/one.{two} as three\npub fn baz() { two() }"
+        "import gleam/one.{two} as three\npub fn wibble() { two() }"
     );
 }
 
 #[test]
 fn unused_imported_module_no_warning_on_used_function_test() {
     assert_no_warnings!(
-        ("thepackage", "gleam/foo", "pub fn bar() { 1 }"),
-        "import gleam/foo pub fn baz() { foo.bar() }",
+        ("thepackage", "gleam/wibble", "pub fn wobble() { 1 }"),
+        "import gleam/wibble pub fn wibble() { wibble.wobble() }",
     );
 }
 
 #[test]
 fn unused_imported_module_no_warning_on_used_type_test() {
     assert_no_warnings!(
-        ("thepackage", "gleam/foo", "pub type Foo = Int"),
-        "import gleam/foo pub fn baz(a: foo.Foo) { a }",
+        ("thepackage", "gleam/wibble", "pub type Wibble = Int"),
+        "import gleam/wibble pub fn wibble(a: wibble.Wibble) { a }",
     );
 }
 
 #[test]
 fn unused_imported_module_no_warning_on_used_unqualified_function_test() {
     assert_no_warnings!(
-        ("thepackage", "gleam/foo", "pub fn bar() { 1 }"),
-        "import gleam/foo.{bar} pub fn baz() { bar() }",
+        ("thepackage", "gleam/wibble", "pub fn wobble() { 1 }"),
+        "import gleam/wibble.{wobble} pub fn wibble() { wobble() }",
     );
 }
 
 #[test]
 fn unused_imported_module_no_warning_on_used_unqualified_type_test() {
     assert_no_warnings!(
-        ("thepackage", "gleam/foo", "pub type Foo = Int"),
-        "import gleam/foo.{type Foo} pub fn baz(a: Foo) { a }",
+        ("thepackage", "gleam/wibble", "pub type Wibble = Int"),
+        "import gleam/wibble.{type Wibble} pub fn wibble(a: Wibble) { a }",
     );
 }
 
@@ -383,8 +386,12 @@ fn unused_imported_module_no_warning_on_used_unqualified_type_test() {
 #[test]
 fn imported_module_with_alias_no_warning_when_only_used_in_case_test() {
     assert_no_warnings!(
-        ("thepackage", "gleam/foo", "pub type Foo { Foo(Int) }"),
-        "import gleam/foo as f\npub fn baz(a) { case a { f.Foo(int) -> { int } }  }",
+        (
+            "thepackage",
+            "gleam/wibble",
+            "pub type Wibble { Wibble(Int) }"
+        ),
+        "import gleam/wibble as f\npub fn wibble(a) { case a { f.Wibble(int) -> { int } }  }",
     );
 }
 
@@ -967,17 +974,17 @@ fn const_bytes_option() {
 #[test]
 fn unused_module_wuth_alias_warning_test() {
     assert_warning!(
-        ("gleam/foo", "pub const one = 1"),
-        "import gleam/foo as bar"
+        ("gleam/wibble", "pub const one = 1"),
+        "import gleam/wibble as wobble"
     );
 }
 
 #[test]
 fn unused_alias_warning_test() {
     assert_warnings_with_imports!(
-        ("gleam/foo", "pub const one = 1");
+        ("gleam/wibble", "pub const one = 1");
         r#"
-            import gleam/foo.{one} as bar
+            import gleam/wibble.{one} as wobble
             const one = one
         "#,
     );
@@ -986,25 +993,28 @@ fn unused_alias_warning_test() {
 #[test]
 fn used_type_with_import_alias_no_warning_test() {
     assert_no_warnings!(
-        ("gleam", "gleam/foo", "pub const one = 1"),
-        "import gleam/foo as _bar"
+        ("gleam", "gleam/wibble", "pub const one = 1"),
+        "import gleam/wibble as _wobble"
     );
 }
 
 #[test]
 fn discarded_module_no_warnings_test() {
-    assert_no_warnings!(("gleam", "foo", "pub const one = 1"), "import foo as _bar");
+    assert_no_warnings!(
+        ("gleam", "wibble", "pub const one = 1"),
+        "import wibble as _wobble"
+    );
 }
 
 #[test]
 fn unused_alias_for_duplicate_module_no_warning_for_alias_test() {
     assert_warnings_with_imports!(
-        ("a/foo", "pub const one = 1"),
-        ("b/foo", "pub const two = 2");
+        ("a/wibble", "pub const one = 1"),
+        ("b/wibble", "pub const two = 2");
         r#"
-            import a/foo
-            import b/foo as bar
-            const one = foo.one
+            import a/wibble
+            import b/wibble as wobble
+            const one = wibble.one
         "#,
     );
 }

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -1449,7 +1449,7 @@ fn string_pattern_matching_tests() {
     }),
     "match Θ test"
     |> example(fn() {
-      assert_equal(" foo bar", case "Θ foo bar" {
+      assert_equal(" wibble wobble", case "Θ wibble wobble" {
         "Θ" <> rest -> rest
         _ -> panic
       })


### PR DESCRIPTION
Since we wanted to avoid using "foo-bar-baz" I've gone and replaced all those with the much cuter "wibble-wobble-wubble". And hopefully new contributors will follow the example not seeing any foo-bar in the code :)