### PR TITLE
update macos runners to latest compatible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,11 +54,12 @@ jobs:
             target: aarch64-unknown-linux-musl
             use-cross: true
             run-integration-tests: false # Cannot run aarch64 binaries on x86_64
-          - os: macos-12 # intel
+          # macos>=14 runs exclusively on aarch64 and will thus fail to execute properly for x64
+          - os: macos-13 # intel
             target: x86_64-apple-darwin
             use-cross: false
             run-integration-tests: true
-          - os: macos-14 # aarch64
+          - os: macos-latest # aarch64
             toolchain: stable
             target: aarch64-apple-darwin
             use-cross: false

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -66,10 +66,11 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             use-cross: true
-          - os: macos-latest
+          # macos>=14 runs exclusively on aarch64 and will thus fail to execute properly for x64
+          - os: macos-13
             target: x86_64-apple-darwin
             use-cross: false
-          - os: macos-12
+          - os: macos-latest
             target: aarch64-apple-darwin
             use-cross: false
           - os: windows-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,11 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             use-cross: true
-          - os: macos-latest
+          # macos>=14 runs exclusively on aarch64 and will thus fail to execute properly for x64
+          - os: macos-13
             target: x86_64-apple-darwin
             use-cross: false
-          - os: macos-12
+          - os: macos-latest
             target: aarch64-apple-darwin
             use-cross: false
           - os: windows-latest


### PR DESCRIPTION
- intel mac runners to macos-13
- arm mac runners to macos-latest

according to github docs:
> Introducing the new M1 macOS runner available to open source! 🚀
> We are also making the macOS 14 runner image available to GitHub hosted runners. Workflows executed on this image will run exclusively on the 3 vCPU M1 runner announced earlier today. To use the runner, simply update the runs-on: key in your YAML workflow file to macos-14, macos-14-xlarge, or macos-14-large.
