### PR TITLE
LSP: Set type to label_details.detail

### DIFF
--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -681,9 +681,9 @@ fn value_completion(
     CompletionItem {
         label: label.clone(),
         kind,
-        detail: Some(type_),
+        detail: Some(type_.clone()),
         label_details: Some(CompletionItemLabelDetails {
-            detail: None,
+            detail: Some(format!(" {}", type_)),
             description: Some(module_name.into()),
         }),
         documentation,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import.snap
@@ -47,7 +47,9 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
         label: "myfun",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "dep",
                 ),
@@ -94,7 +96,9 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
         label: "wabble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " String",
+                ),
                 description: Some(
                     "dep",
                 ),
@@ -141,7 +145,9 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
         label: "wibble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " String",
+                ),
                 description: Some(
                     "dep",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
@@ -7,7 +7,9 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
         label: "myfun",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "dep",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
@@ -47,7 +47,9 @@ expression: "completion(TestProject::for_source(code).add_module(\"dep\", dep),\
         label: "myfun",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "dep",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Nil",
+                ),
                 description: Some(
                     "dep",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_from_deep_module.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Nil",
+                ),
                 description: Some(
                     "a/b/dep",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__importable_module_function_with_existing_imports.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Nil",
+                ),
                 description: Some(
                     "dep",
                 ),
@@ -70,7 +72,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep2.wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Nil",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_module_function.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Nil",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_enum.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_enum.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.Left",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -54,7 +56,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.Right",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_public_record.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.Box",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn(Int) -> Box",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_module_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_module_function.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Nil",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -54,7 +56,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Nil",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_enum.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_enum.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "Left",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -54,7 +56,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.Left",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -101,7 +105,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.Right",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_unqualified_public_record.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "Box",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn(Int) -> Box",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -54,7 +56,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "dep.Box",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn(Int) -> Box",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
         label: "dep.Wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Wibble",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -54,7 +56,9 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
         label: "dep.main",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -101,7 +105,9 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
         label: "dep.random_float",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Float",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -148,7 +154,9 @@ expression: "completion_at_default_position(TestProject::for_source(\"import dep
         label: "dep.wibble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Int",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "Wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Wibble",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -54,7 +56,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "main",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -101,7 +105,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "random_float",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Float",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -148,7 +154,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "wibble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Int",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "Left",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -54,7 +56,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "Right",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_enum_with_documentation.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "Left",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),
@@ -61,7 +63,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "Right",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Direction",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "main",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_function_with_documentation.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "main",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "Box",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn(Int, Int, Float) -> Box",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__local_public_record_with_documentation.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code))"
         label: "Box",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn(Int, Int, Float) -> Box",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__opaque_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__opaque_type.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "Wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Wibble",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_function.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "private",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " fn() -> Int",
+                ),
                 description: Some(
                     "app",
                 ),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__private_type.snap
@@ -7,7 +7,9 @@ expression: "completion_at_default_position(TestProject::for_source(code).add_mo
         label: "Wobble",
         label_details: Some(
             CompletionItemLabelDetails {
-                detail: None,
+                detail: Some(
+                    " Wibble",
+                ),
                 description: Some(
                     "app",
                 ),


### PR DESCRIPTION
LSP Docs: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemLabelDetails

As discussed in https://github.com/gleam-lang/gleam/issues/3323, this is a PR to show types right after the completion value name.

## Examples:

Import:

<img width="790" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/ea633c66-32cd-4c15-bf02-5dca4a4e28be">

Import 2:

<img width="792" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/846691db-0894-4cc9-9149-94b79e12fe50">

Value:

<img width="705" alt="image" src="https://github.com/gleam-lang/gleam/assets/830536/4111fd63-badd-4236-b218-3cd47fc5515b">
