### PR TITLE
LSP: Code Action to desugar use expression

### DIFF
--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -22,7 +22,10 @@ use lsp_types::{self as lsp, Hover, HoverContents, MarkedString, SignatureHelp, 
 use std::sync::Arc;
 
 use super::{
-    code_action::{CodeActionBuilder, LetAssertToCase, RedundantTupleInCaseSubject},
+    code_action::{
+        CodeActionBuilder, DesugarUseExpressionCodeAction, LetAssertToCase,
+        RedundantTupleInCaseSubject,
+    },
     completer::Completer,
     signature_help, src_span_to_lsp_range, DownloadDependencies, MakeLocker,
 };
@@ -274,6 +277,7 @@ where
             code_action_fix_names(module, &params, &mut actions);
             actions.extend(LetAssertToCase::new(module, &params).code_actions());
             actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
+            actions.extend(DesugarUseExpressionCodeAction::new(module, &params).code_actions());
 
             Ok(if actions.is_empty() {
                 None

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_complex_unformatted.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_complex_unformatted.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  use\t     q:  Int ,  w,  e  <-   wobble( 9 , \n  \" some text \" \n    )\n  q + w + e\n  // a comment\n    3\n}\n\nfn wobble(a: Int, c: String, b: fn(Int, Int, Int) -> Int) {\n  b(1, 2, 3)\n  Nil\n}\n"
+---
+pub fn main() {
+  wobble( 9 , 
+  " some text ", fn(q:  Int, w, e) {
+    q + w + e
+    // a comment
+      3
+  })
+}
+
+fn wobble(a: Int, c: String, b: fn(Int, Int, Int) -> Int) {
+  b(1, 2, 3)
+  Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_fn_without_parenthesis.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_fn_without_parenthesis.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let wobble = fn(cb: fn() -> Int) { cb() + 1 }\n\n  use <- wobble\n\n  2\n}\n"
+---
+pub fn main() {
+  let wobble = fn(cb: fn() -> Int) { cb() + 1 }
+
+  wobble(fn() {
+
+    2
+  })
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_multiple_inner.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_multiple_inner.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  use a <- wobble(1)\n  use b <- wobble(2)\n  3 + a + b\n}\n\nfn wobble(x: Int, b: fn(Int) -> Int) -> Int {\n  x + b(x)\n}\n"
+---
+pub fn main() {
+  use a <- wobble(1)
+  wobble(2, fn(b) {
+    3 + a + b
+  })
+}
+
+fn wobble(x: Int, b: fn(Int) -> Int) -> Int {
+  x + b(x)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_multiple_outer.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_multiple_outer.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  use a <- wobble(1)\n  use b <- wobble(2)\n  3 + a + b\n}\n\nfn wobble(x: Int, b: fn(Int) -> Int) -> Int {\n  x + b(x)\n}\n"
+---
+pub fn main() {
+  wobble(1, fn(a) {
+    use b <- wobble(2)
+    3 + a + b
+  })
+}
+
+fn wobble(x: Int, b: fn(Int) -> Int) -> Int {
+  x + b(x)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_other_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_other_module.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport result\n\npub fn main() {\n  use <- result.lazy\n  2\n}\n"
+---
+import result
+
+pub fn main() {
+  result.lazy(fn() {
+    2
+  })
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_simple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_simple.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  use <- wobble()\n  3\n}\n\nfn wobble(b: fn() -> Int) {\n  Nil\n}\n"
+---
+pub fn main() {
+  wobble(fn() {
+    3
+  })
+}
+
+fn wobble(b: fn() -> Int) {
+  Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_tuple.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let tuple = #(fn(cb: fn() -> Int) { cb() + 1 })\n\n  use <- tuple.0\n\n  2\n}\n"
+---
+pub fn main() {
+  let tuple = #(fn(cb: fn() -> Int) { cb() + 1 })
+
+  tuple.0(fn() {
+
+    2
+  })
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_with_underscore.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_use_expression_with_underscore.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  use _ <- wobble()\n  3\n}\n\nfn wobble(b: fn(x) -> Int) {\n  Nil\n}\n"
+---
+pub fn main() {
+  wobble(fn(_) {
+    3
+  })
+}
+
+fn wobble(b: fn(x) -> Int) {
+  Nil
+}


### PR DESCRIPTION
Issue: https://github.com/gleam-lang/gleam/issues/3314

1. First commit to split code_action.rs into multiple files. I did it because putting all the code actions into 1 file seems overkill and makes hard to read the file.
2. Second commit adds desugaring "use" expressions.

| 1 | 2 | 3 |
|--------|--------|--------|
| ![SCR-20240707-cpdt](https://github.com/gleam-lang/gleam/assets/830536/af9e12dc-bb94-42b9-96ce-94f65557d5a9) | ![SCR-20240707-coww](https://github.com/gleam-lang/gleam/assets/830536/0fd21d11-f86e-4be3-b72f-ca25c4a2c782) | ![SCR-20240707-cohh](https://github.com/gleam-lang/gleam/assets/830536/33f64105-e8a6-4dee-aa7e-dac7c8631320) | 

One more demo (After update on Jul 20, 2024):


![2024-07-20 at 14 07 53 - Purple Antlion](https://github.com/user-attachments/assets/e19fb567-6188-4c70-8867-649befb75286)


