### PR TITLE
Do not show completions when typing strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@
 
 ### Language Server
 
+- The language server no longer shows completions when inside a literal string.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug Fixes
 
 ## v1.3.1 - 2024-07-10
 
 ### Bug Fixes
 
-- Fixes a bug with import cycle detection when there is more than 2 imports in the cycle
+- Fixes a bug with import cycle detection when there is more than 2 imports in
+  the cycle.
   ([Ameen Radwan](https://github.com/Acepie))

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -216,6 +216,9 @@ where
                 Located::PatternSpread { .. } => None,
                 Located::Pattern(_pattern) => None,
 
+                // Do not show completions when typing inside a string.
+                Located::Expression(TypedExpr::String { .. }) => None,
+
                 Located::Statement(_) | Located::Expression(_) => {
                     Some(completer.completion_values())
                 }

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1202,3 +1202,31 @@ pub fn main() {
         vec![],
     );
 }
+
+#[test]
+fn ignore_completions_inside_empty_string() {
+    let code = "
+pub fn main() {
+  \"\"
+}
+";
+
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(2, 2)),
+        vec![],
+    );
+}
+
+#[test]
+fn ignore_completions_inside_string() {
+    let code = "
+pub fn main() {
+  \"Ok()\"
+}
+";
+
+    assert_eq!(
+        completion(TestProject::for_source(code), Position::new(2, 5)),
+        vec![],
+    );
+}


### PR DESCRIPTION
The LS currently shows completions even when writing literal strings, I find that to be a bit distracting and not particularly useful. This PR removes completions when writing inside a String

![Export-1720618609383](https://github.com/gleam-lang/gleam/assets/20598369/b2672e3c-1b50-4436-81e9-d935fced67ec)
