### PR TITLE
Fix dependency resolution for path dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
 
 ### Bug Fixes
 
+- Fixes a bug with path dependencies. If a package was added to a path dependency,
+  it would not be added to the dependant's `manifest.toml`, causing the build to fail.
+  ([Juraj Petráš](https://github.com/Hackder))
+
 ## v1.3.2 - 2024-07-11
 
 ### Language Server


### PR DESCRIPTION
Closes #2278 
If a project **foo** had a path dependency of project **bar**, and the developer adds a new dependency to **bar**, **foo** will become unbuildable, until the manual deletion of the `manifest.toml` file.

During dependency change detection, also check recursively all path dependencies. This will observe any new dependencies added to any of the path deps.

The LSP problem:
- The fix proposed here will not cause the LSP to update automatically. It will need to be restarted after the dependency addition, to see the changes. I could have it watch gleam.toml for every path dependency, but I wanted some feedback before implementing it.

Also, I am not sure if there is an existing setup for tests, which could test this behavior. (Or even if we want to test it at all)