### PR TITLE
Function call fault tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
   expressions.
   ([Thomas](https://github.com/DeviousStoat))
 
+- Function calls are now fault tolerant. This means that errors in the function
+  call arguments won't stop the rest of the call from being analysed.
+  ([Ameen Radwan](https://github.com/Acepie))
+
 ### Formatter
 
 ### Language Server
@@ -95,4 +99,3 @@
 - Fixes a bug with import cycle detection when there is more than 2 imports in
   the cycle.
   ([Ameen Radwan](https://github.com/Acepie))
-

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1103,6 +1103,8 @@ fn match_fun_type(
             Err(MatchFunTypeError::IncorrectArity {
                 expected: args.len(),
                 given: arity,
+                args: args.clone(),
+                return_type: retrn.clone(),
             })
         } else {
             Ok((args.clone(), retrn.clone()))

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -902,10 +902,17 @@ pub fn convert_get_type_constructor_error(
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum MatchFunTypeError {
-    IncorrectArity { expected: usize, given: usize },
-    NotFn { typ: Arc<Type> },
+    IncorrectArity {
+        expected: usize,
+        given: usize,
+        args: Vec<Arc<Type>>,
+        return_type: Arc<Type>,
+    },
+    NotFn {
+        typ: Arc<Type>,
+    },
 }
 
 pub fn convert_not_fun_error(
@@ -915,14 +922,17 @@ pub fn convert_not_fun_error(
     call_kind: CallKind,
 ) -> Error {
     match (call_kind, e) {
-        (CallKind::Function, MatchFunTypeError::IncorrectArity { expected, given }) => {
-            Error::IncorrectArity {
-                labels: vec![],
-                location: call_location,
-                expected,
-                given,
-            }
-        }
+        (
+            CallKind::Function,
+            MatchFunTypeError::IncorrectArity {
+                expected, given, ..
+            },
+        ) => Error::IncorrectArity {
+            labels: vec![],
+            location: call_location,
+            expected,
+            given,
+        },
 
         (CallKind::Function, MatchFunTypeError::NotFn { typ }) => Error::NotFn {
             location: fn_location,
@@ -931,7 +941,9 @@ pub fn convert_not_fun_error(
 
         (
             CallKind::Use { call_location, .. },
-            MatchFunTypeError::IncorrectArity { expected, given },
+            MatchFunTypeError::IncorrectArity {
+                expected, given, ..
+            },
         ) => Error::UseFnIncorrectArity {
             location: call_location,
             expected,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2853,6 +2853,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     let converted_error =
                         convert_not_fun_error(e.clone(), fun.location(), location, kind);
                     match e {
+                        // If the function was valid but had the wrong number of arguments passed.
+                        // Then we keep the error but still want to continue analysing the arguments that were passed.
                         MatchFunTypeError::IncorrectArity {
                             args, return_type, ..
                         } => {

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -217,7 +217,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             args,
             location,
             CallKind::Function,
-        )?;
+        );
         let function = TypedExpr::Call {
             location,
             typ,
@@ -235,7 +235,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             args,
             location,
             CallKind::Function,
-        )?;
+        );
         Ok(TypedExpr::Call {
             location,
             typ,
@@ -262,7 +262,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             arguments,
             location,
             CallKind::Function,
-        )?;
+        );
         Ok(TypedExpr::Call {
             location,
             typ,

--- a/compiler-core/src/type_/tests/functions.rs
+++ b/compiler-core/src/type_/tests/functions.rs
@@ -315,3 +315,33 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn function_call_incorrect_arg_types_fault_tolerance() {
+    assert_module_error!(
+        r#"
+fn add(x: Int, y: Int) {
+  x + y
+}
+
+pub fn main() {
+  add(1.0, 1.0)
+}
+"#
+    );
+}
+
+#[test]
+fn function_call_incorrect_arity_fault_tolerance() {
+    assert_module_error!(
+        r#"
+fn add(x: Int, y: Int) {
+  x + y
+}
+
+pub fn main() {
+  add(1.0)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arg_types_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arg_types_fault_tolerance.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\nfn add(x: Int, y: Int) {\n  x + y\n}\n\npub fn main() {\n  add(1.0, 1.0)\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:7
+  │
+7 │   add(1.0, 1.0)
+  │       ^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Float
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:12
+  │
+7 │   add(1.0, 1.0)
+  │            ^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Float

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_fault_tolerance.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\nfn add(x: Int, y: Int) {\n  x + y\n}\n\npub fn main() {\n  add(1.0)\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:7:3
+  │
+7 │   add(1.0)
+  │   ^^^^^^^^ Expected 2 arguments, got 1
+
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:7
+  │
+7 │   add(1.0)
+  │       ^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Float

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___invalid_callback_type_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___invalid_callback_type_4.snap
@@ -15,3 +15,17 @@ Expected type:
 Found type:
 
     Float
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:6:1
+  │
+6 │ use <- y()
+  │ ^^^^^^^^^^
+
+Expected type:
+
+    String
+
+Found type:
+
+    Int


### PR DESCRIPTION
This improves the fault tolerance by making it so that infer_call always returns a valid TypedExpr. If the function itself is invalid (i.e. not a function) then we just return an Invalid expression. Otherwise, we try to infer each argument and replace invalid arguments with invalid expressions.

For context, the primary motivation for this was to improve the completions when functions have errors. So now with this change if you are writing a function you will get completions even if the number of arguments is wrong or one of the arguments doesn't type check)