### PR TITLE
dont allow private types to leak out of internal modules

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1165,15 +1165,6 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             return;
         }
 
-        // We also don't want to raise a warning if we're inside an internal
-        // module ourselves, the type wouldn't actually be publicly exposed.
-        if self
-            .package_config
-            .is_internal_module(self.module_name.as_str())
-        {
-            return;
-        }
-
         // If a private or internal value references a private type
         if let Some(leaked) = value.type_.find_private_type() {
             self.errors.push(Error::PrivateTypeLeak {

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1,5 +1,6 @@
 use crate::{
-    assert_error, assert_module_error, assert_module_syntax_error, assert_with_module_error,
+    assert_error, assert_internal_module_error, assert_module_error, assert_module_syntax_error,
+    assert_with_module_error,
 };
 
 #[test]
@@ -808,6 +809,16 @@ pub fn go(x: PrivateType) -> Int"#
 #[test]
 fn module_private_type_leak_5() {
     assert_module_error!(
+        r#"type PrivateType
+pub type LeakType { Variant(PrivateType) }"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/3387
+// Private types should not leak even in internal modules
+#[test]
+fn module_private_type_leak_6() {
+    assert_internal_module_error!(
         r#"type PrivateType
 pub type LeakType { Variant(PrivateType) }"#
     );

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_private_type_leak_6.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_private_type_leak_6.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "type PrivateType\npub type LeakType { Variant(PrivateType) }"
+---
+error: Private type used in public interface
+  ┌─ /src/one/two.gleam:2:21
+  │
+2 │ pub type LeakType { Variant(PrivateType) }
+  │                     ^^^^^^^^^^^^^^^^^^^^
+
+The following type is private, but is being used by this public export.
+
+    PrivateType
+
+Private types can only be used within the module that defines them.


### PR DESCRIPTION
Closes #3387

Removed the special casing for internal modules. If the type of a nonprivate module value ever contains anything private then give the error