### PR TITLE
Case fault tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@
 - The error message presented when a function is called in a guard has been improved.
   ([Thomas](https://github.com/DeviousStoat))
 
+- Case expressions are now fault tolerant. This means an subject, pattern,
+  guard, or then body can be properly detected and won't invalidate the rest
+  of the expression.
+  ([Ameen Radwan](https://github.com/Acepie))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1351,7 +1351,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let mut has_a_guard = false;
         let mut all_patterns_are_discards = true;
-        let mut all_clauses_panic = true;
+        // NOTE: if there are 0 clauses then there are 0 panics
+        let mut all_clauses_panic = clauses.len() > 0;
         for clause in clauses {
             has_a_guard = has_a_guard || clause.guard.is_some();
             all_patterns_are_discards =

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -31,22 +31,22 @@ fn bit_arrays4() {
 
 #[test]
 fn bit_array() {
-    assert_error!("case <<1>> { <<2.0, a>> -> 1 }");
+    assert_error!("case <<1>> { <<2.0, a>> -> 1 _ -> 2 }");
 }
 
 #[test]
 fn bit_array_float() {
-    assert_error!("case <<1>> { <<a:float>> if a > 1 -> 1 }");
+    assert_error!("case <<1>> { <<a:float>> if a > 1 -> 1 _ -> 2 }");
 }
 
 #[test]
 fn bit_array_binary() {
-    assert_error!("case <<1>> { <<a:bytes>> if a > 1 -> 1 }");
+    assert_error!("case <<1>> { <<a:bytes>> if a > 1 -> 1 _ -> 2 }");
 }
 
 #[test]
 fn bit_array_guard() {
-    assert_error!("case <<1>> { <<a:utf16_codepoint>> if a == \"test\" -> 1 }");
+    assert_error!("case <<1>> { <<a:utf16_codepoint>> if a == \"test\" -> 1 _ -> 2 }");
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn bit_array_segment_size() {
 
 #[test]
 fn bit_array_segment_size2() {
-    assert_error!("case <<1>> { <<1:size(2)-size(8)>> -> a }");
+    assert_error!("case <<1>> { <<1:size(2)-size(8)>> -> 1 }");
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn bit_array_segment_type_does_not_allow_unit_codepoint_utf16() {
 
 #[test]
 fn bit_array_segment_type_does_not_allow_unit_codepoint_utf32() {
-    assert_error!("case <<1>> { <<1:utf32_codepoint-unit(2)>> -> a }");
+    assert_error!("case <<1>> { <<1:utf32_codepoint-unit(2)>> -> 1 }");
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn bit_array_segment_type_does_not_allow_unit_codepoint_utf16_2() {
 
 #[test]
 fn bit_array_segment_type_does_not_allow_unit_codepoint_utf32_2() {
-    assert_error!("case <<1>> { <<1:utf32_codepoint-size(5)>> -> a }");
+    assert_error!("case <<1>> { <<1:utf32_codepoint-size(5)>> -> 1 }");
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn bit_array_segment_type_does_not_allow_unit_utf16() {
 
 #[test]
 fn bit_array_segment_type_does_not_allow_unit_utf32() {
-    assert_error!("case <<1>> { <<1:utf32-unit(2)>> -> a }");
+    assert_error!("case <<1>> { <<1:utf32-unit(2)>> -> 1 }");
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn bit_array_segment_type_does_not_allow_size_utf16() {
 
 #[test]
 fn bit_array_segment_type_does_not_allow_size_utf32() {
-    assert_error!("case <<1>> { <<1:utf32-size(5)>> -> a }");
+    assert_error!("case <<1>> { <<1:utf32-size(5)>> -> 1 }");
 }
 
 #[test]
@@ -545,7 +545,7 @@ fn duplicate_vars() {
 
 #[test]
 fn duplicate_vars_2() {
-    assert_error!("case [3.33], 1 { x, x if x > x -> 1 }");
+    assert_error!("case [3.33], 1 { x, x -> 1 }");
 }
 
 #[test]
@@ -1493,6 +1493,7 @@ pub fn parse(input: BitArray) -> String {
     <<"(":utf8, b:bytes>> ->
       parse(input)
       |> change
+    _ -> 3
   }
 }"#
     );

--- a/compiler-core/src/type_/tests/functions.rs
+++ b/compiler-core/src/type_/tests/functions.rs
@@ -345,3 +345,68 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn case_subject_fault_tolerance() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  case 1.0 + 1.0, 2.0 + 2.0 {
+    _, _ -> 0
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn case_clause_pattern_fault_tolerance() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  let wibble = True
+  case wibble {
+    True -> 0
+    Wibble -> 1
+    Wibble2 -> 2
+    _ -> 3
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn case_clause_guard_fault_tolerance() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  let wibble = True
+  case wibble {
+    a if a == Wibble -> 0
+    b if b == Wibble -> 0
+    _ -> 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn case_clause_then_fault_tolerance() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  let wibble = True
+  case wibble {
+    True -> {
+      1.0 + 1.0
+    }
+    _ -> {
+      1.0 + 1.0
+    }
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<2.0, a>> -> 1 }"
+expression: "case <<1>> { <<2.0, a>> -> 1 _ -> 2 }"
 ---
 error: Type mismatch
   ┌─ /src/one/two.gleam:1:16
   │
-1 │ case <<1>> { <<2.0, a>> -> 1 }
+1 │ case <<1>> { <<2.0, a>> -> 1 _ -> 2 }
   │                ^^^
 
 Expected type:

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_binary.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_binary.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<a:bytes>> if a > 1 -> 1 }"
+expression: "case <<1>> { <<a:bytes>> if a > 1 -> 1 _ -> 2 }"
 ---
 error: Type mismatch
   ┌─ /src/one/two.gleam:1:29
   │
-1 │ case <<1>> { <<a:bytes>> if a > 1 -> 1 }
+1 │ case <<1>> { <<a:bytes>> if a > 1 -> 1 _ -> 2 }
   │                             ^
 
 Expected type:

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_float.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_float.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<a:float>> if a > 1 -> 1 }"
+expression: "case <<1>> { <<a:float>> if a > 1 -> 1 _ -> 2 }"
 ---
 error: Type mismatch
   ┌─ /src/one/two.gleam:1:29
   │
-1 │ case <<1>> { <<a:float>> if a > 1 -> 1 }
+1 │ case <<1>> { <<a:float>> if a > 1 -> 1 _ -> 2 }
   │                             ^
 
 Expected type:

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_guard.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_guard.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<a:utf16_codepoint>> if a == \"test\" -> 1 }"
+expression: "case <<1>> { <<a:utf16_codepoint>> if a == \"test\" -> 1 _ -> 2 }"
 ---
 error: Type mismatch
   ┌─ /src/one/two.gleam:1:39
   │
-1 │ case <<1>> { <<a:utf16_codepoint>> if a == "test" -> 1 }
+1 │ case <<1>> { <<a:utf16_codepoint>> if a == "test" -> 1 _ -> 2 }
   │                                       ^^^^^^^^^^^
 
 Expected type:

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_size2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_size2.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<1:size(2)-size(8)>> -> a }"
+expression: "case <<1>> { <<1:size(2)-size(8)>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:26
   │
-1 │ case <<1>> { <<1:size(2)-size(8)>> -> a }
+1 │ case <<1>> { <<1:size(2)-size(8)>> -> 1 }
   │                          ^^^^^^^ This is an extra size specifier
 
 Hint: This segment already has a size.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf32.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_size_utf32.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<1:utf32-size(5)>> -> a }"
+expression: "case <<1>> { <<1:utf32-size(5)>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:18
   │
-1 │ case <<1>> { <<1:utf32-size(5)>> -> a }
+1 │ case <<1>> { <<1:utf32-size(5)>> -> 1 }
   │                  ^^^^^ Size cannot be specified here
 
 Hint: utf32 segments have an automatic size.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf32.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf32.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<1:utf32_codepoint-unit(2)>> -> a }"
+expression: "case <<1>> { <<1:utf32_codepoint-unit(2)>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:18
   │
-1 │ case <<1>> { <<1:utf32_codepoint-unit(2)>> -> a }
+1 │ case <<1>> { <<1:utf32_codepoint-unit(2)>> -> 1 }
   │                  ^^^^^^^^^^^^^^^ Unit cannot be specified here
 
 Hint: utf32_codepoint segments are sized based on their value and cannot

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf32_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_codepoint_utf32_2.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<1:utf32_codepoint-size(5)>> -> a }"
+expression: "case <<1>> { <<1:utf32_codepoint-size(5)>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:18
   │
-1 │ case <<1>> { <<1:utf32_codepoint-size(5)>> -> a }
+1 │ case <<1>> { <<1:utf32_codepoint-size(5)>> -> 1 }
   │                  ^^^^^^^^^^^^^^^ Size cannot be specified here
 
 Hint: utf32_codepoint segments have an automatic size.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_utf32.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_unit_utf32.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case <<1>> { <<1:utf32-unit(2)>> -> a }"
+expression: "case <<1>> { <<1:utf32-unit(2)>> -> 1 }"
 ---
 error: Invalid bit array segment
   ┌─ /src/one/two.gleam:1:18
   │
-1 │ case <<1>> { <<1:utf32-unit(2)>> -> a }
+1 │ case <<1>> { <<1:utf32-unit(2)>> -> 1 }
   │                  ^^^^^ Unit cannot be specified here
 
 Hint: utf32 segments are sized based on their value and cannot have a unit.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_clause_pipe_diagnostic.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_clause_pipe_diagnostic.snap
@@ -1,7 +1,30 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\npub fn change(x: String) -> String {\n  \"\"\n}\n\npub fn parse(input: BitArray) -> String {\n  case input {\n    <<>> -> 1\n    <<\"(\":utf8, b:bytes>> ->\n      parse(input)\n      |> change\n  }\n}"
+expression: "\npub fn change(x: String) -> String {\n  \"\"\n}\n\npub fn parse(input: BitArray) -> String {\n  case input {\n    <<>> -> 1\n    <<\"(\":utf8, b:bytes>> ->\n      parse(input)\n      |> change\n    _ -> 3\n  }\n}"
 ---
+error: Type mismatch
+   ┌─ /src/one/two.gleam:7:3
+   │  
+ 7 │ ╭   case input {
+ 8 │ │     <<>> -> 1
+ 9 │ │     <<"(":utf8, b:bytes>> ->
+10 │ │       parse(input)
+11 │ │       |> change
+12 │ │     _ -> 3
+13 │ │   }
+   │ ╰───^
+
+The type of this returned value doesn't match the return type
+annotation of this function.
+
+Expected type:
+
+    String
+
+Found type:
+
+    Int
+
 error: Type mismatch
    ┌─ /src/one/two.gleam:9:5
    │  

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_vars_2.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "case [3.33], 1 { x, x if x > x -> 1 }"
+expression: "case [3.33], 1 { x, x -> 1 }"
 ---
 error: Duplicate variable in pattern
   ┌─ /src/one/two.gleam:1:21
   │
-1 │ case [3.33], 1 { x, x if x > x -> 1 }
+1 │ case [3.33], 1 { x, x -> 1 }
   │                     ^ This has already been used
 
 Variables can only be used once per pattern. This variable `x` appears

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_guard_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_guard_fault_tolerance.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n  let wibble = True\n  case wibble {\n    a if a == Wibble -> 0\n    b if b == Wibble -> 0\n    _ -> 1\n  }\n}\n"
+---
+error: Unknown variable
+  ┌─ /src/one/two.gleam:5:15
+  │
+5 │     a if a == Wibble -> 0
+  │               ^^^^^^ Did you mean `wibble`?
+
+The name `Wibble` is not in scope here.
+
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:15
+  │
+6 │     b if b == Wibble -> 0
+  │               ^^^^^^ Did you mean `wibble`?
+
+The name `Wibble` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_pattern_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_pattern_fault_tolerance.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n  let wibble = True\n  case wibble {\n    True -> 0\n    Wibble -> 1\n    Wibble2 -> 2\n    _ -> 3\n  }\n}\n"
+---
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     Wibble -> 1
+  │     ^^^^^^ Did you mean `wibble`?
+
+The name `Wibble` is not in scope here.
+
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     Wibble2 -> 2
+  │     ^^^^^^^ Did you mean `wibble`?
+
+The name `Wibble2` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n  let wibble = True\n  case wibble {\n    True -> {\n      1.0 + 1.0\n    }\n    _ -> {\n      1.0 + 1.0\n    }\n  }\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:6:7
+  │
+6 │       1.0 + 1.0
+  │       ^^^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    Float
+
+Hint: the +. operator can be used with Floats
+
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:9:7
+  │
+9 │       1.0 + 1.0
+  │       ^^^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    Float
+
+Hint: the +. operator can be used with Floats

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_subject_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_subject_fault_tolerance.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n  case 1.0 + 1.0, 2.0 + 2.0 {\n    _, _ -> 0\n  }\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:8
+  │
+3 │   case 1.0 + 1.0, 2.0 + 2.0 {
+  │        ^^^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    Float
+
+Hint: the +. operator can be used with Floats
+
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:19
+  │
+3 │   case 1.0 + 1.0, 2.0 + 2.0 {
+  │                   ^^^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    Float
+
+Hint: the +. operator can be used with Floats


### PR DESCRIPTION
Makes case inference fault tolerant by individually checking each subject, pattern, guard, and then clause. This ultimately enables better LSP behavior even when a case is inexhaustive or 1 clause/subject has an issue

![Screenshot 2024-07-14 103548](https://github.com/user-attachments/assets/bda4e909-350d-4516-bdc6-5abe2f06389f)
![Screenshot 2024-07-14 103912](https://github.com/user-attachments/assets/b535dd34-e8a3-4477-a1e4-e552c69c8a04)
![Screenshot 2024-07-14 104055](https://github.com/user-attachments/assets/e5fb676b-eeb3-423b-b49f-6b59b708da75)
