### PR TITLE
Adds `deps why` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   platform for the generated documentation.
   ([Jiangda Wang](https://github.com/frank-iii))
 
+- `gleam deps` now supports `why` operation that takes a package name input, finds it in the deps tree, and then print all the requirements for it from the other packages
+  ([Ramkarthik Krishnamurthy](https://github.com/ramkarthik))
+
 ### Compiler
 
 - The warning for the deprecated `[..]` pattern has been improved.

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -336,6 +336,13 @@ enum Dependencies {
 
     /// Update dependency packages to their latest versions
     Update,
+
+    /// Find out version requirements
+    Why {
+        /// The name of the package
+        #[arg(required = true)]
+        package: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -460,6 +467,8 @@ fn main() {
         Command::Deps(Dependencies::Download) => download_dependencies(),
 
         Command::Deps(Dependencies::Update) => dependencies::update(),
+
+        Command::Deps(Dependencies::Why { package }) => dependencies::why(package),
 
         Command::New(options) => new::create(options, COMPILER_VERSION),
 


### PR DESCRIPTION
Addresses #3267 

```
gleam deps why gleam_stdlib
```

For ex: Running this on the `test/project_erlang` project returns the following output:
```
gleam_erlang 0.24.0
gleam_javascript 0.7.1
gleeunit 1.0.2
```

This is my first PR for this project. I appreciate any feedback to improve this.