### PR TITLE
incorrect arity fault tolerance works better with labels

### DIFF
--- a/compiler-core/src/type_/tests/functions.rs
+++ b/compiler-core/src/type_/tests/functions.rs
@@ -347,13 +347,30 @@ pub fn main() {
 }
 
 #[test]
-fn case_subject_fault_tolerance() {
+fn function_call_incorrect_arity_with_labels_fault_tolerance() {
     assert_module_error!(
         r#"
+fn wibble(wibble arg1: fn() -> Int, wobble arg2: Int) -> Int {
+  arg1() + arg2
+}
+
 pub fn main() {
-  case 1.0 + 1.0, 2.0 + 2.0 {
-    _, _ -> 0
-  }
+  wibble(wobble: "")
+}
+"#
+    );
+}
+
+#[test]
+fn function_call_incorrect_arity_with_labels_fault_tolerance2() {
+    assert_module_error!(
+        r#"
+fn wibble(wibble arg1: fn() -> Int, wobble arg2: Int, wabble arg3: Int) -> Int {
+  arg1() + arg2 + arg3
+}
+
+pub fn main() {
+  wibble(fn() {""}, wobble: "")
 }
 "#
     );

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_labels_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_labels_fault_tolerance.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\nfn wibble(wibble arg1: fn() -> Int, wobble arg2: Int) -> Int {\n  arg1() + arg2\n}\n\npub fn main() {\n  wibble(wobble: \"\")\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:7:3
+  │
+7 │   wibble(wobble: "")
+  │   ^^^^^^^^^^^^^^^^^^ Expected 2 arguments, got 1
+
+This call accepts these additional labelled arguments:
+
+  - wibble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_labels_fault_tolerance2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_labels_fault_tolerance2.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\nfn wibble(wibble arg1: fn() -> Int, wobble arg2: Int, wabble arg3: Int) -> Int {\n  arg1() + arg2 + arg3\n}\n\npub fn main() {\n  wibble(fn() {\"\"}, wobble: \"\")\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:7:3
+  │
+7 │   wibble(fn() {""}, wobble: "")
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected 3 arguments, got 2
+
+This call accepts these additional labelled arguments:
+
+  - wabble
+  - wibble
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:10
+  │
+7 │   wibble(fn() {""}, wobble: "")
+  │          ^^^^^^^^^
+
+Expected type:
+
+    fn() -> Int
+
+Found type:
+
+    fn() -> String


### PR DESCRIPTION
Closes #3405

Fixes double arity reporting for functions with labelled arguments and stops type checking of arguments before first labelled argument if arity is incorrect. This still leads to a good experience with signature help but prevents incorrect type checking of the labelled arguments. As far as I can tell this is the best we can do since putting placeholder arguments would break signature help but not putting placeholder arguments makes doing the reordering of arguments impossible in some cases