### PR TITLE
Fix 2015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,53 @@
   of the expression.
   ([Ameen Radwan](https://github.com/Acepie))
 
+- Documentation comments that come before a regular comment are no longer
+  clumped together with the documentation of the following definition.
+  Now commenting out a definition won't result in its documentation merging with
+  the following one's.
+
+  ```gleam
+  /// This doc comment will be ignored!
+  // a commented definition
+  // fn wibble() {}
+
+  /// Wibble's documentation.
+  fn wibble() { todo }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
+
+- The formatter will no longer move a documentation comment below a regular
+  comment following it. This snippet of code is left as it is by the formatter:
+
+  ```gleam
+  /// This doc comment will be ignored!
+  // a commented definition
+  // fn wibble() {}
+
+  /// Wibble's documentation.
+  fn wibble() {
+    todo
+  }
+  ```
+
+  While previously all documentation comments would be merged together into one,
+  ignoring the regular comment separating them:
+
+  ```gleam
+  // a commented definition
+  // fn wibble() {}
+
+  /// This doc comment will be ignored!
+  /// Wibble's documentation.
+  fn wibble() {
+    todo
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ### Language Server
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -997,6 +997,25 @@ impl<A, B, C, E> Definition<A, B, C, E> {
         }
     }
 
+    pub fn get_doc(&self) -> Option<EcoString> {
+        match self {
+            Definition::Import(Import { .. }) => None,
+
+            Definition::Function(Function {
+                documentation: doc, ..
+            })
+            | Definition::TypeAlias(TypeAlias {
+                documentation: doc, ..
+            })
+            | Definition::CustomType(CustomType {
+                documentation: doc, ..
+            })
+            | Definition::ModuleConstant(ModuleConstant {
+                documentation: doc, ..
+            }) => doc.clone(),
+        }
+    }
+
     pub fn is_internal(&self) -> bool {
         match self {
             Definition::Function(Function { publicity, .. })

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -418,7 +418,6 @@ fn doc_comments_before<'a>(
             break;
         }
         if extra.has_comment_between(*end, byte) {
-            println!("Ignore comment with span {start} {end}");
             // We ignore doc comments that come before a regular comment.
             _ = doc_comments_spans.next();
             continue;

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -270,3 +270,70 @@ fn markdown_code_from_module_comment_is_trimmed() {
     )];
     insta::assert_snapshot!(compile(config, modules));
 }
+
+#[test]
+fn doc_for_commented_definitions_is_not_included_in_next_constant() {
+    let config = PackageConfig::default();
+    let modules = vec![(
+        "app.gleam",
+        "
+/// Not included!
+// pub fn wibble() {}
+
+/// Included!
+pub const wobble = 1
+",
+    )];
+    assert!(!compile(config, modules).contains("Not included!"));
+}
+
+#[test]
+fn doc_for_commented_definitions_is_not_included_in_next_type() {
+    let config = PackageConfig::default();
+    let modules = vec![(
+        "app.gleam",
+        "
+/// Not included!
+// pub fn wibble() {}
+
+/// Included!
+pub type Wibble {
+  /// Wobble!
+  Wobble
+}
+",
+    )];
+    assert!(!compile(config, modules).contains("Not included!"));
+}
+
+#[test]
+fn doc_for_commented_definitions_is_not_included_in_next_function() {
+    let config = PackageConfig::default();
+    let modules = vec![(
+        "app.gleam",
+        "
+/// Not included!
+// pub fn wibble() {}
+
+/// Included!
+pub fn wobble(arg) {}
+",
+    )];
+    assert!(!compile(config, modules).contains("Not included!"));
+}
+
+#[test]
+fn doc_for_commented_definitions_is_not_included_in_next_type_alias() {
+    let config = PackageConfig::default();
+    let modules = vec![(
+        "app.gleam",
+        "
+/// Not included!
+// pub fn wibble() {}
+
+/// Included!
+pub type Wibble = Int
+",
+    )];
+    assert!(!compile(config, modules).contains("Not included!"));
+}

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6302,6 +6302,7 @@ fn not_punned_function() {
     assert_format!(
         r#"pub fn main() {
   wibble(x: x)
+}
 "#
     );
 }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6298,10 +6298,103 @@ fn not_punned_record() {
 }
 
 #[test]
-fn not_punned_funcdtion() {
+fn not_punned_function() {
     assert_format!(
         r#"pub fn main() {
   wibble(x: x)
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2015
+#[test]
+fn doc_comments_are_split_by_regular_comments() {
+    assert_format!(
+        r#"/// Doc comment
+// Commented function
+// fn wibble() {}
+
+/// Other doc comment
+pub fn main() {
+  todo
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2015
+#[test]
+fn it_is_easy_to_tell_two_different_doc_comments_apart_when_a_regular_comment_is_separating_those()
+{
+    assert_format_rewrite!(
+        r#"/// Doc comment
+// regular comment
+/// Other doc comment
+pub fn main() {
+  todo
+}
+"#,
+        r#"/// Doc comment
+// regular comment
+
+/// Other doc comment
+pub fn main() {
+  todo
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2015
+#[test]
+fn multiple_commented_definitions_in_a_row_2() {
+    assert_format!(
+        r#"/// Stray comment
+// regular comment
+
+/// Stray comment
+// regular comment
+
+/// Doc comment
+pub fn wibble() {
+  todo
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2015
+#[test]
+fn only_stray_comments_and_definition_with_no_doc_comments() {
+    assert_format!(
+        r#"/// Stray comment
+// regular comment
+
+/// Stray comment
+// regular comment
+
+pub fn wibble() {
+  todo
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2015
+#[test]
+fn only_stray_comments_and_definition_with_no_doc_comments_2() {
+    assert_format_rewrite!(
+        r#"/// Stray comment
+// regular comment
+pub fn wibble () {
+  todo
+}
+"#,
+        r#"/// Stray comment
+// regular comment
+
+pub fn wibble() {
+  todo
 }
 "#
     );

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1723,6 +1723,7 @@ where
         } else {
             self.take_documentation(start)
         };
+
         let mut name_location = SrcSpan::new(start, start);
         let mut name = EcoString::from("");
         if !is_anon {
@@ -3320,10 +3321,17 @@ where
 
     fn take_documentation(&mut self, until: u32) -> Option<EcoString> {
         let mut content = String::new();
+
         while let Some((start, line)) = self.doc_comments.front() {
             if *start >= until {
                 break;
             }
+            if self.extra.has_comment_between(*start, until) {
+                // We ignore doc comments that come before a regular comment.
+                _ = self.doc_comments.pop_front();
+                continue;
+            }
+
             content.push_str(line);
             content.push('\n');
             _ = self.doc_comments.pop_front();

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -34,6 +34,20 @@ impl ModuleExtra {
             || self.doc_comments.binary_search_by(cmp).is_ok()
             || self.module_comments.binary_search_by(cmp).is_ok()
     }
+
+    pub(crate) fn has_comment_between(&self, start: u32, end: u32) -> bool {
+        self.comments
+            .binary_search_by(|comment| {
+                if comment.end < start {
+                    Ordering::Less
+                } else if comment.start > end {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .is_ok()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -7,6 +7,7 @@ use crate::parse::token::Token;
 use crate::warning::WarningEmitter;
 use camino::Utf8PathBuf;
 
+use ecow::EcoString;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
 
@@ -1321,5 +1322,84 @@ pub fn main() {
   let Wibble(arg1: arg2:) = todo
 }
 "
+    );
+}
+
+fn first_parsed_docstring(src: &str) -> EcoString {
+    let parsed =
+        crate::parse::parse_module(Utf8PathBuf::from("test/path"), src, &WarningEmitter::null())
+            .expect("should parse");
+
+    parsed
+        .module
+        .definitions
+        .first()
+        .expect("parsed a definition")
+        .definition
+        .get_doc()
+        .expect("definition without doc")
+}
+
+#[test]
+fn doc_comment_before_comment_is_not_attached_to_following_function() {
+    assert_eq!(
+        first_parsed_docstring(
+            r#"
+    /// Not included!
+    // pub fn call()
+
+    /// Doc!
+    pub fn wibble() {}
+"#
+        ),
+        " Doc!\n"
+    )
+}
+
+#[test]
+fn doc_comment_before_comment_is_not_attached_to_following_type() {
+    assert_eq!(
+        first_parsed_docstring(
+            r#"
+    /// Not included!
+    // pub fn call()
+
+    /// Doc!
+    pub type Wibble
+"#
+        ),
+        " Doc!\n"
+    )
+}
+
+#[test]
+fn doc_comment_before_comment_is_not_attached_to_following_type_alias() {
+    assert_eq!(
+        first_parsed_docstring(
+            r#"
+    /// Not included!
+    // pub fn call()
+
+    /// Doc!
+    pub type Wibble = Int
+"#
+        ),
+        " Doc!\n"
+    )
+}
+
+#[test]
+fn doc_comment_before_comment_is_not_attached_to_following_constant() {
+    assert_eq!(
+        first_parsed_docstring(
+            r#"
+    /// Not included!
+    // pub fn call()
+
+    /// Doc!
+    pub const wibble = 1
+"#
+        ),
+        " Doc!\n"
     );
 }


### PR DESCRIPTION
This PR closes #2015 

This would happen if one commented out a documented definition:
```gleam
/// Wibble's
// pub fn wibble() {}

/// Wobble's
pub fn wobble() {}
```
The compiler would merge wibble's documentation into wobble's one resulting in some confusing behaviour (the formatter would clump those doc strings together, ignoring the comment; the generated doc for wobble would also include wibble's doc; hovering over wobble would also show wibble's doc; ...).

Now if a doc comment comes before a regular comment it is considered as not belonging to any definition. In addition I've implemented some changes in the formatter to make this more evident in case someone messed up:

```gleam
/// Docstring
// some random comment
pub fn wibble() {}
```
Is formatted into:
```gleam
/// Docstring
// some random comment

pub fn wibble() {}
```
I think the additional space makes it clearer that the doc string is not related to the `wibble` function