### PR TITLE
Label shorthand bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,8 @@
 - The language server can now show signature help when writing functions.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- The language server now supports listing document symbols, such as functions and constants, for the current Gleam file.
+- The language server now supports listing document symbols, such as functions
+  and constants, for the current Gleam file.
   ([PgBiel](https://github.com/PgBiel))
 
 - The language server can now suggest a code action to automatically use

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6400,3 +6400,13 @@ pub fn wibble() {
 "#
     );
 }
+
+#[test]
+fn discard_in_pipe_is_not_turned_into_shorthand_label() {
+    assert_format!(
+        r#"pub fn main() {
+  wibble |> wobble(one: 1, label: _, two: 2)
+}
+"#
+    );
+}


### PR DESCRIPTION
This fixes a bug @inoas found where the formatter would treat a labelled function hole as a shorthand label:
```gleam
[] |> list.map(with: fun, over: _)
// Would incorrectly be formatted as
[] |> list.map(with: fun, over:)
```

This PR is based on #3428 so that should be merged first