### PR TITLE
Action to fill labelled args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,33 @@
   function call or record construction.
   ([Ameen Radwan](https://github.com/Acepie))
 
+- The language server can now suggest a code action to fill in the labels of a
+  function call:
+
+  ```gleam
+  pub type Date {
+    Date(year: Int, month: Int, day: Int)
+  }
+
+  pub fn main() {
+    Date()
+  }
+  ```
+
+  Becomes:
+
+  ```gleam
+  pub type Date {
+    Date(year: Int, month: Int, day: Int)
+  }
+
+  pub fn main() {
+    Date(year: todo, month: todo, day: todo)
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug Fixes
 
 - Functions, types and constructors named `module_info` are now escaped

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -364,6 +364,7 @@ fn find_node_module_select() {
             name: "function".into(),
             location: SrcSpan { start: 1, end: 55 },
             documentation: None,
+            field_map: None,
         },
     };
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -580,7 +580,7 @@ impl<'a> FillInMissingLabelledArgs<'a> {
             };
 
             let mut action = Vec::with_capacity(1);
-            CodeActionBuilder::new("Fill in missing labelled arguments")
+            CodeActionBuilder::new("Fill labels")
                 .kind(CodeActionKind::REFACTOR)
                 .changes(self.params.text_document.uri.clone(), vec![add_labels_edit])
                 .preferred(false)

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -579,10 +579,25 @@ impl<'a> TestProject<'a> {
     }
 }
 
+#[derive(Clone)]
 pub struct PositionFinder {
-    value: String,
+    value: EcoString,
     offset: usize,
     nth_occurrence: usize,
+}
+
+pub struct RangeSelector {
+    from: PositionFinder,
+    to: PositionFinder,
+}
+
+impl RangeSelector {
+    pub fn find_range(&self, src: &str) -> lsp_types::Range {
+        lsp_types::Range {
+            start: self.from.find_position(src),
+            end: self.to.find_position(src),
+        }
+    }
 }
 
 impl PositionFinder {
@@ -631,12 +646,26 @@ impl PositionFinder {
         } = self;
 
         let byte_index = src
-            .match_indices(value)
+            .match_indices(value.as_str())
             .nth(nth_occurrence - 1)
             .expect("no match for position")
             .0;
 
         byte_index_to_position(src, byte_index + offset)
+    }
+
+    pub fn select_until(self, end: PositionFinder) -> RangeSelector {
+        RangeSelector {
+            from: self,
+            to: end,
+        }
+    }
+
+    pub fn to_selection(self) -> RangeSelector {
+        RangeSelector {
+            from: self.clone(),
+            to: self,
+        }
     }
 }
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -77,7 +77,7 @@ const REMOVE_UNUSED_IMPORTS: &str = "Remove unused imports";
 const REMOVE_REDUNDANT_TUPLES: &str = "Remove redundant tuples";
 const CONVERT_TO_CASE: &str = "Convert to case";
 const USE_LABEL_SHORTHAND_SYNTAX: &str = "Use label shorthand syntax";
-const FILL_IN_MISSING_LABELLED_ARGS: &str = "Fill in missing labelled arguments";
+const FILL_LABELS: &str = "Fill labels";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -904,7 +904,7 @@ pub type Wibble { Wibble(arg1: Int, arg2: Int) }
 #[test]
 fn fill_in_labelled_args_only_works_if_function_has_no_explicit_arguments_yet() {
     assert_no_code_actions!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   wibble(1,)
@@ -919,7 +919,7 @@ pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
 #[test]
 fn fill_in_labelled_args_only_works_if_function_has_no_explicit_arguments_yet_2() {
     assert_no_code_actions!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   wibble(arg2: 1)
@@ -934,7 +934,7 @@ pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
 #[test]
 fn fill_in_labelled_args_works_with_regular_function() {
     assert_code_action!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   wibble()
@@ -949,7 +949,7 @@ pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
 #[test]
 fn fill_in_labelled_args_works_with_record_constructor() {
     assert_code_action!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   Wibble()
@@ -964,7 +964,7 @@ pub type Wibble { Wibble(arg1: Int, arg2: String) }
 #[test]
 fn fill_in_labelled_args_works_with_pipes() {
     assert_code_action!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   1 |> wibble()
@@ -981,7 +981,7 @@ pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
 #[test]
 fn fill_in_labelled_args_works_with_pipes_2() {
     assert_code_action!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   1 |> wibble()
@@ -998,7 +998,7 @@ pub fn wibble(not_labelled, arg1 arg1, arg2 arg2) { Nil }
 #[test]
 fn fill_in_labelled_args_works_with_use() {
     assert_code_action!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   use <- wibble()
@@ -1013,7 +1013,7 @@ pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
 #[test]
 fn fill_in_labelled_args_selects_innermost_function() {
     assert_code_action!(
-        FILL_IN_MISSING_LABELLED_ARGS,
+        FILL_LABELS,
         r#"
 pub fn main() {
   wibble(

--- a/compiler-core/src/language_server/tests/signature_help.rs
+++ b/compiler-core/src/language_server/tests/signature_help.rs
@@ -438,3 +438,20 @@ pub fn main() {
         find_position_of("to_be_or_not_to_be()").under_last_char()
     );
 }
+
+#[test]
+// Regression introduced by 4112682cdb5d5b0bb6d1defc6cde849b6a6f65ab.
+pub fn help_with_labelled_constructor() {
+    assert_signature_help!(
+        r#"
+pub type Pokemon {
+    Pokemon(name: String, types: List(String), moves: List(String))
+}
+
+pub fn main() {
+    Pokemon(name: "Jirachi",)
+}
+    "#,
+        find_position_of(r#"Pokemon(name: "Jirachi",)"#).under_last_char()
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_custom_type_with_label_shorthands_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_custom_type_with_label_shorthands_to_case.snap
@@ -1,7 +1,18 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub type Wibble { Wibble(arg: Int, arg2: Float) }\npub fn main() {\n  let assert Wibble(arg2:, ..) = Wibble(arg: 1, arg2: 1.0)\n}\n\",\n    3, CONVERT_TO_CASE)"
+expression: "\npub type Wibble { Wibble(arg: Int, arg2: Float) }\npub fn main() {\n  let assert Wibble(arg2:, ..) = Wibble(arg: 1, arg2: 1.0)\n}\n"
 ---
+----- BEFORE ACTION
+
+pub type Wibble { Wibble(arg: Int, arg2: Float) }
+pub fn main() {
+  let assert Wibble(arg2:, ..) = Wibble(arg: 1, arg2: 1.0)
+                    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
+
 pub type Wibble { Wibble(arg: Int, arg2: Float) }
 pub fn main() {
   let arg2 = case Wibble(arg: 1, arg2: 1.0) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_assert_result_to_case.snap
@@ -1,8 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-assertion_line: 595
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert Ok(value) = Ok(1)\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  let assert Ok(value) = Ok(1)\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  let assert Ok(value) = Ok(1)
+      ▔▔▔▔↑                   
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   let value = case Ok(1) {
     Ok(value) -> value

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_inner_let_assert_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_inner_let_assert_to_case.snap
@@ -1,7 +1,20 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let assert [wibble] = {\n        let assert Ok(wobble) = {\n            Ok(1)\n        }\n        [wobble]\n    }\n}\"#,\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n    let assert [wibble] = {\n        let assert Ok(wobble) = {\n            Ok(1)\n        }\n        [wobble]\n    }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert [wibble] = {
+        let assert Ok(wobble) = {
+                          ↑      
+            Ok(1)
+        }
+        [wobble]
+    }
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert [wibble] = {
         let wobble = case {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_alias_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_alias_to_case.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert 10 as ten = 10\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  let assert 10 as ten = 10\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  let assert 10 as ten = 10
+      ▔▔▔▔▔▔▔▔▔▔▔▔▔↑       
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   let ten = case 10 {
     10 as ten -> ten

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_bit_array_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_bit_array_to_case.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert <<bits1, bits2>> = <<73, 98>>\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  let assert <<bits1, bits2>> = <<73, 98>>\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  let assert <<bits1, bits2>> = <<73, 98>>
+               ▔▔▔▔▔▔▔▔▔▔▔↑               
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   let #(bits1, bits2) = case <<73, 98>> {
     <<bits1, bits2>> -> #(bits1, bits2)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_pattern_alias_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_pattern_alias_to_case.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let assert \"123\" as one_two_three <> rest = \"123456\"\n}\"#,\n    1, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n    let assert \"123\" as one_two_three <> rest = \"123456\"\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert "123" as one_two_three <> rest = "123456"
+                ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑      
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let #(one_two_three, rest) = case "123456" {
       "123" as one_two_three <> rest -> #(one_two_three, rest)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_string_prefix_to_case.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(r#\"\npub fn main() {\n  let assert \"_\" <> thing = \"_Hello\"\n}\"#,\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  let assert \"_\" <> thing = \"_Hello\"\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  let assert "_" <> thing = "_Hello"
+              ↑                     
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   let thing = case "_Hello" {
     "_" <> thing -> thing

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_discard.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [_elem] = [6]\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  let assert [_elem] = [6]\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  let assert [_elem] = [6]
+      ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   let _ = case [6] {
     [_elem] -> Nil

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_indented.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_indented.snap
@@ -1,7 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  {\n    let assert Ok(value) = Ok(1)\n  }\n}\n\",\n    3, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  {\n    let assert Ok(value) = Ok(1)\n  }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  {
+    let assert Ok(value) = Ok(1)
+               ↑                
+  }
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   {
     let value = case Ok(1) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_multi_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_multi_variables.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [var1, var2, _var3, var4] = [1, 2, 3, 4]\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  let assert [var1, var2, _var3, var4] = [1, 2, 3, 4]\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  let assert [var1, var2, _var3, var4] = [1, 2, 3, 4]
+              ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑                       
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   let #(var1, var2, var4) = case [1, 2, 3, 4] {
     [var1, var2, _var3, var4] -> #(var1, var2, var4)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_to_case_no_variables.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n  let assert [] = []\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n  let assert [] = []\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  let assert [] = []
+             ↑      
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   let _ = case [] {
     [] -> Nil

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_tuple_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_let_assert_tuple_to_case.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(\"\npub fn main() {\n   let assert #(first, 10, third) = #(5, 10, 15)\n}\n\",\n    2, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n   let assert #(first, 10, third) = #(5, 10, 15)\n}\n"
 ---
+----- BEFORE ACTION
+pub fn main() {
+   let assert #(first, 10, third) = #(5, 10, 15)
+   ↑                                            
+}
+
+
+----- AFTER ACTION
 pub fn main() {
    let #(first, third) = case #(5, 10, 15) {
      #(first, 10, third) -> #(first, third)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_outer_let_assert_to_case.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_outer_let_assert_to_case.snap
@@ -1,7 +1,20 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let assert [wibble] = {\n        let assert Ok(wobble) = {\n            Ok(1)\n        }\n        [wobble]\n    }\n}\"#,\n    1, CONVERT_TO_CASE)"
+expression: "pub fn main() {\n    let assert [wibble] = {\n        let assert Ok(wobble) = {\n            Ok(1)\n        }\n        [wobble]\n    }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert [wibble] = {
+                 ▔▔▔▔▔▔▔↑  
+        let assert Ok(wobble) = {
+            Ok(1)
+        }
+        [wobble]
+    }
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let wibble = case {
         let assert Ok(wobble) = {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_selects_innermost_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_selects_innermost_function.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  wibble(\n    wibble()\n  )\n}\n\npub fn wibble(arg1 arg1, arg2 arg2) { Nil }\n "
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  wibble(
+    wibble()
+           ↑
+  )
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
+ 
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  wibble(
+    wibble(arg1: todo, arg2: todo)
+  )
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_pipes.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_pipes.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1 |> wibble()\n}\n\npub fn wibble(arg1 arg1, arg2 arg2) { Nil }\n "
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1 |> wibble()
+              ↑
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
+ 
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1 |> wibble(arg2: todo)
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_pipes_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_pipes_2.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1 |> wibble()\n}\n\npub fn wibble(not_labelled, arg1 arg1, arg2 arg2) { Nil }\n "
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1 |> wibble()
+              ↑
+}
+
+pub fn wibble(not_labelled, arg1 arg1, arg2 arg2) { Nil }
+ 
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1 |> wibble(arg1: todo, arg2: todo)
+}
+
+pub fn wibble(not_labelled, arg1 arg1, arg2 arg2) { Nil }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_record_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_record_constructor.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  Wibble()\n}\n\npub type Wibble { Wibble(arg1: Int, arg2: String) }\n "
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  Wibble()
+  ▔▔▔▔▔▔▔↑
+}
+
+pub type Wibble { Wibble(arg1: Int, arg2: String) }
+ 
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  Wibble(arg1: todo, arg2: todo)
+}
+
+pub type Wibble { Wibble(arg1: Int, arg2: String) }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_regular_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_regular_function.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  wibble()\n}\n\npub fn wibble(arg1 arg1, arg2 arg2) { Nil }\n "
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  wibble()
+  ↑       
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
+ 
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  wibble(arg1: todo, arg2: todo)
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_use.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fill_in_labelled_args_works_with_use.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  use <- wibble()\n}\n\npub fn wibble(arg1 arg1, arg2 arg2) { Nil }\n "
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  use <- wibble()
+         ▔▔▔▔▔▔▔↑
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
+ 
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  use <- wibble(arg1: todo)
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_only_applies_to_selected_args.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_only_applies_to_selected_args.snap
@@ -8,7 +8,7 @@ pub fn main() {
     let arg1 = 1
     let arg2 = 2
     Wibble(arg2: arg2, arg1: arg1)
-    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑      
+    ▔▔▔▔▔▔▔▔▔▔▔↑                  
 }
 
 pub type Wibble { Wibble(arg1: Int, arg2: Int) }
@@ -19,7 +19,7 @@ pub type Wibble { Wibble(arg1: Int, arg2: Int) }
 pub fn main() {
     let arg1 = 1
     let arg2 = 2
-    Wibble(arg2: , arg1: )
+    Wibble(arg2: , arg1: arg1)
 }
 
 pub type Wibble { Wibble(arg1: Int, arg2: Int) }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_works_on_labelled_call_args.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_works_on_labelled_call_args.snap
@@ -1,7 +1,21 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let arg1 = 1\n    let arg2 = 2\n    wibble(arg2: arg2, arg1: arg1)\n}\n\npub fn wibble(arg1 arg1, arg2 arg2) { Nil }\n\"#,\n    3, USE_LABEL_SHORTHAND_SYNTAX)"
+expression: "\npub fn main() {\n    let arg1 = 1\n    let arg2 = 2\n    wibble(arg2: arg2, arg1: arg1)\n}\n\npub fn wibble(arg1 arg1, arg2 arg2) { Nil }\n"
 ---
+----- BEFORE ACTION
+
+pub fn main() {
+    let arg1 = 1
+    let arg2 = 2
+    wibble(arg2: arg2, arg1: arg1)
+     ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑          
+}
+
+pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
+
+
+----- AFTER ACTION
+
 pub fn main() {
     let arg1 = 1
     let arg2 = 2

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_works_on_labelled_pattern_call_args.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_works_on_labelled_pattern_call_args.snap
@@ -1,7 +1,20 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let Wibble(arg1: arg1, arg2: arg2) = todo\n    arg1 + arg2\n}\n\npub type Wibble { Wibble(arg1: Int, arg2: Int) }\n\"#,\n    1, USE_LABEL_SHORTHAND_SYNTAX)"
+expression: "\npub fn main() {\n    let Wibble(arg1: arg1, arg2: arg2) = todo\n    arg1 + arg2\n}\n\npub type Wibble { Wibble(arg1: Int, arg2: Int) }\n"
 ---
+----- BEFORE ACTION
+
+pub fn main() {
+    let Wibble(arg1: arg1, arg2: arg2) = todo
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑
+    arg1 + arg2
+}
+
+pub type Wibble { Wibble(arg1: Int, arg2: Int) }
+
+
+----- AFTER ACTION
+
 pub fn main() {
     let Wibble(arg1: , arg2: ) = todo
     arg1 + arg2

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_works_on_labelled_update_call_args.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__label_shorthand_action_works_on_labelled_update_call_args.snap
@@ -1,7 +1,20 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action_with_title(r#\"pub fn main() {\n    let arg1 = 1\n    Wibble(..todo, arg1: arg1)\n}\n\npub type Wibble { Wibble(arg1: Int, arg2: Int) }\n\"#,\n    2, USE_LABEL_SHORTHAND_SYNTAX)"
+expression: "\npub fn main() {\n    let arg1 = 1\n    Wibble(..todo, arg1: arg1)\n}\n\npub type Wibble { Wibble(arg1: Int, arg2: Int) }\n"
 ---
+----- BEFORE ACTION
+
+pub fn main() {
+    let arg1 = 1
+    Wibble(..todo, arg1: arg1)
+           ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
+}
+
+pub type Wibble { Wibble(arg1: Int, arg2: Int) }
+
+
+----- AFTER ACTION
+
 pub fn main() {
     let arg1 = 1
     Wibble(..todo, arg1: )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_redundant_tuple_with_catch_all_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_redundant_tuple_with_catch_all_pattern.snap
@@ -1,7 +1,20 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\npub fn main() {\n  case #(1, 2), #(3, 4) {\n    #(2, 2), #(2, 2) -> 0\n    #(1, 2), _ -> 0\n    _, #(1, 2) -> 0\n    _, _ -> 1\n  }\n}\n"
+expression: "pub fn main() {\n  case #(1, 2), #(3, 4) {\n    #(2, 2), #(2, 2) -> 0\n    #(1, 2), _ -> 0\n    _, #(1, 2) -> 0\n    _, _ -> 1\n  }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  case #(1, 2), #(3, 4) {
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑        
+    #(2, 2), #(2, 2) -> 0
+    #(1, 2), _ -> 0
+    _, #(1, 2) -> 0
+    _, _ -> 1
+  }
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   case 1, 2, 3, 4 {
     2, 2, 2, 2 -> 0

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_retain_extras.snap
@@ -2,6 +2,43 @@
 source: compiler-core/src/language_server/tests/action.rs
 expression: "\npub fn main() {\n  case\n    #(\n      // first comment\n      1,\n      // second comment\n      2,\n      3 // third comment before comma\n\n      ,\n\n      // fourth comment after comma\n\n    )\n  {\n    #(\n      // first comment\n      a,\n      // second comment\n      b,\n      c // third comment before comma\n\n      ,\n\n      // fourth comment after comma\n\n    ) -> 0\n  }\n}\n"
 ---
+----- BEFORE ACTION
+
+pub fn main() {
+  case
+    #(
+    ▔▔
+      // first comment
+▔▔▔▔▔▔↑               
+      1,
+      // second comment
+      2,
+      3 // third comment before comma
+
+      ,
+
+      // fourth comment after comma
+
+    )
+  {
+    #(
+      // first comment
+      a,
+      // second comment
+      b,
+      c // third comment before comma
+
+      ,
+
+      // fourth comment after comma
+
+    ) -> 0
+  }
+}
+
+
+----- AFTER ACTION
+
 pub fn main() {
   case
     

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_nested.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_nested.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\npub fn main() {\n  case #(case #(0) { #(a) -> 0 }) { #(b) -> 0 }\n}\n"
+expression: "pub fn main() {\n  case #(case #(0) { #(a) -> 0 }) { #(b) -> 0 }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  case #(case #(0) { #(a) -> 0 }) { #(b) -> 0 }
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑          
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   case case 0 { a -> 0 } { b -> 0 }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_only_safe_remove.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_only_safe_remove.snap
@@ -2,6 +2,20 @@
 source: compiler-core/src/language_server/tests/action.rs
 expression: "\npub fn main() {\n  case #(0), #(1) {\n    #(1), #(b) -> 0\n    a, #(0) -> 1 // The first of this clause is not a tuple\n    #(a), #(b) -> 2\n  }\n}\n"
 ---
+----- BEFORE ACTION
+
+pub fn main() {
+  case #(0), #(1) {
+       ▔▔▔▔▔▔↑     
+    #(1), #(b) -> 0
+    a, #(0) -> 1 // The first of this clause is not a tuple
+    #(a), #(b) -> 2
+  }
+}
+
+
+----- AFTER ACTION
+
 pub fn main() {
   case #(0), 1 {
     #(1), b -> 0

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_simple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_in_case_subject_simple.snap
@@ -1,7 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\npub fn main() {\n  case #(1) { #(a) -> 0 }\n  case #(1, 2) { #(a, b) -> 0 }\n}\n"
+expression: "pub fn main() {\n  case #(1) { #(a) -> 0 }\n  case #(1, 2) { #(a, b) -> 0 }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  case #(1) { #(a) -> 0 }
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  case #(1, 2) { #(a, b) -> 0 }
+▔▔▔▔▔▔▔▔▔▔▔▔▔↑                 
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   case 1 { a -> 0 }
   case 1, 2 { a, b -> 0 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_with_catch_all_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_redundant_tuple_with_catch_all_pattern.snap
@@ -1,7 +1,18 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\npub fn main() {\n  case #(1, 2) {\n    #(1, 2) -> 0\n    _ -> 1\n  }\n}\n"
+expression: "pub fn main() {\n  case #(1, 2) {\n    #(1, 2) -> 0\n    _ -> 1\n  }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+  case #(1, 2) {
+  ▔▔▔▔▔▔▔▔▔▔▔↑  
+    #(1, 2) -> 0
+    _ -> 1
+  }
+}
+
+
+----- AFTER ACTION
 pub fn main() {
   case 1, 2 {
     1, 2 -> 0

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_alias.snap
@@ -2,6 +2,23 @@
 source: compiler-core/src/language_server/tests/action.rs
 expression: "\n// test\nimport result.{is_ok} as res\nimport option\n\npub fn main() {\n  is_ok\n}\n"
 ---
+----- BEFORE ACTION
+
+// test
+▔▔▔▔▔▔▔
+import result.{is_ok} as res
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+import option
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main() {
+↑              
+  is_ok
+}
+
+
+----- AFTER ACTION
+
 // test
 import result.{is_ok} 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_simple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_simple.snap
@@ -1,9 +1,28 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\n// test\nimport // comment\n  list as lispy\nimport result\nimport option\n\npub fn main() {\n  result.is_ok\n}\n"
+expression: "\n// test\nimport // comment\nlist as lispy\nimport result\nimport option\n\npub fn main() {\n  result.is_ok\n}\n"
 ---
+----- BEFORE ACTION
+
 // test
+▔▔▔▔▔▔▔
+import // comment
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+list as lispy
+▔▔▔▔▔▔▔▔▔▔▔▔▔
 import result
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+import option
+▔▔▔▔▔▔▔↑     
+
+pub fn main() {
+  result.is_ok
+}
+
+
+----- AFTER ACTION
+
+// test
 
 pub fn main() {
   result.is_ok

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_start_of_file.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_start_of_file.snap
@@ -2,7 +2,19 @@
 source: compiler-core/src/language_server/tests/action.rs
 expression: "import option\nimport result\n\npub fn main() {\n  result.is_ok\n}\n"
 ---
+----- BEFORE ACTION
+import option
+▔▔▔▔▔▔▔▔▔▔▔▔▔
 import result
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main() {
+↑              
+  result.is_ok
+}
+
+
+----- AFTER ACTION
 
 pub fn main() {
   result.is_ok

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_bit_array_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_bit_array_pattern.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let assert <<bitValue>> = <<73>>\n}\",\n    1)"
+expression: "pub fn main() {\n    let assert <<bitValue>> = <<73>>\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert <<bitValue>> = <<73>>
+               ▔▔▔▔▔▔▔▔▔▔↑          
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert <<bit_value>> = <<73>>
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_bit_array_pattern_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_bit_array_pattern_discard.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let assert <<_iDontCare>> = <<97>>\n}\",\n    1)"
+expression: "pub fn main() {\n    let assert <<_iDontCare>> = <<97>>\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert <<_iDontCare>> = <<97>>
+               ▔▔▔▔▔▔▔▔↑              
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert <<_i_dont_care>> = <<97>>
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_case_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_case_variable.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    case 21 { twentyOne -> {Nil} }\n}\",\n    1)"
+expression: "pub fn main() {\n    case 21 { twentyOne -> {Nil} }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    case 21 { twentyOne -> {Nil} }
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑     
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     case 21 { twenty_one -> {Nil} }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_case_variable_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_case_variable_discard.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    case 21 { _twentyOne -> {Nil} }\n}\",\n    1)"
+expression: "pub fn main() {\n    case 21 { _twentyOne -> {Nil} }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    case 21 { _twentyOne -> {Nil} }
+         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑         
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     case 21 { _twenty_one -> {Nil} }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_const.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_const.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"const myInvalid_Constant = 42\", 0)"
+expression: const myInvalid_Constant = 42
 ---
+----- BEFORE ACTION
+const myInvalid_Constant = 42
+               ↑             
+
+
+----- AFTER ACTION
 const my_invalid_constant = 42

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"type MyType { The_Constructor(Int) }\", 0)"
+expression: "type MyType { The_Constructor(Int) }"
 ---
+----- BEFORE ACTION
+type MyType { The_Constructor(Int) }
+               ↑                    
+
+
+----- AFTER ACTION
 type MyType { TheConstructor(Int) }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor_arg.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor_arg.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"type IntWrapper { IntWrapper(innerInt: Int) }\", 0)"
+expression: "type IntWrapper { IntWrapper(innerInt: Int) }"
 ---
+----- BEFORE ACTION
+type IntWrapper { IntWrapper(innerInt: Int) }
+                  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑       
+
+
+----- AFTER ACTION
 type IntWrapper { IntWrapper(inner_int: Int) }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor_pattern.snap
@@ -1,7 +1,16 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub type Box { Box(Int) }\npub fn main() {\n    let Box(innerValue) = Box(203)\n}\",\n    2)"
+expression: "pub type Box { Box(Int) }\npub fn main() {\n    let Box(innerValue) = Box(203)\n}"
 ---
+----- BEFORE ACTION
+pub type Box { Box(Int) }
+pub fn main() {
+    let Box(innerValue) = Box(203)
+            ↑                     
+}
+
+
+----- AFTER ACTION
 pub type Box { Box(Int) }
 pub fn main() {
     let Box(inner_value) = Box(203)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor_pattern_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_constructor_pattern_discard.snap
@@ -1,7 +1,16 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub type Box { Box(Int) }\npub fn main() {\n    let Box(_ignoredInner) = Box(203)\n}\",\n    2)"
+expression: "pub type Box { Box(Int) }\npub fn main() {\n    let Box(_ignoredInner) = Box(203)\n}"
 ---
+----- BEFORE ACTION
+pub type Box { Box(Int) }
+pub fn main() {
+    let Box(_ignoredInner) = Box(203)
+            ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
 pub type Box { Box(Int) }
 pub fn main() {
     let Box(_ignored_inner) = Box(203)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_custom_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_custom_type.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"type Boxed_value { Box(Int) }\", 0)"
+expression: "type Boxed_value { Box(Int) }"
 ---
+----- BEFORE ACTION
+type Boxed_value { Box(Int) }
+     ▔▔▔▔▔↑                  
+
+
+----- AFTER ACTION
 type BoxedValue { Box(Int) }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_function.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn doStuff() {}\", 0)"
+expression: "fn doStuff() {}"
 ---
+----- BEFORE ACTION
+fn doStuff() {}
+▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
+
+
+----- AFTER ACTION
 fn do_stuff() {}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_list_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_list_pattern.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let assert [theElement] = [9.4]\n}\",\n    1)"
+expression: "pub fn main() {\n    let assert [theElement] = [9.4]\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert [theElement] = [9.4]
+        ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert [the_element] = [9.4]
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_list_pattern_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_list_pattern_discard.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let assert [_elemOne] = [False]\n}\",\n    1)"
+expression: "pub fn main() {\n    let assert [_elemOne] = [False]\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert [_elemOne] = [False]
+                     ↑             
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert [_elem_one] = [False]
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn add(numA: Int, num_b: Int) { numA + num_b }\", 0)"
+expression: "fn add(numA: Int, num_b: Int) { numA + num_b }"
 ---
+----- BEFORE ACTION
+fn add(numA: Int, num_b: Int) { numA + num_b }
+       ↑                                      
+
+
+----- AFTER ACTION
 fn add(num_a: Int, num_b: Int) { numA + num_b }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_discard.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn ignore(_ignoreMe: Bool) { 98 }\", 0)"
+expression: "fn ignore(_ignoreMe: Bool) { 98 }"
 ---
+----- BEFORE ACTION
+fn ignore(_ignoreMe: Bool) { 98 }
+   ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+
+
+----- AFTER ACTION
 fn ignore(_ignore_me: Bool) { 98 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_discard_name2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_discard_name2.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn ignore(labelled_discard _ignoreMe: Bool) { 98 }\",\n    0)"
+expression: "fn ignore(labelled_discard _ignoreMe: Bool) { 98 }"
 ---
+----- BEFORE ACTION
+fn ignore(labelled_discard _ignoreMe: Bool) { 98 }
+   ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+
+
+----- AFTER ACTION
 fn ignore(labelled_discard _ignore_me: Bool) { 98 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_discard_name3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_discard_name3.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let ignore = fn(_ignoreMe: Bool) { 98 }\n}\",\n    1)"
+expression: "pub fn main() {\n    let ignore = fn(_ignoreMe: Bool) { 98 }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let ignore = fn(_ignoreMe: Bool) { 98 }
+        ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let ignore = fn(_ignore_me: Bool) { 98 }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_label.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_label.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn func(thisIsALabel param: Int) { param }\", 0)"
+expression: "fn func(thisIsALabel param: Int) { param }"
 ---
+----- BEFORE ACTION
+fn func(thisIsALabel param: Int) { param }
+        ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑             
+
+
+----- AFTER ACTION
 fn func(this_is_a_label param: Int) { param }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_label2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_label2.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn ignore(thisIsALabel _ignore: Int) { 25 }\", 0)"
+expression: "fn ignore(thisIsALabel _ignore: Int) { 25 }"
 ---
+----- BEFORE ACTION
+fn ignore(thisIsALabel _ignore: Int) { 25 }
+            ↑                              
+
+
+----- AFTER ACTION
 fn ignore(this_is_a_label _ignore: Int) { 25 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_name2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_name2.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn pass(label paramName: Bool) { paramName }\", 0)"
+expression: "fn pass(label paramName: Bool) { paramName }"
 ---
+----- BEFORE ACTION
+fn pass(label paramName: Bool) { paramName }
+              ↑                             
+
+
+----- AFTER ACTION
 fn pass(label param_name: Bool) { paramName }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_name3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_parameter_name3.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let add = fn(numA: Int, num_b: Int) { numA + num_b }\n}\",\n    1)"
+expression: "pub fn main() {\n    let add = fn(numA: Int, num_b: Int) { numA + num_b }\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let add = fn(numA: Int, num_b: Int) { numA + num_b }
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑                           
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let add = fn(num_a: Int, num_b: Int) { numA + num_b }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_pattern_assignment.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_pattern_assignment.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let assert 42 as theAnswer = 42\n}\",\n    1)"
+expression: "pub fn main() {\n    let assert 42 as theAnswer = 42\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert 42 as theAnswer = 42
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert 42 as the_answer = 42
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_string_prefix_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_string_prefix_pattern.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(r#\"pub fn main() {\n    let assert \"prefix\" <> coolSuffix = \"prefix-suffix\"\n}\"#,\n    1)"
+expression: "pub fn main() {\n    let assert \"prefix\" <> coolSuffix = \"prefix-suffix\"\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert "prefix" <> coolSuffix = "prefix-suffix"
+                        ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑       
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert "prefix" <> cool_suffix = "prefix-suffix"
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_string_prefix_pattern_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_string_prefix_pattern_alias.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(r#\"pub fn main() {\n    let assert \"prefix\" as thePrefix <> _suffix = \"prefix-suffix\"\n}\"#,\n    1)"
+expression: "pub fn main() {\n    let assert \"prefix\" as thePrefix <> _suffix = \"prefix-suffix\"\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert "prefix" as thePrefix <> _suffix = "prefix-suffix"
+                ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑       
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert "prefix" as the_prefix <> _suffix = "prefix-suffix"
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_string_prefix_pattern_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_string_prefix_pattern_discard.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(r#\"pub fn main() {\n    let assert \"prefix\" <> _boringSuffix = \"prefix-suffix\"\n}\"#,\n    1)"
+expression: "pub fn main() {\n    let assert \"prefix\" <> _boringSuffix = \"prefix-suffix\"\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let assert "prefix" <> _boringSuffix = "prefix-suffix"
+                        ▔▔▔▔▔▔▔▔▔▔↑                       
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let assert "prefix" <> _boring_suffix = "prefix-suffix"
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_tuple_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_tuple_pattern.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let #(a, secondValue) = #(1, 2)\n}\",\n    1)"
+expression: "pub fn main() {\n    let #(a, secondValue) = #(1, 2)\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let #(a, secondValue) = #(1, 2)
+             ▔▔▔▔↑                 
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let #(a, second_value) = #(1, 2)
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_tuple_pattern_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_tuple_pattern_discard.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let #(a, _secondValue) = #(1, 2)\n}\",\n    1)"
+expression: "pub fn main() {\n    let #(a, _secondValue) = #(1, 2)\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let #(a, _secondValue) = #(1, 2)
+             ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑      
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let #(a, _second_value) = #(1, 2)
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_type_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_type_alias.snap
@@ -1,5 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"type Fancy_Bool = Bool\", 0)"
+expression: type Fancy_Bool = Bool
 ---
+----- BEFORE ACTION
+type Fancy_Bool = Bool
+      ▔▔▔▔▔▔▔▔▔▔↑     
+
+
+----- AFTER ACTION
 type FancyBool = Bool

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_use.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_use.snap
@@ -1,6 +1,13 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn use_test(f) { f(Nil) }\npub fn main() {use useVar <- use_test()}\",\n    1)"
+expression: "fn use_test(f) { f(Nil) }\npub fn main() {use useVar <- use_test()}"
 ---
+----- BEFORE ACTION
+fn use_test(f) { f(Nil) }
+pub fn main() {use useVar <- use_test()}
+               ▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑          
+
+
+----- AFTER ACTION
 fn use_test(f) { f(Nil) }
 pub fn main() {use use_var <- use_test()}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_use_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_use_discard.snap
@@ -1,6 +1,13 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"fn use_test(f) { f(Nil) }\npub fn main() {use _discardVar <- use_test()}\",\n    1)"
+expression: "fn use_test(f) { f(Nil) }\npub fn main() {use _discardVar <- use_test()}"
 ---
+----- BEFORE ACTION
+fn use_test(f) { f(Nil) }
+pub fn main() {use _discardVar <- use_test()}
+                             ↑               
+
+
+----- AFTER ACTION
 fn use_test(f) { f(Nil) }
 pub fn main() {use _discard_var <- use_test()}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_variable.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let theAnswer = 42\n}\", 1)"
+expression: "pub fn main() {\n    let theAnswer = 42\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let theAnswer = 42
+        ▔▔▔↑          
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let the_answer = 42
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_variable_discard.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_variable_discard.snap
@@ -1,7 +1,15 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "apply_first_code_action(\"pub fn main() {\n    let _boringNumber = 72\n}\", 1)"
+expression: "pub fn main() {\n    let _boringNumber = 72\n}"
 ---
+----- BEFORE ACTION
+pub fn main() {
+    let _boringNumber = 72
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
+}
+
+
+----- AFTER ACTION
 pub fn main() {
     let _boring_number = 72
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_with_labelled_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_with_labelled_constructor.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/signature_help.rs
+expression: "\npub type Pokemon {\n    Pokemon(name: String, types: List(String), moves: List(String))\n}\n\npub fn main() {\n    Pokemon(name: \"Jirachi\",)\n}\n    "
+---
+pub type Pokemon {
+    Pokemon(name: String, types: List(String), moves: List(String))
+}
+
+pub fn main() {
+    Pokemon(name: "Jirachi",)
+                            ↑
+}
+    
+
+
+----- Signature help -----
+Pokemon(name: String, types: List(String), moves: List(String)) -> Pokemon
+                      ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+No documentation

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -458,6 +458,7 @@ impl ValueConstructorVariant {
                 module: module_name.clone(),
                 documentation: None,
                 location: *location,
+                field_map: None,
             },
 
             Self::ModuleFn {
@@ -465,12 +466,14 @@ impl ValueConstructorVariant {
                 module,
                 location,
                 documentation,
+                field_map,
                 ..
             } => ModuleValueConstructor::Fn {
                 name: name.clone(),
                 module: module.clone(),
                 documentation: documentation.clone(),
                 location: *location,
+                field_map: field_map.clone(),
             },
         }
     }
@@ -555,6 +558,7 @@ pub enum ModuleValueConstructor {
         ///
         module: EcoString,
         name: EcoString,
+        field_map: Option<FieldMap>,
         documentation: Option<EcoString>,
     },
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2946,7 +2946,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                 ignored_labelled_args = args
                                     .iter()
                                     .skip_while(|arg| arg.label.is_none())
-                                    .map(|arg| (arg.label.clone(), arg.location.clone()))
+                                    .map(|arg| (arg.label.clone(), arg.location))
                                     .collect_vec();
                                 let args_to_keep = first_labelled_arg.unwrap_or(args.len());
                                 (


### PR DESCRIPTION
This PR:
- Adds an action to fill in the missing labelled arguments of a function call
  - It only works on calls that haven't been explicitly supplied args
  - It still plays nicely with pipes and the use syntax
- Fixes a bug where the LS would give the wrong signature hint for calls with labelled arguments
- Changes the code action snapshot:
  - Now the snapshots include the original code and highlight the selected code that triggered the action
  - All the tests have been rewritten to use the `PositionFinder` api to allow more granular control over the pieces of code to select to test if an action can be triggered. Before it was only possible to select entire lines