### PR TITLE
Fix formatting of internal definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,9 @@
   thus generating invalid JavaScript.
   ([Ameen Radwan](https://github.com/Acepie))
 
+- Fixed formatting of function definitions marked as `@internal`
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.3.2 - 2024-07-11
 
 ### Language Server

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6410,3 +6410,17 @@ fn discard_in_pipe_is_not_turned_into_shorthand_label() {
 "#
     );
 }
+
+// Bug found by Louis
+#[test]
+fn internal_attribute_does_not_change_formatting_of_a_function() {
+    assert_format!(
+        r#"@internal
+pub fn init(
+  start: #(SupervisorFlags, List(ChildSpecification)),
+) -> Result(#(Dynamic, Dynamic), never) {
+  todo
+}
+"#
+    );
+}


### PR DESCRIPTION
This PR fixes a bug with the formatting of internal definitions discovered by Louis:
```gleam
@internal
pub fn init(start: #(SupervisorFlags, List(ChildSpecification))) -> Result(
  #(Dynamic, Dynamic),
  never,
) {
  todo
}
```
Now if properly formatted into:
```gleam
@internal
pub fn init(
  start: #(SupervisorFlags, List(ChildSpecification)),
) -> Result(#(Dynamic, Dynamic), never) {
  todo
}
```