### PR TITLE
Support UTF-8 constants in patterns on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@
   expressions and patterns on the JavaScript target.
   ([Richard Viney](https://github.com/richard-viney))
 
+- The `utf8` option can now be used with constant strings in bit array patterns
+  on the JavaScript target.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ### Formatter
 
 - The formatter will no longer move a documentation comment below a regular

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -628,6 +628,27 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                                 }),
                             },
 
+                            [Opt::Utf8 { .. }] => match segment.value.as_ref() {
+                                Pattern::String { value, .. } => {
+                                    for byte in value.as_bytes() {
+                                        self.push_byte_at(offset.bytes);
+                                        self.push_equality_check(
+                                            subject.clone(),
+                                            EcoString::from(format!("0x{:X}", byte)).to_doc(),
+                                        );
+                                        self.pop();
+                                        offset.increment(1);
+                                    }
+
+                                    Ok(())
+                                }
+
+                                _ => Err(Error::Unsupported {
+                                    feature: "This bit array segment option in patterns".into(),
+                                    location: segment.location,
+                                }),
+                            },
+
                             _ => Err(Error::Unsupported {
                                 feature: "This bit array segment option in patterns".into(),
                                 location: segment.location,

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -188,6 +188,17 @@ fn go(x) {
 }
 
 #[test]
+fn match_utf8() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<"Gleam 👍":utf8>> = x
+}
+"#,
+    );
+}
+
+#[test]
 fn utf8_codepoint() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+assertion_line: 192
+expression: "\nfn go(x) {\n  let assert <<\"Gleam 👍\":utf8>> = x\n}\n"
+---
+import { makeError } from "../gleam.mjs";
+
+function go(x) {
+  if (
+    x.byteAt(0) !== 0x47 ||
+    x.byteAt(1) !== 0x6C ||
+    x.byteAt(2) !== 0x65 ||
+    x.byteAt(3) !== 0x61 ||
+    x.byteAt(4) !== 0x6D ||
+    x.byteAt(5) !== 0x20 ||
+    x.byteAt(6) !== 0xF0 ||
+    x.byteAt(7) !== 0x9F ||
+    x.byteAt(8) !== 0x91 ||
+    x.byteAt(9) !== 0x8D ||
+    !(x.length == 10)
+  ) {
+    throw makeError(
+      "assignment_no_match",
+      "my/mod",
+      3,
+      "go",
+      "Assignment pattern did not match",
+      { value: x }
+    )
+  }
+  return x;
+}

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -21,9 +21,9 @@ pub fn main() {
       suite("strings", strings_tests()),
       suite("equality", equality_tests()),
       suite("constants", constants_tests()),
-      suite("bit strings target", bit_array_target_tests()),
-      suite("bit strings", bit_array_tests()),
-      suite("sized bit strings", sized_bit_array_tests()),
+      suite("bit arrays target", bit_array_target_tests()),
+      suite("bit arrays", bit_array_tests()),
+      suite("sized bit arrays", sized_bit_array_tests()),
       suite("list spread", list_spread_tests()),
       suite("clause guards", clause_guard_tests()),
       suite("imported custom types", imported_custom_types_test()),
@@ -42,7 +42,7 @@ pub fn main() {
       suite("unicode overflow", unicode_overflow_tests()),
       suite("bool negation", bool_negation_tests()),
       suite("number negation", int_negation_tests()),
-      suite("bit string match", bit_array_match_tests()),
+      suite("bit array match", bit_array_match_tests()),
       suite("anonymous functions", anonymous_function_tests()),
       suite("string pattern matching", string_pattern_matching_tests()),
       suite("typescript file inclusion", typescript_file_included_tests()),
@@ -966,6 +966,8 @@ fn bit_array_tests() -> List(Test) {
     }),
     "<<\"abc\":utf8>> == <<97, 98, 99>>"
     |> example(fn() { assert_equal(True, <<"abc":utf8>> == <<97, 98, 99>>) }),
+    "<<\"😀\":utf8>> == <<\"\u{1F600}\":utf8>>"
+    |> example(fn() { assert_equal(True, <<"😀":utf8>> == <<"\u{1F600}":utf8>>) }),
     "<<<<1>>:bit_array, 2>> == <<1, 2>>"
     |> example(fn() { assert_equal(True, <<<<1>>:bits, 2>> == <<1, 2>>) }),
     "<<1>> == <<1:int>>"
@@ -986,16 +988,21 @@ fn bit_array_tests() -> List(Test) {
     |> example(fn() {
       assert_equal(True, <<63, 240, 0, 0, 0, 0, 0, 0>> == <<1.0:float-64-big>>)
     }),
+    "pattern match on bit array containing utf8"
+    |> example(fn() {
+      assert_equal(True, case <<0x20, "😀👍":utf8, 0x20>> {
+        <<" ":utf8, "😀👍":utf8, 0x20>> -> True
+        _ -> False
+      })
+    })
   ]
 }
 
 @target(erlang)
 fn bit_array_target_tests() -> List(Test) {
   [
-    "<<60,0>> == <<1.0:float-size(16)>>"
+    "<<60, 0>> == <<1.0:float-16>>"
     |> example(fn() { assert_equal(True, <<60, 0>> == <<1.0:float-16>>) }),
-    "<<\"😀\":utf8>> == <<\"\u{1F600}\":utf8>>"
-    |> example(fn() { assert_equal(True, <<"😀":utf8>> == <<"\u{1F600}":utf8>>) }),
   ]
 }
 


### PR DESCRIPTION
This change makes UTF-8 constants in patterns work on the JavaScript target, e.g.

```gleam
pub fn main() {
  let assert <<0x20, "AB":utf8, 0x20>> = <<0x20, 0x41, 0x42, 0x20>>

  case <<0x20, 0x41, 0x42, 0x20>> {
    <<0x20, "AB":utf8, 0x20>> -> io.println("matched")
    _ -> panic as "did not match"
  }
}
```