### PR TITLE
Make sure shorthand label code action triggers in all cases

### DIFF
--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -915,6 +915,11 @@ where
     for pattern in clause.pattern.iter() {
         v.visit_typed_pattern(pattern);
     }
+    for patterns in clause.alternative_patterns.iter() {
+        for pattern in patterns {
+            v.visit_typed_pattern(pattern);
+        }
+    }
     v.visit_typed_expr(&clause.then);
 }
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3,7 +3,10 @@ use std::{iter, sync::Arc};
 use crate::{
     ast::{
         self,
-        visit::{visit_typed_expr_call, Visit as _},
+        visit::{
+            visit_typed_call_arg, visit_typed_expr_call, visit_typed_pattern_call_arg,
+            visit_typed_record_update_arg, Visit as _,
+        },
         AssignName, AssignmentKind, CallArg, ImplicitCallArgOrigin, Pattern, SrcSpan, TypedExpr,
         TypedPattern, TypedRecordUpdateArg,
     },
@@ -481,6 +484,8 @@ impl<'ast> ast::visit::Visit<'ast> for LabelShorthandSyntax<'_> {
             }
             _ => (),
         }
+
+        visit_typed_call_arg(self, arg)
     }
 
     fn visit_typed_pattern_call_arg(&mut self, arg: &'ast CallArg<TypedPattern>) {
@@ -497,6 +502,8 @@ impl<'ast> ast::visit::Visit<'ast> for LabelShorthandSyntax<'_> {
             }
             _ => (),
         }
+
+        visit_typed_pattern_call_arg(self, arg)
     }
 
     fn visit_typed_record_update_arg(&mut self, arg: &'ast TypedRecordUpdateArg) {
@@ -513,6 +520,8 @@ impl<'ast> ast::visit::Visit<'ast> for LabelShorthandSyntax<'_> {
             }
             _ => (),
         }
+
+        visit_typed_record_update_arg(self, arg)
     }
 }
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1029,6 +1029,73 @@ pub fn wibble(arg1 arg1, arg2 arg2) { Nil }
     );
 }
 
+#[test]
+fn use_label_shorthand_works_for_nested_calls() {
+    assert_code_action!(
+        USE_LABEL_SHORTHAND_SYNTAX,
+        r#"
+pub fn wibble(arg arg: Int) -> Int { arg }
+
+pub fn main() {
+  let arg = 1
+  wibble(wibble(arg: arg))
+}
+ "#,
+        find_position_of("main").select_until(find_position_of("}").nth_occurrence(2)),
+    );
+}
+
+#[test]
+fn use_label_shorthand_works_for_nested_record_updates() {
+    assert_code_action!(
+        USE_LABEL_SHORTHAND_SYNTAX,
+        r#"
+pub type Wibble { Wibble(arg: Int, arg2: Wobble) }
+pub type Wobble { Wobble(arg: Int, arg2: String) }
+
+pub fn main() {
+  let arg = 1
+  let arg2 = "a"
+  Wibble(..todo, arg2: Wobble(arg: arg, arg2: arg2))
+}
+ "#,
+        find_position_of("todo").select_until(find_position_of("arg2: arg2")),
+    );
+}
+
+#[test]
+fn use_label_shorthand_works_for_nested_patterns() {
+    assert_code_action!(
+        USE_LABEL_SHORTHAND_SYNTAX,
+        r#"
+pub type Wibble { Wibble(arg: Int, arg2: Wobble) }
+pub type Wobble { Wobble(arg: Int, arg2: String) }
+
+pub fn main() {
+  let Wibble(arg2: Wobble(arg: arg, arg2: arg2), ..) = todo
+}
+ "#,
+        find_position_of("main").select_until(find_position_of("todo")),
+    );
+}
+
+#[test]
+fn use_label_shorthand_works_for_alternative_patterns() {
+    assert_code_action!(
+        USE_LABEL_SHORTHAND_SYNTAX,
+        r#"
+pub type Wibble { Wibble(arg: Int, arg2: String) }
+
+pub fn main() {
+  case Wibble(1, "wibble") {
+    Wibble(arg2: arg2, ..) | Wibble(arg: 1, arg2: arg2) -> todo
+  }
+}
+ "#,
+        find_position_of("main").select_until(find_position_of("todo")),
+    );
+}
+
 /* TODO: implement qualified unused location
 #[test]
 fn test_remove_unused_qualified_action() {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_alternative_patterns.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_alternative_patterns.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble { Wibble(arg: Int, arg2: String) }\n\npub fn main() {\n  case Wibble(1, \"wibble\") {\n    Wibble(arg2: arg2, ..) | Wibble(arg: 1, arg2: arg2) -> todo\n  }\n}\n "
+---
+----- BEFORE ACTION
+
+pub type Wibble { Wibble(arg: Int, arg2: String) }
+
+pub fn main() {
+       ▔▔▔▔▔▔▔▔
+  case Wibble(1, "wibble") {
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    Wibble(arg2: arg2, ..) | Wibble(arg: 1, arg2: arg2) -> todo
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+  }
+}
+ 
+
+
+----- AFTER ACTION
+
+pub type Wibble { Wibble(arg: Int, arg2: String) }
+
+pub fn main() {
+  case Wibble(1, "wibble") {
+    Wibble(arg2: , ..) | Wibble(arg: 1, arg2: ) -> todo
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_nested_calls.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_nested_calls.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn wibble(arg arg: Int) -> Int { arg }\n\npub fn main() {\n  let arg = 1\n  wibble(wibble(arg: arg))\n}\n "
+---
+----- BEFORE ACTION
+
+pub fn wibble(arg arg: Int) -> Int { arg }
+
+pub fn main() {
+       ▔▔▔▔▔▔▔▔
+  let arg = 1
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+  wibble(wibble(arg: arg))
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+}
+↑
+ 
+
+
+----- AFTER ACTION
+
+pub fn wibble(arg arg: Int) -> Int { arg }
+
+pub fn main() {
+  let arg = 1
+  wibble(wibble(arg: ))
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_nested_patterns.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_nested_patterns.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble { Wibble(arg: Int, arg2: Wobble) }\npub type Wobble { Wobble(arg: Int, arg2: String) }\n\npub fn main() {\n  let Wibble(arg2: Wobble(arg: arg, arg2: arg2), ..) = todo\n}\n "
+---
+----- BEFORE ACTION
+
+pub type Wibble { Wibble(arg: Int, arg2: Wobble) }
+pub type Wobble { Wobble(arg: Int, arg2: String) }
+
+pub fn main() {
+       ▔▔▔▔▔▔▔▔
+  let Wibble(arg2: Wobble(arg: arg, arg2: arg2), ..) = todo
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+}
+ 
+
+
+----- AFTER ACTION
+
+pub type Wibble { Wibble(arg: Int, arg2: Wobble) }
+pub type Wobble { Wobble(arg: Int, arg2: String) }
+
+pub fn main() {
+  let Wibble(arg2: Wobble(arg: , arg2: ), ..) = todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_nested_record_updates.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__use_label_shorthand_works_for_nested_record_updates.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble { Wibble(arg: Int, arg2: Wobble) }\npub type Wobble { Wobble(arg: Int, arg2: String) }\n\npub fn main() {\n  let arg = 1\n  let arg2 = \"a\"\n  Wibble(..todo, arg2: Wobble(arg: arg, arg2: arg2))\n}\n "
+---
+----- BEFORE ACTION
+
+pub type Wibble { Wibble(arg: Int, arg2: Wobble) }
+pub type Wobble { Wobble(arg: Int, arg2: String) }
+
+pub fn main() {
+  let arg = 1
+  let arg2 = "a"
+  Wibble(..todo, arg2: Wobble(arg: arg, arg2: arg2))
+           ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑           
+}
+ 
+
+
+----- AFTER ACTION
+
+pub type Wibble { Wibble(arg: Int, arg2: Wobble) }
+pub type Wobble { Wobble(arg: Int, arg2: String) }
+
+pub fn main() {
+  let arg = 1
+  let arg2 = "a"
+  Wibble(..todo, arg2: Wobble(arg: , arg2: ))
+}


### PR DESCRIPTION
I was testing the compiler on one of my projects and noticed the "Use label shorthands" action didn't work properly for:
- nested calls `wibble(wibble(arg: arg))`
- nested record updates `Wibble(..todo, arg: Wibble(..todo, arg: arg))`
- nested patterns `Ok(Wibble(arg: arg))`
- alternative patterns `Wibble(arg: arg) | Wibble(arg: arg)`

I've fixed all those bugs and now it should work for all possible cases!