### PR TITLE
right-align and restyle opaque tag

### DIFF
--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -532,16 +532,13 @@ body.drawer-open .label-closed {
 }
 
 .visibility-tag {
-  background-color: var(--bg-shade-2);
+  background-color: var(--bg-shade-3);
   color: var(--text);
-  padding: 2px 6px;
+  padding: 0px 6px 4px;
   border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: var(--fg-shade-2);
   font-size: 0.9em;
-  margin-left: 8px;
-  float: right;
+  margin-left: auto;
+  line-height: normal;
 }
 
 /* Custom type constructors */


### PR DESCRIPTION
small and simple PR! this just right aligns the `opaque` tag for generated documentation. I've also removed the border and darkened the background to keep it standing out but make it a bit less intense, since it is not something that needs to be so in-your-face. This fixes #3340 

![Pasted image](https://github.com/user-attachments/assets/2b89c282-e6b4-43a5-b766-fef139f2c103)
