### PR TITLE
Fix record constructors in guards using non-aliased names in JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,11 @@
 - Fixed formatting of function definitions marked as `@internal`
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where importing a record constructor in an unqualified fashion and
+  aliasing it and then using it in a case guard expression would generate
+  invalid JavaScript.
+  ([PgBiel](https://github.com/PgBiel))
+
 ## v1.3.2 - 2024-07-11
 
 ### Language Server

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1287,10 +1287,11 @@ pub(crate) fn guard_constant_expression<'a>(
         Constant::Record { typ, .. } if typ.is_nil() => Ok("undefined".to_doc()),
 
         Constant::Record {
-            tag,
-            typ,
             args,
             module,
+            name,
+            tag,
+            typ,
             ..
         } => {
             if typ.is_result() {
@@ -1304,7 +1305,7 @@ pub(crate) fn guard_constant_expression<'a>(
                 .iter()
                 .map(|arg| guard_constant_expression(assignments, tracker, &arg.value))
                 .try_collect()?;
-            Ok(construct_record(module.as_deref(), tag, field_values))
+            Ok(construct_record(module.as_deref(), name, field_values))
         }
 
         Constant::BitArray { segments, .. } => bit_array(tracker, segments, |tracker, constant| {

--- a/compiler-core/src/javascript/tests/case_clause_guards.rs
+++ b/compiler-core/src/javascript/tests/case_clause_guards.rs
@@ -468,3 +468,52 @@ fn not_two() {
 "#,
     );
 }
+
+#[test]
+fn custom_type_constructor_imported_and_aliased() {
+    assert_js!(
+        ("package", "other_module", "pub type T { A }"),
+        r#"import other_module.{A as B}
+fn func() {
+  case B {
+    x if x == B -> True
+    _ -> False
+  }
+}
+"#,
+    );
+}
+
+#[test]
+fn imported_aliased_ok() {
+    assert_js!(
+        r#"import gleam.{Ok as Y}
+pub type X {
+  Ok
+}
+fn func() {
+  case Y {
+    y if y == Y -> True
+    _ -> False
+  }
+}
+"#,
+    );
+}
+
+#[test]
+fn imported_ok() {
+    assert_js!(
+        r#"import gleam
+pub type X {
+  Ok
+}
+fn func(x) {
+  case gleam.Ok {
+    _ if [] == [ gleam.Ok ] -> True
+    _ -> False
+  }
+}
+"#,
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__custom_type_constructor_imported_and_aliased.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__custom_type_constructor_imported_and_aliased.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/case_clause_guards.rs
+expression: "import other_module.{A as B}\nfn func() {\n  case B {\n    x if x == B -> True\n    _ -> False\n  }\n}\n"
+---
+import * as $other_module from "../../package/other_module.mjs";
+import { A as B } from "../../package/other_module.mjs";
+import { isEqual } from "../gleam.mjs";
+
+function func() {
+  let $ = new B();
+  if (isEqual($, new B())) {
+    let x = $;
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_aliased_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_aliased_ok.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/javascript/tests/case_clause_guards.rs
+expression: "import gleam.{Ok as Y}\npub type X {\n  Ok\n}\nfn func() {\n  case Y {\n    y if y == Y -> True\n    _ -> False\n  }\n}\n"
+---
+import * as $gleam from "../gleam.mjs";
+import { Ok as Y, CustomType as $CustomType, isEqual } from "../gleam.mjs";
+
+export class Ok extends $CustomType {}
+
+function func() {
+  let $ = (var0) => { return new Y(var0); };
+  if (isEqual($, new Y())) {
+    let y = $;
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/case_clause_guards.rs
+expression: "import gleam\npub type X {\n  Ok\n}\nfn func(x) {\n  case gleam.Ok {\n    _ if [] == [ gleam.Ok ] -> True\n    _ -> False\n  }\n}\n"
+---
+import * as $gleam from "../gleam.mjs";
+import { toList, CustomType as $CustomType, isEqual } from "../gleam.mjs";
+
+export class Ok extends $CustomType {}
+
+function func(x) {
+  let $ = (var0) => { return new $gleam.Ok(var0); };
+  if (isEqual(toList([]), toList([new $gleam.Ok()]))) {
+    return true;
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
It appears the fix for https://github.com/gleam-lang/gleam/issues/3294 was incomplete (only fixed aliased constructors in top-level constants, not in guards). This PR fixes this.