### PR TITLE
Fix confusing `There must be a let to bind variable to value` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   produce the correct location, but remain in the same file.
   ([Surya Rose](https://github.com/gearsdatapacks))
 
+- Fixed a bug where incorrect syntax error message were shown,
+  when using `:` or `=` in wrong possitions in expressions.
+
 ## v1.4.1 - 2024-08-04
 
 ### Bug Fixes

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -996,7 +996,7 @@ where
         // Better error: name definitions must start with `let`
         if let Some((_, Token::Name { .. }, _)) = self.tok0.as_ref() {
             match self.tok1 {
-                Some((start, Token::Equal, end)) | Some((start, Token::Colon, end)) => {
+                Some((start, Token::Equal | Token::Colon, end)) => {
                     return parse_error(ParseErrorType::NoLetBinding, SrcSpan { start, end })
                 }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -995,12 +995,8 @@ where
     fn parse_statement_errors(&mut self) -> Result<(), ParseError> {
         // Better error: name definitions must start with `let`
         if let Some((_, Token::Name { .. }, _)) = self.tok0.as_ref() {
-            match self.tok1 {
-                Some((start, Token::Equal | Token::Colon, end)) => {
-                    return parse_error(ParseErrorType::NoLetBinding, SrcSpan { start, end })
-                }
-
-                _ => (),
+            if let Some((start, Token::Equal | Token::Colon, end)) = self.tok1 {
+                return parse_error(ParseErrorType::NoLetBinding, SrcSpan { start, end });
             }
         }
         Ok(())

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -994,7 +994,7 @@ where
 
     fn parse_statement_errors(&mut self) -> Result<(), ParseError> {
         // Better error: name definitions must start with `let`
-        if let Some((start, Token::Name { .. }, end)) = self.tok0.as_ref() {
+        if let Some((_, Token::Name { .. }, _)) = self.tok0.as_ref() {
             match self.tok1 {
                 Some((start, Token::Equal, end)) | Some((start, Token::Colon, end)) => {
                     return parse_error(ParseErrorType::NoLetBinding, SrcSpan { start, end })

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand.snap
@@ -6,7 +6,7 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:10
   │
 3 │   wibble(:)
-  │          ^ There must be a 'let' to bind variable to value
+  │          ^ I was not expecting this
 
-Hint: Use let for binding.
-See: https://tour.gleam.run/basics/assignments/
+Found `:`, expected one of: 
+- `)`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_2.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_2.snap
@@ -6,7 +6,7 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:10
   │
 3 │   wibble(:,)
-  │          ^ There must be a 'let' to bind variable to value
+  │          ^ I was not expecting this
 
-Hint: Use let for binding.
-See: https://tour.gleam.run/basics/assignments/
+Found `:`, expected one of: 
+- `)`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_3.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_3.snap
@@ -6,7 +6,7 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:10
   │
 3 │   wibble(:arg)
-  │          ^ There must be a 'let' to bind variable to value
+  │          ^ I was not expecting this
 
-Hint: Use let for binding.
-See: https://tour.gleam.run/basics/assignments/
+Found `:`, expected one of: 
+- `)`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_4.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_4.snap
@@ -6,7 +6,7 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:14
   │
 3 │   wibble(arg::)
-  │              ^ There must be a 'let' to bind variable to value
+  │              ^ I was not expecting this
 
-Hint: Use let for binding.
-See: https://tour.gleam.run/basics/assignments/
+Found `:`, expected one of: 
+- `)`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_5.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_label_shorthand_5.snap
@@ -6,7 +6,7 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:14
   │
 3 │   wibble(arg::arg)
-  │              ^ There must be a 'let' to bind variable to value
+  │              ^ I was not expecting this
 
-Hint: Use let for binding.
-See: https://tour.gleam.run/basics/assignments/
+Found `:`, expected one of: 
+- `)`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3.snap
@@ -1,0 +1,55 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "let assert [x] = [2]"
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 0,
+                end: 20,
+            },
+            value: List {
+                location: SrcSpan {
+                    start: 17,
+                    end: 20,
+                },
+                elements: [
+                    Int {
+                        location: SrcSpan {
+                            start: 18,
+                            end: 19,
+                        },
+                        value: "2",
+                    },
+                ],
+                tail: None,
+            },
+            pattern: List {
+                location: SrcSpan {
+                    start: 11,
+                    end: 14,
+                },
+                elements: [
+                    Variable {
+                        location: SrcSpan {
+                            start: 12,
+                            end: 13,
+                        },
+                        name: "x",
+                        type_: (),
+                    },
+                ],
+                tail: None,
+                type_: (),
+            },
+            kind: Assert {
+                location: SrcSpan {
+                    start: 4,
+                    end: 10,
+                },
+            },
+            annotation: None,
+        },
+    ),
+]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
@@ -1,0 +1,79 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "let assert [x]: List(Int) = [2]"
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 0,
+                end: 31,
+            },
+            value: List {
+                location: SrcSpan {
+                    start: 28,
+                    end: 31,
+                },
+                elements: [
+                    Int {
+                        location: SrcSpan {
+                            start: 29,
+                            end: 30,
+                        },
+                        value: "2",
+                    },
+                ],
+                tail: None,
+            },
+            pattern: List {
+                location: SrcSpan {
+                    start: 11,
+                    end: 14,
+                },
+                elements: [
+                    Variable {
+                        location: SrcSpan {
+                            start: 12,
+                            end: 13,
+                        },
+                        name: "x",
+                        type_: (),
+                    },
+                ],
+                tail: None,
+                type_: (),
+            },
+            kind: Assert {
+                location: SrcSpan {
+                    start: 4,
+                    end: 10,
+                },
+            },
+            annotation: Some(
+                Constructor(
+                    TypeAstConstructor {
+                        location: SrcSpan {
+                            start: 16,
+                            end: 25,
+                        },
+                        module: None,
+                        name: "List",
+                        arguments: [
+                            Constructor(
+                                TypeAstConstructor {
+                                    location: SrcSpan {
+                                        start: 21,
+                                        end: 24,
+                                    },
+                                    module: None,
+                                    name: "Int",
+                                    arguments: [],
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+        },
+    ),
+]

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -433,6 +433,17 @@ fn no_let_binding3() {
 }
 
 #[test]
+fn with_let_binding3() {
+    // The same with `let assert` must parse:
+    assert_parse!("let assert [x] = [2]");
+}
+
+#[test]
+fn with_let_binding3_and_annotation() {
+    assert_parse!("let assert [x]: List(Int) = [2]");
+}
+
+#[test]
 fn no_eq_after_binding() {
     assert_error!(
         "let wibble",

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -427,11 +427,7 @@ fn no_let_binding3() {
         "[x] = [2]",
         ParseError {
             location: SrcSpan { start: 4, end: 5 },
-            error: ParseErrorType::UnexpectedToken {
-                token: Token::Equal,
-                expected: vec!["An import, const, type, or function.".into()],
-                hint: None,
-            },
+            error: ParseErrorType::NoLetBinding
         }
     );
 }

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -343,8 +343,8 @@ fn triple_equals_with_whitespace() {
         "let wobble:Int = 32
         wobble ==     = 42",
         ParseError {
-            error: ParseErrorType::NoLetBinding,
-            location: SrcSpan { start: 42, end: 43 },
+            error: ParseErrorType::OpNakedRight,
+            location: SrcSpan { start: 35, end: 37 },
         }
     );
 }
@@ -427,7 +427,11 @@ fn no_let_binding3() {
         "[x] = [2]",
         ParseError {
             location: SrcSpan { start: 4, end: 5 },
-            error: ParseErrorType::NoLetBinding
+            error: ParseErrorType::UnexpectedToken {
+                token: Token::Equal,
+                expected: vec!["An import, const, type, or function.".into()],
+                hint: None,
+            },
         }
     );
 }


### PR DESCRIPTION
I don't think that it was safe to check for `:` and `=` in expression parsing. We should instead validate statements that look like assignments start with `let`.

Instead `wobble(:)` now generates `I was not expecting this`, which is expected by me 😆 

Closes https://github.com/gleam-lang/gleam/issues/3424