### PR TITLE
Report bad name errors for type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed a bug where pipe function arity errors could have an incorrect error
   message.
+  ([sobolevn](https://github.com/sobolevn))
+
+- Fixed a bug where the case of type parameters would not be checked.
+  ([Surya Rose](https://github.com/gearsdatapacks))
 
 ## v1.4.0-rc1 - 2024-07-29
 

--- a/compiler-core/src/analyse/name.rs
+++ b/compiler-core/src/analyse/name.rs
@@ -45,10 +45,13 @@ fn valid_upname(name: &EcoString) -> bool {
 
 pub fn check_name_case(location: SrcSpan, name: &EcoString, kind: Named) -> Result<(), Error> {
     let valid = match kind {
-        Named::Type | Named::TypeVariable | Named::CustomTypeVariant => valid_upname(name),
-        Named::Variable | Named::Argument | Named::Label | Named::Constant | Named::Function => {
-            valid_name(name)
-        }
+        Named::Type | Named::TypeAlias | Named::CustomTypeVariant => valid_upname(name),
+        Named::Variable
+        | Named::TypeVariable
+        | Named::Argument
+        | Named::Label
+        | Named::Constant
+        | Named::Function => valid_name(name),
         Named::Discard => valid_discard_name(name),
     };
 
@@ -65,12 +68,15 @@ pub fn check_name_case(location: SrcSpan, name: &EcoString, kind: Named) -> Resu
 
 pub fn correct_name_case(location: SrcSpan, name: &EcoString, kind: Named) -> NameCorrection {
     let correction = match kind {
-        Named::Type | Named::TypeVariable | Named::CustomTypeVariant => {
+        Named::Type | Named::TypeAlias | Named::CustomTypeVariant => {
             name.to_upper_camel_case().into()
         }
-        Named::Variable | Named::Argument | Named::Label | Named::Constant | Named::Function => {
-            name.to_snake_case().into()
-        }
+        Named::Variable
+        | Named::TypeVariable
+        | Named::Argument
+        | Named::Label
+        | Named::Constant
+        | Named::Function => name.to_snake_case().into(),
         Named::Discard => eco_format!("_{}", name.to_snake_case()),
     };
     NameCorrection {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -743,7 +743,7 @@ pub struct CustomType<T> {
     pub deprecation: Deprecation,
     pub opaque: bool,
     /// The names of the type parameters.
-    pub parameters: Vec<EcoString>,
+    pub parameters: Vec<(SrcSpan, EcoString)>,
     /// Once type checked this field will contain the type information for the
     /// type parameters.
     pub typed_parameters: Vec<T>,
@@ -773,7 +773,7 @@ pub struct TypeAlias<T> {
     pub location: SrcSpan,
     pub alias: EcoString,
     pub name_location: SrcSpan,
-    pub parameters: Vec<EcoString>,
+    pub parameters: Vec<(SrcSpan, EcoString)>,
     pub type_ast: TypeAst,
     pub type_: T,
     pub publicity: Publicity,

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -139,7 +139,6 @@ fn compile_expression(src: &str) -> TypedStatement {
         },
     );
     let mut problems = Problems::new();
-    let name_corrections = &mut vec![];
     ExprTyper::new(
         &mut environment,
         FunctionDefinition {
@@ -148,7 +147,6 @@ fn compile_expression(src: &str) -> TypedStatement {
             has_javascript_external: false,
         },
         &mut problems,
-        name_corrections,
     )
     .infer_statements(ast)
     .first()

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -56,7 +56,6 @@ fn write_cache(
         values: Default::default(),
         accessors: Default::default(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         line_numbers: line_numbers.clone(),
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2956,10 +2956,11 @@ See: https://tour.gleam.run/advanced-features/use/");
                     let label = format!("This is not a valid {kind_str} name");
                     let text = match kind {
                         Named::Type |
-                        Named::TypeVariable |
+                        Named::TypeAlias |
                         Named::CustomTypeVariant => wrap_format!("Hint: {} names start with an uppercase letter and contain only lowercase letters, numbers, and uppercase letters.
 Try: {}", kind_str.to_title_case(), name.to_upper_camel_case()),
                         Named::Variable |
+                        Named::TypeVariable |
                         Named::Argument |
                         Named::Label |
                         Named::Constant  |

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -704,7 +704,7 @@ impl<'comments> Formatter<'comments> {
         &mut self,
         publicity: Publicity,
         name: &'a str,
-        args: &'a [EcoString],
+        args: &'a [(SrcSpan, EcoString)],
         typ: &'a TypeAst,
         deprecation: &'a Deprecation,
         location: &SrcSpan,
@@ -718,7 +718,7 @@ impl<'comments> Formatter<'comments> {
         let head = if args.is_empty() {
             head
         } else {
-            let args = args.iter().map(|e| e.to_doc()).collect_vec();
+            let args = args.iter().map(|(_, e)| e.to_doc()).collect_vec();
             head.append(self.wrap_args(args, location.end).group())
         };
 
@@ -1605,7 +1605,7 @@ impl<'comments> Formatter<'comments> {
             .append(if ct.parameters.is_empty() {
                 Document::EcoString(ct.name.clone())
             } else {
-                let args = ct.parameters.iter().map(|e| e.to_doc()).collect_vec();
+                let args = ct.parameters.iter().map(|(_, e)| e.to_doc()).collect_vec();
                 Document::EcoString(ct.name.clone())
                     .append(self.wrap_args(args, ct.location.end))
                     .group()
@@ -1640,7 +1640,7 @@ impl<'comments> Formatter<'comments> {
         &mut self,
         publicity: Publicity,
         name: &'a str,
-        args: &'a [EcoString],
+        args: &'a [(SrcSpan, EcoString)],
         location: &'a SrcSpan,
     ) -> Document<'a> {
         let _ = self.pop_empty_lines(location.start);
@@ -1652,7 +1652,7 @@ impl<'comments> Formatter<'comments> {
             .append(if args.is_empty() {
                 name.to_doc()
             } else {
-                let args = args.iter().map(|e| e.to_doc()).collect_vec();
+                let args = args.iter().map(|(_, e)| e.to_doc()).collect_vec();
                 name.to_doc().append(self.wrap_args(args, location.end))
             })
     }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -640,6 +640,24 @@ fn rename_invalid_case_variable_discard() {
 }
 
 #[test]
+fn rename_invalid_type_parameter_name() {
+    assert_code_action!(
+        "Rename to inner_type",
+        "type Wrapper(innerType) {}",
+        find_position_of("innerType").select_until(find_position_of(")"))
+    );
+}
+
+#[test]
+fn rename_invalid_type_alias_parameter_name() {
+    assert_code_action!(
+        "Rename to phantom_type",
+        "type Phantom(phantomType) = Int",
+        find_position_of("phantomType").select_until(find_position_of(")"))
+    );
+}
+
+#[test]
 fn test_convert_assert_result_to_case() {
     assert_code_action!(
         CONVERT_TO_CASE,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -658,6 +658,15 @@ fn rename_invalid_type_alias_parameter_name() {
 }
 
 #[test]
+fn rename_invalid_function_type_parameter_name() {
+    assert_code_action!(
+        "Rename to some_type",
+        "fn identity(value: someType) { value }",
+        find_position_of("someType").select_until(find_position_of(")"))
+    );
+}
+
+#[test]
 fn test_convert_assert_result_to_case() {
     assert_code_action!(
         CONVERT_TO_CASE,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_function_type_parameter_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_function_type_parameter_name.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "fn identity(value: someType) { value }"
+---
+----- BEFORE ACTION
+fn identity(value: someType) { value }
+                   ▔▔▔▔▔▔▔▔↑          
+
+
+----- AFTER ACTION
+fn identity(value: some_type) { value }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_type_alias_parameter_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_type_alias_parameter_name.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: type Phantom(phantomType) = Int
+---
+----- BEFORE ACTION
+type Phantom(phantomType) = Int
+             ▔▔▔▔▔▔▔▔▔▔▔↑      
+
+
+----- AFTER ACTION
+type Phantom(phantom_type) = Int

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_type_parameter_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__rename_invalid_type_parameter_name.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "type Wrapper(innerType) {}"
+---
+----- BEFORE ACTION
+type Wrapper(innerType) {}
+             ▔▔▔▔▔▔▔▔▔↑   
+
+
+----- AFTER ACTION
+type Wrapper(inner_type) {}

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -79,7 +79,6 @@ impl ModuleDecoder {
             ),
             accessors: read_hashmap!(reader.get_accessors()?, self, accessors_map),
             unused_imports: read_vec!(reader.get_unused_imports()?, self, src_span),
-            name_corrections: Vec::new(),
             line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
             src_path: reader.get_src_path()?.into(),
             warnings: vec![],

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -38,7 +38,6 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -94,7 +93,6 @@ fn empty_module() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -114,7 +112,6 @@ fn with_line_numbers() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(
             "const a = 1
@@ -150,7 +147,6 @@ fn module_with_private_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -172,7 +168,6 @@ fn module_with_unused_import() {
             SrcSpan { start: 0, end: 10 },
             SrcSpan { start: 13, end: 42 },
         ],
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
@@ -205,7 +200,6 @@ fn module_with_app_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -237,7 +231,6 @@ fn module_with_fn_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -269,7 +262,6 @@ fn module_with_tuple_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -307,7 +299,6 @@ fn module_with_generic_type() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
-            name_corrections: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -345,7 +336,6 @@ fn module_with_type_links() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
-            name_corrections: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -383,7 +373,6 @@ fn module_with_type_constructor_documentation() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
-            name_corrections: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -424,7 +413,6 @@ fn module_with_type_constructor_origin() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
-            name_corrections: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -455,7 +443,6 @@ fn module_type_to_constructors_mapping() {
         )]
         .into(),
         unused_imports: Default::default(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
@@ -475,7 +462,6 @@ fn module_fn_value() {
         name: "a".into(),
         types: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         types_value_constructors: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
@@ -522,7 +508,6 @@ fn deprecated_module_fn_value() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -569,7 +554,6 @@ fn private_module_fn_value() {
         name: "a".into(),
         types: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         types_value_constructors: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
@@ -618,7 +602,6 @@ fn module_fn_value_regression() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -665,7 +648,6 @@ fn module_fn_value_with_field_map() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -714,7 +696,6 @@ fn record_value() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -758,7 +739,6 @@ fn record_value_with_field_map() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -804,7 +784,6 @@ fn accessors() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: [
             (
                 "one".into(),
@@ -1018,7 +997,6 @@ fn constant_var() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [
             (
@@ -1254,7 +1232,6 @@ fn deprecated_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -1273,7 +1250,6 @@ fn module_fn_value_with_external_implementations() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -1320,7 +1296,6 @@ fn internal_module_fn() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -1387,7 +1362,6 @@ fn type_variable_ids_in_constructors_are_shared() {
             },
         )]),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         accessors: HashMap::new(),
         values: [].into(),
         line_numbers: LineNumbers::new(""),

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -141,6 +141,8 @@ impl Attributes {
     }
 }
 
+type SpannedString = (SrcSpan, EcoString);
+
 //
 // Public Interface
 //
@@ -2122,7 +2124,7 @@ where
     //   A(one, two)
     fn expect_type_name(
         &mut self,
-    ) -> Result<(u32, EcoString, Vec<(SrcSpan, EcoString)>, u32, u32), ParseError> {
+    ) -> Result<(u32, EcoString, Vec<SpannedString>, u32, u32), ParseError> {
         let (start, upname, end) = self.expect_upname()?;
         if self.maybe_one(&Token::LeftParen).is_some() {
             let args =

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2122,13 +2122,16 @@ where
     //   A(one, two)
     fn expect_type_name(
         &mut self,
-    ) -> Result<(u32, EcoString, Vec<EcoString>, u32, u32), ParseError> {
+    ) -> Result<(u32, EcoString, Vec<(SrcSpan, EcoString)>, u32, u32), ParseError> {
         let (start, upname, end) = self.expect_upname()?;
         if self.maybe_one(&Token::LeftParen).is_some() {
             let args =
                 Parser::series_of(self, &|p| Ok(Parser::maybe_name(p)), Some(&Token::Comma))?;
             let (_, par_e) = self.expect_one_following_series(&Token::RightParen, "a name")?;
-            let args2 = args.into_iter().map(|(_, a, _)| a).collect();
+            let args2 = args
+                .into_iter()
+                .map(|(start, name, end)| (SrcSpan { start, end }, name))
+                .collect();
             Ok((start, upname, args2, par_e, end))
         } else {
             Ok((start, upname, vec![], end, end))

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -644,13 +644,13 @@ pub struct TypeVariantConstructors {
 impl TypeVariantConstructors {
     pub(crate) fn new(
         variants: Vec<TypeValueConstructor>,
-        type_parameters: &[EcoString],
+        type_parameters: &[&EcoString],
         hydrator: Hydrator,
     ) -> TypeVariantConstructors {
         let named_types = hydrator.named_type_variables();
         let type_parameters = type_parameters
             .iter()
-            .map(|p| {
+            .map(|&p| {
                 let t = named_types
                     .get(p)
                     .expect("Type parameter not found in hydrator");

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -21,7 +21,6 @@ pub use prelude::*;
 use serde::Serialize;
 
 use crate::{
-    analyse::name::NameCorrection,
     ast::{
         ArgNames, BitArraySegment, CallArg, Constant, DefinitionLocation, Pattern, Publicity,
         SrcSpan, TypedConstant, TypedExpr, TypedPattern, TypedPatternBitArraySegment,
@@ -602,7 +601,6 @@ pub struct ModuleInterface {
     pub values: HashMap<EcoString, ValueConstructor>,
     pub accessors: HashMap<EcoString, AccessorsMap>,
     pub unused_imports: Vec<SrcSpan>,
-    pub name_corrections: Vec<NameCorrection>,
     /// Used for mapping to original source locations on disk
     pub line_numbers: LineNumbers,
     /// Used for determining the source path of the module on disk
@@ -700,7 +698,6 @@ impl ModuleInterface {
             values: Default::default(),
             accessors: Default::default(),
             unused_imports: Default::default(),
-            name_corrections: Default::default(),
             is_internal: false,
             line_numbers,
             src_path,

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -508,6 +508,7 @@ pub enum LiteralCollectionKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Named {
     Type,
+    TypeAlias,
     TypeVariable,
     CustomTypeVariant,
     Variable,
@@ -522,7 +523,8 @@ impl Named {
     pub fn as_str(self) -> &'static str {
         match self {
             Named::Type => "type",
-            Named::TypeVariable => "type alias",
+            Named::TypeAlias => "type alias",
+            Named::TypeVariable => "type variable",
             Named::CustomTypeVariant => "type variant",
             Named::Variable => "variable",
             Named::Argument => "argument",

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::ast::{
-    Layer, TypeAst, TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar,
+use crate::{
+    analyse::name::check_name_case,
+    ast::{Layer, TypeAst, TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar},
 };
 use std::sync::Arc;
 
@@ -211,6 +212,9 @@ impl Hydrator {
                     }
 
                     None if self.permit_new_type_variables => {
+                        if let Err(error) = check_name_case(*location, name, Named::TypeVariable) {
+                            problems.error(error);
+                        }
                         let t = environment.new_generic_var();
                         let _ = self
                             .rigid_type_names

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -6,10 +6,7 @@ use itertools::Itertools;
 ///
 use super::*;
 use crate::{
-    analyse::{
-        name::{check_name_case, correct_name_case, NameCorrection},
-        Inferred,
-    },
+    analyse::{name::check_name_case, Inferred},
     ast::{AssignName, ImplicitCallArgOrigin, Layer, UntypedPatternBitArraySegment},
 };
 use std::sync::Arc;
@@ -20,7 +17,6 @@ pub struct PatternTyper<'a, 'b> {
     mode: PatternMode,
     initial_pattern_vars: HashSet<EcoString>,
     problems: &'a mut Problems,
-    name_corrections: &'a mut Vec<NameCorrection>,
 }
 
 enum PatternMode {
@@ -33,7 +29,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
         environment: &'a mut Environment<'b>,
         hydrator: &'a Hydrator,
         problems: &'a mut Problems,
-        name_corrections: &'a mut Vec<NameCorrection>,
     ) -> Self {
         Self {
             environment,
@@ -41,7 +36,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             mode: PatternMode::Initial,
             initial_pattern_vars: HashSet::new(),
             problems,
-            name_corrections,
         }
     }
 
@@ -684,8 +678,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
     fn check_name_case(&mut self, location: SrcSpan, name: &EcoString, kind: Named) {
         if let Err(error) = check_name_case(location, name, kind) {
             self.problems.error(error);
-            self.name_corrections
-                .push(correct_name_case(location, name, kind));
         }
     }
 }

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -210,7 +210,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         values: HashMap::new(),
         accessors: HashMap::new(),
         unused_imports: Vec::new(),
-        name_corrections: Vec::new(),
         is_internal: false,
         warnings: vec![],
         // prelude doesn't have real src

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -259,7 +259,6 @@ fn compile_statement_sequence(
     // place.
     let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
     let mut problems = Problems::new();
-    let name_corrections = &mut vec![];
     let res = ExprTyper::new(
         &mut Environment::new(
             ids,
@@ -275,7 +274,6 @@ fn compile_statement_sequence(
             has_javascript_external: false,
         },
         &mut problems,
-        name_corrections,
     )
     .infer_statements(ast);
     match Vec1::try_from_vec(problems.take_errors()) {
@@ -718,7 +716,6 @@ fn infer_module_type_retention_test() {
             values: HashMap::new(),
             accessors: HashMap::new(),
             unused_imports: Vec::new(),
-            name_corrections: Vec::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "".into(),
         }

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1358,6 +1358,11 @@ fn invalid_type_alias_parameter_name() {
 }
 
 #[test]
+fn invalid_function_type_parameter_name() {
+    assert_module_error!("fn identity(value: someType) { value }");
+}
+
+#[test]
 fn correct_pipe_arity_error_location() {
     // https://github.com/gleam-lang/gleam/issues/672
     assert_module_error!(

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1348,6 +1348,16 @@ fn invalid_case_variable_discard_name() {
 }
 
 #[test]
+fn invalid_type_parameter_name() {
+    assert_module_error!("type Wrapper(innerType) {}");
+}
+
+#[test]
+fn invalid_type_alias_parameter_name() {
+    assert_module_error!("type GleamOption(okType) = Result(okType, Nil)");
+}
+
+#[test]
 fn correct_pipe_arity_error_location() {
     // https://github.com/gleam-lang/gleam/issues/672
     assert_module_error!(

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__duplicate_variable_error_does_not_stop_analysis.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__duplicate_variable_error_does_not_stop_analysis.snap
@@ -3,19 +3,19 @@ source: compiler-core/src/type_/tests/custom_types.rs
 expression: "\ntype Two(a, a) {\n  Two(a, a)\n}\n\ntype Three(a, a) {\n  Three\n}\n"
 ---
 error: Duplicate type parameter
-  ┌─ /src/one/two.gleam:2:1
+  ┌─ /src/one/two.gleam:2:13
   │
 2 │ type Two(a, a) {
-  │ ^^^^^^^^^^^^^^
+  │             ^
 
 This definition has multiple type parameters named `a`.
 Rename or remove one of them.
 
 error: Duplicate type parameter
-  ┌─ /src/one/two.gleam:6:1
+  ┌─ /src/one/two.gleam:6:15
   │
 6 │ type Three(a, a) {
-  │ ^^^^^^^^^^^^^^^^
+  │               ^
 
 This definition has multiple type parameters named `a`.
 Rename or remove one of them.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_type_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_type_parameter_name.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "fn identity(value: someType) { value }"
+---
+error: Invalid type variable name
+  ┌─ /src/one/two.gleam:1:20
+  │
+1 │ fn identity(value: someType) { value }
+  │                    ^^^^^^^^ This is not a valid type variable name
+
+Hint: Type Variable names start with a lowercase letter and contain a-z, 0-
+9, or _.
+Try: some_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_parameter_name.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "type GleamOption(okType) = Result(okType, Nil)"
+---
+error: Invalid type variable name
+  ┌─ /src/one/two.gleam:1:18
+  │
+1 │ type GleamOption(okType) = Result(okType, Nil)
+  │                  ^^^^^^ This is not a valid type variable name
+
+Hint: Type Variable names start with a lowercase letter and contain a-z, 0-
+9, or _.
+Try: ok_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_parameter_name.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "type Wrapper(innerType) {}"
+---
+error: Invalid type variable name
+  ┌─ /src/one/two.gleam:1:14
+  │
+1 │ type Wrapper(innerType) {}
+  │              ^^^^^^^^^ This is not a valid type variable name
+
+Hint: Type Variable names start with a lowercase letter and contain a-z, 0-
+9, or _.
+Try: inner_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__duplicate_parameter.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__duplicate_parameter.snap
@@ -3,11 +3,10 @@ source: compiler-core/src/type_/tests/type_alias.rs
 expression: "\ntype A(a, a) =\n  List(a)\n"
 ---
 error: Duplicate type parameter
-  ┌─ /src/one/two.gleam:2:1
-  │  
-2 │ ╭ type A(a, a) =
-3 │ │   List(a)
-  │ ╰─────────^
+  ┌─ /src/one/two.gleam:2:11
+  │
+2 │ type A(a, a) =
+  │           ^
 
 This definition has multiple type parameters named `a`.
 Rename or remove one of them.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__duplicate_variable_error_does_not_stop_analysis.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__duplicate_variable_error_does_not_stop_analysis.snap
@@ -3,11 +3,10 @@ source: compiler-core/src/type_/tests/type_alias.rs
 expression: "\ntype Two(a, a) =\n  #(a, a)\n\ntype UnknownType =\n  Dunno\n"
 ---
 error: Duplicate type parameter
-  ┌─ /src/one/two.gleam:2:1
-  │  
-2 │ ╭ type Two(a, a) =
-3 │ │   #(a, a)
-  │ ╰─────────^
+  ┌─ /src/one/two.gleam:2:13
+  │
+2 │ type Two(a, a) =
+  │             ^
 
 This definition has multiple type parameters named `a`.
 Rename or remove one of them.


### PR DESCRIPTION
I realised that when I implemented bad name checking in the analyser, I forgot to check type parameter names. That is now all fixed. I've also changed the rename bad name code action to read errors and removed `name_corrections` from the `ModuleInterface`, because it made part of this easier.