### PR TITLE
Fix incorrect error message on `|>` to a function with a different arity

### DIFF
--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__pipe_arity_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__pipe_arity_error.snap
@@ -10,8 +10,8 @@ error: Type mismatch
 
 Expected type:
 
-    fn(Int, Int) -> Int
+    fn(Int) -> a
 
 Found type:
 
-    fn(Int) -> a
+    fn(Int, Int) -> Int


### PR DESCRIPTION
Turns out this even had a test case with a wrong message in tests.
Closes https://github.com/gleam-lang/gleam/issues/3336