### PR TITLE
Do not create intermediate vector in `pipe.infer_each_expression`

### DIFF
--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -80,7 +80,6 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         expressions: impl IntoIterator<Item = UntypedExpr>,
     ) -> Result<TypedExpr, Error> {
         let mut finally = None;
-        let expressions = expressions.into_iter().collect_vec();
 
         for (i, call) in expressions.into_iter().enumerate() {
             if self.expr_typer.previous_panics {


### PR DESCRIPTION
Looks like that line is no longer needed. I am not sure if compiler optimizes this or not, so why not be specific?