### PR TITLE
Fix go to definition for unqualified functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   two constructors of the same name were created.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where jumping to the definition of an unqualified function would
+  produce the correct location, but remain in the same file.
+  ([Surya Rose](https://github.com/gearsdatapacks))
+
 ## v1.4.1 - 2024-08-04
 
 ### Bug Fixes

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -907,6 +907,41 @@ fn main() {
 }
 
 #[test]
+fn goto_definition_unqualified_function() {
+    let code = "
+import wibble.{wobble}
+fn main() {
+  wobble()
+}
+";
+
+    assert_eq!(
+        definition(
+            TestProject::for_source(code).add_module("wibble", "pub fn wobble() {}"),
+            Position::new(3, 5)
+        ),
+        Some(Location {
+            uri: Url::from_file_path(Utf8PathBuf::from(if cfg!(target_family = "windows") {
+                r"\\?\C:\src\wibble.gleam"
+            } else {
+                "/src/wibble.gleam"
+            }))
+            .unwrap(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0
+                },
+                end: Position {
+                    line: 0,
+                    character: 15
+                }
+            }
+        })
+    )
+}
+
+#[test]
 fn goto_definition_import_unqualified_type() {
     let code = "
 import example_module.{type MyType}

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -963,6 +963,9 @@ impl ValueConstructor {
             }
             | ValueConstructorVariant::ModuleConstant {
                 location, module, ..
+            }
+            | ValueConstructorVariant::ModuleFn {
+                location, module, ..
             } => DefinitionLocation {
                 module: Some(module.as_str()),
                 span: *location,
@@ -973,8 +976,7 @@ impl ValueConstructor {
                 span: literal.location(),
             },
 
-            ValueConstructorVariant::ModuleFn { location, .. }
-            | ValueConstructorVariant::LocalVariable { location } => DefinitionLocation {
+            ValueConstructorVariant::LocalVariable { location } => DefinitionLocation {
                 module: None,
                 span: *location,
             },


### PR DESCRIPTION
Fixes #3457
Very simple fix, functions just weren't returning their module in `definition_location`.