### PR TITLE
add `GLEAM_CACERTS_PATH` env variable

### DIFF
--- a/compiler-cli/src/http.rs
+++ b/compiler-cli/src/http.rs
@@ -6,6 +6,7 @@ use gleam_core::{Error, Result};
 use http::{Request, Response};
 
 static REQWEST_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+static CERTS_ENV_VAR: &str = "GLEAM_CACERTS_PATH";
 
 #[derive(Debug)]
 pub struct HttpClient;
@@ -27,7 +28,7 @@ impl gleam_core::io::HttpClient for HttpClient {
             .try_into()
             .expect("Unable to convert HTTP request for use by reqwest library");
         let mut response = REQWEST_CLIENT
-            .get_or_init(reqwest::Client::new)
+            .get_or_init(init_client)
             .execute(request)
             .await
             .map_err(Error::http)?;
@@ -40,5 +41,34 @@ impl gleam_core::io::HttpClient for HttpClient {
         builder
             .body(response.bytes().await.map_err(Error::http)?.to_vec())
             .map_err(Error::http)
+    }
+}
+
+fn init_client() -> reqwest::Client {
+    if let Some(cert) = get_certificate() {
+        return reqwest::Client::builder()
+            .add_root_certificate(cert)
+            .build()
+            .expect("Unable to initialize a reqwest HTTP client");
+    } else {
+        return reqwest::Client::new();
+    }
+}
+
+fn get_certificate() -> Option<reqwest::Certificate> {
+    match std::env::var(CERTS_ENV_VAR) {
+        Ok(certs_path) => {
+            let data = std::fs::read(certs_path).expect(&format!(
+                "Unable to read certs file set as `{}`",
+                CERTS_ENV_VAR
+            ));
+            let cert = reqwest::Certificate::from_pem(&data).expect(&format!(
+                "Unable to construct a certificate from certs file set as `{}`",
+                CERTS_ENV_VAR
+            ));
+
+            Some(cert)
+        }
+        _ => None,
     }
 }


### PR DESCRIPTION
Resolves #3246

This PR adds a `GLEAM_CACERTS_PATH` environment variable to allow users to configure a custom certificate for HTTP requests. This follows the established naming convention of `HEX_CACERTS_PATH`, which is used in [the Elixir world](https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys).  The issue above does a great job with a more thorough explanation. 

I encountered this issue myself when trying to set up a new Gleam app on my work machine and thought I'd take a stab at this. 

This is my first Rust contribution, so please don't hesitate to request any changes! 
I also imagine that we'd want to document this change, so let me know the best place for that.


<details>
  <summary>Before and After</summary>

![Screenshot 2024-07-31 at 12 09 48 PM](https://github.com/user-attachments/assets/6a20b131-7e87-4753-8853-09abe737f10a)



</details>



