### PR TITLE
Help to infer unannotated `fn` args from the call context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@
   was imported then the alias would be shown.
   ([Surya Rose](https://github.com/gearsdatapacks))
 
+- Improves how inference works for anonymous functions followed by call
+  arguments. For example:
+
+  ```gleam
+  fn(x) { x.0 }(#(1, 2))
+  ```
+
+  would be infered as `fn() -> Int` in this context.
+  ([sobolevn](https://github.com/sobolevn))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_and_call.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_and_call.snap
@@ -7,6 +7,6 @@ expression: "\npub fn main(x) {\n  fn(x) { x }(x)\n}\n"
 
 -export([main/1]).
 
--spec main(I) -> I.
+-spec main(K) -> K.
 main(X) ->
     (fun(X@1) -> X@1 end)(X).

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2873,7 +2873,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 body,
                 return_annotation,
                 ..
-            } => self.infer_fn_with_call_context(
+            } if arguments.len() == args.len() => self.infer_fn_with_call_context(
                 arguments,
                 &args,
                 body,

--- a/compiler-core/src/type_/tests/functions.rs
+++ b/compiler-core/src/type_/tests/functions.rs
@@ -533,3 +533,42 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn provide_two_args_type_to_fn() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+   let a = #(1,2)
+   let b = #(1,2)
+   fn(x, y) { x.0 + y.1 }(a, b)
+}
+"#,
+        vec![("main", "fn() -> Int")]
+    );
+}
+
+#[test]
+fn provide_one_arg_type_to_two_args_fn() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+   let a = #(1,2)
+   fn(x, y) { x.0 + y.1 }(a)
+}
+"#
+    );
+}
+
+#[test]
+fn provide_two_args_type_to_fn_wrong_types() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+   let a = 1
+   let b = "not an int"
+   fn(x, y) { x + y }(a, b)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/functions.rs
+++ b/compiler-core/src/type_/tests/functions.rs
@@ -521,3 +521,15 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn provide_arg_type_to_fn_not_a_tuple() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+   let z = "not a tuple"
+   fn(x) { x.2 }(z)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/functions.rs
+++ b/compiler-core/src/type_/tests/functions.rs
@@ -459,3 +459,65 @@ pub fn main() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2504
+#[test]
+fn provide_arg_type_to_fn_implicit_ok() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+   let z = #(1,2)
+   fn(x) { x.0 }(z)
+}
+"#,
+        vec![("main", "fn() -> Int")]
+    );
+}
+
+#[test]
+fn provide_arg_type_to_fn_explicit_ok() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+   let z = #(1,2)
+   fn(x: #(Int, Int)) { x.0 }(z)
+}
+"#,
+        vec![("main", "fn() -> Int")]
+    );
+}
+
+#[test]
+fn provide_arg_type_to_fn_implicit_error() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+   let z = #(1,2)
+   fn(x) { x.2 }(z)
+}
+"#
+    );
+}
+
+#[test]
+fn provide_arg_type_to_fn_explicit_error() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+   let z = #(1,2)
+   fn(x: #(Int, Int)) { x.2 }(z)
+}
+"#
+    );
+}
+
+#[test]
+fn provide_arg_type_to_fn_arg_infer_error() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+   fn(x) { x.2 }(z)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_arg_infer_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_arg_infer_error.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n   fn(x) { x.2 }(z)\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:12
+  │
+3 │    fn(x) { x.2 }(z)
+  │            ^ What type is this?
+
+To index into a tuple we need to know it size, but we don't know
+anything about this type yet. Please add some type annotations so
+we can continue.
+
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:18
+  │
+3 │    fn(x) { x.2 }(z)
+  │                  ^
+
+The name `z` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_explicit_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_explicit_error.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n   let z = #(1,2)\n   fn(x: #(Int, Int)) { x.2 }(z)\n}\n"
+---
+error: Out of bounds tuple index
+  ┌─ /src/one/two.gleam:4:26
+  │
+4 │    fn(x: #(Int, Int)) { x.2 }(z)
+  │                          ^^ This index is too large
+
+The index being accessed for this tuple is 2, but this tuple has 2 elements
+so the highest valid index is 1.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_implicit_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_implicit_error.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n   let z = #(1,2)\n   fn(x) { x.2 }(z)\n}\n"
+---
+error: Out of bounds tuple index
+  ┌─ /src/one/two.gleam:4:13
+  │
+4 │    fn(x) { x.2 }(z)
+  │             ^^ This index is too large
+
+The index being accessed for this tuple is 2, but this tuple has 2 elements
+so the highest valid index is 1.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_not_a_tuple.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_not_a_tuple.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n   let z = \"not a tuple\"\n   fn(x) { x.2 }(z)\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:12
+  │
+4 │    fn(x) { x.2 }(z)
+  │            ^ This is not a tuple
+
+To index into this value it needs to be a tuple, however it has this type:
+
+    String

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_one_arg_type_to_two_args_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_one_arg_type_to_two_args_fn.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n   let a = #(1,2)\n   fn(x, y) { x.0 + y.1 }(a)\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:4:4
+  │
+4 │    fn(x, y) { x.0 + y.1 }(a)
+  │    ^^^^^^^^^^^^^^^^^^^^^^^^^ Expected 2 arguments, got 1
+
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:15
+  │
+4 │    fn(x, y) { x.0 + y.1 }(a)
+  │               ^ What type is this?
+
+To index into a tuple we need to know it size, but we don't know
+anything about this type yet. Please add some type annotations so
+we can continue.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_two_args_type_to_fn_wrong_types.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_two_args_type_to_fn_wrong_types.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/functions.rs
+expression: "\npub fn main() {\n   let a = 1\n   let b = \"not an int\"\n   fn(x, y) { x + y }(a, b)\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:19
+  │
+5 │    fn(x, y) { x + y }(a, b)
+  │                   ^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    String
+
+Hint: Strings can be joined using the `append` or `concat` functions from the
+`gleam/string` module.


### PR DESCRIPTION
This is a little first step in better annotated `fn` inference. Right now I teached it how to infer the arg types from the call context. Something similar to `infer_lambda_type_using_context` https://github.com/python/mypy/blob/8b74b5ab03742ba86348dfe14d0468a995f74ee7/mypy/checkexpr.py#L5318-L5393 in MyPy / CPython. 

This test still fails:

```rust
#[test]
fn pipe_into_annonymous_annotated_function() {
    assert_module_infer!(
        r#"
pub fn main() {
  let a = 1
     |> fn (x) { #(x, x + 1) }
     |> fn (x) { x.0 }
     |> fn (x) { x }
}
"#,
        vec![("main", "Int")]
    );
}
```

```
---- type_::tests::pipes::pipe_into_annonymous_annotated_function stdout ----
thread 'type_::tests::pipes::pipe_into_annonymous_annotated_function' panicked at compiler-core/src/type_/tests.rs:324:6:
should successfully infer: [NotATupleUnbound { location: SrcSpan { start: 77, end: 78 } }]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

But, let's do it incrementally.