### PR TITLE
refactor: Use `ast` type aliases where possible

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -10,7 +10,8 @@ use crate::{
         GroupedStatements, Import, ModuleConstant, Publicity, RecordConstructor,
         RecordConstructorArg, SrcSpan, Statement, TypeAlias, TypeAst, TypeAstConstructor,
         TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar, TypedDefinition, TypedExpr,
-        TypedFunction, TypedModule, UntypedArg, UntypedFunction, UntypedModule, UntypedStatement,
+        TypedFunction, TypedModule, UntypedArg, UntypedCustomType, UntypedFunction, UntypedImport,
+        UntypedModule, UntypedModuleConstant, UntypedStatement, UntypedTypeAlias,
     },
     build::{Origin, Outcome, Target},
     call_graph::{into_dependency_order, CallGraphNode},
@@ -342,7 +343,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
     fn infer_module_constant(
         &mut self,
-        c: ModuleConstant<(), ()>,
+        c: UntypedModuleConstant,
         environment: &mut Environment<'_>,
     ) -> TypedDefinition {
         let ModuleConstant {
@@ -666,7 +667,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
     fn analyse_import(
         &mut self,
-        i: Import<()>,
+        i: UntypedImport,
         environment: &Environment<'_>,
     ) -> Option<TypedDefinition> {
         let Import {
@@ -714,7 +715,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
     fn analyse_custom_type(
         &mut self,
-        t: CustomType<()>,
+        t: UntypedCustomType,
         environment: &mut Environment<'_>,
     ) -> Option<TypedDefinition> {
         match self.do_analyse_custom_type(t, environment) {
@@ -729,7 +730,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
     // TODO: split this into a new class.
     fn do_analyse_custom_type(
         &mut self,
-        t: CustomType<()>,
+        t: UntypedCustomType,
         environment: &mut Environment<'_>,
     ) -> Result<TypedDefinition, Error> {
         self.register_values_from_custom_type(
@@ -824,7 +825,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
     fn register_values_from_custom_type(
         &mut self,
-        t: &CustomType<()>,
+        t: &UntypedCustomType,
         environment: &mut Environment<'_>,
         type_parameters: &[&EcoString],
     ) -> Result<(), Error> {
@@ -977,7 +978,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
     fn register_types_from_custom_type(
         &mut self,
-        t: &CustomType<()>,
+        t: &UntypedCustomType,
         environment: &mut Environment<'a>,
     ) -> Result<(), Error> {
         let CustomType {
@@ -1061,7 +1062,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         Ok(())
     }
 
-    fn register_type_alias(&mut self, t: &TypeAlias<()>, environment: &mut Environment<'_>) {
+    fn register_type_alias(&mut self, t: &UntypedTypeAlias, environment: &mut Environment<'_>) {
         let TypeAlias {
             location,
             publicity,
@@ -1305,7 +1306,7 @@ fn target_function_implementation<'a>(
     }
 }
 
-fn analyse_type_alias(t: TypeAlias<()>, environment: &mut Environment<'_>) -> TypedDefinition {
+fn analyse_type_alias(t: UntypedTypeAlias, environment: &mut Environment<'_>) -> TypedDefinition {
     let TypeAlias {
         documentation: doc,
         location,
@@ -1672,7 +1673,7 @@ fn get_type_dependencies(typ: &TypeAst) -> Vec<EcoString> {
     deps
 }
 
-fn sorted_type_aliases(aliases: &Vec<TypeAlias<()>>) -> Result<Vec<&TypeAlias<()>>, Error> {
+fn sorted_type_aliases(aliases: &Vec<UntypedTypeAlias>) -> Result<Vec<&UntypedTypeAlias>, Error> {
     let mut deps: Vec<(EcoString, Vec<EcoString>)> = Vec::with_capacity(aliases.len());
 
     for alias in aliases {

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -1,7 +1,7 @@
 use ecow::EcoString;
 
 use crate::{
-    ast::{Import, SrcSpan, UnqualifiedImport},
+    ast::{SrcSpan, UnqualifiedImport, UntypedImport},
     build::Origin,
     type_::{
         EntityKind, Environment, Error, ModuleInterface, Problems, UnusedModuleAlias,
@@ -32,7 +32,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
     pub fn run<'code>(
         origin: Origin,
         env: Environment<'context>,
-        imports: &'code [Import<()>],
+        imports: &'code [UntypedImport],
         problems: &'problems mut Problems,
     ) -> Environment<'context> {
         let mut importer = Self::new(origin, env, problems);
@@ -42,7 +42,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         importer.environment
     }
 
-    fn register_import(&mut self, import: &Import<()>) {
+    fn register_import(&mut self, import: &UntypedImport) {
         let location = import.location;
         let name = import.module.clone();
 
@@ -189,7 +189,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
 
     fn register_module(
         &mut self,
-        import: &Import<()>,
+        import: &UntypedImport,
         import_info: &'context ModuleInterface,
     ) -> Result<(), Error> {
         if let Some(used_name) = import.used_name() {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -2128,9 +2128,9 @@ pub enum TodoKind {
 pub struct GroupedStatements {
     pub functions: Vec<UntypedFunction>,
     pub constants: Vec<UntypedModuleConstant>,
-    pub custom_types: Vec<CustomType<()>>,
-    pub imports: Vec<Import<()>>,
-    pub type_aliases: Vec<TypeAlias<()>>,
+    pub custom_types: Vec<UntypedCustomType>,
+    pub imports: Vec<UntypedImport>,
+    pub type_aliases: Vec<UntypedTypeAlias>,
 }
 
 impl GroupedStatements {

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -49,7 +49,7 @@ pub enum TypedExpr {
         location: SrcSpan,
         typ: Arc<Type>,
         is_capture: bool,
-        args: Vec<Arg<Arc<Type>>>,
+        args: Vec<TypedArg>,
         body: Vec1<TypedStatement>,
         return_annotation: Option<TypeAst>,
     },

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -37,7 +37,7 @@ pub enum UntypedExpr {
         /// The byte location of the end of the function head before the opening bracket
         end_of_head_byte_index: u32,
         is_capture: bool,
-        arguments: Vec<Arg<()>>,
+        arguments: Vec<UntypedArg>,
         body: Vec1<UntypedStatement>,
         return_annotation: Option<TypeAst>,
     },

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -49,10 +49,10 @@ use ecow::EcoString;
 use crate::type_::Type;
 
 use super::{
-    AssignName, BinOp, BitArrayOption, BitArraySegment, CallArg, Definition, Pattern, SrcSpan,
-    Statement, TodoKind, TypeAst, TypedArg, TypedAssignment, TypedClause, TypedDefinition,
-    TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule, TypedPattern,
-    TypedRecordUpdateArg, TypedStatement, Use,
+    AssignName, BinOp, BitArrayOption, CallArg, Definition, Pattern, SrcSpan, Statement, TodoKind,
+    TypeAst, TypedArg, TypedAssignment, TypedClause, TypedDefinition, TypedExpr,
+    TypedExprBitArraySegment, TypedFunction, TypedModule, TypedPattern,
+    TypedPatternBitArraySegment, TypedRecordUpdateArg, TypedStatement, Use,
 };
 
 pub trait Visit<'ast> {
@@ -419,7 +419,7 @@ pub trait Visit<'ast> {
     fn visit_typed_pattern_bit_array(
         &mut self,
         location: &'ast SrcSpan,
-        segments: &'ast Vec<BitArraySegment<TypedPattern, Arc<Type>>>,
+        segments: &'ast Vec<TypedPatternBitArraySegment>,
     ) {
         visit_typed_pattern_bit_array(self, location, segments);
     }
@@ -1166,7 +1166,7 @@ pub fn visit_typed_pattern_tuple<'a, V>(
 pub fn visit_typed_pattern_bit_array<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    segments: &'a Vec<BitArraySegment<TypedPattern, Arc<Type>>>,
+    segments: &'a Vec<TypedPatternBitArraySegment>,
 ) where
     V: Visit<'a> + ?Sized,
 {

--- a/compiler-core/src/bit_array.rs
+++ b/compiler-core/src/bit_array.rs
@@ -276,7 +276,7 @@ pub trait GetLiteralValue {
     fn as_int_literal(&self) -> Option<i64>;
 }
 
-impl GetLiteralValue for crate::ast::Pattern<Arc<Type>> {
+impl GetLiteralValue for crate::ast::TypedPattern {
     fn as_int_literal(&self) -> Option<i64> {
         match self {
             crate::ast::Pattern::Int { value, .. } => {

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -310,7 +310,7 @@ pub enum Located<'a> {
     Pattern(&'a TypedPattern),
     PatternSpread {
         spread_location: SrcSpan,
-        arguments: &'a Vec<CallArg<Pattern<Arc<Type>>>>,
+        arguments: &'a Vec<CallArg<TypedPattern>>,
     },
     Statement(&'a TypedStatement),
     Expression(&'a TypedExpr),

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -4,11 +4,11 @@
 #[cfg(test)]
 mod into_dependency_order_tests;
 
-use crate::ast::{ModuleConstant, UntypedModuleConstant};
 use crate::{
     ast::{
         AssignName, BitArrayOption, ClauseGuard, Constant, Pattern, SrcSpan, Statement,
-        UntypedExpr, UntypedFunction, UntypedPattern, UntypedStatement,
+        UntypedClauseGuard, UntypedExpr, UntypedFunction, UntypedModuleConstant, UntypedPattern,
+        UntypedStatement,
     },
     type_::Error,
     Result,
@@ -28,7 +28,7 @@ struct CallGraphBuilder<'a> {
 pub enum CallGraphNode {
     Function(UntypedFunction),
 
-    ModuleConstant(ModuleConstant<(), ()>),
+    ModuleConstant(UntypedModuleConstant),
 }
 
 impl<'a> CallGraphBuilder<'a> {
@@ -389,7 +389,7 @@ impl<'a> CallGraphBuilder<'a> {
         }
     }
 
-    fn guard(&mut self, guard: &'a ClauseGuard<(), ()>) {
+    fn guard(&mut self, guard: &'a UntypedClauseGuard) {
         match guard {
             ClauseGuard::Equals { left, right, .. }
             | ClauseGuard::NotEquals { left, right, .. }

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    ast::{Arg, Function, Publicity},
+    ast::{Arg, Function, ModuleConstant, Publicity},
     type_::{expression::Implementations, Deprecation},
 };
 use ecow::EcoString;

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -647,7 +647,7 @@ fn bit_array<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> 
 
 fn const_segment<'a>(
     value: &'a TypedConstant,
-    options: &'a [BitArrayOption<TypedConstant>],
+    options: &'a [TypedConstantBitArraySegmentOption],
     env: &mut Env<'a>,
 ) -> Document<'a> {
     let document = match value {
@@ -1782,7 +1782,7 @@ fn expr<'a>(expression: &'a TypedExpr, env: &mut Env<'a>) -> Document<'a> {
 }
 
 fn pipeline<'a>(
-    assignments: &'a [Assignment<Arc<Type>, TypedExpr>],
+    assignments: &'a [TypedAssignment],
     finally: &'a TypedExpr,
     env: &mut Env<'a>,
 ) -> Document<'a> {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2123,8 +2123,8 @@ impl<'comments> Formatter<'comments> {
 
     fn list_pattern<'a>(
         &mut self,
-        elements: &'a [Pattern<()>],
-        tail: &'a Option<Box<Pattern<()>>>,
+        elements: &'a [UntypedPattern],
+        tail: &'a Option<Box<UntypedPattern>>,
     ) -> Document<'a> {
         if elements.is_empty() {
             return match tail {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1432,7 +1432,7 @@ pub(crate) fn constant_expression<'a>(
 
 fn bit_array<'a>(
     tracker: &mut UsageTracker,
-    segments: &'a [BitArraySegment<TypedConstant, Arc<Type>>],
+    segments: &'a [TypedConstantBitArraySegment],
     mut constant_expr_fun: impl FnMut(&mut UsageTracker, &'a TypedConstant) -> Output<'a>,
 ) -> Output<'a> {
     tracker.bit_array_literal_used = true;
@@ -1510,7 +1510,7 @@ struct SizedBitArraySegmentDetails<'a> {
 }
 
 fn sized_bit_array_segment_details<'a>(
-    segment: &'a BitArraySegment<TypedConstant, Arc<Type>>,
+    segment: &'a TypedConstantBitArraySegment,
     tracker: &mut UsageTracker,
     constant_expr_fun: &mut impl FnMut(&mut UsageTracker, &'a TypedConstant) -> Output<'a>,
 ) -> Result<SizedBitArraySegmentDetails<'a>, Error> {

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -1,11 +1,11 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use super::{expression::is_js_scalar, *};
 use crate::{
     analyse::Inferred,
     javascript::endianness::Endianness,
     strings::convert_string_escape_chars,
-    type_::{FieldMap, PatternConstructor, Type},
+    type_::{FieldMap, PatternConstructor},
 };
 
 pub static ASSIGNMENT_VAR: &str = "$";
@@ -669,7 +669,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
     }
 
     fn sized_bit_array_segment_details(
-        segment: &BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>,
+        segment: &TypedPatternBitArraySegment,
     ) -> Result<SizedBitArraySegmentDetails, Error> {
         use BitArrayOption as Opt;
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -1,7 +1,7 @@
 use crate::{
     analyse::name::correct_name_case,
     ast::{
-        Arg, CustomType, Definition, ModuleConstant, SrcSpan, TypedExpr, TypedFunction,
+        CustomType, Definition, ModuleConstant, SrcSpan, TypedArg, TypedExpr, TypedFunction,
         TypedModule, TypedPattern,
     },
     build::{type_constructor_from_modules, Located, Module, UnqualifiedImport},
@@ -784,7 +784,7 @@ fn hover_for_function_head(fun: &TypedFunction, line_numbers: LineNumbers) -> Ho
     }
 }
 
-fn hover_for_function_argument(argument: &Arg<Arc<Type>>, line_numbers: LineNumbers) -> Hover {
+fn hover_for_function_argument(argument: &TypedArg, line_numbers: LineNumbers) -> Hover {
     let type_ = Printer::new().pretty_print(&argument.type_, 0);
     let contents = format!("```gleam\n{type_}\n```");
     Hover {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1995,10 +1995,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
     fn infer_guard_record_access(
         &mut self,
-        container: ClauseGuard<Arc<Type>, EcoString>,
+        container: TypedClauseGuard,
         label: EcoString,
         location: SrcSpan,
-    ) -> Result<ClauseGuard<Arc<Type>, EcoString>, Error> {
+    ) -> Result<TypedClauseGuard, Error> {
         let container = Box::new(container);
         let container_type = container.type_();
         let (index, label, type_) = self.infer_known_record_access(
@@ -2023,7 +2023,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         label: EcoString,
         location: SrcSpan,
         record_access_erorr: Error,
-    ) -> Result<ClauseGuard<Arc<Type>, EcoString>, Error> {
+    ) -> Result<TypedClauseGuard, Error> {
         let module_access = self
             .infer_module_access(&name, label, &location, location)
             .and_then(|ma| match ma {
@@ -3280,7 +3280,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         location: SrcSpan,
         subject_types: &[Arc<Type>],
-        clauses: &[Clause<TypedExpr, Arc<Type>, EcoString>],
+        clauses: &[TypedClause],
     ) -> Result<(), Error> {
         use exhaustiveness::{Body, Column, Compiler, PatternArena, Row};
 
@@ -3468,7 +3468,7 @@ struct UseAssignments {
     /// fn(_use1) { let Box(x) = _use1 }
     /// // ^^^^^ The function arguments
     /// ```
-    function_arguments: Vec<Arg<()>>,
+    function_arguments: Vec<UntypedArg>,
 
     /// With sugar
     /// ```gleam


### PR DESCRIPTION
It caught my eye that there are places where established type aliases are duplicated.