### PR TITLE
Implement `let assert as "msg"` syntax

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1942,27 +1942,6 @@ impl<A> HasLocation for Pattern<A> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AssignmentKind {
-    // let x = ...
-    Let,
-    // let assert x = ...
-    Assert { location: SrcSpan },
-}
-
-impl AssignmentKind {
-    /// Returns `true` if the assignment kind is [`Assert`].
-    ///
-    /// [`Assert`]: AssignmentKind::Assert
-    #[must_use]
-    pub fn is_assert(&self) -> bool {
-        match self {
-            Self::Assert { .. } => true,
-            Self::Let => false,
-        }
-    }
-}
-
 // BitArrays
 
 pub type UntypedExprBitArraySegment = BitArraySegment<UntypedExpr, ()>;
@@ -2291,12 +2270,28 @@ impl TypedStatement {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssertAssignment<ExpressionT> {
+    pub location: SrcSpan,
+    pub message: Option<Box<ExpressionT>>,
+}
+
+pub type TypedAssertAssignment = AssertAssignment<TypedExpr>;
+pub type UntypedAssertAssignment = AssertAssignment<UntypedExpr>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Assignment<TypeT, ExpressionT> {
     pub location: SrcSpan,
     pub value: Box<ExpressionT>,
     pub pattern: Pattern<TypeT>,
-    pub kind: AssignmentKind,
+    pub assert: Option<Box<AssertAssignment<ExpressionT>>>,
     pub annotation: Option<TypeAst>,
+}
+
+impl<TypeT, ExpressionT> Assignment<TypeT, ExpressionT> {
+    #[must_use]
+    pub fn is_assert(&self) -> bool {
+        self.assert.is_some()
+    }
 }
 
 pub type TypedAssignment = Assignment<Arc<Type>, TypedExpr>;

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -4,13 +4,14 @@ use vec1::Vec1;
 use crate::{
     analyse::Inferred,
     ast::{
-        AssignName, Assignment, BinOp, CallArg, Constant, Definition, Pattern, RecordUpdateSpread,
-        SrcSpan, Statement, TargetedDefinition, TodoKind, TypeAst, TypeAstConstructor, TypeAstFn,
-        TypeAstHole, TypeAstTuple, TypeAstVar, UntypedArg, UntypedAssignment, UntypedClause,
-        UntypedConstant, UntypedConstantBitArraySegment, UntypedCustomType, UntypedDefinition,
-        UntypedExpr, UntypedExprBitArraySegment, UntypedFunction, UntypedImport, UntypedModule,
-        UntypedModuleConstant, UntypedPattern, UntypedPatternBitArraySegment,
-        UntypedRecordUpdateArg, UntypedStatement, UntypedTypeAlias, Use, UseAssignment,
+        AssertAssignment, AssignName, Assignment, BinOp, CallArg, Constant, Definition, Pattern,
+        RecordUpdateSpread, SrcSpan, Statement, TargetedDefinition, TodoKind, TypeAst,
+        TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar, UntypedArg,
+        UntypedAssignment, UntypedClause, UntypedConstant, UntypedConstantBitArraySegment,
+        UntypedCustomType, UntypedDefinition, UntypedExpr, UntypedExprBitArraySegment,
+        UntypedFunction, UntypedImport, UntypedModule, UntypedModuleConstant, UntypedPattern,
+        UntypedPatternBitArraySegment, UntypedRecordUpdateArg, UntypedStatement, UntypedTypeAlias,
+        Use, UseAssignment,
     },
     build::Target,
 };
@@ -583,17 +584,24 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 location,
                 value,
                 pattern,
-                kind,
+                assert,
                 annotation,
             }) => {
                 let pattern = self.fold_pattern(pattern);
                 let annotation = annotation.map(|t| self.fold_type(t));
+                let assert = assert.map(|a| {
+                    let message = a.message.map(|message| Box::new(self.fold_expr(*message)));
+                    Box::new(AssertAssignment {
+                        location: a.location,
+                        message,
+                    })
+                });
                 let value = Box::new(self.fold_expr(*value));
                 Statement::Assignment(Assignment {
                     location,
                     value,
                     pattern,
-                    kind,
+                    assert,
                     annotation,
                 })
             }

--- a/compiler-core/src/erlang/tests/let_assert.rs
+++ b/compiler-core/src/erlang/tests/let_assert.rs
@@ -45,6 +45,27 @@ fn variable_rewrites() {
     );
 }
 
+#[test]
+fn let_assert_as() {
+    assert_erl!(
+        r#"pub fn main() {
+  let msg = "custom" <> " error"
+  let assert as msg Ok(y) = Ok(1)
+  y
+}"#
+    );
+}
+
+#[test]
+fn let_assert_as_no_var() {
+    assert_erl!(
+        r#"pub fn main() {
+  let assert as "custom error" Ok(y) = Ok(1)
+  y
+}"#
+    );
+}
+
 // TODO: patterns that are just vars don't render a case expression
 // #[test]
 // fn just_pattern() {

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_as.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_as.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn main() {\n  let msg = \"custom\" <> \" error\"\n  let assert as msg Ok(y) = Ok(1)\n  y\n}"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> integer().
+main() ->
+    Msg = <<"custom"/utf8, " error"/utf8>>,
+    _assert_subject = {ok, 1},
+    {ok, Y} = case _assert_subject of
+        {ok, _} -> _assert_subject;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => Msg,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"main"/utf8>>,
+                        line => 3})
+    end,
+    Y.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_as_no_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_as_no_var.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn main() {\n  let assert as \"custom error\" Ok(y) = Ok(1)\n  y\n}"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> integer().
+main() ->
+    _assert_subject = {ok, 1},
+    {ok, Y} = case _assert_subject of
+        {ok, _} -> _assert_subject;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"custom error"/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"main"/utf8>>,
+                        line => 2})
+    end,
+    Y.

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6424,3 +6424,30 @@ pub fn init(
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3216
+#[test]
+fn let_assert_with_message_formats() {
+    assert_format!(
+        r#"pub fn main() {
+  let assert as "error message" Ok(a) = Ok(1)
+}
+"#
+    );
+}
+
+#[test]
+fn let_assert_with_message_formats_long_error_message() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  let assert as "very-very-very-very-very-very-very-very-very long error message" Ok(a) = Ok(1)
+}
+"#,
+        r#"pub fn main() {
+  let assert as "very-very-very-very-very-very-very-very-very long error message" Ok(
+    a,
+  ) = Ok(1)
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -749,15 +749,11 @@ impl<'module> Generator<'module> {
         location: SrcSpan,
         subject: Document<'a>,
     ) -> Output<'a> {
-        let scope_position = self.scope_position;
-        self.scope_position = Position::NotTail;
-
         let message = match message {
-            Some(m) => self.expression(m)?,
+            Some(m) => self.not_in_tail_position(|gen| gen.expression(m))?,
             None => string("Assignment pattern did not match"),
         };
 
-        self.scope_position = scope_position;
         Ok(self.throw_error(
             "assignment_no_match",
             &message,

--- a/compiler-core/src/javascript/tests/assignments.rs
+++ b/compiler-core/src/javascript/tests/assignments.rs
@@ -22,6 +22,29 @@ fn assert1() {
 }
 
 #[test]
+fn assert2() {
+    assert_js!(
+        r#"
+    fn go(x) {
+        let msg = "custom" <> " error"
+        let assert as msg Ok(x) = Ok(1)
+    }
+    "#
+    );
+}
+
+#[test]
+fn assert3() {
+    assert_js!(
+        r#"
+    fn go(x) {
+        let assert as "custom error" Ok(x) = Ok(1)
+    }
+    "#
+    );
+}
+
+#[test]
 fn nested_binding() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert2.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/javascript/tests/assignments.rs
+expression: "\n    fn go(x) {\n        let msg = \"custom\" <> \" error\"\n        let assert as msg Ok(x) = Ok(1)\n    }\n    "
+---
+import { Ok, makeError } from "../gleam.mjs";
+
+function go(x) {
+  let msg = "custom" + " error";
+  let $ = new Ok(1);
+  if (!$.isOk()) {
+    throw makeError("assignment_no_match", "my/mod", 4, "go", msg, { value: $ })
+  }
+  let x$1 = $[0];
+  return $;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert3.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert3.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/javascript/tests/assignments.rs
+expression: "\n    fn go(x) {\n        let assert as \"custom error\" Ok(x) = Ok(1)\n    }\n    "
+---
+import { Ok, makeError } from "../gleam.mjs";
+
+function go(x) {
+  let $ = new Ok(1);
+  if (!$.isOk()) {
+    throw makeError(
+      "assignment_no_match",
+      "my/mod",
+      3,
+      "go",
+      "custom error",
+      { value: $ }
+    )
+  }
+  let x$1 = $[0];
+  return $;
+}

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -7,8 +7,8 @@ use crate::{
             visit_typed_call_arg, visit_typed_expr_call, visit_typed_pattern_call_arg,
             visit_typed_record_update_arg, Visit as _,
         },
-        AssignName, AssignmentKind, CallArg, ImplicitCallArgOrigin, Pattern, SrcSpan, TypedExpr,
-        TypedPattern, TypedRecordUpdateArg,
+        AssignName, CallArg, ImplicitCallArgOrigin, Pattern, SrcSpan, TypedExpr, TypedPattern,
+        TypedRecordUpdateArg,
     },
     build::Module,
     line_numbers::LineNumbers,
@@ -316,9 +316,9 @@ impl<'ast> ast::visit::Visit<'ast> for LetAssertToCase<'_> {
         }
 
         // This pattern only applies to `let assert`
-        if !matches!(assignment.kind, AssignmentKind::Assert { .. }) {
+        if !assignment.is_assert() {
             return;
-        };
+        }
 
         // Get the source code for the tested expression
         let location = assignment.value.location();

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -292,6 +292,9 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 "Unsupported expression",
                 vec!["Functions cannot be called in clause guards.".into()],
             ),
+            ParseErrorType::ExpectedAssignmentAssert => {
+                ("I was expecting a '=' or 'as' after 'let assert'", vec![])
+            }
         }
     }
 }
@@ -357,7 +360,8 @@ pub enum ParseErrorType {
         field: EcoString,
         field_type: Option<TypeAst>,
     },
-    CallInClauseGuard, // case x { _ if f() -> 1 }
+    CallInClauseGuard,        // case x { _ if f() -> 1 }
+    ExpectedAssignmentAssert, // expect "=" or "as" after `let assert`
 }
 
 impl LexicalError {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
@@ -56,7 +56,7 @@ expression: "\nlet tup = #(#(#(#(4))))\n{{{tup.0}.0}.0}.0\n"
                 name: "tup",
                 type_: (),
             },
-            kind: Let,
+            assert: None,
             annotation: None,
         },
     ),

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
@@ -56,7 +56,7 @@ expression: "\nlet tup = #(#(#(#(4))))\ntup.0.0.0.0\n"
                 name: "tup",
                 type_: (),
             },
-            kind: Let,
+            assert: None,
             annotation: None,
         },
     ),

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__inner_single_quote_parses.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__inner_single_quote_parses.snap
@@ -24,7 +24,7 @@ expression: "\nlet a = \"inner 'quotes'\"\n"
                 name: "a",
                 type_: (),
             },
-            kind: Let,
+            assert: None,
             annotation: None,
         },
     ),

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
@@ -47,7 +47,7 @@ expression: "\nlet tup = #(#(5, 6))\n{tup.0}.1\n"
                 name: "tup",
                 type_: (),
             },
-            kind: Let,
+            assert: None,
             annotation: None,
         },
     ),

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
@@ -47,7 +47,7 @@ expression: "\nlet tup = #(#(5, 6))\ntup.0.1\n"
                 name: "tup",
                 type_: (),
             },
-            kind: Let,
+            assert: None,
             annotation: None,
         },
     ),

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_after_let_assert.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_after_let_assert.snap
@@ -1,0 +1,74 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: let assert Ok(a) as b = some()
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 0,
+                end: 30,
+            },
+            value: Call {
+                location: SrcSpan {
+                    start: 24,
+                    end: 30,
+                },
+                fun: Var {
+                    location: SrcSpan {
+                        start: 24,
+                        end: 28,
+                    },
+                    name: "some",
+                },
+                arguments: [],
+            },
+            pattern: Assign {
+                name: "b",
+                location: SrcSpan {
+                    start: 20,
+                    end: 21,
+                },
+                pattern: Constructor {
+                    location: SrcSpan {
+                        start: 11,
+                        end: 16,
+                    },
+                    name: "Ok",
+                    arguments: [
+                        CallArg {
+                            label: None,
+                            location: SrcSpan {
+                                start: 14,
+                                end: 15,
+                            },
+                            value: Variable {
+                                location: SrcSpan {
+                                    start: 14,
+                                    end: 15,
+                                },
+                                name: "a",
+                                type_: (),
+                            },
+                            implicit: None,
+                        },
+                    ],
+                    module: None,
+                    constructor: Unknown,
+                    spread: None,
+                    type_: (),
+                },
+            },
+            assert: Some(
+                AssertAssignment {
+                    location: SrcSpan {
+                        start: 4,
+                        end: 10,
+                    },
+                    message: None,
+                },
+            ),
+            annotation: None,
+        },
+    ),
+]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert.snap
@@ -1,0 +1,75 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "let assert as \"error\" Ok(a) = some()"
+---
+[
+    Assignment(
+        Assignment {
+            location: SrcSpan {
+                start: 0,
+                end: 36,
+            },
+            value: Call {
+                location: SrcSpan {
+                    start: 30,
+                    end: 36,
+                },
+                fun: Var {
+                    location: SrcSpan {
+                        start: 30,
+                        end: 34,
+                    },
+                    name: "some",
+                },
+                arguments: [],
+            },
+            pattern: Constructor {
+                location: SrcSpan {
+                    start: 22,
+                    end: 27,
+                },
+                name: "Ok",
+                arguments: [
+                    CallArg {
+                        label: None,
+                        location: SrcSpan {
+                            start: 25,
+                            end: 26,
+                        },
+                        value: Variable {
+                            location: SrcSpan {
+                                start: 25,
+                                end: 26,
+                            },
+                            name: "a",
+                            type_: (),
+                        },
+                        implicit: None,
+                    },
+                ],
+                module: None,
+                constructor: Unknown,
+                spread: None,
+                type_: (),
+            },
+            assert: Some(
+                AssertAssignment {
+                    location: SrcSpan {
+                        start: 4,
+                        end: 21,
+                    },
+                    message: Some(
+                        String {
+                            location: SrcSpan {
+                                start: 14,
+                                end: 21,
+                            },
+                            value: "error",
+                        },
+                    ),
+                },
+            ),
+            annotation: None,
+        },
+    ),
+]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert_no_as_keyword.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert_no_as_keyword.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "let assert \"error\" Ok(a) = some()"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:12
+  │
+1 │ let assert "error" Ok(a) = some()
+  │            ^^^^^^^ I was expecting a '=' or 'as' after 'let assert'

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert_no_message.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert_no_message.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: let assert as Ok(a) = some()
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:21
+  │
+1 │ let assert as Ok(a) = some()
+  │                     ^ I was not expecting this
+
+Found `=`, expected one of: 
+- A pattern

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert_not_a_unit.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_as_def_in_let_assert_not_a_unit.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "let assert \"custom\" <> \"error\" Ok(a) = some()"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:24
+  │
+1 │ let assert "custom" <> "error" Ok(a) = some()
+  │                        ^^^^^^^ I was expecting a name here

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1403,3 +1403,29 @@ fn doc_comment_before_comment_is_not_attached_to_following_constant() {
         " Doc!\n"
     );
 }
+
+#[test]
+fn parse_as_def_after_let_assert() {
+    assert_parse!("let assert Ok(a) as b = some()");
+}
+
+// https://github.com/gleam-lang/gleam/issues/3216
+#[test]
+fn parse_as_def_in_let_assert() {
+    assert_parse!(r#"let assert as "error" Ok(a) = some()"#);
+}
+
+#[test]
+fn parse_as_def_in_let_assert_no_as_keyword() {
+    assert_error!(r#"let assert "error" Ok(a) = some()"#);
+}
+
+#[test]
+fn parse_as_def_in_let_assert_no_message() {
+    assert_error!(r#"let assert as Ok(a) = some()"#);
+}
+
+#[test]
+fn parse_as_def_in_let_assert_not_a_unit() {
+    assert_error!(r#"let assert "custom" <> "error" Ok(a) = some()"#);
+}

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -2,8 +2,7 @@ use self::expression::CallKind;
 
 use super::*;
 use crate::ast::{
-    Assignment, AssignmentKind, ImplicitCallArgOrigin, Statement, TypedAssignment, UntypedExpr,
-    PIPE_VARIABLE,
+    Assignment, ImplicitCallArgOrigin, Statement, TypedAssignment, UntypedExpr, PIPE_VARIABLE,
 };
 use vec1::Vec1;
 
@@ -196,7 +195,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         let assignment = Assignment {
             location,
             annotation: None,
-            kind: AssignmentKind::Let,
+            assert: None,
             pattern: Pattern::Variable {
                 location,
                 name: PIPE_VARIABLE.into(),

--- a/compiler-core/src/type_/tests/assert.rs
+++ b/compiler-core/src/type_/tests/assert.rs
@@ -1,4 +1,5 @@
 use crate::assert_infer;
+use crate::assert_module_error;
 
 #[test]
 fn empty_list() {
@@ -88,4 +89,33 @@ fn expression2() {
 #[test]
 fn expression3() {
     assert_infer!("let assert 1 = 1", "Int");
+}
+
+#[test]
+fn expression4() {
+    assert_infer!(r#"let assert as "err" x = 1"#, "Int");
+}
+
+#[test]
+fn expression5() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+    let assert as 1 x = 1
+}
+"#
+    );
+}
+
+#[test]
+fn expression6() {
+    assert_infer!(
+        r#"
+        fn(x) {
+            let message = "error"
+            let assert as message [a] = x a
+        }
+    "#,
+        "fn(List(a)) -> a"
+    );
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__assert__expression5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__assert__expression5.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/assert.rs
+expression: "\npub fn main() {\n    let assert as 1 x = 1\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:9
+  │
+3 │     let assert as 1 x = 1
+  │         ^^^^^^^^^^^
+
+Expected type:
+
+    String
+
+Found type:
+
+    Int


### PR DESCRIPTION
This is a draft of https://github.com/gleam-lang/gleam/issues/3216

## Design

- I went with option `3.` from https://github.com/gleam-lang/gleam/issues/3216#issue-2326145589 since option `2.` means something different and option `1.` was very confusing, `let assert as msg` is similar to `todo as msg` and `panic as msg`
- I remove `AssignmentKind` enum and replaced it with `AssertAssignment` struct which contains both location and optional message of `assert`
- In `let assert as MSG` our `MSG` can only be a unit expression: basically a name or `String`
- I added a inference of `MSG` to only be `String` and nothing else

## Further steps

I understand that this feature was not fully discussed and not fully specified.
So, please: feel free to close this PR if you don't want this.

I did it just for fun :)

## Impressions

I really had fun working on this! 
The compiler is very simple and is pleasant to work with. Tests are really intuitive with the help of `insta`.

Thanks a lot for writting Gleam, it is so refreshing and cool!

