### PR TITLE
WIP: Links in type signatures

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -715,6 +715,7 @@ pub struct ModuleConstant<T, ConstantRecordTag> {
 }
 
 pub type UntypedCustomType = CustomType<()>;
+pub type TypedCustomType = CustomType<Arc<Type>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A newly defined type with one or more constructors.

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
@@ -267,7 +267,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn discard(discarded: a) -&gt; Int</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title">discard</span>(<span class="hljs-variable">discarded</span>: <span class="hljs-variable">a</span>) -&gt; <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>
@@ -346,6 +346,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
@@ -273,8 +273,8 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam">pub type Wibble {
-  Wobble(wabble: Int)
+      <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">type</span> <span class="hljs-title">Wibble</span> {
+  <span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)
 }</code></pre>
       
       <h3>
@@ -285,7 +285,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">Wobble(wabble: Int)</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -342,7 +342,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn main() -&gt; a</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title">main</span>() -&gt; <span class="hljs-variable">a</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>
@@ -421,6 +421,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
@@ -267,7 +267,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title">one</span>() -&gt; <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -347,6 +347,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
@@ -316,6 +316,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -273,9 +273,9 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam">pub type Option(t) {
-  Some(t)
-  None
+      <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">type</span> <span class="hljs-title">Option</span>(<span class="hljs-variable">t</span>) {
+  <span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)
+  <span class="hljs-title">None</span>
 }</code></pre>
       
       <h3>
@@ -286,7 +286,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">Some(t)</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -299,7 +299,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">None</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-title">None</span></code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -336,10 +336,10 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn lazy_or(
-  first: Option(a),
-  second: fn() -&gt; Option(a),
-) -&gt; Option(a)</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title">lazy_or</span>(
+  <span class="hljs-variable">first</span>: <a href="#Option" title="app.{type Option}"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>),
+  <span class="hljs-variable">second</span>: <span class="hljs-keyword">fn</span>() -&gt; <a href="#Option" title="app.{type Option}"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>),
+) -&gt; <a href="#Option" title="app.{type Option}"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>)</code></pre>
     
     <div class="rendered-markdown"><p>Returns the first value if it is <code>Some</code>, otherwise evaluates the given
 function for a fallback value.</p>
@@ -420,6 +420,9 @@ function for a fallback value.</p>
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
@@ -267,7 +267,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn indentation_test() -&gt; a</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title">indentation_test</span>() -&gt; <span class="hljs-variable">a</span></code></pre>
     
     <div class="rendered-markdown"><p>Here’s an example code snippet:</p>
 <pre><code>wibble
@@ -350,6 +350,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
@@ -320,6 +320,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
@@ -310,6 +310,9 @@ expression: "compile_with_markdown_pages(config, vec![], pages)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
@@ -267,7 +267,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore"><span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title">one</span>() -&gt; <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><table><thead><tr><th>heading 1</th><th>heading 2</th></tr></thead><tbody>
 <tr><td>row 1 cell 1</td><td>row 1 cell 2</td></tr>
@@ -350,6 +350,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>    

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -1,14 +1,7 @@
-use std::{collections::HashSet, time::SystemTime};
+use std::{collections::HashSet, default::Default, time::SystemTime};
 
 use crate::{
-    build::{Mode, NullTelemetry, PackageCompiler, StaleTracker, TargetCodegenConfiguration},
-    config::{DocsPage, PackageConfig},
-    docs::DocContext,
-    io::{memory::InMemoryFileSystem, FileSystemWriter},
-    paths::ProjectPaths,
-    uid::UniqueIdGenerator,
-    version::COMPILER_VERSION,
-    warning::WarningEmitter,
+    build::{Mode, NullTelemetry, PackageCompiler, StaleTracker, TargetCodegenConfiguration}, config::{DocsPage, PackageConfig}, docs::DocContext, io::{memory::InMemoryFileSystem, FileSystemWriter}, manifest::Manifest, paths::ProjectPaths, uid::UniqueIdGenerator, version::COMPILER_VERSION, warning::WarningEmitter
 };
 use camino::Utf8PathBuf;
 use ecow::EcoString;
@@ -79,6 +72,10 @@ fn compile_with_markdown_pages(
     super::generate_html(
         &paths,
         &config,
+        &Manifest {
+            requirements: Default::default(),
+            packages: Default::default(),
+        },
         &modules,
         &docs_pages,
         pages_fs,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use ecow::EcoString;
 use itertools::Itertools;
-use std::ops::Deref;
 use std::{cmp::Ordering, sync::Arc};
 use vec1::Vec1;
 
@@ -618,7 +617,7 @@ impl<'comments> Formatter<'comments> {
         publicity: Publicity,
         name: &'a str,
         value: &'a TypedConstant,
-        printer: &mut type_::pretty::Printer,
+        printer: &mut type_::pretty::Printer<'_>,
     ) -> Document<'a> {
         let type_ = printer.print(&value.type_());
         let attributes = AttributesPrinter::new().set_internal(publicity);
@@ -1611,7 +1610,7 @@ impl<'comments> Formatter<'comments> {
     pub fn docs_record_constructor<'a>(
         &mut self,
         constructor: &'a TypedRecordConstructor,
-        printer: &mut type_::pretty::Printer,
+        printer: &mut type_::pretty::Printer<'_>,
     ) -> Document<'a> {
         let comments = self.pop_comments(constructor.location.start);
         let doc_comments = self.doc_comments(constructor.location.start);
@@ -1706,7 +1705,7 @@ impl<'comments> Formatter<'comments> {
     pub fn docs_custom_type<'a>(
         &mut self,
         ct: &'a TypedCustomType,
-        printer: &mut type_::pretty::Printer,
+        printer: &mut type_::pretty::Printer<'_>,
     ) -> Document<'a> {
         let _ = self.pop_empty_lines(ct.location.end);
 
@@ -1789,7 +1788,7 @@ impl<'comments> Formatter<'comments> {
         args: &'a [TypedArg],
         return_type: Arc<Type>,
         location: &SrcSpan,
-        printer: &mut type_::pretty::Printer,
+        printer: &mut type_::pretty::Printer<'_>,
     ) -> Document<'a> {
         let fn_args = self.docs_fn_args(args, printer, location);
         let return_type = printer.print(&return_type);
@@ -1811,7 +1810,7 @@ impl<'comments> Formatter<'comments> {
     fn docs_fn_args<'a>(
         &mut self,
         args: &'a [TypedArg],
-        printer: &mut type_::pretty::Printer,
+        printer: &mut type_::pretty::Printer<'_>,
         location: &SrcSpan,
     ) -> Document<'a> {
         let args = args

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     build::Target,
     docvec,
-    io::Utf8Writer,
     parse::extra::{Comment, ModuleExtra},
     pretty::{self, *},
     type_::{self, Type},
@@ -25,7 +24,7 @@ use camino::Utf8Path;
 
 const INDENT: isize = 2;
 
-pub fn pretty(writer: &mut impl Utf8Writer, src: &EcoString, path: &Utf8Path) -> Result<()> {
+pub fn pretty(writer: &mut impl DocumentWriter, src: &EcoString, path: &Utf8Path) -> Result<()> {
     let parsed = crate::parse::parse_module(path.to_owned(), src, &WarningEmitter::null())
         .map_err(|error| Error::Parse {
             path: path.to_path_buf(),

--- a/compiler-core/src/language_server/signature_help.rs
+++ b/compiler-core/src/language_server/signature_help.rs
@@ -220,7 +220,7 @@ fn active_parameter_index(
 /// `ParameterInformation` for all its arguments.
 ///
 fn print_signature_help(
-    mut printer: Printer,
+    mut printer: Printer<'_>,
     function_name: EcoString,
     args: Vec<Arc<Type>>,
     return_: Arc<Type>,

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -354,19 +354,20 @@ impl<T: Utf8Writer> DocumentWriter for HtmlWriter<T> {
             Annotation::String => self.write_raw("<span class=\"hljs-string\">"),
             Annotation::Number => self.write_raw("<span class=\"hljs-number\">"),
             Annotation::Comment => self.write_raw("<span class=\"hljs-comment\">"),
-            Annotation::Meta { link, hover_text } => write!(
-                self.0,
-                "<a href=\"{}\" title=\"{}\">",
-                self.html_escape(link),
-                self.html_escape(hover_text)
-            )
-            .map_err(|e| self.convert_err(e)),
+            Annotation::Meta { link, hover_text } =>
+                if link.is_empty() {
+                    write!(self.0, "<span title=\"{}\">", self.html_escape(hover_text))
+                        .map_err(|e| self.convert_err(e))
+                } else {
+                    write!(self.0, "<a href=\"{}\" title=\"{}\">", self.html_escape(link), self.html_escape(hover_text))
+                        .map_err(|e| self.convert_err(e))
+                },
         }
     }
 
     fn exit(&mut self, annotation: &Annotation) -> Result<()> {
         match annotation {
-            Annotation::Meta { .. } => self.write_raw("</a>"),
+            Annotation::Meta { link, .. } if !link.is_empty() => self.write_raw("</a>"),
             _ => self.write_raw("</span>"),
         }
     }

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -15,76 +15,172 @@ fn fits_test() {
 
     // ForceBreak never fits
     let doc = ForceBroken(Box::new(nil()));
-    assert!(!fits(100, 0, vector![(0, Unbroken, &doc)]));
+    assert!(!fits(
+        100,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
     let doc = ForceBroken(Box::new(nil()));
-    assert!(!fits(100, 0, vector![(0, Broken, &doc)]));
+    assert!(!fits(
+        100,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
 
     // Break in Broken fits always
     assert!(fits(
         1,
         0,
-        vector![(
-            0,
-            Broken,
-            &Break {
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &Break {
                 broken: "12",
                 unbroken: "",
                 kind: BreakKind::Strict,
             }
-        )]
+        }]
     ));
 
     // Break in Unbroken mode fits if `unbroken` fits
     assert!(fits(
         3,
         0,
-        vector![(
-            0,
-            Unbroken,
-            &Break {
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &Break {
                 broken: "",
                 unbroken: "123",
                 kind: BreakKind::Strict,
             }
-        )]
+        }]
     ));
     assert!(!fits(
         2,
         0,
-        vector![(
-            0,
-            Unbroken,
-            &Break {
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &Break {
                 broken: "",
                 unbroken: "123",
                 kind: BreakKind::Strict,
             }
-        )]
+        }]
     ));
 
     // Line always fits
-    assert!(fits(0, 0, vector![(0, Broken, &Line(100))]));
-    assert!(fits(0, 0, vector![(0, Unbroken, &Line(100))]));
+    assert!(fits(
+        0,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &Line(100)
+        }]
+    ));
+    assert!(fits(
+        0,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &Line(100)
+        }]
+    ));
 
     // String fits if smaller than limit
     let doc = String("Hello".into());
-    assert!(fits(5, 0, vector![(0, Broken, &doc)]));
+    assert!(fits(
+        5,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
     let doc = String("Hello".into());
-    assert!(fits(5, 0, vector![(0, Unbroken, &doc)]));
+    assert!(fits(
+        5,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
     let doc = String("Hello".into());
-    assert!(!fits(4, 0, vector![(0, Broken, &doc)]));
+    assert!(!fits(
+        4,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
     let doc = String("Hello".into());
-    assert!(!fits(4, 0, vector![(0, Unbroken, &doc)]));
+    assert!(!fits(
+        4,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
 
     // Cons fits if combined smaller than limit
     let doc = String("1".into()).append(String("2".into()));
-    assert!(fits(2, 0, vector![(0, Broken, &doc)]));
+    assert!(fits(
+        2,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
     let doc = String("1".into()).append(String("2".into()));
-    assert!(fits(2, 0, vector![(0, Unbroken, &doc,)]));
+    assert!(fits(
+        2,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
     let doc = String("1".into()).append(String("2".into()));
-    assert!(!fits(1, 0, vector![(0, Broken, &doc)]));
+    assert!(!fits(
+        1,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
     let doc = String("1".into()).append(String("2".into()));
-    assert!(!fits(1, 0, vector![(0, Unbroken, &doc)]));
+    assert!(!fits(
+        1,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
 
     // Nest fits if combined smaller than limit
     let doc = Nest(
@@ -93,10 +189,42 @@ fn fits_test() {
         NestCondition::Always,
         Box::new(String("12".into())),
     );
-    assert!(fits(2, 0, vector![(0, Broken, &doc)]));
-    assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
-    assert!(!fits(1, 0, vector![(0, Broken, &doc)]));
-    assert!(!fits(1, 0, vector![(0, Unbroken, &doc)]));
+    assert!(fits(
+        2,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
+    assert!(fits(
+        2,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
+    assert!(!fits(
+        1,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
+    assert!(!fits(
+        1,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
 
     // Nest fits if combined smaller than limit
     let doc = Nest(
@@ -105,10 +233,42 @@ fn fits_test() {
         NestCondition::Always,
         Box::new(String("12".into())),
     );
-    assert!(fits(2, 0, vector![(0, Broken, &doc)]));
-    assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
-    assert!(!fits(1, 0, vector![(0, Broken, &doc)]));
-    assert!(!fits(1, 0, vector![(0, Unbroken, &doc)]));
+    assert!(fits(
+        2,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
+    assert!(fits(
+        2,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
+    assert!(!fits(
+        1,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Broken,
+            doc: &doc
+        }]
+    ));
+    assert!(!fits(
+        1,
+        0,
+        vector![Cmd::Doc {
+            indent: 0,
+            mode: Unbroken,
+            doc: &doc
+        }]
+    ));
 }
 
 #[test]

--- a/compiler-core/src/type_/tests/pretty.rs
+++ b/compiler-core/src/type_/tests/pretty.rs
@@ -1,25 +1,101 @@
-use std::sync::Arc;
+use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
-use crate::type_::{
-    prelude::{bool, int, tuple},
-    pretty::Printer,
-    Type,
+use camino::Utf8PathBuf;
+use hexpm::version::Version;
+
+use crate::{
+    manifest::{Base16Checksum, Manifest, ManifestPackage, ManifestPackageSource},
+    type_::{
+        prelude::{bool, int, tuple},
+        pretty::Printer,
+        Type,
+    }
 };
 
-use super::Publicity;
+use super::{Publicity, TypeVar};
 
 fn print(type_: Arc<Type>) -> String {
     Printer::new().pretty_print(&type_, 0)
 }
 
 fn custom_bool() -> Arc<Type> {
+    named("wibble", "one/two", "Bool", Publicity::Public, vec![])
+}
+
+fn fn_(args: Vec<Arc<Type>>, retrn: Arc<Type>) -> Arc<Type> {
+    Arc::new(Type::Fn { retrn, args })
+}
+
+fn named(
+    package: &str,
+    module: &str,
+    name: &str,
+    publicity: Publicity,
+    args: Vec<Arc<Type>>,
+) -> Arc<Type> {
     Arc::new(Type::Named {
-        publicity: Publicity::Public,
-        package: "wibble".into(),
-        module: "one/two".into(),
-        name: "Bool".into(),
-        args: vec![],
+        publicity,
+        package: package.into(),
+        module: module.into(),
+        name: name.into(),
+        args,
     })
+}
+
+fn unbound(id: u64) -> Arc<Type> {
+    Arc::new(Type::Var {
+        type_: Arc::new(RefCell::new(TypeVar::Unbound { id }))
+    })
+}
+
+fn generic(id: u64) -> Arc<Type> {
+    Arc::new(Type::Var {
+        type_: Arc::new(RefCell::new(TypeVar::Generic { id }))
+    })
+}
+
+fn doc_print(type_: Arc<Type>) -> String {
+    let manifest = Manifest {
+        // hashmap is not used
+        requirements: HashMap::new(),
+        packages: vec![
+            ManifestPackage {
+                name: "onhex".into(),
+                version: Version::new(1, 2, 3),
+                build_tools: vec!["gleam".into()],
+                otp_app: None,
+                requirements: vec![],
+                source: ManifestPackageSource::Hex { outer_checksum: Base16Checksum(vec![]) } 
+            },
+            ManifestPackage {
+                name: "local".into(),
+                version: Version::new(0, 0, 1),
+                build_tools: vec!["gleam".into()],
+                otp_app: None,
+                requirements: vec![],
+                source: ManifestPackageSource::Local {
+                    path: Utf8PathBuf::from("../local")
+                }
+            },
+            ManifestPackage {
+                name: "git".into(),
+                version: Version::new(1, 0, 0),
+                build_tools: vec!["gleam".into()],
+                otp_app: None,
+                requirements: vec![],
+                source: ManifestPackageSource::Git {
+                    repo: "repo".into(),
+                    commit: "commit".into(),
+                }
+            }
+        ]
+    };
+
+    let mut printer = Printer::new();
+    printer.with_context("mypkg", "mymod");
+    printer.with_manifest(&manifest);
+
+    printer.doc_pretty_print(&type_, 0)
 }
 
 #[test]
@@ -35,4 +111,70 @@ fn prelude_type_clash_prelude_first() {
 #[test]
 fn prelude_type_clash_custom_first() {
     insta::assert_snapshot!(print(tuple(vec![custom_bool(), bool()])));
+}
+
+#[test]
+fn doc_prelude_type() {
+    insta::assert_snapshot!(doc_print(tuple(vec![int(), int(), int()])));
+}
+
+#[test]
+fn doc_same_module_type() {
+    insta::assert_snapshot!(doc_print(named("mypkg", "mymod", "Int", Publicity::Public, vec![])))
+}
+
+#[test]
+fn doc_same_package_type() {
+    insta::assert_snapshot!(doc_print(named("mypkg", "wibble/wobble", "Int", Publicity::Public, vec![])))
+}
+
+#[test]
+fn doc_unknown_package() {
+    insta::assert_snapshot!(doc_print(custom_bool()));
+}
+
+#[test]
+fn doc_hex_package() {
+    insta::assert_snapshot!(doc_print(named("onhex", "wibble/wobble", "Whatever", Publicity::Public, vec![])))
+}
+
+#[test]
+fn doc_private_type() {
+    insta::assert_snapshot!(doc_print(named("onhex", "wibble/wobble", "Whatever", Publicity::Private, vec![])))
+}
+
+#[test]
+fn doc_local_package() {
+    insta::assert_snapshot!(doc_print(named("local", "wibble/wobble", "Whatever", Publicity::Public, vec![])))
+}
+
+#[test]
+fn doc_git_package() {
+    insta::assert_snapshot!(doc_print(named("git", "wibble/wobble", "Whatever", Publicity::Public, vec![])))
+}
+
+#[test]
+fn doc_parameterised_type() {
+    insta::assert_snapshot!(doc_print(named("onhex", "wibble/wobble", "Whatever", Publicity::Public, vec![
+        named("onhex", "something/else/entirely", "HttpFactorProxyBean", Publicity::Public, vec![]),
+        custom_bool(),
+        named("mypkg", "wibble/wabble", "Helper", Publicity::Public, vec![int(), int()]),
+    ])))
+}
+
+#[test]
+fn doc_fn_type() {
+    insta::assert_snapshot!(doc_print(fn_(vec![
+        int(),
+        named("onhex", "something/else/entirely", "HttpFactorProxyBean", Publicity::Public, vec![]),
+        named("mypkg", "wibble/wabble", "Helper", Publicity::Public, vec![int(), int()]),        
+    ], custom_bool())))
+}
+
+#[test]
+fn doc_generics() {
+    insta::assert_snapshot!(doc_print(tuple(vec![
+        fn_(vec![unbound(78), unbound(2)], unbound(2)),
+        fn_(vec![generic(79), generic(2231)], generic(2)),
+    ])))
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_fn_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_fn_type.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(fn_(vec![int(),\n            named(\"onhex\", \"something/else/entirely\", \"HttpFactorProxyBean\",\n            Publicity::Public, vec![]),\n            named(\"mypkg\", \"wibble/wabble\", \"Helper\", Publicity::Public,\n            vec![int(), int()]),], custom_bool()))"
+---
+<span class="hljs-keyword">fn</span>(<span class="hljs-title">Int</span>, <a href="https://hexdocs.pm/onhex/1.2.3/something/else/entirely.html#HttpFactorProxyBean" title="something/else/entirely.{type HttpFactorProxyBean}, Package: onhex"><span class="hljs-title">HttpFactorProxyBean</span></a>, <a href="../wibble/wabble.html#Helper" title="wibble/wabble.{type Helper}, Package: mypkg"><span class="hljs-title">Helper</span></a>(<span class="hljs-title">Int</span>, <span class="hljs-title">Int</span>)) -&gt; <span title="one/two.{type Bool}, Package: wibble"><span class="hljs-title">Bool</span></span>

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_generics.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_generics.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(tuple(vec![fn_(vec![unbound(78), unbound(2)], unbound(2)),\n            fn_(vec![generic(79), generic(2231)], generic(2)),]))"
+---
+#(<span class="hljs-keyword">fn</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>) -&gt; <span class="hljs-variable">b</span>, <span class="hljs-keyword">fn</span>(<span class="hljs-variable">c</span>, <span class="hljs-variable">d</span>) -&gt; <span class="hljs-variable">b</span>)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_git_package.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_git_package.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(named(\"git\", \"wibble/wobble\", \"Whatever\", Publicity::Public,\n        vec![]))"
+---
+<span title="wibble/wobble.{type Whatever}, Package: git"><span class="hljs-title">Whatever</span></span>

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_hex_package.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_hex_package.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(named(\"onhex\", \"wibble/wobble\", \"Whatever\", Publicity::Public,\n        vec![]))"
+---
+<a href="https://hexdocs.pm/onhex/1.2.3/wibble/wobble.html#Whatever" title="wibble/wobble.{type Whatever}, Package: onhex"><span class="hljs-title">Whatever</span></a>

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_local_package.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_local_package.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(named(\"local\", \"wibble/wobble\", \"Whatever\", Publicity::Public,\n        vec![]))"
+---
+<span title="wibble/wobble.{type Whatever}, Package: local"><span class="hljs-title">Whatever</span></span>

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_parameterised_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_parameterised_type.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(named(\"onhex\", \"wibble/wobble\", \"Whatever\", Publicity::Public,\n        vec![named(\"onhex\", \"something/else/entirely\", \"HttpFactorProxyBean\",\n            Publicity::Public, vec![]), custom_bool(),\n            named(\"mypkg\", \"wibble/wabble\", \"Helper\", Publicity::Public,\n            vec![int(), int()]),]))"
+---
+<a href="https://hexdocs.pm/onhex/1.2.3/wibble/wobble.html#Whatever" title="wibble/wobble.{type Whatever}, Package: onhex"><span class="hljs-title">Whatever</span></a>(<a href="https://hexdocs.pm/onhex/1.2.3/something/else/entirely.html#HttpFactorProxyBean" title="something/else/entirely.{type HttpFactorProxyBean}, Package: onhex"><span class="hljs-title">HttpFactorProxyBean</span></a>, <span title="one/two.{type Bool}, Package: wibble"><span class="hljs-title">Bool</span></span>, <a href="../wibble/wabble.html#Helper" title="wibble/wabble.{type Helper}, Package: mypkg"><span class="hljs-title">Helper</span></a>(<span class="hljs-title">Int</span>, <span class="hljs-title">Int</span>))

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_prelude_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_prelude_type.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(tuple(vec![int(), int(), int()]))"
+---
+#(<span class="hljs-title">Int</span>, <span class="hljs-title">Int</span>, <span class="hljs-title">Int</span>)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_private_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_private_type.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(named(\"onhex\", \"wibble/wobble\", \"Whatever\", Publicity::Private,\n        vec![]))"
+---
+<span class="hljs-title">Whatever</span>

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_same_module_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_same_module_type.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(named(\"mypkg\", \"mymod\", \"Int\", Publicity::Public, vec![]))"
+---
+<a href="#Int" title="mymod.{type Int}, Package: mypkg"><span class="hljs-title">Int</span></a>

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_same_package_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_same_package_type.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: "doc_print(named(\"mypkg\", \"wibble/wobble\", \"Int\", Publicity::Public, vec![]))"
+---
+<a href="../wibble/wobble.html#Int" title="wibble/wobble.{type Int}, Package: mypkg"><span class="hljs-title">Int</span></a>

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_unknown_package.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pretty__doc_unknown_package.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/type_/tests/pretty.rs
+expression: doc_print(custom_bool())
+---
+<span title="one/two.{type Bool}, Package: wibble"><span class="hljs-title">Bool</span></span>

--- a/compiler-core/templates/documentation_layout.html
+++ b/compiler-core/templates/documentation_layout.html
@@ -299,6 +299,9 @@
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
     <script src="{{ unnest }}/js/lunr.min.js?v={{ gleam_version }}"></script>    

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -64,7 +64,7 @@
     {% endif %}
     <div class="custom-type-constructors">
       <div class="rendered-markdown">{{ typ.documentation|safe }}</div>
-      <pre><code class="hljs gleam">{{ typ.definition }}</code></pre>
+      <pre><code class="hljs gleam language-gleam hljs-ignore">{{ typ.definition|safe }}</code></pre>
       {% if !typ.constructors.is_empty() %}
       <h3>
         Constructors
@@ -74,7 +74,7 @@
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">{{ constructor.definition }}</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam language-gleam hljs-ignore">{{ constructor.definition|safe }}</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -132,7 +132,7 @@
       </a>
       {% endif %}
     </div>
-    <pre><code class="hljs gleam">{{ constant.definition }}</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore">{{ constant.definition|safe }}</code></pre>
     <div class="rendered-markdown">{{ constant.documentation|safe }}</div>
   </div>
   {% endfor %}
@@ -160,7 +160,7 @@
       {% endif %}
     </div>
 
-    <pre><code class="hljs gleam">{{ function.signature }}</code></pre>
+    <pre><code class="hljs gleam language-gleam hljs-ignore">{{ function.signature|safe }}</code></pre>
     {% if !function.deprecation_message.is_empty() %}
     <p>
       <b>Deprecated:</b> {{ function.deprecation_message }}


### PR DESCRIPTION
I feel like this has already gotten quite big, so I thought I'd stop at the early point before you say it's all unreasonable anyways and I waste a bunch of time :D

First: I cannot "just" generate links, since [highlight.js will not allow them.](https://github.com/highlightjs/highlight.js/wiki/security).

Instead, all code relevant to type/function/constant signatures is highlighted at compile time, and types are always printed using the `type_::pretty::Printer` in the docs. It introduces a new variant to the Document, and a new DocumentWriter trait that can react on them. Since it looked like the documents formatter goes to great length to avoid being recursive, I've also  tried to do that. This introduces another new `Cmd` type that gets used instead of the list of `(indent, mode, doc)` triples, and consequently changes a lot of types around in format. Just doing recursion would basically get rid of all of that.

Overall, this allows for all signatures (with small extensions all parseable Gleam code) to be highlighted by the compiler directly, without relying on Javascript. This could potentially also be used to add colors/links to error messages, or annotate all examples in the docs as well.

If a resolved type (ignoring aliases) is publicly exposed, a link to its documentation will be generated as well. Versions are currently ignored. Ignoring aliases means that a common pattern doesn't work currently (lustre for example does this with every type), where an internal type is re-exported using a type alias.

### Questions

- What about tests? There are existing tests for the docs output which I updated, but generally, I'm a bit lost what you would expect.
- What to do about the alias thing?

fix #3461 #828
