### PR TITLE
Do not show completions when writing inside a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Fixed a bug where the case of type parameters would not be checked.
   ([Surya Rose](https://github.com/gearsdatapacks))
 
+- Fixed a bug where the language server would still show completions when inside
+  a comment.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.4.0-rc1 - 2024-07-29
 
 ### Build tool

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -211,14 +211,6 @@ where
             };
 
             let completer = Completer::new(&src, &params, &this.compiler, module);
-
-            // Check current filercontents if the user is writing an import
-            // and handle separately from the rest of the completion flow
-            // Check if an import is being written
-            if let Some(value) = completer.import_completions() {
-                return value;
-            }
-
             let byte_index = completer
                 .module_line_numbers
                 .byte_index(params.position.line, params.position.character);
@@ -226,6 +218,13 @@ where
             // If in comment context, do not provide completions
             if module.extra.is_within_comment(byte_index) {
                 return Ok(None);
+            }
+
+            // Check current filercontents if the user is writing an import
+            // and handle separately from the rest of the completion flow
+            // Check if an import is being written
+            if let Some(value) = completer.import_completions() {
+                return value;
             }
 
             let Some(found) = module.find_node(byte_index) else {

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1265,7 +1265,7 @@ pub type Wibble {
   Wibble(wibble: Int, wobble: Int)
   Wobble(wabble: Int, wobble: Int)
 }
-  
+
 fn fun() {
   let wibble = Wibble(1, 2)
   wibble.wobble
@@ -1281,7 +1281,7 @@ fn completions_for_record_labels() {
 pub type Wibble {
   Wibble(wibble: String, wobble: Int)
 }
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = Wibble()
 }
@@ -1294,7 +1294,7 @@ fn fun() { // completion inside parens below includes labels
 fn completions_for_imported_record_labels() {
     let code = "
 import dep
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = dep.Wibble()
 }
@@ -1317,7 +1317,7 @@ fn completions_for_function_labels() {
 fn wibble(wibble arg1: String, wobble arg2: String) {
   arg1 <> arg2
 }
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = wibble()
 }
@@ -1330,7 +1330,7 @@ fn fun() { // completion inside parens below includes labels
 fn completions_for_imported_function_labels() {
     let code = "
 import dep
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = dep.wibble()
 }
@@ -1345,4 +1345,24 @@ pub fn wibble(wibble arg1: String, wobble arg2: String) {
         TestProject::for_source(code).add_dep_module("dep", dep),
         Position::new(4, 26)
     );
+}
+
+#[test]
+fn no_completion_inside_comment_that_is_more_than_three_lines() {
+    let code = "import list
+
+// list.
+// list.
+fn fun() {
+  // list.
+  todo
+}
+";
+
+    let dep = "pub fn map() {}";
+    let completions = completion(
+        TestProject::for_source(code).add_dep_module("list", dep),
+        Position::new(5, 10),
+    );
+    assert_eq!(completions, vec![],);
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_function_labels.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_function_labels.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "\nfn wibble(wibble arg1: String, wobble arg2: String) {\n  arg1 <> arg2\n}\n  \nfn fun() { // completion inside parens below includes labels\n  let wibble = wibble()\n}\n"
+expression: "\nfn wibble(wibble arg1: String, wobble arg2: String) {\n  arg1 <> arg2\n}\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = wibble()\n}\n"
 ---
 fn wibble(wibble arg1: String, wobble arg2: String) {
   arg1 <> arg2
 }
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = wibble(|)
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_imported_function_labels.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_imported_function_labels.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "\nimport dep\n  \nfn fun() { // completion inside parens below includes labels\n  let wibble = dep.wibble()\n}\n"
+expression: "\nimport dep\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = dep.wibble()\n}\n"
 ---
 import dep
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = dep.wibble(|)
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_imported_record_labels.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_imported_record_labels.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "\nimport dep\n  \nfn fun() { // completion inside parens below includes labels\n  let wibble = dep.Wibble()\n}\n"
+expression: "\nimport dep\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = dep.Wibble()\n}\n"
 ---
 import dep
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = dep.Wibble(|)
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Int)\n  Wobble(wabble: Int, wobble: Int)\n}\n  \nfn fun() {\n  let wibble = Wibble(1, 2)\n  wibble.wobble\n}\n"
+expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Int)\n  Wobble(wabble: Int, wobble: Int)\n}\n\nfn fun() {\n  let wibble = Wibble(1, 2)\n  wibble.wobble\n}\n"
 ---
 pub type Wibble {
   Wibble(wibble: Int, wobble: Int)
   Wobble(wabble: Int, wobble: Int)
 }
-  
+
 fn fun() {
   let wibble = Wibble(1, 2)
   wibble.wobble|

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_labels.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_labels.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/completion.rs
-expression: "\npub type Wibble {\n  Wibble(wibble: String, wobble: Int)\n}\n  \nfn fun() { // completion inside parens below includes labels\n  let wibble = Wibble()\n}\n"
+expression: "\npub type Wibble {\n  Wibble(wibble: String, wobble: Int)\n}\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = Wibble()\n}\n"
 ---
 pub type Wibble {
   Wibble(wibble: String, wobble: Int)
 }
-  
+
 fn fun() { // completion inside parens below includes labels
   let wibble = Wibble(|)
 }

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -22,9 +22,9 @@ impl ModuleExtra {
     pub fn is_within_comment(&self, byte_index: u32) -> bool {
         let cmp = |span: &SrcSpan| {
             if byte_index < span.start {
-                Ordering::Less
-            } else if span.end < byte_index {
                 Ordering::Greater
+            } else if byte_index > span.end {
+                Ordering::Less
             } else {
                 Ordering::Equal
             }


### PR DESCRIPTION
This PR fixes a bug in the release candidate where the LS would show completions when writing inside a comment.