### PR TITLE
Adds initial plumbing for computing external usages of a module

### DIFF
--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -478,7 +478,7 @@ pub mod module {
       !self.reader.get_pointer_field(6).is_null()
     }
     #[inline]
-    pub fn get_external_value_usages(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
+    pub fn get_external_value_usages(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(7), ::core::option::Option::None)
     }
     #[inline]
@@ -486,7 +486,7 @@ pub mod module {
       !self.reader.get_pointer_field(7).is_null()
     }
     #[inline]
-    pub fn get_external_type_usages(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
+    pub fn get_external_type_usages(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(8), ::core::option::Option::None)
     }
     #[inline]
@@ -676,15 +676,15 @@ pub mod module {
       !self.builder.get_pointer_field(6).is_null()
     }
     #[inline]
-    pub fn get_external_value_usages(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
+    pub fn get_external_value_usages(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(7), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_external_value_usages(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>) -> ::capnp::Result<()> {
+    pub fn set_external_value_usages(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(7), value, false)
     }
     #[inline]
-    pub fn init_external_value_usages(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>> {
+    pub fn init_external_value_usages(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>> {
       ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(7), size)
     }
     #[inline]
@@ -692,15 +692,15 @@ pub mod module {
       !self.builder.get_pointer_field(7).is_null()
     }
     #[inline]
-    pub fn get_external_type_usages(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
+    pub fn get_external_type_usages(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(8), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_external_type_usages(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>) -> ::capnp::Result<()> {
+    pub fn set_external_type_usages(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(8), value, false)
     }
     #[inline]
-    pub fn init_external_type_usages(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>> {
+    pub fn init_external_type_usages(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::external_usages::Owned>> {
       ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(8), size)
     }
     #[inline]
@@ -764,6 +764,143 @@ pub mod module {
     use capnp::private::layout;
     pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 11 };
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
+  }
+}
+
+pub mod external_usages {
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  #[derive(Clone, Copy)]
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+
+  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      Reader { reader,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Reader { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn get_usages(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_usages(&self) -> bool {
+      !self.reader.get_pointer_field(0).is_null()
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
+    #[inline]
+    fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
+  }
+  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      Builder { builder,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { .. *self }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.into_reader().total_size()
+    }
+    #[inline]
+    pub fn get_usages(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_usages(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+    }
+    #[inline]
+    pub fn init_usages(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
+    }
+    #[inline]
+    pub fn has_usages(&self) -> bool {
+      !self.builder.get_pointer_field(0).is_null()
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      Pipeline { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+  }
+  mod _private {
+    use capnp::private::layout;
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 0, pointers: 1 };
+    pub const TYPE_ID: u64 = 0xe338_f315_6005_480b;
   }
 }
 

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -478,20 +478,36 @@ pub mod module {
       !self.reader.get_pointer_field(6).is_null()
     }
     #[inline]
-    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Reader<'a>> {
+    pub fn get_external_value_usages(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(7), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_line_numbers(&self) -> bool {
+    pub fn has_external_value_usages(&self) -> bool {
       !self.reader.get_pointer_field(7).is_null()
     }
     #[inline]
-    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+    pub fn get_external_type_usages(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(8), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_src_path(&self) -> bool {
+    pub fn has_external_type_usages(&self) -> bool {
       !self.reader.get_pointer_field(8).is_null()
+    }
+    #[inline]
+    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(9), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_line_numbers(&self) -> bool {
+      !self.reader.get_pointer_field(9).is_null()
+    }
+    #[inline]
+    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(10), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_src_path(&self) -> bool {
+      !self.reader.get_pointer_field(10).is_null()
     }
     #[inline]
     pub fn get_is_internal(self) -> bool {
@@ -660,36 +676,68 @@ pub mod module {
       !self.builder.get_pointer_field(6).is_null()
     }
     #[inline]
-    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Builder<'a>> {
+    pub fn get_external_value_usages(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(7), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_line_numbers(&mut self, value: crate::schema_capnp::line_numbers::Reader<'_>) -> ::capnp::Result<()> {
+    pub fn set_external_value_usages(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(7), value, false)
     }
     #[inline]
-    pub fn init_line_numbers(self, ) -> crate::schema_capnp::line_numbers::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(7), 0)
+    pub fn init_external_value_usages(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(7), size)
     }
     #[inline]
-    pub fn has_line_numbers(&self) -> bool {
+    pub fn has_external_value_usages(&self) -> bool {
       !self.builder.get_pointer_field(7).is_null()
     }
     #[inline]
-    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+    pub fn get_external_type_usages(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(8), ::core::option::Option::None)
     }
     #[inline]
+    pub fn set_external_type_usages(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(8), value, false)
+    }
+    #[inline]
+    pub fn init_external_type_usages(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::src_span::Owned>>>>> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(8), size)
+    }
+    #[inline]
+    pub fn has_external_type_usages(&self) -> bool {
+      !self.builder.get_pointer_field(8).is_null()
+    }
+    #[inline]
+    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(9), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_line_numbers(&mut self, value: crate::schema_capnp::line_numbers::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(9), value, false)
+    }
+    #[inline]
+    pub fn init_line_numbers(self, ) -> crate::schema_capnp::line_numbers::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(9), 0)
+    }
+    #[inline]
+    pub fn has_line_numbers(&self) -> bool {
+      !self.builder.get_pointer_field(9).is_null()
+    }
+    #[inline]
+    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(10), ::core::option::Option::None)
+    }
+    #[inline]
     pub fn set_src_path(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(8).set_text(value);
+      self.builder.get_pointer_field(10).set_text(value);
     }
     #[inline]
     pub fn init_src_path(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(8).init_text(size)
+      self.builder.get_pointer_field(10).init_text(size)
     }
     #[inline]
     pub fn has_src_path(&self) -> bool {
-      !self.builder.get_pointer_field(8).is_null()
+      !self.builder.get_pointer_field(10).is_null()
     }
     #[inline]
     pub fn get_is_internal(self) -> bool {
@@ -709,12 +757,12 @@ pub mod module {
   }
   impl Pipeline  {
     pub fn get_line_numbers(&self) -> crate::schema_capnp::line_numbers::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(7))
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(9))
     }
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 9 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 11 };
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -27,9 +27,11 @@ struct Module {
   package @4 :Text;
   typesConstructors @5 :List(Property(TypesVariantConstructors));
   unusedImports @6 :List(SrcSpan);
-  lineNumbers @7 :LineNumbers;
-  srcPath @8 :Text;
-  isInternal @9 :Bool;
+  externalValueUsages @7 :List(Property(List(Property(List(SrcSpan)))));
+  externalTypeUsages @8 :List(Property(List(Property(List(SrcSpan)))));
+  lineNumbers @9 :LineNumbers;
+  srcPath @10 :Text;
+  isInternal @11 :Bool;
 }
 
 struct TypesVariantConstructors {

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -27,11 +27,15 @@ struct Module {
   package @4 :Text;
   typesConstructors @5 :List(Property(TypesVariantConstructors));
   unusedImports @6 :List(SrcSpan);
-  externalValueUsages @7 :List(Property(List(Property(List(SrcSpan)))));
-  externalTypeUsages @8 :List(Property(List(Property(List(SrcSpan)))));
+  externalValueUsages @7 :List(Property(ExternalUsages));
+  externalTypeUsages @8 :List(Property(ExternalUsages));
   lineNumbers @9 :LineNumbers;
   srcPath @10 :Text;
   isInternal @11 :Bool;
+}
+
+struct ExternalUsages {
+  usages @0 :List(Property(List(SrcSpan)));
 }
 
 struct TypesVariantConstructors {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -311,9 +311,8 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             self.warnings.emit(warning.clone());
         }
 
-        // Need to deduplicate locations for external type usages
-        // since type usages are incremented on unification
-        let external_type_usages = external_type_usages
+        // Deduplicate locations for external usages
+        let external_value_usages = external_value_usages
             .into_iter()
             .map(|(module, used_values)| {
                 (
@@ -323,6 +322,27 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                         .map(|(value, locations)| {
                             (
                                 value,
+                                locations
+                                    .into_iter()
+                                    .unique_by(|loc| (loc.start, loc.end))
+                                    .sorted_by_key(|loc| loc.start)
+                                    .collect(),
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+        let external_type_usages = external_type_usages
+            .into_iter()
+            .map(|(module, used_types)| {
+                (
+                    module,
+                    used_types
+                        .into_iter()
+                        .map(|(type_, locations)| {
+                            (
+                                type_,
                                 locations
                                     .into_iter()
                                     .unique_by(|loc| (loc.start, loc.end))

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -103,10 +103,14 @@ impl<'context, 'problems> Importer<'context, 'problems> {
 
         self.environment.init_usage(
             imported_name.clone(),
-            EntityKind::ImportedType,
+            EntityKind::ImportedType {
+                module: module.name.clone(),
+            },
             import.location,
             self.problems,
         );
+        self.environment
+            .increment_imported_type_usage(&module.name, &import.name, &import.location)
     }
 
     fn register_unqualified_value(&mut self, import: &UnqualifiedImport, module: &ModuleInterface) {
@@ -142,7 +146,9 @@ impl<'context, 'problems> Importer<'context, 'problems> {
             ValueConstructorVariant::Record { name, module, .. } => {
                 self.environment.init_usage(
                     used_name.clone(),
-                    EntityKind::ImportedConstructor,
+                    EntityKind::ImportedConstructor {
+                        module: module.clone(),
+                    },
                     location,
                     self.problems,
                 );
@@ -154,7 +160,9 @@ impl<'context, 'problems> Importer<'context, 'problems> {
             }
             _ => self.environment.init_usage(
                 used_name.clone(),
-                EntityKind::ImportedValue,
+                EntityKind::ImportedValue {
+                    module: module.name.clone(),
+                },
                 location,
                 self.problems,
             ),
@@ -176,6 +184,8 @@ impl<'context, 'problems> Importer<'context, 'problems> {
             .environment
             .unqualified_imported_names
             .insert(used_name.clone(), location);
+        self.environment
+            .increment_imported_value_usage(&module.name, import_name, &location)
     }
 
     fn check_src_does_not_import_test(

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -56,6 +56,8 @@ fn write_cache(
         values: Default::default(),
         accessors: Default::default(),
         unused_imports: Vec::new(),
+        external_value_usages: Default::default(),
+        external_type_usages: Default::default(),
         line_numbers: line_numbers.clone(),
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -82,12 +82,12 @@ impl ModuleDecoder {
             external_value_usages: read_hashmap!(
                 reader.get_external_value_usages()?,
                 self,
-                src_spans_map
+                external_usages
             ),
             external_type_usages: read_hashmap!(
                 reader.get_external_type_usages()?,
                 self,
-                src_spans_map
+                external_usages
             ),
             line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
             src_path: reader.get_src_path()?.into(),
@@ -487,14 +487,11 @@ impl ModuleDecoder {
         Ok(read_vec!(reader, self, src_span))
     }
 
-    fn src_spans_map(
+    fn external_usages(
         &self,
-        reader: &capnp::struct_list::Reader<
-            '_,
-            property::Owned<capnp::struct_list::Owned<src_span::Owned>>,
-        >,
+        reader: &external_usages::Reader<'_>,
     ) -> Result<HashMap<EcoString, Vec<SrcSpan>>> {
-        Ok(read_hashmap!(reader, self, src_span_list))
+        Ok(read_hashmap!(reader.get_usages()?, self, src_span_list))
     }
 
     fn module_fn_variant(

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -79,6 +79,16 @@ impl ModuleDecoder {
             ),
             accessors: read_hashmap!(reader.get_accessors()?, self, accessors_map),
             unused_imports: read_vec!(reader.get_unused_imports()?, self, src_span),
+            external_value_usages: read_hashmap!(
+                reader.get_external_value_usages()?,
+                self,
+                src_spans_map
+            ),
+            external_type_usages: read_hashmap!(
+                reader.get_external_type_usages()?,
+                self,
+                src_spans_map
+            ),
             line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
             src_path: reader.get_src_path()?.into(),
             warnings: vec![],
@@ -468,6 +478,23 @@ impl ModuleDecoder {
             start: reader.get_start(),
             end: reader.get_end(),
         })
+    }
+
+    fn src_span_list(
+        &self,
+        reader: &capnp::struct_list::Reader<'_, src_span::Owned>,
+    ) -> Result<Vec<SrcSpan>> {
+        Ok(read_vec!(reader, self, src_span))
+    }
+
+    fn src_spans_map(
+        &self,
+        reader: &capnp::struct_list::Reader<
+            '_,
+            property::Owned<capnp::struct_list::Owned<src_span::Owned>>,
+        >,
+    ) -> Result<HashMap<EcoString, Vec<SrcSpan>>> {
+        Ok(read_hashmap!(reader, self, src_span_list))
     }
 
     fn module_fn_variant(

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -99,12 +99,10 @@ impl<'a> ModuleEncoder<'a> {
 
     fn build_external_usage(
         &mut self,
-        mut builder: capnp::struct_list::Builder<
-            '_,
-            property::Owned<capnp::struct_list::Owned<src_span::Owned>>,
-        >,
+        mut builder: external_usages::Builder<'_>,
         map: &HashMap<EcoString, Vec<SrcSpan>>,
     ) {
+        let mut builder = builder.reborrow().init_usages(map.len() as u32);
         for (i, (key, spans)) in map.iter().enumerate() {
             let mut property = builder.reborrow().get(i as u32);
             property.set_key(key);

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -38,6 +38,8 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -93,6 +95,8 @@ fn empty_module() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -112,6 +116,8 @@ fn with_line_numbers() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(
             "const a = 1
@@ -147,6 +153,8 @@ fn module_with_private_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -168,6 +176,74 @@ fn module_with_unused_import() {
             SrcSpan { start: 0, end: 10 },
             SrcSpan { start: 13, end: 42 },
         ],
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
+        accessors: HashMap::new(),
+        values: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
+    };
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
+fn module_with_external_value_usages() {
+    let module = ModuleInterface {
+        warnings: vec![],
+        is_internal: false,
+        package: "some_package".into(),
+        origin: Origin::Src,
+        name: "a".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        unused_imports: Vec::new(),
+        external_value_usages: [(
+            "other_module".into(),
+            [(
+                "value_name".into(),
+                [
+                    SrcSpan { start: 0, end: 10 },
+                    SrcSpan { start: 10, end: 20 },
+                ]
+                .into(),
+            )]
+            .into(),
+        )]
+        .into(),
+        external_type_usages: HashMap::new(),
+        accessors: HashMap::new(),
+        values: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
+    };
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
+fn module_with_external_type_usages() {
+    let module = ModuleInterface {
+        warnings: vec![],
+        is_internal: false,
+        package: "some_package".into(),
+        origin: Origin::Src,
+        name: "a".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: [(
+            "other_module".into(),
+            [(
+                "TypeName".into(),
+                [
+                    SrcSpan { start: 0, end: 10 },
+                    SrcSpan { start: 10, end: 20 },
+                ]
+                .into(),
+            )]
+            .into(),
+        )]
+        .into(),
         accessors: HashMap::new(),
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
@@ -200,6 +276,8 @@ fn module_with_app_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -231,6 +309,8 @@ fn module_with_fn_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -262,6 +342,8 @@ fn module_with_tuple_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -299,6 +381,8 @@ fn module_with_generic_type() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
+            external_value_usages: HashMap::new(),
+            external_type_usages: HashMap::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -336,6 +420,8 @@ fn module_with_type_links() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
+            external_value_usages: HashMap::new(),
+            external_type_usages: HashMap::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -373,6 +459,8 @@ fn module_with_type_constructor_documentation() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
+            external_value_usages: HashMap::new(),
+            external_type_usages: HashMap::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -413,6 +501,8 @@ fn module_with_type_constructor_origin() {
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
             unused_imports: Vec::new(),
+            external_value_usages: HashMap::new(),
+            external_type_usages: HashMap::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -443,6 +533,8 @@ fn module_type_to_constructors_mapping() {
         )]
         .into(),
         unused_imports: Default::default(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
@@ -462,6 +554,8 @@ fn module_fn_value() {
         name: "a".into(),
         types: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         types_value_constructors: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
@@ -508,6 +602,8 @@ fn deprecated_module_fn_value() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -554,6 +650,8 @@ fn private_module_fn_value() {
         name: "a".into(),
         types: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         types_value_constructors: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
@@ -602,6 +700,8 @@ fn module_fn_value_regression() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -648,6 +748,8 @@ fn module_fn_value_with_field_map() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -696,6 +798,8 @@ fn record_value() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -739,6 +843,8 @@ fn record_value_with_field_map() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -784,6 +890,8 @@ fn accessors() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: [
             (
                 "one".into(),
@@ -997,6 +1105,8 @@ fn constant_var() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [
             (
@@ -1232,6 +1342,8 @@ fn deprecated_type() {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -1250,6 +1362,8 @@ fn module_fn_value_with_external_implementations() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -1296,6 +1410,8 @@ fn internal_module_fn() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -1362,6 +1478,8 @@ fn type_variable_ids_in_constructors_are_shared() {
             },
         )]),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         accessors: HashMap::new(),
         values: [].into(),
         line_numbers: LineNumbers::new(""),

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -570,13 +570,12 @@ impl<'a> Environment<'a> {
     ) {
         self.increment_usage(name);
         if module != &self.current_module {
-            let _ = self
-                .imported_module_value_usages
+            self.imported_module_value_usages
                 .entry(module.clone())
-                .or_insert_with(HashMap::new)
+                .or_default()
                 .entry(name.clone())
-                .or_insert_with(Vec::new)
-                .push(location.clone());
+                .or_default()
+                .push(*location);
         }
     }
 
@@ -588,13 +587,12 @@ impl<'a> Environment<'a> {
     ) {
         self.increment_usage(name);
         if module != &self.current_module {
-            let _ = self
-                .imported_module_type_usages
+            self.imported_module_type_usages
                 .entry(module.clone())
-                .or_insert_with(HashMap::new)
+                .or_default()
                 .entry(name.clone())
-                .or_insert_with(Vec::new)
-                .push(location.clone());
+                .or_default()
+                .push(*location);
         }
     }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2123,6 +2123,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             // warnings of unused imports later
             let _ = self.environment.unused_modules.remove(module_alias);
             let _ = self.environment.unused_module_aliases.remove(module_alias);
+            self.environment.increment_usage(&label, &select_location);
             self.environment
                 .increment_imported_value_usage(&mod_name, &label, &select_location);
 
@@ -2400,13 +2401,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         })?;
 
                 // Register the value as seen for detection of unused values
-                self.environment.increment_usage(name);
+                self.environment.increment_usage(name, location);
 
                 constructor
             }
 
             // Look in an imported module for a binding with this name
             Some(module_name) => {
+                self.environment.increment_usage(name, location);
                 self.environment
                     .increment_imported_value_usage(module_name, name, location);
                 let (_, module) = &self

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2123,7 +2123,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             // warnings of unused imports later
             let _ = self.environment.unused_modules.remove(module_alias);
             let _ = self.environment.unused_module_aliases.remove(module_alias);
-            self.environment.increment_usage(&label, &select_location);
             self.environment
                 .increment_imported_value_usage(&mod_name, &label, &select_location);
 
@@ -2408,7 +2407,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             // Look in an imported module for a binding with this name
             Some(module_name) => {
-                self.environment.increment_usage(name, location);
                 self.environment
                     .increment_imported_value_usage(module_name, name, location);
                 let (_, module) = &self

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2117,12 +2117,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 })
             }
 
+            let mod_name = module.name.clone();
+
             // Register this imported module as having been used, to inform
             // warnings of unused imports later
             let _ = self.environment.unused_modules.remove(module_alias);
             let _ = self.environment.unused_module_aliases.remove(module_alias);
+            self.environment
+                .increment_imported_value_usage(&mod_name, &label, &select_location);
 
-            (module.name.clone(), constructor.clone())
+            (mod_name, constructor.clone())
         };
 
         let type_ = self.instantiate(constructor.type_, &mut hashmap![]);
@@ -2403,6 +2407,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             // Look in an imported module for a binding with this name
             Some(module_name) => {
+                self.environment
+                    .increment_imported_value_usage(module_name, name, location);
                 let (_, module) = &self
                     .environment
                     .imported_modules

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -149,8 +149,11 @@ impl Hydrator {
                 // Register the type constructor as being used if it is unqualified.
                 // We do not track use of qualified type constructors as they may be
                 // used in another module.
-                if module.is_none() {
-                    environment.increment_usage(name);
+                match module {
+                    None => environment.increment_usage(name),
+                    Some(module) => {
+                        environment.increment_imported_type_usage(module, name, location)
+                    }
                 }
 
                 // Ensure that the correct number of arguments have been given to the constructor

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -129,6 +129,7 @@ impl Hydrator {
                     parameters,
                     typ: return_type,
                     deprecation,
+                    module: full_module,
                     ..
                 } = environment
                     .get_type_constructor(module, name)
@@ -151,8 +152,8 @@ impl Hydrator {
                 // used in another module.
                 match module {
                     None => environment.increment_usage(name),
-                    Some(module) => {
-                        environment.increment_imported_type_usage(module, name, location)
+                    Some(_) => {
+                        environment.increment_imported_type_usage(&full_module, name, location)
                     }
                 }
 

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -151,8 +151,9 @@ impl Hydrator {
                 // We do not track use of qualified type constructors as they may be
                 // used in another module.
                 match module {
-                    None => environment.increment_usage(name),
+                    None => environment.increment_usage(name, location),
                     Some(_) => {
+                        environment.increment_usage(name, location);
                         environment.increment_imported_type_usage(&full_module, name, location)
                     }
                 }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -268,9 +268,10 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     })?;
                 match vc.variant.module_defined() {
                     None => {
-                        self.environment.increment_usage(&name);
+                        self.environment.increment_usage(&name, &location);
                     }
                     Some(module) => {
+                        self.environment.increment_usage(&name, &location);
                         self.environment
                             .increment_imported_value_usage(&module, &name, &location);
                     }
@@ -616,8 +617,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     }
                 }
                 match cons.variant.module_defined() {
-                    None => self.environment.increment_usage(&name),
+                    None => self.environment.increment_usage(&name, &location),
                     Some(module) => {
+                        self.environment.increment_usage(&name, &location);
                         self.environment
                             .increment_imported_value_usage(&module, &name, &location);
                     }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -266,15 +266,10 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             .keys()
                             .any(|typ| typ == &name),
                     })?;
-                match vc.variant.module_defined() {
-                    None => {
-                        self.environment.increment_usage(&name, &location);
-                    }
-                    Some(module) => {
-                        self.environment.increment_usage(&name, &location);
-                        self.environment
-                            .increment_imported_value_usage(&module, &name, &location);
-                    }
+                self.environment.increment_usage(&name, &location);
+                if let Some(module) = vc.variant.module_defined() {
+                    self.environment
+                        .increment_imported_value_usage(&module, &name, &location);
                 };
                 let typ =
                     self.environment
@@ -462,6 +457,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 ..
             } => {
                 // Register the value as seen for detection of unused values
+                self.environment.increment_usage(&name, &location);
 
                 let cons = self
                     .environment
@@ -616,13 +612,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         })
                     }
                 }
-                match cons.variant.module_defined() {
-                    None => self.environment.increment_usage(&name, &location),
-                    Some(module) => {
-                        self.environment.increment_usage(&name, &location);
-                        self.environment
-                            .increment_imported_value_usage(&module, &name, &location);
-                    }
+                if let Some(module) = cons.variant.module_defined() {
+                    self.environment
+                        .increment_imported_value_usage(&module, &name, &location)
                 }
 
                 let instantiated_constructor_type =

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -210,6 +210,8 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         values: HashMap::new(),
         accessors: HashMap::new(),
         unused_imports: Vec::new(),
+        external_value_usages: HashMap::new(),
+        external_type_usages: HashMap::new(),
         is_internal: false,
         warnings: vec![],
         // prelude doesn't have real src

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -22,6 +22,7 @@ mod conditional_compilation;
 mod custom_types;
 mod errors;
 mod exhaustiveness;
+mod external_usages;
 mod externals;
 mod functions;
 mod guards;

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -716,6 +716,8 @@ fn infer_module_type_retention_test() {
             values: HashMap::new(),
             accessors: HashMap::new(),
             unused_imports: Vec::new(),
+            external_value_usages: HashMap::new(),
+            external_type_usages: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "".into(),
         }

--- a/compiler-core/src/type_/tests/external_usages.rs
+++ b/compiler-core/src/type_/tests/external_usages.rs
@@ -181,3 +181,96 @@ pub fn main() -> test_module_inner.Wibble {
         .into()
     );
 }
+
+#[test]
+fn external_qualified_type_in_custom_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub type Wobble {
+  Wobble(test_module_inner.Wibble)
+}
+
+pub fn main() {
+    Wobble(test_module_inner.Wibble(1))
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [("Wibble".into(), [SrcSpan { start: 66, end: 90 }].into()),].into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_qualified_type_in_alias_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub type Wobble = test_module_inner.Wibble
+
+pub fn main() -> Wobble {
+    test_module_inner.Wibble(1)
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [("Wibble".into(), [SrcSpan { start: 57, end: 81 }].into()),].into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_qualified_type_annotation_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub fn main() {
+  let w: test_module_inner.Wibble = test_module_inner.Wibble(1)
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [("Wibble".into(), [SrcSpan { start: 64, end: 88 }].into()),].into()
+        )]
+        .into()
+    );
+}

--- a/compiler-core/src/type_/tests/external_usages.rs
+++ b/compiler-core/src/type_/tests/external_usages.rs
@@ -222,6 +222,64 @@ pub fn main() {
 }
 
 #[test]
+fn external_unqualified_pattern_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{Wibble, Wobble}
+
+pub fn main() {
+  let wibble = Wibble(1)
+  case wibble {
+    Wibble(x) -> x + 1
+    Wobble(x) -> 2
+  }
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [
+                (
+                    "Wibble".into(),
+                    [
+                        SrcSpan { start: 39, end: 45 },
+                        SrcSpan { start: 87, end: 93 },
+                        SrcSpan {
+                            start: 117,
+                            end: 126
+                        }
+                    ]
+                    .into()
+                ),
+                (
+                    "Wobble".into(),
+                    [
+                        SrcSpan { start: 47, end: 53 },
+                        SrcSpan {
+                            start: 140,
+                            end: 149
+                        }
+                    ]
+                    .into()
+                )
+            ]
+            .into()
+        )]
+        .into()
+    );
+}
+
+#[test]
 fn external_qualified_pattern_usages() {
     let module = compile_module(
         "test_module",
@@ -274,6 +332,42 @@ pub fn main() {
         .into()
     );
 }
+#[test]
+fn external_unqualified_type_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{type Wibble}
+
+pub fn main() -> Wibble {
+  test_module_inner.Wibble(1)
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [(
+                "Wibble".into(),
+                [
+                    SrcSpan { start: 39, end: 50 },
+                    SrcSpan { start: 70, end: 76 }
+                ]
+                .into()
+            ),]
+            .into()
+        )]
+        .into()
+    );
+}
 
 #[test]
 fn external_qualified_type_usages() {
@@ -299,6 +393,47 @@ pub fn main() -> test_module_inner.Wibble {
         [(
             "test_module/test_module_inner".into(),
             [("Wibble".into(), [SrcSpan { start: 56, end: 80 }].into()),].into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_unqualified_type_in_custom_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{type Wibble}
+
+pub type Wobble {
+  Wobble(Wibble)
+}
+
+pub fn main() {
+    Wobble(test_module_inner.Wibble(1))
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [(
+                "Wibble".into(),
+                [
+                    SrcSpan { start: 39, end: 50 },
+                    SrcSpan { start: 80, end: 86 }
+                ]
+                .into()
+            ),]
+            .into()
         )]
         .into()
     );
@@ -338,6 +473,45 @@ pub fn main() {
 }
 
 #[test]
+fn external_unqualified_type_in_alias_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{type Wibble}
+
+pub type Wobble = Wibble
+
+pub fn main() -> Wobble {
+    test_module_inner.Wibble(1)
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [(
+                "Wibble".into(),
+                [
+                    SrcSpan { start: 39, end: 50 },
+                    SrcSpan { start: 71, end: 77 }
+                ]
+                .into()
+            ),]
+            .into()
+        )]
+        .into()
+    );
+}
+
+#[test]
 fn external_qualified_type_in_alias_usages() {
     let module = compile_module(
         "test_module",
@@ -363,6 +537,43 @@ pub fn main() -> Wobble {
         [(
             "test_module/test_module_inner".into(),
             [("Wibble".into(), [SrcSpan { start: 57, end: 81 }].into()),].into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_unqualified_type_annotation_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{type Wibble}
+
+pub fn main() {
+  let w: Wibble = test_module_inner.Wibble(1)
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [(
+                "Wibble".into(),
+                [
+                    SrcSpan { start: 39, end: 50 },
+                    SrcSpan { start: 78, end: 84 }
+                ]
+                .into()
+            ),]
+            .into()
         )]
         .into()
     );

--- a/compiler-core/src/type_/tests/external_usages.rs
+++ b/compiler-core/src/type_/tests/external_usages.rs
@@ -1,0 +1,183 @@
+use crate::{ast::SrcSpan, type_::tests::compile_module};
+
+#[test]
+fn external_qualified_function_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub fn main() {
+  test_module_inner.wibble()
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub fn wibble() { 1 }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [("wibble".into(), [SrcSpan { start: 74, end: 81 }].into())].into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_qualified_constant_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub fn main() {
+  test_module_inner.wibble
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub const wibble = 1",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [("wibble".into(), [SrcSpan { start: 74, end: 81 }].into())].into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_qualified_constructor_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub fn main() {
+  test_module_inner.Wibble(1)
+  test_module_inner.Wobble(\"wibble\")
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [
+                ("Wibble".into(), [SrcSpan { start: 74, end: 81 }].into()),
+                (
+                    "Wobble".into(),
+                    [SrcSpan {
+                        start: 104,
+                        end: 111
+                    }]
+                    .into()
+                )
+            ]
+            .into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_qualified_pattern_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub fn main() {
+  let wibble = test_module_inner.Wibble(1)
+  case wibble {
+    test_module_inner.Wibble(x) -> x + 1
+    test_module_inner.Wobble(x) -> 2
+  }
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [
+                (
+                    "Wibble".into(),
+                    [
+                        SrcSpan { start: 87, end: 94 },
+                        SrcSpan {
+                            start: 118,
+                            end: 145
+                        }
+                    ]
+                    .into()
+                ),
+                (
+                    "Wobble".into(),
+                    [SrcSpan {
+                        start: 159,
+                        end: 186
+                    }]
+                    .into()
+                )
+            ]
+            .into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_qualified_type_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner
+
+pub fn main() -> test_module_inner.Wibble {
+  test_module_inner.Wibble(1)
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_type_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [("Wibble".into(), [SrcSpan { start: 56, end: 80 }].into()),].into()
+        )]
+        .into()
+    );
+}

--- a/compiler-core/src/type_/tests/external_usages.rs
+++ b/compiler-core/src/type_/tests/external_usages.rs
@@ -1,6 +1,43 @@
 use crate::{ast::SrcSpan, type_::tests::compile_module};
 
 #[test]
+fn external_unqualified_function_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{wibble}
+
+pub fn main() {
+  wibble()
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub fn wibble() { 1 }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [(
+                "wibble".into(),
+                [
+                    SrcSpan { start: 39, end: 45 },
+                    SrcSpan { start: 66, end: 72 }
+                ]
+                .into()
+            )]
+            .into()
+        )]
+        .into()
+    );
+}
+
+#[test]
 fn external_qualified_function_usages() {
     let module = compile_module(
         "test_module",
@@ -30,6 +67,43 @@ pub fn main() {
 }
 
 #[test]
+fn external_unqualified_constant_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{wibble}
+
+pub fn main() {
+  wibble
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub const wibble = 1",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [(
+                "wibble".into(),
+                [
+                    SrcSpan { start: 39, end: 45 },
+                    SrcSpan { start: 66, end: 72 }
+                ]
+                .into()
+            )]
+            .into()
+        )]
+        .into()
+    );
+}
+
+#[test]
 fn external_qualified_constant_usages() {
     let module = compile_module(
         "test_module",
@@ -53,6 +127,54 @@ pub fn main() {
         [(
             "test_module/test_module_inner".into(),
             [("wibble".into(), [SrcSpan { start: 74, end: 81 }].into())].into()
+        )]
+        .into()
+    );
+}
+
+#[test]
+fn external_unqualified_constructor_usages() {
+    let module = compile_module(
+        "test_module",
+        "
+import test_module/test_module_inner.{Wibble, Wobble}
+
+pub fn main() {
+  Wibble(1)
+  Wobble(\"wibble\")
+}
+",
+        None,
+        vec![(
+            "thepackage",
+            "test_module/test_module_inner",
+            "pub type Wibble { Wibble(Int) Wobble(String) }",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        module.type_info.external_value_usages,
+        [(
+            "test_module/test_module_inner".into(),
+            [
+                (
+                    "Wibble".into(),
+                    [
+                        SrcSpan { start: 39, end: 45 },
+                        SrcSpan { start: 74, end: 80 }
+                    ]
+                    .into()
+                ),
+                (
+                    "Wobble".into(),
+                    [
+                        SrcSpan { start: 47, end: 53 },
+                        SrcSpan { start: 86, end: 92 }
+                    ]
+                    .into()
+                )
+            ]
+            .into()
         )]
         .into()
     );


### PR DESCRIPTION
ModuleInterfaces will now include all the locations of usages of external values and types. Since gleam does not allow cyclical module imports, this would allow us to find all references of another module used in the module without having to recompile the module or do a post processing step on all the modules as a whole later. Using these values for doing "find all references" in the lsp would come next but didn't want this pr to get too long