### PR TITLE
Report non-byte aligned bit array patterns as compile errors for JS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,6 +316,11 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- On the JavaScript target, non-byte aligned integers in bit array patterns are
+  now reported as a compile-time error.
+
+  ([Richard Viney](https://github.com/richard-viney))
+
 ### Formatter
 
 - The formatter now adds a `todo` after a `use` expression if it is the last

--- a/changelog/v1.3.md
+++ b/changelog/v1.3.md
@@ -91,7 +91,7 @@
   Unsupported feature for Javascript since they would already cause
   a runtime error on Javascript.
 
-  This means if you compile specifically for Javascript you will now recieve
+  This means if you compile specifically for Javascript you will now receive
   this error:
 
   ```

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -706,7 +706,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                     .parse::<usize>()
                     .expect("part of an Int node should always parse as integer")),
                 _ => Err(Error::Unsupported {
-                    feature: "This bit array size option in patterns".into(),
+                    feature: "Non-constant size option in patterns".into(),
                     location: segment.location,
                 }),
             },
@@ -723,9 +723,17 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
         }?;
 
         // 16-bit floats are not supported
-        if segment.type_ == crate::type_::float() && size == 16usize {
+        if segment.type_ == crate::type_::float() && size == 16 {
             return Err(Error::Unsupported {
-                feature: "This bit array size option in patterns".into(),
+                feature: "Float width of 16 bits in patterns".into(),
+                location: segment.location,
+            });
+        }
+
+        // Ints that aren't byte-aligned are not supported
+        if segment.type_ == crate::type_::int() && size % 8 != 0 {
+            return Err(Error::Unsupported {
+                feature: "Non byte aligned integer in patterns".into(),
                 location: segment.location,
             });
         }

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -386,6 +386,29 @@ fn go(x) {
 }
 
 #[test]
+fn match_dynamic_size_error() {
+    assert_js_error!(
+        r#"
+fn go(x) {
+  let n = 16
+  let assert <<a:size(n)>> = x
+}
+"#
+    );
+}
+
+#[test]
+fn match_non_byte_aligned_size_error() {
+    assert_js_error!(
+        r#"
+fn go(x) {
+  let assert <<a:size(7)>> = x
+}
+"#
+    );
+}
+
+#[test]
 fn discard_sized() {
     assert_js!(
         r#"
@@ -471,6 +494,17 @@ fn go(x) {
   let assert <<a:float-32-little, b:int>> = x
 }
 "#,
+    );
+}
+
+#[test]
+fn match_float_16_bit_error() {
+    assert_js_error!(
+        r#"
+fn go(x) {
+  let assert <<a:float-size(16)>> = x
+}
+"#
     );
 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_error.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_error.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+assertion_line: 390
+expression: "\nfn go(x) {\n  let n = 16\n  let assert <<a:size(n)>> = x\n}\n"
+---
+error: Unsupported feature for compilation target
+  ┌─ /src/javascript/error.gleam:4:16
+  │
+4 │   let assert <<a:size(n)>> = x
+  │                ^^^^^^^^^
+
+Non-constant size option in patterns is not supported for JavaScript compilation.

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit_error.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit_error.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+assertion_line: 500
+expression: "\nfn go(x) {\n  let assert <<a:float-size(16)>> = x\n}\n"
+---
+error: Unsupported feature for compilation target
+  ┌─ /src/javascript/error.gleam:3:16
+  │
+3 │   let assert <<a:float-size(16)>> = x
+  │                ^^^^^^^^^^^^^^^^
+
+Float width of 16 bits in patterns is not supported for JavaScript compilation.

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_non_byte_aligned_size_error.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_non_byte_aligned_size_error.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+assertion_line: 401
+expression: "\nfn go(x) {\n  let assert <<a:size(7)>> = x\n}\n"
+---
+error: Unsupported feature for compilation target
+  ┌─ /src/javascript/error.gleam:3:16
+  │
+3 │   let assert <<a:size(7)>> = x
+  │                ^^^^^^^^^
+
+Non byte aligned integer in patterns is not supported for JavaScript compilation.

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -174,20 +174,20 @@ export function sizedInt(value, size, isBigEndian) {
   }
 
   if (isBigEndian) {
-    for (let i = 0; i < byteArray.length; i++) {
+    for (let i = byteArray.length - 1; i >= 0; i--) {
       const byte = value % 256;
       byteArray[i] = byte;
       value = (value - byte) / 256;
     }
   } else {
-    for (let i = byteArray.length - 1; i >= 0; i--) {
+    for (let i = 0; i < byteArray.length; i++) {
       const byte = value % 256;
       byteArray[i] = byte;
       value = (value - byte) / 256;
     }
   }
 
-  return byteArray.reverse();
+  return byteArray;
 }
 
 // @internal


### PR DESCRIPTION
This PR contains three small changes:

- Non-byte aligned integers in bit array patterns are now compile time errors on JS
- A couple of existing errors related to unsupported bit array features on JS are now more descriptive
- Small optimisation to `sizedInt()` in the JS prelude that avoids a `.reverse()` call

Can split these out to separate PRs if that's preferred