### PR TITLE
Fix crash on duplicate construcor definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Bug Fixes
 
+- Fixed a bug which caused the language server and compiler to crash when
+  two constructors of the same name were created.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.4.1 - 2024-08-04
 
 ### Bug Fixes

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -867,11 +867,14 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         let mut constructors_data = vec![];
 
         for (index, constructor) in constructors.iter().enumerate() {
-            assert_unique_name(
+            if let Err(error) = assert_unique_name(
                 &mut self.value_names,
                 &constructor.name,
                 constructor.location,
-            )?;
+            ) {
+                self.problems.error(error);
+                continue;
+            }
 
             let mut field_map = FieldMap::new(constructor.arguments.len() as u32);
             let mut args_types = Vec::with_capacity(constructor.arguments.len());

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2172,3 +2172,23 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn no_crash_on_duplicate_definition() {
+    // This previous caused the compiler to crash
+    assert_module_error!(
+        "
+type Wibble {
+  Wobble
+  Wobble
+}
+
+pub fn main() {
+  let wibble = Wobble
+  case wibble {
+    Wobble -> Nil
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\ntype Wibble {\n  Wobble\n  Wobble\n}\n\npub fn main() {\n  let wibble = Wobble\n  case wibble {\n    Wobble -> Nil\n  }\n}\n"
+---
+error: Duplicate definition
+  ┌─ /src/one/two.gleam:3:3
+  │
+3 │   Wobble
+  │   ^^^^^^ First defined here
+4 │   Wobble
+  │   ^^^^^^ Redefined here
+
+`Wobble` has been defined multiple times.
+Names in a Gleam module must be unique so one will need to be renamed.


### PR DESCRIPTION
Fixes #3489 
This is similar to #3209, where the analyser would return from the `register_values_from_custom_type` function if it found any duplicate names, and so would never get round to actually registering the values. I have now just made it report the error and continue, so it can get to the end of the function.