### PR TITLE
Add `no-print-progress` flag to `run` and `build`

### DIFF
--- a/compiler-cli/src/build_lock.rs
+++ b/compiler-cli/src/build_lock.rs
@@ -29,7 +29,7 @@ impl BuildLock {
     }
 
     /// Lock the specified directory
-    pub fn lock<Telem: Telemetry>(&self, telemetry: &Telem) -> Result<Guard> {
+    pub fn lock<Telem: Telemetry + ?Sized>(&self, telemetry: &Telem) -> Result<Guard> {
         tracing::debug!(path=?self.directory, "locking_build_directory");
 
         crate::fs::mkdir(&self.directory)?;

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -19,8 +19,16 @@ impl Reporter {
 }
 
 impl Telemetry for Reporter {
+    fn compiled_package(&self, duration: Duration) {
+        print_compiled(duration);
+    }
+
     fn compiling_package(&self, name: &str) {
         print_compiling(name);
+    }
+
+    fn checked_package(&self, duration: Duration) {
+        print_checked(duration);
     }
 
     fn checking_package(&self, name: &str) {
@@ -37,6 +45,10 @@ impl Telemetry for Reporter {
 
     fn resolving_package_versions(&self) {
         print_resolving_versions()
+    }
+
+    fn running(&self, name: &str) {
+        print_running(name);
     }
 
     fn waiting_for_build_directory_lock(&self) {

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -75,8 +75,9 @@ pub fn build(options: BuildOptions) -> Result<()> {
             codegen: Codegen::All,
             warnings_as_errors: false,
             root_target_support: TargetSupport::Enforced,
+            no_print_progress: false,
         },
-        crate::build::download_dependencies()?,
+        crate::build::download_dependencies(cli::Reporter::new())?,
     )?;
     let outputs = build_documentation(&config, &mut built.root_package, DocContext::Build)?;
 
@@ -168,8 +169,9 @@ impl PublishCommand {
                 codegen: Codegen::All,
                 mode: Mode::Prod,
                 target: None,
+                no_print_progress: false,
             },
-            crate::build::download_dependencies()?,
+            crate::build::download_dependencies(cli::Reporter::new())?,
         )?;
         let outputs =
             build_documentation(&config, &mut built.root_package, DocContext::HexPublish)?;

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -47,8 +47,9 @@ pub(crate) fn erlang_shipment() -> Result<()> {
             codegen: Codegen::All,
             mode,
             target: Some(target),
+            no_print_progress: false,
         },
-        crate::build::download_dependencies()?,
+        crate::build::download_dependencies(crate::cli::Reporter::new())?,
     )?;
 
     for entry in crate::fs::read_dir(&build)?.filter_map(Result::ok) {
@@ -136,8 +137,9 @@ pub fn package_interface(path: Utf8PathBuf) -> Result<()> {
             codegen: Codegen::All,
             warnings_as_errors: false,
             root_target_support: TargetSupport::Enforced,
+            no_print_progress: false,
         },
-        crate::build::download_dependencies()?,
+        crate::build::download_dependencies(crate::cli::Reporter::new())?,
     )?;
     built.root_package.attach_doc_and_module_comments();
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -77,7 +77,7 @@ pub use gleam_core::error::{Error, Result};
 
 use gleam_core::{
     analyse::TargetSupport,
-    build::{Codegen, Mode, Options, Runtime, Target},
+    build::{Codegen, Mode, NullTelemetry, Options, Runtime, Target},
     hex::RetirementReason,
     paths::ProjectPaths,
     version::COMPILER_VERSION,
@@ -118,6 +118,10 @@ enum Command {
 
         #[arg(short, long, ignore_case = true, help = target_doc())]
         target: Option<Target>,
+
+        /// Don't print progress information
+        #[clap(long)]
+        no_print_progress: bool,
     },
 
     /// Type check the project
@@ -191,6 +195,10 @@ enum Command {
         /// The module to run
         #[arg(short, long)]
         module: Option<String>,
+
+        /// Don't print progress information
+        #[clap(long)]
+        no_print_progress: bool,
 
         arguments: Vec<String>,
     },
@@ -435,7 +443,8 @@ fn main() {
         Command::Build {
             target,
             warnings_as_errors,
-        } => command_build(target, warnings_as_errors),
+            no_print_progress,
+        } => command_build(target, warnings_as_errors, no_print_progress),
 
         Command::Check { target } => command_check(target),
 
@@ -470,13 +479,21 @@ fn main() {
             arguments,
             runtime,
             module,
-        } => run::command(arguments, target, runtime, module, run::Which::Src),
+            no_print_progress,
+        } => run::command(
+            arguments,
+            target,
+            runtime,
+            module,
+            run::Which::Src,
+            no_print_progress,
+        ),
 
         Command::Test {
             target,
             arguments,
             runtime,
-        } => run::command(arguments, target, runtime, None, run::Which::Test),
+        } => run::command(arguments, target, runtime, None, run::Which::Test, false),
 
         Command::CompilePackage(opts) => compile_package::command(opts),
 
@@ -538,13 +555,23 @@ fn command_check(target: Option<Target>) -> Result<()> {
             codegen: Codegen::DepsOnly,
             mode: Mode::Dev,
             target,
+            no_print_progress: false,
         },
-        build::download_dependencies()?,
+        build::download_dependencies(cli::Reporter::new())?,
     )?;
     Ok(())
 }
 
-fn command_build(target: Option<Target>, warnings_as_errors: bool) -> Result<()> {
+fn command_build(
+    target: Option<Target>,
+    warnings_as_errors: bool,
+    no_print_progress: bool,
+) -> Result<()> {
+    let manifest = if no_print_progress {
+        build::download_dependencies(NullTelemetry)?
+    } else {
+        build::download_dependencies(cli::Reporter::new())?
+    };
     let _ = build::main(
         Options {
             root_target_support: TargetSupport::Enforced,
@@ -552,8 +579,9 @@ fn command_build(target: Option<Target>, warnings_as_errors: bool) -> Result<()>
             codegen: Codegen::All,
             mode: Mode::Dev,
             target,
+            no_print_progress,
         },
-        build::download_dependencies()?,
+        manifest,
     )?;
     Ok(())
 }

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -262,8 +262,9 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &PackageConfig) -> Result<
             mode: Mode::Prod,
             target: Some(target),
             codegen: Codegen::All,
+            no_print_progress: false,
         },
-        build::download_dependencies()?,
+        build::download_dependencies(cli::Reporter::new())?,
     )?;
 
     // If any of the modules in the package contain a todo then refuse to

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -16,8 +16,9 @@ pub fn command() -> Result<(), Error> {
             codegen: Codegen::All,
             mode: Mode::Dev,
             target: Some(Target::Erlang),
+            no_print_progress: false,
         },
-        crate::build::download_dependencies()?,
+        crate::build::download_dependencies(crate::cli::Reporter::new())?,
     )?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -54,6 +54,7 @@ pub struct Options {
     pub codegen: Codegen,
     pub warnings_as_errors: bool,
     pub root_target_support: TargetSupport,
+    pub no_print_progress: bool,
 }
 
 #[derive(Debug)]
@@ -91,7 +92,7 @@ pub struct ProjectCompiler<IO> {
     /// successful compilation.
     incomplete_modules: HashSet<EcoString>,
     warnings: WarningEmitter,
-    telemetry: Box<dyn Telemetry>,
+    telemetry: &'static dyn Telemetry,
     options: Options,
     paths: ProjectPaths,
     ids: UniqueIdGenerator,
@@ -112,7 +113,7 @@ where
         config: PackageConfig,
         options: Options,
         packages: Vec<ManifestPackage>,
-        telemetry: Box<dyn Telemetry>,
+        telemetry: &'static dyn Telemetry,
         warning_emitter: Arc<dyn WarningEmitterIO>,
         paths: ProjectPaths,
         io: IO,
@@ -580,7 +581,7 @@ where
             &mut self.defined_modules,
             &mut self.stale_modules,
             &mut self.incomplete_modules,
-            self.telemetry.as_ref(),
+            self.telemetry,
         )
     }
 }

--- a/compiler-core/src/build/telemetry.rs
+++ b/compiler-core/src/build/telemetry.rs
@@ -7,10 +7,13 @@ use crate::Warning;
 
 pub trait Telemetry: Debug {
     fn waiting_for_build_directory_lock(&self);
+    fn running(&self, name: &str);
     fn resolving_package_versions(&self);
     fn downloading_package(&self, name: &str);
     fn packages_downloaded(&self, start: Instant, count: usize);
+    fn compiled_package(&self, duration: Duration);
     fn compiling_package(&self, name: &str);
+    fn checked_package(&self, duration: Duration);
     fn checking_package(&self, name: &str);
 }
 
@@ -19,9 +22,12 @@ pub struct NullTelemetry;
 
 impl Telemetry for NullTelemetry {
     fn waiting_for_build_directory_lock(&self) {}
+    fn running(&self, name: &str) {}
     fn resolving_package_versions(&self) {}
     fn downloading_package(&self, _name: &str) {}
+    fn compiled_package(&self, _duration: Duration) {}
     fn compiling_package(&self, _name: &str) {}
+    fn checked_package(&self, _duration: Duration) {}
     fn checking_package(&self, _name: &str) {}
     fn packages_downloaded(&self, _start: Instant, _count: usize) {}
 }

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -50,7 +50,6 @@ where
         io: IO,
         locker: Box<dyn Locker>,
     ) -> Result<Self> {
-        let telemetry = NullTelemetry;
         let target = config.target;
         let name = config.name.clone();
         let warnings = Arc::new(VectorWarningEmitterIO::default());
@@ -71,12 +70,13 @@ where
             target: None,
             codegen: build::Codegen::None,
             root_target_support: TargetSupport::Enforced,
+            no_print_progress: false,
         };
         let mut project_compiler = ProjectCompiler::new(
             config,
             options,
             manifest.packages,
-            Box::new(telemetry),
+            &NullTelemetry,
             warnings.clone(),
             paths,
             io,

--- a/compiler-wasm/src/log_telemetry.rs
+++ b/compiler-wasm/src/log_telemetry.rs
@@ -3,8 +3,16 @@ use gleam_core::build::Telemetry;
 pub struct LogTelemetry;
 
 impl Telemetry for LogTelemetry {
+    fn compiled_package(&self, duration: std::time::Duration) {
+        tracing::info!("Compiled in {} ", seconds(duration));
+    }
+
     fn compiling_package(&self, name: &str) {
         tracing::info!("Compiling package: {}", name);
+    }
+
+    fn checked_package(&self, duration: std::time::Duration) {
+        tracing::info!("Checked in {}", seconds(duration));
     }
 
     fn checking_package(&self, name: &str) {
@@ -13,6 +21,10 @@ impl Telemetry for LogTelemetry {
 
     fn downloading_package(&self, name: &str) {
         tracing::info!("Downloading package: {}", name);
+    }
+
+    fn running(&self, name: &str) {
+        tracing::info!("Running {}", name);
     }
 
     fn resolving_package_versions(&self) {
@@ -26,4 +38,8 @@ impl Telemetry for LogTelemetry {
     fn waiting_for_build_directory_lock(&self) {
         tracing::info!("Waiting for build directory lock");
     }
+}
+
+pub fn seconds(duration: std::time::Duration) -> String {
+    format!("{:.2}s", duration.as_millis() as f32 / 1000.)
 }


### PR DESCRIPTION
Implements #2299

Mostly similar to #2455 but with some changes to the telemetry object based on @lpil 's comments.