### PR TITLE
Add --no-print-progress flag

### DIFF
--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -48,8 +48,8 @@ pub fn main(options: Options, manifest: Manifest, telemetry: Arc<dyn Telemetry>)
     };
 
     match perform_codegen {
-        Codegen::All | Codegen::DepsOnly => cli::print_compiled(start.elapsed()),
-        Codegen::None => cli::print_checked(start.elapsed()),
+        Codegen::All | Codegen::DepsOnly => telemetry.compiled_packages(start),
+        Codegen::None => telemetry.checked_packages(start),
     };
 
     Ok(result)

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Instant};
 
 use gleam_core::{
-    build::{Built, Codegen, Options, ProjectCompiler},
+    build::{Built, Codegen, Options, ProjectCompiler, Telemetry},
     manifest::Manifest,
     paths::ProjectPaths,
     Result,
@@ -19,11 +19,10 @@ pub fn download_dependencies() -> Result<Manifest> {
     crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)
 }
 
-pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
+pub fn main(options: Options, manifest: Manifest, telemetry: Box<dyn Telemetry>) -> Result<Built> {
     let paths = crate::find_project_paths()?;
     let perform_codegen = options.codegen;
     let root_config = crate::config::root_config()?;
-    let telemetry = Box::new(cli::Reporter::new());
     let io = fs::ProjectIO::new();
     let start = Instant::now();
     let lock = BuildLock::new_target(

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -19,7 +19,7 @@ pub fn download_dependencies() -> Result<Manifest> {
     crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)
 }
 
-pub fn main(options: Options, manifest: Manifest, telemetry: Box<dyn Telemetry>) -> Result<Built> {
+pub fn main(options: Options, manifest: Manifest, telemetry: Arc<dyn Telemetry>) -> Result<Built> {
     let paths = crate::find_project_paths()?;
     let perform_codegen = options.codegen;
     let root_config = crate::config::root_config()?;
@@ -39,7 +39,7 @@ pub fn main(options: Options, manifest: Manifest, telemetry: Box<dyn Telemetry>)
             root_config,
             options,
             manifest.packages,
-            telemetry,
+            telemetry.clone(),
             Arc::new(ConsoleWarningEmitter),
             ProjectPaths::new(current_dir),
             io,

--- a/compiler-cli/src/build_lock.rs
+++ b/compiler-cli/src/build_lock.rs
@@ -29,7 +29,7 @@ impl BuildLock {
     }
 
     /// Lock the specified directory
-    pub fn lock<Telem: Telemetry>(&self, telemetry: &Telem) -> Result<Guard> {
+    pub fn lock(&self, telemetry: &dyn Telemetry) -> Result<Guard> {
         tracing::debug!(path=?self.directory, "locking_build_directory");
 
         crate::fs::mkdir(&self.directory)?;

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -19,12 +19,20 @@ impl Reporter {
 }
 
 impl Telemetry for Reporter {
-    fn compiling_package(&self, name: &str) {
-        print_compiling(name);
+    fn checked_packages(&self, start: Instant) {
+        print_checked(start.elapsed())
     }
 
     fn checking_package(&self, name: &str) {
         print_checking(name);
+    }
+
+    fn compiled_packages(&self, start: Instant) {
+        print_compiled(start.elapsed())
+    }
+
+    fn compiling_package(&self, name: &str) {
+        print_compiling(name);
     }
 
     fn downloading_package(&self, name: &str) {

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -42,6 +42,10 @@ impl Telemetry for Reporter {
     fn waiting_for_build_directory_lock(&self) {
         print_waiting_for_build_directory_lock()
     }
+
+    fn running_module(&self, name: &str) {
+        print_running(&format!("{name}.main"))
+    }
 }
 
 pub fn ask(question: &str) -> Result<String, Error> {

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -77,6 +77,7 @@ pub fn build(options: BuildOptions) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
         },
         crate::build::download_dependencies()?,
+        Box::new(cli::Reporter::new()),
     )?;
     let outputs = build_documentation(&config, &mut built.root_package, DocContext::Build)?;
 
@@ -170,6 +171,7 @@ impl PublishCommand {
                 target: None,
             },
             crate::build::download_dependencies()?,
+            Box::new(cli::Reporter::new()),
         )?;
         let outputs =
             build_documentation(&config, &mut built.root_package, DocContext::HexPublish)?;

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -77,7 +78,7 @@ pub fn build(options: BuildOptions) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
         },
         crate::build::download_dependencies()?,
-        Box::new(cli::Reporter::new()),
+        Arc::new(cli::Reporter::new()),
     )?;
     let outputs = build_documentation(&config, &mut built.root_package, DocContext::Build)?;
 
@@ -171,7 +172,7 @@ impl PublishCommand {
                 target: None,
             },
             crate::build::download_dependencies()?,
-            Box::new(cli::Reporter::new()),
+            Arc::new(cli::Reporter::new()),
         )?;
         let outputs =
             build_documentation(&config, &mut built.root_package, DocContext::HexPublish)?;

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -49,6 +49,7 @@ pub(crate) fn erlang_shipment() -> Result<()> {
             target: Some(target),
         },
         crate::build::download_dependencies()?,
+        Box::new(crate::cli::Reporter::new()),
     )?;
 
     for entry in crate::fs::read_dir(&build)?.filter_map(Result::ok) {
@@ -138,6 +139,7 @@ pub fn package_interface(path: Utf8PathBuf) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
         },
         crate::build::download_dependencies()?,
+        Box::new(crate::cli::Reporter::new()),
     )?;
     built.root_package.attach_doc_and_module_comments();
 

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use camino::Utf8PathBuf;
 use gleam_core::{
     analyse::TargetSupport,
@@ -49,7 +51,7 @@ pub(crate) fn erlang_shipment() -> Result<()> {
             target: Some(target),
         },
         crate::build::download_dependencies()?,
-        Box::new(crate::cli::Reporter::new()),
+        Arc::new(crate::cli::Reporter::new()),
     )?;
 
     for entry in crate::fs::read_dir(&build)?.filter_map(Result::ok) {
@@ -139,7 +141,7 @@ pub fn package_interface(path: Utf8PathBuf) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
         },
         crate::build::download_dependencies()?,
-        Box::new(crate::cli::Reporter::new()),
+        Arc::new(crate::cli::Reporter::new()),
     )?;
     built.root_package.attach_doc_and_module_comments();
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -192,6 +192,10 @@ enum Command {
         #[arg(short, long)]
         module: Option<String>,
 
+        /// Don't print progress information
+        #[arg(long)]
+        no_print_progress: bool,
+
         arguments: Vec<String>,
     },
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -84,6 +84,7 @@ use gleam_core::{
 };
 use hex::ApiKeyCommand as _;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use camino::Utf8PathBuf;
 
@@ -552,7 +553,7 @@ fn command_check(target: Option<Target>) -> Result<()> {
             target,
         },
         build::download_dependencies()?,
-        Box::new(cli::Reporter::new()),
+        Arc::new(cli::Reporter::new()),
     )?;
     Ok(())
 }
@@ -567,7 +568,7 @@ fn command_build(target: Option<Target>, warnings_as_errors: bool) -> Result<()>
             target,
         },
         build::download_dependencies()?,
-        Box::new(cli::Reporter::new()),
+        Arc::new(cli::Reporter::new()),
     )?;
     Ok(())
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -474,13 +474,21 @@ fn main() {
             arguments,
             runtime,
             module,
-        } => run::command(arguments, target, runtime, module, run::Which::Src),
+            no_print_progress,
+        } => run::command(
+            arguments,
+            target,
+            runtime,
+            module,
+            no_print_progress,
+            run::Which::Src,
+        ),
 
         Command::Test {
             target,
             arguments,
             runtime,
-        } => run::command(arguments, target, runtime, None, run::Which::Test),
+        } => run::command(arguments, target, runtime, None, false, run::Which::Test),
 
         Command::CompilePackage(opts) => compile_package::command(opts),
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -552,6 +552,7 @@ fn command_check(target: Option<Target>) -> Result<()> {
             target,
         },
         build::download_dependencies()?,
+        Box::new(cli::Reporter::new()),
     )?;
     Ok(())
 }
@@ -566,6 +567,7 @@ fn command_build(target: Option<Target>, warnings_as_errors: bool) -> Result<()>
             target,
         },
         build::download_dependencies()?,
+        Box::new(cli::Reporter::new()),
     )?;
     Ok(())
 }

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -264,6 +264,7 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &PackageConfig) -> Result<
             codegen: Codegen::All,
         },
         build::download_dependencies()?,
+        Box::new(cli::Reporter::new()),
     )?;
 
     // If any of the modules in the package contain a todo then refuse to

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -13,7 +13,7 @@ use gleam_core::{
 use hexpm::version::{Range, Version};
 use itertools::Itertools;
 use sha2::Digest;
-use std::{io::Write, path::PathBuf, time::Instant};
+use std::{io::Write, path::PathBuf, time::Instant, sync::Arc};
 
 use crate::{build, cli, docs, fs, hex::ApiKeyCommand, http::HttpClient};
 
@@ -264,7 +264,7 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &PackageConfig) -> Result<
             codegen: Codegen::All,
         },
         build::download_dependencies()?,
-        Box::new(cli::Reporter::new()),
+        Arc::new(cli::Reporter::new()),
     )?;
 
     // If any of the modules in the package contain a todo then refuse to

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::{sync::Arc, sync::OnceLock};
 
 use camino::Utf8PathBuf;
 use ecow::EcoString;
@@ -79,10 +79,10 @@ pub fn command(
         },
     };
 
-    let telemetry: Box<dyn Telemetry> = if no_print_progress {
-        Box::new(NullTelemetry)
+    let telemetry: Arc<dyn Telemetry> = if no_print_progress {
+        Arc::new(NullTelemetry)
     } else {
-        Box::new(crate::cli::Reporter::new())
+        Arc::new(crate::cli::Reporter::new())
     };
 
     let built = crate::build::main(options, manifest, telemetry)?;

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -85,7 +85,7 @@ pub fn command(
         Arc::new(crate::cli::Reporter::new())
     };
 
-    let built = crate::build::main(options, manifest, telemetry)?;
+    let built = crate::build::main(options, manifest, telemetry.clone())?;
 
     // A module can not be run if it does not exist or does not have a public main function.
     let main_function = get_or_suggest_main_function(built, &module, target)?;
@@ -93,7 +93,7 @@ pub fn command(
     // Don't exit on ctrl+c as it is used by child erlang shell
     ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
 
-    crate::cli::print_running(&format!("{module}.main"));
+    telemetry.running_module(&module);
 
     // Run the command
     let status = match target {

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -26,6 +26,7 @@ pub fn command(
     target: Option<Target>,
     runtime: Option<Runtime>,
     module: Option<String>,
+    no_print_progress: bool,
     which: Which,
 ) -> Result<(), Error> {
     let paths = crate::find_project_paths()?;

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -4,7 +4,7 @@ use camino::Utf8PathBuf;
 use ecow::EcoString;
 use gleam_core::{
     analyse::TargetSupport,
-    build::{Built, Codegen, Mode, Options, Runtime, Target},
+    build::{Built, Codegen, Mode, NullTelemetry, Options, Runtime, Target, Telemetry},
     config::{DenoFlag, PackageConfig},
     error::Error,
     io::{CommandExecutor, Stdio},
@@ -79,7 +79,13 @@ pub fn command(
         },
     };
 
-    let built = crate::build::main(options, manifest, Box::new(crate::cli::Reporter::new()))?;
+    let telemetry: Box<dyn Telemetry> = if no_print_progress {
+        Box::new(NullTelemetry)
+    } else {
+        Box::new(crate::cli::Reporter::new())
+    };
+
+    let built = crate::build::main(options, manifest, telemetry)?;
 
     // A module can not be run if it does not exist or does not have a public main function.
     let main_function = get_or_suggest_main_function(built, &module, target)?;

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -79,7 +79,7 @@ pub fn command(
         },
     };
 
-    let built = crate::build::main(options, manifest)?;
+    let built = crate::build::main(options, manifest, Box::new(crate::cli::Reporter::new()))?;
 
     // A module can not be run if it does not exist or does not have a public main function.
     let main_function = get_or_suggest_main_function(built, &module, target)?;

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -3,7 +3,7 @@ use gleam_core::{
     build::{Codegen, Mode, Options, Target},
     error::Error,
 };
-use std::process::Command;
+use std::{process::Command, sync::Arc};
 
 pub fn command() -> Result<(), Error> {
     let paths = crate::find_project_paths()?;
@@ -18,7 +18,7 @@ pub fn command() -> Result<(), Error> {
             target: Some(Target::Erlang),
         },
         crate::build::download_dependencies()?,
-        Box::new(crate::cli::Reporter::new()),
+        Arc::new(crate::cli::Reporter::new()),
     )?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -18,6 +18,7 @@ pub fn command() -> Result<(), Error> {
             target: Some(Target::Erlang),
         },
         crate::build::download_dependencies()?,
+        Box::new(crate::cli::Reporter::new()),
     )?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -91,7 +91,7 @@ pub struct ProjectCompiler<IO> {
     /// successful compilation.
     incomplete_modules: HashSet<EcoString>,
     warnings: WarningEmitter,
-    telemetry: Box<dyn Telemetry>,
+    telemetry: Arc<dyn Telemetry>,
     options: Options,
     paths: ProjectPaths,
     ids: UniqueIdGenerator,
@@ -112,7 +112,7 @@ where
         config: PackageConfig,
         options: Options,
         packages: Vec<ManifestPackage>,
-        telemetry: Box<dyn Telemetry>,
+        telemetry: Arc<dyn Telemetry>,
         warning_emitter: Arc<dyn WarningEmitterIO>,
         paths: ProjectPaths,
         io: IO,

--- a/compiler-core/src/build/telemetry.rs
+++ b/compiler-core/src/build/telemetry.rs
@@ -12,6 +12,7 @@ pub trait Telemetry: Debug {
     fn packages_downloaded(&self, start: Instant, count: usize);
     fn compiling_package(&self, name: &str);
     fn checking_package(&self, name: &str);
+    fn running_module(&self, name: &str);
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -24,4 +25,5 @@ impl Telemetry for NullTelemetry {
     fn compiling_package(&self, _name: &str) {}
     fn checking_package(&self, _name: &str) {}
     fn packages_downloaded(&self, _start: Instant, _count: usize) {}
+    fn running_module(&self, _name: &str) {}
 }

--- a/compiler-core/src/build/telemetry.rs
+++ b/compiler-core/src/build/telemetry.rs
@@ -6,19 +6,23 @@ use std::{
 use crate::Warning;
 
 pub trait Telemetry: Debug {
-    fn waiting_for_build_directory_lock(&self);
-    fn resolving_package_versions(&self);
+    fn checked_packages(&self, start: Instant);
+    fn checking_package(&self, name: &str);
+    fn compiled_packages(&self, start: Instant);
+    fn compiling_package(&self, name: &str);
     fn downloading_package(&self, name: &str);
     fn packages_downloaded(&self, start: Instant, count: usize);
-    fn compiling_package(&self, name: &str);
-    fn checking_package(&self, name: &str);
+    fn resolving_package_versions(&self);
     fn running_module(&self, name: &str);
+    fn waiting_for_build_directory_lock(&self);
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct NullTelemetry;
 
 impl Telemetry for NullTelemetry {
+    fn checked_packages(&self, _start: Instant) {}
+    fn compiled_packages(&self, _start: Instant) {}
     fn waiting_for_build_directory_lock(&self) {}
     fn resolving_package_versions(&self) {}
     fn downloading_package(&self, _name: &str) {}

--- a/compiler-core/src/build/telemetry.rs
+++ b/compiler-core/src/build/telemetry.rs
@@ -22,12 +22,12 @@ pub struct NullTelemetry;
 
 impl Telemetry for NullTelemetry {
     fn checked_packages(&self, _start: Instant) {}
-    fn compiled_packages(&self, _start: Instant) {}
-    fn waiting_for_build_directory_lock(&self) {}
-    fn resolving_package_versions(&self) {}
-    fn downloading_package(&self, _name: &str) {}
-    fn compiling_package(&self, _name: &str) {}
     fn checking_package(&self, _name: &str) {}
+    fn compiled_packages(&self, _start: Instant) {}
+    fn compiling_package(&self, _name: &str) {}
+    fn downloading_package(&self, _name: &str) {}
     fn packages_downloaded(&self, _start: Instant, _count: usize) {}
+    fn resolving_package_versions(&self) {}
     fn running_module(&self, _name: &str) {}
+    fn waiting_for_build_directory_lock(&self) {}
 }

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -50,7 +50,7 @@ where
         io: IO,
         locker: Box<dyn Locker>,
     ) -> Result<Self> {
-        let telemetry = NullTelemetry;
+        let telemetry = Arc::new(NullTelemetry);
         let target = config.target;
         let name = config.name.clone();
         let warnings = Arc::new(VectorWarningEmitterIO::default());
@@ -76,7 +76,7 @@ where
             config,
             options,
             manifest.packages,
-            Box::new(telemetry),
+            telemetry,
             warnings.clone(),
             paths,
             io,

--- a/compiler-wasm/src/log_telemetry.rs
+++ b/compiler-wasm/src/log_telemetry.rs
@@ -26,4 +26,8 @@ impl Telemetry for LogTelemetry {
     fn waiting_for_build_directory_lock(&self) {
         tracing::info!("Waiting for build directory lock");
     }
+
+    fn running_module(&self, name: &str) {
+        tracing::info!("Running {}.main", name);
+    }
 }

--- a/compiler-wasm/src/log_telemetry.rs
+++ b/compiler-wasm/src/log_telemetry.rs
@@ -3,6 +3,14 @@ use gleam_core::build::Telemetry;
 pub struct LogTelemetry;
 
 impl Telemetry for LogTelemetry {
+    fn checked_packages(&self, _start: std::time::Instant) {
+        tracing::info!("Checked packages");
+    }
+
+    fn compiled_packages(&self, _start: std::time::Instant) {
+        tracing::info!("Compiled packages");
+    }
+
     fn compiling_package(&self, name: &str) {
         tracing::info!("Compiling package: {}", name);
     }
@@ -15,19 +23,19 @@ impl Telemetry for LogTelemetry {
         tracing::info!("Downloading package: {}", name);
     }
 
-    fn resolving_package_versions(&self) {
-        tracing::info!("Resolving package versions");
-    }
-
     fn packages_downloaded(&self, _start: std::time::Instant, count: usize) {
         tracing::info!("Downloaded {} packages", count);
     }
 
-    fn waiting_for_build_directory_lock(&self) {
-        tracing::info!("Waiting for build directory lock");
+    fn resolving_package_versions(&self) {
+        tracing::info!("Resolving package versions");
     }
 
     fn running_module(&self, name: &str) {
         tracing::info!("Running {}.main", name);
+    }
+
+    fn waiting_for_build_directory_lock(&self) {
+        tracing::info!("Waiting for build directory lock");
     }
 }


### PR DESCRIPTION
🚧 WIP

Fixes https://github.com/gleam-lang/gleam/issues/2299 for `gleam run`

**Primary changes**: 

- Added `--no-print-progress` as a flag for `gleam run`. 
- Added `checked_packages` and `compiled_packages` as methods on `Telemetry`

The other changes are mostly related to: 

- Passing around `Telemetry` in more places
- Alphabetical ordering of methods inside Telemetry implementations so that they're consistent