### PR TITLE
Fix another compiler crash for duplicate constructor definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
 
 - Fixed a bug where incorrect syntax error message were shown,
   when using `:` or `=` in wrong possitions in expressions.
+  ([Ankit Goel](https://github.com/crazymerlyn))
+
+- Fixed a bug where the compiler would crash when pattern matching on a type
+  which had constructors of duplicate names.
+  ([Surya Rose](https://github.com/gearsdatapacks))
 
 ## v1.4.1 - 2024-08-04
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -866,7 +866,8 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
         let mut constructors_data = vec![];
 
-        for (index, constructor) in constructors.iter().enumerate() {
+        let mut index = 0;
+        for constructor in constructors.iter() {
             if let Err(error) = assert_unique_name(
                 &mut self.value_names,
                 &constructor.name,
@@ -926,6 +927,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 module: self.module_name.clone(),
                 constructor_index: index as u16,
             };
+            index += 1;
 
             // If the contructor belongs to an opaque type then it's going to be
             // considered as private.

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2178,7 +2178,7 @@ fn no_crash_on_duplicate_definition() {
     // This previous caused the compiler to crash
     assert_module_error!(
         "
-type Wibble {
+pub type Wibble {
   Wobble
   Wobble
 }
@@ -2187,6 +2187,30 @@ pub fn main() {
   let wibble = Wobble
   case wibble {
     Wobble -> Nil
+  }
+}
+"
+    );
+}
+
+#[test]
+fn no_crash_on_duplicate_definition2() {
+    // This also caused a compiler crash, separate to the above test
+    assert_module_error!(
+        "
+pub type Wibble {
+  Wibble
+  Wobble
+  Wobble
+  Wubble
+}
+
+pub fn main() {
+  let wibble = Wobble
+  case wibble {
+    Wibble -> Nil
+    Wobble -> Nil
+    Wubble -> Nil
   }
 }
 "

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition2.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble {\n  Wibble\n  Wobble\n  Wobble\n  Wubble\n}\n\npub fn main() {\n  let wibble = Wobble\n  case wibble {\n    Wibble -> Nil\n    Wobble -> Nil\n    Wubble -> Nil\n  }\n}\n"
+---
+error: Duplicate definition
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   Wobble
+  │   ^^^^^^ First defined here
+5 │   Wobble
+  │   ^^^^^^ Redefined here
+
+`Wobble` has been defined multiple times.
+Names in a Gleam module must be unique so one will need to be renamed.


### PR DESCRIPTION
Fixes #3506 

This is a similar issue to #3489; this crash was caused by a mismatch of `constructor_index`s and actual registered constructors. If a duplicate constructor existed, it would not be registered but the index was still incremented, which broke an assumption made in another place in the compiler. I've just changed it to manually increment an index instead of using `Iterator::enumerate`.

I didn't add another changelog entry since this is just another edge-case of the aforementioned issue, and doesn't really require a separate entry in my opinion.