### PR TITLE
Fix tag generation URL in docs for some VCSs

### DIFF
--- a/compiler-core/src/docs/source_links.rs
+++ b/compiler-core/src/docs/source_links.rs
@@ -51,21 +51,21 @@ impl SourceLinker {
             )),
             Repository::CodeBerg { user, repo } => Some((
                 format!(
-                    "https://codeberg.org/{}/{}/src/tag/{}/{}#L",
+                    "https://codeberg.org/{}/{}/src/tag/v{}/{}#L",
                     user, repo, project_config.version, path_in_repo
                 ),
                 "-".into(),
             )),
             Repository::SourceHut { user, repo } => Some((
                 format!(
-                    "https://git.sr.ht/~{}/{}/tree/{}/item/{}#L",
+                    "https://git.sr.ht/~{}/{}/tree/v{}/item/{}#L",
                     user, repo, project_config.version, path_in_repo
                 ),
                 "-".into(),
             )),
             Repository::Gitea { user, repo, host } => Some((
                 format!(
-                    "{host}/{user}/{repo}/src/tag/{}/{}#L",
+                    "{host}/{user}/{repo}/src/tag/v{}/{}#L",
                     project_config.version, path_in_repo
                 ),
                 "-".into(),


### PR DESCRIPTION
The change itself is rather simple, however, I am not really comfortable with it.

Imagine this use-case:
1. Some user has SourceHut repo configured. They released `1.0.0` version and their doc links work as they expect to.
2. With gleam version update their links will change, so their tag naming scheme would also have to change: from `1.0.0` to `v1.0.0`
3. Docs does not say anything about this (at least ones I was able to find): https://gleam.run/writing-gleam/command-line-reference/#docs
4. It is basically a breaking change (despite it being a bug fix probably). So, we cannot release it in a patch release. And we need to communicate the change correctly. In CPython we provide a `DeprecationWarning` for 2 minor releases before the behavior change itself.

However, I guess that there would not be a lot of real affected users, because platforms are not very popular. So, I guess it is better to do this sooner than later.

Closes https://github.com/gleam-lang/gleam/issues/3503