### PR TITLE
Fix bit array codegen bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@
   Codeberg, SourceHut, and Gitea.
   ([sobolevn](https://github.com/sobolevn))
 
+- Fixed a bug with Erlang code generation for discard utf8 patterns in bit
+  arrays.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.4.1 - 2024-08-04
 
 ### Bug Fixes

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -194,3 +194,13 @@ pub fn main() {
 }"#
     );
 }
+
+#[test]
+fn discard_utf8_pattern() {
+    assert_erl!(
+        r#"
+pub fn main() {
+    let assert <<_:utf8, rest:bits>> = <<>>
+}"#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\npub fn main() {\n    let assert <<_:utf8, rest:bits>> = <<>>\n}"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-spec main() -> bitstring().
+main() ->
+    _assert_subject = <<>>,
+    <<_/utf8, Rest/bitstring>> = case _assert_subject of
+        <<_/utf8, _/bitstring>> -> _assert_subject;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Assertion pattern match failed"/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"main"/utf8>>,
+                        line => 3})
+    end.


### PR DESCRIPTION
This PR fixes a bug with Erlang code generation.

This bug cannot happen unless the list of typed options is empty and it never is since the compiler always adds one, so I can't really add a test for it. Still I think it was worth fixing in case this invariant changes in the future