### PR TITLE
Replace `typ` with `type_`

### DIFF
--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -5154,11 +5154,11 @@ pub mod constant {
         !self.reader.get_pointer_field(1).is_null()
       }
       #[inline]
-      pub fn get_typ(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
         ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
       }
       #[inline]
-      pub fn has_typ(&self) -> bool {
+      pub fn has_type(&self) -> bool {
         !self.reader.get_pointer_field(2).is_null()
       }
     }
@@ -5244,19 +5244,19 @@ pub mod constant {
         !self.builder.get_pointer_field(1).is_null()
       }
       #[inline]
-      pub fn get_typ(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
         ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
       }
       #[inline]
-      pub fn set_typ(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
+      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
         ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
       }
       #[inline]
-      pub fn init_typ(self, ) -> crate::schema_capnp::type_::Builder<'a> {
+      pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
         ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
       }
       #[inline]
-      pub fn has_typ(&self) -> bool {
+      pub fn has_type(&self) -> bool {
         !self.builder.get_pointer_field(2).is_null()
       }
     }
@@ -5268,7 +5268,7 @@ pub mod constant {
       }
     }
     impl Pipeline  {
-      pub fn get_typ(&self) -> crate::schema_capnp::type_::Pipeline {
+      pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
         ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
       }
     }
@@ -5342,11 +5342,11 @@ pub mod constant {
         !self.reader.get_pointer_field(1).is_null()
       }
       #[inline]
-      pub fn get_typ(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
         ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
       }
       #[inline]
-      pub fn has_typ(&self) -> bool {
+      pub fn has_type(&self) -> bool {
         !self.reader.get_pointer_field(2).is_null()
       }
       #[inline]
@@ -5440,19 +5440,19 @@ pub mod constant {
         !self.builder.get_pointer_field(1).is_null()
       }
       #[inline]
-      pub fn get_typ(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+      pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
         ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
       }
       #[inline]
-      pub fn set_typ(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
+      pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
         ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
       }
       #[inline]
-      pub fn init_typ(self, ) -> crate::schema_capnp::type_::Builder<'a> {
+      pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
         ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
       }
       #[inline]
-      pub fn has_typ(&self) -> bool {
+      pub fn has_type(&self) -> bool {
         !self.builder.get_pointer_field(2).is_null()
       }
       #[inline]
@@ -5480,7 +5480,7 @@ pub mod constant {
       }
     }
     impl Pipeline  {
-      pub fn get_typ(&self) -> crate::schema_capnp::type_::Pipeline {
+      pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
         ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
       }
       pub fn get_constructor(&self) -> crate::schema_capnp::value_constructor::Pipeline {

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -183,7 +183,7 @@ struct Constant {
     record :group {
       args @6 :List(Constant);
       tag @7 :Text;
-      typ @8 :Type;
+      type @8 :Type;
     }
 
     bitArray @9 :List(BitArraySegment);
@@ -191,7 +191,7 @@ struct Constant {
     var :group {
       module @10 :Text;
       name @11 :Text;
-      typ @12 :Type;
+      type @12 :Type;
       constructor @13 :ValueConstructor;
     }
 

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -29,7 +29,7 @@ pub enum Constant<T, RecordTag> {
     List {
         location: SrcSpan,
         elements: Vec<Self>,
-        typ: T,
+        type_: T,
     },
 
     Record {
@@ -38,7 +38,7 @@ pub enum Constant<T, RecordTag> {
         name: EcoString,
         args: Vec<CallArg<Self>>,
         tag: RecordTag,
-        typ: T,
+        type_: T,
         field_map: Option<FieldMap>,
     },
 
@@ -52,7 +52,7 @@ pub enum Constant<T, RecordTag> {
         module: Option<EcoString>,
         name: EcoString,
         constructor: Option<Box<ValueConstructor>>,
-        typ: T,
+        type_: T,
     },
 
     StringConcatenation {
@@ -65,7 +65,7 @@ pub enum Constant<T, RecordTag> {
     /// even when there are type errors. Should never end up in generated code.
     Invalid {
         location: SrcSpan,
-        typ: T,
+        type_: T,
     },
 }
 
@@ -79,10 +79,10 @@ impl TypedConstant {
             Constant::Tuple { elements, .. } => {
                 type_::tuple(elements.iter().map(|e| e.type_()).collect())
             }
-            Constant::List { typ, .. }
-            | Constant::Record { typ, .. }
-            | Constant::Var { typ, .. }
-            | Constant::Invalid { typ, .. } => typ.clone(),
+            Constant::List { type_, .. }
+            | Constant::Record { type_, .. }
+            | Constant::Var { type_, .. }
+            | Constant::Invalid { type_, .. } => type_.clone(),
         }
     }
 }

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -219,7 +219,7 @@ wibble}"#,
     let int1 = TypedExpr::Int {
         location: SrcSpan { start: 14, end: 15 },
         value: "1".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     let var = TypedExpr::Var {
@@ -261,17 +261,17 @@ fn find_node_list() {
 
     let int1 = TypedExpr::Int {
         location: SrcSpan { start: 1, end: 2 },
-        typ: type_::int(),
+        type_: type_::int(),
         value: "1".into(),
     };
     let int2 = TypedExpr::Int {
         location: SrcSpan { start: 4, end: 5 },
-        typ: type_::int(),
+        type_: type_::int(),
         value: "2".into(),
     };
     let int3 = TypedExpr::Int {
         location: SrcSpan { start: 7, end: 8 },
-        typ: type_::int(),
+        type_: type_::int(),
         value: "3".into(),
     };
 
@@ -294,17 +294,17 @@ fn find_node_tuple() {
 
     let int1 = TypedExpr::Int {
         location: SrcSpan { start: 2, end: 3 },
-        typ: type_::int(),
+        type_: type_::int(),
         value: "1".into(),
     };
     let int2 = TypedExpr::Int {
         location: SrcSpan { start: 5, end: 6 },
-        typ: type_::int(),
+        type_: type_::int(),
         value: "2".into(),
     };
     let int3 = TypedExpr::Int {
         location: SrcSpan { start: 8, end: 9 },
-        typ: type_::int(),
+        type_: type_::int(),
         value: "3".into(),
     };
 
@@ -341,7 +341,7 @@ fn find_node_tuple_index() {
     let int = TypedExpr::Int {
         location: SrcSpan { start: 2, end: 3 },
         value: "1".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     assert_eq!(expr.find_node(2), Some(Located::Expression(&int)));
@@ -353,7 +353,7 @@ fn find_node_tuple_index() {
 fn find_node_module_select() {
     let expr = TypedExpr::ModuleSelect {
         location: SrcSpan { start: 1, end: 3 },
-        typ: type_::int(),
+        type_: type_::int(),
         label: "label".into(),
         module_name: "name".into(),
         module_alias: "alias".into(),
@@ -380,7 +380,7 @@ fn find_node_fn() {
     let int = TypedExpr::Int {
         location: SrcSpan { start: 7, end: 8 },
         value: "1".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     assert_eq!(expr.find_node(0), Some(Located::Expression(expr)));
@@ -399,19 +399,19 @@ fn find_node_call() {
     let retrn = TypedExpr::Int {
         location: SrcSpan { start: 11, end: 12 },
         value: "1".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     let arg1 = TypedExpr::Int {
         location: SrcSpan { start: 15, end: 16 },
         value: "1".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     let arg2 = TypedExpr::Int {
         location: SrcSpan { start: 18, end: 19 },
         value: "2".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     assert_eq!(expr.find_node(11), Some(Located::Expression(&retrn)));
@@ -431,13 +431,13 @@ fn find_node_record_access() {
     let string = TypedExpr::String {
         location: SrcSpan { start: 4, end: 10 },
         value: "Nubi".into(),
-        typ: type_::string(),
+        type_: type_::string(),
     };
 
     let int = TypedExpr::Int {
         location: SrcSpan { start: 12, end: 13 },
         value: "3".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     assert_eq!(access.find_node(4), Some(Located::Expression(&string)));
@@ -456,7 +456,7 @@ fn find_node_record_update() {
     let int = TypedExpr::Int {
         location: SrcSpan { start: 27, end: 28 },
         value: "4".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     assert_eq!(update.find_node(0), Some(Located::Expression(update)));
@@ -480,19 +480,19 @@ case 1, 2 {
     let int1 = TypedExpr::Int {
         location: SrcSpan { start: 6, end: 7 },
         value: "1".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     let int2 = TypedExpr::Int {
         location: SrcSpan { start: 9, end: 10 },
         value: "2".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     let int3 = TypedExpr::Int {
         location: SrcSpan { start: 23, end: 24 },
         value: "3".into(),
-        typ: type_::int(),
+        type_: type_::int(),
     };
 
     assert_eq!(case.find_node(1), Some(Located::Expression(case)));

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -7,19 +7,19 @@ use crate::type_::{bool, HasType, Type, ValueConstructorVariant};
 pub enum TypedExpr {
     Int {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         value: EcoString,
     },
 
     Float {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         value: EcoString,
     },
 
     String {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         value: EcoString,
     },
 
@@ -47,7 +47,7 @@ pub enum TypedExpr {
 
     Fn {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         is_capture: bool,
         args: Vec<TypedArg>,
         body: Vec1<TypedStatement>,
@@ -56,21 +56,21 @@ pub enum TypedExpr {
 
     List {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         elements: Vec<Self>,
         tail: Option<Box<Self>>,
     },
 
     Call {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         fun: Box<Self>,
         args: Vec<CallArg<Self>>,
     },
 
     BinOp {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         name: BinOp,
         left: Box<Self>,
         right: Box<Self>,
@@ -78,14 +78,14 @@ pub enum TypedExpr {
 
     Case {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         subjects: Vec<Self>,
         clauses: Vec<Clause<Self, Arc<Type>, EcoString>>,
     },
 
     RecordAccess {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         label: EcoString,
         index: u64,
         record: Box<Self>,
@@ -93,7 +93,7 @@ pub enum TypedExpr {
 
     ModuleSelect {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         label: EcoString,
         module_name: EcoString,
         module_alias: EcoString,
@@ -102,13 +102,13 @@ pub enum TypedExpr {
 
     Tuple {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         elems: Vec<Self>,
     },
 
     TupleIndex {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         index: u64,
         tuple: Box<Self>,
     },
@@ -128,13 +128,13 @@ pub enum TypedExpr {
 
     BitArray {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         segments: Vec<TypedExprBitArraySegment>,
     },
 
     RecordUpdate {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         spread: Box<Self>,
         args: Vec<TypedRecordUpdateArg>,
     },
@@ -153,7 +153,7 @@ pub enum TypedExpr {
     /// even when there are type errors. Should never end up in generated code.
     Invalid {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
     },
 }
 
@@ -410,23 +410,23 @@ impl TypedExpr {
             Self::NegateBool { .. } => bool(),
             Self::NegateInt { value, .. } => value.type_(),
             Self::Var { constructor, .. } => constructor.type_.clone(),
-            Self::Fn { typ, .. }
-            | Self::Int { typ, .. }
-            | Self::Todo { type_: typ, .. }
-            | Self::Case { typ, .. }
-            | Self::List { typ, .. }
-            | Self::Call { typ, .. }
-            | Self::Float { typ, .. }
-            | Self::Panic { type_: typ, .. }
-            | Self::BinOp { typ, .. }
-            | Self::Tuple { typ, .. }
-            | Self::String { typ, .. }
-            | Self::BitArray { typ, .. }
-            | Self::TupleIndex { typ, .. }
-            | Self::ModuleSelect { typ, .. }
-            | Self::RecordAccess { typ, .. }
-            | Self::RecordUpdate { typ, .. }
-            | Self::Invalid { typ, .. } => typ.clone(),
+            Self::Fn { type_, .. }
+            | Self::Int { type_, .. }
+            | Self::Todo { type_, .. }
+            | Self::Case { type_, .. }
+            | Self::List { type_, .. }
+            | Self::Call { type_, .. }
+            | Self::Float { type_, .. }
+            | Self::Panic { type_, .. }
+            | Self::BinOp { type_, .. }
+            | Self::Tuple { type_, .. }
+            | Self::String { type_, .. }
+            | Self::BitArray { type_, .. }
+            | Self::TupleIndex { type_, .. }
+            | Self::ModuleSelect { type_, .. }
+            | Self::RecordAccess { type_, .. }
+            | Self::RecordUpdate { type_, .. }
+            | Self::Invalid { type_, .. } => type_.clone(),
             Self::Pipeline { finally, .. } => finally.type_(),
             Self::Block { statements, .. } => statements.last().type_(),
         }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -75,28 +75,28 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_int(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         value: &'ast EcoString,
     ) {
-        visit_typed_expr_int(self, location, typ, value);
+        visit_typed_expr_int(self, location, type_, value);
     }
 
     fn visit_typed_expr_float(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         value: &'ast EcoString,
     ) {
-        visit_typed_expr_float(self, location, typ, value);
+        visit_typed_expr_float(self, location, type_, value);
     }
 
     fn visit_typed_expr_string(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         value: &'ast EcoString,
     ) {
-        visit_typed_expr_string(self, location, typ, value);
+        visit_typed_expr_string(self, location, type_, value);
     }
 
     fn visit_typed_expr_block(
@@ -128,7 +128,7 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_fn(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         is_capture: &'ast bool,
         args: &'ast [TypedArg],
         body: &'ast [TypedStatement],
@@ -137,7 +137,7 @@ pub trait Visit<'ast> {
         visit_typed_expr_fn(
             self,
             location,
-            typ,
+            type_,
             is_capture,
             args,
             body,
@@ -148,59 +148,59 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_list(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         elements: &'ast [TypedExpr],
         tail: &'ast Option<Box<TypedExpr>>,
     ) {
-        visit_typed_expr_list(self, location, typ, elements, tail);
+        visit_typed_expr_list(self, location, type_, elements, tail);
     }
 
     fn visit_typed_expr_call(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         fun: &'ast TypedExpr,
         args: &'ast [TypedCallArg],
     ) {
-        visit_typed_expr_call(self, location, typ, fun, args);
+        visit_typed_expr_call(self, location, type_, fun, args);
     }
 
     fn visit_typed_expr_bin_op(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         name: &'ast BinOp,
         left: &'ast TypedExpr,
         right: &'ast TypedExpr,
     ) {
-        visit_typed_expr_bin_op(self, location, typ, name, left, right);
+        visit_typed_expr_bin_op(self, location, type_, name, left, right);
     }
 
     fn visit_typed_expr_case(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         subjects: &'ast [TypedExpr],
         clauses: &'ast [TypedClause],
     ) {
-        visit_typed_expr_case(self, location, typ, subjects, clauses);
+        visit_typed_expr_case(self, location, type_, subjects, clauses);
     }
 
     fn visit_typed_expr_record_access(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         label: &'ast EcoString,
         index: &'ast u64,
         record: &'ast TypedExpr,
     ) {
-        visit_typed_expr_record_access(self, location, typ, label, index, record);
+        visit_typed_expr_record_access(self, location, type_, label, index, record);
     }
 
     fn visit_typed_expr_module_select(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         label: &'ast EcoString,
         module_name: &'ast EcoString,
         module_alias: &'ast EcoString,
@@ -209,7 +209,7 @@ pub trait Visit<'ast> {
         visit_typed_expr_module_select(
             self,
             location,
-            typ,
+            type_,
             label,
             module_name,
             module_alias,
@@ -220,20 +220,20 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_tuple(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         elems: &'ast [TypedExpr],
     ) {
-        visit_typed_expr_tuple(self, location, typ, elems);
+        visit_typed_expr_tuple(self, location, type_, elems);
     }
 
     fn visit_typed_expr_tuple_index(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         index: &'ast u64,
         tuple: &'ast TypedExpr,
     ) {
-        visit_typed_expr_tuple_index(self, location, typ, index, tuple);
+        visit_typed_expr_tuple_index(self, location, type_, index, tuple);
     }
 
     fn visit_typed_expr_todo(
@@ -258,20 +258,20 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_bit_array(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         segments: &'ast [TypedExprBitArraySegment],
     ) {
-        visit_typed_expr_bit_array(self, location, typ, segments);
+        visit_typed_expr_bit_array(self, location, type_, segments);
     }
 
     fn visit_typed_expr_record_update(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         spread: &'ast TypedExpr,
         args: &'ast [TypedRecordUpdateArg],
     ) {
-        visit_typed_expr_record_update(self, location, typ, spread, args);
+        visit_typed_expr_record_update(self, location, type_, spread, args);
     }
 
     fn visit_typed_expr_negate_bool(&mut self, location: &'ast SrcSpan, value: &'ast TypedExpr) {
@@ -282,8 +282,8 @@ pub trait Visit<'ast> {
         visit_typed_expr_negate_int(self, location, value)
     }
 
-    fn visit_typed_expr_invalid(&mut self, location: &'ast SrcSpan, typ: &'ast Arc<Type>) {
-        visit_typed_expr_invalid(self, location, typ);
+    fn visit_typed_expr_invalid(&mut self, location: &'ast SrcSpan, type_: &'ast Arc<Type>) {
+        visit_typed_expr_invalid(self, location, type_);
     }
 
     fn visit_typed_statement(&mut self, stmt: &'ast TypedStatement) {
@@ -482,19 +482,19 @@ where
     match node {
         TypedExpr::Int {
             location,
-            typ,
+            type_,
             value,
-        } => v.visit_typed_expr_int(location, typ, value),
+        } => v.visit_typed_expr_int(location, type_, value),
         TypedExpr::Float {
             location,
-            typ,
+            type_,
             value,
-        } => v.visit_typed_expr_float(location, typ, value),
+        } => v.visit_typed_expr_float(location, type_, value),
         TypedExpr::String {
             location,
-            typ,
+            type_,
             value,
-        } => v.visit_typed_expr_string(location, typ, value),
+        } => v.visit_typed_expr_string(location, type_, value),
         TypedExpr::Block {
             location,
             statements,
@@ -511,54 +511,54 @@ where
         } => v.visit_typed_expr_var(location, constructor, name),
         TypedExpr::Fn {
             location,
-            typ,
+            type_,
             is_capture,
             args,
             body,
             return_annotation,
-        } => v.visit_typed_expr_fn(location, typ, is_capture, args, body, return_annotation),
+        } => v.visit_typed_expr_fn(location, type_, is_capture, args, body, return_annotation),
         TypedExpr::List {
             location,
-            typ,
+            type_,
             elements,
             tail,
-        } => v.visit_typed_expr_list(location, typ, elements, tail),
+        } => v.visit_typed_expr_list(location, type_, elements, tail),
         TypedExpr::Call {
             location,
-            typ,
+            type_,
             fun,
             args,
-        } => v.visit_typed_expr_call(location, typ, fun, args),
+        } => v.visit_typed_expr_call(location, type_, fun, args),
         TypedExpr::BinOp {
             location,
-            typ,
+            type_,
             name,
             left,
             right,
-        } => v.visit_typed_expr_bin_op(location, typ, name, left, right),
+        } => v.visit_typed_expr_bin_op(location, type_, name, left, right),
         TypedExpr::Case {
             location,
-            typ,
+            type_,
             subjects,
             clauses,
-        } => v.visit_typed_expr_case(location, typ, subjects, clauses),
+        } => v.visit_typed_expr_case(location, type_, subjects, clauses),
         TypedExpr::RecordAccess {
             location,
-            typ,
+            type_,
             label,
             index,
             record,
-        } => v.visit_typed_expr_record_access(location, typ, label, index, record),
+        } => v.visit_typed_expr_record_access(location, type_, label, index, record),
         TypedExpr::ModuleSelect {
             location,
-            typ,
+            type_,
             label,
             module_name,
             module_alias,
             constructor,
         } => v.visit_typed_expr_module_select(
             location,
-            typ,
+            type_,
             label,
             module_name,
             module_alias,
@@ -566,15 +566,15 @@ where
         ),
         TypedExpr::Tuple {
             location,
-            typ,
+            type_,
             elems,
-        } => v.visit_typed_expr_tuple(location, typ, elems),
+        } => v.visit_typed_expr_tuple(location, type_, elems),
         TypedExpr::TupleIndex {
             location,
-            typ,
+            type_,
             index,
             tuple,
-        } => v.visit_typed_expr_tuple_index(location, typ, index, tuple),
+        } => v.visit_typed_expr_tuple_index(location, type_, index, tuple),
         TypedExpr::Todo {
             location,
             message,
@@ -588,20 +588,20 @@ where
         } => v.visit_typed_expr_panic(location, message, type_),
         TypedExpr::BitArray {
             location,
-            typ,
+            type_,
             segments,
-        } => v.visit_typed_expr_bit_array(location, typ, segments),
+        } => v.visit_typed_expr_bit_array(location, type_, segments),
         TypedExpr::RecordUpdate {
             location,
-            typ,
+            type_,
             spread,
             args,
-        } => v.visit_typed_expr_record_update(location, typ, spread, args),
+        } => v.visit_typed_expr_record_update(location, type_, spread, args),
         TypedExpr::NegateBool { location, value } => {
             v.visit_typed_expr_negate_bool(location, value)
         }
         TypedExpr::NegateInt { location, value } => v.visit_typed_expr_negate_int(location, value),
-        TypedExpr::Invalid { location, typ } => v.visit_typed_expr_invalid(location, typ),
+        TypedExpr::Invalid { location, type_ } => v.visit_typed_expr_invalid(location, type_),
     }
 }
 

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -853,7 +853,7 @@ pub trait UntypedConstantFolder {
             Constant::List {
                 location,
                 elements,
-                typ: (),
+                type_: (),
             } => self.fold_constant_list(location, elements),
 
             Constant::Record {
@@ -862,7 +862,7 @@ pub trait UntypedConstantFolder {
                 name,
                 args,
                 tag: (),
-                typ: (),
+                type_: (),
                 field_map: _,
             } => self.fold_constant_record(location, module, name, args),
 
@@ -875,7 +875,7 @@ pub trait UntypedConstantFolder {
                 module,
                 name,
                 constructor: _,
-                typ: (),
+                type_: (),
             } => self.fold_constant_var(location, module, name),
 
             Constant::StringConcatenation {
@@ -884,7 +884,10 @@ pub trait UntypedConstantFolder {
                 right,
             } => self.fold_constant_string_concatenation(location, left, right),
 
-            Constant::Invalid { location, typ: () } => self.fold_constant_invalid(location),
+            Constant::Invalid {
+                location,
+                type_: (),
+            } => self.fold_constant_invalid(location),
         }
     }
 
@@ -916,7 +919,7 @@ pub trait UntypedConstantFolder {
         Constant::List {
             location,
             elements,
-            typ: (),
+            type_: (),
         }
     }
 
@@ -933,7 +936,7 @@ pub trait UntypedConstantFolder {
             name,
             args,
             tag: (),
-            typ: (),
+            type_: (),
             field_map: None,
         }
     }
@@ -957,7 +960,7 @@ pub trait UntypedConstantFolder {
             module,
             name,
             constructor: None,
-            typ: (),
+            type_: (),
         }
     }
 
@@ -975,7 +978,10 @@ pub trait UntypedConstantFolder {
     }
 
     fn fold_constant_invalid(&mut self, location: SrcSpan) -> UntypedConstant {
-        Constant::Invalid { location, typ: () }
+        Constant::Invalid {
+            location,
+            type_: (),
+        }
     }
 
     /// You probably don't want to override this method.
@@ -991,7 +997,7 @@ pub trait UntypedConstantFolder {
             Constant::List {
                 location,
                 elements,
-                typ,
+                type_,
             } => {
                 let elements = elements
                     .into_iter()
@@ -1000,7 +1006,7 @@ pub trait UntypedConstantFolder {
                 Constant::List {
                     location,
                     elements,
-                    typ,
+                    type_,
                 }
             }
 
@@ -1010,7 +1016,7 @@ pub trait UntypedConstantFolder {
                 name,
                 args,
                 tag,
-                typ,
+                type_,
                 field_map,
             } => {
                 let args = args
@@ -1026,7 +1032,7 @@ pub trait UntypedConstantFolder {
                     name,
                     args,
                     tag,
-                    typ,
+                    type_,
                     field_map,
                 }
             }

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -186,8 +186,8 @@ pub fn generate_html<IO: FileSystemReader>(
             .sorted()
             .collect();
 
-        types.iter().for_each(|typ| {
-            let constructors = typ
+        types.iter().for_each(|type_| {
+            let constructors = type_
                 .constructors
                 .iter()
                 .map(|constructor| {
@@ -206,15 +206,15 @@ pub fn generate_html<IO: FileSystemReader>(
 
             search_indexes.push(SearchIndex {
                 doc: module.name.to_string(),
-                title: typ.name.to_string(),
+                title: type_.name.to_string(),
                 content: format!(
                     "{}\n{}\n{}\n{}",
-                    typ.definition,
-                    typ.text_documentation,
+                    type_.definition,
+                    type_.text_documentation,
                     constructors,
-                    import_synonyms(&module.name, typ.name)
+                    import_synonyms(&module.name, type_.name)
                 ),
-                url: format!("{}.html#{}", module.name, typ.name),
+                url: format!("{}.html#{}", module.name, type_.name),
             })
         });
         constants.iter().for_each(|constant| {
@@ -663,7 +663,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
         Definition::TypeAlias(TypeAlias {
             publicity: Publicity::Public,
             alias: name,
-            type_ast: typ,
+            type_ast: type_,
             documentation: doc,
             parameters: args,
             location,
@@ -673,7 +673,7 @@ fn type_<'a>(source_links: &SourceLinker, statement: &'a TypedDefinition) -> Opt
             name,
             definition: print(
                 formatter
-                    .type_alias(Publicity::Public, name, args, typ, deprecation, location)
+                    .type_alias(Publicity::Public, name, args, type_, deprecation, location)
                     .group(),
             ),
             documentation: markdown_documentation(doc),

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1492,11 +1492,11 @@ Hint: Add some type annotations and try again."
                     }
                 }
 
-                TypeError::NotFn { location, typ } => {
+                TypeError::NotFn { location, type_ } => {
                     let mut printer = Printer::new();
                     let text = format!(
                         "This value is being called as a function but its type is:\n\n{}",
-                        printer.pretty_print(typ, 4)
+                        printer.pretty_print(type_, 4)
                     );
                     Diagnostic {
                         title: "Type mismatch".into(),
@@ -1518,7 +1518,7 @@ Hint: Add some type annotations and try again."
                 TypeError::UnknownRecordField {
                     usage,
                     location,
-                    typ,
+                    type_,
                     label,
                     fields,
                     variants,
@@ -1528,7 +1528,7 @@ Hint: Add some type annotations and try again."
                     // Give a hint about what type this value has.
                     let mut text = format!(
                         "The value being accessed has this type:\n\n{}\n",
-                        printer.pretty_print(typ, 4)
+                        printer.pretty_print(type_, 4)
                     );
 
                     // Give a hint about what record fields this value has, if any.
@@ -2314,17 +2314,17 @@ function and try again."
                                 vec!["Hint: This option has no effect in BitArray values.".into()],
                             ),
 
-                            bit_array::ErrorType::SignednessUsedOnNonInt { typ } => (
+                            bit_array::ErrorType::SignednessUsedOnNonInt { type_ } => (
                                 "Signedness is only valid with int types",
-                                vec![format!("Hint: This segment has a type of {typ}")],
+                                vec![format!("Hint: This segment has a type of {type_}")],
                             ),
-                            bit_array::ErrorType::TypeDoesNotAllowSize { typ } => (
+                            bit_array::ErrorType::TypeDoesNotAllowSize { type_ } => (
                                 "Size cannot be specified here",
-                                vec![format!("Hint: {typ} segments have an automatic size.")],
+                                vec![format!("Hint: {type_} segments have an automatic size.")],
                             ),
-                            bit_array::ErrorType::TypeDoesNotAllowUnit { typ } => (
+                            bit_array::ErrorType::TypeDoesNotAllowUnit { type_ } => (
                                 "Unit cannot be specified here",
-                                vec![wrap(&format!("Hint: {typ} segments are sized based on their value \
+                                vec![wrap(&format!("Hint: {type_} segments are sized based on their value \
     and cannot have a unit."))],
                             ),
                             bit_array::ErrorType::VariableUtfSegmentInPattern => (
@@ -2784,7 +2784,7 @@ Rename or remove one of them.",
                     }
                 },
 
-                TypeError::NotFnInUse { location, typ } => {
+                TypeError::NotFnInUse { location, type_ } => {
                     let mut printer = Printer::new();
                     let text = wrap_format!(
                         "In a use expression, there should be a function on the right hand side \
@@ -2793,7 +2793,7 @@ of `<-`, but this value has type:
 {}
 
 See: https://tour.gleam.run/advanced-features/use/",
-                        printer.pretty_print(typ, 4)
+                        printer.pretty_print(type_, 4)
                     );
 
                     Diagnostic {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -705,7 +705,7 @@ impl<'comments> Formatter<'comments> {
         publicity: Publicity,
         name: &'a str,
         args: &'a [(SrcSpan, EcoString)],
-        typ: &'a TypeAst,
+        type_: &'a TypeAst,
         deprecation: &'a Deprecation,
         location: &SrcSpan,
     ) -> Document<'a> {
@@ -723,7 +723,7 @@ impl<'comments> Formatter<'comments> {
         };
 
         head.append(" =")
-            .append(line().append(self.type_ast(typ)).group().nest(INDENT))
+            .append(line().append(self.type_ast(type_)).group().nest(INDENT))
     }
 
     fn fn_arg<'a, A>(&mut self, arg: &'a Arg<A>) -> Document<'a> {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -326,7 +326,7 @@ impl<'module> Generator<'module> {
                 let size_int = match *size.clone() {
                     TypedExpr::Int {
                         location: _,
-                        typ: _,
+                        type_: _,
                         value,
                     } => value.parse().unwrap_or(0),
                     _ => 0,
@@ -1216,23 +1216,23 @@ pub(crate) fn guard_constant_expression<'a>(
                     .map(|e| guard_constant_expression(assignments, tracker, e)),
             )
         }
-        Constant::Record { typ, name, .. } if typ.is_bool() && name == "True" => {
+        Constant::Record { type_, name, .. } if type_.is_bool() && name == "True" => {
             Ok("true".to_doc())
         }
-        Constant::Record { typ, name, .. } if typ.is_bool() && name == "False" => {
+        Constant::Record { type_, name, .. } if type_.is_bool() && name == "False" => {
             Ok("false".to_doc())
         }
-        Constant::Record { typ, .. } if typ.is_nil() => Ok("undefined".to_doc()),
+        Constant::Record { type_, .. } if type_.is_nil() => Ok("undefined".to_doc()),
 
         Constant::Record {
             args,
             module,
             name,
             tag,
-            typ,
+            type_,
             ..
         } => {
-            if typ.is_result() {
+            if type_.is_result() {
                 if tag == "Ok" {
                     tracker.ok_used = true;
                 } else {
@@ -1301,23 +1301,23 @@ pub(crate) fn constant_expression<'a>(
             }
         }
 
-        Constant::Record { typ, name, .. } if typ.is_bool() && name == "True" => {
+        Constant::Record { type_, name, .. } if type_.is_bool() && name == "True" => {
             Ok("true".to_doc())
         }
-        Constant::Record { typ, name, .. } if typ.is_bool() && name == "False" => {
+        Constant::Record { type_, name, .. } if type_.is_bool() && name == "False" => {
             Ok("false".to_doc())
         }
-        Constant::Record { typ, .. } if typ.is_nil() => Ok("undefined".to_doc()),
+        Constant::Record { type_, .. } if type_.is_nil() => Ok("undefined".to_doc()),
 
         Constant::Record {
             args,
             module,
             name,
             tag,
-            typ,
+            type_,
             ..
         } => {
-            if typ.is_result() {
+            if type_.is_result() {
                 if tag == "Ok" {
                     tracker.ok_used = true;
                 } else {
@@ -1328,10 +1328,16 @@ pub(crate) fn constant_expression<'a>(
             // If there's no arguments and the type is a function that takes
             // arguments then this is the constructor being referenced, not the
             // function being called.
-            if let Some(arity) = typ.fn_arity() {
+            if let Some(arity) = type_.fn_arity() {
                 if args.is_empty() && arity != 0 {
                     let arity = arity as u16;
-                    return Ok(record_constructor(typ.clone(), None, name, arity, tracker));
+                    return Ok(record_constructor(
+                        type_.clone(),
+                        None,
+                        name,
+                        arity,
+                        tracker,
+                    ));
                 }
             }
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -84,20 +84,20 @@ fn collect_generic_usages<'a>(
     mut ids: HashMap<u64, u64>,
     types: impl IntoIterator<Item = &'a Arc<Type>>,
 ) -> HashMap<u64, u64> {
-    for typ in types {
-        generic_ids(typ, &mut ids);
+    for type_ in types {
+        generic_ids(type_, &mut ids);
     }
     ids
 }
 
 fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
     match type_ {
-        Type::Var { type_: typ } => match typ.borrow().deref() {
+        Type::Var { type_ } => match type_.borrow().deref() {
             TypeVar::Unbound { id, .. } | TypeVar::Generic { id, .. } => {
                 let count = ids.entry(*id).or_insert(0);
                 *count += 1;
             }
-            TypeVar::Link { type_: typ } => generic_ids(typ, ids),
+            TypeVar::Link { type_ } => generic_ids(type_, ids),
         },
         Type::Named { args, .. } => {
             for arg in args {
@@ -555,7 +555,7 @@ impl<'a> TypeScriptGenerator<'a> {
         generic_usages: Option<&HashMap<u64, u64>>,
     ) -> Document<'static> {
         match type_ {
-            Type::Var { type_: typ } => self.print_var(&typ.borrow(), generic_usages, false),
+            Type::Var { type_ } => self.print_var(&type_.borrow(), generic_usages, false),
 
             Type::Named {
                 name, module, args, ..
@@ -573,7 +573,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
     fn do_print_force_generic_param(&mut self, type_: &Type) -> Document<'static> {
         match type_ {
-            Type::Var { type_: typ } => self.print_var(&typ.borrow(), None, true),
+            Type::Var { type_ } => self.print_var(&type_.borrow(), None, true),
 
             Type::Named {
                 name, module, args, ..
@@ -610,7 +610,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     }
                 }
             },
-            TypeVar::Link { type_: typ } => self.do_print(typ, generic_usages),
+            TypeVar::Link { type_ } => self.do_print(type_, generic_usages),
         }
     }
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -119,7 +119,7 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
     fn visit_typed_expr_case(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         subjects: &'ast [TypedExpr],
         clauses: &'ast [ast::TypedClause],
     ) {
@@ -164,7 +164,7 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
             self.edits.extend(clause_edits);
         }
 
-        ast::visit::visit_typed_expr_case(self, location, typ, subjects, clauses)
+        ast::visit::visit_typed_expr_case(self, location, type_, subjects, clauses)
     }
 }
 
@@ -605,7 +605,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
     fn visit_typed_expr_call(
         &mut self,
         location: &'ast SrcSpan,
-        typ: &'ast Arc<Type>,
+        type_: &'ast Arc<Type>,
         fun: &'ast TypedExpr,
         args: &'ast [TypedCallArg],
     ) {
@@ -632,6 +632,6 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
         // containing the current selection so we can't stop at the first call
         // we find (the outermost one) and have to keep traversing it in case
         // we're inside a nested call.
-        visit_typed_expr_call(self, location, typ, fun, args)
+        visit_typed_expr_call(self, location, type_, fun, args)
     }
 }

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -665,10 +665,10 @@ where
 
     /// Provides completions for field accessors when the context being editted
     /// is a custom type instance
-    pub fn completion_field_accessors(&'a self, typ: Arc<Type>) -> Vec<CompletionItem> {
+    pub fn completion_field_accessors(&'a self, type_: Arc<Type>) -> Vec<CompletionItem> {
         self.type_accessors_from_modules(
             self.compiler.project_compiler.get_importable_modules(),
-            typ,
+            type_,
         )
         .map(|accessors_map| {
             accessors_map
@@ -830,7 +830,7 @@ fn type_completion(
         None => name.to_string(),
     };
 
-    let kind = Some(if type_.typ.is_variable() {
+    let kind = Some(if type_.type_.is_variable() {
         CompletionItemKind::VARIABLE
     } else {
         CompletionItemKind::CLASS

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -487,7 +487,7 @@ where
                     .and_then(|module| {
                         if is_type {
                             module.types.get(name).map(|t| {
-                                hover_for_annotation(*location, t.typ.as_ref(), Some(t), lines)
+                                hover_for_annotation(*location, t.type_.as_ref(), Some(t), lines)
                             })
                         } else {
                             module.values.get(name).map(|v| {

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -101,7 +101,7 @@ impl ModuleDecoder {
             origin: self.src_span(&reader.get_origin()?)?,
             module: reader.get_module()?.into(),
             parameters: read_vec!(reader.get_parameters()?, self, type_),
-            typ: type_,
+            type_,
             deprecation,
             documentation: self.optional_string(reader.get_documentation()?),
         })
@@ -286,12 +286,12 @@ impl ModuleDecoder {
         Ok(Constant::List {
             location: Default::default(),
             elements: read_vec!(reader.get_elements()?, self, constant),
-            typ: type_,
+            type_,
         })
     }
 
     fn constant_record(&mut self, reader: &constant::record::Reader<'_>) -> Result<TypedConstant> {
-        let type_ = self.type_(&reader.get_typ()?)?;
+        let type_ = self.type_(&reader.get_type()?)?;
         let tag = reader.get_tag()?.into();
         let args = read_vec!(reader.get_args()?, self, constant_call_arg);
         Ok(Constant::Record {
@@ -300,7 +300,7 @@ impl ModuleDecoder {
             name: Default::default(),
             args,
             tag,
-            typ: type_,
+            type_,
             field_map: None,
         })
     }
@@ -328,7 +328,7 @@ impl ModuleDecoder {
     }
 
     fn constant_var(&mut self, reader: &constant::var::Reader<'_>) -> Result<TypedConstant> {
-        let type_ = self.type_(&reader.get_typ()?)?;
+        let type_ = self.type_(&reader.get_type()?)?;
         let module = match reader.get_module()? {
             "" => None,
             module_str => Some(module_str),
@@ -340,7 +340,7 @@ impl ModuleDecoder {
             module: module.map(EcoString::from),
             name: name.into(),
             constructor: Some(Box::from(constructor)),
-            typ: type_,
+            type_,
         })
     }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -173,7 +173,7 @@ impl<'a> ModuleEncoder<'a> {
         });
         builder.set_publicity(self.publicity(constructor.publicity));
         let type_builder = builder.reborrow().init_type();
-        self.build_type(type_builder, &constructor.typ);
+        self.build_type(type_builder, &constructor.type_);
         self.build_types(
             builder
                 .reborrow()
@@ -342,13 +342,15 @@ impl<'a> ModuleEncoder<'a> {
                 self.build_constants(builder.init_tuple(elements.len() as u32), elements)
             }
 
-            Constant::List { elements, typ, .. } => {
+            Constant::List {
+                elements, type_, ..
+            } => {
                 let mut builder = builder.init_list();
                 self.build_constants(
                     builder.reborrow().init_elements(elements.len() as u32),
                     elements,
                 );
-                self.build_type(builder.init_type(), typ);
+                self.build_type(builder.init_type(), type_);
             }
 
             Constant::BitArray { segments, .. } => {
@@ -358,7 +360,9 @@ impl<'a> ModuleEncoder<'a> {
                 }
             }
 
-            Constant::Record { args, tag, typ, .. } => {
+            Constant::Record {
+                args, tag, type_, ..
+            } => {
                 let mut builder = builder.init_record();
                 {
                     let mut builder = builder.reborrow().init_args(args.len() as u32);
@@ -367,13 +371,13 @@ impl<'a> ModuleEncoder<'a> {
                     }
                 }
                 builder.reborrow().set_tag(tag);
-                self.build_type(builder.reborrow().init_typ(), typ);
+                self.build_type(builder.reborrow().init_type(), type_);
             }
 
             Constant::Var {
                 module,
                 name,
-                typ,
+                type_,
                 constructor,
                 ..
             } => {
@@ -383,7 +387,7 @@ impl<'a> ModuleEncoder<'a> {
                     None => builder.set_module(""),
                 };
                 builder.set_name(name);
-                self.build_type(builder.reborrow().init_typ(), typ);
+                self.build_type(builder.reborrow().init_type(), type_);
                 self.build_value_constructor(
                     builder.reborrow().init_constructor(),
                     constructor
@@ -496,8 +500,8 @@ impl<'a> ModuleEncoder<'a> {
                 elems,
             ),
 
-            Type::Var { type_: typ } => match typ.borrow().deref() {
-                TypeVar::Link { type_: typ } => self.build_type(builder, typ),
+            Type::Var { type_ } => match type_.borrow().deref() {
+                TypeVar::Link { type_ } => self.build_type(builder, type_),
                 TypeVar::Unbound { id, .. } | TypeVar::Generic { id } => {
                     self.build_type_var(builder.init_var(), *id)
                 }

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -134,7 +134,7 @@ fn module_with_private_type() {
         types: [(
             "ListIntType".into(),
             TypeConstructor {
-                typ: type_::list(type_::int()),
+                type_: type_::list(type_::int()),
                 publicity: Publicity::Private,
                 origin: Default::default(),
                 module: "the/module".into(),
@@ -187,7 +187,7 @@ fn module_with_app_type() {
         types: [(
             "ListIntType".into(),
             TypeConstructor {
-                typ: type_::list(type_::int()),
+                type_: type_::list(type_::int()),
                 publicity: Publicity::Public,
                 origin: Default::default(),
                 module: "the/module".into(),
@@ -218,7 +218,7 @@ fn module_with_fn_type() {
         types: [(
             "FnType".into(),
             TypeConstructor {
-                typ: type_::fn_(vec![type_::nil(), type_::float()], type_::int()),
+                type_: type_::fn_(vec![type_::nil(), type_::float()], type_::int()),
                 publicity: Publicity::Public,
                 origin: Default::default(),
                 module: "the/module".into(),
@@ -249,7 +249,7 @@ fn module_with_tuple_type() {
         types: [(
             "TupleType".into(),
             TypeConstructor {
-                typ: type_::tuple(vec![type_::nil(), type_::float(), type_::int()]),
+                type_: type_::tuple(vec![type_::nil(), type_::float(), type_::int()]),
                 publicity: Publicity::Public,
                 origin: Default::default(),
                 module: "the/module".into(),
@@ -286,7 +286,7 @@ fn module_with_generic_type() {
             types: [(
                 "TupleType".into(),
                 TypeConstructor {
-                    typ: type_::tuple(vec![t1.clone(), t1.clone(), t2.clone()]),
+                    type_: type_::tuple(vec![t1.clone(), t1.clone(), t2.clone()]),
                     publicity: Publicity::Public,
                     origin: Default::default(),
                     module: "the/module".into(),
@@ -323,7 +323,7 @@ fn module_with_type_links() {
             types: [(
                 "SomeType".into(),
                 TypeConstructor {
-                    typ: type_,
+                    type_: type_,
                     publicity: Publicity::Public,
                     origin: Default::default(),
                     module: "a".into(),
@@ -360,7 +360,7 @@ fn module_with_type_constructor_documentation() {
             types: [(
                 "SomeType".into(),
                 TypeConstructor {
-                    typ: type_,
+                    type_: type_,
                     publicity: Publicity::Public,
                     origin: Default::default(),
                     module: "a".into(),
@@ -397,7 +397,7 @@ fn module_with_type_constructor_origin() {
             types: [(
                 "SomeType".into(),
                 TypeConstructor {
-                    typ: type_,
+                    type_: type_,
                     publicity: Publicity::Public,
                     origin: SrcSpan {
                         start: 535,
@@ -902,7 +902,7 @@ fn constant_tuple() {
 fn constant_list() {
     let module = constant_module(Constant::List {
         location: Default::default(),
-        typ: type_::int(),
+        type_: type_::int(),
         elements: vec![
             Constant::Int {
                 location: Default::default(),
@@ -949,7 +949,7 @@ fn constant_record() {
             },
         ],
         tag: "thetag".into(),
-        typ: type_::int(),
+        type_: type_::int(),
         field_map: None,
     });
 
@@ -967,7 +967,7 @@ fn constant_var() {
         location: Default::default(),
         module: None,
         name: "one_original".into(),
-        typ: type_::int(),
+        type_: type_::int(),
         constructor: Some(Box::from(ValueConstructor {
             publicity: Publicity::Public,
             deprecation: Deprecation::NotDeprecated,
@@ -1217,7 +1217,7 @@ fn deprecated_type() {
         types: [(
             "ListIntType".into(),
             TypeConstructor {
-                typ: type_::list(type_::int()),
+                type_: type_::list(type_::int()),
                 publicity: Publicity::Public,
                 origin: Default::default(),
                 module: "the/module".into(),

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2646,7 +2646,7 @@ where
                 Ok(Some(Constant::List {
                     elements,
                     location: SrcSpan { start, end },
-                    typ: (),
+                    type_: (),
                 }))
             }
             // BitArray
@@ -2702,7 +2702,7 @@ where
                                 module: Some(name),
                                 name: end_name,
                                 constructor: None,
-                                typ: (),
+                                type_: (),
                             })),
                         }
                     }
@@ -2736,7 +2736,7 @@ where
                         module: None,
                         name,
                         constructor: None,
-                        typ: (),
+                        type_: (),
                     })),
                 }
             }
@@ -2806,7 +2806,7 @@ where
                 name,
                 args,
                 tag: (),
-                typ: (),
+                type_: (),
                 field_map: None,
             }))
         } else {
@@ -2816,7 +2816,7 @@ where
                 name,
                 args: vec![],
                 tag: (),
-                typ: (),
+                type_: (),
                 field_map: None,
             }))
         }
@@ -2873,7 +2873,7 @@ where
                     constructor: None,
                     module: None,
                     name: label,
-                    typ: (),
+                    type_: (),
                 },
             }))
         } else {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -71,7 +71,7 @@ Parsed {
                                 module: None,
                                 name: "cute",
                                 constructor: None,
-                                typ: (),
+                                type_: (),
                             },
                             right: String {
                                 location: SrcSpan {

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -127,12 +127,12 @@ pub enum Error {
 
     NotFn {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
     },
 
     UnknownRecordField {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         label: EcoString,
         fields: Vec<EcoString>,
         usage: FieldAccessUsage,
@@ -421,7 +421,7 @@ pub enum Error {
     /// ```
     NotFnInUse {
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
     },
 
     /// When the function to the right hand side of `<-` in a `use` expression
@@ -541,7 +541,7 @@ pub enum Warning {
     Todo {
         kind: TodoKind,
         location: SrcSpan,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
     },
 
     ImplicitlyDiscardedResult {
@@ -1039,7 +1039,7 @@ pub enum MatchFunTypeError {
         return_type: Arc<Type>,
     },
     NotFn {
-        typ: Arc<Type>,
+        type_: Arc<Type>,
     },
 }
 
@@ -1062,9 +1062,9 @@ pub fn convert_not_fun_error(
             given,
         },
 
-        (CallKind::Function, MatchFunTypeError::NotFn { typ }) => Error::NotFn {
+        (CallKind::Function, MatchFunTypeError::NotFn { type_ }) => Error::NotFn {
             location: fn_location,
-            typ,
+            type_,
         },
 
         (
@@ -1078,10 +1078,10 @@ pub fn convert_not_fun_error(
             given,
         },
 
-        (CallKind::Use { call_location, .. }, MatchFunTypeError::NotFn { typ }) => {
+        (CallKind::Use { call_location, .. }, MatchFunTypeError::NotFn { type_ }) => {
             Error::NotFnInUse {
                 location: call_location,
-                typ,
+                type_,
             }
         }
     }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -416,7 +416,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         self.problems.warning(Warning::Todo {
             kind,
             location,
-            typ: type_.clone(),
+            type_: type_.clone(),
         });
 
         let message = message
@@ -481,7 +481,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         TypedExpr::String {
             location,
             value,
-            typ: string(),
+            type_: string(),
         }
     }
 
@@ -489,7 +489,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         TypedExpr::Int {
             location,
             value,
-            typ: int(),
+            type_: int(),
         }
     }
 
@@ -497,7 +497,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         TypedExpr::Float {
             location,
             value,
-            typ: float(),
+            type_: float(),
         }
     }
 
@@ -544,7 +544,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         self.error_with_rigid_names(error);
         TypedExpr::Invalid {
             location,
-            typ: self.new_unbound_var(),
+            type_: self.new_unbound_var(),
         }
     }
 
@@ -746,7 +746,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let (args, body) = self.do_infer_fn(args, expected_args, body, &return_annotation)?;
         let args_types = args.iter().map(|a| a.type_.clone()).collect();
-        let typ = fn_(args_types, body.last().type_());
+        let type_ = fn_(args_types, body.last().type_());
 
         // Defining an anonymous function never panics.
         self.already_warned_for_unreachable_code = already_warned_for_unreachable_code;
@@ -754,7 +754,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         Ok(TypedExpr::Fn {
             location,
-            typ,
+            type_,
             is_capture,
             args,
             body,
@@ -773,7 +773,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             location,
             ..
         } = arg;
-        let typ = annotation
+        let type_ = annotation
             .clone()
             .map(|t| self.type_from_ast(&t))
             .unwrap_or_else(|| Ok(self.new_unbound_var()))?;
@@ -784,14 +784,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // function being type checked, resulting in better type errors and the
         // record field access syntax working.
         if let Some(expected) = expected {
-            unify(expected, typ.clone()).map_err(|e| convert_unify_error(e, location))?;
+            unify(expected, type_.clone()).map_err(|e| convert_unify_error(e, location))?;
         }
 
         Ok(Arg {
             names,
             location,
             annotation,
-            type_: typ,
+            type_,
         })
     }
 
@@ -802,7 +802,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         location: SrcSpan,
         kind: CallKind,
     ) -> TypedExpr {
-        let (fun, args, typ) = self.do_infer_call(fun, args, location, kind);
+        let (fun, args, type_) = self.do_infer_call(fun, args, location, kind);
 
         // One common mistake is to think that the syntax for adding a message
         // to a `todo` or a `panic` exception is to `todo("...")`, but really
@@ -832,7 +832,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         TypedExpr::Call {
             location,
-            typ,
+            type_,
             args,
             fun: Box::new(fun),
         }
@@ -844,26 +844,26 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         tail: Option<Box<UntypedExpr>>,
         location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
-        let typ = self.new_unbound_var();
+        let type_ = self.new_unbound_var();
         // Type check each elements
         let elements = elements
             .into_iter()
             .map(|element| {
                 let element = self.infer(element)?;
                 // Ensure they all have the same type
-                unify(typ.clone(), element.type_()).map_err(|e| {
+                unify(type_.clone(), element.type_()).map_err(|e| {
                     convert_unify_error(e.list_element_mismatch(), element.location())
                 })?;
                 Ok(element)
             })
             .try_collect()?;
         // Type check the ..tail, if there is one
-        let typ = list(typ);
+        let type_ = list(type_);
         let tail = match tail {
             Some(tail) => {
                 let tail = self.infer(*tail)?;
                 // Ensure the tail has the same type as the preceding elements
-                unify(typ.clone(), tail.type_())
+                unify(type_.clone(), tail.type_())
                     .map_err(|e| convert_unify_error(e.list_tail_mismatch(), tail.location()))?;
                 Some(Box::new(tail))
             }
@@ -871,7 +871,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         };
         Ok(TypedExpr::List {
             location,
-            typ,
+            type_,
             elements,
             tail,
         })
@@ -883,11 +883,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
         let elems: Vec<_> = elems.into_iter().map(|e| self.infer(e)).try_collect()?;
-        let typ = tuple(elems.iter().map(HasType::type_).collect());
+        let type_ = tuple(elems.iter().map(HasType::type_).collect());
         Ok(TypedExpr::Tuple {
             location,
             elems,
-            typ,
+            type_,
         })
     }
 
@@ -981,7 +981,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 self.problems.error(module_access_err);
                 TypedExpr::Invalid {
                     location: label_location,
-                    typ: self.new_unbound_var(),
+                    type_: self.new_unbound_var(),
                 }
             }
             // In any other case use the record access for the error
@@ -993,14 +993,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     // Even if the access is not valid
                     Ok(record) => TypedExpr::RecordAccess {
                         location: label_location,
-                        typ: self.new_unbound_var(),
+                        type_: self.new_unbound_var(),
                         label: "".into(),
                         index: u64::MAX,
                         record: Box::new(record),
                     },
                     Err(_) => TypedExpr::Invalid {
                         location: label_location,
-                        typ: self.new_unbound_var(),
+                        type_: self.new_unbound_var(),
                     },
                 }
             }
@@ -1016,7 +1016,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let tuple = self.infer(tuple)?;
         match collapse_links(tuple.type_()).as_ref() {
             Type::Tuple { elems } => {
-                let typ = elems
+                let type_ = elems
                     .get(index as usize)
                     .ok_or_else(|| Error::OutOfBoundsTupleIndex {
                         location: SrcSpan {
@@ -1031,11 +1031,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     location,
                     index,
                     tuple: Box::new(tuple),
-                    typ,
+                    type_,
                 })
             }
 
-            typ if typ.is_unbound() => Err(Error::NotATupleUnbound {
+            type_ if type_.is_unbound() => Err(Error::NotATupleUnbound {
                 location: tuple.location(),
             }),
 
@@ -1061,7 +1061,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Ok(TypedExpr::BitArray {
             location,
             segments,
-            typ: bits(),
+            type_: bits(),
         })
     }
 
@@ -1096,9 +1096,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let value = infer(self, value)?;
 
         let infer_option = |segment_option: BitArrayOption<UntypedValue>| {
-            infer_bit_array_option(segment_option, |value, typ| {
+            infer_bit_array_option(segment_option, |value, type_| {
                 let typed_value = infer(self, value)?;
-                unify(typ, typed_value.type_())
+                unify(type_, typed_value.type_())
                     .map_err(|e| convert_unify_error(e, typed_value.location()))?;
                 Ok(typed_value)
             })
@@ -1106,18 +1106,19 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let options: Vec<_> = options.into_iter().map(infer_option).try_collect()?;
 
-        let typ = bit_array::type_options_for_value(&options).map_err(|error| {
+        let type_ = bit_array::type_options_for_value(&options).map_err(|error| {
             Error::BitArraySegmentError {
                 error: error.error,
                 location: error.location,
             }
         })?;
 
-        unify(typ.clone(), value.type_()).map_err(|e| convert_unify_error(e, value.location()))?;
+        unify(type_.clone(), value.type_())
+            .map_err(|e| convert_unify_error(e, value.location()))?;
 
         Ok(BitArraySegment {
             location,
-            type_: typ,
+            type_,
             value: Box::new(value),
             options,
         })
@@ -1142,7 +1143,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 return Ok(TypedExpr::BinOp {
                     location,
                     name,
-                    typ: bool(),
+                    type_: bool(),
                     left: Box::new(left),
                     right: Box::new(right),
                 });
@@ -1185,7 +1186,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Ok(TypedExpr::BinOp {
             location,
             name,
-            typ: output_type,
+            type_: output_type,
             left: Box::new(left),
             right: Box::new(right),
         })
@@ -1393,7 +1394,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         TypedExpr::Case {
             location,
-            typ: return_type,
+            type_: return_type,
             subjects: typed_subjects,
             clauses: typed_clauses,
         }
@@ -1450,7 +1451,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     None,
                     TypedExpr::Invalid {
                         location: then_location,
-                        typ: self.new_unbound_var(),
+                        type_: self.new_unbound_var(),
                     },
                     vec![],
                     vec![],
@@ -1559,7 +1560,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         })
                     }
 
-                    typ if typ.is_unbound() => Err(Error::NotATupleUnbound {
+                    type_ if type_.is_unbound() => Err(Error::NotATupleUnbound {
                         location: tuple.location(),
                     }),
 
@@ -2029,7 +2030,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             .and_then(|ma| match ma {
                 TypedExpr::ModuleSelect {
                     location,
-                    typ,
+                    type_,
                     label,
                     module_name,
                     module_alias,
@@ -2038,7 +2039,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     ModuleValueConstructor::Constant { literal, .. } => {
                         Ok(ClauseGuard::ModuleSelect {
                             location,
-                            type_: typ,
+                            type_,
                             label,
                             module_name,
                             module_alias,
@@ -2130,7 +2131,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         Ok(TypedExpr::ModuleSelect {
             label,
-            typ: Arc::clone(&type_),
+            type_: Arc::clone(&type_),
             location: select_location,
             module_name,
             module_alias: module_alias.clone(),
@@ -2147,14 +2148,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     ) -> Result<TypedExpr, Error> {
         let record = Box::new(record);
         let record_type = record.type_();
-        let (index, label, typ) =
+        let (index, label, type_) =
             self.infer_known_record_access(record_type, record.location(), usage, location, label)?;
         Ok(TypedExpr::RecordAccess {
             record,
             label,
             index,
             location,
-            typ,
+            type_,
         })
     }
 
@@ -2189,7 +2190,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let unknown_field = |fields| Error::UnknownRecordField {
             usage,
-            typ: record_type.clone(),
+            type_: record_type.clone(),
             location,
             label: label.clone(),
             fields,
@@ -2217,7 +2218,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let RecordAccessor {
             index,
             label,
-            type_: typ,
+            type_,
         } = accessors
             .accessors
             .get(&label)
@@ -2226,10 +2227,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let accessor_record_type = accessors.type_.clone();
         let mut type_vars = hashmap![];
         let accessor_record_type = self.instantiate(accessor_record_type, &mut type_vars);
-        let typ = self.instantiate(typ, &mut type_vars);
+        let type_ = self.instantiate(type_, &mut type_vars);
         unify(accessor_record_type, record_type)
             .map_err(|e| convert_unify_error(e, record_location))?;
-        Ok((index, label, typ))
+        Ok((index, label, type_))
     }
 
     fn infer_record_update(
@@ -2351,7 +2352,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         Ok(TypedExpr::RecordUpdate {
             location,
-            typ: spread.type_(),
+            type_: spread.type_(),
             spread: Box::new(spread),
             args,
         })
@@ -2378,7 +2379,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                 .environment
                                 .module_types
                                 .keys()
-                                .any(|typ| typ == name),
+                                .any(|type_| type_ == name),
                         })?;
 
                 // Register the value as seen for detection of unused values
@@ -2420,7 +2421,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let ValueConstructor {
             publicity,
             variant,
-            type_: typ,
+            type_,
             deprecation,
         } = constructor;
 
@@ -2436,12 +2437,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         self.narrow_implementations(*location, &variant)?;
 
         // Instantiate generic variables into unbound variables for this usage
-        let typ = self.instantiate(typ, &mut hashmap![]);
+        let type_ = self.instantiate(type_, &mut hashmap![]);
         Ok(ValueConstructor {
             publicity,
             deprecation,
             variant,
-            type_: typ,
+            type_,
         })
     }
 
@@ -2511,7 +2512,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     location,
                     name,
                     args: vec![],
-                    typ: constructor.type_,
+                    type_: constructor.type_,
                     tag,
                     field_map,
                 })
@@ -2557,7 +2558,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 // have to convert to this other data structure.
                 let fun = match &module {
                     Some(module_alias) => {
-                        let typ = Arc::clone(&constructor.type_);
+                        let type_ = Arc::clone(&constructor.type_);
                         let module_name = self
                             .environment
                             .imported_modules
@@ -2571,7 +2572,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             name: name.clone(),
                             field_map: field_map.clone(),
                             arity: args.len() as u16,
-                            type_: Arc::clone(&typ),
+                            type_: Arc::clone(&type_),
                             location: constructor.variant.definition_location(),
                             documentation: None,
                         };
@@ -2580,7 +2581,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             label: name.clone(),
                             module_alias: module_alias.clone(),
                             module_name,
-                            typ,
+                            type_,
                             constructor: module_value_constructor,
                             location,
                         }
@@ -2616,7 +2617,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 let args = args_types
                     .iter_mut()
                     .zip(args)
-                    .map(|(typ, arg): (&mut Arc<Type>, _)| {
+                    .map(|(type_, arg): (&mut Arc<Type>, _)| {
                         let CallArg {
                             label,
                             value,
@@ -2624,7 +2625,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             implicit,
                         } = arg;
                         let value = self.infer_const(&None, value);
-                        unify(typ.clone(), value.type_())
+                        unify(type_.clone(), value.type_())
                             .map_err(|e| convert_unify_error(e, value.location()))?;
                         Ok(CallArg {
                             label,
@@ -2640,7 +2641,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     location,
                     name,
                     args,
-                    typ: return_type,
+                    type_: return_type,
                     tag,
                     field_map,
                 })
@@ -2668,7 +2669,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         location,
                         module,
                         name,
-                        typ: Arc::clone(&constructor.type_),
+                        type_: Arc::clone(&constructor.type_),
                         constructor: Some(Box::from(constructor)),
                     }),
                     // It cannot be a Record because then this constant would have been
@@ -2722,7 +2723,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 self.problems.error(e);
                 Constant::Invalid {
                     location: loc,
-                    typ: self.new_unbound_var(),
+                    type_: self.new_unbound_var(),
                 }
             }
             // Type annotation and inferred value are valid. Ensure they are unifiable.
@@ -2734,7 +2735,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     self.problems.error(e);
                     Constant::Invalid {
                         location: loc,
-                        typ: const_ann,
+                        type_: const_ann,
                     }
                 } else {
                     inferred
@@ -2746,7 +2747,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 self.problems.error(value_err);
                 Constant::Invalid {
                     location: loc,
-                    typ: const_ann,
+                    type_: const_ann,
                 }
             }
             // Type annotation is invalid but the inferred value is ok. Use the inferred type.
@@ -2761,7 +2762,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 self.problems.error(value_err);
                 Constant::Invalid {
                     location: loc,
-                    typ: self.new_unbound_var(),
+                    type_: self.new_unbound_var(),
                 }
             }
         }
@@ -2787,12 +2788,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         untyped_elements: Vec<UntypedConstant>,
         location: SrcSpan,
     ) -> Result<TypedConstant, Error> {
-        let typ = self.new_unbound_var();
+        let type_ = self.new_unbound_var();
         let mut elements = Vec::with_capacity(untyped_elements.len());
 
         for element in untyped_elements {
             let element = self.infer_const(&None, element);
-            unify(typ.clone(), element.type_())
+            unify(type_.clone(), element.type_())
                 .map_err(|e| convert_unify_error(e, element.location()))?;
             elements.push(element);
         }
@@ -2800,7 +2801,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Ok(Constant::List {
             elements,
             location,
-            typ: list(typ),
+            type_: list(type_),
         })
     }
 
@@ -2857,8 +2858,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             }
         };
 
-        let (fun, args, typ) = self.do_infer_call_with_known_fun(fun, args, location, kind);
-        (fun, args, typ)
+        let (fun, args, type_) = self.do_infer_call_with_known_fun(fun, args, location, kind);
+        (fun, args, type_)
     }
 
     pub fn do_infer_call_with_known_fun(
@@ -2992,7 +2993,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             .iter_mut()
             .zip(args)
             .enumerate()
-            .map(|(i, (typ, arg))| {
+            .map(|(i, (type_, arg))| {
                 let CallArg {
                     label,
                     value,
@@ -3026,7 +3027,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     )
                 }
 
-                let value = match self.infer_call_argument(value, typ.clone(), argument_kind) {
+                let value = match self.infer_call_argument(value, type_.clone(), argument_kind) {
                     Ok(value) => value,
                     Err(e) => self.error_expr_with_rigid_names(location, e),
                 };
@@ -3057,7 +3058,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     label,
                     value: TypedExpr::Invalid {
                         location,
-                        typ: self.new_unbound_var(),
+                        type_: self.new_unbound_var(),
                     },
                     implicit: None,
                     location,
@@ -3078,12 +3079,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     fn infer_call_argument(
         &mut self,
         value: UntypedExpr,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         kind: ArgumentKind,
     ) -> Result<TypedExpr, Error> {
-        let typ = collapse_links(typ);
+        let type_ = collapse_links(type_);
 
-        let value = match (&*typ, value) {
+        let value = match (&*type_, value) {
             // If the argument is expected to be a function and we are passed a
             // function literal with the correct number of arguments then we
             // have special handling of this argument, passing in information
@@ -3117,7 +3118,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             (_, value) => self.infer(value),
         }?;
 
-        unify(typ, value.type_())
+        unify(type_, value.type_())
             .map_err(|e| convert_unify_call_error(e, value.location(), kind))?;
         Ok(value)
     }
@@ -3219,7 +3220,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             start: body.last().location().end,
                             end: body.last().location().end,
                         },
-                        typ: body_typer.new_unbound_var(),
+                        type_: body_typer.new_unbound_var(),
                     }))
                 };
             }

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -120,14 +120,14 @@ impl Hydrator {
                 // Hydrate the type argument AST into types
                 let mut argument_types = Vec::with_capacity(args.len());
                 for t in args {
-                    let typ = self.type_from_ast(t, environment, problems)?;
-                    argument_types.push((t.location(), typ));
+                    let type_ = self.type_from_ast(t, environment, problems)?;
+                    argument_types.push((t.location(), type_));
                 }
 
                 // Look up the constructor
                 let TypeConstructor {
                     parameters,
-                    typ: return_type,
+                    type_: return_type,
                     deprecation,
                     ..
                 } = environment
@@ -168,7 +168,7 @@ impl Hydrator {
                 #[allow(clippy::needless_collect)] // Not needless, used for side effects
                 let parameter_types: Vec<_> = parameters
                     .into_iter()
-                    .map(|typ| environment.instantiate(typ, &mut type_vars, self))
+                    .map(|type_| environment.instantiate(type_, &mut type_vars, self))
                     .collect();
 
                 let return_type = environment.instantiate(return_type, &mut type_vars, self);

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -42,7 +42,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
     fn insert_variable(
         &mut self,
         name: &str,
-        typ: Arc<Type>,
+        type_: Arc<Type>,
         location: SrcSpan,
     ) -> Result<(), UnifyError> {
         self.check_name_case(location, &EcoString::from(name), Named::Variable);
@@ -69,7 +69,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 // And now insert the variable for use in the code that comes
                 // after the pattern.
                 self.environment
-                    .insert_local_variable(name.into(), location, typ);
+                    .insert_local_variable(name.into(), location, type_);
                 Ok(())
             }
 
@@ -79,7 +79,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     Some(initial) if self.initial_pattern_vars.contains(name) => {
                         assigned.push(name.into());
                         let initial_typ = initial.type_.clone();
-                        unify(initial_typ, typ)
+                        unify(initial_typ, type_)
                     }
 
                     // This variable was not defined in the Initial multi-pattern
@@ -181,7 +181,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
 
         let options: Vec<_> = options
             .into_iter()
-            .map(|o| crate::analyse::infer_bit_array_option(o, |value, typ| self.unify(value, typ)))
+            .map(|o| {
+                crate::analyse::infer_bit_array_option(o, |value, type_| self.unify(value, type_))
+            })
             .try_collect()?;
 
         let segment_type = bit_array::type_options_for_pattern(&options, !is_last_segment)
@@ -190,7 +192,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 location: error.location,
             })?;
 
-        let typ = {
+        let type_ = {
             match value.deref() {
                 Pattern::Variable { .. } if segment_type == string() => {
                     Err(Error::BitArraySegmentError {
@@ -201,13 +203,13 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 _ => Ok(segment_type),
             }
         }?;
-        let typed_value = self.unify(*value, typ.clone())?;
+        let typed_value = self.unify(*value, type_.clone())?;
 
         Ok(BitArraySegment {
             location,
             value: Box::new(typed_value),
             options,
-            type_: typ,
+            type_,
         })
     }
 
@@ -255,19 +257,19 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             .environment
                             .module_types
                             .keys()
-                            .any(|typ| typ == &name),
+                            .any(|type_| type_ == &name),
                     })?;
                 self.environment.increment_usage(&name);
-                let typ =
+                let type_ =
                     self.environment
                         .instantiate(vc.type_.clone(), &mut hashmap![], self.hydrator);
-                unify(int(), typ.clone()).map_err(|e| convert_unify_error(e, location))?;
+                unify(int(), type_.clone()).map_err(|e| convert_unify_error(e, location))?;
 
                 Ok(Pattern::VarUsage {
                     name,
                     location,
                     constructor: Some(vc),
-                    type_: typ,
+                    type_,
                 })
             }
 
@@ -396,7 +398,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     let elems = elems
                         .into_iter()
                         .zip(type_elems)
-                        .map(|(pattern, typ)| self.unify(pattern, typ.clone()))
+                        .map(|(pattern, type_)| self.unify(pattern, type_.clone()))
                         .try_collect()?;
                     Ok(Pattern::Tuple { elems, location })
                 }
@@ -609,14 +611,14 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             let pattern_args = pattern_args
                                 .into_iter()
                                 .zip(args)
-                                .map(|(arg, typ)| {
+                                .map(|(arg, type_)| {
                                     let CallArg {
                                         value,
                                         location,
                                         implicit,
                                         label,
                                     } = arg;
-                                    let value = self.unify(value, typ.clone())?;
+                                    let value = self.unify(value, type_.clone())?;
                                     Ok(CallArg {
                                         value,
                                         location,

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -213,7 +213,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         args: Vec<CallArg<UntypedExpr>>,
         location: SrcSpan,
     ) -> TypedExpr {
-        let (function, args, typ) = self.expr_typer.do_infer_call_with_known_fun(
+        let (function, args, type_) = self.expr_typer.do_infer_call_with_known_fun(
             function,
             args,
             location,
@@ -221,7 +221,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         );
         let function = TypedExpr::Call {
             location,
-            typ,
+            type_,
             args,
             fun: Box::new(function),
         };
@@ -231,7 +231,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         // the function below. If it is not we don't know if the error comes
         // from incorrect usage of the pipe or if it originates from the
         // argument expressions.
-        let (function, args, typ) = self.expr_typer.do_infer_call_with_known_fun(
+        let (function, args, type_) = self.expr_typer.do_infer_call_with_known_fun(
             function,
             args,
             location,
@@ -239,7 +239,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         );
         TypedExpr::Call {
             location,
-            typ,
+            type_,
             args,
             fun: Box::new(function),
         }
@@ -258,7 +258,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         // the function below. If it is not we don't know if the error comes
         // from incorrect usage of the pipe or if it originates from the
         // argument expressions.
-        let (fun, args, typ) = self.expr_typer.do_infer_call_with_known_fun(
+        let (fun, args, type_) = self.expr_typer.do_infer_call_with_known_fun(
             function,
             arguments,
             location,
@@ -266,7 +266,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         );
         TypedExpr::Call {
             location,
-            typ,
+            type_,
             args,
             fun: Box::new(fun),
         }
@@ -296,7 +296,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
 
         Ok(TypedExpr::Call {
             location: function.location(),
-            typ: return_type,
+            type_: return_type,
             fun: function,
             args: vec![self.typed_left_hand_value_variable_call_argument()],
         })

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -224,7 +224,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let v = TypeConstructor {
                     origin: Default::default(),
                     parameters: vec![],
-                    typ: bits(),
+                    type_: bits(),
                     module: PRELUDE_MODULE_NAME.into(),
                     publicity: Publicity::Public,
                     deprecation: NotDeprecated,
@@ -287,7 +287,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         origin: Default::default(),
                         parameters: vec![],
-                        typ: bool(),
+                        type_: bool(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
@@ -302,7 +302,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         origin: Default::default(),
                         parameters: vec![],
-                        typ: float(),
+                        type_: float(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
@@ -316,7 +316,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     INT.into(),
                     TypeConstructor {
                         parameters: vec![],
-                        typ: int(),
+                        type_: int(),
                         origin: Default::default(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
@@ -333,7 +333,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         origin: Default::default(),
                         parameters: vec![list_parameter.clone()],
-                        typ: list(list_parameter),
+                        type_: list(list_parameter),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
@@ -364,7 +364,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         origin: Default::default(),
                         parameters: vec![],
-                        typ: nil(),
+                        type_: nil(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
@@ -393,7 +393,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         origin: Default::default(),
                         parameters: vec![result_value.clone(), result_error.clone()],
-                        typ: result(result_value.clone(), result_error.clone()),
+                        type_: result(result_value.clone(), result_error.clone()),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
@@ -464,7 +464,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         origin: Default::default(),
                         parameters: vec![],
-                        typ: string(),
+                        type_: string(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
@@ -479,7 +479,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         origin: Default::default(),
                         parameters: vec![],
-                        typ: utf_codepoint(),
+                        type_: utf_codepoint(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -35,14 +35,14 @@ impl Printer {
 
     /// Render a Type as a well formatted string.
     ///
-    pub fn pretty_print(&mut self, typ: &Type, initial_indent: usize) -> String {
+    pub fn pretty_print(&mut self, type_: &Type, initial_indent: usize) -> String {
         let mut buffer = String::with_capacity(initial_indent);
         for _ in 0..initial_indent {
             buffer.push(' ');
         }
         buffer
             .to_doc()
-            .append(self.print(typ))
+            .append(self.print(type_))
             .nest(initial_indent as isize)
             .to_pretty_string(80)
     }
@@ -50,8 +50,8 @@ impl Printer {
     // TODO: have this function return a Document that borrows from the Type.
     // Is this possible? The lifetime would have to go through the Arc<Refcell<Type>>
     // for TypeVar::Link'd types.
-    pub fn print<'a>(&mut self, typ: &Type) -> Document<'a> {
-        match typ {
+    pub fn print<'a>(&mut self, type_: &Type) -> Document<'a> {
+        match type_ {
             Type::Named {
                 name, args, module, ..
             } => {
@@ -81,7 +81,7 @@ impl Printer {
                         .group(),
                 ),
 
-            Type::Var { type_: typ, .. } => self.type_var_doc(&typ.borrow()),
+            Type::Var { type_, .. } => self.type_var_doc(&type_.borrow()),
 
             Type::Tuple { elems, .. } => self.args_to_gleam_doc(elems).surround("#(", ")"),
         }
@@ -95,9 +95,9 @@ impl Printer {
         }
     }
 
-    fn type_var_doc<'a>(&mut self, typ: &TypeVar) -> Document<'a> {
-        match typ {
-            TypeVar::Link { type_: ref typ, .. } => self.print(typ),
+    fn type_var_doc<'a>(&mut self, type_: &TypeVar) -> Document<'a> {
+        match type_ {
+            TypeVar::Link { ref type_, .. } => self.print(type_),
             TypeVar::Unbound { id, .. } | TypeVar::Generic { id, .. } => self.generic_type_var(*id),
         }
     }
@@ -247,9 +247,9 @@ fn next_letter_test() {
 #[test]
 fn pretty_print_test() {
     macro_rules! assert_string {
-        ($src:expr, $typ:expr $(,)?) => {
+        ($src:expr, $type_:expr $(,)?) => {
             let mut printer = Printer::new();
-            assert_eq!($typ.to_string(), printer.pretty_print(&$src, 0),);
+            assert_eq!($type_.to_string(), printer.pretty_print(&$src, 0),);
         };
     }
 
@@ -455,6 +455,6 @@ fn function_test() {
 }
 
 #[cfg(test)]
-fn pretty_print(typ: Arc<Type>) -> String {
-    Printer::new().pretty_print(&typ, 0)
+fn pretty_print(type_: Arc<Type>) -> String {
+    Printer::new().pretty_print(&type_, 0)
 }

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -253,8 +253,8 @@ impl<'a> Printer<'a> {
                 self.print(retrn, buffer);
             }
 
-            Type::Var { type_: typ, .. } => match *typ.borrow() {
-                TypeVar::Link { type_: ref typ, .. } => self.print(typ, buffer),
+            Type::Var { type_, .. } => match *type_.borrow() {
+                TypeVar::Link { ref type_, .. } => self.print(type_, buffer),
                 TypeVar::Unbound { id, .. } | TypeVar::Generic { id, .. } => {
                     buffer.push_str(&self.names.type_variable(id))
                 }
@@ -284,7 +284,7 @@ fn test_local_type() {
     names.named_type_in_scope("mod".into(), "Tiger".into(), "Cat".into());
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Tiger".into(),
         args: vec![],
         module: "mod".into(),
@@ -292,7 +292,7 @@ fn test_local_type() {
         package: "".into(),
     };
 
-    assert_eq!(printer.print_type(&typ), "Cat");
+    assert_eq!(printer.print_type(&type_), "Cat");
 }
 
 #[test]
@@ -301,11 +301,11 @@ fn test_generic_type_annotation() {
     names.type_variable_in_scope(0, "one".into());
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Var {
+    let type_ = Type::Var {
         type_: Arc::new(std::cell::RefCell::new(TypeVar::Generic { id: 0 })),
     };
 
-    assert_eq!(printer.print_type(&typ), "one");
+    assert_eq!(printer.print_type(&type_), "one");
 }
 
 #[test]
@@ -313,7 +313,7 @@ fn test_generic_type_var() {
     let mut names = TypeNames::new("module".into());
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Var {
+    let type_ = Type::Var {
         type_: Arc::new(std::cell::RefCell::new(TypeVar::Unbound { id: 0 })),
     };
 
@@ -321,7 +321,7 @@ fn test_generic_type_var() {
         type_: Arc::new(std::cell::RefCell::new(TypeVar::Unbound { id: 1 })),
     };
 
-    assert_eq!(printer.print_type(&typ), "a");
+    assert_eq!(printer.print_type(&type_), "a");
     assert_eq!(printer.print_type(&typ2), "b");
 }
 
@@ -330,7 +330,7 @@ fn test_tuple_type() {
     let mut names = TypeNames::new("module".into());
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Tuple {
+    let type_ = Type::Tuple {
         elems: vec![
             Arc::new(Type::Named {
                 name: "Int".into(),
@@ -349,7 +349,7 @@ fn test_tuple_type() {
         ],
     };
 
-    assert_eq!(printer.print_type(&typ), "#(gleam.Int, gleam.String)");
+    assert_eq!(printer.print_type(&type_), "#(gleam.Int, gleam.String)");
 }
 
 #[test]
@@ -359,7 +359,7 @@ fn test_fn_type() {
     names.named_type_in_scope("gleam".into(), "Bool".into(), "Bool".into());
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Fn {
+    let type_ = Type::Fn {
         args: vec![
             Arc::new(Type::Named {
                 name: "Int".into(),
@@ -385,7 +385,7 @@ fn test_fn_type() {
         }),
     };
 
-    assert_eq!(printer.print_type(&typ), "fn(Int, gleam.String) -> Bool");
+    assert_eq!(printer.print_type(&type_), "fn(Int, gleam.String) -> Bool");
 }
 
 #[test]
@@ -394,7 +394,7 @@ fn test_module_alias() {
     names.imported_module("mod1".into(), "animals".into());
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Cat".into(),
         args: vec![],
         module: "mod1".into(),
@@ -402,7 +402,7 @@ fn test_module_alias() {
         package: "".into(),
     };
 
-    assert_eq!(printer.print_type(&typ), "animals.Cat");
+    assert_eq!(printer.print_type(&type_), "animals.Cat");
 }
 
 #[test]
@@ -415,7 +415,7 @@ fn test_type_alias_and_generics() {
 
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Tiger".into(),
         args: vec![Arc::new(Type::Var {
             type_: Arc::new(std::cell::RefCell::new(TypeVar::Generic { id: 0 })),
@@ -425,7 +425,7 @@ fn test_type_alias_and_generics() {
         package: "".into(),
     };
 
-    assert_eq!(printer.print_type(&typ), "Cat(one)");
+    assert_eq!(printer.print_type(&type_), "Cat(one)");
 }
 
 #[test]
@@ -438,7 +438,7 @@ fn test_unqualified_import_and_generic() {
 
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Cat".into(),
         args: vec![Arc::new(Type::Var {
             type_: Arc::new(std::cell::RefCell::new(TypeVar::Generic { id: 0 })),
@@ -448,14 +448,14 @@ fn test_unqualified_import_and_generic() {
         package: "".into(),
     };
 
-    assert_eq!(printer.print_type(&typ), "C(one)");
+    assert_eq!(printer.print_type(&type_), "C(one)");
 }
 
 #[test]
 fn nested_module() {
     let mut names = TypeNames::new("module".into());
     let mut printer = Printer::new(&mut names);
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Cat".into(),
         args: vec![],
         module: "one/two/three".into(),
@@ -463,7 +463,7 @@ fn nested_module() {
         package: "".into(),
     };
 
-    assert_eq!(printer.print_type(&typ), "three.Cat");
+    assert_eq!(printer.print_type(&type_), "three.Cat");
 }
 
 #[test]
@@ -478,7 +478,7 @@ fn test_unqualified_import_and_module_alias() {
 
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Cat".into(),
         args: vec![],
         module: "mod1".into(),
@@ -486,7 +486,7 @@ fn test_unqualified_import_and_module_alias() {
         package: "".into(),
     };
 
-    assert_eq!(printer.print_type(&typ), "C");
+    assert_eq!(printer.print_type(&type_), "C");
 }
 
 #[test]
@@ -499,7 +499,7 @@ fn test_module_imports() {
 
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Cat".into(),
         args: vec![],
         module: "mod".into(),
@@ -515,7 +515,7 @@ fn test_module_imports() {
         package: "".into(),
     };
 
-    assert_eq!(printer.print_type(&typ), "animals.Cat");
+    assert_eq!(printer.print_type(&type_), "animals.Cat");
     assert_eq!(printer.print_type(&typ1), "Cat");
 }
 
@@ -528,7 +528,7 @@ fn test_multiple_generic_annotations() {
 
     let mut printer = Printer::new(&mut names);
 
-    let typ = Type::Named {
+    let type_ = Type::Named {
         name: "Tiger".into(),
         args: vec![
             Arc::new(Type::Var {
@@ -547,7 +547,7 @@ fn test_multiple_generic_annotations() {
         type_: Arc::new(std::cell::RefCell::new(TypeVar::Generic { id: 2 })),
     };
 
-    assert_eq!(printer.print_type(&typ), "tigermodule.Tiger(one, two)");
+    assert_eq!(printer.print_type(&type_), "tigermodule.Tiger(one, two)");
     assert_eq!(printer.print_type(&typ1), "a");
 }
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -35,9 +35,9 @@ mod warnings;
 
 #[macro_export]
 macro_rules! assert_infer {
-    ($src:expr, $typ:expr $(,)?) => {
+    ($src:expr, $type_:expr $(,)?) => {
         let t = $crate::type_::tests::infer($src);
-        assert_eq!(($src, t), ($src, $typ.to_string()),);
+        assert_eq!(($src, t), ($src, $type_.to_string()),);
     };
 }
 

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -282,7 +282,7 @@ To match on all possible lists, use the `_` catch-all pattern instead.",
                 type_::Warning::Todo {
                     kind,
                     location,
-                    typ,
+                    type_,
                 } => {
                     let mut text = String::new();
                     text.push_str(
@@ -303,10 +303,10 @@ expression.",
                         }
                     }
                     .into();
-                    if !typ.is_variable() {
+                    if !type_.is_variable() {
                         text.push_str(&format!(
                             "\n\nHint: I think its type is `{}`.\n",
-                            Printer::new().pretty_print(typ, 0)
+                            Printer::new().pretty_print(type_, 0)
                         ));
                     }
 


### PR DESCRIPTION
I remove all leftover occurrences of `typ` in favour of `type_` so everything should be consistent now (and in the capnp schema there where two leftover `typ` fields that I renamed to `type` like all the other ones).