### PR TITLE
Improve lambda functions inference in pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@
   would be infered as `fn() -> Int` in this context.
   ([sobolevn](https://github.com/sobolevn))
 
+- Improves how inference works for anonymous functions inside a pipe.
+  For example:
+
+  ```gleam
+  pub fn main() {
+  let a = 1
+     |> fn (x) { #(x, x + 1) }
+     |> fn (x) { x.0 }
+     |> fn (x) { x }
+  }
+  ```
+
+  Now inferes correctly to return `Int`.
+  ([sobolevn](https://github.com/sobolevn))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_pipe.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_pipe.snap
@@ -7,7 +7,7 @@ expression: "\npub fn main(x) {\n  x\n  |> fn(x) { x }\n}\n"
 
 -export([main/1]).
 
--spec main(L) -> L.
+-spec main(K) -> K.
 main(X) ->
     _pipe = X,
     (fun(X@1) -> X@1 end)(_pipe).

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -90,6 +90,21 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             self.warn_if_call_first_argument_is_hole(&call);
 
             let call = match call {
+                func @ UntypedExpr::Fn { location, .. } => {
+                    let (func, args, return_type) = self.expr_typer.do_infer_call(
+                        func.clone(),
+                        vec![self.untyped_left_hand_value_variable_call_argument()],
+                        location,
+                        CallKind::Function,
+                    );
+                    TypedExpr::Call {
+                        location,
+                        args,
+                        type_: return_type,
+                        fun: Box::new(func),
+                    }
+                }
+
                 // left |> right(..args)
                 UntypedExpr::Call {
                     fun,

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity1.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity1.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "\npub fn main() {\n  let a = 1\n     |> fn (x) { #(x, x + 1) }\n     |> fn (x, y) { x.0 }\n     |> fn (x) { x }\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:5:9
+  │
+5 │      |> fn (x, y) { x.0 }
+  │         ^^^^^^^^^^^^^^^^^ Expected 2 arguments, got 1
+
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:21
+  │
+5 │      |> fn (x, y) { x.0 }
+  │                     ^ What type is this?
+
+To index into a tuple we need to know it size, but we don't know
+anything about this type yet. Please add some type annotations so
+we can continue.

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity2.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity2.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "\npub fn main() {\n  let a = 1\n     |> fn (x) { #(x, x + 1) }\n     |> fn (x) { x.0 }\n     |> fn (x, y) { x }\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:6:9
+  │
+6 │      |> fn (x, y) { x }
+  │         ^^^^^^^^^^^^^^^ Expected 2 arguments, got 1

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity3.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity3.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "\npub fn main() {\n  let a = 1\n     |> fn (x) { #(x, x + 1) }\n     |> fn (x) { x.0 }\n     |> fn () { x }\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:6:9
+  │
+6 │      |> fn () { x }
+  │         ^^^^^^^^^^^ Expected no arguments, got 1
+
+
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:17
+  │
+6 │      |> fn () { x }
+  │                 ^
+
+The name `x` is not in scope here.

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -2356,6 +2356,20 @@ pub fn main() {
 }
 
 #[test]
+fn pipe_with_annonymous_unannotated_functions_wrong_arity3() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  let a = 1
+     |> fn (x) { #(x, x + 1) }
+     |> fn (x) { x.0 }
+     |> fn () { x }
+}
+"#
+    );
+}
+
+#[test]
 fn pipe_with_annonymous_mixed_functions() {
     assert_module_infer!(
         r#"

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -2311,3 +2311,86 @@ fn assert_suitable_main_function_javascript_not_supported() {
     };
     assert!(assert_suitable_main_function(&value, &"module".into(), Target::JavaScript).is_err(),);
 }
+
+#[test]
+fn pipe_with_annonymous_unannotated_functions() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+  let a = 1
+     |> fn (x) { #(x, x + 1) }
+     |> fn (x) { x.0 }
+     |> fn (x) { x }
+}
+"#,
+        vec![("main", "fn() -> Int")]
+    );
+}
+
+#[test]
+fn pipe_with_annonymous_unannotated_functions_wrong_arity1() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  let a = 1
+     |> fn (x) { #(x, x + 1) }
+     |> fn (x, y) { x.0 }
+     |> fn (x) { x }
+}
+"#
+    );
+}
+
+#[test]
+fn pipe_with_annonymous_unannotated_functions_wrong_arity2() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  let a = 1
+     |> fn (x) { #(x, x + 1) }
+     |> fn (x) { x.0 }
+     |> fn (x, y) { x }
+}
+"#
+    );
+}
+
+#[test]
+fn pipe_with_annonymous_mixed_functions() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+  let a = "abc"
+     |> fn (x) { #(x, x <> "d") }
+     |> fn (x) { x.0 }
+     |> fn (x: String) { x }
+}
+"#,
+        vec![("main", "fn() -> String")]
+    );
+}
+
+#[test]
+fn pipe_with_annonymous_functions_using_structs() {
+    // https://github.com/gleam-lang/gleam/issues/2504
+    assert_module_infer!(
+        r#"
+type Date {
+  Date(day: Day)
+}
+type Day {
+  Day(year: Int)
+}
+fn now() -> Date {
+  Date(Day(2024))
+}
+fn get_day(date: Date) -> Day {
+  date.day
+}
+pub fn main() {
+  now() |> get_day() |> fn (it) { it.year }
+}
+"#,
+        vec![("main", "fn() -> Int")]
+    );
+}


### PR DESCRIPTION
This is the second step after https://github.com/gleam-lang/gleam/pull/3460

Now I reuse the function inference we have in `expression.rs` to infer individual `fn` expressions in pipes.

Closes https://github.com/gleam-lang/gleam/issues/2504