### PR TITLE
refactoring: Use `SpannedString` alias where possible

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -18,6 +18,7 @@ use crate::{
     config::PackageConfig,
     dep_tree,
     line_numbers::LineNumbers,
+    parse::SpannedString,
     type_::{
         self,
         environment::*,
@@ -1141,7 +1142,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
     fn make_type_vars(
         &mut self,
-        args: &[(SrcSpan, EcoString)],
+        args: &[SpannedString],
         hydrator: &mut Hydrator,
         environment: &mut Environment<'_>,
     ) -> Vec<Arc<Type>> {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -13,6 +13,7 @@ pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 
 use crate::analyse::Inferred;
 use crate::build::{Located, Target};
+use crate::parse::SpannedString;
 use crate::type_::expression::Implementations;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
@@ -236,7 +237,7 @@ pub type TypedRecordConstructorArg = RecordConstructorArg<Arc<Type>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecordConstructorArg<T> {
-    pub label: Option<(SrcSpan, EcoString)>,
+    pub label: Option<SpannedString>,
     pub ast: TypeAst,
     pub location: SrcSpan,
     pub type_: T,
@@ -629,7 +630,7 @@ impl Publicity {
 pub struct Function<T, Expr> {
     pub location: SrcSpan,
     pub end_position: u32,
-    pub name: Option<(SrcSpan, EcoString)>,
+    pub name: Option<SpannedString>,
     pub arguments: Vec<Arg<T>>,
     pub body: Vec1<Statement<T, Expr>>,
     pub publicity: Publicity,
@@ -743,7 +744,7 @@ pub struct CustomType<T> {
     pub deprecation: Deprecation,
     pub opaque: bool,
     /// The names of the type parameters.
-    pub parameters: Vec<(SrcSpan, EcoString)>,
+    pub parameters: Vec<SpannedString>,
     /// Once type checked this field will contain the type information for the
     /// type parameters.
     pub typed_parameters: Vec<T>,
@@ -773,7 +774,7 @@ pub struct TypeAlias<T> {
     pub location: SrcSpan,
     pub alias: EcoString,
     pub name_location: SrcSpan,
-    pub parameters: Vec<(SrcSpan, EcoString)>,
+    pub parameters: Vec<SpannedString>,
     pub type_ast: TypeAst,
     pub type_: T,
     pub publicity: Publicity,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -10,6 +10,7 @@ use crate::{
     docvec,
     io::Utf8Writer,
     parse::extra::{Comment, ModuleExtra},
+    parse::SpannedString,
     pretty::{self, *},
     type_::{self, Type},
     warning::WarningEmitter,
@@ -704,7 +705,7 @@ impl<'comments> Formatter<'comments> {
         &mut self,
         publicity: Publicity,
         name: &'a str,
-        args: &'a [(SrcSpan, EcoString)],
+        args: &'a [SpannedString],
         type_: &'a TypeAst,
         deprecation: &'a Deprecation,
         location: &SrcSpan,
@@ -1640,7 +1641,7 @@ impl<'comments> Formatter<'comments> {
         &mut self,
         publicity: Publicity,
         name: &'a str,
-        args: &'a [(SrcSpan, EcoString)],
+        args: &'a [SpannedString],
         location: &'a SrcSpan,
     ) -> Document<'a> {
         let _ = self.pop_empty_lines(location.start);

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -141,11 +141,12 @@ impl Attributes {
     }
 }
 
-type SpannedString = (SrcSpan, EcoString);
-
 //
 // Public Interface
 //
+
+pub type SpannedString = (SrcSpan, EcoString);
+
 pub fn parse_module(
     path: Utf8PathBuf,
     src: &str,


### PR DESCRIPTION
This alias is quite useful, because we have a lot of similar annotations.