### PR TITLE
Fix function calls inference in pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,11 @@
   arrays.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug which affected inference of function
+  calls in pipe expressions.
+
+  ([sobolevn](https://github.com/sobolevn))
+
 ## v1.4.1 - 2024-08-04
 
 ### Bug Fixes

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -115,9 +115,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                     let fun = self.expr_typer.infer(*fun)?;
                     match fun.type_().fn_types() {
                         // Rewrite as right(..args)(left)
-                        Some((args, return_))
-                            if args.len() == arguments.len() && return_.fn_arity() == Some(1) =>
-                        {
+                        Some((args, _)) if args.len() == arguments.len() => {
                             self.infer_apply_to_call_pipe(fun, arguments, location)
                         }
                         // Rewrite as right(left, ..args)

--- a/compiler-core/src/type_/tests/pipes.rs
+++ b/compiler-core/src/type_/tests/pipes.rs
@@ -1,4 +1,4 @@
-use crate::assert_module_infer;
+use crate::{assert_module_error, assert_module_infer};
 
 // https://github.com/gleam-lang/gleam/issues/2392
 #[test]
@@ -39,5 +39,117 @@ pub fn main() {
 }
 "#,
         vec![("main", "fn() -> fn(Int) -> Int")]
+    );
+}
+
+#[test]
+fn pipe_regression_gh3515() {
+    // https://github.com/gleam-lang/gleam/issues/3515
+    assert_module_infer!(
+        r#"
+fn relu(t) {
+  fn(theta: String) {
+    // use t and theta and return a Float
+    0.0
+  }
+}
+
+pub fn k_relu(k: Int) {
+  fn(t: Float) {
+    fn(theta: String) {
+      case k {
+        0 -> t
+        _ -> {
+          // following code is OK on gleam 1.3.2,
+          // but raised error on gleam 1.4.1
+          // The key here is that it is not a direct function call,
+          // but a "var" call, which points to the same function.
+          let next_layer = theta |> relu(t) |> k_relu(k - 1)
+          theta |> next_layer
+        }
+      }
+    }
+  }
+}"#,
+        vec![("k_relu", "fn(Int) -> fn(Float) -> fn(String) -> Float")],
+    );
+}
+
+#[test]
+fn pipe_callback_var_function1() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+  let f = fn(a) { fn(b) { #(a, b) } }
+  let x = 1 |> f()
+}
+"#,
+        vec![("main", "fn() -> fn(a) -> #(Int, a)")],
+    );
+}
+
+#[test]
+fn pipe_callback_var_function2() {
+    assert_module_infer!(
+        r#"
+pub fn main() {
+  let f = fn(a) { fn(b) { #(a, b) } }
+  let x = 1 |> f(1)
+}
+"#,
+        vec![("main", "fn() -> #(Int, Int)")],
+    );
+}
+
+#[test]
+fn pipe_callback_correct_arity1() {
+    assert_module_infer!(
+        r#"
+fn callback(a: Int) {
+  fn() -> String {
+    "Called"
+  }
+}
+
+pub fn main() {
+  let x = 1 |> callback()
+}
+"#,
+        vec![("main", "fn() -> fn() -> String")],
+    );
+}
+
+#[test]
+fn pipe_callback_correct_arity2() {
+    assert_module_infer!(
+        r#"
+fn callback(a: Float) {
+  fn(b: Int) -> String {
+    "Called"
+  }
+}
+
+pub fn main() {
+  let x = 1 |> callback(2.5)
+}
+"#,
+        vec![("main", "fn() -> String")],
+    );
+}
+
+#[test]
+fn pipe_callback_wrong_arity() {
+    assert_module_error!(
+        r#"
+fn callback(a: Int) {
+  fn() -> String {
+    "Called"
+  }
+}
+
+pub fn main() {
+  let x = 1 |> callback(2)
+}
+"#
     );
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pipes__pipe_callback_wrong_arity.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__pipes__pipe_callback_wrong_arity.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/type_/tests/pipes.rs
+expression: "\nfn callback(a: Int) {\n  fn() -> String {\n    \"Called\"\n  }\n}\n\npub fn main() {\n  let x = 1 |> callback(2)\n}\n"
+---
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:9:16
+  │
+9 │   let x = 1 |> callback(2)
+  │                ^^^^^^^^^^^ Expected no arguments, got 1


### PR DESCRIPTION
So, why did I make this change?

In some cases `return_.fn_arity()` was returning `None`, because `return_` was not a function type, but `Type::Var { type_ }`. Which does not have an arity.

Why is it safe not to check the arity here? Because it will be checked in the second `self.expr_typer.do_infer_call_with_known_fun` call here: https://github.com/gleam-lang/gleam/blob/72f4ac9cf1e3bfe5d188076b95561acd9876dd6b/compiler-core/src/type_/pipe.rs#L249-L260

Closes https://github.com/gleam-lang/gleam/issues/3515