### PR TITLE
LSP Code Action: Add missing patterns to inexhaustive case expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,26 @@
 
   ([Surya Rose](https://github.com/gearsdatapacks))
 
+- The Language Server can now suggest a code action to fill in the missing
+  patterns of a case expression:
+
+  ```gleam
+  let a = True
+  case a {}
+  ```
+
+  Becomes:
+
+  ```gleam
+  let a = True
+  case a {
+    False -> todo
+    True -> todo
+  }
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Bug Fixes
 
 - Fixed a bug where the warnings were printed above the errors without any new line between them.
@@ -273,7 +293,7 @@
   ([Surya Rose](https://github.com/gearsdatapacks))
 
 - Fixed a bug where incorrect syntax error message were shown, when using `:` or
-  `=` in wrong possitions in expressions.
+  `=` in wrong positions in expressions.
   ([Ankit Goel](https://github.com/crazymerlyn))
 
 - Fixed a bug where the compiler would crash when pattern matching on a type

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -806,8 +806,12 @@ pub fn code_action_add_missing_patterns(
         // we think we are more indented than we actually are
         //
         let mut indent_size = 0;
+        let line_start = *line_numbers
+            .line_starts
+            .get(range.start.line as usize)
+            .expect("Line number should be valid");
         let chars = module.code.chars();
-        let mut chars = chars.skip(line_numbers.line_starts[range.start.line as usize] as usize);
+        let mut chars = chars.skip(line_start as usize);
         // Count indentation
         while chars.next() == Some(' ') {
             indent_size += 1;
@@ -871,10 +875,7 @@ pub fn code_action_add_missing_patterns(
             // last subject, to skip, so we can find the opening brace.
             // That is: the location we want to get to, minus the start of the line which we skipped to begin with,
             // minus the number we skipped for the indent, minus one more because we go one past the end of indentation
-            let num_to_skip = last_subject_location
-                - line_numbers.line_starts[range.start.line as usize]
-                - indent_size as u32
-                - 1;
+            let num_to_skip = last_subject_location - line_start - indent_size as u32 - 1;
             let chars = chars.skip(num_to_skip as usize);
             let mut start_brace_location = last_subject_location;
             for char in chars {

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -30,8 +30,9 @@ use std::sync::Arc;
 
 use super::{
     code_action::{
-        code_action_import_module, CodeActionBuilder, FillInMissingLabelledArgs,
-        LabelShorthandSyntax, LetAssertToCase, RedundantTupleInCaseSubject,
+        code_action_add_missing_patterns, code_action_import_module, CodeActionBuilder,
+        FillInMissingLabelledArgs, LabelShorthandSyntax, LetAssertToCase,
+        RedundantTupleInCaseSubject,
     },
     completer::Completer,
     signature_help, src_span_to_lsp_range, DownloadDependencies, MakeLocker,
@@ -297,6 +298,7 @@ where
             code_action_unused_imports(module, &params, &mut actions);
             code_action_fix_names(module, &params, &this.error, &mut actions);
             code_action_import_module(module, &params, &this.error, &mut actions);
+            code_action_add_missing_patterns(module, &params, &this.error, &mut actions);
             actions.extend(LetAssertToCase::new(module, &params).code_actions());
             actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
             actions.extend(LabelShorthandSyntax::new(module, &params).code_actions());

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -79,6 +79,7 @@ const CONVERT_TO_CASE: &str = "Convert to case";
 const USE_LABEL_SHORTHAND_SYNTAX: &str = "Use label shorthand syntax";
 const FILL_LABELS: &str = "Fill labels";
 const ASSIGN_UNUSED_RESULT: &str = "Assign unused Result value to `_`";
+const ADD_MISSING_PATTERNS: &str = "Add missing patterns";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -1418,6 +1419,91 @@ fn test_no_action_to_import_module_with_constructor_named_same_as_type() {
         TestProject::for_source(src)
             .add_hex_module("shapes", "pub type Shape { Rectangle, Circle }"),
         find_position_of("shapes").select_until(find_position_of("."))
+    );
+}
+
+#[test]
+fn add_missing_patterns_bool() {
+    assert_code_action!(
+        ADD_MISSING_PATTERNS,
+        "
+pub fn main() {
+  let bool = True
+  case bool {}
+}
+",
+        find_position_of("case").select_until(find_position_of("bool {"))
+    );
+}
+
+#[test]
+fn add_missing_patterns_custom_type() {
+    assert_code_action!(
+        ADD_MISSING_PATTERNS,
+        "
+type Wibble {
+  Wibble
+  Wobble
+  Wubble
+}
+
+pub fn main() {
+  let wibble = Wobble
+  case wibble {
+    Wobble -> Nil
+  }
+}
+",
+        find_position_of("case").select_until(find_position_of("wibble {"))
+    );
+}
+
+#[test]
+fn add_missing_patterns_tuple() {
+    assert_code_action!(
+        ADD_MISSING_PATTERNS,
+        "
+pub fn main() {
+  let two_at_once = #(True, Ok(1))
+  case two_at_once {
+    #(False, Error(_)) -> Nil
+  }
+}
+",
+        find_position_of("case").select_until(find_position_of("two_at_once {"))
+    );
+}
+
+#[test]
+fn add_missing_patterns_list() {
+    assert_code_action!(
+        ADD_MISSING_PATTERNS,
+        "
+pub fn main() {
+  let list = [1, 2, 3]
+  case list {
+    [a, b, c, 4 as d] -> d
+  }
+}
+",
+        find_position_of("case").select_until(find_position_of("list {"))
+    );
+}
+
+fn add_missing_patterns_infinite() {
+    assert_code_action!(
+        ADD_MISSING_PATTERNS,
+        r#"
+pub fn main() {
+  let value = 3
+  case value {
+    1 -> "one"
+    2 -> "two"
+    3 -> "three"
+  }
+}
+"#,
+        find_position_of("case").select_until(find_position_of("value {"))
     );
 }
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1490,6 +1490,7 @@ pub fn main() {
     );
 }
 
+#[test]
 fn add_missing_patterns_infinite() {
     assert_code_action!(
         ADD_MISSING_PATTERNS,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1508,6 +1508,23 @@ pub fn main() {
     );
 }
 
+#[test]
+fn add_missing_patterns_multi() {
+    assert_code_action!(
+        ADD_MISSING_PATTERNS,
+        r#"
+pub fn main() {
+  let a = True
+  let b = 1
+  case a, b {
+
+  }
+}
+"#,
+        find_position_of("case").select_until(find_position_of("b {"))
+    );
+}
+
 /* TODO: implement qualified unused location
 #[test]
 fn test_remove_unused_qualified_action() {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1525,6 +1525,22 @@ pub fn main() {
     );
 }
 
+#[test]
+fn add_missing_patterns_inline() {
+    // Ensure we correctly detect the indentation, if the case expression
+    // does not start at the beginning of the line
+    assert_code_action!(
+        ADD_MISSING_PATTERNS,
+        r#"
+pub fn main() {
+  let a = True
+  let value = case a {}
+}
+"#,
+        find_position_of("case").select_until(find_position_of("a {"))
+    );
+}
+
 /* TODO: implement qualified unused location
 #[test]
 fn test_remove_unused_qualified_action() {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_bool.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_bool.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let bool = True\n  case bool {}\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let bool = True
+  case bool {}
+  ▔▔▔▔▔↑      
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let bool = True
+  case bool {
+    _ -> todo
+}
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_bool.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_bool.snap
@@ -16,6 +16,7 @@ pub fn main() {
 pub fn main() {
   let bool = True
   case bool {
-    _ -> todo
-}
+    False -> todo
+    True -> todo
+  }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_custom_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_custom_type.snap
@@ -31,8 +31,7 @@ pub fn main() {
   let wibble = Wobble
   case wibble {
     Wobble -> Nil
-  
     Wibble -> todo
     Wubble -> todo
-}
+  }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_custom_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_custom_type.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\ntype Wibble {\n  Wibble\n  Wobble\n  Wubble\n}\n\npub fn main() {\n  let wibble = Wobble\n  case wibble {\n    Wobble -> Nil\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+type Wibble {
+  Wibble
+  Wobble
+  Wubble
+}
+
+pub fn main() {
+  let wibble = Wobble
+  case wibble {
+  ▔▔▔▔▔↑       
+    Wobble -> Nil
+  }
+}
+
+
+----- AFTER ACTION
+
+type Wibble {
+  Wibble
+  Wobble
+  Wubble
+}
+
+pub fn main() {
+  let wibble = Wobble
+  case wibble {
+    Wobble -> Nil
+  
+    Wibble -> todo
+    Wubble -> todo
+}
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_infinite.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_infinite.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let value = 3\n  case value {\n    1 -> \"one\"\n    2 -> \"two\"\n    3 -> \"three\"\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let value = 3
+  case value {
+  ▔▔▔▔▔↑      
+    1 -> "one"
+    2 -> "two"
+    3 -> "three"
+  }
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let value = 3
+  case value {
+    1 -> "one"
+    2 -> "two"
+    3 -> "three"
+  
+    _ -> todo
+}
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_infinite.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_infinite.snap
@@ -23,7 +23,6 @@ pub fn main() {
     1 -> "one"
     2 -> "two"
     3 -> "three"
-  
     _ -> todo
-}
+  }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_inline.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_inline.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let a = True\n  let value = case a {}\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let a = True
+  let value = case a {}
+              ▔▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let a = True
+  let value = case a {
+    False -> todo
+    True -> todo
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_list.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_list.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let list = [1, 2, 3]\n  case list {\n    [a, b, c, 4 as d] -> d\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let list = [1, 2, 3]
+  case list {
+  ▔▔▔▔▔↑     
+    [a, b, c, 4 as d] -> d
+  }
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let list = [1, 2, 3]
+  case list {
+    [a, b, c, 4 as d] -> d
+  
+    [] -> todo
+    [_, _, _, _, _, ..] -> todo
+    [_, _, _, _] -> todo
+    [_, _, _] -> todo
+    [_, _] -> todo
+    [_] -> todo
+}
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_list.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_list.snap
@@ -19,12 +19,11 @@ pub fn main() {
   let list = [1, 2, 3]
   case list {
     [a, b, c, 4 as d] -> d
-  
     [] -> todo
     [_, _, _, _, _, ..] -> todo
     [_, _, _, _] -> todo
     [_, _, _] -> todo
     [_, _] -> todo
     [_] -> todo
-}
+  }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_multi.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_multi.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let a = True\n  let b = 1\n  case a, b {\n\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let a = True
+  let b = 1
+  case a, b {
+  ▔▔▔▔▔▔▔▔↑  
+
+  }
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let a = True
+  let b = 1
+  case a, b {
+    False, _ -> todo
+    True, _ -> todo
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_tuple.snap
@@ -19,8 +19,7 @@ pub fn main() {
   let two_at_once = #(True, Ok(1))
   case two_at_once {
     #(False, Error(_)) -> Nil
-  
     #(True, Error(_)) -> todo
     #(_, Ok(_)) -> todo
-}
+  }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_tuple.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let two_at_once = #(True, Ok(1))\n  case two_at_once {\n    #(False, Error(_)) -> Nil\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let two_at_once = #(True, Ok(1))
+  case two_at_once {
+  ▔▔▔▔▔↑            
+    #(False, Error(_)) -> Nil
+  }
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let two_at_once = #(True, Ok(1))
+  case two_at_once {
+    #(False, Error(_)) -> Nil
+  
+    #(True, Error(_)) -> todo
+    #(_, Ok(_)) -> todo
+}
+}


### PR DESCRIPTION
Closes #2957 
I have added a code action which fills in the missing patterns for an inexhaustive case expression. The formatting of the resulting syntax isn't great at the moment, but it works.
Let me know if I should work on adapting the generated code actions to produce nicer looking code as per the situation.

NOTE: This currently doesn't work properly with multi-patterns due to #2426. But I think it's useful enough to have now, and it will work fine as soon as that issue is fixed.