### PR TITLE
Fix several bit_array tests on js to expect a compilation error on supported features

### DIFF
--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -1,4 +1,4 @@
-use crate::{assert_js, assert_ts_def};
+use crate::{assert_js, assert_js_error, assert_ts_def};
 
 #[test]
 fn empty() {
@@ -545,7 +545,7 @@ fn go() {
 // https://github.com/gleam-lang/gleam/issues/1591
 #[test]
 fn not_byte_aligned() {
-    assert_js!(
+    assert_js_error!(
         r#"
 fn thing() {
   4
@@ -560,12 +560,27 @@ fn go() {
 
 #[test]
 fn not_byte_aligned_explicit_sized() {
-    assert_js!(
+    assert_js_error!(
         r#"
 fn go() {
   <<256:size(4)>>
 }
 "#,
+    );
+}
+
+#[test]
+fn bit_arrays_on_js_do_not_support_bits() {
+    // https://github.com/gleam-lang/gleam/issues/3524
+    assert_js_error!(
+        r#"
+fn main() {
+  case <<1, 2>> {
+    <<b:bits>> -> 1
+    _ -> 0
+  }
+}
+"#
     );
 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_arrays_on_js_do_not_support_bits.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_arrays_on_js_do_not_support_bits.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn main() {\n  case <<1, 2>> {\n    <<b:bits>> -> 1\n    _ -> 0\n  }\n}\n"
+---
+error: Unsupported feature for compilation target
+  ┌─ /src/javascript/error.gleam:4:7
+  │
+4 │     <<b:bits>> -> 1
+  │       ^^^^^^
+
+This bit array segment option in patterns is not supported for JavaScript compilation.

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned.snap
@@ -2,8 +2,10 @@
 source: compiler-core/src/javascript/tests/bit_arrays.rs
 expression: "\nfn thing() {\n  4\n}\n\nfn go() {\n  <<256:4>>\n}\n"
 ---
-import { toBitArray } from "../gleam.mjs";
+error: Unsupported feature for compilation target
+  ┌─ /src/javascript/error.gleam:7:5
+  │
+7 │   <<256:4>>
+  │     ^^^^^
 
-function thing() {
-  return 4;
-}
+Non byte aligned array is not supported for JavaScript compilation.

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned_explicit_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__not_byte_aligned_explicit_sized.snap
@@ -2,4 +2,10 @@
 source: compiler-core/src/javascript/tests/bit_arrays.rs
 expression: "\nfn go() {\n  <<256:size(4)>>\n}\n"
 ---
-import { toBitArray } from "../gleam.mjs";
+error: Unsupported feature for compilation target
+  ┌─ /src/javascript/error.gleam:3:5
+  │
+3 │   <<256:size(4)>>
+  │     ^^^^^^^^^^^
+
+Non byte aligned array is not supported for JavaScript compilation.


### PR DESCRIPTION
There are several parts to it.
1. Errors are produced together with the invalid code.
2. They were not checked, invalid code was asserted instead.
3. gleam.run probably also does not raise these compilation errors to user for some reason