### PR TITLE
Improve import error suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,9 @@
                ^^
                I was not expecting this.
 
-  Hint: did you mean `import gleam/io`?
+  This syntax for import is not correct. Probably, you meant:
+  - `import gleam/io` to import module `io` from package `gleam`
+  - `import gleam.{io}` to import value `io` from module `gleam`
   ```
   ([sobolevn](https://github.com/sobolevn))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@
 - Adds a hint to syntax error when defining a function inside a type.
   ([sobolevn](https://github.com/sobolevn))
 
+- Improve import error messages.
+
+  Now we recommend fixes for `import a.b`
+  and have better suggestions for `import a/b` when `b` is acutally a value.
+  ([sobolevn](https://github.com/sobolevn))
+
 ### Formatter
 
 ### Language Server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,10 +106,15 @@
 - Adds a hint to syntax error when defining a function inside a type.
   ([sobolevn](https://github.com/sobolevn))
 
-- Improve import error messages.
+- Improve import error messages. Now this code produces:
 
-  Now we recommend fixes for `import a.b`
-  and have better suggestions for `import a/b` when `b` is acutally a value.
+  ```gleam
+  import gleam.io
+               ^^
+               I was not expecting this.
+
+  Hint: did you mean `import gleam/io`?
+  ```
   ([sobolevn](https://github.com/sobolevn))
 
 ### Formatter

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1958,10 +1958,11 @@ Private types can only be used within the module that defines them.",
                     location,
                     name,
                     imported_modules,
+                    hint,
                 } => Diagnostic {
                     title: "Unknown module".into(),
                     text: format!("No module has been found with the name `{name}`."),
-                    hint: None,
+                    hint: hint.clone(),
                     level: Level::Error,
                     location: Some(Location {
                         label: Label {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1958,21 +1958,58 @@ Private types can only be used within the module that defines them.",
                     location,
                     name,
                     imported_modules,
-                    hint,
                 } => Diagnostic {
-                    title: "Unknown module".into(),
-                    text: format!("No module has been found with the name `{name}`."),
-                    hint: hint.clone(),
-                    level: Level::Error,
-                    location: Some(Location {
-                        label: Label {
-                            text: did_you_mean(name, imported_modules),
-                            span: *location,
-                        },
-                        path: path.clone(),
-                        src: src.clone(),
-                        extra_labels: vec![],
-                    }),
+                        title: "Unknown module".into(),
+                        text: format!("No module has been found with the name `{name}`."),
+                        hint: None,
+                        level: Level::Error,
+                        location: Some(Location {
+                            label: Label {
+                                text: did_you_mean(name, imported_modules),
+                                span: *location,
+                            },
+                            path: path.clone(),
+                            src: src.clone(),
+                            extra_labels: vec![],
+                        }),
+                },
+
+                TypeError::UnknownModuleWithRichSuggestions {
+                    location,
+                    name,
+                    name_parts,
+                    importable_modules,
+                } => {
+                    // Improve error message when users confuse `import one/two`
+                    // with `import one.{two}`.
+                    let (basename, last_part) = name_parts;
+                    let hint = Some(
+                        wrap(
+                            format!(
+                                "Did you mean `import {basename}.{{{last_part}}}`?
+
+See: https://tour.gleam.run/basics/unqualified-imports
+                        "
+                            )
+                            .as_str(),
+                        )
+                        .to_string(),
+                    );
+                    Diagnostic {
+                        title: "Unknown module".into(),
+                        text: format!("No module has been found with the name `{name}`."),
+                        hint,
+                        level: Level::Error,
+                        location: Some(Location {
+                            label: Label {
+                                text: did_you_mean(name, importable_modules),
+                                span: *location,
+                            },
+                            path: path.clone(),
+                            src: src.clone(),
+                            extra_labels: vec![],
+                        }),
+                    }
                 },
 
                 TypeError::UnknownModuleType {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2497,7 +2497,7 @@ where
                 ..
             } => ParseError {
                 location: err.location,
-                error: ParseErrorType::InvalidImportSyntax {
+                error: ParseErrorType::ImportDottedName {
                     module: module.into(),
                     name: name.clone(),
                     upname: false,
@@ -2509,7 +2509,7 @@ where
                 ..
             } => ParseError {
                 location: err.location,
-                error: ParseErrorType::InvalidImportSyntax {
+                error: ParseErrorType::ImportDottedName {
                     module: module.into(),
                     name: name.clone(),
                     upname: true,

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -292,7 +292,7 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 "Unsupported expression",
                 vec!["Functions cannot be called in clause guards.".into()],
             ),
-            ParseErrorType::InvalidImportSyntax {
+            ParseErrorType::ImportDottedName {
                 module,
                 name,
                 upname,
@@ -388,7 +388,8 @@ pub enum ParseErrorType {
         field_type: Option<TypeAst>,
     },
     CallInClauseGuard, // case x { _ if f() -> 1 }
-    InvalidImportSyntax {
+    ImportDottedName {
+        // import x.y
         module: EcoString,
         name: EcoString,
         upname: bool,

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -292,6 +292,36 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 "Unsupported expression",
                 vec!["Functions cannot be called in clause guards.".into()],
             ),
+            ParseErrorType::InvalidImportSyntax {
+                module,
+                name,
+                upname,
+            } => {
+                let mut hint = vec![wrap(
+                    "This syntax for import is not correct. Probably, you meant:",
+                )];
+                if *upname {
+                    let l_name = name.to_lowercase();
+                    hint.push(wrap(format!(
+                        "- `import {module}/{l_name}` to import module `{l_name}` from package `{module}`").as_str(),
+                    ));
+                    hint.push(wrap(format!(
+                        "- `import {module}.{{{name}}}` to import value `{name}` from module `{module}`").as_str(),
+                    ));
+                    hint.push(wrap(format!(
+                        "- `import {module}.{{type {name}}}` to import type `{name}` from module `{module}`").as_str(),
+                    ));
+                } else {
+                    hint.push(wrap(format!(
+                        "- `import {module}/{name}` to import module `{name}` from package `{module}`").as_str(),
+                    ));
+                    hint.push(wrap(format!(
+                        "- `import {module}.{{{name}}}` to import value `{name}` from module `{module}`").as_str(),
+                    ));
+                }
+
+                ("I was not expecting this", hint)
+            }
         }
     }
 }
@@ -358,6 +388,11 @@ pub enum ParseErrorType {
         field_type: Option<TypeAst>,
     },
     CallInClauseGuard, // case x { _ if f() -> 1 }
+    InvalidImportSyntax {
+        module: EcoString,
+        name: EcoString,
+        upname: bool,
+    },
 }
 
 impl LexicalError {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_dotted_name.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_dotted_name.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nimport one.two\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:12
+  │
+2 │ import one.two
+  │            ^^^ I was not expecting this
+
+This syntax for import is not correct. Probably, you meant:
+- `import one/two` to import module `two` from package `one`
+- `import one.{two}` to import value `two` from module `one`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_dotted_name_multiple_dots.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_dotted_name_multiple_dots.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nimport one.two.three\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:12
+  │
+2 │ import one.two.three
+  │            ^^^ I was not expecting this
+
+This syntax for import is not correct. Probably, you meant:
+- `import one/two` to import module `two` from package `one`
+- `import one.{two}` to import value `two` from module `one`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_dotted_upname.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_dotted_upname.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nimport one.Two\n"
+---
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:12
+  │
+2 │ import one.Two
+  │            ^^^ I was not expecting this
+
+This syntax for import is not correct. Probably, you meant:
+- `import one/two` to import module `two` from package `one`
+- `import one.{Two}` to import value `Two` from module `one`
+- `import one.{type Two}` to import type `Two` from module `one`

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1482,3 +1482,21 @@ type Wibble {
 "#
     );
 }
+
+#[test]
+fn import_dotted_name() {
+    assert_module_error!(
+        r#"
+import one.two
+"#
+    );
+}
+
+#[test]
+fn import_dotted_upname() {
+    assert_module_error!(
+        r#"
+import one.Two
+"#
+    );
+}

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1493,6 +1493,15 @@ import one.two
 }
 
 #[test]
+fn import_dotted_name_multiple_dots() {
+    assert_module_error!(
+        r#"
+import one.two.three
+"#
+    );
+}
+
+#[test]
 fn import_dotted_upname() {
     assert_module_error!(
         r#"

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -107,7 +107,13 @@ pub enum Error {
         location: SrcSpan,
         name: EcoString,
         imported_modules: Vec<EcoString>,
-        hint: Option<String>,
+    },
+
+    UnknownModuleWithRichSuggestions {
+        location: SrcSpan,
+        name: EcoString,
+        name_parts: (EcoString, EcoString),
+        importable_modules: Vec<EcoString>,
     },
 
     UnknownModuleType {
@@ -776,6 +782,7 @@ impl Error {
             | Error::UnknownVariable { location, .. }
             | Error::UnknownType { location, .. }
             | Error::UnknownModule { location, .. }
+            | Error::UnknownModuleWithRichSuggestions { location, .. }
             | Error::UnknownModuleType { location, .. }
             | Error::UnknownModuleValue { location, .. }
             | Error::ModuleAliasUsedAsName { location, .. }
@@ -959,7 +966,6 @@ pub fn convert_get_value_constructor_error(
             location,
             name,
             imported_modules,
-            hint: None,
         },
 
         UnknownValueConstructorError::ModuleValue {
@@ -1021,7 +1027,6 @@ pub fn convert_get_type_constructor_error(
             location: *location,
             name,
             imported_modules,
-            hint: None,
         },
 
         UnknownTypeConstructorError::ModuleType {

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -107,6 +107,7 @@ pub enum Error {
         location: SrcSpan,
         name: EcoString,
         imported_modules: Vec<EcoString>,
+        hint: Option<String>,
     },
 
     UnknownModuleType {
@@ -958,6 +959,7 @@ pub fn convert_get_value_constructor_error(
             location,
             name,
             imported_modules,
+            hint: None,
         },
 
         UnknownValueConstructorError::ModuleValue {
@@ -1019,6 +1021,7 @@ pub fn convert_get_type_constructor_error(
             location: *location,
             name,
             imported_modules,
+            hint: None,
         },
 
         UnknownTypeConstructorError::ModuleType {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2098,6 +2098,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     name: module_alias.clone(),
                     location: *module_location,
                     imported_modules: self.environment.imported_modules.keys().cloned().collect(),
+                    hint: None,
                 })?;
 
             let constructor =
@@ -2407,6 +2408,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     .ok_or_else(|| Error::UnknownModule {
                         location: *location,
                         name: module_name.clone(),
+                        hint: None,
                         imported_modules: self
                             .environment
                             .imported_modules

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2098,7 +2098,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     name: module_alias.clone(),
                     location: *module_location,
                     imported_modules: self.environment.imported_modules.keys().cloned().collect(),
-                    hint: None,
                 })?;
 
             let constructor =
@@ -2408,7 +2407,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     .ok_or_else(|| Error::UnknownModule {
                         location: *location,
                         name: module_name.clone(),
-                        hint: None,
                         imported_modules: self
                             .environment
                             .imported_modules

--- a/compiler-core/src/type_/tests/imports.rs
+++ b/compiler-core/src/type_/tests/imports.rs
@@ -348,6 +348,17 @@ fn import_value_as_submodule3() {
 }
 
 #[test]
+fn import_value_as_submodule_very_long_name() {
+    assert_with_module_error!(
+        (
+            "this_is_a_very_long_name_for_a_module_even_hard_to_read",
+            "pub fn this_is_a_very_long_submodule_name() {}"
+        ),
+        "import this_is_a_very_long_name_for_a_module_even_hard_to_read/this_is_a_very_long_submodule_name"
+    );
+}
+
+#[test]
 fn import_value_as_submodule_no_hint() {
     assert_with_module_error!(("one/two", ""), "import one/two/wibble");
 }

--- a/compiler-core/src/type_/tests/imports.rs
+++ b/compiler-core/src/type_/tests/imports.rs
@@ -329,20 +329,35 @@ pub fn main() {
 
 #[test]
 fn import_value_as_submodule() {
-    assert_with_module_error!(
-        ("one", "pub fn wibble() {}"),
-        "
-        import one/wibble
-        "
-    );
+    assert_with_module_error!(("one", "pub fn wibble() {}"), "import one/wibble");
 }
 
 #[test]
 fn import_value_as_submodule2() {
+    assert_with_module_error!(("one/two", "pub fn wibble() {}"), "import one/two/wibble");
+}
+#[test]
+fn import_value_as_submodule3() {
+    // Two possible suggestions: `import one/wobble` or `import one.{wibble}`
+    // One via hint, one via `did_you_mean`.
     assert_with_module_error!(
-        ("one/two", "pub fn wibble() {}"),
-        "
-        import one/two/wibble
-        "
+        ("one", "pub fn wibble() {}"),
+        ("one/wobble", ""),
+        "import one/wibble"
     );
+}
+
+#[test]
+fn import_value_as_submodule_no_hint() {
+    assert_with_module_error!(("one/two", ""), "import one/two/wibble");
+}
+
+#[test]
+fn import_value_as_submodule_no_hint2() {
+    assert_with_module_error!(("one/two", "pub fn wibble() {}"), "import some/other");
+}
+
+#[test]
+fn import_value_as_submodule_no_hint3() {
+    assert_module_error!("import some/other");
 }

--- a/compiler-core/src/type_/tests/imports.rs
+++ b/compiler-core/src/type_/tests/imports.rs
@@ -326,3 +326,23 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn import_value_as_submodule() {
+    assert_with_module_error!(
+        ("one", "pub fn wibble() {}"),
+        "
+        import one/wibble
+        "
+    );
+}
+
+#[test]
+fn import_value_as_submodule2() {
+    assert_with_module_error!(
+        ("one/two", "pub fn wibble() {}"),
+        "
+        import one/two/wibble
+        "
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module.snap
@@ -6,6 +6,6 @@ error: Unknown module
   ┌─ /src/one/two.gleam:1:1
   │
 1 │ import xpto
-  │ ^^^^^^^^^^^
+  │ ^^^^^^^^^^^ Did you mean `gleam`?
 
 No module has been found with the name `xpto`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_errors_do_not_block_analysis.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_errors_do_not_block_analysis.snap
@@ -6,7 +6,7 @@ error: Unknown module
   ┌─ /src/one/two.gleam:1:1
   │
 1 │ import unknown_module
-  │ ^^^^^^^^^^^^^^^^^^^^^
+  │ ^^^^^^^^^^^^^^^^^^^^^ Did you mean `gleam`?
 
 No module has been found with the name `unknown_module`.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests/imports.rs
+expression: "\n        import one/wibble\n        "
+---
+error: Unknown module
+  ┌─ /src/one/two.gleam:2:9
+  │
+2 │         import one/wibble
+  │         ^^^^^^^^^^^^^^^^^
+
+No module has been found with the name `one/wibble`.
+Hint: Maybe you meant `import one.{wibble}`?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule2.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/type_/tests/imports.rs
+expression: "\n        import one/two/wibble\n        "
+---
+error: Unknown module
+  ┌─ /src/one/two.gleam:2:9
+  │
+2 │         import one/two/wibble
+  │         ^^^^^^^^^^^^^^^^^^^^^
+
+No module has been found with the name `one/two/wibble`.
+Hint: Maybe you meant `import one/two.{wibble}`?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule3.snap
@@ -6,7 +6,7 @@ error: Unknown module
   ┌─ /src/one/two.gleam:1:1
   │
 1 │ import one/wibble
-  │ ^^^^^^^^^^^^^^^^^
+  │ ^^^^^^^^^^^^^^^^^ Did you mean `one/wobble`?
 
 No module has been found with the name `one/wibble`.
 Hint: Did you mean `import one.{wibble}`?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint.snap
@@ -9,6 +9,3 @@ error: Unknown module
   │ ^^^^^^^^^^^^^^^^^^^^^ Did you mean `one/two`?
 
 No module has been found with the name `one/two/wibble`.
-Hint: Did you mean `import one/two.{wibble}`?
-
-See: https://tour.gleam.run/basics/unqualified-imports

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint2.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/type_/tests/imports.rs
+expression: import some/other
+---
+error: Unknown module
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ import some/other
+  │ ^^^^^^^^^^^^^^^^^
+
+No module has been found with the name `some/other`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint3.snap
@@ -6,6 +6,6 @@ error: Unknown module
   ┌─ /src/one/two.gleam:1:1
   │
 1 │ import some/other
-  │ ^^^^^^^^^^^^^^^^^
+  │ ^^^^^^^^^^^^^^^^^ Did you mean `gleam`?
 
 No module has been found with the name `some/other`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_no_hint3.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/type_/tests/imports.rs
+expression: import some/other
+---
+error: Unknown module
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ import some/other
+  │ ^^^^^^^^^^^^^^^^^
+
+No module has been found with the name `some/other`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_very_long_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_value_as_submodule_very_long_name.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/imports.rs
+expression: import this_is_a_very_long_name_for_a_module_even_hard_to_read/this_is_a_very_long_submodule_name
+---
+error: Unknown module
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ import this_is_a_very_long_name_for_a_module_even_hard_to_read/this_is_a_very_long_submodule_name
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Did you mean `this_is_a_very_long_name_for_a_module_even_hard_to_read`?
+
+No module has been found with the name `this_is_a_very_long_name_for_a_module_even_hard_to_read/this_is_a_very_long_submodule_name`.
+Hint: Did you mean `import
+this_is_a_very_long_name_for_a_module_even_hard_to_read.
+{this_is_a_very_long_submodule_name}`?
+
+See: https://tour.gleam.run/basics/unqualified-imports


### PR DESCRIPTION
This is the first PR in the series. 

This case is not covered yet:

```rust
#[test]
fn import_submodule_as_value() {
    assert_with_module_error!(
        ("one/two", "pub fn whatever() {}"),
        "
        import one.{two}
        "
    );
}
```

It requires a bit tricky logic to get right, so I decided to split it out.

Better wordings are more than welcome! 👍 