### PR TITLE
Infer minimum Gleam version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "lsp-types",
  "opener",
  "pretty_assertions",
+ "pubgrub",
  "regex",
  "reqwest",
  "rpassword",

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -35,6 +35,8 @@ fslock = "0"
 same-file = "1"
 # Open generated docs in browser
 opener = "0"
+# Pubgrub dependency resolution algorithm
+pubgrub = "0"
 camino = { workspace = true, features = ["serde1"] }
 async-trait.workspace = true
 base16.workspace = true

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -105,8 +105,8 @@ the {file} script.
 
 pub fn hex_tarball() -> Result<()> {
     let paths = crate::find_project_paths()?;
-    let config = crate::config::root_config()?;
-    let data: Vec<u8> = crate::publish::build_hex_tarball(&paths, &config)?;
+    let mut config = crate::config::root_config()?;
+    let data: Vec<u8> = crate::publish::build_hex_tarball(&paths, &mut config)?;
 
     let path = paths.build_export_hex_tarball(&config.name, &config.version.to_string());
     crate::fs::write_bytes(&path, &data)?;

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -5,6 +5,7 @@ use gleam_core::{
     build::{Codegen, Compile, Mode, Options, Package, Target},
     config::{PackageConfig, SpdxLicense},
     docs::DocContext,
+    error::SmallVersion,
     hex,
     paths::{self, ProjectPaths},
     requirement::Requirement,
@@ -285,8 +286,12 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
             if let Some(lowest_allowed_version) = gleam_version.lowest_version() {
                 if lowest_allowed_version < minimum_required_version {
                     return Err(Error::CannotPublishWrongVersion {
-                        minimum_required_version,
-                        wrongfully_allowed_version: lowest_allowed_version,
+                        minimum_required_version: SmallVersion::from_hexpm(
+                            minimum_required_version,
+                        ),
+                        wrongfully_allowed_version: SmallVersion::from_hexpm(
+                            lowest_allowed_version,
+                        ),
                     });
                 }
             }

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -1404,32 +1404,36 @@ pub mod type_constructor {
       !self.reader.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn get_publicity(self) -> ::core::result::Result<crate::schema_capnp::Publicity,::capnp::NotInSchema> {
-      ::capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(0))
-    }
-    #[inline]
-    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+    pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_deprecated(&self) -> bool {
+    pub fn has_publicity(&self) -> bool {
       !self.reader.get_pointer_field(3).is_null()
     }
     #[inline]
-    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Reader<'a>> {
+    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_origin(&self) -> bool {
+    pub fn has_deprecated(&self) -> bool {
       !self.reader.get_pointer_field(4).is_null()
     }
     #[inline]
-    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_documentation(&self) -> bool {
+    pub fn has_origin(&self) -> bool {
       !self.reader.get_pointer_field(5).is_null()
+    }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(6), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.reader.get_pointer_field(6).is_null()
     }
   }
 
@@ -1530,60 +1534,68 @@ pub mod type_constructor {
       !self.builder.get_pointer_field(2).is_null()
     }
     #[inline]
-    pub fn get_publicity(self) -> ::core::result::Result<crate::schema_capnp::Publicity,::capnp::NotInSchema> {
-      ::capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(0))
-    }
-    #[inline]
-    pub fn set_publicity(&mut self, value: crate::schema_capnp::Publicity)  {
-      self.builder.set_data_field::<u16>(0, value as u16)
-    }
-    #[inline]
-    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+    pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Builder<'a>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_deprecated(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(3).set_text(value);
+    pub fn set_publicity(&mut self, value: crate::schema_capnp::publicity::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(3), value, false)
     }
     #[inline]
-    pub fn init_deprecated(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(3).init_text(size)
+    pub fn init_publicity(self, ) -> crate::schema_capnp::publicity::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(3), 0)
     }
     #[inline]
-    pub fn has_deprecated(&self) -> bool {
+    pub fn has_publicity(&self) -> bool {
       !self.builder.get_pointer_field(3).is_null()
     }
     #[inline]
-    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Builder<'a>> {
+    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_origin(&mut self, value: crate::schema_capnp::src_span::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(4), value, false)
+    pub fn set_deprecated(&mut self, value: ::capnp::text::Reader<'_>)  {
+      self.builder.get_pointer_field(4).set_text(value);
     }
     #[inline]
-    pub fn init_origin(self, ) -> crate::schema_capnp::src_span::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), 0)
+    pub fn init_deprecated(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(4).init_text(size)
     }
     #[inline]
-    pub fn has_origin(&self) -> bool {
+    pub fn has_deprecated(&self) -> bool {
       !self.builder.get_pointer_field(4).is_null()
     }
     #[inline]
-    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Builder<'a>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
     }
     #[inline]
+    pub fn set_origin(&mut self, value: crate::schema_capnp::src_span::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(5), value, false)
+    }
+    #[inline]
+    pub fn init_origin(self, ) -> crate::schema_capnp::src_span::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), 0)
+    }
+    #[inline]
+    pub fn has_origin(&self) -> bool {
+      !self.builder.get_pointer_field(5).is_null()
+    }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(6), ::core::option::Option::None)
+    }
+    #[inline]
     pub fn set_documentation(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(5).set_text(value);
+      self.builder.get_pointer_field(6).set_text(value);
     }
     #[inline]
     pub fn init_documentation(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(5).init_text(size)
+      self.builder.get_pointer_field(6).init_text(size)
     }
     #[inline]
     pub fn has_documentation(&self) -> bool {
-      !self.builder.get_pointer_field(5).is_null()
+      !self.builder.get_pointer_field(6).is_null()
     }
   }
 
@@ -1597,13 +1609,16 @@ pub mod type_constructor {
     pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
       ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
     }
+    pub fn get_publicity(&self) -> crate::schema_capnp::publicity::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(3))
+    }
     pub fn get_origin(&self) -> crate::schema_capnp::src_span::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(4))
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(5))
     }
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 6 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 0, pointers: 7 };
     pub const TYPE_ID: u64 = 0xb1fb_6d62_e00b_6d7a;
   }
 }
@@ -2849,16 +2864,20 @@ pub mod value_constructor {
       !self.reader.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_publicity(self) -> ::core::result::Result<crate::schema_capnp::Publicity,::capnp::NotInSchema> {
-      ::capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(0))
-    }
-    #[inline]
-    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+    pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_deprecated(&self) -> bool {
+    pub fn has_publicity(&self) -> bool {
       !self.reader.get_pointer_field(2).is_null()
+    }
+    #[inline]
+    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_deprecated(&self) -> bool {
+      !self.reader.get_pointer_field(3).is_null()
     }
   }
 
@@ -2943,28 +2962,36 @@ pub mod value_constructor {
       !self.builder.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_publicity(self) -> ::core::result::Result<crate::schema_capnp::Publicity,::capnp::NotInSchema> {
-      ::capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(0))
-    }
-    #[inline]
-    pub fn set_publicity(&mut self, value: crate::schema_capnp::Publicity)  {
-      self.builder.set_data_field::<u16>(0, value as u16)
-    }
-    #[inline]
-    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+    pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Builder<'a>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
     }
     #[inline]
+    pub fn set_publicity(&mut self, value: crate::schema_capnp::publicity::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(2), value, false)
+    }
+    #[inline]
+    pub fn init_publicity(self, ) -> crate::schema_capnp::publicity::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
+    }
+    #[inline]
+    pub fn has_publicity(&self) -> bool {
+      !self.builder.get_pointer_field(2).is_null()
+    }
+    #[inline]
+    pub fn get_deprecated(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+    }
+    #[inline]
     pub fn set_deprecated(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(2).set_text(value);
+      self.builder.get_pointer_field(3).set_text(value);
     }
     #[inline]
     pub fn init_deprecated(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(2).init_text(size)
+      self.builder.get_pointer_field(3).init_text(size)
     }
     #[inline]
     pub fn has_deprecated(&self) -> bool {
-      !self.builder.get_pointer_field(2).is_null()
+      !self.builder.get_pointer_field(3).is_null()
     }
   }
 
@@ -2981,39 +3008,207 @@ pub mod value_constructor {
     pub fn get_variant(&self) -> crate::schema_capnp::value_constructor_variant::Pipeline {
       ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
     }
+    pub fn get_publicity(&self) -> crate::schema_capnp::publicity::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+    }
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 3 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 0, pointers: 4 };
     pub const TYPE_ID: u64 = 0xd4c6_d8f1_a8fb_051c;
   }
 }
 
-#[repr(u16)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Publicity {
-  Public = 0,
-  Private = 1,
-  Internal = 2,
-}
-impl ::capnp::traits::FromU16 for Publicity {
-  #[inline]
-  fn from_u16(value: u16) -> ::core::result::Result<Publicity, ::capnp::NotInSchema> {
-    match value {
-      0 => ::core::result::Result::Ok(Publicity::Public),
-      1 => ::core::result::Result::Ok(Publicity::Private),
-      2 => ::core::result::Result::Ok(Publicity::Internal),
-      n => ::core::result::Result::Err(::capnp::NotInSchema(n)),
+pub mod publicity {
+  pub use self::Which::{Public,Private,Internal};
+
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  #[derive(Clone, Copy)]
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+
+  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      Reader { reader,  }
     }
   }
-}
-impl ::capnp::traits::ToU16 for Publicity {
-  #[inline]
-  fn to_u16(self) -> u16 { self as u16 }
-}
-impl ::capnp::traits::HasTypeId for Publicity {
-  #[inline]
-  fn type_id() -> u64 { 0xc549_d3c8_21e9_1c66u64 }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Reader { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn has_internal(&self) -> bool {
+      if self.reader.get_data_field::<u16>(0) != 2 { return false; }
+      !self.reader.get_pointer_field(0).is_null()
+    }
+    #[inline]
+    pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+      match self.reader.get_data_field::<u16>(0) {
+        0 => {
+          ::core::result::Result::Ok(Public(
+            ()
+          ))
+        }
+        1 => {
+          ::core::result::Result::Ok(Private(
+            ()
+          ))
+        }
+        2 => {
+          ::core::result::Result::Ok(Internal(
+            ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+          ))
+        }
+        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+      }
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
+    #[inline]
+    fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
+  }
+  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      Builder { builder,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { .. *self }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.into_reader().total_size()
+    }
+    #[inline]
+    pub fn set_public(&mut self, _value: ())  {
+      self.builder.set_data_field::<u16>(0, 0);
+    }
+    #[inline]
+    pub fn set_private(&mut self, _value: ())  {
+      self.builder.set_data_field::<u16>(0, 1);
+    }
+    #[inline]
+    pub fn set_internal(&mut self, value: crate::schema_capnp::option::Reader<'_,crate::schema_capnp::src_span::Owned>) -> ::capnp::Result<()> {
+      self.builder.set_data_field::<u16>(0, 2);
+      <crate::schema_capnp::option::Reader<'_,crate::schema_capnp::src_span::Owned> as ::capnp::traits::SetPointerBuilder>::set_pointer_builder(self.builder.get_pointer_field(0), value, false)
+    }
+    #[inline]
+    pub fn init_internal(self, ) -> crate::schema_capnp::option::Builder<'a,crate::schema_capnp::src_span::Owned> {
+      self.builder.set_data_field::<u16>(0, 2);
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+    }
+    #[inline]
+    pub fn has_internal(&self) -> bool {
+      if self.builder.get_data_field::<u16>(0) != 2 { return false; }
+      !self.builder.get_pointer_field(0).is_null()
+    }
+    #[inline]
+    pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+      match self.builder.get_data_field::<u16>(0) {
+        0 => {
+          ::core::result::Result::Ok(Public(
+            ()
+          ))
+        }
+        1 => {
+          ::core::result::Result::Ok(Private(
+            ()
+          ))
+        }
+        2 => {
+          ::core::result::Result::Ok(Internal(
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+          ))
+        }
+        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+      }
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      Pipeline { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+  }
+  mod _private {
+    use capnp::private::layout;
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 1 };
+    pub const TYPE_ID: u64 = 0xc549_d3c8_21e9_1c66;
+  }
+  pub enum Which<A0> {
+    Public(()),
+    Private(()),
+    Internal(A0),
+  }
+  pub type WhichReader<'a,> = Which<::capnp::Result<crate::schema_capnp::option::Reader<'a,crate::schema_capnp::src_span::Owned>>>;
+  pub type WhichBuilder<'a,> = Which<::capnp::Result<crate::schema_capnp::option::Builder<'a,crate::schema_capnp::src_span::Owned>>>;
 }
 
 pub mod implementations {

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -489,6 +489,14 @@ pub mod module {
     pub fn get_is_internal(self) -> bool {
       self.reader.get_bool_field(0)
     }
+    #[inline]
+    pub fn get_required_version(self) -> ::capnp::Result<crate::schema_capnp::version::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(8), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_required_version(&self) -> bool {
+      !self.reader.get_pointer_field(8).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -675,6 +683,22 @@ pub mod module {
     pub fn set_is_internal(&mut self, value: bool)  {
       self.builder.set_bool_field(0, value);
     }
+    #[inline]
+    pub fn get_required_version(self) -> ::capnp::Result<crate::schema_capnp::version::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(8), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_required_version(&mut self, value: crate::schema_capnp::version::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(8), value, false)
+    }
+    #[inline]
+    pub fn init_required_version(self, ) -> crate::schema_capnp::version::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(8), 0)
+    }
+    #[inline]
+    pub fn has_required_version(&self) -> bool {
+      !self.builder.get_pointer_field(8).is_null()
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -687,11 +711,163 @@ pub mod module {
     pub fn get_line_numbers(&self) -> crate::schema_capnp::line_numbers::Pipeline {
       ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(6))
     }
+    pub fn get_required_version(&self) -> crate::schema_capnp::version::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(8))
+    }
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 8 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 9 };
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
+  }
+}
+
+pub mod version {
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  #[derive(Clone, Copy)]
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+
+  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
+    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
+      Reader { reader,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Reader { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn get_major(self) -> u32 {
+      self.reader.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn get_minor(self) -> u32 {
+      self.reader.get_data_field::<u32>(1)
+    }
+    #[inline]
+    pub fn get_patch(self) -> u32 {
+      self.reader.get_data_field::<u32>(2)
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
+    #[inline]
+    fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
+  }
+  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
+    #[inline]
+    fn type_id() -> u64 { _private::TYPE_ID }
+  }
+  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
+    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
+      Builder { builder,  }
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
+      ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
+      ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
+    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { .. *self }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.into_reader().total_size()
+    }
+    #[inline]
+    pub fn get_major(self) -> u32 {
+      self.builder.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn set_major(&mut self, value: u32)  {
+      self.builder.set_data_field::<u32>(0, value);
+    }
+    #[inline]
+    pub fn get_minor(self) -> u32 {
+      self.builder.get_data_field::<u32>(1)
+    }
+    #[inline]
+    pub fn set_minor(&mut self, value: u32)  {
+      self.builder.set_data_field::<u32>(1, value);
+    }
+    #[inline]
+    pub fn get_patch(self) -> u32 {
+      self.builder.get_data_field::<u32>(2)
+    }
+    #[inline]
+    pub fn set_patch(&mut self, value: u32)  {
+      self.builder.set_data_field::<u32>(2, value);
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+      Pipeline { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+  }
+  mod _private {
+    use capnp::private::layout;
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 2, pointers: 0 };
+    pub const TYPE_ID: u64 = 0xfc86_6c3f_4528_fa9c;
   }
 }
 

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -29,6 +29,13 @@ struct Module {
   lineNumbers @6 :LineNumbers;
   srcPath @7 :Text;
   isInternal @8 :Bool;
+  requiredVersion @9 :Version;
+}
+
+struct Version {
+  major @0 :UInt32;
+  minor @1 :UInt32;
+  patch @2 :UInt32;
 }
 
 struct TypesVariantConstructors {

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -107,10 +107,12 @@ struct ValueConstructor {
   deprecated @3 :Text;
 }
 
-enum Publicity {
-  public @0;
-  private @1;
-  internal @2;
+struct Publicity {
+    union {
+        public @0 :Void;
+        private @1 :Void;
+        internal @2 :Option(SrcSpan);
+    }
 }
 
 struct Implementations {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -179,7 +179,6 @@ struct ModuleAnalyzer<'a, A> {
     warnings: &'a TypeWarningEmitter,
     direct_dependencies: &'a HashMap<EcoString, A>,
     target_support: TargetSupport,
-    minimum_required_version: Version,
     package_config: &'a PackageConfig,
     line_numbers: LineNumbers,
     src_path: Utf8PathBuf,
@@ -187,6 +186,9 @@ struct ModuleAnalyzer<'a, A> {
     value_names: HashMap<EcoString, SrcSpan>,
     hydrators: HashMap<EcoString, Hydrator>,
     module_name: EcoString,
+
+    /// The minimum Gleam version required to compile the analysed module.
+    minimum_required_version: Version,
 }
 
 impl<'a, A> ModuleAnalyzer<'a, A> {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -329,6 +329,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 line_numbers: self.line_numbers,
                 src_path: self.src_path,
                 warnings,
+                required_version: self.required_version,
             },
         };
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -571,7 +571,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
         if let Some((module, _, location)) = &external_javascript {
             if module.contains('@') {
-                self.track_feature_usage(FeatureKind::AtInJavascriptModules, location.clone())
+                self.track_feature_usage(FeatureKind::AtInJavascriptModules, *location)
             }
         }
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -782,6 +782,10 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             ..
         } = t;
 
+        if publicity.is_internal() {
+            self.require_version(Version::new(1, 1, 0));
+        }
+
         let constructors = constructors
             .into_iter()
             .map(

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -165,7 +165,7 @@ impl<'a, A> ModuleAnalyzerConstructor<'a, A> {
             value_names: HashMap::with_capacity(module.definitions.len()),
             hydrators: HashMap::with_capacity(module.definitions.len()),
             module_name: module.name.clone(),
-            required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(1, 0, 0),
         }
         .infer_module(module)
     }
@@ -179,7 +179,7 @@ struct ModuleAnalyzer<'a, A> {
     warnings: &'a TypeWarningEmitter,
     direct_dependencies: &'a HashMap<EcoString, A>,
     target_support: TargetSupport,
-    required_version: Version,
+    minimum_required_version: Version,
     package_config: &'a PackageConfig,
     line_numbers: LineNumbers,
     src_path: Utf8PathBuf,
@@ -330,7 +330,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 line_numbers: self.line_numbers,
                 src_path: self.src_path,
                 warnings,
-                required_version: self.required_version,
+                minimum_required_version: self.minimum_required_version,
             },
         };
 
@@ -373,8 +373,8 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         let implementations = expr_typer.implementations;
 
         let minimum_required_version = expr_typer.minimum_required_version;
-        if minimum_required_version > self.required_version {
-            self.required_version = minimum_required_version;
+        if minimum_required_version > self.minimum_required_version {
+            self.minimum_required_version = minimum_required_version;
         }
 
         match publicity {
@@ -553,8 +553,8 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             }
         };
 
-        if required_version > self.required_version {
-            self.required_version = required_version;
+        if required_version > self.minimum_required_version {
+            self.minimum_required_version = required_version;
         }
 
         match publicity {
@@ -1360,8 +1360,8 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             }
         }
 
-        if minimum_required_version > self.required_version {
-            self.required_version = minimum_required_version;
+        if minimum_required_version > self.minimum_required_version {
+            self.minimum_required_version = minimum_required_version;
         }
     }
 }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -578,20 +578,20 @@ fn type_ast_print_tuple() {
 pub enum Publicity {
     Public,
     Private,
-    Internal,
+    Internal { attribute_location: Option<SrcSpan> },
 }
 
 impl Publicity {
     pub fn is_private(&self) -> bool {
         match self {
             Self::Private => true,
-            Self::Public | Self::Internal => false,
+            Self::Public | Self::Internal { .. } => false,
         }
     }
 
     pub fn is_internal(&self) -> bool {
         match self {
-            Self::Internal => true,
+            Self::Internal { .. } => true,
             Self::Public | Self::Private => false,
         }
     }
@@ -599,13 +599,13 @@ impl Publicity {
     pub fn is_public(&self) -> bool {
         match self {
             Self::Public => true,
-            Self::Internal | Self::Private => false,
+            Self::Internal { .. } | Self::Private => false,
         }
     }
 
     pub fn is_importable(&self) -> bool {
         match self {
-            Self::Internal | Self::Public => true,
+            Self::Internal { .. } | Self::Public => true,
             Self::Private => false,
         }
     }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -638,8 +638,8 @@ pub struct Function<T, Expr> {
     pub return_annotation: Option<TypeAst>,
     pub return_type: T,
     pub documentation: Option<(u32, EcoString)>,
-    pub external_erlang: Option<(EcoString, EcoString)>,
-    pub external_javascript: Option<(EcoString, EcoString)>,
+    pub external_erlang: Option<(EcoString, EcoString, SrcSpan)>,
+    pub external_javascript: Option<(EcoString, EcoString, SrcSpan)>,
     pub implementations: Implementations,
 }
 

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -77,6 +77,7 @@ fn compile_expression(src: &str) -> TypedStatement {
     let mut environment = Environment::new(
         ids,
         "mypackage".into(),
+        None,
         "mymod".into(),
         Target::Erlang,
         &modules,

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -60,7 +60,7 @@ fn write_cache(
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),
         warnings: vec![],
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     let path = Utf8Path::new("/artefact").join(format!("{name}.cache"));
     fs.write_bytes(

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -1,4 +1,5 @@
 use ecow::{eco_format, EcoString};
+use hexpm::version::Version;
 
 use super::*;
 use crate::{
@@ -59,6 +60,7 @@ fn write_cache(
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),
         warnings: vec![],
+        required_version: Version::new(1, 0, 0),
     };
     let path = Utf8Path::new("/artefact").join(format!("{name}.cache"));
     fs.write_bytes(

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -86,7 +86,7 @@ impl Built {
     pub fn minimum_required_version(&self) -> Version {
         self.module_interfaces
             .values()
-            .map(|interface| &interface.required_version)
+            .map(|interface| &interface.minimum_required_version)
             .reduce(|one_version, other_version| cmp::max(one_version, other_version))
             .map(|minimum_required_version| minimum_required_version.clone())
             .unwrap_or(Version::new(1, 0, 0))

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -19,8 +19,11 @@ use crate::{
     Error, Result, Warning,
 };
 use ecow::EcoString;
+use hexpm::version::Version;
 use itertools::Itertools;
+use pubgrub::range::Range;
 use std::{
+    cmp,
     collections::{HashMap, HashSet},
     fmt::Write,
     io::BufReader,
@@ -78,6 +81,15 @@ impl Built {
                 suggestion: None,
             }),
         }
+    }
+
+    pub fn minimum_required_version(&self) -> Version {
+        self.module_interfaces
+            .values()
+            .map(|interface| &interface.required_version)
+            .reduce(|one_version, other_version| cmp::max(one_version, other_version))
+            .map(|minimum_required_version| minimum_required_version.clone())
+            .unwrap_or(Version::new(1, 0, 0))
     }
 }
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -409,7 +409,7 @@ fn module_function<'a>(
     let body = function
         .external_erlang
         .as_ref()
-        .map(|(module, function)| {
+        .map(|(module, function, _location)| {
             docvec![
                 atom(module),
                 ":",

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -289,6 +289,12 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
 
     #[error("Version already published")]
     HexPublishReplaceRequired { version: String },
+
+    #[error("Auga")]
+    CannotPublishWrongVersion {
+        minimum_required_version: hexpm::version::Version,
+        wrongfully_allowed_version: hexpm::version::Version,
+    },
 }
 
 impl Error {
@@ -896,6 +902,24 @@ Please remove them and try again.
                 ),
                 level: Level::Error,
                 hint: None,
+                location: None,
+            }],
+
+            Error::CannotPublishWrongVersion { minimum_required_version, wrongfully_allowed_version } => vec![Diagnostic {
+                title: "Cannot publish package with wrong Gleam version range".into(),
+                text: wrap(&format!(
+                    "Your package uses features that require at least v{minimum_required_version}.
+But the Gleam version range specified in your `gleam.toml` would allow this \
+code to run on an earlier version like v{wrongfully_allowed_version}, \
+resulting in compilation errors!"
+                )),
+                level: Level::Error,
+                hint: Some(format!(
+                    "Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = \">= {}\"",
+                    minimum_required_version
+                )),
                 location: None,
             }],
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -20,7 +20,7 @@ use pubgrub::report::DerivationTree;
 use pubgrub::version::Version;
 use std::collections::HashSet;
 use std::env;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::io::Write;
 use std::path::PathBuf;
 use termcolor::Buffer;
@@ -290,11 +290,39 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
     #[error("Version already published")]
     HexPublishReplaceRequired { version: String },
 
-    #[error("Auga")]
+    #[error("The gleam version constraint is wrong and so cannot be published")]
     CannotPublishWrongVersion {
-        minimum_required_version: hexpm::version::Version,
-        wrongfully_allowed_version: hexpm::version::Version,
+        minimum_required_version: SmallVersion,
+        wrongfully_allowed_version: SmallVersion,
     },
+}
+
+/// This is to make clippy happy and not make the error variant too big by
+/// storing an entire `hexpm::version::Version` in the error.
+///
+/// This is enough to report wrong Gleam compiler versions.
+///
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct SmallVersion {
+    major: u8,
+    minor: u8,
+    patch: u8,
+}
+
+impl Display for SmallVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("{}.{}.{}", self.major, self.minor, self.patch))
+    }
+}
+
+impl SmallVersion {
+    pub fn from_hexpm(version: hexpm::version::Version) -> Self {
+        Self {
+            major: version.major as u8,
+            minor: version.minor as u8,
+            patch: version.patch as u8,
+        }
+    }
 }
 
 impl Error {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2648,7 +2648,7 @@ impl<'a> Documentable<'a> for &'a ArgNames {
 
 fn pub_(publicity: Publicity) -> Document<'static> {
     match publicity {
-        Publicity::Public | Publicity::Internal => "pub ".to_doc(),
+        Publicity::Public | Publicity::Internal { .. } => "pub ".to_doc(),
         Publicity::Private => nil(),
     }
 }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2962,8 +2962,8 @@ fn constant_call_arg_formatting<A, B>(
 }
 
 struct AttributesPrinter<'a> {
-    external_erlang: &'a Option<(EcoString, EcoString)>,
-    external_javascript: &'a Option<(EcoString, EcoString)>,
+    external_erlang: &'a Option<(EcoString, EcoString, SrcSpan)>,
+    external_javascript: &'a Option<(EcoString, EcoString, SrcSpan)>,
     deprecation: &'a Deprecation,
     internal: bool,
 }
@@ -2978,12 +2978,18 @@ impl<'a> AttributesPrinter<'a> {
         }
     }
 
-    pub fn set_external_erlang(mut self, external: &'a Option<(EcoString, EcoString)>) -> Self {
+    pub fn set_external_erlang(
+        mut self,
+        external: &'a Option<(EcoString, EcoString, SrcSpan)>,
+    ) -> Self {
         self.external_erlang = external;
         self
     }
 
-    pub fn set_external_javascript(mut self, external: &'a Option<(EcoString, EcoString)>) -> Self {
+    pub fn set_external_javascript(
+        mut self,
+        external: &'a Option<(EcoString, EcoString, SrcSpan)>,
+    ) -> Self {
         self.external_javascript = external;
         self
     }
@@ -3009,11 +3015,11 @@ impl<'a> Documentable<'a> for AttributesPrinter<'a> {
         };
 
         // @external attributes
-        if let Some((m, f)) = self.external_erlang {
+        if let Some((m, f, _)) = self.external_erlang {
             attributes.push(docvec!["@external(erlang, \"", m, "\", \"", f, "\")"])
         };
 
-        if let Some((m, f)) = self.external_javascript {
+        if let Some((m, f, _)) = self.external_javascript {
             attributes.push(docvec!["@external(javascript, \"", m, "\", \"", f, "\")"])
         };
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -353,7 +353,7 @@ impl<'a> Generator<'a> {
                 Definition::Function(Function {
                     name: Some((_, name)),
                     publicity,
-                    external_javascript: Some((module, function)),
+                    external_javascript: Some((module, function, _location)),
                     ..
                 }) => {
                     self.register_external_function(

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -765,8 +765,8 @@ where
             Publicity::Private => false,
             // We only skip internal types if those are not defined in
             // the root package.
-            Publicity::Internal if package != self.root_package_name() => false,
-            Publicity::Internal => true,
+            Publicity::Internal { .. } if package != self.root_package_name() => false,
+            Publicity::Internal { .. } => true,
             // We never skip public types.
             Publicity::Public => true,
         }

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -81,7 +81,7 @@ impl ModuleDecoder {
             line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
             src_path: reader.get_src_path()?.into(),
             warnings: vec![],
-            required_version: self.version(&reader.get_required_version()?),
+            minimum_required_version: self.version(&reader.get_required_version()?),
         })
     }
 

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -81,6 +81,7 @@ impl ModuleDecoder {
             line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
             src_path: reader.get_src_path()?.into(),
             warnings: vec![],
+            required_version: self.version(&reader.get_required_version()?),
         })
     }
 
@@ -553,5 +554,9 @@ impl ModuleDecoder {
             length: reader.get_length(),
             line_starts: read_vec!(reader.get_line_starts()?, self, line_starts),
         })
+    }
+
+    fn version(&self, reader: &version::Reader<'_>) -> hexpm::version::Version {
+        hexpm::version::Version::new(reader.get_major(), reader.get_minor(), reader.get_patch())
     }
 }

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -153,9 +153,9 @@ impl<'a> ModuleEncoder<'a> {
 
     fn set_version(&mut self, module: &mut module::Builder<'_>) {
         let mut version = module.reborrow().init_required_version();
-        version.set_major(self.data.required_version.major);
-        version.set_minor(self.data.required_version.minor);
-        version.set_patch(self.data.required_version.patch);
+        version.set_major(self.data.minimum_required_version.major);
+        version.set_minor(self.data.minimum_required_version.minor);
+        version.set_patch(self.data.minimum_required_version.patch);
     }
 
     fn build_type_constructor(

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -47,6 +47,7 @@ impl<'a> ModuleEncoder<'a> {
         self.set_module_accessors(&mut module);
         self.set_module_types_constructors(&mut module);
         self.set_line_numbers(&mut module);
+        self.set_version(&mut module);
 
         capnp::serialize_packed::write_message(&mut buffer, &message).expect("capnp encode");
         Ok(buffer)
@@ -148,6 +149,13 @@ impl<'a> ModuleEncoder<'a> {
             property.set_key(name);
             self.build_value_constructor(property.init_value(), value)
         }
+    }
+
+    fn set_version(&mut self, module: &mut module::Builder<'_>) {
+        let mut version = module.reborrow().init_required_version();
+        version.set_major(self.data.required_version.major);
+        version.set_minor(self.data.required_version.minor);
+        version.set_patch(self.data.required_version.patch);
     }
 
     fn build_type_constructor(

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -302,7 +302,7 @@ fn module_with_type_links() {
             types: [(
                 "SomeType".into(),
                 TypeConstructor {
-                    type_: type_,
+                    type_,
                     publicity: Publicity::Public,
                     origin: Default::default(),
                     module: "a".into(),
@@ -339,7 +339,7 @@ fn module_with_type_constructor_documentation() {
             types: [(
                 "SomeType".into(),
                 TypeConstructor {
-                    type_: type_,
+                    type_,
                     publicity: Publicity::Public,
                     origin: Default::default(),
                     module: "a".into(),
@@ -376,7 +376,7 @@ fn module_with_type_constructor_origin() {
             types: [(
                 "SomeType".into(),
                 TypeConstructor {
-                    type_: type_,
+                    type_,
                     publicity: Publicity::Public,
                     origin: SrcSpan {
                         start: 535,
@@ -1278,7 +1278,60 @@ fn internal_module_fn() {
         values: [(
             "one".into(),
             ValueConstructor {
-                publicity: Publicity::Internal,
+                publicity: Publicity::Internal {
+                    attribute_location: None,
+                },
+                deprecation: Deprecation::NotDeprecated,
+                type_: type_::int(),
+                variant: ValueConstructorVariant::ModuleFn {
+                    documentation: Some("wabble!".into()),
+                    name: "one".into(),
+                    field_map: None,
+                    module: "a".into(),
+                    arity: 5,
+                    location: SrcSpan {
+                        start: 52,
+                        end: 1100,
+                    },
+                    implementations: Implementations {
+                        gleam: false,
+                        uses_erlang_externals: true,
+                        uses_javascript_externals: true,
+                        can_run_on_erlang: true,
+                        can_run_on_javascript: true,
+                    },
+                },
+            },
+        )]
+        .into(),
+        line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
+    };
+
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
+fn internal_annotated_module_fn() {
+    let module = ModuleInterface {
+        warnings: vec![],
+        is_internal: false,
+        package: "some_package".into(),
+        origin: Origin::Src,
+        name: "a/b/c".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        accessors: HashMap::new(),
+        values: [(
+            "one".into(),
+            ValueConstructor {
+                publicity: Publicity::Internal {
+                    attribute_location: Some(SrcSpan {
+                        start: 11,
+                        end: 111,
+                    }),
+                },
                 deprecation: Deprecation::NotDeprecated,
                 type_: type_::int(),
                 variant: ValueConstructorVariant::ModuleFn {

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -1,3 +1,4 @@
+use hexpm::version::Version;
 use rand::Rng;
 use type_::{AccessorsMap, FieldMap, RecordAccessor};
 
@@ -62,6 +63,7 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     }
 }
 
@@ -94,6 +96,7 @@ fn empty_module() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -116,6 +119,7 @@ fn with_line_numbers() {
         const c = 3",
         ),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -146,6 +150,7 @@ fn module_with_private_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -176,6 +181,7 @@ fn module_with_app_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -206,6 +212,7 @@ fn module_with_fn_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -236,6 +243,7 @@ fn module_with_tuple_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -272,6 +280,7 @@ fn module_with_generic_type() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
+            required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -308,6 +317,7 @@ fn module_with_type_links() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
+            required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -344,6 +354,7 @@ fn module_with_type_constructor_documentation() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
+            required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -383,6 +394,7 @@ fn module_with_type_constructor_origin() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
+            required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -413,6 +425,7 @@ fn module_type_to_constructors_mapping() {
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -458,6 +471,7 @@ fn module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -504,6 +518,7 @@ fn deprecated_module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -548,6 +563,7 @@ fn private_module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -594,6 +610,7 @@ fn module_fn_value_regression() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -639,6 +656,7 @@ fn module_fn_value_with_field_map() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -681,6 +699,7 @@ fn record_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -726,6 +745,7 @@ fn record_value_with_field_map() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -789,6 +809,7 @@ fn accessors() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1002,6 +1023,7 @@ fn constant_var() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1191,6 +1213,7 @@ fn deprecated_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1235,6 +1258,7 @@ fn module_fn_value_with_external_implementations() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1280,6 +1304,7 @@ fn internal_module_fn() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1319,6 +1344,7 @@ fn type_variable_ids_in_constructors_are_shared() {
         values: [].into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
+        required_version: Version::new(1, 0, 0),
     };
 
     let expected = HashMap::from([(

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -63,7 +63,7 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     }
 }
 
@@ -96,7 +96,7 @@ fn empty_module() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -119,7 +119,7 @@ fn with_line_numbers() {
         const c = 3",
         ),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -150,7 +150,7 @@ fn module_with_private_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -181,7 +181,7 @@ fn module_with_app_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -212,7 +212,7 @@ fn module_with_fn_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -243,7 +243,7 @@ fn module_with_tuple_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -280,7 +280,7 @@ fn module_with_generic_type() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -317,7 +317,7 @@ fn module_with_type_links() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -354,7 +354,7 @@ fn module_with_type_constructor_documentation() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -394,7 +394,7 @@ fn module_with_type_constructor_origin() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(1, 0, 0),
         }
     }
 
@@ -425,7 +425,7 @@ fn module_type_to_constructors_mapping() {
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -471,7 +471,7 @@ fn module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -518,7 +518,7 @@ fn deprecated_module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -563,7 +563,7 @@ fn private_module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -610,7 +610,7 @@ fn module_fn_value_regression() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -656,7 +656,7 @@ fn module_fn_value_with_field_map() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -699,7 +699,7 @@ fn record_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -745,7 +745,7 @@ fn record_value_with_field_map() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -809,7 +809,7 @@ fn accessors() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1023,7 +1023,7 @@ fn constant_var() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1213,7 +1213,7 @@ fn deprecated_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1258,7 +1258,7 @@ fn module_fn_value_with_external_implementations() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1306,7 +1306,7 @@ fn internal_module_fn() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1357,7 +1357,7 @@ fn internal_annotated_module_fn() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1397,7 +1397,7 @@ fn type_variable_ids_in_constructors_are_shared() {
         values: [].into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     let expected = HashMap::from([(

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -362,7 +362,11 @@ impl PackageInterface {
         PackageInterface {
             name: package.config.name.clone(),
             version: package.config.version.to_string().into(),
-            gleam_version_constraint: package.config.gleam_version.clone(),
+            gleam_version_constraint: package
+                .config
+                .gleam_version
+                .clone()
+                .map(|version| EcoString::from(version.to_string())),
             modules: package
                 .modules
                 .iter()

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -152,7 +152,11 @@ fn package_from_module(module: Module) -> Package {
                 ],
                 build: Some("build".into()),
             },
-            gleam_version: Some("1.0.0".into()),
+            gleam_version: Some(
+                hexpm::version::Range::new("1.0.0".into())
+                    .to_pubgrub()
+                    .unwrap(),
+            ),
             licences: vec![],
             description: "description".into(),
             documentation: Docs { pages: vec![] },

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1875,7 +1875,9 @@ where
         match (internal, public) {
             (InternalAttribute::Missing, true) => Ok(Publicity::Public),
             (InternalAttribute::Missing, false) => Ok(Publicity::Private),
-            (InternalAttribute::Present(_), true) => Ok(Publicity::Internal),
+            (InternalAttribute::Present(location), true) => Ok(Publicity::Internal {
+                attribute_location: Some(location.clone()),
+            }),
             (InternalAttribute::Present(location), false) => Err(ParseError {
                 error: ParseErrorType::RedundantInternalAttribute,
                 location,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -117,8 +117,8 @@ enum InternalAttribute {
 struct Attributes {
     target: Option<Target>,
     deprecated: Deprecation,
-    external_erlang: Option<(EcoString, EcoString)>,
-    external_javascript: Option<(EcoString, EcoString)>,
+    external_erlang: Option<(EcoString, EcoString, SrcSpan)>,
+    external_javascript: Option<(EcoString, EcoString, SrcSpan)>,
     internal: InternalAttribute,
 }
 
@@ -134,7 +134,7 @@ impl Attributes {
         }
     }
 
-    fn set_external_for(&mut self, target: Target, ext: Option<(EcoString, EcoString)>) {
+    fn set_external_for(&mut self, target: Target, ext: Option<(EcoString, EcoString, SrcSpan)>) {
         match target {
             Target::Erlang => self.external_erlang = ext,
             Target::JavaScript => self.external_javascript = ext,
@@ -3549,7 +3549,7 @@ functions are declared separately from types.";
             return parse_error(ParseErrorType::DuplicateAttribute, SrcSpan { start, end });
         }
 
-        attributes.set_external_for(target, Some((module, function)));
+        attributes.set_external_for(target, Some((module, function, SrcSpan { start, end })));
         Ok(end)
     }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1876,7 +1876,7 @@ where
             (InternalAttribute::Missing, true) => Ok(Publicity::Public),
             (InternalAttribute::Missing, false) => Ok(Publicity::Private),
             (InternalAttribute::Present(location), true) => Ok(Publicity::Internal {
-                attribute_location: Some(location.clone()),
+                attribute_location: Some(location),
             }),
             (InternalAttribute::Present(location), false) => Err(ParseError {
                 error: ParseErrorType::RedundantInternalAttribute,

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -17,6 +17,7 @@ pub use environment::*;
 pub use error::{Error, Problems, UnifyErrorSituation, Warning};
 pub(crate) use expression::ExprTyper;
 pub use fields::FieldMap;
+use hexpm::version::Version;
 pub use prelude::*;
 use serde::Serialize;
 
@@ -610,6 +611,8 @@ pub struct ModuleInterface {
     pub is_internal: bool,
     /// Warnings emitted during analysis of this module.
     pub warnings: Vec<Warning>,
+    /// The minimum Gleam version needed to use this module.
+    pub required_version: Version,
 }
 
 impl ModuleInterface {
@@ -681,28 +684,6 @@ pub struct TypeValueConstructorField {
 }
 
 impl ModuleInterface {
-    pub fn new(
-        name: EcoString,
-        origin: Origin,
-        package: EcoString,
-        line_numbers: LineNumbers,
-        src_path: Utf8PathBuf,
-    ) -> Self {
-        Self {
-            name,
-            origin,
-            package,
-            types: Default::default(),
-            types_value_constructors: Default::default(),
-            values: Default::default(),
-            accessors: Default::default(),
-            is_internal: false,
-            line_numbers,
-            src_path,
-            warnings: vec![],
-        }
-    }
-
     pub fn get_public_value(&self, name: &str) -> Option<&ValueConstructor> {
         let value = self.values.get(name)?;
         if value.publicity.is_importable() {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -612,7 +612,7 @@ pub struct ModuleInterface {
     /// Warnings emitted during analysis of this module.
     pub warnings: Vec<Warning>,
     /// The minimum Gleam version needed to use this module.
-    pub required_version: Version,
+    pub minimum_required_version: Version,
 }
 
 impl ModuleInterface {

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -1,3 +1,5 @@
+use pubgrub::range::Range;
+
 use crate::{
     analyse::TargetSupport,
     ast::{Publicity, PIPE_VARIABLE},
@@ -13,6 +15,11 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct Environment<'a> {
     pub current_package: EcoString,
+
+    /// The gleam version range required by the current package as stated in its
+    /// gleam.toml
+    pub gleam_version: Option<Range<Version>>,
+
     pub current_module: EcoString,
     pub target: Target,
     pub ids: UniqueIdGenerator,
@@ -64,6 +71,7 @@ impl<'a> Environment<'a> {
     pub fn new(
         ids: UniqueIdGenerator,
         current_package: EcoString,
+        gleam_version: Option<Range<Version>>,
         current_module: EcoString,
         target: Target,
         importable_modules: &'a im::HashMap<EcoString, ModuleInterface>,
@@ -84,6 +92,7 @@ impl<'a> Environment<'a> {
 
         Self {
             current_package: current_package.clone(),
+            gleam_version,
             previous_id: ids.next(),
             ids,
             target,

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -816,6 +816,20 @@ pub enum FeatureKind {
     AtInJavascriptModules,
 }
 
+impl FeatureKind {
+    pub fn required_version(&self) -> Version {
+        match self {
+            FeatureKind::InternalAnnotation => Version::new(1, 1, 0),
+            FeatureKind::NestedTupleAccess => Version::new(1, 1, 0),
+            FeatureKind::AtInJavascriptModules => Version::new(1, 2, 0),
+            FeatureKind::ArithmeticInGuards => Version::new(1, 3, 0),
+            FeatureKind::LabelShorthandSyntax => Version::new(1, 4, 0),
+            FeatureKind::ConstantStringConcatenation => Version::new(1, 4, 0),
+            FeatureKind::UnannotatedUtf8StringSegment => Version::new(1, 5, 0),
+        }
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum PanicPosition {
     /// When the unreachable part is a function argument, this means that one

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1023,7 +1023,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         index: u64,
         location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
-        if let UntypedExpr::TupleIndex { location, .. } = tuple {
+        if let UntypedExpr::TupleIndex { .. } = tuple {
             self.track_feature_usage(FeatureKind::NestedTupleAccess, location);
         }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -195,6 +195,9 @@ pub enum ArgumentKind {
 pub(crate) struct ExprTyper<'a, 'b> {
     pub(crate) environment: &'a mut Environment<'b>,
 
+    /// The minimum Gleam version required to compile the typed expression.
+    pub minimum_required_version: Version,
+
     // This is set to true if the previous expression that has been typed is
     // determined to always panic.
     // For example when typing a literal `panic`, this flag will be set to true.
@@ -209,9 +212,6 @@ pub(crate) struct ExprTyper<'a, 'b> {
 
     pub(crate) implementations: Implementations,
     pub(crate) current_function_definition: FunctionDefinition,
-
-    // The minimum Gleam version required to compile the typed expression.
-    pub(crate) required_version: Version,
 
     // Type hydrator for creating types from annotations
     pub(crate) hydrator: Hydrator,
@@ -247,7 +247,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             environment,
             implementations,
             current_function_definition: definition,
-            required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(1, 0, 0),
             problems,
         }
     }
@@ -1023,13 +1023,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         index: u64,
         location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
-        // Nested tuple access was introduced in 1.1
         if let UntypedExpr::TupleIndex { location, .. } = tuple {
-            self.require_version(
-                Version::new(1, 1, 0),
-                FeatureKind::NestedTupleAccess,
-                location,
-            );
+            self.track_feature_usage(FeatureKind::NestedTupleAccess, location);
         }
 
         let tuple = self.infer(tuple)?;
@@ -1074,13 +1069,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             .into_iter()
             .map(|s| {
                 let options = match s.value.as_ref() {
-                    // Allowing literal string segments to omit the `:utf8` option
-                    // was introduced in v1.5
                     UntypedExpr::String { location, .. } if s.options.is_empty() => {
-                        self.require_version(
-                            Version::new(1, 5, 0),
+                        self.track_feature_usage(
                             FeatureKind::UnannotatedUtf8StringSegment,
-                            location.clone(),
+                            *location,
                         );
                         vec![BitArrayOption::Utf8 {
                             location: SrcSpan::default(),
@@ -1109,12 +1101,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             .map(|s| {
                 let options = match s.value.as_ref() {
                     Constant::String { location, .. } if s.options.is_empty() => {
-                        // Allowing literal string segments to omit the `:utf8` option
-                        // was introduced in v1.5
-                        self.require_version(
-                            Version::new(1, 5, 0),
+                        self.track_feature_usage(
                             FeatureKind::UnannotatedUtf8StringSegment,
-                            location.clone(),
+                            *location,
                         );
                         vec![BitArrayOption::Utf8 {
                             location: SrcSpan::default(),
@@ -1318,9 +1307,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             pattern::PatternTyper::new(self.environment, &self.hydrator, self.problems);
         let unify_result = pattern_typer.unify(pattern, value_typ.clone());
 
-        let version = pattern_typer.required_version;
-        if version > self.required_version {
-            self.required_version = version;
+        let minimum_required_version = pattern_typer.minimum_required_version;
+        if minimum_required_version > self.minimum_required_version {
+            self.minimum_required_version = minimum_required_version;
         }
 
         let pattern = match unify_result {
@@ -1543,9 +1532,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .push(pattern_typer.infer_alternative_multi_pattern(m, subjects, location)?);
         }
 
-        let version = pattern_typer.required_version;
-        if version > self.required_version {
-            self.required_version = version;
+        let minimum_required_version = pattern_typer.minimum_required_version;
+        if minimum_required_version > self.minimum_required_version {
+            self.minimum_required_version = minimum_required_version;
         }
 
         Ok((typed_pattern, typed_alternatives))
@@ -1888,12 +1877,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // + in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
                 let right = self.infer_clause_guard(*right)?;
@@ -1912,12 +1896,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // +. in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(float(), left.type_())
                     .map_err(|e| convert_unify_error(e, left.location()))?;
@@ -1937,12 +1916,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // - in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
                 let right = self.infer_clause_guard(*right)?;
@@ -1961,12 +1935,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // -. in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(float(), left.type_())
                     .map_err(|e| convert_unify_error(e, left.location()))?;
@@ -1986,12 +1955,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // * in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
                 let right = self.infer_clause_guard(*right)?;
@@ -2010,12 +1974,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // *. in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(float(), left.type_())
                     .map_err(|e| convert_unify_error(e, left.location()))?;
@@ -2035,12 +1994,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // / in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
                 let right = self.infer_clause_guard(*right)?;
@@ -2059,12 +2013,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // /. in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(float(), left.type_())
                     .map_err(|e| convert_unify_error(e, left.location()))?;
@@ -2084,12 +2033,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 right,
                 ..
             } => {
-                // % in a guard was introduced in v1.3
-                self.require_version(
-                    Version::new(1, 3, 0),
-                    FeatureKind::ArithmeticInGuards,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
                 let left = self.infer_clause_guard(*left)?;
                 unify(int(), left.type_()).map_err(|e| convert_unify_error(e, left.location()))?;
                 let right = self.infer_clause_guard(*right)?;
@@ -2753,10 +2697,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     .iter_mut()
                     .zip(args)
                     .map(|(type_, arg): (&mut Arc<Type>, _)| {
-                        // label shorthand syntax was introduced in v1.4
                         if arg.uses_label_shorthand() {
-                            self.require_version(
-                                Version::new(1, 4, 0),
+                            self.track_feature_usage(
                                 FeatureKind::LabelShorthandSyntax,
                                 arg.location,
                             );
@@ -2826,12 +2768,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 left,
                 right,
             } => {
-                // string concatenation in constants was introduced in v1.4
-                self.require_version(
-                    Version::new(1, 4, 0),
-                    FeatureKind::ConstantStringConcatenation,
-                    location,
-                );
+                self.track_feature_usage(FeatureKind::ConstantStringConcatenation, location);
                 let left = self.infer_const(&None, *left);
                 unify(string(), left.type_()).map_err(|e| {
                     e.operator_situation(BinOp::Concatenate)
@@ -3188,13 +3125,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             .zip(args)
             .enumerate()
             .map(|(i, (type_, arg))| {
-                // label shorthand syntax was introduced in v1.4
                 if arg.uses_label_shorthand() {
-                    self.require_version(
-                        Version::new(1, 4, 0),
-                        FeatureKind::LabelShorthandSyntax,
-                        arg.location,
-                    );
+                    self.track_feature_usage(FeatureKind::LabelShorthandSyntax, arg.location);
                 }
 
                 let CallArg {
@@ -3547,7 +3479,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Ok(())
     }
 
-    fn require_version(&mut self, version: Version, feature_kind: FeatureKind, location: SrcSpan) {
+    fn track_feature_usage(&mut self, feature_kind: FeatureKind, location: SrcSpan) {
+        let minimum_required_version = feature_kind.required_version();
+
         // Then if the required version is not in the specified version for the
         // range we emit a warning highlighting the usage of the feature.
         if let Some(gleam_version) = &self.environment.gleam_version {
@@ -3556,20 +3490,20 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 // the one required by this feature! This means that the
                 // specified range is wrong and would allow someone to run a
                 // compiler that is too old to know of this feature.
-                if version > lowest_allowed_version {
+                if minimum_required_version > lowest_allowed_version {
                     self.problems
                         .warning(Warning::FeatureRequiresHigherGleamVersion {
                             location,
                             feature_kind,
-                            minimum_required_version: version.clone(),
+                            minimum_required_version: minimum_required_version.clone(),
                             wrongfully_allowed_version: lowest_allowed_version,
                         })
                 }
             }
         }
 
-        if version > self.required_version {
-            self.required_version = version;
+        if minimum_required_version > self.minimum_required_version {
+            self.minimum_required_version = minimum_required_version;
         }
     }
 }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1073,6 +1073,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     // Allowing literal string segments to omit the `:utf8` option
                     // was introduced in v1.5
                     UntypedExpr::String { .. } if s.options.is_empty() => {
+                        self.require_version(Version::new(1, 5, 0));
                         vec![BitArrayOption::Utf8 {
                             location: SrcSpan::default(),
                         }]

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -20,7 +20,9 @@ pub struct PatternTyper<'a, 'b> {
     mode: PatternMode,
     initial_pattern_vars: HashSet<EcoString>,
     problems: &'a mut Problems,
-    pub(crate) minimum_required_version: Version,
+
+    /// The minimum Gleam version required to compile the typed pattern.
+    pub minimum_required_version: Version,
 }
 
 enum PatternMode {

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -216,7 +216,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         src_path: "".into(),
         // prelude doesn't have real line numbers
         line_numbers: LineNumbers::new(""),
-        required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(1, 0, 0),
     };
 
     for t in PreludeType::iter() {

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -1,3 +1,4 @@
+use hexpm::version::Version;
 use strum::{EnumIter, IntoEnumIterator};
 
 use crate::{
@@ -215,6 +216,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         src_path: "".into(),
         // prelude doesn't have real line numbers
         line_numbers: LineNumbers::new(""),
+        required_version: Version::new(1, 0, 0),
     };
 
     for t in PreludeType::iter() {

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -28,7 +28,6 @@ mod guards;
 mod imports;
 mod pipes;
 mod pretty;
-mod required_version;
 mod target_implementations;
 mod type_alias;
 mod use_;

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -264,6 +264,7 @@ fn compile_statement_sequence(
         &mut Environment::new(
             ids,
             "thepackage".into(),
+            None,
             "themodule".into(),
             Target::Erlang,
             &modules,

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -32,6 +32,7 @@ mod required_version;
 mod target_implementations;
 mod type_alias;
 mod use_;
+mod version_inference;
 mod warnings;
 
 #[macro_export]

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -28,6 +28,7 @@ mod guards;
 mod imports;
 mod pipes;
 mod pretty;
+mod required_version;
 mod target_implementations;
 mod type_alias;
 mod use_;

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -753,7 +753,7 @@ fn infer_module_type_retention_test() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "".into(),
-            required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(1, 0, 0),
         }
     );
 }

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -718,6 +718,7 @@ fn infer_module_type_retention_test() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "".into(),
+            required_version: Version::new(1, 0, 0),
         }
     );
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constant_string_concatenation_requires_v1_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constant_string_concatenation_requires_v1_4.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub const string = \"wibble\" <> \"wobble\""
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:1:20
+  │
+1 │ pub const string = "wibble" <> "wobble"
+  │                    ^^^^^^^^^^^^^^^^^^^^ This requires a Gleam version >= 1.4.0
+
+Constant strings concatenation was introduced in version v1.4.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.4.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_divide_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_divide_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n  _ if 1.0 /. 1.0 == 0.0 -> Nil\n  _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:8
+  │
+4 │   _ if 1.0 /. 1.0 == 0.0 -> Nil
+  │        ^^^^^^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_minus_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_minus_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n    _ if 1.0 -. 1.0 == 0.0 -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:10
+  │
+4 │     _ if 1.0 -. 1.0 == 0.0 -> Nil
+  │          ^^^^^^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_multiplication_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_multiplication_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n  _ if 1.0 *. 1.0 == 0.0 -> Nil\n  _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:8
+  │
+4 │   _ if 1.0 *. 1.0 == 0.0 -> Nil
+  │        ^^^^^^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_plus_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__float_plus_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n    _ if 1.0 +. 1.0 == 2.0 -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:10
+  │
+4 │     _ if 1.0 +. 1.0 == 2.0 -> Nil
+  │          ^^^^^^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_divide_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_divide_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n  _ if 1 / 1 == 0 -> Nil\n  _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:8
+  │
+4 │   _ if 1 / 1 == 0 -> Nil
+  │        ^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_minus_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_minus_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n    _ if 1 - 1 == 0 -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:10
+  │
+4 │     _ if 1 - 1 == 0 -> Nil
+  │          ^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_multiplication_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_multiplication_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n  _ if 1 * 1 == 0 -> Nil\n  _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:8
+  │
+4 │   _ if 1 * 1 == 0 -> Nil
+  │        ^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_plus_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_plus_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n    _ if 1 + 1 == 2 -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:10
+  │
+4 │     _ if 1 + 1 == 2 -> Nil
+  │          ^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_remainder_in_guards_requires_v1_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__int_remainder_in_guards_requires_v1_3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case Nil {\n  _ if 1 % 1 == 0 -> Nil\n  _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:8
+  │
+4 │   _ if 1 % 1 == 0 -> Nil
+  │        ^^^^^ This requires a Gleam version >= 1.3.0
+
+Arithmetic operations in guards were introduced in version v1.3.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.3.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_annotation_on_constant_requires_v1_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_annotation_on_constant_requires_v1_1.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub const wibble = 1\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:2:1
+  │
+2 │ @internal
+  │ ^^^^^^^^^ This requires a Gleam version >= 1.1.0
+
+The `@internal` annotation was introduced in version v1.1.0. But the Gleam
+version range specified in your `gleam.toml` would allow this code to run
+on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.1.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_annotation_on_function_requires_v1_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_annotation_on_function_requires_v1_1.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub fn wibble() { Nil }\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:2:1
+  │
+2 │ @internal
+  │ ^^^^^^^^^ This requires a Gleam version >= 1.1.0
+
+The `@internal` annotation was introduced in version v1.1.0. But the Gleam
+version range specified in your `gleam.toml` would allow this code to run
+on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.1.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_annotation_on_type_requires_v1_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_annotation_on_type_requires_v1_1.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type Wibble\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:2:1
+  │
+2 │ @internal
+  │ ^^^^^^^^^ This requires a Gleam version >= 1.1.0
+
+The `@internal` annotation was introduced in version v1.1.0. But the Gleam
+version range specified in your `gleam.toml` would allow this code to run
+on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.1.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_external_module_with_at_requires_v1_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_external_module_with_at_requires_v1_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@external(javascript, \"module@module\", \"func\")\npub fn main() { Nil }\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:2:1
+  │
+2 │ @external(javascript, "module@module", "func")
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This requires a Gleam version >= 1.2.0
+
+The ability to have `@` in a Javascript module's name was introduced in
+version v1.2.0. But the Gleam version range specified in your `gleam.toml`
+would allow this code to run on an earlier version like v1.0.0, resulting
+in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.2.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__label_shorthand_in_call_requires_v1_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__label_shorthand_in_call_requires_v1_4.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub type Wibble { Wibble(wibble: Int) }\n\npub fn main() {\n  let wibble = 1\n  Wibble(wibble:)\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:6:10
+  │
+6 │   Wibble(wibble:)
+  │          ^^^^^^^ This requires a Gleam version >= 1.4.0
+
+The label shorthand syntax was introduced in version v1.4.0. But the Gleam
+version range specified in your `gleam.toml` would allow this code to run
+on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.4.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__label_shorthand_in_constand_requires_v1_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__label_shorthand_in_constand_requires_v1_4.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub type Wibble { Wibble(wibble: Int) }\n\npub const wibble = 1\npub const wobble = Wibble(wibble:)\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:5:27
+  │
+5 │ pub const wobble = Wibble(wibble:)
+  │                           ^^^^^^^ This requires a Gleam version >= 1.4.0
+
+The label shorthand syntax was introduced in version v1.4.0. But the Gleam
+version range specified in your `gleam.toml` would allow this code to run
+on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.4.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__label_shorthand_in_pattern_requires_v1_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__label_shorthand_in_pattern_requires_v1_4.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub type Wibble { Wibble(wibble: Int) }\n\npub fn main(wibble) {\n  case wibble {\n    Wibble(wibble:) -> wibble\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:6:12
+  │
+6 │     Wibble(wibble:) -> wibble
+  │            ^^^^^^^ This requires a Gleam version >= 1.4.0
+
+The label shorthand syntax was introduced in version v1.4.0. But the Gleam
+version range specified in your `gleam.toml` would allow this code to run
+on an earlier version like v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.4.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_constant_segment_requires_v1_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_constant_segment_requires_v1_5.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub const bits = <<\"hello\">>"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:1:20
+  │
+1 │ pub const bits = <<"hello">>
+  │                    ^^^^^^^ This requires a Gleam version >= 1.5.0
+
+The ability to omit the `utf8` annotation for string segments was
+introduced in version v1.5.0. But the Gleam version range specified in
+your `gleam.toml` would allow this code to run on an earlier version like
+v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.5.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_pattern_segment_requires_v1_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_pattern_segment_requires_v1_5.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(a) {\n  case a {\n    <<\"hello\">> -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:7
+  │
+4 │     <<"hello">> -> Nil
+  │       ^^^^^^^ This requires a Gleam version >= 1.5.0
+
+The ability to omit the `utf8` annotation for string segments was
+introduced in version v1.5.0. But the Gleam version range specified in
+your `gleam.toml` would allow this code to run on an earlier version like
+v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.5.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_segment_requires_v1_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_segment_requires_v1_5.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  <<\"hello\">>\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │   <<"hello">>
+  │     ^^^^^^^ This requires a Gleam version >= 1.5.0
+
+The ability to omit the `utf8` annotation for string segments was
+introduced in version v1.5.0. But the Gleam version range specified in
+your `gleam.toml` would allow this code to run on an earlier version like
+v1.0.0, resulting in compilation errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.5.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__nested_tuple_access_requires_v1_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__nested_tuple_access_requires_v1_1.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  let tuple = #(1, #(1, 1))\n  tuple.1.0\n}\n"
+---
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:3
+  │
+4 │   tuple.1.0
+  │   ^^^^^^^^^ This requires a Gleam version >= 1.1.0
+
+The ability to access nested tuple fields was introduced in version v1.1.0.
+But the Gleam version range specified in your `gleam.toml` would allow this
+code to run on an earlier version like v1.0.0, resulting in compilation
+errors!
+Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+    gleam = ">= 1.1.0"

--- a/compiler-core/src/type_/tests/target_implementations.rs
+++ b/compiler-core/src/type_/tests/target_implementations.rs
@@ -26,6 +26,7 @@ pub fn implementations(src: &str) -> Vec<(EcoString, Implementations)> {
         vec![],
         Target::Erlang,
         TargetSupport::NotEnforced,
+        None,
     )
     .expect("compile src")
     .type_info
@@ -320,6 +321,7 @@ pub fn no_valid_erlang_impl() {
         vec![],
         Target::Erlang,
         TargetSupport::Enforced,
+        None,
     );
     assert!(out.is_err());
 }
@@ -346,6 +348,7 @@ pub fn no_valid_javascript_impl() {
         vec![],
         Target::JavaScript,
         TargetSupport::Enforced,
+        None,
     );
     assert!(out.is_err());
 }
@@ -372,6 +375,7 @@ pub fn no_valid_erlang_impl() {
         vec![],
         Target::Erlang,
         TargetSupport::Enforced,
+        None,
     );
     assert!(out.is_err());
 }
@@ -398,6 +402,7 @@ pub fn no_valid_javascript_impl() {
         vec![],
         Target::JavaScript,
         TargetSupport::Enforced,
+        None,
     );
     assert!(out.is_err());
 }
@@ -420,6 +425,7 @@ pub fn no_valid_erlang_impl() {
         vec![],
         Target::Erlang,
         TargetSupport::Enforced,
+        None,
     );
     assert!(out.is_err());
 }
@@ -442,6 +448,7 @@ pub fn no_valid_javascript_impl() {
         vec![],
         Target::JavaScript,
         TargetSupport::Enforced,
+        None,
     );
     assert!(out.is_err());
 }

--- a/compiler-core/src/type_/tests/version_inference.rs
+++ b/compiler-core/src/type_/tests/version_inference.rs
@@ -283,3 +283,33 @@ pub fn main() {
     );
     assert_eq!(version, Version::new(1, 5, 0));
 }
+
+#[test]
+fn inference_picks_the_bigger_of_two_versions() {
+    let version = infer_version(
+        "
+pub fn main() {
+  case todo {
+    <<\"hello\", \" world!\">> -> todo
+    _ if 1 + 1 == 2-> todo
+    _ -> todo
+  }
+}
+",
+    );
+    assert_eq!(version, Version::new(1, 5, 0));
+}
+
+#[test]
+fn inference_picks_the_bigger_of_two_versions_2() {
+    let version = infer_version(
+        "
+@external(javascript, \"module@module\", \"func\")
+pub fn main() {
+  let tuple = #(1, #(1, 1))
+  tuple.1.0
+}
+",
+    );
+    assert_eq!(version, Version::new(1, 2, 0));
+}

--- a/compiler-core/src/type_/tests/version_inference.rs
+++ b/compiler-core/src/type_/tests/version_inference.rs
@@ -6,7 +6,7 @@ fn infer_version(module: &str) -> Version {
     compile_module("test_module", module, None, vec![])
         .expect("module to compile")
         .type_info
-        .required_version
+        .minimum_required_version
 }
 
 #[test]

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2105,3 +2105,19 @@ pub fn main() {
 "#
     );
 }
+
+//#[test]
+//fn unused_label_shorthand_pattern_arg_shadowing() {
+//    assert_warning_with_version_constraint!(
+//        ">= 1.1.0",
+//        r#"
+//pub type Wibble { Wibble(arg1: Int, arg2: Bool ) }
+//
+//pub fn main() {
+//  let Wibble(arg1:, arg2:) = Wibble(1, True)
+//  let arg1 = False
+//  arg1
+//}
+//"#
+//    );
+//}

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{assert_no_warnings, assert_warning, assert_warnings_with_imports};
+use crate::{
+    assert_no_warnings, assert_warning, assert_warnings_with_gleam_version,
+    assert_warnings_with_imports,
+};
 
 #[test]
 fn unknown_label() {
@@ -2106,18 +2109,281 @@ pub fn main() {
     );
 }
 
-//#[test]
-//fn unused_label_shorthand_pattern_arg_shadowing() {
-//    assert_warning_with_version_constraint!(
-//        ">= 1.1.0",
-//        r#"
-//pub type Wibble { Wibble(arg1: Int, arg2: Bool ) }
-//
-//pub fn main() {
-//  let Wibble(arg1:, arg2:) = Wibble(1, True)
-//  let arg1 = False
-//  arg1
-//}
-//"#
-//    );
-//}
+#[test]
+fn internal_annotation_on_constant_requires_v1_1() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+@internal
+pub const wibble = 1
+",
+    );
+}
+
+#[test]
+fn internal_annotation_on_type_requires_v1_1() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+@internal
+pub type Wibble
+",
+    );
+}
+
+#[test]
+fn internal_annotation_on_function_requires_v1_1() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+@internal
+pub fn wibble() { Nil }
+",
+    );
+}
+
+#[test]
+fn nested_tuple_access_requires_v1_1() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  let tuple = #(1, #(1, 1))
+  tuple.1.0
+}
+",
+    );
+}
+
+#[test]
+fn javascript_external_module_with_at_requires_v1_2() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+@external(javascript, \"module@module\", \"func\")
+pub fn main() { Nil }
+",
+    );
+}
+
+#[test]
+fn int_plus_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+    _ if 1 + 1 == 2 -> Nil
+    _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn float_plus_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+    _ if 1.0 +. 1.0 == 2.0 -> Nil
+    _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn int_minus_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+    _ if 1 - 1 == 0 -> Nil
+    _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn float_minus_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+    _ if 1.0 -. 1.0 == 0.0 -> Nil
+    _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn int_multiplication_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+  _ if 1 * 1 == 0 -> Nil
+  _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn float_multiplication_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+  _ if 1.0 *. 1.0 == 0.0 -> Nil
+  _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn int_divide_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+  _ if 1 / 1 == 0 -> Nil
+  _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn float_divide_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+  _ if 1.0 /. 1.0 == 0.0 -> Nil
+  _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn int_remainder_in_guards_requires_v1_3() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  case Nil {
+  _ if 1 % 1 == 0 -> Nil
+  _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
+fn label_shorthand_in_constand_requires_v1_4() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub type Wibble { Wibble(wibble: Int) }
+
+pub const wibble = 1
+pub const wobble = Wibble(wibble:)
+",
+    );
+}
+
+#[test]
+fn label_shorthand_in_call_requires_v1_4() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub type Wibble { Wibble(wibble: Int) }
+
+pub fn main() {
+  let wibble = 1
+  Wibble(wibble:)
+}
+",
+    );
+}
+
+#[test]
+fn label_shorthand_in_pattern_requires_v1_4() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub type Wibble { Wibble(wibble: Int) }
+
+pub fn main(wibble) {
+  case wibble {
+    Wibble(wibble:) -> wibble
+  }
+}
+",
+    );
+}
+
+#[test]
+fn constant_string_concatenation_requires_v1_4() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "pub const string = \"wibble\" <> \"wobble\""
+    );
+}
+
+#[test]
+fn missing_utf_8_option_in_bit_array_segment_requires_v1_5() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main() {
+  <<\"hello\">>
+}
+",
+    );
+}
+
+#[test]
+fn missing_utf_8_option_in_bit_array_constant_segment_requires_v1_5() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "pub const bits = <<\"hello\">>"
+    );
+}
+
+#[test]
+fn missing_utf_8_option_in_bit_array_pattern_segment_requires_v1_5() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub fn main(a) {
+  case a {
+    <<\"hello\">> -> Nil
+    _ -> Nil
+  }
+}
+",
+    );
+}


### PR DESCRIPTION
This PR closes #3492

It's still a WIP because I have some questions before I can move forward:
1. I used the `Version` type that comes from `hexpm::version`, should we use our own minimal custom type instead of relying on this one?
2. If someone specifies an insufficient version (let's say `gleam.toml` has `1.2` but we inferred the minimum one to be `1.5`) how should the error be presented to the user?
   Do we want the error message to include an example of a usage of a feature that explains why we inferred that number? For example something that looks like this:
   ```txt
   error: invalid Gleam version
   
   1 | tuple.0.1
            ^^^^

   Nested tuple access requires a Gleam version >= 1.2 but the version specified in
   your `gleam.toml` is 1.1!
   ```
   Even if someone used multiple features I think it would be better to show just one, I don't think there's much value in making the error message any longer
3. What if the `gleam.toml` doesn't specify any gleam version? Do we want to manually add the constraint when publishing it or have an error and force the programmer to explicitly write the inferred version down? Is there any downside to doing it implicitly?