### PR TITLE
Improve suggestions for inexhaustive case expression error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,36 @@
 
   ([Surya Rose](https://github.com/gearsdatapacks))
 
+  - The compiler now provides improved suggestions in the error for an
+    inexhaustive case expression. The following code:
+
+    ```gleam
+    let a = True
+    case a {}
+    ```
+
+    Now produces this error:
+
+    ```
+    error: Inexhaustive patterns
+      ┌─ /src/file.gleam:3:3
+      │
+    3 │   case a {}
+      │   ^^^^^^^^^
+
+    This case expression does not have a pattern for all possible values. If it
+    is run on one of the values without a pattern then it will crash.
+
+    The missing patterns are:
+
+        False
+        True
+    ```
+
+    Whereas before, it would suggest `_` as the only missing pattern.
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -303,7 +303,7 @@ impl<'a> Compiler<'a> {
         // run one pass of compiling to ensure we don't just suggest `_`
         if rows.is_empty() {
             // Even though we run a compile pass, an empty case expression is always
-            // invalid, so we make sure to report than here
+            // invalid, so we make sure to report that here
             self.diagnostics.missing = true;
             let tree = self.compile_cases(
                 self.subject_variables
@@ -351,6 +351,7 @@ impl<'a> Compiler<'a> {
             };
         }
 
+        // Get the most referred to variable across all rows
         let mut counts = HashMap::new();
         for row in rows.iter() {
             for col in &row.columns {
@@ -360,7 +361,7 @@ impl<'a> Compiler<'a> {
 
         let variable = rows
             .first()
-            .expect("Must have at least one row")
+            .expect("Must have at least one row, otherwise we don't reach this point")
             .columns
             .iter()
             .map(|col| col.variable.clone())
@@ -751,13 +752,8 @@ impl<'a> Compiler<'a> {
         }
     }
 
-    /// Given a row, returns the kind of branch that is referred to the
-    /// most across all rows.
-    ///
-    /// # Panics
-    ///
-    /// Panics if there or no rows, or if the first row has no columns.
-    ///
+    /// Given a variable, returns the kind of branch associated with
+    /// that variable.
     fn branch_mode(&self, variable: Variable) -> BranchMode {
         match collapse_links(variable.type_.clone()).as_ref() {
             Type::Fn { .. } | Type::Var { .. } => BranchMode::Infinite { variable },

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -3332,7 +3332,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let mut compiler = Compiler::new(self.environment, Arena::new());
         let mut arena = PatternArena::new();
 
-        let subject_variable = compiler.new_variable(subject.clone());
+        let subject_variable = compiler.subject_variable(subject.clone());
 
         let mut rows = Vec::with_capacity(1);
 
@@ -3371,7 +3371,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let subject_variables = subject_types
             .iter()
-            .map(|t| compiler.new_variable(t.clone()))
+            .map(|t| compiler.subject_variable(t.clone()))
             .collect_vec();
 
         let mut rows = Vec::with_capacity(clauses.iter().map(Clause::pattern_count).sum::<usize>());

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1166,3 +1166,33 @@ case list {}
 "
     );
 }
+
+#[test]
+fn empty_case_of_int() {
+    assert_error!(
+        "
+let num = 24
+case num {}
+"
+    );
+}
+
+#[test]
+fn empty_case_of_float() {
+    assert_error!(
+        "
+let age = 10.6
+case age {}
+"
+    );
+}
+
+#[test]
+fn empty_case_of_string() {
+    assert_error!(
+        r#"
+let name = "John Doe"
+case name {}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1,4 +1,6 @@
-use crate::{assert_module_error, assert_no_warnings, assert_warning, assert_with_module_error};
+use crate::{
+    assert_error, assert_module_error, assert_no_warnings, assert_warning, assert_with_module_error,
+};
 
 #[test]
 fn whatever() {
@@ -1126,6 +1128,41 @@ pub fn main() {
     mod.Wobble -> Nil
   }
 }
+"
+    );
+}
+
+// The following few tests all verify that the compiler provides useful errors
+// when there are no case arms, instead of just suggesting `_` as it did previously.
+#[test]
+fn empty_case_of_bool() {
+    assert_error!(
+        "
+let b = True
+case b {}
+"
+    );
+}
+
+#[test]
+fn empty_case_of_custom_type() {
+    assert_module_error!(
+        "
+type Wibble { Wibble Wobble Wubble }
+pub fn main() {
+  let wibble = Wobble
+  case wibble {}
+}
+"
+    );
+}
+
+#[test]
+fn empty_case_of_list() {
+    assert_error!(
+        "
+let list = []
+case list {}
 "
     );
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_bool.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_bool.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet b = True\ncase b {}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:3:1
+  │
+3 │ case b {}
+  │ ^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    False
+    True

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_custom_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_custom_type.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\ntype Wibble { Wibble Wobble Wubble }\npub fn main() {\n  let wibble = Wobble\n  case wibble {}\n}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:5:3
+  │
+5 │   case wibble {}
+  │   ^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    Wibble
+    Wobble
+    Wubble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_float.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_float.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet age = 10.6\ncase age {}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:3:1
+  │
+3 │ case age {}
+  │ ^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_int.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_int.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet num = 24\ncase num {}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:3:1
+  │
+3 │ case num {}
+  │ ^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_list.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_list.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet list = []\ncase list {}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:3:1
+  │
+3 │ case list {}
+  │ ^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    []
+    [_, ..]

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_string.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_string.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet name = \"John Doe\"\ncase name {}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:3:1
+  │
+3 │ case name {}
+  │ ^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _


### PR DESCRIPTION
Closes #3544.
Instead of just returning `Failure` when there are no rows, it runs exhaustiveness checking on the first subject of the case expression to give better suggestions to improve it. 
In future we should maybe check other subjects too, to further improve this. Although this could produce a big decision tree, and we don't do that at the moment for other patterns so I left it.
For example, at the moment, for this code:
```gleam
case True, False {}
```
It will suggest `True, _` and `False, _`. (Actually it won't, because of #2426, but that's a separate issue)

However, if we check both subjects, it will suggest all four possible combinations.
However, consider this possibility:
```
type Wibble { A B C D }
case A, B, C, D {}
```
This would produce `4^4 = 256` possible options, which is a bit much. So I've left it with just the one for now.