### PR TITLE
cleanup unused import

### DIFF
--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -470,28 +470,20 @@ pub mod module {
       !self.reader.get_pointer_field(5).is_null()
     }
     #[inline]
-    pub fn get_unused_imports(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::src_span::Owned>> {
+    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(6), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_unused_imports(&self) -> bool {
+    pub fn has_line_numbers(&self) -> bool {
       !self.reader.get_pointer_field(6).is_null()
     }
     #[inline]
-    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Reader<'a>> {
+    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(7), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_line_numbers(&self) -> bool {
-      !self.reader.get_pointer_field(7).is_null()
-    }
-    #[inline]
-    pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(8), ::core::option::Option::None)
-    }
-    #[inline]
     pub fn has_src_path(&self) -> bool {
-      !self.reader.get_pointer_field(8).is_null()
+      !self.reader.get_pointer_field(7).is_null()
     }
     #[inline]
     pub fn get_is_internal(self) -> bool {
@@ -644,52 +636,36 @@ pub mod module {
       !self.builder.get_pointer_field(5).is_null()
     }
     #[inline]
-    pub fn get_unused_imports(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::src_span::Owned>> {
+    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Builder<'a>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(6), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_unused_imports(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::src_span::Owned>) -> ::capnp::Result<()> {
+    pub fn set_line_numbers(&mut self, value: crate::schema_capnp::line_numbers::Reader<'_>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(6), value, false)
     }
     #[inline]
-    pub fn init_unused_imports(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::src_span::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(6), size)
-    }
-    #[inline]
-    pub fn has_unused_imports(&self) -> bool {
-      !self.builder.get_pointer_field(6).is_null()
-    }
-    #[inline]
-    pub fn get_line_numbers(self) -> ::capnp::Result<crate::schema_capnp::line_numbers::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(7), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn set_line_numbers(&mut self, value: crate::schema_capnp::line_numbers::Reader<'_>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(7), value, false)
-    }
-    #[inline]
     pub fn init_line_numbers(self, ) -> crate::schema_capnp::line_numbers::Builder<'a> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(7), 0)
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(6), 0)
     }
     #[inline]
     pub fn has_line_numbers(&self) -> bool {
-      !self.builder.get_pointer_field(7).is_null()
+      !self.builder.get_pointer_field(6).is_null()
     }
     #[inline]
     pub fn get_src_path(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(8), ::core::option::Option::None)
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(7), ::core::option::Option::None)
     }
     #[inline]
     pub fn set_src_path(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.get_pointer_field(8).set_text(value);
+      self.builder.get_pointer_field(7).set_text(value);
     }
     #[inline]
     pub fn init_src_path(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(8).init_text(size)
+      self.builder.get_pointer_field(7).init_text(size)
     }
     #[inline]
     pub fn has_src_path(&self) -> bool {
-      !self.builder.get_pointer_field(8).is_null()
+      !self.builder.get_pointer_field(7).is_null()
     }
     #[inline]
     pub fn get_is_internal(self) -> bool {
@@ -709,12 +685,12 @@ pub mod module {
   }
   impl Pipeline  {
     pub fn get_line_numbers(&self) -> crate::schema_capnp::line_numbers::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(7))
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(6))
     }
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 9 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 8 };
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -26,10 +26,9 @@ struct Module {
   accessors @3 :List(Property(AccessorsMap));
   package @4 :Text;
   typesConstructors @5 :List(Property(TypesVariantConstructors));
-  unusedImports @6 :List(SrcSpan);
-  lineNumbers @7 :LineNumbers;
-  srcPath @8 :Text;
-  isInternal @9 :Bool;
+  lineNumbers @6 :LineNumbers;
+  srcPath @7 :Text;
+  isInternal @8 :Bool;
 }
 
 struct TypesVariantConstructors {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -273,7 +273,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         }
 
         // Generate warnings for unused items
-        let unused_imports = env.convert_unused_to_warnings(&mut self.problems);
+        env.convert_unused_to_warnings(&mut self.problems);
 
         // Remove imported types and values to create the public interface
         // Private types and values are retained so they can be used in the language
@@ -323,7 +323,6 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 origin: self.origin,
                 package: self.package_config.name.clone(),
                 is_internal,
-                unused_imports,
                 line_numbers: self.line_numbers,
                 src_path: self.src_path,
                 warnings,

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -55,7 +55,6 @@ fn write_cache(
         types_value_constructors: Default::default(),
         values: Default::default(),
         accessors: Default::default(),
-        unused_imports: Vec::new(),
         line_numbers: line_numbers.clone(),
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -976,7 +976,17 @@ fn code_action_unused_imports(
     actions: &mut Vec<CodeAction>,
 ) {
     let uri = &params.text_document.uri;
-    let unused = &module.ast.type_info.unused_imports;
+    let unused: Vec<&SrcSpan> = module
+        .ast
+        .type_info
+        .warnings
+        .iter()
+        .filter_map(|warning| match warning {
+            type_::Warning::UnusedImportedModuleAlias { location, .. }
+            | type_::Warning::UnusedImportedModule { location, .. } => Some(location),
+            _ => None,
+        })
+        .collect();
 
     if unused.is_empty() {
         return;

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -78,7 +78,6 @@ impl ModuleDecoder {
                 type_variants_constructors
             ),
             accessors: read_hashmap!(reader.get_accessors()?, self, accessors_map),
-            unused_imports: read_vec!(reader.get_unused_imports()?, self, src_span),
             line_numbers: self.line_numbers(&reader.get_line_numbers()?)?,
             src_path: reader.get_src_path()?.into(),
             warnings: vec![],

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -46,7 +46,6 @@ impl<'a> ModuleEncoder<'a> {
         self.set_module_values(&mut module);
         self.set_module_accessors(&mut module);
         self.set_module_types_constructors(&mut module);
-        self.set_unused_imports(&mut module);
         self.set_line_numbers(&mut module);
 
         capnp::serialize_packed::write_message(&mut buffer, &message).expect("capnp encode");
@@ -60,16 +59,6 @@ impl<'a> ModuleEncoder<'a> {
             line_numbers.init_line_starts(self.data.line_numbers.line_starts.len() as u32);
         for (i, l) in self.data.line_numbers.line_starts.iter().enumerate() {
             line_starts.reborrow().set(i as u32, *l);
-        }
-    }
-
-    fn set_unused_imports(&mut self, module: &mut module::Builder<'_>) {
-        let mut unused_imports = module
-            .reborrow()
-            .init_unused_imports(self.data.unused_imports.len() as u32);
-        for (i, span) in self.data.unused_imports.iter().enumerate() {
-            let unused_import = unused_imports.reborrow().get(i as u32);
-            self.build_src_span(unused_import, *span)
         }
     }
 

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -37,7 +37,6 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         name: "a".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -92,7 +91,6 @@ fn empty_module() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -111,7 +109,6 @@ fn with_line_numbers() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(
             "const a = 1
@@ -146,30 +143,7 @@ fn module_with_private_type() {
         .into(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
-        line_numbers: LineNumbers::new(""),
-        src_path: "some_path".into(),
-    };
-    assert_eq!(roundtrip(&module), module);
-}
-
-#[test]
-fn module_with_unused_import() {
-    let module = ModuleInterface {
-        warnings: vec![],
-        is_internal: false,
-        package: "some_package".into(),
-        origin: Origin::Src,
-        name: "a".into(),
-        types: HashMap::new(),
-        types_value_constructors: HashMap::new(),
-        unused_imports: vec![
-            SrcSpan { start: 0, end: 10 },
-            SrcSpan { start: 13, end: 42 },
-        ],
-        accessors: HashMap::new(),
-        values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
     };
@@ -199,7 +173,6 @@ fn module_with_app_type() {
         .into(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -230,7 +203,6 @@ fn module_with_fn_type() {
         .into(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -261,7 +233,6 @@ fn module_with_tuple_type() {
         .into(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -298,7 +269,6 @@ fn module_with_generic_type() {
             .into(),
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
-            unused_imports: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -335,7 +305,6 @@ fn module_with_type_links() {
             .into(),
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
-            unused_imports: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -372,7 +341,6 @@ fn module_with_type_constructor_documentation() {
             .into(),
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
-            unused_imports: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -412,7 +380,6 @@ fn module_with_type_constructor_origin() {
             .into(),
             types_value_constructors: HashMap::new(),
             values: HashMap::new(),
-            unused_imports: Vec::new(),
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
@@ -442,7 +409,6 @@ fn module_type_to_constructors_mapping() {
             },
         )]
         .into(),
-        unused_imports: Default::default(),
         accessors: HashMap::new(),
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
@@ -461,7 +427,6 @@ fn module_fn_value() {
         origin: Origin::Src,
         name: "a".into(),
         types: HashMap::new(),
-        unused_imports: Vec::new(),
         types_value_constructors: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
@@ -507,7 +472,6 @@ fn deprecated_module_fn_value() {
         name: "a".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -553,7 +517,6 @@ fn private_module_fn_value() {
         origin: Origin::Src,
         name: "a".into(),
         types: HashMap::new(),
-        unused_imports: Vec::new(),
         types_value_constructors: HashMap::new(),
         accessors: HashMap::new(),
         values: [(
@@ -601,7 +564,6 @@ fn module_fn_value_regression() {
         name: "a/b/c".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -647,7 +609,6 @@ fn module_fn_value_with_field_map() {
         name: "a".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -695,7 +656,6 @@ fn record_value() {
         name: "a".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -738,7 +698,6 @@ fn record_value_with_field_map() {
         name: "a".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -783,7 +742,6 @@ fn accessors() {
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: [
             (
                 "one".into(),
@@ -996,7 +954,6 @@ fn constant_var() {
         name: "a".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [
             (
@@ -1231,7 +1188,6 @@ fn deprecated_type() {
         .into(),
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
@@ -1249,7 +1205,6 @@ fn module_fn_value_with_external_implementations() {
         name: "a/b/c".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -1295,7 +1250,6 @@ fn internal_module_fn() {
         name: "a/b/c".into(),
         types: HashMap::new(),
         types_value_constructors: HashMap::new(),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [(
             "one".into(),
@@ -1361,7 +1315,6 @@ fn type_variable_ids_in_constructors_are_shared() {
                 }],
             },
         )]),
-        unused_imports: Vec::new(),
         accessors: HashMap::new(),
         values: [].into(),
         line_numbers: LineNumbers::new(""),

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -600,7 +600,6 @@ pub struct ModuleInterface {
     pub types_value_constructors: HashMap<EcoString, TypeVariantConstructors>,
     pub values: HashMap<EcoString, ValueConstructor>,
     pub accessors: HashMap<EcoString, AccessorsMap>,
-    pub unused_imports: Vec<SrcSpan>,
     /// Used for mapping to original source locations on disk
     pub line_numbers: LineNumbers,
     /// Used for determining the source path of the module on disk
@@ -697,7 +696,6 @@ impl ModuleInterface {
             types_value_constructors: Default::default(),
             values: Default::default(),
             accessors: Default::default(),
-            unused_imports: Default::default(),
             is_internal: false,
             line_numbers,
             src_path,

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -592,20 +592,18 @@ impl<'a> Environment<'a> {
 
     /// Converts entities with a usage count of 0 to warnings.
     /// Returns the list of unused imported module location for the removed unused lsp action.
-    pub fn convert_unused_to_warnings(&mut self, problems: &mut Problems) -> Vec<SrcSpan> {
+    pub fn convert_unused_to_warnings(&mut self, problems: &mut Problems) {
         let unused = self
             .entity_usages
             .pop()
             .expect("Expected a bottom level of entity usages.");
         self.handle_unused(unused, problems);
 
-        let mut locations = Vec::new();
         for (name, location) in self.unused_modules.clone().into_iter() {
             problems.warning(Warning::UnusedImportedModule {
                 name: name.clone(),
                 location,
             });
-            locations.push(location);
         }
 
         for (name, info) in self.unused_module_aliases.iter() {
@@ -615,10 +613,8 @@ impl<'a> Environment<'a> {
                     location: info.location,
                     module_name: info.module_name.clone(),
                 });
-                locations.push(info.location);
             }
         }
-        locations
     }
 
     fn handle_unused(

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -209,7 +209,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         types_value_constructors: HashMap::new(),
         values: HashMap::new(),
         accessors: HashMap::new(),
-        unused_imports: Vec::new(),
         is_internal: false,
         warnings: vec![],
         // prelude doesn't have real src

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -715,7 +715,6 @@ fn infer_module_type_retention_test() {
             ]),
             values: HashMap::new(),
             accessors: HashMap::new(),
-            unused_imports: Vec::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "".into(),
         }


### PR DESCRIPTION
similar to what we did with `unused_values` in #3435, it seems that we could remove `unused_imports` from module interface.