### PR TITLE
Print correct missing patterns for inexhaustive case expressions with multiple subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,10 @@
 - Fixed a bug where the provided `REBAR_BARE_COMPILER_OUTPUT_DIR` env var would use relative path instead of absolute path causing compilation errors in some packages.
   ([Gustavo Inacio](https://github.com/gusinacio))
 
+- Fixed a bug where the compiler would print incorrect missing patterns for
+  inexhaustive case expressions matching on more than one subject.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.4.1 - 2024-08-04
 
 ### Bug Fixes

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -221,6 +221,7 @@ pub struct Diagnostics {
 pub struct Match {
     pub tree: Decision,
     pub diagnostics: Diagnostics,
+    pub subject_variables: Vec<Variable>,
 }
 
 impl Match {
@@ -267,6 +268,7 @@ impl<'a> Compiler<'a> {
         Match {
             tree: self.check_empty_rows(rows),
             diagnostics: self.diagnostics,
+            subject_variables: self.subject_variables,
         }
     }
 

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1196,3 +1196,81 @@ case name {}
 "#
     );
 }
+
+#[test]
+fn empty_case_of_multi_pattern() {
+    assert_error!(
+        "
+let a = Ok(1)
+let b = True
+case a, b {}
+"
+    );
+}
+
+#[test]
+fn inexhaustive_multi_pattern() {
+    assert_error!(
+        "
+let a = Ok(1)
+let b = True
+case a, b {
+  Error(_), _ -> Nil
+}
+"
+    );
+}
+
+#[test]
+fn inexhaustive_multi_pattern2() {
+    assert_error!(
+        "
+let a = Ok(1)
+let b = True
+case a, b {
+  Ok(1), True -> Nil
+}
+"
+    );
+}
+
+#[test]
+fn inexhaustive_multi_pattern3() {
+    assert_error!(
+        "
+let a = Ok(1)
+let b = True
+case a, b {
+  _, False -> Nil
+}
+"
+    );
+}
+
+#[test]
+fn inexhaustive_multi_pattern4() {
+    assert_error!(
+        "
+let a = 12
+let b = 3.14
+let c = False
+case a, b, c {
+  1, 2.0, True -> Nil
+}
+"
+    );
+}
+
+#[test]
+fn inexhaustive_multi_pattern5() {
+    assert_error!(
+        "
+let a = 12
+let b = 3.14
+let c = False
+case a, b, c {
+  12, _, False -> Nil
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_multi_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__empty_case_of_multi_pattern.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet a = Ok(1)\nlet b = True\ncase a, b {}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:4:1
+  │
+4 │ case a, b {}
+  │ ^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    Error(_), _
+    Ok(_), _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet a = Ok(1)\nlet b = True\ncase a, b {\n  Error(_), _ -> Nil\n}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:4:1
+  │  
+4 │ ╭ case a, b {
+5 │ │   Error(_), _ -> Nil
+6 │ │ }
+  │ ╰─^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    Ok(_), _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern2.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet a = Ok(1)\nlet b = True\ncase a, b {\n  Ok(1), True -> Nil\n}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:4:1
+  │  
+4 │ ╭ case a, b {
+5 │ │   Ok(1), True -> Nil
+6 │ │ }
+  │ ╰─^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    Error(_), True
+    Ok(_), True
+    _, False

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern3.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet a = Ok(1)\nlet b = True\ncase a, b {\n  _, False -> Nil\n}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:4:1
+  │  
+4 │ ╭ case a, b {
+5 │ │   _, False -> Nil
+6 │ │ }
+  │ ╰─^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, True

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern4.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet a = 12\nlet b = 3.14\nlet c = False\ncase a, b, c {\n  1, 2.0, True -> Nil\n}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:5:1
+  │  
+5 │ ╭ case a, b, c {
+6 │ │   1, 2.0, True -> Nil
+7 │ │ }
+  │ ╰─^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, False
+    _, _, True

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern5.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nlet a = 12\nlet b = 3.14\nlet c = False\ncase a, b, c {\n  12, _, False -> Nil\n}\n"
+---
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:5:1
+  │  
+5 │ ╭ case a, b, c {
+6 │ │   12, _, False -> Nil
+7 │ │ }
+  │ ╰─^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, False
+    _, _, True


### PR DESCRIPTION
Fixes #2426.
This ensures that a pattern is printed for every subject of the expression, in the correct order.