### PR TITLE
Check target support when a value is imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,6 +330,10 @@
   inexhaustive case expressions matching on more than one subject.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where the compiler would not check the target support of a function
+  if it was imported and not used, and generate invalid code.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.4.1 - 2024-08-04
 
 ### Bug Fixes

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -119,6 +119,17 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         // Register the unqualified import if it is a value
         let variant = match module.get_public_value(import_name) {
             Some(value) => {
+                let implementations = value.variant.implementations();
+                // Check the target support of the imported value
+                if self.environment.target_support.is_enforced()
+                    && !implementations.supports(self.environment.target)
+                {
+                    self.problems.error(Error::UnsupportedExpressionTarget {
+                        target: self.environment.target,
+                        location,
+                    })
+                }
+
                 self.environment.insert_variable(
                     used_name.clone(),
                     value.variant.clone(),

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__unsupported_target_for_unused_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__unsupported_target_for_unused_import.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/type_/tests/externals.rs
+expression: "import mod.{wobble}"
+---
+error: Unsupported target
+  ┌─ /src/one/two.gleam:1:13
+  │
+1 │ import mod.{wobble}
+  │             ^^^^^^
+
+This value is not available as it is defined using externals, and there is
+no implementation for the Erlang target.
+
+Hint: Did you mean to build for a different target?


### PR DESCRIPTION
Fixes #3371 
We now check the target support of a value when it is imported, as well as when it is used.