### PR TITLE
improve error title for unknown module value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,8 +233,11 @@
   Whereas before, it would suggest `_` as the only missing pattern.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- Improve error message for using @external with unknown target
+- Improve error message for using `@external` with unknown target
   ([Jiangda Wang](https://github.com/frank-iii))
+
+- Improved error title when using an unknown module value.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ### Formatter
 
@@ -363,7 +366,8 @@
   unused.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- The Language Server now correctly shows completions for values in the Gleam prelude.
+- The Language Server now correctly shows completions for values in the Gleam
+  prelude.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
 ## v1.4.1 - 2024-08-04

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2020,7 +2020,7 @@ Private types can only be used within the module that defines them.",
                         format!("The module `{module_name}` does not have a `{name}` value.")
                     };
                     Diagnostic {
-                        title: "Unknown module field".into(),
+                        title: "Unknown module value".into(),
                         text,
                         hint: None,
                         level: Level::Error,

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/errors.rs
 expression: "import gleam/wibble.{Wibble}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:22
   │
 1 │ import gleam/wibble.{Wibble}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{One, type One}\n\npub fn main() -> One {\n  todo\n}\n"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{One, type One}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_import_errors_do_not_block_later_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_import_errors_do_not_block_later_unqualified.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import gleam.{Unknown, type Int as Integer}\n\npub fn main() -> Integer {\n  Nil\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:15
   │
 1 │ import gleam.{Unknown, type Int as Integer}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructo.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{Two}\n\npub fn main() {\n  Two\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{Two}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructo.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{Two}\n\npub fn main() {\n  Two\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{Two}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor_pattern.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{Two}\n\npub fn main(x) {\n  let Two = x\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{Two}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_function.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{two}\n\npub fn main() {\n  two\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{two}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_opaque_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_opaque_constructo.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.Two\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:4:6
   │
 4 │   one.Two

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructo.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.Two\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:4:6
   │
 4 │   one.Two

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructor_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructor_pattern.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main(x) {\n  let one.Two = x\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:4:7
   │
 4 │   let one.Two = x

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_custom_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_custom_type.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.X\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:4:6
   │
 4 │   one.X

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_external_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_external_type.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.X\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:4:6
   │
 4 │   one.X

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_function.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.two\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:4:6
   │
 4 │   one.two

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_type_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_type_alias.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.X\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:4:6
   │
 4 │   one.X

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_custom_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_custom_type.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{X}\n\npub fn main() {\n  X\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{X}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_external_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_external_type.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{X}\n\npub fn main() {\n  X\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{X}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_type_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_type_alias.snap
@@ -2,7 +2,7 @@
 source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{X}\n\npub fn main() {\n  X\n}"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ /src/one/two.gleam:1:13
   │
 1 │ import one.{X}

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_destructure.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_destructure.snap
@@ -2,7 +2,7 @@
 source: test-package-compiler/src/generated_tests.rs
 expression: "./cases/opaque_type_destructure"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ src/two.gleam:7:7
   │
 7 │   let one.User(name: name, score: score) = user

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_constant.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_constant.snap
@@ -1,13 +1,11 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 285
 expression: "./cases/unknown_module_field_in_constant"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ src/two.gleam:3:16
   │
 3 │ pub const it = one.B
   │                ^ Did you mean `A`?
 
 The module `one` does not have a `B` value.
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_expression.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_expression.snap
@@ -1,13 +1,11 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 297
 expression: "./cases/unknown_module_field_in_expression"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ src/two.gleam:4:6
   │
 4 │   one.B
   │      ^ Did you mean `A`?
 
 The module `one` does not have a `B` value.
-

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_import.snap
@@ -1,13 +1,11 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 309
 expression: "./cases/unknown_module_field_in_import"
 ---
-error: Unknown module field
+error: Unknown module value
   ┌─ src/two.gleam:1:13
   │
 1 │ import one.{B}
   │             ^ Did you mean `A`?
 
 The module `one` does not have a `B` value.
-


### PR DESCRIPTION
This closes #3534, as suggested by Louis I went with "unknown module value" since it's also how it is referred to in the error message itself instead of "module field"