### PR TITLE
lsp: Watch for gleam.toml paths in worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,10 @@
   ```
   ([Jiangda Wang](https://github.com/Frank-III))
 
+- The Language Server now looks for gleam.toml in the workspace directories,
+  whereas previously it was dependent on clients implementation of file watching.
+  ([Piotr Osiewicz](https://github.com/osiewicz))
+
 ### Bug Fixes
 
 - Fixed a bug in the compiler where shadowing a sized value in a bit pattern


### PR DESCRIPTION
Currently Gleam Language Server watches for changes to **/gleam.toml - which is a global path. This is probably undesired, as we only really need to watch for changes in the worktree this server is spawned for. 
This PR uses workspace_folders provided by clients to root the watched paths.

This came up (and unsurfaced a bug) in https://github.com/zed-industries/zed/pull/17206.