### PR TITLE
Display qualified type names on LSP hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@
 
 ### Language Server
 
+- The Language Server now displays correctly qualified or aliased type names
+  when hovering over a value in a Gleam file:
+
+  ```gleam
+  import gleam/option
+
+  const value = option.Some(1)
+  //    ^ hovering here shows `option.Option(Int)`
+  ```
+
+  ```gleam
+  import gleam/option.{type Option as Maybe}
+
+  const none = option.Some(1)
+  //    ^ hovering here shows `Maybe(Int)`
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Bug Fixes
 
 - Fixed a bug where the formatter would not format strings with big grapheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   ```gleam
   import gleam/option.{type Option as Maybe}
 
-  const none = option.Some(1)
+  const value = option.Some(1)
   //    ^ hovering here shows `Maybe(Int)`
   ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +852,7 @@ dependencies = [
  "askama",
  "async-trait",
  "base16",
+ "bimap",
  "bincode",
  "bytes",
  "camino",

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -40,6 +40,10 @@ pubgrub = "0"
 pathdiff = { version = "0", features = ["camino"] }
 # Memory arena using ids rather than references
 id-arena = "2"
+# Unicode grapheme traversal
+unicode-segmentation = "1.12.0"
+# Bijective (bi-directional) hashmap
+bimap = "0.6.3"
 async-trait.workspace = true
 base16.workspace = true
 bytes.workspace = true
@@ -63,7 +67,6 @@ termcolor.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
-unicode-segmentation = "1.12.0"
 
 [build-dependencies]
 # Data (de)serialisation

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1181,27 +1181,9 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             hydrator.disallow_new_type_variables();
             let type_ = hydrator.type_from_ast(resolved_type, environment, &mut self.problems)?;
 
-            if let Type::Named {
-                module,
-                name: type_name,
-                args,
-                ..
-            } = type_.as_ref()
-            {
-                // If the alias or type itself have any parameters, it requires a
-                // lot of work to reconstruct and correctly print the alias,
-                // so we just don't register it.
-                //
-                // Maybe in future we could do this extra work, but for the time
-                // being, it's simpler not to.
-                if parameters.is_empty() && args.is_empty() {
-                    environment.names.named_type_in_scope(
-                        module.clone(),
-                        type_name.clone(),
-                        name.clone(),
-                    );
-                }
-            }
+            environment
+                .names
+                .type_in_scope(name.clone(), type_.as_ref());
 
             // Insert the alias so that it can be used by other code.
             environment.insert_type_constructor(

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1200,14 +1200,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                         type_name.clone(),
                         name.clone(),
                     );
-                } else {
-                    // We need to make sure we register the type as existing, even if we don't define
-                    // the underlying type for printing, because these types do still affect printing,
-                    // for shadowing prelude types, even if they aren't printed at all.
-                    environment.names.type_exists_in_scope(name);
                 }
-            } else {
-                environment.names.type_exists_in_scope(name);
             }
 
             // Insert the alias so that it can be used by other code.

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1184,14 +1184,23 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             if let Type::Named {
                 module,
                 name: type_name,
+                args,
                 ..
             } = type_.as_ref()
             {
-                environment.names.named_type_in_scope(
-                    module.clone(),
-                    type_name.clone(),
-                    name.clone(),
-                );
+                // If the alias or type itself have any parameters, it requires a
+                // lot of work to reconstruct and correctly print the alias,
+                // so we just don't register it.
+                //
+                // Maybe in future we could do this extra work, but for the time
+                // being, it's simpler not to.
+                if parameters.is_empty() && args.is_empty() {
+                    environment.names.named_type_in_scope(
+                        module.clone(),
+                        type_name.clone(),
+                        name.clone(),
+                    );
+                }
             }
 
             // Insert the alias so that it can be used by other code.

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1200,7 +1200,14 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                         type_name.clone(),
                         name.clone(),
                     );
+                } else {
+                    // We need to make sure we register the type as existing, even if we don't define
+                    // the underlying type for printing, because these types do still affect printing,
+                    // for shadowing prelude types, even if they aren't printed at all.
+                    environment.names.type_exists_in_scope(name);
                 }
+            } else {
+                environment.names.type_exists_in_scope(name);
             }
 
             // Insert the alias so that it can be used by other code.

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -335,7 +335,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 warnings,
                 minimum_required_version: self.minimum_required_version,
             },
-            extra: type_names,
+            names: type_names,
         };
 
         match Vec1::try_from_vec(self.problems.take_errors()) {
@@ -1181,17 +1181,17 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             hydrator.disallow_new_type_variables();
             let type_ = hydrator.type_from_ast(resolved_type, environment, &mut self.problems)?;
 
-            match type_.as_ref() {
-                Type::Named {
-                    module,
-                    name: type_name,
-                    ..
-                } => environment.type_names.named_type_in_scope(
+            if let Type::Named {
+                module,
+                name: type_name,
+                ..
+            } = type_.as_ref()
+            {
+                environment.type_names.named_type_in_scope(
                     module.clone(),
                     type_name.clone(),
                     name.clone(),
-                ),
-                _ => {}
+                );
             }
 
             // Insert the alias so that it can be used by other code.

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -298,7 +298,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             module_types_constructors: types_constructors,
             module_values: values,
             accessors,
-            type_names,
+            names: type_names,
             ..
         } = env;
 
@@ -1040,7 +1040,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 deprecation.clone(),
             );
 
-            environment.value_names.named_constructor_in_scope(
+            environment.names.named_constructor_in_scope(
                 environment.current_module.clone(),
                 constructor.name.clone(),
                 constructor.name.clone(),
@@ -1127,7 +1127,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             )
             .expect("name uniqueness checked above");
 
-        environment.type_names.named_type_in_scope(
+        environment.names.named_type_in_scope(
             environment.current_module.clone(),
             name.clone(),
             name.clone(),
@@ -1187,7 +1187,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 ..
             } = type_.as_ref()
             {
-                environment.type_names.named_type_in_scope(
+                environment.names.named_type_in_scope(
                     module.clone(),
                     type_name.clone(),
                     name.clone(),

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -110,7 +110,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
             self.problems,
         );
 
-        self.environment.type_names.named_type_in_scope(
+        self.environment.names.named_type_in_scope(
             module.name.clone(),
             import.name.clone(),
             imported_name.clone(),
@@ -165,7 +165,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                     location,
                     self.problems,
                 );
-                self.environment.value_names.named_constructor_in_scope(
+                self.environment.names.named_constructor_in_scope(
                     module.clone(),
                     name.clone(),
                     used_name.clone(),
@@ -254,11 +254,11 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 .insert(used_name.clone(), (import.location, import_info));
 
             self.environment
-                .value_names
+                .names
                 .imported_module(import.module.clone(), used_name.clone());
 
             self.environment
-                .type_names
+                .names
                 .imported_module(import.module.clone(), used_name);
         };
 

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -109,6 +109,12 @@ impl<'context, 'problems> Importer<'context, 'problems> {
             import.location,
             self.problems,
         );
+
+        self.environment.type_names.named_type_in_scope(
+            module.name.clone(),
+            import.name.clone(),
+            imported_name.clone(),
+        )
     }
 
     fn register_unqualified_value(&mut self, import: &UnqualifiedImport, module: &ModuleInterface) {
@@ -249,7 +255,11 @@ impl<'context, 'problems> Importer<'context, 'problems> {
 
             self.environment
                 .value_names
-                .imported_module(import.module.clone(), used_name)
+                .imported_module(import.module.clone(), used_name.clone());
+
+            self.environment
+                .type_names
+                .imported_module(import.module.clone(), used_name);
         };
 
         Ok(())

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -102,8 +102,6 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 name.clone(),
                 imported_name.clone(),
             );
-        } else {
-            self.environment.names.type_exists_in_scope(imported_name);
         }
 
         if let Err(e) = self

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -102,6 +102,8 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 name.clone(),
                 imported_name.clone(),
             );
+        } else {
+            self.environment.names.type_exists_in_scope(imported_name);
         }
 
         if let Err(e) = self

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::{SrcSpan, UnqualifiedImport, UntypedImport},
     build::Origin,
     type_::{
-        EntityKind, Environment, Error, ModuleInterface, Problems, Type, UnusedModuleAlias,
+        EntityKind, Environment, Error, ModuleInterface, Problems, UnusedModuleAlias,
         ValueConstructorVariant,
     },
 };
@@ -95,14 +95,9 @@ impl<'context, 'problems> Importer<'context, 'problems> {
 
         let type_info = type_info.clone().with_location(import.location);
 
-        // We only register types if they are named
-        if let Type::Named { module, name, .. } = type_info.type_.as_ref() {
-            self.environment.names.named_type_in_scope(
-                module.clone(),
-                name.clone(),
-                imported_name.clone(),
-            );
-        }
+        self.environment
+            .names
+            .type_in_scope(imported_name.clone(), type_info.type_.as_ref());
 
         if let Err(e) = self
             .environment

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -260,10 +260,6 @@ impl<'context, 'problems> Importer<'context, 'problems> {
 
             self.environment
                 .names
-                .imported_module(import.module.clone(), used_name.clone());
-
-            self.environment
-                .names
                 .imported_module(import.module.clone(), used_name);
         };
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -42,12 +42,12 @@ pub type TypedModule = Module<type_::ModuleInterface, TypedDefinition, TypeNames
 pub type UntypedModule = Module<(), TargetedDefinition, ()>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Module<Info, Statements, Extra> {
+pub struct Module<Info, Statements, Names> {
     pub name: EcoString,
     pub documentation: Vec<EcoString>,
     pub type_info: Info,
     pub definitions: Vec<Statements>,
-    pub extra: Extra,
+    pub names: Names,
 }
 
 impl TypedModule {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -37,12 +37,12 @@ pub trait HasLocation {
     fn location(&self) -> SrcSpan;
 }
 
-pub type TypedModule = Module<type_::ModuleInterface, TypedDefinition, Names>;
+pub type TypedModule = Module<type_::ModuleInterface, TypedDefinition>;
 
-pub type UntypedModule = Module<(), TargetedDefinition, ()>;
+pub type UntypedModule = Module<(), TargetedDefinition>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Module<Info, Statements, Names> {
+pub struct Module<Info, Statements> {
     pub name: EcoString,
     pub documentation: Vec<EcoString>,
     pub type_info: Info,

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -15,6 +15,7 @@ use crate::analyse::Inferred;
 use crate::build::{Located, Target};
 use crate::parse::SpannedString;
 use crate::type_::expression::Implementations;
+use crate::type_::printer::TypeNames;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
@@ -36,16 +37,17 @@ pub trait HasLocation {
     fn location(&self) -> SrcSpan;
 }
 
-pub type TypedModule = Module<type_::ModuleInterface, TypedDefinition>;
+pub type TypedModule = Module<type_::ModuleInterface, TypedDefinition, TypeNames>;
 
-pub type UntypedModule = Module<(), TargetedDefinition>;
+pub type UntypedModule = Module<(), TargetedDefinition, ()>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Module<Info, Statements> {
+pub struct Module<Info, Statements, Extra> {
     pub name: EcoString,
     pub documentation: Vec<EcoString>,
     pub type_info: Info,
     pub definitions: Vec<Statements>,
+    pub extra: Extra,
 }
 
 impl TypedModule {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -15,7 +15,7 @@ use crate::analyse::Inferred;
 use crate::build::{Located, Target};
 use crate::parse::SpannedString;
 use crate::type_::expression::Implementations;
-use crate::type_::printer::TypeNames;
+use crate::type_::printer::Names;
 use crate::type_::{
     self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
@@ -37,7 +37,7 @@ pub trait HasLocation {
     fn location(&self) -> SrcSpan;
 }
 
-pub type TypedModule = Module<type_::ModuleInterface, TypedDefinition, TypeNames>;
+pub type TypedModule = Module<type_::ModuleInterface, TypedDefinition, Names>;
 
 pub type UntypedModule = Module<(), TargetedDefinition, ()>;
 

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -20,7 +20,6 @@ use crate::ast::{
     CallArg, CustomType, DefinitionLocation, Pattern, TypeAst, TypedArg, TypedDefinition,
     TypedExpr, TypedFunction, TypedPattern, TypedStatement,
 };
-use crate::type_::printer::TypeNames;
 use crate::type_::Type;
 use crate::{
     ast::{Definition, SrcSpan, TypedModule},

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -20,6 +20,7 @@ use crate::ast::{
     CallArg, CustomType, DefinitionLocation, Pattern, TypeAst, TypedArg, TypedDefinition,
     TypedExpr, TypedFunction, TypedPattern, TypedStatement,
 };
+use crate::type_::printer::TypeNames;
 use crate::type_::Type;
 use crate::{
     ast::{Definition, SrcSpan, TypedModule},

--- a/compiler-core/src/exhaustiveness/missing_patterns.rs
+++ b/compiler-core/src/exhaustiveness/missing_patterns.rs
@@ -74,7 +74,7 @@ fn add_missing_patterns(
 
         Decision::Failure => {
             let mut mapping = HashMap::new();
-            let printer = Printer::new(&environment.value_names);
+            let printer = Printer::new(&environment.names);
 
             // At this point the terms stack looks something like this:
             // `[term, term + arguments, term, ...]`. To construct a pattern

--- a/compiler-core/src/exhaustiveness/printer.rs
+++ b/compiler-core/src/exhaustiveness/printer.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use ecow::EcoString;
 
-use crate::type_::printer::{NameQualifier, Names};
+use crate::type_::printer::{NameContextInformation, Names};
 
 use super::{missing_patterns::Term, Variable};
 
@@ -54,9 +54,9 @@ impl<'a> Printer<'a> {
                 ..
             } => {
                 let (module, name) = match self.names.named_constructor(module, name) {
-                    NameQualifier::Qualified(m, n) => (Some(m), n),
-                    NameQualifier::Unqualified(n) => (None, n),
-                    NameQualifier::Unimported(n) => {
+                    NameContextInformation::Qualified(m, n) => (Some(m), n),
+                    NameContextInformation::Unqualified(n) => (None, n),
+                    NameContextInformation::Unimported(n) => {
                         (Some(module.split('/').last().unwrap_or(module)), n)
                     }
                 };

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -13,7 +13,7 @@ use crate::{
     line_numbers::LineNumbers,
     paths::ProjectPaths,
     type_::{
-        self, pretty::Printer, Deprecation, ModuleInterface, Type, TypeConstructor,
+        self, printer::Printer, Deprecation, ModuleInterface, Type, TypeConstructor,
         ValueConstructorVariant,
     },
     Error, Result, Warning,
@@ -360,7 +360,9 @@ where
                         symbols.push(DocumentSymbol {
                             name: name.to_string(),
                             detail: Some(
-                                Printer::new().pretty_print(&get_function_type(function), 0),
+                                Printer::new(&module.ast.extra)
+                                    .print_type(&get_function_type(function))
+                                    .to_string(),
                             ),
                             kind: SymbolKind::FUNCTION,
                             tags: make_deprecated_symbol_tag(&function.deprecation),
@@ -386,7 +388,11 @@ where
                         #[allow(deprecated)]
                         symbols.push(DocumentSymbol {
                             name: alias.alias.to_string(),
-                            detail: Some(Printer::new().pretty_print(&alias.type_, 0)),
+                            detail: Some(
+                                Printer::new(&module.ast.extra)
+                                    .print_type(&alias.type_)
+                                    .to_string(),
+                            ),
                             kind: SymbolKind::CLASS,
                             tags: make_deprecated_symbol_tag(&alias.deprecation),
                             deprecated: None,
@@ -400,7 +406,7 @@ where
                     }
 
                     Definition::CustomType(type_) => {
-                        symbols.push(custom_type_symbol(type_, &line_numbers));
+                        symbols.push(custom_type_symbol(type_, &line_numbers, module));
                     }
 
                     Definition::ModuleConstant(constant) => {
@@ -425,7 +431,11 @@ where
                         #[allow(deprecated)]
                         symbols.push(DocumentSymbol {
                             name: constant.name.to_string(),
-                            detail: Some(Printer::new().pretty_print(&constant.type_, 0)),
+                            detail: Some(
+                                Printer::new(&module.ast.extra)
+                                    .print_type(&constant.type_)
+                                    .to_string(),
+                            ),
                             kind: SymbolKind::CONSTANT,
                             tags: make_deprecated_symbol_tag(&constant.deprecation),
                             deprecated: None,
@@ -471,40 +481,50 @@ where
                 None => return Ok(None),
             };
 
+            let Some(module) = this.module_for_uri(&params.text_document.uri) else {
+                return Ok(None);
+            };
+
             Ok(match found {
                 Located::Statement(_) => None, // TODO: hover for statement
                 Located::ModuleStatement(Definition::Function(fun)) => {
-                    Some(hover_for_function_head(fun, lines))
+                    Some(hover_for_function_head(fun, lines, module))
                 }
                 Located::ModuleStatement(Definition::ModuleConstant(constant)) => {
-                    Some(hover_for_module_constant(constant, lines))
+                    Some(hover_for_module_constant(constant, lines, module))
                 }
                 Located::ModuleStatement(_) => None,
                 Located::UnqualifiedImport(UnqualifiedImport {
                     name,
-                    module,
+                    module: module_name,
                     is_type,
                     location,
                 }) => this
                     .compiler
-                    .get_module_interface(module.as_str())
-                    .and_then(|module| {
+                    .get_module_interface(module_name.as_str())
+                    .and_then(|module_interface| {
                         if is_type {
-                            module.types.get(name).map(|t| {
-                                hover_for_annotation(*location, t.type_.as_ref(), Some(t), lines)
+                            module_interface.types.get(name).map(|t| {
+                                hover_for_annotation(
+                                    *location,
+                                    t.type_.as_ref(),
+                                    Some(t),
+                                    lines,
+                                    module,
+                                )
                             })
                         } else {
-                            module.values.get(name).map(|v| {
-                                let m = if this.hex_deps.contains(&module.package) {
-                                    Some(module)
+                            module_interface.values.get(name).map(|v| {
+                                let m = if this.hex_deps.contains(&module_interface.package) {
+                                    Some(module_interface)
                                 } else {
                                     None
                                 };
-                                hover_for_imported_value(v, location, lines, m, name)
+                                hover_for_imported_value(v, location, lines, m, name, module)
                             })
                         }
                     }),
-                Located::Pattern(pattern) => Some(hover_for_pattern(pattern, lines)),
+                Located::Pattern(pattern) => Some(hover_for_pattern(pattern, lines, module)),
                 Located::PatternSpread {
                     spread_location,
                     arguments,
@@ -521,7 +541,8 @@ where
                             continue;
                         }
 
-                        let type_ = Printer::new().pretty_print(argument.value.type_().as_ref(), 0);
+                        let type_ = Printer::new(&module.ast.extra)
+                            .print_type(argument.value.type_().as_ref());
                         match &argument.label {
                             Some(label) => labelled.push(format!("- `{label}: {type_}`")),
                             None => positional.push(format!("- `{type_}`")),
@@ -547,17 +568,13 @@ Unused labelled fields:
                         range,
                     })
                 }
-                Located::Expression(expression) => {
-                    let module = this.module_for_uri(&params.text_document.uri);
-
-                    Some(hover_for_expression(
-                        expression,
-                        lines,
-                        module,
-                        &this.hex_deps,
-                    ))
-                }
-                Located::Arg(arg) => Some(hover_for_function_argument(arg, lines)),
+                Located::Expression(expression) => Some(hover_for_expression(
+                    expression,
+                    lines,
+                    module,
+                    &this.hex_deps,
+                )),
+                Located::Arg(arg) => Some(hover_for_function_argument(arg, lines, module)),
                 Located::FunctionBody(_) => None,
                 Located::Annotation(annotation, type_) => {
                     let type_constructor = type_constructor_from_modules(
@@ -569,6 +586,7 @@ Unused labelled fields:
                         &type_,
                         type_constructor,
                         lines,
+                        module,
                     ))
                 }
             })
@@ -633,7 +651,11 @@ Unused labelled fields:
     }
 }
 
-fn custom_type_symbol(type_: &CustomType<Arc<Type>>, line_numbers: &LineNumbers) -> DocumentSymbol {
+fn custom_type_symbol(
+    type_: &CustomType<Arc<Type>>,
+    line_numbers: &LineNumbers,
+    module: &Module,
+) -> DocumentSymbol {
     let constructors = type_
         .constructors
         .iter()
@@ -660,7 +682,11 @@ fn custom_type_symbol(type_: &CustomType<Arc<Type>>, line_numbers: &LineNumbers)
                 #[allow(deprecated)]
                 arguments.push(DocumentSymbol {
                     name: label.to_string(),
-                    detail: Some(Printer::new().pretty_print(&argument.type_, 0)),
+                    detail: Some(
+                        Printer::new(&module.ast.extra)
+                            .print_type(&argument.type_)
+                            .to_string(),
+                    ),
                     kind: SymbolKind::FIELD,
                     tags: None,
                     deprecated: None,
@@ -742,11 +768,11 @@ fn custom_type_symbol(type_: &CustomType<Arc<Type>>, line_numbers: &LineNumbers)
     }
 }
 
-fn hover_for_pattern(pattern: &TypedPattern, line_numbers: LineNumbers) -> Hover {
+fn hover_for_pattern(pattern: &TypedPattern, line_numbers: LineNumbers, module: &Module) -> Hover {
     let documentation = pattern.get_documentation().unwrap_or_default();
 
     // Show the type of the hovered node to the user
-    let type_ = Printer::new().pretty_print(pattern.type_().as_ref(), 0);
+    let type_ = Printer::new(&module.ast.extra).print_type(pattern.type_().as_ref());
     let contents = format!(
         "```gleam
 {type_}
@@ -766,7 +792,11 @@ fn get_function_type(fun: &TypedFunction) -> Type {
     }
 }
 
-fn hover_for_function_head(fun: &TypedFunction, line_numbers: LineNumbers) -> Hover {
+fn hover_for_function_head(
+    fun: &TypedFunction,
+    line_numbers: LineNumbers,
+    module: &Module,
+) -> Hover {
     let empty_str = EcoString::from("");
     let documentation = fun
         .documentation
@@ -774,7 +804,7 @@ fn hover_for_function_head(fun: &TypedFunction, line_numbers: LineNumbers) -> Ho
         .map(|(_, doc)| doc)
         .unwrap_or(&empty_str);
     let function_type = get_function_type(fun);
-    let formatted_type = Printer::new().pretty_print(&function_type, 0);
+    let formatted_type = Printer::new(&module.ast.extra).print_type(&function_type);
     let contents = format!(
         "```gleam
 {formatted_type}
@@ -787,8 +817,12 @@ fn hover_for_function_head(fun: &TypedFunction, line_numbers: LineNumbers) -> Ho
     }
 }
 
-fn hover_for_function_argument(argument: &TypedArg, line_numbers: LineNumbers) -> Hover {
-    let type_ = Printer::new().pretty_print(&argument.type_, 0);
+fn hover_for_function_argument(
+    argument: &TypedArg,
+    line_numbers: LineNumbers,
+    module: &Module,
+) -> Hover {
+    let type_ = Printer::new(&module.ast.extra).print_type(&argument.type_);
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
         contents: HoverContents::Scalar(MarkedString::String(contents)),
@@ -801,12 +835,13 @@ fn hover_for_annotation(
     annotation_type: &Type,
     type_constructor: Option<&TypeConstructor>,
     line_numbers: LineNumbers,
+    module: &Module,
 ) -> Hover {
     let empty_str = EcoString::from("");
     let documentation = type_constructor
         .and_then(|t| t.documentation.as_ref())
         .unwrap_or(&empty_str);
-    let type_ = Printer::new().pretty_print(annotation_type, 0);
+    let type_ = Printer::new(&module.ast.extra).print_type(annotation_type);
     let contents = format!(
         "```gleam
 {type_}
@@ -822,9 +857,10 @@ fn hover_for_annotation(
 fn hover_for_module_constant(
     constant: &ModuleConstant<Arc<Type>, EcoString>,
     line_numbers: LineNumbers,
+    module: &Module,
 ) -> Hover {
     let empty_str = EcoString::from("");
-    let type_ = Printer::new().pretty_print(&constant.type_, 0);
+    let type_ = Printer::new(&module.ast.extra).print_type(&constant.type_);
     let documentation = constant
         .documentation
         .as_ref()
@@ -840,20 +876,19 @@ fn hover_for_module_constant(
 fn hover_for_expression(
     expression: &TypedExpr,
     line_numbers: LineNumbers,
-    module: Option<&Module>,
+    module: &Module,
     hex_deps: &std::collections::HashSet<EcoString>,
 ) -> Hover {
     let documentation = expression.get_documentation().unwrap_or_default();
 
-    let link_section = module
-        .and_then(|m: &Module| {
-            let (module_name, name) = get_expr_qualified_name(expression)?;
-            get_hexdocs_link_section(module_name, name, &m.ast, hex_deps)
+    let link_section = get_expr_qualified_name(expression)
+        .and_then(|(module_name, name)| {
+            get_hexdocs_link_section(module_name, name, &module.ast, hex_deps)
         })
         .unwrap_or("".to_string());
 
     // Show the type of the hovered node to the user
-    let type_ = Printer::new().pretty_print(expression.type_().as_ref(), 0);
+    let type_ = Printer::new(&module.ast.extra).print_type(expression.type_().as_ref());
     let contents = format!(
         "```gleam
 {type_}
@@ -872,6 +907,7 @@ fn hover_for_imported_value(
     line_numbers: LineNumbers,
     hex_module_imported_from: Option<&ModuleInterface>,
     name: &EcoString,
+    module: &Module,
 ) -> Hover {
     let documentation = value.get_documentation().unwrap_or_default();
 
@@ -880,7 +916,7 @@ fn hover_for_imported_value(
     });
 
     // Show the type of the hovered node to the user
-    let type_ = Printer::new().pretty_print(value.type_.as_ref(), 0);
+    let type_ = Printer::new(&module.ast.extra).print_type(value.type_.as_ref());
     let contents = format!(
         "```gleam
 {type_}

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -390,7 +390,10 @@ where
                             name: alias.alias.to_string(),
                             detail: Some(
                                 Printer::new(&module.ast.names)
-                                    .print_type(&alias.type_)
+                                    // If we print with aliases, we end up printing the alias which the user
+                                    // is currently hovering, which is not helpful. Instead, we print the
+                                    // raw type, so the user can see which type the alias represents
+                                    .print_type_without_aliases(&alias.type_)
                                     .to_string(),
                             ),
                             kind: SymbolKind::CLASS,
@@ -841,7 +844,11 @@ fn hover_for_annotation(
     let documentation = type_constructor
         .and_then(|t| t.documentation.as_ref())
         .unwrap_or(&empty_str);
-    let type_ = Printer::new(&module.ast.names).print_type(annotation_type);
+    // If a user is hovering an annotation, it's not very useful to show the
+    // local representation of that type, since that's probably what they see
+    // in the source code anyway. So here, we print the raw type,
+    // which is probably more helpful.
+    let type_ = Printer::new(&module.ast.names).print_type_without_aliases(annotation_type);
     let contents = format!(
         "```gleam
 {type_}

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -360,7 +360,7 @@ where
                         symbols.push(DocumentSymbol {
                             name: name.to_string(),
                             detail: Some(
-                                Printer::new(&module.ast.extra)
+                                Printer::new(&module.ast.names)
                                     .print_type(&get_function_type(function))
                                     .to_string(),
                             ),
@@ -389,7 +389,7 @@ where
                         symbols.push(DocumentSymbol {
                             name: alias.alias.to_string(),
                             detail: Some(
-                                Printer::new(&module.ast.extra)
+                                Printer::new(&module.ast.names)
                                     .print_type(&alias.type_)
                                     .to_string(),
                             ),
@@ -432,7 +432,7 @@ where
                         symbols.push(DocumentSymbol {
                             name: constant.name.to_string(),
                             detail: Some(
-                                Printer::new(&module.ast.extra)
+                                Printer::new(&module.ast.names)
                                     .print_type(&constant.type_)
                                     .to_string(),
                             ),
@@ -541,7 +541,7 @@ where
                             continue;
                         }
 
-                        let type_ = Printer::new(&module.ast.extra)
+                        let type_ = Printer::new(&module.ast.names)
                             .print_type(argument.value.type_().as_ref());
                         match &argument.label {
                             Some(label) => labelled.push(format!("- `{label}: {type_}`")),
@@ -683,7 +683,7 @@ fn custom_type_symbol(
                 arguments.push(DocumentSymbol {
                     name: label.to_string(),
                     detail: Some(
-                        Printer::new(&module.ast.extra)
+                        Printer::new(&module.ast.names)
                             .print_type(&argument.type_)
                             .to_string(),
                     ),
@@ -772,7 +772,7 @@ fn hover_for_pattern(pattern: &TypedPattern, line_numbers: LineNumbers, module: 
     let documentation = pattern.get_documentation().unwrap_or_default();
 
     // Show the type of the hovered node to the user
-    let type_ = Printer::new(&module.ast.extra).print_type(pattern.type_().as_ref());
+    let type_ = Printer::new(&module.ast.names).print_type(pattern.type_().as_ref());
     let contents = format!(
         "```gleam
 {type_}
@@ -804,7 +804,7 @@ fn hover_for_function_head(
         .map(|(_, doc)| doc)
         .unwrap_or(&empty_str);
     let function_type = get_function_type(fun);
-    let formatted_type = Printer::new(&module.ast.extra).print_type(&function_type);
+    let formatted_type = Printer::new(&module.ast.names).print_type(&function_type);
     let contents = format!(
         "```gleam
 {formatted_type}
@@ -822,7 +822,7 @@ fn hover_for_function_argument(
     line_numbers: LineNumbers,
     module: &Module,
 ) -> Hover {
-    let type_ = Printer::new(&module.ast.extra).print_type(&argument.type_);
+    let type_ = Printer::new(&module.ast.names).print_type(&argument.type_);
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
         contents: HoverContents::Scalar(MarkedString::String(contents)),
@@ -841,7 +841,7 @@ fn hover_for_annotation(
     let documentation = type_constructor
         .and_then(|t| t.documentation.as_ref())
         .unwrap_or(&empty_str);
-    let type_ = Printer::new(&module.ast.extra).print_type(annotation_type);
+    let type_ = Printer::new(&module.ast.names).print_type(annotation_type);
     let contents = format!(
         "```gleam
 {type_}
@@ -860,7 +860,7 @@ fn hover_for_module_constant(
     module: &Module,
 ) -> Hover {
     let empty_str = EcoString::from("");
-    let type_ = Printer::new(&module.ast.extra).print_type(&constant.type_);
+    let type_ = Printer::new(&module.ast.names).print_type(&constant.type_);
     let documentation = constant
         .documentation
         .as_ref()
@@ -888,7 +888,7 @@ fn hover_for_expression(
         .unwrap_or("".to_string());
 
     // Show the type of the hovered node to the user
-    let type_ = Printer::new(&module.ast.extra).print_type(expression.type_().as_ref());
+    let type_ = Printer::new(&module.ast.names).print_type(expression.type_().as_ref());
     let contents = format!(
         "```gleam
 {type_}
@@ -916,7 +916,7 @@ fn hover_for_imported_value(
     });
 
     // Show the type of the hovered node to the user
-    let type_ = Printer::new(&module.ast.extra).print_type(value.type_.as_ref());
+    let type_ = Printer::new(&module.ast.names).print_type(value.type_.as_ref());
     let contents = format!(
         "```gleam
 {type_}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -796,3 +796,183 @@ pub fn main() {
         find_position_of("arg2:").nth_occurrence(2).under_char('r')
     );
 }
+
+#[test]
+fn hover_contextual_type() {
+    let code = "
+import wibble/wobble
+const value = wobble.Wobble
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wobble }"),
+        find_position_of("value").under_char('v')
+    );
+}
+
+#[test]
+fn hover_contextual_type_aliased_module() {
+    let code = "
+import wibble/wobble as wubble
+const value = wubble.Wobble
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wobble }"),
+        find_position_of("value").under_char('v')
+    );
+}
+
+#[test]
+fn hover_contextual_type_unqualified() {
+    let code = "
+import wibble/wobble.{type Wibble}
+const value = wobble.Wobble
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wobble }"),
+        find_position_of("value").under_char('v')
+    );
+}
+
+#[test]
+fn hover_contextual_type_unqualified_aliased() {
+    let code = "
+import wibble/wobble.{type Wibble as Wobble}
+const value = wobble.Wobble
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wobble }"),
+        find_position_of("value").under_char('v')
+    );
+}
+
+#[test]
+fn hover_contextual_type_aliased() {
+    let code = "
+import wibble/wobble
+type Local = wobble.Wibble
+const value = wobble.Wobble
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wobble }"),
+        find_position_of("value").under_char('v')
+    );
+}
+
+#[test]
+fn hover_contextual_type_function() {
+    let code = "
+import wibble/wobble
+type MyInt = Int
+fn func(value: wobble.Wibble) -> MyInt { 1 }
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wobble }"),
+        find_position_of("func").under_char('f')
+    );
+}
+
+#[test]
+fn hover_contextual_type_unqualified_import() {
+    let code = "
+import wibble/wobble.{type Wibble as Wobble, Wobble}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wobble }"),
+        find_position_of("Wobble}").under_char('W')
+    );
+}
+
+#[test]
+fn hover_contextual_type_pattern() {
+    let code = "
+import wibble/wobble.{Wibble, Wobble, Wubble}
+
+pub fn cycle(wibble: wobble.Wibble) {
+  case wibble {
+    Wibble -> Wobble
+    Wobble -> Wubble
+    Wubble -> Wibble
+  }
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code)
+            .add_hex_module("wibble/wobble", "pub type Wibble { Wibble Wobble Wubble }"),
+        find_position_of("Wubble ->").under_char('u')
+    );
+}
+
+#[test]
+fn hover_contextual_type_pattern_spread() {
+    let code = "
+import wibble/wobble.{type Wibble as Wobble}
+
+type Thing {
+  Thing(id: Int, value: Wobble)
+}
+
+pub fn main(thing: Thing) {
+  case thing {
+    Thing(id: 0, ..) -> 12
+    _ -> 14
+  }
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of("..").under_char('.')
+    );
+}
+
+#[test]
+fn hover_contextual_type_expression() {
+    let code = "
+import wibble/wobble
+
+pub fn main() {
+  let wibble = wobble.Wibble
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of(".Wibble").under_char('l')
+    );
+}
+
+#[test]
+fn hover_contextual_type_arg() {
+    let code = "
+import wibble/wobble
+
+fn do_things(wibble: wobble.Wibble) { wibble }
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of("wibble:").under_char('w')
+    );
+}
+
+#[test]
+fn hover_contextual_type_annotation() {
+    let code = "
+import wibble/wobble
+
+fn make_wibble() -> wobble.Wibble { wobble.Wibble }
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of("-> wobble").under_char('o')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -964,20 +964,6 @@ fn do_things(wibble: wobble.Wibble) { wibble }
 }
 
 #[test]
-fn hover_contextual_type_annotation() {
-    let code = "
-import wibble/wobble
-
-fn make_wibble() -> wobble.Wibble { wobble.Wibble }
-";
-
-    assert_hover!(
-        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
-        find_position_of("-> wobble").under_char('o')
-    );
-}
-
-#[test]
 fn hover_print_type_variable_names() {
     let code = "
 fn main(value: Result(ok, error)) {
@@ -1070,5 +1056,99 @@ const number = 100
     assert_hover!(
         TestProject::for_source(code).add_hex_module("numbers", "pub type Int"),
         find_position_of("number =").under_char('b')
+    );
+}
+
+#[test]
+fn hover_contextual_type_annotation() {
+    let code = "
+import wibble/wobble
+
+fn make_wibble() -> wobble.Wibble { wobble.Wibble }
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of("-> wobble").under_char('o')
+    );
+}
+
+#[test]
+fn hover_contextual_type_annotation_prelude() {
+    let code = "
+fn add_one(a: Int) -> Int {
+  a + 1
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of("-> Int").under_char('I')
+    );
+}
+
+#[test]
+fn hover_contextual_type_annotation_unqualified() {
+    let code = "
+import wibble/wobble.{type Wibble}
+
+fn main(wibble: Wibble) {
+  wibble
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of(": Wibble").under_char('W')
+    );
+}
+
+#[test]
+fn hover_contextual_type_annotation_unqualified_aliased() {
+    let code = "
+import wibble/wobble.{type Wibble as Wubble}
+
+fn main(wibble: Wubble) {
+  wibble
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of(": Wubble").under_char('W')
+    );
+}
+
+#[test]
+fn hover_contextual_type_annotation_aliased_module() {
+    let code = "
+import wibble/wobble as wubble
+
+fn main(wibble: wubble.Wibble) {
+  wibble
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of(": wubble").under_char('e')
+    );
+}
+
+#[test]
+fn hover_contextual_type_annotation_aliased() {
+    let code = "
+import wibble/wobble
+
+type Wubble = wobble.Wibble
+
+fn main(wibble: Wubble) {
+  wibble
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
+        find_position_of(": Wubble").under_char('e')
     );
 }

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1168,3 +1168,29 @@ fn do_thing() -> LocalResult {
         find_position_of("do_thing").under_char('d')
     );
 }
+
+#[test]
+fn hover_print_qualified_prelude_type_when_shadowed_by_alias() {
+    let code = "
+type Result = #(Bool, String)
+const ok = Ok(10)
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("ok").under_char('k')
+    );
+}
+
+#[test]
+fn hover_print_qualified_prelude_type_when_shadowed_by_imported_alias() {
+    let code = "
+import alias.{type Bool}
+const value = True
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("alias", "pub type Bool = #(Int, Int)"),
+        find_position_of("value").under_char('v')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1152,3 +1152,19 @@ fn main(wibble: Wubble) {
         find_position_of(": Wubble").under_char('e')
     );
 }
+
+#[test]
+fn hover_print_underlying_for_alias_with_parameters() {
+    let code = "
+type LocalResult = Result(String, Int)
+
+fn do_thing() -> LocalResult {
+  Error(1)
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("do_thing").under_char('d')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -20,7 +20,7 @@ pub fn show_hover(code: &str, range: Range, position: Position) -> String {
     // When we display the over range the end character is always excluded!
     let end = Position::new(end.line, end.character);
 
-    let mut str: String = "".into();
+    let mut buffer: String = "".into();
     for (line_number, line) in code.lines().enumerate() {
         let mut underline: String = "".into();
         let mut underline_empty = true;
@@ -38,15 +38,15 @@ pub fn show_hover(code: &str, range: Range, position: Position) -> String {
             }
         }
 
-        str.push_str(line);
+        buffer.push_str(line);
         if !underline_empty {
-            str.push('\n');
-            str.push_str(&underline);
+            buffer.push('\n');
+            buffer.push_str(&underline);
         }
-        str.push('\n');
+        buffer.push('\n');
     }
 
-    str
+    buffer
 }
 
 #[macro_export]

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1034,3 +1034,41 @@ const thing: Aliased = 10
         find_position_of("thing").under_char('g')
     );
 }
+
+#[test]
+fn hover_prelude_type() {
+    let code = "
+const number = 100
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("number").under_char('b')
+    );
+}
+
+#[test]
+fn hover_shadowed_prelude_type() {
+    let code = "
+type Int { Int }
+const number = 100
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("number").under_char('b')
+    );
+}
+
+#[test]
+fn hover_shadowed_prelude_type_imported() {
+    let code = "
+import numbers.{type Int}
+const number = 100
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("numbers", "pub type Int"),
+        find_position_of("number =").under_char('b')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -976,3 +976,48 @@ fn make_wibble() -> wobble.Wibble { wobble.Wibble }
         find_position_of("-> wobble").under_char('o')
     );
 }
+
+#[test]
+fn hover_print_type_variable_names() {
+    let code = "
+fn main(value: Result(ok, error)) {
+  let v = value
+  v
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("let v").under_char('v')
+    );
+}
+
+#[test]
+fn hover_print_unbound_type_variable_names() {
+    let code = "
+fn make_ok(value: some_type) {
+  let result = Ok(value)
+  result
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("result =").under_char('s')
+    );
+}
+
+#[test]
+fn hover_print_unbound_type_variable_name_without_conflicts() {
+    let code = "
+fn make_ok(value: a) {
+  let result = Ok(value)
+  result
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("result =").under_char('s')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1021,3 +1021,16 @@ fn make_ok(value: a) {
         find_position_of("result =").under_char('s')
     );
 }
+
+#[test]
+fn hover_print_imported_alias() {
+    let code = "
+import aliases.{type Aliased}
+const thing: Aliased = 10
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("aliases", "pub type Aliased = Int"),
+        find_position_of("thing").under_char('g')
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__document_symbols__doc_symbols_type_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__document_symbols__doc_symbols_type_alias.snap
@@ -6,7 +6,7 @@ expression: "doc_symbols(TestProject::for_source(code))"
     DocumentSymbol {
         name: "FFF",
         detail: Some(
-            "Int",
+            "gleam.Int",
         ),
         kind: Class,
         tags: None,
@@ -36,7 +36,7 @@ expression: "doc_symbols(TestProject::for_source(code))"
     DocumentSymbol {
         name: "FFFF",
         detail: Some(
-            "List(Int)",
+            "gleam.List(gleam.Int)",
         ),
         kind: Class,
         tags: None,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_assignment_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_assignment_annotation.snap
@@ -12,6 +12,6 @@ fn wibble() {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nInt\n```\n",
+        "```gleam\ngleam.Int\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\nconst value = wobble.Wobble\n"
+---
+import wibble/wobble
+const value = wobble.Wobble
+▔▔▔▔▔▔↑▔▔▔▔                
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\ntype Local = wobble.Wibble\nconst value = wobble.Wobble\n"
+---
+import wibble/wobble
+type Local = wobble.Wibble
+const value = wobble.Wobble
+▔▔▔▔▔▔↑▔▔▔▔                
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nLocal\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased_module.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble as wubble\nconst value = wubble.Wobble\n"
+---
+import wibble/wobble as wubble
+const value = wubble.Wobble
+▔▔▔▔▔▔↑▔▔▔▔                
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwubble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\n\nfn make_wibble() -> wobble.Wibble { wobble.Wibble }\n"
+---
+import wibble/wobble
+
+fn make_wibble() -> wobble.Wibble { wobble.Wibble }
+                    ▔↑▔▔▔▔▔▔▔▔▔▔▔                  
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_aliased.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_aliased.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\n\ntype Wubble = wobble.Wibble\n\nfn main(wibble: Wubble) {\n  wibble\n}\n"
+---
+import wibble/wobble
+
+type Wubble = wobble.Wibble
+
+fn main(wibble: Wubble) {
+                ▔▔▔▔▔↑   
+  wibble
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_aliased_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_aliased_module.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble as wubble\n\nfn main(wibble: wubble.Wibble) {\n  wibble\n}\n"
+---
+import wibble/wobble as wubble
+
+fn main(wibble: wubble.Wibble) {
+                ▔▔▔▔▔↑▔▔▔▔▔▔▔   
+  wibble
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwubble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_prelude.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_prelude.snap
@@ -1,9 +1,11 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: type Wibble = Int
+expression: "\nfn add_one(a: Int) -> Int {\n  a + 1\n}\n"
 ---
-type Wibble = Int
-              ▔↑▔
+fn add_one(a: Int) -> Int {
+                      ↑▔▔  
+  a + 1
+}
 
 
 ----- Hover content -----

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_unqualified.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_unqualified.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble.{type Wibble}\n\nfn main(wibble: Wibble) {\n  wibble\n}\n"
+---
+import wibble/wobble.{type Wibble}
+
+fn main(wibble: Wibble) {
+                ↑▔▔▔▔▔   
+  wibble
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_unqualified_aliased.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_unqualified_aliased.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble.{type Wibble as Wubble}\n\nfn main(wibble: Wubble) {\n  wibble\n}\n"
+---
+import wibble/wobble.{type Wibble as Wubble}
+
+fn main(wibble: Wubble) {
+                ↑▔▔▔▔▔   
+  wibble
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_arg.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_arg.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\n\nfn do_things(wibble: wobble.Wibble) { wibble }\n"
+---
+import wibble/wobble
+
+fn do_things(wibble: wobble.Wibble) { wibble }
+             ↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔            
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_expression.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_expression.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\n\npub fn main() {\n  let wibble = wobble.Wibble\n}\n"
+---
+import wibble/wobble
+
+pub fn main() {
+  let wibble = wobble.Wibble
+                     ▔▔▔▔▔↑▔
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/wibble/wobble.html#Wibble)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_function.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\ntype MyInt = Int\nfn func(value: wobble.Wibble) -> MyInt { 1 }\n"
+---
+import wibble/wobble
+type MyInt = Int
+fn func(value: wobble.Wibble) -> MyInt { 1 }
+▔▔▔↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔      
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(wobble.Wibble) -> MyInt\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_pattern.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble.{Wibble, Wobble, Wubble}\n\npub fn cycle(wibble: wobble.Wibble) {\n  case wibble {\n    Wibble -> Wobble\n    Wobble -> Wubble\n    Wubble -> Wibble\n  }\n}\n"
+---
+import wibble/wobble.{Wibble, Wobble, Wubble}
+
+pub fn cycle(wibble: wobble.Wibble) {
+  case wibble {
+    Wibble -> Wobble
+    Wobble -> Wubble
+    Wubble -> Wibble
+    ▔↑▔▔▔▔          
+  }
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwobble.Wibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_pattern_spread.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_pattern_spread.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble.{type Wibble as Wobble}\n\ntype Thing {\n  Thing(id: Int, value: Wobble)\n}\n\npub fn main(thing: Thing) {\n  case thing {\n    Thing(id: 0, ..) -> 12\n    _ -> 14\n  }\n}\n"
+---
+import wibble/wobble.{type Wibble as Wobble}
+
+type Thing {
+  Thing(id: Int, value: Wobble)
+}
+
+pub fn main(thing: Thing) {
+  case thing {
+    Thing(id: 0, ..) -> 12
+                 ↑▔       
+    _ -> 14
+  }
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "Unused labelled fields:\n- `value: Wobble`",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble.{type Wibble}\nconst value = wobble.Wobble\n"
+---
+import wibble/wobble.{type Wibble}
+const value = wobble.Wobble
+▔▔▔▔▔▔↑▔▔▔▔                
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nWibble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified_aliased.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified_aliased.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble.{type Wibble as Wobble}\nconst value = wobble.Wobble\n"
+---
+import wibble/wobble.{type Wibble as Wobble}
+const value = wobble.Wobble
+▔▔▔▔▔▔↑▔▔▔▔                
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nWobble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified_import.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified_import.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble.{type Wibble as Wobble, Wobble}\n"
+---
+import wibble/wobble.{type Wibble as Wobble, Wobble}
+                                             ↑▔▔▔▔▔ 
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nWobble\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/wibble/wobble.html#Wobble)",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_2.snap
@@ -13,6 +13,6 @@ fn append(x: String, y: String) -> String {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nString\n```\n",
+        "```gleam\ngleam.String\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_with_documentation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_arg_annotation_with_documentation.snap
@@ -17,6 +17,6 @@ fn identity(x: Wibble) -> Wibble {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nWibble\n```\n Exciting documentation\n Maybe even multiple lines\n",
+        "```gleam\napp.Wibble\n```\n Exciting documentation\n Maybe even multiple lines\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation.snap
@@ -13,6 +13,6 @@ fn append(x: String, y: String) -> String {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nString\n```\n",
+        "```gleam\ngleam.String\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation_with_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_return_annotation_with_tuple.snap
@@ -13,6 +13,6 @@ fn append(x: String, y: String) -> #(String, String) {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nString\n```\n",
+        "```gleam\ngleam.String\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_import_unqualified_type.snap
@@ -12,6 +12,6 @@ fn main() -> MyType {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nMyType\n```\n Exciting documentation\n Maybe even multiple lines\n",
+        "```gleam\nexample_module.MyType\n```\n Exciting documentation\n Maybe even multiple lines\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant_annotation.snap
@@ -11,6 +11,6 @@ const one: Int = 1
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nInt\n```\n",
+        "```gleam\ngleam.Int\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_prelude_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_prelude_type.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst number = 100\n"
+---
+const number = 100
+▔▔▔▔▔▔▔▔▔↑▔▔      
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_imported_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_imported_alias.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport aliases.{type Aliased}\nconst thing: Aliased = 10\n"
+---
+import aliases.{type Aliased}
+const thing: Aliased = 10
+▔▔▔▔▔▔▔▔▔▔↑▔▔▔▔▔▔▔▔▔     
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nAliased\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_alias.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype Result = #(Bool, String)\nconst ok = Ok(10)\n"
+---
+type Result = #(Bool, String)
+const ok = Ok(10)
+▔▔▔▔▔▔▔↑         
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\ngleam.Result(Int, a)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_imported_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_imported_alias.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport alias.{type Bool}\nconst value = True\n"
+---
+import alias.{type Bool}
+const value = True
+▔▔▔▔▔▔↑▔▔▔▔       
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\ngleam.Bool\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_type_variable_names.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_type_variable_names.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn main(value: Result(ok, error)) {\n  let v = value\n  v\n}\n"
+---
+fn main(value: Result(ok, error)) {
+  let v = value
+      ↑        
+  v
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nResult(ok, error)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_unbound_type_variable_name_without_conflicts.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_unbound_type_variable_name_without_conflicts.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn make_ok(value: a) {\n  let result = Ok(value)\n  result\n}\n"
+---
+fn make_ok(value: a) {
+  let result = Ok(value)
+      ▔▔↑▔▔▔            
+  result
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nResult(a, b)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_unbound_type_variable_names.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_unbound_type_variable_names.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nfn make_ok(value: some_type) {\n  let result = Ok(value)\n  result\n}\n"
+---
+fn make_ok(value: some_type) {
+  let result = Ok(value)
+      ▔▔↑▔▔▔            
+  result
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nResult(some_type, a)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_alias_with_parameters.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_alias_with_parameters.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype LocalResult = Result(String, Int)\n\nfn do_thing() -> LocalResult {\n  Error(1)\n}\n"
+---
+type LocalResult = Result(String, Int)
+
+fn do_thing() -> LocalResult {
+▔▔▔↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔  
+  Error(1)
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Result(String, Int)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_alias_with_parameters.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_alias_with_parameters.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
+assertion_line: 1166
 expression: "\ntype LocalResult = Result(String, Int)\n\nfn do_thing() -> LocalResult {\n  Error(1)\n}\n"
 ---
 type LocalResult = Result(String, Int)
@@ -13,6 +14,6 @@ fn do_thing() -> LocalResult {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nfn() -> Result(String, Int)\n```\n",
+        "```gleam\nfn() -> LocalResult(String, Int)\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype Int { Int }\nconst number = 100\n"
+---
+type Int { Int }
+const number = 100
+▔▔▔▔▔▔▔▔▔↑▔▔      
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\ngleam.Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type_imported.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport numbers.{type Int}\nconst number = 100\n"
+---
+import numbers.{type Int}
+const number = 100
+▔▔▔▔▔▔▔▔▔↑▔▔      
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\ngleam.Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_constructor_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_constructor_annotation.snap
@@ -11,6 +11,6 @@ type Wibble {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nString\n```\n",
+        "```gleam\ngleam.String\n```\n",
     ),
 )

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -242,7 +242,7 @@ where
             documentation: vec![],
             type_info: (),
             definitions,
-            names: (),
+            names: Default::default(),
         };
         Ok(Parsed {
             module,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -242,7 +242,7 @@ where
             documentation: vec![],
             type_info: (),
             definitions,
-            extra: (),
+            names: (),
         };
         Ok(Parsed {
             module,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -242,6 +242,7 @@ where
             documentation: vec![],
             type_info: (),
             definitions,
+            extra: (),
         };
         Ok(Parsed {
             module,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -95,7 +95,14 @@ Parsed {
                 target: None,
             },
         ],
-        names: (),
+        names: Names {
+            local_types: {},
+            unshadowed_prelude_types: {},
+            imported_modules: {},
+            type_variables: {},
+            local_value_constructors: {},
+            constructor_names: {},
+        },
     },
     extra: ModuleExtra {
         module_comments: [],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -97,7 +97,6 @@ Parsed {
         ],
         names: Names {
             local_types: {},
-            unshadowed_prelude_types: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -95,6 +95,7 @@ Parsed {
                 target: None,
             },
         ],
+        names: (),
     },
     extra: ModuleExtra {
         module_comments: [],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -52,7 +52,14 @@ Parsed {
                 target: None,
             },
         ],
-        names: (),
+        names: Names {
+            local_types: {},
+            unshadowed_prelude_types: {},
+            imported_modules: {},
+            type_variables: {},
+            local_value_constructors: {},
+            constructor_names: {},
+        },
     },
     extra: ModuleExtra {
         module_comments: [],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -54,7 +54,6 @@ Parsed {
         ],
         names: Names {
             local_types: {},
-            unshadowed_prelude_types: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -52,6 +52,7 @@ Parsed {
                 target: None,
             },
         ],
+        names: (),
     },
     extra: ModuleExtra {
         module_comments: [],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -159,7 +159,6 @@ Parsed {
         ],
         names: Names {
             local_types: {},
-            unshadowed_prelude_types: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -157,7 +157,14 @@ Parsed {
                 target: None,
             },
         ],
-        names: (),
+        names: Names {
+            local_types: {},
+            unshadowed_prelude_types: {},
+            imported_modules: {},
+            type_variables: {},
+            local_value_constructors: {},
+            constructor_names: {},
+        },
     },
     extra: ModuleExtra {
         module_comments: [],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -157,6 +157,7 @@ Parsed {
                 target: None,
             },
         ],
+        names: (),
     },
     extra: ModuleExtra {
         module_comments: [],

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -19,7 +19,7 @@ pub(crate) use expression::ExprTyper;
 pub use fields::FieldMap;
 use hexpm::version::Version;
 pub use prelude::*;
-use printer::TypeNames;
+use printer::Names;
 use serde::Serialize;
 
 use crate::{

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -19,6 +19,7 @@ pub(crate) use expression::ExprTyper;
 pub use fields::FieldMap;
 use hexpm::version::Version;
 pub use prelude::*;
+use printer::TypeNames;
 use serde::Serialize;
 
 use crate::{

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -90,7 +90,7 @@ impl<'a> Environment<'a> {
         }
 
         for name in prelude.types.keys() {
-            names.prelude_type(name.clone());
+            names.named_type_in_scope(PRELUDE_MODULE_NAME.into(), name.clone(), name.clone());
         }
 
         Self {

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -90,7 +90,7 @@ impl<'a> Environment<'a> {
         }
 
         for name in prelude.types.keys() {
-            names.named_type_in_scope(PRELUDE_MODULE_NAME.into(), name.clone(), name.clone());
+            names.prelude_type(name.clone());
         }
 
         Self {

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -64,7 +64,9 @@ pub struct Environment<'a> {
     /// compilation target.
     pub target_support: TargetSupport,
 
+    // TODO: Merge these into one struct
     pub value_names: ValueNames,
+    pub type_names: TypeNames,
 }
 
 impl<'a> Environment<'a> {
@@ -90,6 +92,11 @@ impl<'a> Environment<'a> {
             );
         }
 
+        let mut type_names = TypeNames::new();
+        for name in prelude.types.keys() {
+            type_names.named_type_in_scope(PRELUDE_MODULE_NAME.into(), name.clone(), name.clone());
+        }
+
         Self {
             current_package: current_package.clone(),
             gleam_version,
@@ -112,6 +119,7 @@ impl<'a> Environment<'a> {
             entity_usages: vec![HashMap::new()],
             target_support,
             value_names,
+            type_names,
         }
     }
 }

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -5,7 +5,6 @@ use crate::{
     ast::{Publicity, PIPE_VARIABLE},
     build::Target,
     error::edit_distance,
-    exhaustiveness::printer::ValueNames,
     uid::UniqueIdGenerator,
 };
 
@@ -64,9 +63,7 @@ pub struct Environment<'a> {
     /// compilation target.
     pub target_support: TargetSupport,
 
-    // TODO: Merge these into one struct
-    pub value_names: ValueNames,
-    pub type_names: TypeNames,
+    pub names: Names,
 }
 
 impl<'a> Environment<'a> {
@@ -83,18 +80,17 @@ impl<'a> Environment<'a> {
             .get(PRELUDE_MODULE_NAME)
             .expect("Unable to find prelude in importable modules");
 
-        let mut value_names = ValueNames::new();
+        let mut names = Names::new();
         for name in prelude.values.keys() {
-            value_names.named_constructor_in_scope(
+            names.named_constructor_in_scope(
                 PRELUDE_MODULE_NAME.into(),
                 name.clone(),
                 name.clone(),
             );
         }
 
-        let mut type_names = TypeNames::new();
         for name in prelude.types.keys() {
-            type_names.named_type_in_scope(PRELUDE_MODULE_NAME.into(), name.clone(), name.clone());
+            names.named_type_in_scope(PRELUDE_MODULE_NAME.into(), name.clone(), name.clone());
         }
 
         Self {
@@ -118,8 +114,7 @@ impl<'a> Environment<'a> {
             current_module,
             entity_usages: vec![HashMap::new()],
             target_support,
-            value_names,
-            type_names,
+            names,
         }
     }
 }

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -226,7 +226,7 @@ impl Hydrator {
                             .rigid_type_names
                             .insert(environment.previous_uid(), name.clone());
                         environment
-                            .type_names
+                            .names
                             .type_variable_in_scope(environment.previous_uid(), name.clone());
                         let _ = self.created_type_variables.insert(
                             name.clone(),
@@ -290,7 +290,7 @@ impl Hydrator {
         };
 
         environment
-            .type_names
+            .names
             .type_variable_in_scope(environment.previous_uid(), name.clone());
         match self.created_type_variables.insert(name.clone(), v) {
             Some(_) => Err(t),

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -225,6 +225,9 @@ impl Hydrator {
                         let _ = self
                             .rigid_type_names
                             .insert(environment.previous_uid(), name.clone());
+                        environment
+                            .type_names
+                            .type_variable_in_scope(environment.previous_uid(), name.clone());
                         let _ = self.created_type_variables.insert(
                             name.clone(),
                             CreatedTypeVariable {
@@ -285,6 +288,10 @@ impl Hydrator {
             type_: t.clone(),
             usage_count: 0,
         };
+
+        environment
+            .type_names
+            .type_variable_in_scope(environment.previous_uid(), name.clone());
         match self.created_type_variables.insert(name.clone(), v) {
             Some(_) => Err(t),
             None => Ok(t),

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -165,12 +165,22 @@ impl Names {
         type_name: EcoString,
         local_alias: EcoString,
     ) {
-        // If this is a type in the prelude, it is now shadowed.
-        _ = self.unshadowed_prelude_types.remove(&local_alias);
-
+        self.type_exists_in_scope(&local_alias);
         _ = self
             .local_types
             .insert((module_name, type_name), local_alias);
+    }
+
+    /// Record a type existing in the current module. This is for types
+    /// which define a name in the current scope, but do not represent a
+    /// named type (aliases). This exists so we can correctly print
+    /// prelude types, even if they are shadowed by an alias like:
+    /// ```gleam
+    /// type Pair = #(String, Int)
+    /// ```
+    pub fn type_exists_in_scope(&mut self, name: &EcoString) {
+        // If this is a type in the prelude, it is now shadowed.
+        _ = self.unshadowed_prelude_types.remove(name);
     }
 
     pub fn prelude_type(&mut self, name: EcoString) {

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -666,7 +666,7 @@ fn infer_module_type_retention_test() {
         name: "ok".into(),
         definitions: vec![],
         type_info: (),
-        extra: (),
+        names: (),
     };
     let direct_dependencies = HashMap::from_iter(vec![]);
     let ids = UniqueIdGenerator::new();

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -666,6 +666,7 @@ fn infer_module_type_retention_test() {
         name: "ok".into(),
         definitions: vec![],
         type_info: (),
+        extra: (),
     };
     let direct_dependencies = HashMap::from_iter(vec![]);
     let ids = UniqueIdGenerator::new();

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -666,7 +666,7 @@ fn infer_module_type_retention_test() {
         name: "ok".into(),
         definitions: vec![],
         type_info: (),
-        names: (),
+        names: Default::default(),
     };
     let direct_dependencies = HashMap::from_iter(vec![]);
     let ids = UniqueIdGenerator::new();


### PR DESCRIPTION
Closes #2993 
This uses the `Printer` implemented in #3007 to print correctly qualified or aliased type names when hovering with the language server. I've had to slightly rework the printer so it doesn't take a mutable reference to `TypeNames`, because that wasn't really feasible in the context of the language server.

**TODO**
<details>
<summary>Done</summary>

- [x] Fix the case where a type alias's generics don't map one-to-one with the aliased type, for example:
  ```gleam
  type LocalResult = Result(LocalType, LocalError)
  let a: LocalResult = local_fallible_function()
  //  ^ hovering here shows `LocalResult(LocalType, LocalError)`
  ```

- [x] Write tests for these new cases
- [x] Merge the `TypeNames` struct with the `ValueNames` struct for pattern-printing, as they have very similar semantics and functionality
- [x] Store information about type variables in the `TypeNames` struct when they are created, so we can print these properly
- [x] Correctly qualify prelude types when shadowed
- [x] When importing a type alias, treat is as a local alias rather than a local custom type
- [x] Don't alias types when hovering over the annotation for an alias itself:
```gleam
type Number = Int
//            ^ Hovering here shows `Number`, because we've aliased it, but it should probably print `Int`
```
</details>

**Questions**
1. Currently, this change is for hover and document symbols, which are the two things which use the pretty printer in `engine.rs`. There's also signature help, which could probably benefit from this. Any other places we would want this? Maybe in the little hint for value completions?
2. How should aliases other than the trivial case of `type A = B` be handled? Should we try to print alias names for complex types like `#(fn(Int) -> Float, Result(String, BitArray))`, or just leave it as is?