### PR TITLE
Add support for updating specific packages and their dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@
   symlinks.
   ([Louis Pilfold](https://github.com/lpil))
 
+- The cli can now update individual dependencies.
+
+  `gleam update` and `gleam deps update` now take an optional list of package names to update:
+
+  ```shell
+  gleam update package_a
+  gleam deps update package_b package_c
+  ```
+
+  This allows for selective updating of dependencies.
+  When package names are provided, only those packages and their unique dependencies are unlocked and updated.
+  If no package names are specified, the command behaves as before, updating all dependencies.
+
+  ([Jason Sipula](https://github.com/SnakeDoc))
+
 ### Compiler
 
 - The compiler now prints correctly qualified or aliased type names when

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -25,6 +25,7 @@ pub fn command(packages_to_add: Vec<String>, dev: bool) -> Result<()> {
         &paths,
         cli::Reporter::new(),
         Some((new_package_requirements.clone(), dev)),
+        None,
         UseManifest::Yes,
     )?;
 

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -25,7 +25,7 @@ pub fn command(packages_to_add: Vec<String>, dev: bool) -> Result<()> {
         &paths,
         cli::Reporter::new(),
         Some((new_package_requirements.clone(), dev)),
-        None,
+        Vec::new(),
         UseManifest::Yes,
     )?;
 

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -17,7 +17,7 @@ use crate::{
 
 pub fn download_dependencies(telemetry: impl Telemetry) -> Result<Manifest> {
     let paths = crate::find_project_paths()?;
-    crate::dependencies::download(&paths, telemetry, None, None, UseManifest::Yes)
+    crate::dependencies::download(&paths, telemetry, None, Vec::new(), UseManifest::Yes)
 }
 
 pub fn main(options: Options, manifest: Manifest) -> Result<Built> {

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -17,7 +17,7 @@ use crate::{
 
 pub fn download_dependencies(telemetry: impl Telemetry) -> Result<Manifest> {
     let paths = crate::find_project_paths()?;
-    crate::dependencies::download(&paths, telemetry, None, UseManifest::Yes)
+    crate::dependencies::download(&paths, telemetry, None, None, UseManifest::Yes)
 }
 
 pub fn main(options: Options, manifest: Manifest) -> Result<Built> {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1572,53 +1572,6 @@ fn test_unlock_nonexistent_package() {
 }
 
 #[test]
-fn test_unlock_circular_dependencies() {
-    let mut locked = HashMap::from([
-        ("package_a".into(), Version::new(1, 0, 0)),
-        ("package_b".into(), Version::new(2, 0, 0)),
-        ("package_c".into(), Version::new(3, 0, 0)),
-    ]);
-
-    let manifest_packages = vec![
-        ManifestPackage {
-            name: "package_a".into(),
-            version: Version::new(1, 0, 0),
-            build_tools: vec!["gleam".into()],
-            otp_app: None,
-            requirements: vec!["package_b".into()],
-            source: ManifestPackageSource::Hex {
-                outer_checksum: Base16Checksum(vec![]),
-            },
-        },
-        ManifestPackage {
-            name: "package_b".into(),
-            version: Version::new(2, 0, 0),
-            build_tools: vec!["gleam".into()],
-            otp_app: None,
-            requirements: vec!["package_c".into()],
-            source: ManifestPackageSource::Hex {
-                outer_checksum: Base16Checksum(vec![]),
-            },
-        },
-        ManifestPackage {
-            name: "package_c".into(),
-            version: Version::new(3, 0, 0),
-            build_tools: vec!["gleam".into()],
-            otp_app: None,
-            requirements: vec!["package_a".into()],
-            source: ManifestPackageSource::Hex {
-                outer_checksum: Base16Checksum(vec![]),
-            },
-        },
-    ];
-
-    let packages_to_unlock = vec!["package_a".into()];
-    unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
-
-    assert!(locked.is_empty(), "All packages should be unlocked due to circular dependency");
-}
-
-#[test]
 fn test_unlock_multiple_packages() {
     let mut locked = HashMap::from([
         ("package_a".into(), Version::new(1, 0, 0)),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1459,7 +1459,7 @@ fn verified_requirements_equality_with_canonicalized_paths() {
 
 #[test]
 fn test_unlock_package() {
-    let locked = HashMap::from([
+    let mut locked = HashMap::from([
         ("package_a".into(), Version::new(1, 0, 0)),
         ("package_b".into(), Version::new(2, 0, 0)),
         ("package_c".into(), Version::new(3, 0, 0)),
@@ -1510,33 +1510,33 @@ fn test_unlock_package() {
     ];
 
     let packages_to_unlock = vec!["package_a".into()];
-    let result = unlock_packages(&packages_to_unlock, &locked, Some(&manifest_packages)).unwrap();
+    unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
 
-    assert!(!result.contains_key("package_a"));
-    assert!(!result.contains_key("package_b"));
-    assert!(!result.contains_key("package_c"));
-    assert!(result.contains_key("package_d"));
+    assert!(!locked.contains_key("package_a"));
+    assert!(!locked.contains_key("package_b"));
+    assert!(!locked.contains_key("package_c"));
+    assert!(locked.contains_key("package_d"));
 }
 
 #[test]
 fn test_unlock_package_without_manifest() {
-    let locked = HashMap::from([
+    let mut locked = HashMap::from([
         ("package_a".into(), Version::new(1, 0, 0)),
         ("package_b".into(), Version::new(2, 0, 0)),
         ("package_c".into(), Version::new(3, 0, 0)),
     ]);
 
     let packages_to_unlock = vec!["package_a".into()];
-    let result = unlock_packages(&packages_to_unlock, &locked, None).unwrap();
+    unlock_packages(&mut locked, &packages_to_unlock, None).unwrap();
 
-    assert!(!result.contains_key("package_a"));
-    assert!(result.contains_key("package_b"));
-    assert!(result.contains_key("package_c"));
+    assert!(!locked.contains_key("package_a"));
+    assert!(locked.contains_key("package_b"));
+    assert!(locked.contains_key("package_c"));
 }
 
 #[test]
 fn test_unlock_nonexistent_package() {
-    let locked = HashMap::from([
+    let initial_locked = HashMap::from([
         ("package_a".into(), Version::new(1, 0, 0)),
         ("package_b".into(), Version::new(2, 0, 0)),
     ]);
@@ -1565,14 +1565,15 @@ fn test_unlock_nonexistent_package() {
     ];
 
     let packages_to_unlock = vec!["nonexistent_package".into()];
-    let result = unlock_packages(&packages_to_unlock, &locked, Some(&manifest_packages)).unwrap();
+    let mut locked = initial_locked.clone();
+    unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
 
-    assert_eq!(result, locked, "Locked packages should remain unchanged");
+    assert_eq!(initial_locked, locked, "Locked packages should remain unchanged");
 }
 
 #[test]
 fn test_unlock_circular_dependencies() {
-    let locked = HashMap::from([
+    let mut locked = HashMap::from([
         ("package_a".into(), Version::new(1, 0, 0)),
         ("package_b".into(), Version::new(2, 0, 0)),
         ("package_c".into(), Version::new(3, 0, 0)),
@@ -1612,14 +1613,14 @@ fn test_unlock_circular_dependencies() {
     ];
 
     let packages_to_unlock = vec!["package_a".into()];
-    let result = unlock_packages(&packages_to_unlock, &locked, Some(&manifest_packages)).unwrap();
+    unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
 
-    assert!(result.is_empty(), "All packages should be unlocked due to circular dependency");
+    assert!(locked.is_empty(), "All packages should be unlocked due to circular dependency");
 }
 
 #[test]
 fn test_unlock_multiple_packages() {
-    let locked = HashMap::from([
+    let mut locked = HashMap::from([
         ("package_a".into(), Version::new(1, 0, 0)),
         ("package_b".into(), Version::new(2, 0, 0)),
         ("package_c".into(), Version::new(3, 0, 0)),
@@ -1681,18 +1682,18 @@ fn test_unlock_multiple_packages() {
     ];
 
     let packages_to_unlock = vec!["package_a".into(), "package_d".into()];
-    let result = unlock_packages(&packages_to_unlock, &locked, Some(&manifest_packages)).unwrap();
+    unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
 
-    assert!(!result.contains_key("package_a"));
-    assert!(!result.contains_key("package_b"));
-    assert!(!result.contains_key("package_c"));
-    assert!(!result.contains_key("package_d"));
-    assert!(!result.contains_key("package_e"));
+    assert!(!locked.contains_key("package_a"));
+    assert!(!locked.contains_key("package_b"));
+    assert!(!locked.contains_key("package_c"));
+    assert!(!locked.contains_key("package_d"));
+    assert!(!locked.contains_key("package_e"));
 }
 
 #[test]
 fn test_unlock_packages_empty_input() {
-    let locked = HashMap::from([
+    let initial_locked = HashMap::from([
         ("package_a".into(), Version::new(1, 0, 0)),
         ("package_b".into(), Version::new(2, 0, 0)),
     ]);
@@ -1721,7 +1722,8 @@ fn test_unlock_packages_empty_input() {
     ];
 
     let packages_to_unlock: Vec<EcoString> = vec![];
-    let result = unlock_packages(&packages_to_unlock, &locked, Some(&manifest_packages)).unwrap();
+    let mut locked = initial_locked.clone();
+    unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
 
-    assert_eq!(result, locked, "Locked packages should remain unchanged when no packages are specified to unlock");
+    assert_eq!(initial_locked, locked, "Locked packages should remain unchanged when no packages are specified to unlock");
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1057,11 +1057,12 @@ fn find_deps_to_unlock(
         .requirements
         .iter()
         .filter(|&dep| {
-            locked.contains_key(dep) &&
-            !manifest.requirements.contains_key(dep) &&
-            manifest.packages
-                .iter()
-                .all(|p| !locked.contains_key(&p.name) || !p.requirements.contains(dep))
+            locked.contains_key(dep)
+                && !manifest.requirements.contains_key(dep)
+                && manifest
+                    .packages
+                    .iter()
+                    .all(|p| !locked.contains_key(&p.name) || !p.requirements.contains(dep))
         })
         .cloned()
         .collect()
@@ -1530,7 +1531,12 @@ fn create_testable_unlock_manifest(
     let root_requirements = requirements
         .into_iter()
         .map(|(name, range)| {
-            (name, Requirement::Hex { version: hexpm::version::Range::new(range.into()) })
+            (
+                name,
+                Requirement::Hex {
+                    version: hexpm::version::Range::new(range.into()),
+                },
+            )
         })
         .collect();
 
@@ -1550,8 +1556,16 @@ fn test_unlock_package() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_b".into()]),
-        ("package_b".into(), Version::new(2, 0, 0), vec!["package_c".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_b".into()],
+        ),
+        (
+            "package_b".into(),
+            Version::new(2, 0, 0),
+            vec!["package_c".into()],
+        ),
         ("package_c".into(), Version::new(3, 0, 0), vec![]),
         ("package_d".into(), Version::new(4, 0, 0), vec![]),
     ];
@@ -1591,7 +1605,11 @@ fn test_unlock_nonexistent_package() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_b".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_b".into()],
+        ),
         ("package_b".into(), Version::new(2, 0, 0), vec![]),
     ];
 
@@ -1618,10 +1636,22 @@ fn test_unlock_multiple_packages() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_b".into()]),
-        ("package_b".into(), Version::new(2, 0, 0), vec!["package_c".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_b".into()],
+        ),
+        (
+            "package_b".into(),
+            Version::new(2, 0, 0),
+            vec!["package_c".into()],
+        ),
         ("package_c".into(), Version::new(3, 0, 0), vec![]),
-        ("package_d".into(), Version::new(4, 0, 0), vec!["package_e".into()]),
+        (
+            "package_d".into(),
+            Version::new(4, 0, 0),
+            vec!["package_e".into()],
+        ),
         ("package_e".into(), Version::new(5, 0, 0), vec![]),
     ];
 
@@ -1645,7 +1675,11 @@ fn test_unlock_packages_empty_input() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_b".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_b".into()],
+        ),
         ("package_b".into(), Version::new(2, 0, 0), vec![]),
     ];
 
@@ -1670,8 +1704,16 @@ fn test_unlock_package_preserve_shared_deps() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_c".into()]),
-        ("package_b".into(), Version::new(2, 0, 0), vec!["package_c".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_c".into()],
+        ),
+        (
+            "package_b".into(),
+            Version::new(2, 0, 0),
+            vec!["package_c".into()],
+        ),
         ("package_c".into(), Version::new(3, 0, 0), vec![]),
     ];
 
@@ -1694,14 +1736,20 @@ fn test_unlock_package_with_root_dep() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_b".into()]),
-        ("package_b".into(), Version::new(2, 0, 0), vec!["package_c".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_b".into()],
+        ),
+        (
+            "package_b".into(),
+            Version::new(2, 0, 0),
+            vec!["package_c".into()],
+        ),
         ("package_c".into(), Version::new(3, 0, 0), vec![]),
     ];
 
-    let requirements = vec![
-        ("package_b".into(), ">= 2.0.0".into()),
-    ];
+    let requirements = vec![("package_b".into(), ">= 2.0.0".into())];
 
     let manifest = create_testable_unlock_manifest(packages, requirements);
 
@@ -1722,14 +1770,16 @@ fn test_unlock_root_dep_package() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_b".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_b".into()],
+        ),
         ("package_b".into(), Version::new(2, 0, 0), vec![]),
         ("package_c".into(), Version::new(3, 0, 0), vec![]),
     ];
 
-    let requirements = vec![
-        ("package_a".into(), ">= 1.0.0".into()),
-    ];
+    let requirements = vec![("package_a".into(), ">= 1.0.0".into())];
 
     let manifest = create_testable_unlock_manifest(packages, requirements);
 
@@ -1750,14 +1800,16 @@ fn test_unlock_package_with_and_without_root_dep() {
     ]);
 
     let packages = vec![
-        ("package_a".into(), Version::new(1, 0, 0), vec!["package_b".into(), "package_c".into()]),
+        (
+            "package_a".into(),
+            Version::new(1, 0, 0),
+            vec!["package_b".into(), "package_c".into()],
+        ),
         ("package_b".into(), Version::new(2, 0, 0), vec![]),
         ("package_c".into(), Version::new(3, 0, 0), vec![]),
     ];
 
-    let requirements = vec![
-        ("package_b".into(), ">= 2.0.0".into()),
-    ];
+    let requirements = vec![("package_b".into(), ">= 2.0.0".into())];
 
     let manifest = create_testable_unlock_manifest(packages, requirements);
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -118,11 +118,23 @@ pub fn update(packages: Vec<String>) -> Result<()> {
 
     if packages.is_empty() {
         // Update all packages
-        _ = download(&paths, cli::Reporter::new(), None, Vec::new(), UseManifest::No)?;
+        _ = download(
+            &paths,
+            cli::Reporter::new(),
+            None,
+            Vec::new(),
+            UseManifest::No,
+        )?;
     } else {
         // Update specific packages
         let packages_to_update = packages.into_iter().map(EcoString::from).collect();
-        _ = download(&paths, cli::Reporter::new(), None, packages_to_update, UseManifest::Yes)?;
+        _ = download(
+            &paths,
+            cli::Reporter::new(),
+            None,
+            packages_to_update,
+            UseManifest::Yes,
+        )?;
     }
 
     Ok(())
@@ -640,16 +652,26 @@ fn get_manifest<Telem: Telemetry>(
 
     // If there are no requested updates, and the config is unchanged
     // since the manifest was written then it is up to date so we can return it unmodified.
-    if packages_to_update.is_empty() && is_same_requirements(
-        &manifest.requirements,
-        &config.all_drect_dependencies()?,
-        paths.root(),
-    )? {
+    if packages_to_update.is_empty()
+        && is_same_requirements(
+            &manifest.requirements,
+            &config.all_drect_dependencies()?,
+            paths.root(),
+        )?
+    {
         tracing::debug!("manifest_up_to_date");
         Ok((false, manifest))
     } else {
         tracing::debug!("manifest_outdated");
-        let manifest = resolve_versions(runtime, mode, paths, config, Some(&manifest), telemetry, packages_to_update)?;
+        let manifest = resolve_versions(
+            runtime,
+            mode,
+            paths,
+            config,
+            Some(&manifest),
+            telemetry,
+            packages_to_update,
+        )?;
         Ok((true, manifest))
     }
 }
@@ -1568,7 +1590,10 @@ fn test_unlock_nonexistent_package() {
     let mut locked = initial_locked.clone();
     unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
 
-    assert_eq!(initial_locked, locked, "Locked packages should remain unchanged");
+    assert_eq!(
+        initial_locked, locked,
+        "Locked packages should remain unchanged"
+    );
 }
 
 #[test]
@@ -1678,5 +1703,8 @@ fn test_unlock_packages_empty_input() {
     let mut locked = initial_locked.clone();
     unlock_packages(&mut locked, &packages_to_unlock, Some(&manifest_packages)).unwrap();
 
-    assert_eq!(initial_locked, locked, "Locked packages should remain unchanged when no packages are specified to unlock");
+    assert_eq!(
+        initial_locked, locked,
+        "Locked packages should remain unchanged when no packages are specified to unlock"
+    );
 }

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -252,7 +252,7 @@ impl MakeLocker for ProjectIO {
 
 impl DownloadDependencies for ProjectIO {
     fn download_dependencies(&self, paths: &ProjectPaths) -> Result<Manifest> {
-        crate::dependencies::download(paths, NullTelemetry, None, UseManifest::Yes)
+        crate::dependencies::download(paths, NullTelemetry, None, None, UseManifest::Yes)
     }
 }
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -252,7 +252,7 @@ impl MakeLocker for ProjectIO {
 
 impl DownloadDependencies for ProjectIO {
     fn download_dependencies(&self, paths: &ProjectPaths) -> Result<Manifest> {
-        crate::dependencies::download(paths, NullTelemetry, None, None, UseManifest::Yes)
+        crate::dependencies::download(paths, NullTelemetry, None, Vec::new(), UseManifest::Yes)
     }
 }
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -636,6 +636,6 @@ fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
 
 fn download_dependencies() -> Result<()> {
     let paths = find_project_paths()?;
-    _ = dependencies::download(&paths, cli::Reporter::new(), None, None, UseManifest::Yes)?;
+    _ = dependencies::download(&paths, cli::Reporter::new(), None, Vec::new(), UseManifest::Yes)?;
     Ok(())
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -636,6 +636,12 @@ fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
 
 fn download_dependencies() -> Result<()> {
     let paths = find_project_paths()?;
-    _ = dependencies::download(&paths, cli::Reporter::new(), None, Vec::new(), UseManifest::Yes)?;
+    _ = dependencies::download(
+        &paths,
+        cli::Reporter::new(),
+        None,
+        Vec::new(),
+        UseManifest::Yes,
+    )?;
     Ok(())
 }

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -94,6 +94,14 @@ use clap::{
 };
 use strum::VariantNames;
 
+#[derive(Args, Debug, Clone)]
+struct UpdateOptions {
+    /// (optional) Names of the packages to update
+    /// If omitted, all dependencies will be updated
+    #[arg(verbatim_doc_comment)]
+    packages: Vec<String>,
+}
+
 #[derive(Parser, Debug)]
 #[command(
     version,
@@ -155,7 +163,7 @@ enum Command {
     Deps(Dependencies),
 
     /// Update dependency packages to their latest versions
-    Update,
+    Update(UpdateOptions),
 
     /// Work with the Hex package manager
     #[command(subcommand)]
@@ -348,7 +356,7 @@ enum Dependencies {
     Download,
 
     /// Update dependency packages to their latest versions
-    Update,
+    Update(UpdateOptions),
 }
 
 #[derive(Subcommand, Debug)]
@@ -473,7 +481,7 @@ fn main() {
 
         Command::Deps(Dependencies::Download) => download_dependencies(),
 
-        Command::Deps(Dependencies::Update) => dependencies::update(),
+        Command::Deps(Dependencies::Update(options)) => dependencies::update(options.packages),
 
         Command::New(options) => new::create(options, COMPILER_VERSION),
 
@@ -523,7 +531,7 @@ fn main() {
 
         Command::Remove { packages } => remove::command(packages),
 
-        Command::Update => dependencies::update(),
+        Command::Update(options) => dependencies::update(options.packages),
 
         Command::Clean => clean(),
 
@@ -628,6 +636,6 @@ fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
 
 fn download_dependencies() -> Result<()> {
     let paths = find_project_paths()?;
-    _ = dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)?;
+    _ = dependencies::download(&paths, cli::Reporter::new(), None, None, UseManifest::Yes)?;
     Ok(())
 }

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -45,7 +45,7 @@ pub fn command(packages: Vec<String>) -> Result<()> {
     // Write the updated config
     fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
     let paths = crate::find_project_paths()?;
-    _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, None, UseManifest::Yes)?;
+    _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, Vec::new(), UseManifest::Yes)?;
     for package_to_remove in packages {
         cli::print_removed(&package_to_remove);
     }

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -45,7 +45,13 @@ pub fn command(packages: Vec<String>) -> Result<()> {
     // Write the updated config
     fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
     let paths = crate::find_project_paths()?;
-    _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, Vec::new(), UseManifest::Yes)?;
+    _ = crate::dependencies::download(
+        &paths,
+        cli::Reporter::new(),
+        None,
+        Vec::new(),
+        UseManifest::Yes,
+    )?;
     for package_to_remove in packages {
         cli::print_removed(&package_to_remove);
     }

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -45,7 +45,7 @@ pub fn command(packages: Vec<String>) -> Result<()> {
     // Write the updated config
     fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
     let paths = crate::find_project_paths()?;
-    _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, UseManifest::Yes)?;
+    _ = crate::dependencies::download(&paths, cli::Reporter::new(), None, None, UseManifest::Yes)?;
     for package_to_remove in packages {
         cli::print_removed(&package_to_remove);
     }


### PR DESCRIPTION
In reference to #2170 

Add support for updating specific packages and their dependencies via the Gleam CLI.

Updated commands:
```
gleam update <packages>
gleam deps update <packages>
```

Help output:
```
gleam deps update --help
Update dependency packages to their latest versions

Usage: gleam deps update [PACKAGES]...

Arguments:
  [PACKAGES]...  (optional) Names of the packages to update
                 If omitted, all dependencies will be updated

Options:
  -h, --help  Print help
```

The updated commands can be used like:
```
gleam deps update package_a package_b package_c
```

To update all packages, the existing functionality was kept:
```
gleam deps update
```

This is my first time with rust - let me know if I missed anything.