### PR TITLE
Warn about unused qualified constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,7 +289,7 @@
 ### Bug Fixes
 
 - Fixed a bug where the warnings were printed above the errors without any new line between them.
-([Victor Kobinski](https://github.com/vkobinski))
+  ([Victor Kobinski](https://github.com/vkobinski))
 
 - Fixed a bug which caused the language server and compiler to crash when two
   constructors of the same name were created.
@@ -336,6 +336,10 @@
 - Fixed a bug where the compiler would not check the target support of a function
   if it was imported and not used, and generate invalid code.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where an qualified unused constructor wouldn't be reported as
+  unused.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ## v1.4.1 - 2024-08-04
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\nimport wibble\n\npub fn main() {\n  wibble.Wibble(1)\n  1\n}\n"
+---
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:5:3
+  │
+5 │   wibble.Wibble(1)
+  │   ^^^^^^^^^^^^^^^^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\nimport wibble\n\npub fn wobble(a) { a }\n\npub fn main() {\n  1 |> wobble |> wibble.Wibble\n  1\n}\n"
+---
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:7:3
+  │
+7 │   1 |> wobble |> wibble.Wibble
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This value is never used

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1333,6 +1333,23 @@ pub fn main() {
 }
 
 #[test]
+fn unused_pipeline_ending_with_variant_raises_a_warning_2() {
+    assert_warning!(
+        ("wibble", "pub type Wibble { Wibble(Int) }"),
+        r#"
+import wibble
+
+pub fn wobble(a) { a }
+
+pub fn main() {
+  1 |> wobble |> wibble.Wibble
+  1
+}
+"#
+    );
+}
+
+#[test]
 fn unused_pipeline_not_ending_with_variant_raises_no_warnings() {
     assert_no_warnings!(
         r#"
@@ -1341,6 +1358,21 @@ pub fn wibble(a) { a }
 
 pub fn main() {
   1 |> wibble |> wibble
+  1
+}
+"#
+    );
+}
+
+#[test]
+fn unused_module_select_constructor() {
+    assert_warning!(
+        ("wibble", "pub type Wibble { Wibble(Int) }"),
+        r#"
+import wibble
+
+pub fn main() {
+  wibble.Wibble(1)
   1
 }
 "#


### PR DESCRIPTION
This PR fixes a bug where an unused qualified constructor wouldn't be reported as unused