### PR TITLE
Fix undef error message spacing

### DIFF
--- a/compiler-core/templates/gleam@@main.erl
+++ b/compiler-core/templates/gleam@@main.erl
@@ -54,7 +54,7 @@ error_class(Class, _) -> ["Erlang ", atom_to_binary(Class)].
 error_message(#{gleam_error := _, message := M}) ->
     M;
 error_message(undef) ->
-    <<"A function was called but it did not exist.\n"/utf8 >>;
+    <<"A function was called but it did not exist."/utf8 >>;
 error_message({case_clause, _}) ->
     <<"No pattern matched in an Erlang case expression."/utf8>>;
 error_message({badmatch, _}) ->


### PR DESCRIPTION
Trying the nightly release I noticed the error you get when trying to run an undef function has an additional newline after the "A function was called but it did not exist." message. All the other errors do not have that, so I removed it to make everything look consistent.
![Screenshot 2024-09-09 alle 10 30 15](https://github.com/user-attachments/assets/d3daa804-dd1f-41ef-aed3-b301c362f427)
