### PR TITLE
Fix minimum required version with `gleam fix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@
 - OTP application trees are now shut down gracefully when `main` exits.
   ([Louis Pilfold](https://github.com/lpil))
 
+- The `gleam fix` command can now update a project's `gleam` version contraint
+  to make sure it respects the inferred minimum required version.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The build tool now refuses to publish a project where the `gleam` version
+  constraint would include a compiler version that doesn't support the features
+  used by the package.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- If a project doesn't specify a `gleam` version constraint, the build tool will
+  automatically infer it and add it to the project's `gleam.toml` before
+  publishing it.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Compiler
 
 - Compiler progress is now printed to stderr, instead of stdout.
@@ -267,6 +281,37 @@
       }
 
   See: https://tour.gleam.run/flow-control/case-expressions/
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The compiler can now infer the minimum Gleam version needed for your code to
+  compile and emits a warning if the project's `gleam` version constraint
+  doesn't include it.
+  For example, let's say your `gleam.toml` has the constraint
+  `gleam = ">= 1.1.0"` and your code is using some feature introduced in a later
+  version:
+
+  ```gleam
+  // Concatenating constant strings was introduced in v1.4.0!
+  pub const greeting = "hello " <> "world!"
+  ```
+
+  You would now get the following warning:
+
+  ```txt
+  warning: Incompatible gleam version range
+    ┌─ /Users/giacomocavalieri/Desktop/datalog/src/datalog.gleam:1:22
+    │
+  1 │ pub const greeting = "hello " <> "world!"
+    │                      ^^^^^^^^^^^^^^^^^^^^ This requires a Gleam version >= 1.4.0
+
+  Constant strings concatenation was introduced in version v1.4.0. But the
+  Gleam version range specified in your `gleam.toml` would allow this code to
+  run on an earlier version like v1.1.0, resulting in compilation errors!
+  Hint: Remove the version constraint from your `gleam.toml` or update it to be:
+
+      gleam = ">= 1.4.0"
   ```
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::{rc::Rc, time::Instant};
 
 use gleam_core::{
     build::{Built, Codegen, NullTelemetry, Options, ProjectCompiler, Telemetry},
@@ -21,13 +21,13 @@ pub fn download_dependencies(telemetry: impl Telemetry) -> Result<Manifest> {
 }
 
 pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
-    main_with_warnings(options, manifest, Arc::new(ConsoleWarningEmitter))
+    main_with_warnings(options, manifest, Rc::new(ConsoleWarningEmitter))
 }
 
 pub(crate) fn main_with_warnings(
     options: Options,
     manifest: Manifest,
-    warnings: Arc<dyn WarningEmitterIO>,
+    warnings: Rc<dyn WarningEmitterIO>,
 ) -> Result<Built> {
     let paths = crate::find_project_paths()?;
     let perform_codegen = options.codegen;

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -4,6 +4,7 @@ use gleam_core::{
     build::{Built, Codegen, NullTelemetry, Options, ProjectCompiler, Telemetry},
     manifest::Manifest,
     paths::ProjectPaths,
+    warning::WarningEmitterIO,
     Result,
 };
 
@@ -20,6 +21,14 @@ pub fn download_dependencies(telemetry: impl Telemetry) -> Result<Manifest> {
 }
 
 pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
+    main_with_warnings(options, manifest, Arc::new(ConsoleWarningEmitter))
+}
+
+pub(crate) fn main_with_warnings(
+    options: Options,
+    manifest: Manifest,
+    warnings: Arc<dyn WarningEmitterIO>,
+) -> Result<Built> {
     let paths = crate::find_project_paths()?;
     let perform_codegen = options.codegen;
     let root_config = crate::config::root_config()?;
@@ -45,7 +54,7 @@ pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
             options,
             manifest.packages,
             telemetry,
-            Arc::new(ConsoleWarningEmitter),
+            warnings,
             ProjectPaths::new(current_dir),
             io,
         );

--- a/compiler-cli/src/compile_package.rs
+++ b/compiler-cli/src/compile_package.rs
@@ -16,13 +16,13 @@ use gleam_core::{
     warning::WarningEmitter,
     Error, Result,
 };
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, rc::Rc};
 
 pub fn command(options: CompilePackage) -> Result<()> {
     let ids = UniqueIdGenerator::new();
     let mut type_manifests = load_libraries(&ids, &options.libraries_directory)?;
     let mut defined_modules = im::HashMap::new();
-    let warnings = WarningEmitter::new(Arc::new(ConsoleWarningEmitter));
+    let warnings = WarningEmitter::new(Rc::new(ConsoleWarningEmitter));
     let paths = ProjectPaths::new(options.package_directory.clone());
     let config = config::read(paths.root_config())?;
 

--- a/compiler-cli/src/fix.rs
+++ b/compiler-cli/src/fix.rs
@@ -91,5 +91,5 @@ fn minimum_required_version_from_warnings(warnings: Vec<Warning>) -> Option<Vers
             _ => None,
         })
         .reduce(std::cmp::max)
-        .map(|version| version.clone())
+        .cloned()
 }

--- a/compiler-cli/src/fix.rs
+++ b/compiler-cli/src/fix.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::rc::Rc;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use gleam_core::{
@@ -22,7 +22,7 @@ pub fn run() -> Result<()> {
     // When running gleam fix we want all the compilation warnings to be hidden,
     // at the same time we need to access those to apply the fixes: so we
     // accumulate those into a vector.
-    let warnings = Arc::new(VectorWarningEmitterIO::new());
+    let warnings = Rc::new(VectorWarningEmitterIO::new());
     let _built = build::main_with_warnings(
         Options {
             root_target_support: TargetSupport::Enforced,

--- a/compiler-cli/src/fix.rs
+++ b/compiler-cli/src/fix.rs
@@ -1,13 +1,47 @@
+use std::sync::Arc;
+
 use camino::{Utf8Path, Utf8PathBuf};
 use gleam_core::{
+    analyse::TargetSupport,
+    build::{Codegen, Compile, Mode, Options},
     error::{FileIoAction, FileKind},
-    Error, Result,
+    type_,
+    warning::VectorWarningEmitterIO,
+    Error, Result, Warning,
 };
+use hexpm::version::Version;
+
+use crate::{build, cli};
 
 pub fn run() -> Result<()> {
-    for path in crate::fs::gleam_files_excluding_gitignore(Utf8Path::new(".")) {
-        fix_file(path)?;
-    }
+    // When running gleam fix we want all the compilation warnings to be hidden,
+    // at the same time we need to access those to apply the fixes: so we
+    // accumulate those into a vector.
+    let warnings = Arc::new(VectorWarningEmitterIO::new());
+    let _built = build::main_with_warnings(
+        Options {
+            root_target_support: TargetSupport::Enforced,
+            warnings_as_errors: false,
+            codegen: Codegen::DepsOnly,
+            compile: Compile::All,
+            mode: Mode::Dev,
+            target: None,
+            no_print_progress: false,
+        },
+        build::download_dependencies(cli::Reporter::new())?,
+        warnings.clone(),
+    )?;
+    let warnings = warnings.take();
+
+    fix_minimum_required_version(warnings)?;
+
+    Ok(())
+}
+
+fn fix_minimum_required_version(warnings: Vec<Warning>) -> Result<()> {
+    let Some(minimum_required_version) = minimum_required_version_from_warnings(warnings) else {
+        return Ok(());
+    };
 
     // Set the version requirement in gleam.toml
     let mut toml = crate::fs::read("gleam.toml")?
@@ -21,25 +55,31 @@ pub fn run() -> Result<()> {
 
     #[allow(clippy::indexing_slicing)]
     {
-        toml["gleam"] = toml_edit::value(">= 0.32.0");
+        toml["gleam"] = toml_edit::value(format!(">= {minimum_required_version}"));
     }
 
     // Write the updated config
     crate::fs::write(Utf8Path::new("gleam.toml"), &toml.to_string())?;
-
-    println!(
-        "Your Gleam code has been fixed!
-
-If you have any JavaScript code that used the BitString class
-you will need to update it to use the BitArray class instead.
-"
-    );
     Ok(())
 }
 
-fn fix_file(path: Utf8PathBuf) -> Result<()> {
-    let src = crate::fs::read(&path)?;
-    let out = gleam_core::fix::parse_fix_and_format(&src.into(), &path)?;
-    crate::fs::write(&path, &out)?;
-    Ok(())
+/// Returns the highest minimum required version among all warnings requiring a
+/// specific Gleam version that is not allowed by the `gleam` version contraint
+/// in the `gleam.toml`.
+fn minimum_required_version_from_warnings(warnings: Vec<Warning>) -> Option<Version> {
+    warnings
+        .iter()
+        .filter_map(|warning| match warning {
+            Warning::Type {
+                warning:
+                    type_::Warning::FeatureRequiresHigherGleamVersion {
+                        minimum_required_version,
+                        ..
+                    },
+                ..
+            } => Some(minimum_required_version),
+            _ => None,
+        })
+        .reduce(std::cmp::max)
+        .map(|version| version.clone())
 }

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -27,6 +27,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Write,
     io::BufReader,
+    rc::Rc,
     sync::Arc,
     time::Instant,
 };
@@ -127,7 +128,7 @@ where
         options: Options,
         packages: Vec<ManifestPackage>,
         telemetry: &'static dyn Telemetry,
-        warning_emitter: Arc<dyn WarningEmitterIO>,
+        warning_emitter: Rc<dyn WarningEmitterIO>,
         paths: ProjectPaths,
         io: IO,
     ) -> Self {

--- a/compiler-core/src/language_server/compiler.rs
+++ b/compiler-core/src/language_server/compiler.rs
@@ -15,7 +15,7 @@ use crate::{
     warning::VectorWarningEmitterIO,
     Error, Result, Warning,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc};
 
 use camino::Utf8PathBuf;
 
@@ -32,7 +32,7 @@ pub struct LspProjectCompiler<IO> {
     pub sources: HashMap<EcoString, ModuleSourceInformation>,
 
     /// The storage for the warning emitter.
-    pub warnings: Arc<VectorWarningEmitterIO>,
+    pub warnings: Rc<VectorWarningEmitterIO>,
 
     /// A lock to ensure that multiple instances of the LSP don't try and use
     /// build directory at the same time.
@@ -52,7 +52,7 @@ where
     ) -> Result<Self> {
         let target = config.target;
         let name = config.name.clone();
-        let warnings = Arc::new(VectorWarningEmitterIO::default());
+        let warnings = Rc::new(VectorWarningEmitterIO::default());
 
         // The build caches do not contain all the information we need in the
         // LSP (e.g. the typed AST) so delete the caches for the top level

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -12,7 +12,7 @@ use crate::{
 use ecow::EcoString;
 use itertools::Itertools;
 use pubgrub::range::Range;
-use std::sync::Arc;
+use std::rc::Rc;
 use vec1::Vec1;
 
 use camino::Utf8PathBuf;
@@ -183,7 +183,7 @@ fn get_warnings(
     _ = compile_module_with_opts(
         "test_module",
         src,
-        Some(Arc::new(warnings.clone())),
+        Some(Rc::new(warnings.clone())),
         deps,
         Target::Erlang,
         TargetSupport::NotEnforced,
@@ -368,7 +368,7 @@ pub fn infer_module_with_target(
 pub fn compile_module(
     module_name: &str,
     src: &str,
-    warnings: Option<Arc<dyn WarningEmitterIO>>,
+    warnings: Option<Rc<dyn WarningEmitterIO>>,
     dep: Vec<DependencyModule<'_>>,
 ) -> Result<TypedModule, Vec<crate::type_::Error>> {
     compile_module_with_opts(
@@ -385,7 +385,7 @@ pub fn compile_module(
 pub fn compile_module_with_opts(
     module_name: &str,
     src: &str,
-    warnings: Option<Arc<dyn WarningEmitterIO>>,
+    warnings: Option<Rc<dyn WarningEmitterIO>>,
     dep: Vec<DependencyModule<'_>>,
     target: Target,
     target_support: TargetSupport,
@@ -394,9 +394,8 @@ pub fn compile_module_with_opts(
     let ids = UniqueIdGenerator::new();
     let mut modules = im::HashMap::new();
 
-    let emitter = WarningEmitter::new(
-        warnings.unwrap_or_else(|| Arc::new(VectorWarningEmitterIO::default())),
-    );
+    let emitter =
+        WarningEmitter::new(warnings.unwrap_or_else(|| Rc::new(VectorWarningEmitterIO::default())));
 
     // DUPE: preludeinsertion
     // TODO: Currently we do this here and also in the tests. It would be better

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -790,7 +790,7 @@ pub fn main() {
   x
 }"#;
     let warnings = VectorWarningEmitterIO::default();
-    _ = compile_module("test_module", src, Some(Arc::new(warnings.clone())), vec![]).unwrap_err();
+    _ = compile_module("test_module", src, Some(Rc::new(warnings.clone())), vec![]).unwrap_err();
     assert!(warnings.take().is_empty());
 }
 

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -16,7 +16,7 @@ use gleam_core::{
 };
 use hexpm::version::Version;
 use im::HashMap;
-use std::{cell::RefCell, collections::HashSet, sync::Arc};
+use std::{cell::RefCell, collections::HashSet, rc::Rc};
 use wasm_filesystem::WasmFileSystem;
 
 use wasm_bindgen::prelude::*;
@@ -169,7 +169,7 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
     let mut type_manifests = im::HashMap::new();
     let mut defined_modules = im::HashMap::new();
     #[allow(clippy::arc_with_non_send_sync)]
-    let warning_emitter = WarningEmitter::new(Arc::new(project.warnings));
+    let warning_emitter = WarningEmitter::new(Rc::new(project.warnings));
     let config = PackageConfig {
         name: "library".into(),
         version: Version::new(1, 0, 0),

--- a/test-package-compiler/src/lib.rs
+++ b/test-package-compiler/src/lib.rs
@@ -21,7 +21,8 @@ use regex::Regex;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Write,
-    sync::{Arc, OnceLock},
+    rc::Rc,
+    sync::OnceLock,
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -48,7 +49,7 @@ pub fn prepare(path: &str) -> String {
     let ids = gleam_core::uid::UniqueIdGenerator::new();
     let mut modules = im::HashMap::new();
     let warnings = VectorWarningEmitterIO::default();
-    let warning_emitter = WarningEmitter::new(Arc::new(warnings.clone()));
+    let warning_emitter = WarningEmitter::new(Rc::new(warnings.clone()));
     let filesystem = to_in_memory_filesystem(&root);
     let initial_files = filesystem.paths();
     let root = Utf8PathBuf::from("");


### PR DESCRIPTION
As we've decided the other day, before drafting a release we wanted `gleam fix` to fix the `gleam.toml`'s `gleam` version constraint. I've implemented the fix in this PR, this doesn't close the issue <https://github.com/gleam-lang/gleam/issues/3611> yet but all the machinery needed for it should already be in place after this gets merged!