### PR TITLE
Fix minimum version inference bug

### DIFF
--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -276,6 +276,11 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
         // correct and folks getting the package from Hex won't have unpleasant
         // surprises if the author forgot to manualy write it down.
         None => {
+            // If we're automatically adding the minimum required version
+            // constraint we want it to at least be `>= 1.0.0`, even if the
+            // inferred lower bound could be lower.
+            let minimum_required_version =
+                std::cmp::max(minimum_required_version, Version::new(1, 0, 0));
             let inferred_version_range =
                 pubgrub::range::Range::higher_than(minimum_required_version);
             config.gleam_version = Some(inferred_version_range);

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -165,7 +165,7 @@ impl<'a, A> ModuleAnalyzerConstructor<'a, A> {
             value_names: HashMap::with_capacity(module.definitions.len()),
             hydrators: HashMap::with_capacity(module.definitions.len()),
             module_name: module.name.clone(),
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
         }
         .infer_module(module)
     }

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -60,7 +60,7 @@ fn write_cache(
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),
         warnings: vec![],
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     let path = Utf8Path::new("/artefact").join(format!("{name}.cache"));
     fs.write_bytes(

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -90,7 +90,7 @@ impl Built {
             .map(|interface| &interface.minimum_required_version)
             .reduce(|one_version, other_version| cmp::max(one_version, other_version))
             .map(|minimum_required_version| minimum_required_version.clone())
-            .unwrap_or(Version::new(1, 0, 0))
+            .unwrap_or(Version::new(0, 1, 0))
     }
 }
 

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -63,7 +63,7 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     }
 }
 
@@ -96,7 +96,7 @@ fn empty_module() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -119,7 +119,7 @@ fn with_line_numbers() {
         const c = 3",
         ),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -150,7 +150,7 @@ fn module_with_private_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -181,7 +181,7 @@ fn module_with_app_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -212,7 +212,7 @@ fn module_with_fn_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -243,7 +243,7 @@ fn module_with_tuple_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -280,7 +280,7 @@ fn module_with_generic_type() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
         }
     }
 
@@ -317,7 +317,7 @@ fn module_with_type_links() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
         }
     }
 
@@ -354,7 +354,7 @@ fn module_with_type_constructor_documentation() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
         }
     }
 
@@ -394,7 +394,7 @@ fn module_with_type_constructor_origin() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
         }
     }
 
@@ -425,7 +425,7 @@ fn module_type_to_constructors_mapping() {
         values: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -473,7 +473,7 @@ fn module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -522,7 +522,7 @@ fn deprecated_module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -569,7 +569,7 @@ fn private_module_fn_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -618,7 +618,7 @@ fn module_fn_value_regression() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -666,7 +666,7 @@ fn module_fn_value_with_field_map() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -709,7 +709,7 @@ fn record_value() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -755,7 +755,7 @@ fn record_value_with_field_map() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -819,7 +819,7 @@ fn accessors() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1033,7 +1033,7 @@ fn constant_var() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1223,7 +1223,7 @@ fn deprecated_type() {
         accessors: HashMap::new(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1270,7 +1270,7 @@ fn module_fn_value_with_external_implementations() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1320,7 +1320,7 @@ fn internal_module_fn() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1373,7 +1373,7 @@ fn internal_annotated_module_fn() {
         .into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1413,7 +1413,7 @@ fn type_variable_ids_in_constructors_are_shared() {
         values: [].into(),
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     let expected = HashMap::from([(

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -247,7 +247,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             environment,
             implementations,
             current_function_definition: definition,
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
             problems,
         }
     }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -41,7 +41,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             hydrator,
             mode: PatternMode::Initial,
             initial_pattern_vars: HashSet::new(),
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
             problems,
         }
     }

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -216,7 +216,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         src_path: "".into(),
         // prelude doesn't have real line numbers
         line_numbers: LineNumbers::new(""),
-        minimum_required_version: Version::new(1, 0, 0),
+        minimum_required_version: Version::new(0, 1, 0),
     };
 
     for t in PreludeType::iter() {

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -752,7 +752,7 @@ fn infer_module_type_retention_test() {
             accessors: HashMap::new(),
             line_numbers: LineNumbers::new(""),
             src_path: "".into(),
-            minimum_required_version: Version::new(1, 0, 0),
+            minimum_required_version: Version::new(0, 1, 0),
         }
     );
 }


### PR DESCRIPTION
With this change the version lower bound is `0.1.0` by default.
- If someone is not using any feature that would warrant increasing the lower bound, this won't cause any problems when publishing even if you have a version constraint like `>= 0.x`, and `gleam fix` won't change it.
- However, when no constraint is explicitly added and the compiler adds the inferred one it makes sure that is still `>= 1.x`, even if the inferred one might be lower.