### PR TITLE
Added handling to guard logic for const record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Fix a bug that caused the compiler to crash when accessing a field of a const record, that had a function param in a guard clause.
+  ([Neil Wadden](https://github.com/Neilerino))
+
 ## v1.5.0-rc1 - 2024-09-14
 
 ### Build tool

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_access.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 568
 expression: "\n          import hero\n          pub fn main() {\n            let name = \"Tony Stark\"\n            case name {\n              n if n == hero.ironman.name -> True\n              _ -> False\n            }\n          }\n        "
 ---
 -module(my@mod).
@@ -13,7 +12,7 @@ expression: "\n          import hero\n          pub fn main() {\n            let
 main() ->
     Name = <<"Tony Stark"/utf8>>,
     case Name of
-        N when N =:= erlang:element(2, {hero, <<"Tony Stark"/utf8>>}) ->
+        N when N =:= <<"Tony Stark"/utf8>> ->
             true;
 
         _ ->

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_nested_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_nested_access.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 594
 expression: "\n          import hero\n          pub fn main() {\n            let name = \"Bruce Wayne\"\n            case name {\n              n if n == hero.batman.secret_identity.name -> True\n              _ -> False\n            }\n          }\n        "
 ---
 -module(my@mod).
@@ -13,10 +12,7 @@ expression: "\n          import hero\n          pub fn main() {\n            let
 main() ->
     Name = <<"Bruce Wayne"/utf8>>,
     case Name of
-        N when N =:= erlang:element(
-            2,
-            erlang:element(2, {hero, {person, <<"Bruce Wayne"/utf8>>}})
-        ) ->
+        N when N =:= erlang:element(2, {person, <<"Bruce Wayne"/utf8>>}) ->
             true;
 
         _ ->

--- a/compiler-core/src/type_/tests/guards.rs
+++ b/compiler-core/src/type_/tests/guards.rs
@@ -1,4 +1,4 @@
-use crate::{assert_module_error, assert_module_infer};
+use crate::{assert_module_error, assert_module_infer, assert_no_warnings};
 
 #[test]
 fn nested_record_access() {
@@ -40,6 +40,35 @@ pub fn a(a: String) {
   case a {
     _ if a.b -> 1
     _ -> 0
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn constant_record_with_function_in_guard_compiles() {
+    assert_no_warnings!(
+        r#"
+pub fn test_function(x: Int) -> Int {
+  x + 1
+}
+
+pub type Test {
+  Test(input_string: String, func: fn(Int) -> Int)
+}
+
+pub const case_test = Test("test", test_function)
+
+pub fn main() {
+  let case_var = ["test", "test2"]
+  case case_var {
+    [head, ..] if head == case_test.input_string -> {
+      io.println("test")
+    }
+    _ -> {
+      io.println("not test")
+    }
   }
 }
 "#


### PR DESCRIPTION
Added compiler logic so that if you're referencing a constant record in a guard clause it compiles the referenced field instead of creating a tuple accessor for that specific field.

I'm very new to rust, gleam, and erlang so please leave any suggestion you might have on the code 

Fixes: https://github.com/gleam-lang/gleam/issues/3614 