### PR TITLE
Properly format lines with big grapheme clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 ### Language Server
 
 ### Bug Fixes
+
+- Fixed a bug where the formatter would not format strings with big grapheme
+  clusters properly.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,7 @@ dependencies = [
  "thiserror",
  "toml",
  "tracing",
+ "unicode-segmentation",
  "vec1",
  "xxhash-rust",
 ]
@@ -2569,6 +2570,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -63,6 +63,7 @@ termcolor.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
+unicode-segmentation = "1.12.0"
 
 [build-dependencies]
 # Data (de)serialisation

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -221,7 +221,7 @@ fn pattern_segment<'a>(
         )
     };
 
-    let unit = |value: &'a u8| Some(Document::String(format!("unit:{value}")));
+    let unit = |value: &'a u8| Some(Document::from_string(format!("unit:{value}")));
 
     bit_array_segment(
         document,

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -1,3 +1,5 @@
+use ecow::eco_format;
+
 use crate::analyse::Inferred;
 
 use super::*;
@@ -221,7 +223,7 @@ fn pattern_segment<'a>(
         )
     };
 
-    let unit = |value: &'a u8| Some(format!("unit:{value}").to_doc());
+    let unit = |value: &'a u8| Some(eco_format!("unit:{value}").to_doc());
 
     bit_array_segment(
         document,

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -221,7 +221,7 @@ fn pattern_segment<'a>(
         )
     };
 
-    let unit = |value: &'a u8| Some(Document::from_string(format!("unit:{value}")));
+    let unit = |value: &'a u8| Some(format!("unit:{value}").to_doc());
 
     bit_array_segment(
         document,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -16,7 +16,7 @@ use crate::{
     warning::WarningEmitter,
     Error, Result,
 };
-use ecow::EcoString;
+use ecow::{eco_format, EcoString};
 use itertools::Itertools;
 use std::{cmp::Ordering, sync::Arc};
 use vec1::Vec1;
@@ -208,7 +208,7 @@ impl<'comments> Formatter<'comments> {
         let doc_comments = join(
             self.doc_comments
                 .iter()
-                .map(|comment| "///".to_doc().append(comment.content.to_string())),
+                .map(|comment| "///".to_doc().append(EcoString::from(comment.content))),
             line(),
         );
 
@@ -221,7 +221,7 @@ impl<'comments> Formatter<'comments> {
             let comments = self
                 .module_comments
                 .iter()
-                .map(|s| "////".to_doc().append(s.content.to_string()));
+                .map(|s| "////".to_doc().append(EcoString::from(s.content)));
             join(comments, line()).append(line())
         } else {
             nil()
@@ -633,7 +633,7 @@ impl<'comments> Formatter<'comments> {
             None => nil(),
             Some(_) => join(
                 comments.map(|c| match c {
-                    Some(c) => "///".to_doc().append(c.to_string()),
+                    Some(c) => "///".to_doc().append(EcoString::from(c)),
                     None => unreachable!("empty lines dropped by pop_doc_comments"),
                 }),
                 line(),
@@ -2622,7 +2622,7 @@ impl<'comments> Formatter<'comments> {
                 }
                 (_, None) => continue,
             };
-            doc.push("//".to_doc().append(c.to_string()));
+            doc.push("//".to_doc().append(EcoString::from(c)));
             match comments.peek() {
                 // Next line is a comment
                 Some((_, Some(_))) => doc.push(line()),
@@ -2743,7 +2743,7 @@ fn printed_comments<'a, 'comments>(
             Some(c) => c,
             None => continue,
         };
-        doc.push("//".to_doc().append(c.to_string()));
+        doc.push("//".to_doc().append(EcoString::from(c)));
         match comments.peek() {
             // Next line is a comment
             Some(Some(_)) => doc.push(line()),
@@ -2842,7 +2842,7 @@ where
         BitArrayOption::Unit { value, .. } => "unit"
             .to_doc()
             .append("(")
-            .append(format!("{value}"))
+            .append(eco_format!("{value}"))
             .append(")"),
     }
 }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -206,11 +206,9 @@ impl<'comments> Formatter<'comments> {
         // and doc comments (///) remain. Freestanding comments aren't associated
         // with any statement, and are moved to the bottom of the module.
         let doc_comments = join(
-            self.doc_comments.iter().map(|comment| {
-                "///"
-                    .to_doc()
-                    .append(Document::from_string(comment.content.to_string()))
-            }),
+            self.doc_comments
+                .iter()
+                .map(|comment| "///".to_doc().append(comment.content.to_string())),
             line(),
         );
 
@@ -220,11 +218,10 @@ impl<'comments> Formatter<'comments> {
         };
 
         let module_comments = if !self.module_comments.is_empty() {
-            let comments = self.module_comments.iter().map(|s| {
-                "////"
-                    .to_doc()
-                    .append(Document::from_string(s.content.to_string()))
-            });
+            let comments = self
+                .module_comments
+                .iter()
+                .map(|s| "////".to_doc().append(s.content.to_string()));
             join(comments, line()).append(line())
         } else {
             nil()
@@ -636,7 +633,7 @@ impl<'comments> Formatter<'comments> {
             None => nil(),
             Some(_) => join(
                 comments.map(|c| match c {
-                    Some(c) => "///".to_doc().append(Document::from_string(c.to_string())),
+                    Some(c) => "///".to_doc().append(c.to_string()),
                     None => unreachable!("empty lines dropped by pop_doc_comments"),
                 }),
                 line(),
@@ -1611,10 +1608,12 @@ impl<'comments> Formatter<'comments> {
             .append(pub_(ct.publicity))
             .append(if ct.opaque { "opaque type " } else { "type " })
             .append(if ct.parameters.is_empty() {
-                Document::from_eco_string(ct.name.clone())
+                ct.name.clone().to_doc()
             } else {
                 let args = ct.parameters.iter().map(|(_, e)| e.to_doc()).collect_vec();
-                Document::from_eco_string(ct.name.clone())
+                ct.name
+                    .clone()
+                    .to_doc()
                     .append(self.wrap_args(args, ct.location.end))
                     .group()
             });
@@ -2623,7 +2622,7 @@ impl<'comments> Formatter<'comments> {
                 }
                 (_, None) => continue,
             };
-            doc.push("//".to_doc().append(Document::from_string(c.to_string())));
+            doc.push("//".to_doc().append(c.to_string()));
             match comments.peek() {
                 // Next line is a comment
                 Some((_, Some(_))) => doc.push(line()),
@@ -2744,7 +2743,7 @@ fn printed_comments<'a, 'comments>(
             Some(c) => c,
             None => continue,
         };
-        doc.push("//".to_doc().append(Document::from_string(c.to_string())));
+        doc.push("//".to_doc().append(c.to_string()));
         match comments.peek() {
             // Next line is a comment
             Some(Some(_)) => doc.push(line()),
@@ -2843,7 +2842,7 @@ where
         BitArrayOption::Unit { value, .. } => "unit"
             .to_doc()
             .append("(")
-            .append(Document::from_string(format!("{value}")))
+            .append(format!("{value}"))
             .append(")"),
     }
 }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -209,7 +209,7 @@ impl<'comments> Formatter<'comments> {
             self.doc_comments.iter().map(|comment| {
                 "///"
                     .to_doc()
-                    .append(Document::String(comment.content.to_string()))
+                    .append(Document::from_string(comment.content.to_string()))
             }),
             line(),
         );
@@ -223,7 +223,7 @@ impl<'comments> Formatter<'comments> {
             let comments = self.module_comments.iter().map(|s| {
                 "////"
                     .to_doc()
-                    .append(Document::String(s.content.to_string()))
+                    .append(Document::from_string(s.content.to_string()))
             });
             join(comments, line()).append(line())
         } else {
@@ -636,7 +636,7 @@ impl<'comments> Formatter<'comments> {
             None => nil(),
             Some(_) => join(
                 comments.map(|c| match c {
-                    Some(c) => "///".to_doc().append(Document::String(c.to_string())),
+                    Some(c) => "///".to_doc().append(Document::from_string(c.to_string())),
                     None => unreachable!("empty lines dropped by pop_doc_comments"),
                 }),
                 line(),
@@ -1611,10 +1611,10 @@ impl<'comments> Formatter<'comments> {
             .append(pub_(ct.publicity))
             .append(if ct.opaque { "opaque type " } else { "type " })
             .append(if ct.parameters.is_empty() {
-                Document::EcoString(ct.name.clone())
+                Document::from_eco_string(ct.name.clone())
             } else {
                 let args = ct.parameters.iter().map(|(_, e)| e.to_doc()).collect_vec();
-                Document::EcoString(ct.name.clone())
+                Document::from_eco_string(ct.name.clone())
                     .append(self.wrap_args(args, ct.location.end))
                     .group()
             });
@@ -2623,7 +2623,7 @@ impl<'comments> Formatter<'comments> {
                 }
                 (_, None) => continue,
             };
-            doc.push("//".to_doc().append(Document::String(c.to_string())));
+            doc.push("//".to_doc().append(Document::from_string(c.to_string())));
             match comments.peek() {
                 // Next line is a comment
                 Some((_, Some(_))) => doc.push(line()),
@@ -2744,7 +2744,7 @@ fn printed_comments<'a, 'comments>(
             Some(c) => c,
             None => continue,
         };
-        doc.push("//".to_doc().append(Document::String(c.to_string())));
+        doc.push("//".to_doc().append(Document::from_string(c.to_string())));
         match comments.peek() {
             // Next line is a comment
             Some(Some(_)) => doc.push(line()),
@@ -2843,7 +2843,7 @@ where
         BitArrayOption::Unit { value, .. } => "unit"
             .to_doc()
             .append("(")
-            .append(Document::String(format!("{value}")))
+            .append(Document::from_string(format!("{value}")))
             .append(")"),
     }
 }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6424,3 +6424,14 @@ pub fn init(
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3627
+#[test]
+fn big_grapheme_cluster() {
+    assert_format!(
+        r#"pub fn main() {
+  sw("👩‍👩‍👧‍👦👩‍👩‍👧‍👦👩‍👩‍👧‍👦", [])
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -69,7 +69,7 @@ impl<'a> Generator<'a> {
 
     fn type_reference(&self) -> Document<'a> {
         if self.typescript == TypeScriptDeclarations::None {
-            return Document::from_str("");
+            return "".to_doc();
         }
 
         // Get the name of the module relative the directory (similar to basename)
@@ -81,9 +81,7 @@ impl<'a> Generator<'a> {
             .last()
             .expect("JavaScript generator could not identify imported module name.");
 
-        let name = Document::from_str(module);
-
-        docvec!["/// <reference types=\"./", name, ".d.mts\" />", line()]
+        docvec!["/// <reference types=\"./", module, ".d.mts\" />", line()]
     }
 
     pub fn compile(&mut self) -> Output<'a> {
@@ -271,7 +269,7 @@ impl<'a> Generator<'a> {
             arg.label
                 .as_ref()
                 .map(|(_, s)| maybe_escape_identifier_doc(s))
-                .unwrap_or_else(|| Document::from_string(format!("x{i}")))
+                .unwrap_or_else(|| format!("x{i}").to_doc())
         }
 
         let head = if publicity.is_private() || opaque {
@@ -444,7 +442,7 @@ impl<'a> Generator<'a> {
             alias: if name == fun && !needs_escaping {
                 None
             } else if needs_escaping {
-                Some(Document::from_string(escape_identifier(name)))
+                Some(escape_identifier(name).to_doc())
             } else {
                 Some(name.to_doc())
             },
@@ -616,12 +614,12 @@ fn fun_args(args: &'_ [TypedArg], tail_recursion_used: bool) -> Document<'_> {
             let doc = if discards == 0 {
                 "_".to_doc()
             } else {
-                Document::from_string(format!("_{discards}"))
+                format!("_{discards}").to_doc()
             };
             discards += 1;
             doc
         }
-        Some(name) if tail_recursion_used => Document::from_string(format!("loop${name}")),
+        Some(name) if tail_recursion_used => format!("loop${name}").to_doc(),
         Some(name) => maybe_escape_identifier_doc(name),
     }))
 }
@@ -758,7 +756,7 @@ fn maybe_escape_identifier_doc(word: &str) -> Document<'_> {
     if is_usable_js_identifier(word) {
         word.to_doc()
     } else {
-        Document::from_string(escape_identifier(word))
+        escape_identifier(word).to_doc()
     }
 }
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -69,7 +69,7 @@ impl<'a> Generator<'a> {
 
     fn type_reference(&self) -> Document<'a> {
         if self.typescript == TypeScriptDeclarations::None {
-            return Document::Str("");
+            return Document::from_str("");
         }
 
         // Get the name of the module relative the directory (similar to basename)
@@ -81,7 +81,7 @@ impl<'a> Generator<'a> {
             .last()
             .expect("JavaScript generator could not identify imported module name.");
 
-        let name = Document::Str(module);
+        let name = Document::from_str(module);
 
         docvec!["/// <reference types=\"./", name, ".d.mts\" />", line()]
     }
@@ -271,7 +271,7 @@ impl<'a> Generator<'a> {
             arg.label
                 .as_ref()
                 .map(|(_, s)| maybe_escape_identifier_doc(s))
-                .unwrap_or_else(|| Document::String(format!("x{i}")))
+                .unwrap_or_else(|| Document::from_string(format!("x{i}")))
         }
 
         let head = if publicity.is_private() || opaque {
@@ -444,7 +444,7 @@ impl<'a> Generator<'a> {
             alias: if name == fun && !needs_escaping {
                 None
             } else if needs_escaping {
-                Some(Document::String(escape_identifier(name)))
+                Some(Document::from_string(escape_identifier(name)))
             } else {
                 Some(name.to_doc())
             },
@@ -616,12 +616,12 @@ fn fun_args(args: &'_ [TypedArg], tail_recursion_used: bool) -> Document<'_> {
             let doc = if discards == 0 {
                 "_".to_doc()
             } else {
-                Document::String(format!("_{discards}"))
+                Document::from_string(format!("_{discards}"))
             };
             discards += 1;
             doc
         }
-        Some(name) if tail_recursion_used => Document::String(format!("loop${name}")),
+        Some(name) if tail_recursion_used => Document::from_string(format!("loop${name}")),
         Some(name) => maybe_escape_identifier_doc(name),
     }))
 }
@@ -758,7 +758,7 @@ fn maybe_escape_identifier_doc(word: &str) -> Document<'_> {
     if is_usable_js_identifier(word) {
         word.to_doc()
     } else {
-        Document::String(escape_identifier(word))
+        Document::from_string(escape_identifier(word))
     }
 }
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -373,22 +373,22 @@ impl<'a> Generator<'a> {
         imports
     }
 
-    fn import_path(&self, package: &'a str, module: &'a str) -> String {
+    fn import_path(&self, package: &'a str, module: &'a str) -> EcoString {
         // TODO: strip shared prefixed between current module and imported
         // module to avoid descending and climbing back out again
         if package == self.module.type_info.package || package.is_empty() {
             // Same package
             match self.current_module_name_segments_count {
-                1 => format!("./{module}.mjs"),
+                1 => eco_format!("./{module}.mjs"),
                 _ => {
                     let prefix = "../".repeat(self.current_module_name_segments_count - 1);
-                    format!("{prefix}{module}.mjs")
+                    eco_format!("{prefix}{module}.mjs")
                 }
             }
         } else {
             // Different package
             let prefix = "../".repeat(self.current_module_name_segments_count);
-            format!("{prefix}{package}/{module}.mjs")
+            eco_format!("{prefix}{package}/{module}.mjs")
         }
     }
 
@@ -413,7 +413,7 @@ impl<'a> Generator<'a> {
             Some((AssignName::Variable(name), _)) => (false, name.as_str()),
         };
 
-        let module_name = format!("${module_name}");
+        let module_name = eco_format!("${module_name}");
         let path = self.import_path(package, module);
         let unqualified_imports = unqualified.iter().map(|i| {
             let alias = i.as_name.as_ref().map(|n| {
@@ -448,9 +448,9 @@ impl<'a> Generator<'a> {
             },
         };
         if publicity.is_importable() {
-            imports.register_export(maybe_escape_identifier_string(name).to_string())
+            imports.register_export(maybe_escape_identifier_string(name))
         }
-        imports.register_module(module.to_string(), [], [member]);
+        imports.register_module(EcoString::from(module), [], [member]);
     }
 
     fn module_constant(

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -17,7 +17,7 @@ use crate::{
     pretty::*,
 };
 use camino::Utf8Path;
-use ecow::EcoString;
+use ecow::{eco_format, EcoString};
 use expression::Context;
 use itertools::Itertools;
 
@@ -269,7 +269,7 @@ impl<'a> Generator<'a> {
             arg.label
                 .as_ref()
                 .map(|(_, s)| maybe_escape_identifier_doc(s))
-                .unwrap_or_else(|| format!("x{i}").to_doc())
+                .unwrap_or_else(|| eco_format!("x{i}").to_doc())
         }
 
         let head = if publicity.is_private() || opaque {
@@ -448,7 +448,7 @@ impl<'a> Generator<'a> {
             },
         };
         if publicity.is_importable() {
-            imports.register_export(maybe_escape_identifier_string(name))
+            imports.register_export(maybe_escape_identifier_string(name).to_string())
         }
         imports.register_module(module.to_string(), [], [member]);
     }
@@ -614,12 +614,12 @@ fn fun_args(args: &'_ [TypedArg], tail_recursion_used: bool) -> Document<'_> {
             let doc = if discards == 0 {
                 "_".to_doc()
             } else {
-                format!("_{discards}").to_doc()
+                eco_format!("_{discards}").to_doc()
             };
             discards += 1;
             doc
         }
-        Some(name) if tail_recursion_used => format!("loop${name}").to_doc(),
+        Some(name) if tail_recursion_used => eco_format!("loop${name}").to_doc(),
         Some(name) => maybe_escape_identifier_doc(name),
     }))
 }
@@ -740,16 +740,16 @@ fn is_usable_js_identifier(word: &str) -> bool {
     )
 }
 
-fn maybe_escape_identifier_string(word: &str) -> String {
+fn maybe_escape_identifier_string(word: &str) -> EcoString {
     if is_usable_js_identifier(word) {
-        word.to_string()
+        EcoString::from(word)
     } else {
         escape_identifier(word)
     }
 }
 
-fn escape_identifier(word: &str) -> String {
-    format!("{word}$")
+fn escape_identifier(word: &str) -> EcoString {
+    eco_format!("{word}$")
 }
 
 fn maybe_escape_identifier_doc(word: &str) -> Document<'_> {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -88,8 +88,8 @@ impl<'module> Generator<'module> {
                 maybe_escape_identifier_doc(name)
             }
             Some(0) => maybe_escape_identifier_doc(name),
-            Some(n) if name == "$" => format!("${n}").to_doc(),
-            Some(n) => format!("{name}${n}").to_doc(),
+            Some(n) if name == "$" => eco_format!("${n}").to_doc(),
+            Some(n) => eco_format!("{name}${n}").to_doc(),
         }
     }
 
@@ -877,7 +877,7 @@ impl<'module> Generator<'module> {
     fn tuple_index<'a>(&mut self, tuple: &'a TypedExpr, index: u64) -> Output<'a> {
         self.not_in_tail_position(|gen| {
             let tuple = gen.wrap_expression(tuple)?;
-            Ok(docvec![tuple, format!("[{index}]")])
+            Ok(docvec![tuple, eco_format!("[{index}]")])
         })
     }
 
@@ -1542,7 +1542,9 @@ fn sized_bit_array_segment_details<'a>(
 
 pub fn string(value: &str) -> Document<'_> {
     if value.contains('\n') {
-        value.replace('\n', r"\n").to_doc().surround("\"", "\"")
+        EcoString::from(value.replace('\n', r"\n"))
+            .to_doc()
+            .surround("\"", "\"")
     } else {
         value.to_doc().surround("\"", "\"")
     }
@@ -1758,7 +1760,7 @@ fn record_constructor<'a>(
             None => docvec!["new ", name, "()"],
         }
     } else {
-        let vars = (0..arity).map(|i| format!("var{i}").to_doc());
+        let vars = (0..arity).map(|i| eco_format!("var{i}").to_doc());
         let body = docvec![
             "return ",
             construct_record(qualifier, name, vars.clone()),

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -88,8 +88,8 @@ impl<'module> Generator<'module> {
                 maybe_escape_identifier_doc(name)
             }
             Some(0) => maybe_escape_identifier_doc(name),
-            Some(n) if name == "$" => Document::from_string(format!("${n}")),
-            Some(n) => Document::from_string(format!("{name}${n}")),
+            Some(n) if name == "$" => format!("${n}").to_doc(),
+            Some(n) => format!("{name}${n}").to_doc(),
         }
     }
 
@@ -781,7 +781,7 @@ impl<'module> Generator<'module> {
                     // Create an assignment for each variable created by the function arguments
                     if let Some(name) = argument {
                         docs.push("loop$".to_doc());
-                        docs.push(Document::from_string((*name).to_string()));
+                        docs.push(name.to_doc());
                         docs.push(" = ".to_doc());
                     }
                     // Render the value given to the function. Even if it is not
@@ -877,7 +877,7 @@ impl<'module> Generator<'module> {
     fn tuple_index<'a>(&mut self, tuple: &'a TypedExpr, index: u64) -> Output<'a> {
         self.not_in_tail_position(|gen| {
             let tuple = gen.wrap_expression(tuple)?;
-            Ok(docvec![tuple, Document::from_string(format!("[{index}]"))])
+            Ok(docvec![tuple, format!("[{index}]")])
         })
     }
 
@@ -1542,7 +1542,7 @@ fn sized_bit_array_segment_details<'a>(
 
 pub fn string(value: &str) -> Document<'_> {
     if value.contains('\n') {
-        Document::from_string(value.replace('\n', r"\n")).surround("\"", "\"")
+        value.replace('\n', r"\n").to_doc().surround("\"", "\"")
     } else {
         value.to_doc().surround("\"", "\"")
     }
@@ -1758,7 +1758,7 @@ fn record_constructor<'a>(
             None => docvec!["new ", name, "()"],
         }
     } else {
-        let vars = (0..arity).map(|i| Document::from_string(format!("var{i}")));
+        let vars = (0..arity).map(|i| format!("var{i}").to_doc());
         let body = docvec![
             "return ",
             construct_record(qualifier, name, vars.clone()),

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -88,8 +88,8 @@ impl<'module> Generator<'module> {
                 maybe_escape_identifier_doc(name)
             }
             Some(0) => maybe_escape_identifier_doc(name),
-            Some(n) if name == "$" => Document::String(format!("${n}")),
-            Some(n) => Document::String(format!("{name}${n}")),
+            Some(n) if name == "$" => Document::from_string(format!("${n}")),
+            Some(n) => Document::from_string(format!("{name}${n}")),
         }
     }
 
@@ -781,7 +781,7 @@ impl<'module> Generator<'module> {
                     // Create an assignment for each variable created by the function arguments
                     if let Some(name) = argument {
                         docs.push("loop$".to_doc());
-                        docs.push(Document::String((*name).to_string()));
+                        docs.push(Document::from_string((*name).to_string()));
                         docs.push(" = ".to_doc());
                     }
                     // Render the value given to the function. Even if it is not
@@ -877,7 +877,7 @@ impl<'module> Generator<'module> {
     fn tuple_index<'a>(&mut self, tuple: &'a TypedExpr, index: u64) -> Output<'a> {
         self.not_in_tail_position(|gen| {
             let tuple = gen.wrap_expression(tuple)?;
-            Ok(docvec![tuple, Document::String(format!("[{index}]"))])
+            Ok(docvec![tuple, Document::from_string(format!("[{index}]"))])
         })
     }
 
@@ -1542,7 +1542,7 @@ fn sized_bit_array_segment_details<'a>(
 
 pub fn string(value: &str) -> Document<'_> {
     if value.contains('\n') {
-        Document::String(value.replace('\n', r"\n")).surround("\"", "\"")
+        Document::from_string(value.replace('\n', r"\n")).surround("\"", "\"")
     } else {
         value.to_doc().surround("\"", "\"")
     }
@@ -1758,7 +1758,7 @@ fn record_constructor<'a>(
             None => docvec!["new ", name, "()"],
         }
     } else {
-        let vars = (0..arity).map(|i| Document::String(format!("var{i}")));
+        let vars = (0..arity).map(|i| Document::from_string(format!("var{i}")));
         let body = docvec![
             "return ",
             construct_record(qualifier, name, vars.clone()),

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -52,7 +52,7 @@ impl<'a> Imports<'a> {
             imports
         } else {
             let names = join(
-                self.exports.into_iter().sorted().map(Document::String),
+                self.exports.into_iter().sorted().map(Document::from_string),
                 break_(",", ", "),
             );
             let names = docvec![
@@ -91,7 +91,7 @@ impl<'a> Import<'a> {
     }
 
     pub fn into_doc(self, codegen_target: JavaScriptCodegenTarget) -> Document<'a> {
-        let path = Document::String(self.path.clone());
+        let path = Document::from_string(self.path.clone());
         let import_modifier = if codegen_target == JavaScriptCodegenTarget::TypeScriptDeclarations {
             "type "
         } else {
@@ -102,7 +102,7 @@ impl<'a> Import<'a> {
                 "import ",
                 import_modifier,
                 "* as ",
-                Document::String(alias),
+                Document::from_string(alias),
                 " from \"",
                 path.clone(),
                 r#"";"#,

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use ecow::EcoString;
 use itertools::Itertools;
 
 use crate::{
@@ -55,7 +56,7 @@ impl<'a> Imports<'a> {
                 self.exports
                     .into_iter()
                     .sorted()
-                    .map(|string| string.to_doc()),
+                    .map(|string| EcoString::from(string).to_doc()),
                 break_(",", ", "),
             );
             let names = docvec![
@@ -94,7 +95,7 @@ impl<'a> Import<'a> {
     }
 
     pub fn into_doc(self, codegen_target: JavaScriptCodegenTarget) -> Document<'a> {
-        let path = self.path.clone().to_doc();
+        let path = EcoString::from(self.path).to_doc();
         let import_modifier = if codegen_target == JavaScriptCodegenTarget::TypeScriptDeclarations {
             "type "
         } else {
@@ -105,7 +106,7 @@ impl<'a> Import<'a> {
                 "import ",
                 import_modifier,
                 "* as ",
-                alias,
+                EcoString::from(alias),
                 " from \"",
                 path.clone(),
                 r#"";"#,

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -52,7 +52,10 @@ impl<'a> Imports<'a> {
             imports
         } else {
             let names = join(
-                self.exports.into_iter().sorted().map(Document::from_string),
+                self.exports
+                    .into_iter()
+                    .sorted()
+                    .map(|string| string.to_doc()),
                 break_(",", ", "),
             );
             let names = docvec![
@@ -91,7 +94,7 @@ impl<'a> Import<'a> {
     }
 
     pub fn into_doc(self, codegen_target: JavaScriptCodegenTarget) -> Document<'a> {
-        let path = Document::from_string(self.path.clone());
+        let path = self.path.clone().to_doc();
         let import_modifier = if codegen_target == JavaScriptCodegenTarget::TypeScriptDeclarations {
             "type "
         } else {
@@ -102,7 +105,7 @@ impl<'a> Import<'a> {
                 "import ",
                 import_modifier,
                 "* as ",
-                Document::from_string(alias),
+                alias,
                 " from \"",
                 path.clone(),
                 r#"";"#,

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -14,8 +14,8 @@ use crate::{
 ///
 #[derive(Debug, Default)]
 pub(crate) struct Imports<'a> {
-    imports: HashMap<String, Import<'a>>,
-    exports: HashSet<String>,
+    imports: HashMap<EcoString, Import<'a>>,
+    exports: HashSet<EcoString>,
 }
 
 impl<'a> Imports<'a> {
@@ -23,14 +23,14 @@ impl<'a> Imports<'a> {
         Self::default()
     }
 
-    pub fn register_export(&mut self, export: String) {
+    pub fn register_export(&mut self, export: EcoString) {
         let _ = self.exports.insert(export);
     }
 
     pub fn register_module(
         &mut self,
-        path: String,
-        aliases: impl IntoIterator<Item = String>,
+        path: EcoString,
+        aliases: impl IntoIterator<Item = EcoString>,
         unqualified_imports: impl IntoIterator<Item = Member<'a>>,
     ) {
         let import = self
@@ -56,7 +56,7 @@ impl<'a> Imports<'a> {
                 self.exports
                     .into_iter()
                     .sorted()
-                    .map(|string| EcoString::from(string).to_doc()),
+                    .map(|string| string.to_doc()),
                 break_(",", ", "),
             );
             let names = docvec![
@@ -80,13 +80,13 @@ impl<'a> Imports<'a> {
 
 #[derive(Debug)]
 struct Import<'a> {
-    path: String,
-    aliases: HashSet<String>,
+    path: EcoString,
+    aliases: HashSet<EcoString>,
     unqualified: Vec<Member<'a>>,
 }
 
 impl<'a> Import<'a> {
-    fn new(path: String) -> Self {
+    fn new(path: EcoString) -> Self {
         Self {
             path,
             aliases: Default::default(),
@@ -95,7 +95,7 @@ impl<'a> Import<'a> {
     }
 
     pub fn into_doc(self, codegen_target: JavaScriptCodegenTarget) -> Document<'a> {
-        let path = EcoString::from(self.path).to_doc();
+        let path = self.path.to_doc();
         let import_modifier = if codegen_target == JavaScriptCodegenTarget::TypeScriptDeclarations {
             "type "
         } else {
@@ -106,7 +106,7 @@ impl<'a> Import<'a> {
                 "import ",
                 import_modifier,
                 "* as ",
-                EcoString::from(alias),
+                alias,
                 " from \"",
                 path.clone(),
                 r#"";"#,

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -154,7 +154,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
 
     fn path_document(&self) -> Document<'a> {
         concat(self.path.iter().map(|segment| match segment {
-            Index::Int(i) => Document::String(format!("[{i}]")),
+            Index::Int(i) => Document::from_string(format!("[{i}]")),
             // TODO: escape string if needed
             Index::String(s) => docvec!(".", s),
             Index::ByteAt(i) => docvec!(".byteAt(", i, ")"),
@@ -958,7 +958,7 @@ impl<'a> Check<'a> {
                 expected_length,
                 has_tail_spread,
             } => {
-                let length_check = Document::String(if has_tail_spread {
+                let length_check = Document::from_string(if has_tail_spread {
                     format!(".atLeastLength({expected_length})")
                 } else {
                     format!(".hasLength({expected_length})")
@@ -975,7 +975,7 @@ impl<'a> Check<'a> {
                 expected_bytes,
                 has_tail_spread,
             } => {
-                let length_check = Document::String(if has_tail_spread {
+                let length_check = Document::from_string(if has_tail_spread {
                     format!(".length >= {expected_bytes}")
                 } else {
                     format!(".length == {expected_bytes}")

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -154,7 +154,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
 
     fn path_document(&self) -> Document<'a> {
         concat(self.path.iter().map(|segment| match segment {
-            Index::Int(i) => format!("[{i}]").to_doc(),
+            Index::Int(i) => eco_format!("[{i}]").to_doc(),
             // TODO: escape string if needed
             Index::String(s) => docvec!(".", s),
             Index::ByteAt(i) => docvec!(".byteAt(", i, ")"),
@@ -959,9 +959,9 @@ impl<'a> Check<'a> {
                 has_tail_spread,
             } => {
                 let length_check = if has_tail_spread {
-                    format!(".atLeastLength({expected_length})").to_doc()
+                    eco_format!(".atLeastLength({expected_length})").to_doc()
                 } else {
-                    format!(".hasLength({expected_length})").to_doc()
+                    eco_format!(".hasLength({expected_length})").to_doc()
                 };
                 if match_desired {
                     docvec![subject, path, length_check,]
@@ -976,9 +976,9 @@ impl<'a> Check<'a> {
                 has_tail_spread,
             } => {
                 let length_check = if has_tail_spread {
-                    format!(".length >= {expected_bytes}").to_doc()
+                    eco_format!(".length >= {expected_bytes}").to_doc()
                 } else {
-                    format!(".length == {expected_bytes}").to_doc()
+                    eco_format!(".length == {expected_bytes}").to_doc()
                 };
                 if match_desired {
                     docvec![subject, path, length_check,]

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -154,7 +154,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
 
     fn path_document(&self) -> Document<'a> {
         concat(self.path.iter().map(|segment| match segment {
-            Index::Int(i) => Document::from_string(format!("[{i}]")),
+            Index::Int(i) => format!("[{i}]").to_doc(),
             // TODO: escape string if needed
             Index::String(s) => docvec!(".", s),
             Index::ByteAt(i) => docvec!(".byteAt(", i, ")"),
@@ -958,11 +958,11 @@ impl<'a> Check<'a> {
                 expected_length,
                 has_tail_spread,
             } => {
-                let length_check = Document::from_string(if has_tail_spread {
-                    format!(".atLeastLength({expected_length})")
+                let length_check = if has_tail_spread {
+                    format!(".atLeastLength({expected_length})").to_doc()
                 } else {
-                    format!(".hasLength({expected_length})")
-                });
+                    format!(".hasLength({expected_length})").to_doc()
+                };
                 if match_desired {
                     docvec![subject, path, length_check,]
                 } else {
@@ -975,11 +975,11 @@ impl<'a> Check<'a> {
                 expected_bytes,
                 has_tail_spread,
             } => {
-                let length_check = Document::from_string(if has_tail_spread {
-                    format!(".length >= {expected_bytes}")
+                let length_check = if has_tail_spread {
+                    format!(".length >= {expected_bytes}").to_doc()
                 } else {
-                    format!(".length == {expected_bytes}")
-                });
+                    format!(".length == {expected_bytes}").to_doc()
+                };
                 if match_desired {
                     docvec![subject, path, length_check,]
                 } else {

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -338,7 +338,7 @@ impl<'a> TypeScriptGenerator<'a> {
     fn type_alias(&mut self, alias: &str, type_: &Type) -> Output<'a> {
         Ok(docvec![
             "export type ",
-            Document::String(ts_safe_type_name(alias.to_string())),
+            Document::from_string(ts_safe_type_name(alias.to_string())),
             " = ",
             self.print_type(type_),
             ";"
@@ -379,7 +379,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
         definitions.push(Ok(docvec![
             "export type ",
-            name_with_generics(Document::String(format!("{name}$")), typed_parameters),
+            name_with_generics(Document::from_string(format!("{name}$")), typed_parameters),
             " = ",
             definition,
             ";",
@@ -422,7 +422,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     .label
                     .as_ref()
                     .map(|(_, s)| super::maybe_escape_identifier_doc(s))
-                    .unwrap_or_else(|| Document::String(format!("argument${i}")));
+                    .unwrap_or_else(|| Document::from_string(format!("argument${i}")));
                 docvec![name, ": ", self.do_print_force_generic_param(&arg.type_)]
             })),
             ";",
@@ -435,7 +435,7 @@ impl<'a> TypeScriptGenerator<'a> {
                         .label
                         .as_ref()
                         .map(|(_, s)| super::maybe_escape_identifier_doc(s))
-                        .unwrap_or_else(|| Document::String(format!("{i}")));
+                        .unwrap_or_else(|| Document::from_string(format!("{i}")));
                     docvec![
                         name,
                         ": ",
@@ -670,14 +670,14 @@ impl<'a> TypeScriptGenerator<'a> {
     ) -> Document<'static> {
         let name = format!("{}$", ts_safe_type_name(name.to_string()));
         let name = match module == self.module.name {
-            true => Document::String(name),
+            true => Document::from_string(name),
             false => {
                 // If type comes from a separate module, use that module's name
                 // as a TypeScript namespace prefix
                 docvec![
-                    Document::String(self.module_name(module)),
+                    Document::from_string(self.module_name(module)),
                     ".",
-                    Document::String(name),
+                    Document::from_string(name),
                 ]
             }
         };

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -338,7 +338,7 @@ impl<'a> TypeScriptGenerator<'a> {
     fn type_alias(&mut self, alias: &str, type_: &Type) -> Output<'a> {
         Ok(docvec![
             "export type ",
-            Document::from_string(ts_safe_type_name(alias.to_string())),
+            ts_safe_type_name(alias.to_string()),
             " = ",
             self.print_type(type_),
             ";"
@@ -379,7 +379,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
         definitions.push(Ok(docvec![
             "export type ",
-            name_with_generics(Document::from_string(format!("{name}$")), typed_parameters),
+            name_with_generics(format!("{name}$").to_doc(), typed_parameters),
             " = ",
             definition,
             ";",
@@ -422,7 +422,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     .label
                     .as_ref()
                     .map(|(_, s)| super::maybe_escape_identifier_doc(s))
-                    .unwrap_or_else(|| Document::from_string(format!("argument${i}")));
+                    .unwrap_or_else(|| format!("argument${i}").to_doc());
                 docvec![name, ": ", self.do_print_force_generic_param(&arg.type_)]
             })),
             ";",
@@ -435,7 +435,7 @@ impl<'a> TypeScriptGenerator<'a> {
                         .label
                         .as_ref()
                         .map(|(_, s)| super::maybe_escape_identifier_doc(s))
-                        .unwrap_or_else(|| Document::from_string(format!("{i}")));
+                        .unwrap_or_else(|| format!("{i}").to_doc());
                     docvec![
                         name,
                         ": ",
@@ -670,15 +670,11 @@ impl<'a> TypeScriptGenerator<'a> {
     ) -> Document<'static> {
         let name = format!("{}$", ts_safe_type_name(name.to_string()));
         let name = match module == self.module.name {
-            true => Document::from_string(name),
+            true => name.to_doc(),
             false => {
                 // If type comes from a separate module, use that module's name
                 // as a TypeScript namespace prefix
-                docvec![
-                    Document::from_string(self.module_name(module)),
-                    ".",
-                    Document::from_string(name),
-                ]
+                docvec![self.module_name(module), ".", name]
             }
         };
         if args.is_empty() {

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -265,28 +265,28 @@ impl<'a> TypeScriptGenerator<'a> {
     ///
     fn register_import(&mut self, imports: &mut Imports<'a>, package: &'a str, module: &'a str) {
         let path = self.import_path(package, module);
-        imports.register_module(path, [self.module_name(module).to_string()], []);
+        imports.register_module(path, [self.module_name(module)], []);
     }
 
     /// Calculates the path of where to import an external module from
     ///
-    fn import_path(&self, package: &'a str, module: &'a str) -> String {
+    fn import_path(&self, package: &'a str, module: &'a str) -> EcoString {
         // DUPE: current_module_name_segments_count
         // TODO: strip shared prefixed between current module and imported
         // module to avoid descending and climbing back out again
         if package == self.module.type_info.package || package.is_empty() {
             // Same package
             match self.current_module_name_segments_count {
-                1 => format!("./{module}.d.mts"),
+                1 => eco_format!("./{module}.d.mts"),
                 _ => {
                     let prefix = "../".repeat(self.current_module_name_segments_count - 1);
-                    format!("{prefix}{module}.d.mts")
+                    eco_format!("{prefix}{module}.d.mts")
                 }
             }
         } else {
             // Different package
             let prefix = "../".repeat(self.current_module_name_segments_count);
-            format!("{prefix}{package}/{module}.d.mts")
+            eco_format!("{prefix}{package}/{module}.d.mts")
         }
     }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -213,7 +213,7 @@ pub struct Parser<T: Iterator<Item = LexResult>> {
     tok0: Option<Spanned>,
     tok1: Option<Spanned>,
     extra: ModuleExtra,
-    doc_comments: VecDeque<(u32, String)>,
+    doc_comments: VecDeque<(u32, EcoString)>,
 }
 impl<T> Parser<T>
 where

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -1,3 +1,5 @@
+use ecow::EcoString;
+
 use crate::ast::SrcSpan;
 use crate::parse::error::{LexicalError, LexicalErrorType};
 use crate::parse::token::Token;
@@ -705,7 +707,7 @@ where
             }
             _ => Kind::Comment,
         };
-        let mut content = String::new();
+        let mut content = EcoString::new();
         let start_pos = self.get_pos();
         while Some('\n') != self.chr0 {
             match self.chr0 {

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -10,7 +10,7 @@ pub enum Token {
     Int { value: EcoString },
     Float { value: EcoString },
     String { value: EcoString },
-    CommentDoc { content: String },
+    CommentDoc { content: EcoString },
     // Groupings
     LeftParen,   // (
     RightParen,  // )

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -42,79 +42,79 @@ pub trait Documentable<'a> {
 
 impl<'a> Documentable<'a> for char {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self}"))
+        Document::string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for String {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(self)
+        Document::string(self)
     }
 }
 
 impl<'a> Documentable<'a> for &'a str {
     fn to_doc(self) -> Document<'a> {
-        Document::from_str(self)
+        Document::str(self)
     }
 }
 
 impl<'a> Documentable<'a> for EcoString {
     fn to_doc(self) -> Document<'a> {
-        Document::from_eco_string(self)
+        Document::eco_string(self)
     }
 }
 
 impl<'a> Documentable<'a> for &EcoString {
     fn to_doc(self) -> Document<'a> {
-        Document::from_eco_string(self.clone())
+        Document::eco_string(self.clone())
     }
 }
 
 impl<'a> Documentable<'a> for isize {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self}"))
+        Document::string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for i64 {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self}"))
+        Document::string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for usize {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self}"))
+        Document::string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for f64 {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self:?}"))
+        Document::string(format!("{self:?}"))
     }
 }
 
 impl<'a> Documentable<'a> for u64 {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self:?}"))
+        Document::string(format!("{self:?}"))
     }
 }
 
 impl<'a> Documentable<'a> for u32 {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self}"))
+        Document::string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for u16 {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self}"))
+        Document::string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for u8 {
     fn to_doc(self) -> Document<'a> {
-        Document::from_string(format!("{self}"))
+        Document::string(format!("{self}"))
     }
 }
 
@@ -598,21 +598,21 @@ pub fn flex_break<'a>(broken: &'a str, unbroken: &'a str) -> Document<'a> {
 }
 
 impl<'a> Document<'a> {
-    pub fn from_string(string: String) -> Self {
+    pub fn string(string: String) -> Self {
         Document::String {
             graphemes: string.graphemes(true).count() as isize,
             string,
         }
     }
 
-    pub fn from_str(string: &'a str) -> Self {
+    pub fn str(string: &'a str) -> Self {
         Document::Str {
             graphemes: string.graphemes(true).count() as isize,
             string,
         }
     }
 
-    pub fn from_eco_string(string: EcoString) -> Self {
+    pub fn eco_string(string: EcoString) -> Self {
         Document::EcoString {
             graphemes: string.graphemes(true).count() as isize,
             string,

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -171,9 +171,9 @@ pub enum Document<'a> {
     /// Nests the given document to the current cursor position
     Group(Box<Self>),
 
-    /// A string to render
-    String {
-        string: String,
+    /// A str to render
+    Str {
+        string: &'a str,
         // The number of extended grapheme clusters in the string.
         // This is what the pretty printer uses as the width of the string as it
         // is closes to what a human would consider the "length" of a string.
@@ -184,9 +184,6 @@ pub enum Document<'a> {
         //
         graphemes: isize,
     },
-
-    /// A str to render
-    Str { string: &'a str, graphemes: isize },
 
     /// A string that is cheap to copy
     EcoString { string: EcoString, graphemes: isize },
@@ -329,9 +326,9 @@ fn fits(
 
             // When we run into a string we increase the current_width; looping
             // back we will check if we've exceeded the maximum allowed width.
-            Document::Str { graphemes, .. }
-            | Document::String { graphemes, .. }
-            | Document::EcoString { graphemes, .. } => current_width += graphemes,
+            Document::Str { graphemes, .. } | Document::EcoString { graphemes, .. } => {
+                current_width += graphemes
+            }
 
             // If we get to a break we need to first see if it has to be
             // rendered as its unbroken or broken string, depending on the mode.
@@ -485,11 +482,6 @@ fn format(
 
             // Strings are printed as they are and the current width is
             // increased accordingly.
-            Document::String { string, graphemes } => {
-                width += graphemes;
-                writer.str_write(string)?;
-            }
-
             Document::EcoString { string, graphemes } => {
                 width += graphemes;
                 writer.str_write(string)?;
@@ -674,7 +666,6 @@ impl<'a> Document<'a> {
         match self {
             Line(n) => *n == 0,
             EcoString { string, .. } => string.is_empty(),
-            String { string, .. } => string.is_empty(),
             Str { string, .. } => string.is_empty(),
             // assuming `broken` and `unbroken` are equivalent
             Break { broken, .. } => broken.is_empty(),

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -18,6 +18,7 @@ mod tests;
 
 use ecow::EcoString;
 use itertools::Itertools;
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{io::Utf8Writer, Result};
 
@@ -41,73 +42,73 @@ pub trait Documentable<'a> {
 
 impl<'a> Documentable<'a> for char {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self}"))
+        Document::from_string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for &'a str {
     fn to_doc(self) -> Document<'a> {
-        Document::Str(self)
+        Document::from_str(self)
     }
 }
 
 impl<'a> Documentable<'a> for EcoString {
     fn to_doc(self) -> Document<'a> {
-        Document::EcoString(self)
+        Document::from_eco_string(self)
     }
 }
 
 impl<'a> Documentable<'a> for &EcoString {
     fn to_doc(self) -> Document<'a> {
-        Document::EcoString(self.clone())
+        Document::from_eco_string(self.clone())
     }
 }
 
 impl<'a> Documentable<'a> for isize {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self}"))
+        Document::from_string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for i64 {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self}"))
+        Document::from_string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for usize {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self}"))
+        Document::from_string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for f64 {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self:?}"))
+        Document::from_string(format!("{self:?}"))
     }
 }
 
 impl<'a> Documentable<'a> for u64 {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self:?}"))
+        Document::from_string(format!("{self:?}"))
     }
 }
 
 impl<'a> Documentable<'a> for u32 {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self}"))
+        Document::from_string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for u16 {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self}"))
+        Document::from_string(format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for u8 {
     fn to_doc(self) -> Document<'a> {
-        Document::String(format!("{self}"))
+        Document::from_string(format!("{self}"))
     }
 }
 
@@ -171,13 +172,24 @@ pub enum Document<'a> {
     Group(Box<Self>),
 
     /// A string to render
-    String(String),
+    String {
+        string: String,
+        // The number of extended grapheme clusters in the string.
+        // This is what the pretty printer uses as the width of the string as it
+        // is closes to what a human would consider the "length" of a string.
+        //
+        // Since computing the number of grapheme clusters requires walking over
+        // the string we precompute it to avoid iterating through a string over
+        // and over again in the pretty printing algorithm.
+        //
+        graphemes: isize,
+    },
 
     /// A str to render
-    Str(&'a str),
+    Str { string: &'a str, graphemes: isize },
 
     /// A string that is cheap to copy
-    EcoString(EcoString),
+    EcoString { string: EcoString, graphemes: isize },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -317,9 +329,9 @@ fn fits(
 
             // When we run into a string we increase the current_width; looping
             // back we will check if we've exceeded the maximum allowed width.
-            Document::Str(s) => current_width += s.len() as isize,
-            Document::String(s) => current_width += s.len() as isize,
-            Document::EcoString(s) => current_width += s.len() as isize,
+            Document::Str { graphemes, .. }
+            | Document::String { graphemes, .. }
+            | Document::EcoString { graphemes, .. } => current_width += graphemes,
 
             // If we get to a break we need to first see if it has to be
             // rendered as its unbroken or broken string, depending on the mode.
@@ -473,19 +485,19 @@ fn format(
 
             // Strings are printed as they are and the current width is
             // increased accordingly.
-            Document::String(s) => {
-                width += s.len() as isize;
-                writer.str_write(s)?;
+            Document::String { string, graphemes } => {
+                width += graphemes;
+                writer.str_write(string)?;
             }
 
-            Document::EcoString(s) => {
-                width += s.len() as isize;
-                writer.str_write(s)?;
+            Document::EcoString { string, graphemes } => {
+                width += graphemes;
+                writer.str_write(string)?;
             }
 
-            Document::Str(s) => {
-                width += s.len() as isize;
-                writer.str_write(s)?;
+            Document::Str { string, graphemes } => {
+                width += graphemes;
+                writer.str_write(string)?;
             }
 
             // If multiple documents need to be printed, then they are all
@@ -580,6 +592,27 @@ pub fn flex_break<'a>(broken: &'a str, unbroken: &'a str) -> Document<'a> {
 }
 
 impl<'a> Document<'a> {
+    pub fn from_string(string: String) -> Self {
+        Document::String {
+            graphemes: string.graphemes(true).count() as isize,
+            string,
+        }
+    }
+
+    pub fn from_str(string: &'a str) -> Self {
+        Document::Str {
+            graphemes: string.graphemes(true).count() as isize,
+            string,
+        }
+    }
+
+    pub fn from_eco_string(string: EcoString) -> Self {
+        Document::EcoString {
+            graphemes: string.graphemes(true).count() as isize,
+            string,
+        }
+    }
+
     pub fn group(self) -> Self {
         Self::Group(Box::new(self))
     }
@@ -647,9 +680,9 @@ impl<'a> Document<'a> {
         use Document::*;
         match self {
             Line(n) => *n == 0,
-            EcoString(s) => s.is_empty(),
-            String(s) => s.is_empty(),
-            Str(s) => s.is_empty(),
+            EcoString { string, .. } => string.is_empty(),
+            String { string, .. } => string.is_empty(),
+            Str { string, .. } => string.is_empty(),
             // assuming `broken` and `unbroken` are equivalent
             Break { broken, .. } => broken.is_empty(),
             ForceBroken(d) | Nest(_, _, _, d) | Group(d) | NextBreakFits(d, _) => d.is_empty(),

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 mod tests;
 
-use ecow::EcoString;
+use ecow::{eco_format, EcoString};
 use itertools::Itertools;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -42,13 +42,7 @@ pub trait Documentable<'a> {
 
 impl<'a> Documentable<'a> for char {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self}"))
-    }
-}
-
-impl<'a> Documentable<'a> for String {
-    fn to_doc(self) -> Document<'a> {
-        Document::string(self)
+        Document::eco_string(eco_format!("{self}"))
     }
 }
 
@@ -72,49 +66,49 @@ impl<'a> Documentable<'a> for &EcoString {
 
 impl<'a> Documentable<'a> for isize {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self}"))
+        Document::eco_string(eco_format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for i64 {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self}"))
+        Document::eco_string(eco_format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for usize {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self}"))
+        Document::eco_string(eco_format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for f64 {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self:?}"))
+        Document::eco_string(eco_format!("{self:?}"))
     }
 }
 
 impl<'a> Documentable<'a> for u64 {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self:?}"))
+        Document::eco_string(eco_format!("{self:?}"))
     }
 }
 
 impl<'a> Documentable<'a> for u32 {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self}"))
+        Document::eco_string(eco_format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for u16 {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self}"))
+        Document::eco_string(eco_format!("{self}"))
     }
 }
 
 impl<'a> Documentable<'a> for u8 {
     fn to_doc(self) -> Document<'a> {
-        Document::string(format!("{self}"))
+        Document::eco_string(eco_format!("{self}"))
     }
 }
 
@@ -598,13 +592,6 @@ pub fn flex_break<'a>(broken: &'a str, unbroken: &'a str) -> Document<'a> {
 }
 
 impl<'a> Document<'a> {
-    pub fn string(string: String) -> Self {
-        Document::String {
-            graphemes: string.graphemes(true).count() as isize,
-            string,
-        }
-    }
-
     pub fn str(string: &'a str) -> Self {
         Document::Str {
             graphemes: string.graphemes(true).count() as isize,

--- a/compiler-core/src/pretty.rs
+++ b/compiler-core/src/pretty.rs
@@ -46,6 +46,12 @@ impl<'a> Documentable<'a> for char {
     }
 }
 
+impl<'a> Documentable<'a> for String {
+    fn to_doc(self) -> Document<'a> {
+        Document::from_string(self)
+    }
+}
+
 impl<'a> Documentable<'a> for &'a str {
     fn to_doc(self) -> Document<'a> {
         Document::from_str(self)

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -67,23 +67,23 @@ fn fits_test() {
     assert!(fits(0, 0, vector![(0, Unbroken, &Line(100))]));
 
     // String fits if smaller than limit
-    let doc = Document::from_string("Hello".into());
+    let doc = Document::string("Hello".into());
     assert!(fits(5, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::from_string("Hello".into());
+    let doc = Document::string("Hello".into());
     assert!(fits(5, 0, vector![(0, Unbroken, &doc)]));
-    let doc = Document::from_string("Hello".into());
+    let doc = Document::string("Hello".into());
     assert!(!fits(4, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::from_string("Hello".into());
+    let doc = Document::string("Hello".into());
     assert!(!fits(4, 0, vector![(0, Unbroken, &doc)]));
 
     // Cons fits if combined smaller than limit
-    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
+    let doc = Document::string("1".into()).append(Document::string("2".into()));
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
+    let doc = Document::string("1".into()).append(Document::string("2".into()));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc,)]));
-    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
+    let doc = Document::string("1".into()).append(Document::string("2".into()));
     assert!(!fits(1, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
+    let doc = Document::string("1".into()).append(Document::string("2".into()));
     assert!(!fits(1, 0, vector![(0, Unbroken, &doc)]));
 
     // Nest fits if combined smaller than limit
@@ -91,7 +91,7 @@ fn fits_test() {
         1,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(Document::from_string("12".into())),
+        Box::new(Document::string("12".into())),
     );
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
@@ -103,7 +103,7 @@ fn fits_test() {
         0,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(Document::from_string("12".into())),
+        Box::new(Document::string("12".into())),
     );
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
@@ -113,10 +113,10 @@ fn fits_test() {
 
 #[test]
 fn format_test() {
-    let doc = Document::from_string("Hi".into());
+    let doc = Document::string("Hi".into());
     assert_eq!("Hi", doc.to_pretty_string(10));
 
-    let doc = Document::from_string("Hi".into()).append(Document::from_string(", world!".into()));
+    let doc = Document::string("Hi".into()).append(Document::string(", world!".into()));
     assert_eq!("Hi, world!", doc.clone().to_pretty_string(10));
 
     let doc = &Break {
@@ -139,10 +139,7 @@ fn format_test() {
         2,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(
-            Document::from_string("1".into())
-                .append(Line(1).append(Document::from_string("2".into()))),
-        ),
+        Box::new(Document::string("1".into()).append(Line(1).append(Document::string("2".into())))),
     );
     assert_eq!("1\n  2", doc.to_pretty_string(1));
 

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -67,23 +67,23 @@ fn fits_test() {
     assert!(fits(0, 0, vector![(0, Unbroken, &Line(100))]));
 
     // String fits if smaller than limit
-    let doc = String("Hello".into());
+    let doc = Document::from_string("Hello".into());
     assert!(fits(5, 0, vector![(0, Broken, &doc)]));
-    let doc = String("Hello".into());
+    let doc = Document::from_string("Hello".into());
     assert!(fits(5, 0, vector![(0, Unbroken, &doc)]));
-    let doc = String("Hello".into());
+    let doc = Document::from_string("Hello".into());
     assert!(!fits(4, 0, vector![(0, Broken, &doc)]));
-    let doc = String("Hello".into());
+    let doc = Document::from_string("Hello".into());
     assert!(!fits(4, 0, vector![(0, Unbroken, &doc)]));
 
     // Cons fits if combined smaller than limit
-    let doc = String("1".into()).append(String("2".into()));
+    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
-    let doc = String("1".into()).append(String("2".into()));
+    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc,)]));
-    let doc = String("1".into()).append(String("2".into()));
+    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
     assert!(!fits(1, 0, vector![(0, Broken, &doc)]));
-    let doc = String("1".into()).append(String("2".into()));
+    let doc = Document::from_string("1".into()).append(Document::from_string("2".into()));
     assert!(!fits(1, 0, vector![(0, Unbroken, &doc)]));
 
     // Nest fits if combined smaller than limit
@@ -91,7 +91,7 @@ fn fits_test() {
         1,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(String("12".into())),
+        Box::new(Document::from_string("12".into())),
     );
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
@@ -103,7 +103,7 @@ fn fits_test() {
         0,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(String("12".into())),
+        Box::new(Document::from_string("12".into())),
     );
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
@@ -113,10 +113,10 @@ fn fits_test() {
 
 #[test]
 fn format_test() {
-    let doc = String("Hi".into());
+    let doc = Document::from_string("Hi".into());
     assert_eq!("Hi", doc.to_pretty_string(10));
 
-    let doc = String("Hi".into()).append(String(", world!".into()));
+    let doc = Document::from_string("Hi".into()).append(Document::from_string(", world!".into()));
     assert_eq!("Hi, world!", doc.clone().to_pretty_string(10));
 
     let doc = &Break {
@@ -139,7 +139,10 @@ fn format_test() {
         2,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(String("1".into()).append(Line(1).append(String("2".into())))),
+        Box::new(
+            Document::from_string("1".into())
+                .append(Line(1).append(Document::from_string("2".into()))),
+        ),
     );
     assert_eq!("1\n  2", doc.to_pretty_string(1));
 

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -67,23 +67,23 @@ fn fits_test() {
     assert!(fits(0, 0, vector![(0, Unbroken, &Line(100))]));
 
     // String fits if smaller than limit
-    let doc = Document::string("Hello".into());
+    let doc = Document::str("Hello");
     assert!(fits(5, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::string("Hello".into());
+    let doc = Document::str("Hello");
     assert!(fits(5, 0, vector![(0, Unbroken, &doc)]));
-    let doc = Document::string("Hello".into());
+    let doc = Document::str("Hello");
     assert!(!fits(4, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::string("Hello".into());
+    let doc = Document::str("Hello");
     assert!(!fits(4, 0, vector![(0, Unbroken, &doc)]));
 
     // Cons fits if combined smaller than limit
-    let doc = Document::string("1".into()).append(Document::string("2".into()));
+    let doc = Document::str("1").append(Document::str("2"));
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::string("1".into()).append(Document::string("2".into()));
+    let doc = Document::str("1").append(Document::str("2"));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc,)]));
-    let doc = Document::string("1".into()).append(Document::string("2".into()));
+    let doc = Document::str("1").append(Document::str("2"));
     assert!(!fits(1, 0, vector![(0, Broken, &doc)]));
-    let doc = Document::string("1".into()).append(Document::string("2".into()));
+    let doc = Document::str("1").append(Document::str("2"));
     assert!(!fits(1, 0, vector![(0, Unbroken, &doc)]));
 
     // Nest fits if combined smaller than limit
@@ -91,7 +91,7 @@ fn fits_test() {
         1,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(Document::string("12".into())),
+        Box::new(Document::str("12")),
     );
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
@@ -103,7 +103,7 @@ fn fits_test() {
         0,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(Document::string("12".into())),
+        Box::new(Document::str("12")),
     );
     assert!(fits(2, 0, vector![(0, Broken, &doc)]));
     assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
@@ -113,10 +113,10 @@ fn fits_test() {
 
 #[test]
 fn format_test() {
-    let doc = Document::string("Hi".into());
+    let doc = Document::str("Hi");
     assert_eq!("Hi", doc.to_pretty_string(10));
 
-    let doc = Document::string("Hi".into()).append(Document::string(", world!".into()));
+    let doc = Document::str("Hi").append(Document::str(", world!"));
     assert_eq!("Hi, world!", doc.clone().to_pretty_string(10));
 
     let doc = &Break {
@@ -139,7 +139,7 @@ fn format_test() {
         2,
         NestMode::Increase,
         NestCondition::Always,
-        Box::new(Document::string("1".into()).append(Line(1).append(Document::string("2".into())))),
+        Box::new(Document::str("1").append(Line(1).append(Document::str("2")))),
     );
     assert_eq!("1\n  2", doc.to_pretty_string(1));
 

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -157,8 +157,7 @@ impl Printer {
 }
 
 fn qualify_type_name(module: &str, type_name: &str) -> Document<'static> {
-    let type_name = Document::from_string(type_name.to_string());
-    docvec![Document::from_string(module.to_string()), ".", type_name]
+    docvec![module.to_string(), ".", type_name.to_string()]
 }
 
 #[test]

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -157,7 +157,7 @@ impl Printer {
 }
 
 fn qualify_type_name(module: &str, type_name: &str) -> Document<'static> {
-    docvec![module.to_string(), ".", type_name.to_string()]
+    docvec![EcoString::from(module), ".", EcoString::from(type_name)]
 }
 
 #[test]

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -157,8 +157,8 @@ impl Printer {
 }
 
 fn qualify_type_name(module: &str, type_name: &str) -> Document<'static> {
-    let type_name = Document::String(type_name.to_string());
-    docvec![Document::String(module.to_string()), ".", type_name]
+    let type_name = Document::from_string(type_name.to_string());
+    docvec![Document::from_string(module.to_string()), ".", type_name]
 }
 
 #[test]


### PR DESCRIPTION
This PR closes #3627
The pretty printer used `str.len()` as the width of a string; but what a human would intuitively think of as the length of a string is its number of grapheme clusters. This would result in some lines looking short but being split nonetheless by the formatter.