### PR TITLE
Improve resolution error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "tracing",
  "unicode-segmentation",
  "vec1",
+ "version-ranges",
  "xxhash-rust",
 ]
 
@@ -2665,6 +2666,15 @@ name = "vec1"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8d079415ceb2be83fc355adbadafe401307d5c309c7e6ade6638e6f9f42f42d"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "version_check"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -36,6 +36,7 @@ globset = { version = "0", features = ["serde1"] }
 xxhash-rust = { version = "0", features = ["xxh3"] }
 # Pubgrub dependency resolution algorithm
 pubgrub = "0"
+version-ranges = "0.1.1"
 # Used for converting absolute path to relative path
 pathdiff = { version = "0", features = ["camino"] }
 # Memory arena using ids rather than references

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn resolution_error_message() {
-        let result = resolve_versions(
+        let _ = resolve_versions(
             interesting_remote(),
             HashMap::new(),
             "app".into(),

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn resolution_error_message() {
-        let _ = resolve_versions(
+        let result = resolve_versions(
             interesting_remote(),
             HashMap::new(),
             "app".into(),
@@ -539,8 +539,13 @@ mod tests {
             ]
             .into_iter(),
             &vec![].into_iter().collect(),
-        )
-        .unwrap();
+        );
+
+        if let Err(Error::DependencyResolutionFailed(message)) = result {
+            insta::assert_snapshot!(message)
+        } else {
+            panic!("expected a resolution error message")
+        }
     }
 
     #[test]

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -421,7 +421,7 @@ fn derivation_tree_to_pretty_error_message(
                         root,
                         root_range,
                         dep,
-                        dep_range,
+                        dep_range_from_root,
                     )),
                 ) => match (cause1.as_ref(), cause2.as_ref()) {
                     (
@@ -443,14 +443,14 @@ fn derivation_tree_to_pretty_error_message(
                         && maybe_root_range == root_range
                         && maybe_dep == dep =>
                     {
-                        format!(
+                        wrap_format!(
                             "Unable to find compatible versions for the version \
 constraints in your gleam.toml.
 
-- `{root}` requires `{dep}` with a version `{dep_range}`.
-- But `{root}` also requires `{common}` with a version `{common_range}`.
-  - And all `{common}` versions in that range require `{dep}` with a version in range `{dep_range_from_common}`,
-    which is incompatible with the previous range!
+- `{root}` requires `{common}` to be `{common_range}`
+- and all versions of `{common}` in that range require `{dep}` to be `{dep_range_from_common}`
+- but `{root}` also requires `{dep}` to be `{dep_range_from_root}`
+- and there is no version of `{dep}` that satiesfies both constraints
 "
                         )
                     }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -473,7 +473,6 @@ fn derivation_tree_to_default_error_message(
     let mut conflicting_packages = HashSet::new();
     collect_conflicting_packages(&derivation_tree, &mut conflicting_packages);
 
-    pprint_error(0, &derivation_tree);
     wrap_format!(
         "Unable to find compatible versions for the version constraints in \
 your gleam.toml. The conflicting packages are:

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -414,6 +414,7 @@ fn derivation_tree_to_pretty_error_message(
     derivation_tree.collapse_no_versions();
     let derivation_tree = simplify_error(derivation_tree);
 
+    pprint_error(0, &derivation_tree);
     // TODO))
     // This order is not deterministic, so sometimes it will default to the
     // original version even though it's almost the same!!
@@ -613,7 +614,7 @@ fn merge_trees_step<'dt, P: Package, V: Version>(
                 cause1_p1,
                 cause1_r1.union(&cause2_r1),
                 cause1_p2,
-                cause1_r2.intersection(&cause2_r2),
+                cause1_r2.union(&cause2_r2),
             ))
         }
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -14,6 +14,7 @@ use heck::{ToSnakeCase, ToTitleCase, ToUpperCamelCase};
 use hexpm::version::ResolutionError;
 use itertools::Itertools;
 use pubgrub::package::Package;
+use pubgrub::range::Range;
 use pubgrub::report::{DerivationTree, Derived, External};
 use pubgrub::version::Version;
 use std::collections::HashSet;
@@ -412,6 +413,10 @@ fn derivation_tree_to_pretty_error_message(
 ) -> String {
     derivation_tree.collapse_no_versions();
     let derivation_tree = simplify_error(derivation_tree);
+
+    // TODO))
+    // This order is not deterministic, so sometimes it will default to the
+    // original version even though it's almost the same!!
     match &derivation_tree {
         DerivationTree::Derived(Derived { cause1, cause2, .. }) => {
             match (cause1.as_ref(), cause2.as_ref()) {
@@ -443,14 +448,20 @@ fn derivation_tree_to_pretty_error_message(
                         && maybe_root_range == root_range
                         && maybe_dep == dep =>
                     {
+                        // TODO))
+                        // The default look of ranges is confusing and we want to switch
+                        // to one more similar to Gleam's constraints.
+                        // However, at the moment there's no way of doing this:
+                        // https://github.com/pubgrub-rs/pubgrub/issues/258
+                        //
                         wrap_format!(
                             "Unable to find compatible versions for the version \
-constraints in your gleam.toml.
+constraints in your gleam.toml:
 
 - `{root}` requires `{common}` to be `{common_range}`
 - and all versions of `{common}` in that range require `{dep}` to be `{dep_range_from_common}`
 - but `{root}` also requires `{dep}` to be `{dep_range_from_root}`
-- and there is no version of `{dep}` that satiesfies both constraints
+- and there is no version of `{dep}` that satisfies both constraints
 "
                         )
                     }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use termcolor::Buffer;
 use thiserror::Error;
 use vec1::Vec1;
+use version_ranges::Ranges;
 
 use camino::{Utf8Path, Utf8PathBuf};
 


### PR DESCRIPTION
This PR tries to improve some messages displayed if version resolution fails.
This only works in a limited case and keeps defaulting to the current error message; solving the problem in the most general way possible seems a really hard problem so I think we could try doing this and keep on improving incrementally as we identify and handle recurring failure reasons.