### PR TITLE
Print qualified type names for type errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@
 
 ### Compiler
 
+- The compiler now prints correctly qualified or aliased type names when
+  printing type errors.
+
+  This code:
+
+  ```gleam
+  pub type Int
+
+  pub fn different_int_types(value: Int) {
+    value
+  }
+
+  pub fn main() {
+    different_int_types(20)
+  }
+  ```
+
+  Produces this error:
+
+  ```
+  error: Type mismatch
+    ┌─ /src/wibble.gleam:8:23
+    │
+  8 │   different_int_types(20)
+    │                       ^^
+
+  Expected type:
+
+      Int
+
+  Found type:
+
+      gleam.Int
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -535,6 +535,7 @@ fn analyse(
 
             Outcome::PartialFailure(ast, errors) => {
                 let error = Error::Type {
+                    names: ast.names.clone(),
                     path: path.clone(),
                     src: code.clone(),
                     errors,
@@ -559,6 +560,7 @@ fn analyse(
 
             Outcome::TotalFailure(errors) => {
                 return Outcome::TotalFailure(Error::Type {
+                    names: Default::default(),
                     path: path.clone(),
                     src: code.clone(),
                     errors,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -100,7 +100,6 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
-            constructor_names: {},
         },
     },
     extra: ModuleExtra {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -57,7 +57,6 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
-            constructor_names: {},
         },
     },
     extra: ModuleExtra {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -162,7 +162,6 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
-            constructor_names: {},
         },
     },
     extra: ModuleExtra {

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -214,7 +214,6 @@ pub enum Error {
         situation: Option<UnifyErrorSituation>,
         expected: Arc<Type>,
         given: Arc<Type>,
-        rigid_type_names: im::HashMap<u64, EcoString>,
     },
 
     RecursiveType {
@@ -933,19 +932,6 @@ impl Error {
             _ => self,
         }
     }
-
-    pub fn with_unify_error_rigid_names(mut self, new_names: &im::HashMap<u64, EcoString>) -> Self {
-        match self {
-            Error::CouldNotUnify {
-                rigid_type_names: ref mut annotated_names,
-                ..
-            } => {
-                *annotated_names = new_names.clone();
-                self
-            }
-            _ => self,
-        }
-    }
 }
 
 impl Warning {
@@ -1467,7 +1453,6 @@ impl UnifyError {
                 expected,
                 given,
                 situation: note,
-                rigid_type_names: im::hashmap![],
             },
 
             Self::ExtraVarInAlternativePattern { name } => {
@@ -1519,7 +1504,6 @@ impl UnifyError {
                     expected: one.clone(),
                     given: other.clone(),
                     situation: None,
-                    rigid_type_names: im::hashmap![],
                 },
 
                 FunctionsMismatchReason::Arity {

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -397,7 +397,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     expected: type_.clone(),
                     situation: None,
                     location,
-                    rigid_type_names: hashmap![],
                 }),
             },
 
@@ -444,7 +443,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         expected: type_,
                         situation: None,
                         location,
-                        rigid_type_names: hashmap![],
                     })
                 }
             },

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_operands.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_operands.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport maths as math\npub fn add_two_vectors(a: math.Vector, b: math.Vector) {\n  a + b\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   a + b
+  │   ^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    math.Vector

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_pipe_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_pipe_argument.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport mod\npub fn main() {\n  Nil |> mod.takes_wibble\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:13
+  │
+4 │   Nil |> mod.takes_wibble
+  │             ^^^^^^^^^^^^^ This function does not accept the piped type
+
+The argument is:
+
+    Nil
+
+But function expects:
+
+    mod.Wibble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_mismatched_type_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_mismatched_type_error.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport wibble\nconst my_wobble: wibble.Wobble = Nil\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:34
+  │
+3 │ const my_wobble: wibble.Wobble = Nil
+  │                                  ^^^
+
+Expected type:
+
+    wibble.Wobble
+
+Found type:
+
+    Nil

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_function.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport wibble.{type Function as FuncWrapper}\npub fn main(f: FuncWrapper) {\n  f()\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   f()
+  │   ^
+
+This value is being called as a function but its type is:
+
+    FuncWrapper

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_tuple.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_tuple.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport mod.{type Pair as Duo}\npub fn first(pair: Duo(a, b)) {\n  pair.0\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   pair.0
+  │   ^^^^ This is not a tuple
+
+To index into this value it needs to be a tuple, however it has this type:
+
+    Duo(a, b)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_fn_in_use.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_fn_in_use.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport some_mod as sm\npub fn main(func: sm.Function(Int, String, Float)) {\n  use <- func()\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:10
+  │
+4 │   use <- func()
+  │          ^^^^^^
+
+In a use expression, there should be a function on the right hand side of
+`<-`, but this value has type:
+
+    sm.Function(Int, String, Float)
+
+See: https://tour.gleam.run/advanced-features/use/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_similar_type_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_similar_type_name.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport wibble\nconst value: wibble.Int = 20\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:27
+  │
+3 │ const value: wibble.Int = 20
+  │                           ^^
+
+Expected type:
+
+    wibble.Int
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_unification_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_unification_error.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport gleam\n\ntype Bool {\n  True\n  False\n}\n\nconst list_of_bools = [True, False, gleam.False]\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:9:37
+  │
+9 │ const list_of_bools = [True, False, gleam.False]
+  │                                     ^^^^^^^^^^^
+
+Expected type:
+
+    Bool
+
+Found type:
+
+    gleam.Bool

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_unknown_field.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_unknown_field.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport gleam\ntype Int {\n  Int(bit_size: gleam.Int, bits: BitArray)\n}\n\npub fn main(not_a_record: gleam.Int) {\n  not_a_record.bits\n}\n"
+---
+error: Unknown record field
+  ┌─ /src/one/two.gleam:8:15
+  │
+8 │   not_a_record.bits
+  │               ^^^^^ This field does not exist
+
+The value being accessed has this type:
+
+    gleam.Int
+
+It does not have any fields.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_use_fn_without_callback.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_use_fn_without_callback.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport some_mod\npub fn main() {\n  use value <- some_mod.do_a_thing(10)\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:16
+  │
+4 │   use value <- some_mod.do_a_thing(10)
+  │                ^^^^^^^^^^^^^^^^^^^^^^^
+
+The function on the right hand side of `<-` has to take a callback function
+as its last argument. But the last argument of this function has type:
+
+    some_mod.NotACallback
+
+See: https://tour.gleam.run/advanced-features/use/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_import_errors_do_not_block_later_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_import_errors_do_not_block_later_unqualified.snap
@@ -21,7 +21,7 @@ annotation of this function.
 
 Expected type:
 
-    Int
+    Integer
 
 Found type:
 


### PR DESCRIPTION
This PR builds on #3599, and uses the `Printer` to print types with contextual information in type errors