### PR TITLE
Suggest to pattern match on a `Result(a, _)` when `a` is expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,47 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The compiler can now suggest to pattern match on a `Result(a, b)` if it's
+  being used where a value of type `a` is expected. For example, this code:
+
+  ```gleam
+  import gleam/list
+  import gleam/int
+
+  pub fn main() {
+    let not_a_number = list.first([1, 2, 3])
+    int.add(1, not_a_number)
+  }
+  ```
+
+  Results in the following error:
+
+  ```txt
+  error: Type mismatch
+    ┌─ /src/one/two.gleam:6:9
+    │
+  6 │   int.add(1, not_a_number)
+    │              ^^^^^^^^^^^^
+
+  Expected type:
+
+      Int
+
+  Found type:
+
+      Result(Int, a)
+
+  Hint: If you want to get a `Int` out of a `Result(Int, a)` you can pattern
+  match on it:
+
+      case result {
+        Ok(value) -> todo
+        Error(error) -> todo
+      }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::build::{Outcome, Runtime, Target};
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
+use crate::type_::collapse_links;
 use crate::type_::error::{MissingAnnotation, UnknownTypeHint};
 use crate::type_::error::{Named, RecordVariants};
 use crate::type_::printer::{Names, Printer};
@@ -19,6 +20,7 @@ use std::env;
 use std::fmt::{Debug, Display};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 use termcolor::Buffer;
 use thiserror::Error;
 use vec1::Vec1;
@@ -1746,6 +1748,7 @@ But function expects:
                     situation,
                 } => {
                     let mut printer = Printer::new(names);
+                    let hint = hint_unwrap_result(expected, given, &mut printer);
                     let mut text = if let Some(description) = situation.as_ref().and_then(|s| s.description()) {
                         let mut text = description.to_string();
                         text.push('\n');
@@ -1758,10 +1761,13 @@ But function expects:
                     text.push_str(&printer.print_type(expected));
                     text.push_str("\n\nFound type:\n\n    ");
                     text.push_str(&printer.print_type(given));
+                    if hint.is_some() {
+                        text.push('\n');
+                    }
                     Diagnostic {
                         title: "Type mismatch".into(),
                         text,
-                        hint: None,
+                        hint,
                         level: Level::Error,
                         location: Some(Location {
                             label: Label {
@@ -3639,6 +3645,31 @@ fn hint_alternative_operator(op: &BinOp, given: &Type) -> Option<String> {
         BinOp::AddFloat if given.is_string() => Some(hint_string_message()),
 
         _ => None,
+    }
+}
+
+fn hint_unwrap_result(
+    expected: &Arc<Type>,
+    given: &Arc<Type>,
+    printer: &mut Printer<'_>,
+) -> Option<String> {
+    // If the got type is `Result(a, _)` and the expected one is
+    // `a` then we can display the hint.
+    let wrapped_type = given.result_ok_type()?;
+    let expected = collapse_links(expected.clone());
+    if collapse_links(wrapped_type) != expected {
+        None
+    } else {
+        Some(wrap_format!(
+            "If you want to get a `{}` out of a `{}` you can pattern match on it:
+
+    case result {{
+      Ok(value) -> todo
+      Error(error) -> todo
+    }}",
+            printer.print_type(&expected),
+            printer.print_type(&given),
+        ))
     }
 }
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3668,7 +3668,7 @@ fn hint_unwrap_result(
       Error(error) -> todo
     }}",
             printer.print_type(&expected),
-            printer.print_type(&given),
+            printer.print_type(given),
         ))
     }
 }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -100,6 +100,16 @@ impl Type {
         }
     }
 
+    pub fn result_ok_type(&self) -> Option<Arc<Type>> {
+        match self {
+            Self::Named {
+                module, name, args, ..
+            } if "Result" == name && is_prelude_module(module) => args.first().cloned(),
+            Self::Var { type_ } => type_.borrow().result_ok_type(),
+            Self::Named { .. } | Self::Tuple { .. } | Type::Fn { .. } => None,
+        }
+    }
+
     pub fn is_unbound(&self) -> bool {
         match self {
             Self::Var { type_ } => type_.borrow().is_unbound(),
@@ -834,6 +844,13 @@ impl TypeVar {
         match self {
             Self::Link { type_ } => type_.is_result(),
             Self::Unbound { .. } | Self::Generic { .. } => false,
+        }
+    }
+
+    pub fn result_ok_type(&self) -> Option<Arc<Type>> {
+        match self {
+            TypeVar::Link { type_ } => type_.result_ok_type(),
+            TypeVar::Unbound { .. } | TypeVar::Generic { .. } => None,
         }
     }
 

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2391,3 +2391,17 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn suggest_unwrapping_a_result_when_types_match() {
+    assert_module_error!(
+        "
+pub fn main() {
+  let value = Ok(1)
+  add_1(value)
+}
+
+fn add_1(to x) { x + 1 }
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unwrapping_a_result_when_types_match.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unwrapping_a_result_when_types_match.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 2397
 expression: "\npub fn main() {\n  let value = Ok(1)\n  add_1(value)\n}\n\nfn add_1(to x) { x + 1 }\n"
 ---
 error: Type mismatch

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unwrapping_a_result_when_types_match.snap.new
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unwrapping_a_result_when_types_match.snap.new
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+assertion_line: 2397
+expression: "\npub fn main() {\n  let value = Ok(1)\n  add_1(value)\n}\n\nfn add_1(to x) { x + 1 }\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:9
+  │
+4 │   add_1(value)
+  │         ^^^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Result(Int, a)
+
+Hint: If you want to get a `Int` out of a `Result(Int, a)` you can pattern match
+on it:
+
+    case result {
+      Ok(value) -> todo
+      Error(error) -> todo
+    }


### PR DESCRIPTION
This PR closes #3644