### PR TITLE
Suggest wrapping value in `Ok` or `Error` if it makes sense 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,9 @@
   solve a type mismatch error:
 
   ```gleam
-  pub fn first(list: List(a)) -> Result(a, Nil) {
-    case number {
-      [] -> Error(Nil)
-      [first, ..rest] -> first
-    }
+  pub fn greet_logged_user() {
+    use <- bool.guard(when: !logged_in, return: Error(Nil))
+    "Hello!"
   }
   ```
 
@@ -38,15 +36,10 @@
 
   ```txt
   error: Type mismatch
-    ┌─ /src/one/two.gleam:5:5
+    ┌─ /main.gleam:7:3
     │
-  5 │     [first, ..rest] -> first
-    │     ^^^^^^^^^^^^^^^^^^^^^^^^
-    │                        │
-    │                        Did you mean to wrap this in an `Ok`?
-
-  This case clause was found to return a different type than the previous
-  one, but all case clauses must return the same type.
+  7 │   "Hello!"
+    │   ^^^^^^^^ Did you mean to wrap this in an `Ok`?
 
   Expected type:
 
@@ -54,7 +47,7 @@
 
   Found type:
 
-      a
+      String
   ```
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,43 @@
   allows the Language Server to provide completion hints for `case` subjects.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The compiler can now suggest to wrap a value in an `Ok` or `Error` if that can
+  solve a type mismatch error:
+
+  ```gleam
+  pub fn first(list: List(a)) -> Result(a, Nil) {
+    case number {
+      [] -> Error(Nil)
+      [first, ..rest] -> first
+    }
+  }
+  ```
+
+  Results in the following error:
+
+  ```txt
+  error: Type mismatch
+    ┌─ /src/one/two.gleam:5:5
+    │
+  5 │     [first, ..rest] -> first
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^
+    │                        │
+    │                        Did you mean to wrap this in an `Ok`?
+
+  This case clause was found to return a different type than the previous
+  one, but all case clauses must return the same type.
+
+  Expected type:
+
+      Result(a, Nil)
+
+  Found type:
+
+      a
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - `gleam new` now has refined project name validation - rather than failing on

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -338,8 +338,6 @@ impl TypedExpr {
         matches!(
             self,
             Self::Int{ value, .. } | Self::Float { value, .. } if NON_ZERO.get_or_init(||
-
-
                 Regex::new(r"[1-9]").expect("NON_ZERO regex")).is_match(value)
         )
     }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -4066,7 +4066,7 @@ fn hint_unwrap_result(
     // If the got type is `Result(a, _)` and the expected one is
     // `a` then we can display the hint.
     let wrapped_type = given.result_ok_type()?;
-    if !wrapped_type.same_as(&expected) {
+    if !wrapped_type.same_as(expected) {
         None
     } else {
         Some(wrap_format!(
@@ -4076,7 +4076,7 @@ fn hint_unwrap_result(
       Ok(value) -> todo
       Error(error) -> todo
     }}",
-            printer.print_type(&expected),
+            printer.print_type(expected),
             printer.print_type(given),
         ))
     }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::build::{Outcome, Runtime, Target};
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
+use crate::type_::collapse_links;
 use crate::type_::error::{
     MissingAnnotation, ModuleValueUsageContext, Named, UnknownField, UnknownTypeHint,
     UnsafeRecordUpdateReason,
@@ -21,6 +22,7 @@ use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 use termcolor::Buffer;
 use thiserror::Error;
 use vec1::Vec1;
@@ -4055,30 +4057,6 @@ fn hint_wrap_value_into_result(expected: &Arc<Type>, given: &Arc<Type>) -> Optio
         Some("Did you mean to wrap this in an `Error`?".into())
     } else {
         None
-    }
-}
-
-fn hint_unwrap_result(
-    expected: &Arc<Type>,
-    given: &Arc<Type>,
-    printer: &mut Printer<'_>,
-) -> Option<String> {
-    // If the got type is `Result(a, _)` and the expected one is
-    // `a` then we can display the hint.
-    let wrapped_type = given.result_ok_type()?;
-    if !wrapped_type.same_as(expected) {
-        None
-    } else {
-        Some(wrap_format!(
-            "If you want to get a `{}` out of a `{}` you can pattern match on it:
-
-    case result {{
-      Ok(value) -> todo
-      Error(error) -> todo
-    }}",
-            printer.print_type(expected),
-            printer.print_type(given),
-        ))
     }
 }
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2016,19 +2016,11 @@ But function expects:
                         // if the error could be resolved just by wrapping the value in an `Ok`
                         // or `Error` we want to add an additional label with this hint below the
                         // offending value.
-                        Some(UnifyErrorSituation::CaseClauseMismatch { clause_location }) =>
-                            match hint_wrap_value_in_result(expected, given) {
-                                None => (clause_location, None, vec![]),
-                                Some(hint) => {
-                                    let label = Label { text: Some(hint), span: *location };
-                                    let extra_labels = vec![ExtraLabel { src_info: None, label }];
-                                    (clause_location, None, extra_labels)
-                                }
-                            },
+                        Some(UnifyErrorSituation::CaseClauseMismatch{ clause_location }) => (clause_location, None, vec![]),
                         // In all other cases we just highlight the offending expression, optionally
                         // adding the wrapping hint if it makes sense.
                         Some(_) | None =>
-                            (location, hint_wrap_value_in_result(expected, given), vec![]),
+                            (location, hint_wrap_value_in_result(expected, given), vec![])
                     };
 
                     Diagnostic {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -4049,10 +4049,9 @@ fn hint_wrap_value_into_result(expected: &Arc<Type>, given: &Arc<Type>) -> Optio
     let expected = collapse_links(expected.clone());
     let (expected_ok_type, expected_error_type) = expected.result_types()?;
 
-    let given = collapse_links(given.clone());
-    if collapse_links(expected_ok_type) == given {
+    if given.same_as(expected_ok_type.as_ref()) {
         Some("Did you mean to wrap this in an `Ok`?".into())
-    } else if collapse_links(expected_error_type) == given {
+    } else if given.same_as(expected_error_type.as_ref()) {
         Some("Did you mean to wrap this in an `Error`?".into())
     } else {
         None
@@ -4067,8 +4066,7 @@ fn hint_unwrap_result(
     // If the got type is `Result(a, _)` and the expected one is
     // `a` then we can display the hint.
     let wrapped_type = given.result_ok_type()?;
-    let expected = collapse_links(expected.clone());
-    if collapse_links(wrapped_type) != expected {
+    if !wrapped_type.same_as(&expected) {
         None
     } else {
         Some(wrap_format!(

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2017,26 +2017,18 @@ But function expects:
                         // or `Error` we want to add an additional label with this hint below the
                         // offending value.
                         Some(UnifyErrorSituation::CaseClauseMismatch { clause_location }) =>
-                            match hint_wrap_value_into_result(expected, given) {
+                            match hint_wrap_value_in_result(expected, given) {
                                 None => (clause_location, None, vec![]),
-                                Some(hint) => (
-                                    clause_location,
-                                    None,
-                                    vec![
-                                        ExtraLabel {
-                                            src_info: None,
-                                            label: Label {
-                                                text: Some(hint),
-                                                span: *location,
-                                            }
-                                        },
-                                    ],
-                                )
+                                Some(hint) => {
+                                    let label = Label { text: Some(hint), span: *location };
+                                    let extra_labels = vec![ExtraLabel { src_info: None, label }];
+                                    (clause_location, None, extra_labels)
+                                }
                             },
                         // In all other cases we just highlight the offending expression, optionally
                         // adding the wrapping hint if it makes sense.
                         Some(_) | None =>
-                            (location, hint_wrap_value_into_result(expected, given), vec![]),
+                            (location, hint_wrap_value_in_result(expected, given), vec![]),
                     };
 
                     Diagnostic {
@@ -4047,7 +4039,7 @@ fn hint_alternative_operator(op: &BinOp, given: &Type) -> Option<String> {
     }
 }
 
-fn hint_wrap_value_into_result(expected: &Arc<Type>, given: &Arc<Type>) -> Option<String> {
+fn hint_wrap_value_in_result(expected: &Arc<Type>, given: &Arc<Type>) -> Option<String> {
     let expected = collapse_links(expected.clone());
     let (expected_ok_type, expected_error_type) = expected.result_types()?;
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -4047,9 +4047,7 @@ fn hint_alternative_operator(op: &BinOp, given: &Type) -> Option<String> {
 
 fn hint_wrap_value_into_result(expected: &Arc<Type>, given: &Arc<Type>) -> Option<String> {
     let expected = collapse_links(expected.clone());
-    let Some((expected_ok_type, expected_error_type)) = expected.result_types() else {
-        return None;
-    };
+    let (expected_ok_type, expected_error_type) = expected.result_types()?;
 
     let given = collapse_links(given.clone());
     if collapse_links(expected_ok_type) == given {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2009,6 +2009,11 @@ But function expects:
                     text.push_str(&printer.print_type(given));
 
                     let (main_message_location, main_message_text, extra_labels) = match situation {
+                        // When the mismatch error comes from a case clause we want to highlight the
+                        // entire branch (pattern included) when reporting the error; in addition,
+                        // if the error could be resolved just by wrapping the value in an `Ok`
+                        // or `Error` we want to add an additional label with this hint below the
+                        // offending value.
                         Some(UnifyErrorSituation::CaseClauseMismatch { clause_location }) =>
                             match hint_wrap_value_into_result(expected, given) {
                                 None => (clause_location, None, vec![]),
@@ -2026,6 +2031,8 @@ But function expects:
                                     ],
                                 )
                             },
+                        // In all other cases we just highlight the offending expression, optionally
+                        // adding the wrapping hint if it makes sense.
                         Some(_) | None =>
                             (location, hint_wrap_value_into_result(expected, given), vec![]),
                     };

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -457,7 +457,33 @@ impl Type {
             (one @ Type::Named { .. }, Type::Var { type_ }) => {
                 type_.as_ref().borrow().same_as_other_type(one)
             }
-            (Type::Named { .. }, Type::Named { .. }) => self == other,
+            // When comparing two types we don't care about the inferred variant:
+            // `True` has the same type as `False`, even if the inferred variants
+            // differ.
+            (
+                Type::Named {
+                    publicity,
+                    package,
+                    module,
+                    name,
+                    args,
+                    inferred_variant: _,
+                },
+                Type::Named {
+                    publicity: other_publicity,
+                    package: other_package,
+                    module: other_module,
+                    name: other_name,
+                    args: other_args,
+                    inferred_variant: _,
+                },
+            ) => {
+                publicity == other_publicity
+                    && package == other_package
+                    && module == other_module
+                    && name == other_name
+                    && args == other_args
+            }
 
             (Type::Fn { .. }, Type::Named { .. } | Type::Tuple { .. }) => false,
             (one @ Type::Fn { .. }, Type::Var { type_ }) => {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -499,15 +499,7 @@ impl TypeVar {
     #[must_use]
     fn same_as_other_type(&self, other: &Type) -> bool {
         match (self, other) {
-            (
-                TypeVar::Unbound { .. },
-                Type::Named { .. } | Type::Fn { .. } | Type::Tuple { .. },
-            ) => false,
-
-            (one @ TypeVar::Unbound { .. }, Type::Var { type_ }) => {
-                one.same_as(&type_.as_ref().borrow())
-            }
-
+            (TypeVar::Unbound { .. }, _) => true,
             (TypeVar::Link { type_ }, other) => type_.same_as(other),
 
             (
@@ -524,24 +516,14 @@ impl TypeVar {
     #[must_use]
     fn same_as(&self, other: &Self) -> bool {
         match (self, other) {
-            (TypeVar::Unbound { id }, TypeVar::Unbound { id: other_id }) => id == other_id,
-            (TypeVar::Unbound { .. }, TypeVar::Generic { .. }) => false,
-            (one @ TypeVar::Unbound { .. }, TypeVar::Link { type_ }) => {
-                one.same_as_other_type(type_)
-            }
-
+            (TypeVar::Unbound { .. }, _) | (_, TypeVar::Unbound { .. }) => true,
             (TypeVar::Link { type_ }, TypeVar::Link { type_: other_type }) => {
                 type_.same_as(other_type)
-            }
-            (TypeVar::Link { type_ }, other @ TypeVar::Unbound { .. }) => {
-                other.same_as_other_type(type_)
             }
             (TypeVar::Link { type_ }, other @ TypeVar::Generic { .. }) => {
                 other.same_as_other_type(type_)
             }
-
             (TypeVar::Generic { id }, TypeVar::Generic { id: other_id }) => id == other_id,
-            (TypeVar::Generic { .. }, TypeVar::Unbound { .. }) => false,
             (one @ TypeVar::Generic { .. }, TypeVar::Link { type_ }) => {
                 one.same_as_other_type(type_)
             }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -138,6 +138,18 @@ impl Type {
         }
     }
 
+    pub fn result_types(&self) -> Option<(Arc<Type>, Arc<Type>)> {
+        match self {
+            Self::Named {
+                module, name, args, ..
+            } if "Result" == name && is_prelude_module(module) => {
+                Some((args.first().cloned()?, args.get(1).cloned()?))
+            }
+            Self::Var { type_ } => type_.borrow().result_types(),
+            Self::Named { .. } | Self::Tuple { .. } | Type::Fn { .. } => None,
+        }
+    }
+
     pub fn is_unbound(&self) -> bool {
         match self {
             Self::Var { type_ } => type_.borrow().is_unbound(),
@@ -966,6 +978,13 @@ impl TypeVar {
     pub fn result_ok_type(&self) -> Option<Arc<Type>> {
         match self {
             TypeVar::Link { type_ } => type_.result_ok_type(),
+            TypeVar::Unbound { .. } | TypeVar::Generic { .. } => None,
+        }
+    }
+
+    pub fn result_types(&self) -> Option<(Arc<Type>, Arc<Type>)> {
+        match self {
+            TypeVar::Link { type_ } => type_.result_types(),
             TypeVar::Unbound { .. } | TypeVar::Generic { .. } => None,
         }
     }

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1340,12 +1340,16 @@ fn flip_unify_error_test() {
         UnifyError::CouldNotUnify {
             expected: crate::type_::int(),
             given: crate::type_::float(),
-            situation: Some(UnifyErrorSituation::CaseClauseMismatch),
+            situation: Some(UnifyErrorSituation::CaseClauseMismatch {
+                clause_location: SrcSpan::default()
+            }),
         },
         flip_unify_error(UnifyError::CouldNotUnify {
             expected: crate::type_::float(),
             given: crate::type_::int(),
-            situation: Some(UnifyErrorSituation::CaseClauseMismatch),
+            situation: Some(UnifyErrorSituation::CaseClauseMismatch {
+                clause_location: SrcSpan::default()
+            }),
         })
     );
 }
@@ -1375,7 +1379,9 @@ fn unify_enclosed_type_test() {
         Err(UnifyError::CouldNotUnify {
             expected: crate::type_::int(),
             given: crate::type_::float(),
-            situation: Some(UnifyErrorSituation::CaseClauseMismatch)
+            situation: Some(UnifyErrorSituation::CaseClauseMismatch {
+                clause_location: SrcSpan::default()
+            })
         }),
         unify_enclosed_type(
             crate::type_::int(),
@@ -1383,7 +1389,9 @@ fn unify_enclosed_type_test() {
             Err(UnifyError::CouldNotUnify {
                 expected: crate::type_::string(),
                 given: crate::type_::bits(),
-                situation: Some(UnifyErrorSituation::CaseClauseMismatch)
+                situation: Some(UnifyErrorSituation::CaseClauseMismatch {
+                    clause_location: SrcSpan::default()
+                })
             })
         )
     );
@@ -1448,7 +1456,9 @@ pub fn unify_wrong_returns(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnifyErrorSituation {
     /// Clauses in a case expression were found to return different types.
-    CaseClauseMismatch,
+    CaseClauseMismatch {
+        clause_location: SrcSpan,
+    },
 
     /// A function was found to return a value that did not match its return
     /// annotation.
@@ -1491,7 +1501,7 @@ pub enum FunctionsMismatchReason {
 impl UnifyErrorSituation {
     pub fn description(&self) -> Option<&'static str> {
         match self {
-            Self::CaseClauseMismatch => Some(
+            Self::CaseClauseMismatch { clause_location: _ } => Some(
                 "This case clause was found to return a different type than the previous
 one, but all case clauses must return the same type.",
             ),
@@ -1556,8 +1566,8 @@ impl UnifyError {
         }
     }
 
-    pub fn case_clause_mismatch(self) -> Self {
-        self.with_unify_error_situation(UnifyErrorSituation::CaseClauseMismatch)
+    pub fn case_clause_mismatch(self, clause_location: SrcSpan) -> Self {
+        self.with_unify_error_situation(UnifyErrorSituation::CaseClauseMismatch { clause_location })
     }
 
     pub fn list_element_mismatch(self) -> Self {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1485,9 +1485,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             let typed_clause = self.infer_clause(clause, &typed_subjects);
             all_clauses_panic = all_clauses_panic && self.previous_panics;
 
-            if let Err(e) = unify(return_type.clone(), typed_clause.then.type_())
-                .map_err(|e| e.case_clause_mismatch().into_error(typed_clause.location()))
-            {
+            if let Err(e) = unify(return_type.clone(), typed_clause.then.type_()).map_err(|e| {
+                e.case_clause_mismatch(typed_clause.location)
+                    .into_error(typed_clause.then.type_defining_location())
+            }) {
                 self.problems.error(e);
             }
             typed_clauses.push(typed_clause);

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -3,7 +3,7 @@ use ecow::EcoString;
 use im::HashMap;
 use std::{collections::HashSet, sync::Arc};
 
-use crate::type_::{collapse_links, Type, TypeVar};
+use crate::type_::{Type, TypeVar};
 
 /// This class keeps track of what names are used for modules in the current
 /// scope, so they can be printed in errors, etc.
@@ -126,9 +126,7 @@ fn compare_arguments(arguments: &[Arc<Type>], parameters: &[Arc<Type>]) -> bool 
     arguments
         .iter()
         .zip(parameters)
-        .all(|(argument, parameter)| {
-            collapse_links(argument.clone()) == collapse_links(parameter.clone())
-        })
+        .all(|(argument, parameter)| argument.same_as(parameter))
 }
 
 impl Names {

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2795,3 +2795,57 @@ fn wibble(arg: Result(Int, String)) { todo }
 "
     );
 }
+
+#[test]
+fn suggest_wrapping_a_function_return_value_in_ok() {
+    assert_module_error!(
+        "
+pub fn main() -> Result(Int, Bool) {
+  1
+}
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_function_return_value_in_error() {
+    assert_module_error!(
+        "
+pub fn main() -> Result(Int, Bool) {
+  True
+}
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_use_returned_value_in_ok() {
+    assert_module_error!(
+        "
+pub fn main() -> Result(Int, Bool) {
+  use <- want_result
+  1
+}
+
+pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
+  todo
+}
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_use_returned_value_in_error() {
+    assert_module_error!(
+        "
+pub fn main() -> Result(Int, Bool) {
+  use <- want_result
+  False
+}
+
+pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
+  todo
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2551,7 +2551,8 @@ pub fn main(wibble: wibble.Wibble) {
   case wibble {
     wibble.Wibble(..) as w -> wibble.Wobble(..w, wubble: 10)
     _ -> panic
-  }
+
+    }
 }
 "
     );
@@ -2689,4 +2690,59 @@ fn negative_out_of_range_erlang_float_in_const() {
 #[test]
 fn missing_case_body() {
     assert_error!("case True");
+}
+
+#[test]
+fn suggest_wrapping_a_value_into_ok_if_types_match() {
+    assert_module_error!(
+        "
+pub fn main() {
+  case todo {
+    1 -> Ok(2)
+    _ -> 1
+
+  }
+}
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_value_into_ok_if_types_match_2() {
+    assert_module_error!(
+        "
+pub fn main() {
+  wibble(1)
+}
+
+fn wibble(arg: Result(Int, String)) { todo }
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_value_into_error_if_types_match() {
+    assert_module_error!(
+        "
+pub fn main() {
+  case todo {
+    1 -> Error(1)
+    _ -> 1
+  }
+}
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_value_into_error_if_types_match_2() {
+    assert_module_error!(
+        "
+pub fn main() {
+    wibble(\"a\")
+}
+
+fn wibble(arg: Result(Int, String)) { todo }
+"
+    );
 }

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2736,6 +2736,20 @@ pub fn main() {
 }
 
 #[test]
+fn suggest_wrapping_a_value_into_ok_with_generic_type() {
+    assert_module_error!(
+        "
+pub fn first(list: List(a)) -> Result(a, Nil) {
+  case list {
+    [] -> Error(Nil)
+    [first, ..rest] -> first
+  }
+}
+"
+    );
+}
+
+#[test]
 fn suggest_wrapping_a_value_into_ok_if_types_match_with_multiline_result_in_block() {
     assert_module_error!(
         "

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2551,8 +2551,7 @@ pub fn main(wibble: wibble.Wibble) {
   case wibble {
     wibble.Wibble(..) as w -> wibble.Wobble(..w, wubble: 10)
     _ -> panic
-
-    }
+  }
 }
 "
     );
@@ -2700,7 +2699,6 @@ pub fn main() {
   case todo {
     1 -> Ok(2)
     _ -> 1
-
   }
 }
 "
@@ -2716,6 +2714,43 @@ pub fn main() {
 }
 
 fn wibble(arg: Result(Int, String)) { todo }
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_value_into_ok_if_types_match_with_block() {
+    assert_module_error!(
+        "
+pub fn main() {
+  case todo {
+    1 -> Ok(2)
+    _ -> {
+      todo
+      1
+    }
+  }
+}
+"
+    );
+}
+
+#[test]
+fn suggest_wrapping_a_value_into_ok_if_types_match_with_multiline_result_in_block() {
+    assert_module_error!(
+        "
+pub fn main() {
+  case todo {
+    1 -> Ok(2)
+    _ -> {
+      todo
+      1
+      |> add_1
+    }
+  }
+}
+
+fn add_1(n: Int) { n + 1 }
 "
     );
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_function_return_value_in_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_function_return_value_in_error.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() -> Result(Int, Bool) {\n  True\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() -> Result(Int, Bool) {
+  True
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:3
+  │
+3 │   True
+  │   ^^^^ Did you mean to wrap this in an `Error`?
+
+The type of this returned value doesn't match the return type
+annotation of this function.
+
+Expected type:
+
+    Result(Int, Bool)
+
+Found type:
+
+    Bool

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_function_return_value_in_ok.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_function_return_value_in_ok.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() -> Result(Int, Bool) {\n  1\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() -> Result(Int, Bool) {
+  1
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:3
+  │
+3 │   1
+  │   ^ Did you mean to wrap this in an `Ok`?
+
+The type of this returned value doesn't match the return type
+annotation of this function.
+
+Expected type:
+
+    Result(Int, Bool)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_use_returned_value_in_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_use_returned_value_in_error.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() -> Result(Int, Bool) {\n  use <- want_result\n  False\n}\n\npub fn want_result(wibble: fn() -> Result(Int, Bool)) {\n  todo\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() -> Result(Int, Bool) {
+  use <- want_result
+  False
+}
+
+pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
+  todo
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   False
+  │   ^^^^^ Did you mean to wrap this in an `Error`?
+
+Expected type:
+
+    Result(Int, Bool)
+
+Found type:
+
+    Bool

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_use_returned_value_in_ok.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_use_returned_value_in_ok.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() -> Result(Int, Bool) {\n  use <- want_result\n  1\n}\n\npub fn want_result(wibble: fn() -> Result(Int, Bool)) {\n  todo\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() -> Result(Int, Bool) {
+  use <- want_result
+  1
+}
+
+pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
+  todo
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   1
+  │   ^ Did you mean to wrap this in an `Ok`?
+
+Expected type:
+
+    Result(Int, Bool)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match.snap
@@ -1,13 +1,25 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 2438
 expression: "\npub fn main() {\n  case todo {\n    1 -> Error(1)\n    _ -> 1\n  }\n}\n"
 ---
+----- SOURCE CODE
+
+pub fn main() {
+  case todo {
+    1 -> Error(1)
+    _ -> 1
+  }
+}
+
+
+----- ERROR
 error: Type mismatch
   ┌─ /src/one/two.gleam:5:5
   │
 5 │     _ -> 1
   │     ^^^^^^
+  │          │
+  │          Did you mean to wrap this in an `Error`?
 
 This case clause was found to return a different type than the previous
 one, but all case clauses must return the same type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match.snap
@@ -18,8 +18,6 @@ error: Type mismatch
   │
 5 │     _ -> 1
   │     ^^^^^^
-  │          │
-  │          Did you mean to wrap this in an `Error`?
 
 This case clause was found to return a different type than the previous
 one, but all case clauses must return the same type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match.snap.new
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match.snap.new
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+assertion_line: 2438
+expression: "\npub fn main() {\n  case todo {\n    1 -> Error(1)\n    _ -> 1\n  }\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:5
+  │
+5 │     _ -> 1
+  │     ^^^^^^
+
+This case clause was found to return a different type than the previous
+one, but all case clauses must return the same type.
+
+Expected type:
+
+    Result(a, Int)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n    wibble(\"a\")\n}\n\nfn wibble(arg: Result(Int, String)) { todo }\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:12
+  │
+3 │     wibble("a")
+  │            ^^^ Did you mean to wrap this in an `Error`?
+
+Expected type:
+
+    Result(Int, String)
+
+Found type:
+
+    String

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_error_if_types_match_2.snap
@@ -2,6 +2,16 @@
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub fn main() {\n    wibble(\"a\")\n}\n\nfn wibble(arg: Result(Int, String)) { todo }\n"
 ---
+----- SOURCE CODE
+
+pub fn main() {
+    wibble("a")
+}
+
+fn wibble(arg: Result(Int, String)) { todo }
+
+
+----- ERROR
 error: Type mismatch
   ┌─ /src/one/two.gleam:3:12
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match.snap
@@ -18,8 +18,6 @@ error: Type mismatch
   │
 5 │     _ -> 1
   │     ^^^^^^
-  │          │
-  │          Did you mean to wrap this in an `Ok`?
 
 This case clause was found to return a different type than the previous
 one, but all case clauses must return the same type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match.snap
@@ -1,13 +1,25 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-assertion_line: 2411
 expression: "\npub fn main() {\n  case todo {\n    1 -> Ok(2)\n    _ -> 1\n  }\n}\n"
 ---
+----- SOURCE CODE
+
+pub fn main() {
+  case todo {
+    1 -> Ok(2)
+    _ -> 1
+  }
+}
+
+
+----- ERROR
 error: Type mismatch
   ┌─ /src/one/two.gleam:5:5
   │
 5 │     _ -> 1
-  │     ^^^^^^ Did you mean to wrap this in an `Ok`?
+  │     ^^^^^^
+  │          │
+  │          Did you mean to wrap this in an `Ok`?
 
 This case clause was found to return a different type than the previous
 one, but all case clauses must return the same type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match.snap.new
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match.snap.new
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+assertion_line: 2411
+expression: "\npub fn main() {\n  case todo {\n    1 -> Ok(2)\n    _ -> 1\n  }\n}\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:5
+  │
+5 │     _ -> 1
+  │     ^^^^^^ Did you mean to wrap this in an `Ok`?
+
+This case clause was found to return a different type than the previous
+one, but all case clauses must return the same type.
+
+Expected type:
+
+    Result(Int, a)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_2.snap
@@ -2,6 +2,16 @@
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub fn main() {\n  wibble(1)\n}\n\nfn wibble(arg: Result(Int, String)) { todo }\n"
 ---
+----- SOURCE CODE
+
+pub fn main() {
+  wibble(1)
+}
+
+fn wibble(arg: Result(Int, String)) { todo }
+
+
+----- ERROR
 error: Type mismatch
   ┌─ /src/one/two.gleam:3:10
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  wibble(1)\n}\n\nfn wibble(arg: Result(Int, String)) { todo }\n"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:10
+  │
+3 │   wibble(1)
+  │          ^ Did you mean to wrap this in an `Ok`?
+
+Expected type:
+
+    Result(Int, String)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_3.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  case todo {\n    1 -> Ok(2)\n    _ -> {\n      todo\n      1\n    }\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case todo {
+    1 -> Ok(2)
+    _ -> {
+      todo
+      1
+    }
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:5
+  │  
+5 │ ╭     _ -> {
+6 │ │       todo
+7 │ │       1
+  │ │       ^ Did you mean to wrap this in an `Ok`?
+8 │ │     }
+  │ ╰─────^
+
+This case clause was found to return a different type than the previous
+one, but all case clauses must return the same type.
+
+Expected type:
+
+    Result(Int, a)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_block.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_block.snap
@@ -22,7 +22,6 @@ error: Type mismatch
 5 │ ╭     _ -> {
 6 │ │       todo
 7 │ │       1
-  │ │       ^ Did you mean to wrap this in an `Ok`?
 8 │ │     }
   │ ╰─────^
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_block.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_block.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  case todo {\n    1 -> Ok(2)\n    _ -> {\n      todo\n      1\n    }\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case todo {
+    1 -> Ok(2)
+    _ -> {
+      todo
+      1
+    }
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:5
+  │  
+5 │ ╭     _ -> {
+6 │ │       todo
+7 │ │       1
+  │ │       ^ Did you mean to wrap this in an `Ok`?
+8 │ │     }
+  │ ╰─────^
+
+This case clause was found to return a different type than the previous
+one, but all case clauses must return the same type.
+
+Expected type:
+
+    Result(Int, a)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_multiline_result_in_block.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_multiline_result_in_block.snap
@@ -1,0 +1,42 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  case todo {\n    1 -> Ok(2)\n    _ -> {\n      todo\n      1\n      |> add_1\n    }\n  }\n}\n\nfn add_1(n: Int) { n + 1 }\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case todo {
+    1 -> Ok(2)
+    _ -> {
+      todo
+      1
+      |> add_1
+    }
+  }
+}
+
+fn add_1(n: Int) { n + 1 }
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:5
+  │    
+5 │ ╭       _ -> {
+6 │ │         todo
+7 │ │ ╭       1
+8 │ │ │       |> add_1
+  │ │ ╰──────────────^ Did you mean to wrap this in an `Ok`?
+9 │ │       }
+  │ ╰───────^
+
+This case clause was found to return a different type than the previous
+one, but all case clauses must return the same type.
+
+Expected type:
+
+    Result(Int, a)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_multiline_result_in_block.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_if_types_match_with_multiline_result_in_block.snap
@@ -21,14 +21,13 @@ fn add_1(n: Int) { n + 1 }
 ----- ERROR
 error: Type mismatch
   ┌─ /src/one/two.gleam:5:5
-  │    
-5 │ ╭       _ -> {
-6 │ │         todo
-7 │ │ ╭       1
-8 │ │ │       |> add_1
-  │ │ ╰──────────────^ Did you mean to wrap this in an `Ok`?
-9 │ │       }
-  │ ╰───────^
+  │  
+5 │ ╭     _ -> {
+6 │ │       todo
+7 │ │       1
+8 │ │       |> add_1
+9 │ │     }
+  │ ╰─────^
 
 This case clause was found to return a different type than the previous
 one, but all case clauses must return the same type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_with_generic_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_with_generic_type.snap
@@ -18,8 +18,6 @@ error: Type mismatch
   │
 5 │     [first, ..rest] -> first
   │     ^^^^^^^^^^^^^^^^^^^^^^^^
-  │                        │
-  │                        Did you mean to wrap this in an `Ok`?
 
 This case clause was found to return a different type than the previous
 one, but all case clauses must return the same type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_with_generic_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_wrapping_a_value_into_ok_with_generic_type.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn first(list: List(a)) -> Result(a, Nil) {\n  case list {\n    [] -> Error(Nil)\n    [first, ..rest] -> first\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn first(list: List(a)) -> Result(a, Nil) {
+  case list {
+    [] -> Error(Nil)
+    [first, ..rest] -> first
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:5
+  │
+5 │     [first, ..rest] -> first
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^
+  │                        │
+  │                        Did you mean to wrap this in an `Ok`?
+
+This case clause was found to return a different type than the previous
+one, but all case clauses must return the same type.
+
+Expected type:
+
+    Result(a, Nil)
+
+Found type:
+
+    a


### PR DESCRIPTION
As suggested by @GearsDatapacks the compiler can now suggest to wrap a value into an `Ok`/`Error` if it would make the types line up:
```gleam
pub fn main() {
  wibble(1)
//       ^ Did you mean to wrap this in an `Ok`?
}

pub fn wibble(value: Result(Int, String)) { todo }
```

This is a WIP because I still have to figure out how to pretty print this information in pattern matching branches, right now it looks quite bad 😁