### PR TITLE
Fix invalid TypeScript definitions for opaque types that use a private type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,10 @@
   JavaScript prelude.
   ([Richard Viney](https://github.com/richard-viney))
 
+- Fixed a bug where generated TypeScript definitions were invalid for opaque
+  types that use a private type.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -204,7 +204,7 @@ impl<'a> JavaScript<'a> {
             let rexport = rexport.replace(".mjs", ".d.mts");
             let prelude_declaration_path = &self.output_directory.join("gleam.d.mts");
 
-            // Type decleration may trigger badly configured watchers
+            // Type declaration may trigger badly configured watchers
             if !writer.exists(prelude_declaration_path) {
                 writer.write(prelude_declaration_path, &rexport)?;
             }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
@@ -4,13 +4,13 @@ expression: "pub opaque type Animal {\n  Cat(goes_outside: Bool)\n  Dog(plays_fe
 ---
 import type * as _ from "../gleam.d.mts";
 
-class Cat extends _.CustomType {
+declare class Cat extends _.CustomType {
   constructor(goes_outside: boolean);
   
   goes_outside: boolean;
 }
 
-class Dog extends _.CustomType {
+declare class Dog extends _.CustomType {
   constructor(plays_fetch: boolean);
   
   plays_fetch: boolean;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__private_type_in_opaque_type.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__private_type_in_opaque_type.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/type_alias.rs
+expression: "\ntype PrivateType {\n  PrivateType\n}\n\npub opaque type OpaqueType {\n  OpaqueType(PrivateType)\n}\n"
+---
+import type * as _ from "../gleam.d.mts";
+
+declare class PrivateType extends _.CustomType {}
+
+declare type PrivateType$ = PrivateType;
+
+declare class OpaqueType extends _.CustomType {
+  constructor(argument$0: PrivateType$);
+  
+  0: PrivateType$;
+}
+
+export type OpaqueType$ = OpaqueType;

--- a/compiler-core/src/javascript/tests/type_alias.rs
+++ b/compiler-core/src/javascript/tests/type_alias.rs
@@ -8,3 +8,18 @@ pub type Headers = List(#(String, String))
 "#,
     );
 }
+
+#[test]
+fn private_type_in_opaque_type() {
+    assert_ts_def!(
+        r#"
+type PrivateType {
+  PrivateType
+}
+
+pub opaque type OpaqueType {
+  OpaqueType(PrivateType)
+}
+"#,
+    );
+}


### PR DESCRIPTION
This code:

```gleam
type Foo {
  Foo
}

pub opaque type Bar {
  Bar(Foo)
}
```

was generating an invalid `.d.mts` file that referenced a non-existent type `Foo$`:

```typescript
import type * as _ from "./gleam.d.mts";

class Bar extends _.CustomType {
  constructor(argument$0: Foo$);
  
  0: Foo$;
}

export type Bar$ = Bar;
```

This PR fixes this by:

- Emitting TypeScript definitions for all types, regardless of visibility
- Only `export`ing relevant parts when they have non-private visibility

Variants of opaque types remain non-exported.