### PR TITLE
Fix TS definitions when importing type aliases that reference unimported modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,9 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- The Language Server now suggests a code action to convert qualified imports to unqualified imports, which updates all occurrences of the qualified name throughout the module:
+- The Language Server now suggests a code action to convert qualified imports to
+  unqualified imports, which updates all occurrences of the qualified name
+  throughout the module:
 
   ```gleam
   import option
@@ -196,6 +198,10 @@
 - Fixed a bug where the compiler would incorrectly type-check and compile
   calls to functions with labelled arguments in certain cases.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where importing type aliases that reference unimported modules
+  would generate invalid TypeScript definitions.
+  ([Richard Viney](https://github.com/richard-viney))
 
 ## v1.5.1 - 2024-09-26
 

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -83,6 +83,18 @@ macro_rules! assert_js_error {
 
 #[macro_export]
 macro_rules! assert_ts_def {
+    (($dep_1_package:expr, $dep_1_name:expr, $dep_1_src:expr), ($dep_2_package:expr, $dep_2_name:expr, $dep_2_src:expr), $src:expr $(,)?) => {{
+        let output = $crate::javascript::tests::compile_ts(
+            $src,
+            vec![
+                ($dep_1_package, $dep_1_name, $dep_1_src),
+                ($dep_2_package, $dep_2_name, $dep_2_src),
+            ],
+        )
+        .expect("compilation failed");
+        insta::assert_snapshot!(insta::internals::AutoName, output, $src);
+    }};
+
     (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr $(,)?) => {{
         let output =
             $crate::javascript::tests::compile_ts($src, vec![($dep_package, $dep_name, $dep_src)])

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_nil_typescript.snap
@@ -2,6 +2,4 @@
 source: compiler-core/src/javascript/tests/prelude.rs
 expression: "import gleam\npub fn go() { gleam.Nil }\n"
 ---
-import type * as $gleam from "../gleam.d.mts";
-
 export function go(): undefined;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__prelude__qualified_ok_typescript.snap
@@ -2,7 +2,6 @@
 source: compiler-core/src/javascript/tests/prelude.rs
 expression: "import gleam\npub fn go() { gleam.Ok(1) }\n"
 ---
-import type * as $gleam from "../gleam.d.mts";
 import type * as _ from "../gleam.d.mts";
 
 export function go(): _.Result<number, any>;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__import_indirect_type_alias.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__import_indirect_type_alias.snap
@@ -1,0 +1,7 @@
+---
+source: compiler-core/src/javascript/tests/type_alias.rs
+expression: "\nimport wobble\n\npub fn main(x: wobble.Wobble) {\n  Nil\n}\n"
+---
+import type * as $wibble from "../../wibble/wibble.d.mts";
+
+export function main(x: $wibble.Wibble$): undefined;

--- a/compiler-core/src/javascript/tests/type_alias.rs
+++ b/compiler-core/src/javascript/tests/type_alias.rs
@@ -23,3 +23,33 @@ pub opaque type OpaqueType {
 "#,
     );
 }
+
+#[test]
+fn import_indirect_type_alias() {
+    assert_ts_def!(
+        (
+            "wibble",
+            "wibble",
+            r#"
+pub type Wibble {
+  Wibble(Int)
+}
+"#
+        ),
+        (
+            "wobble",
+            "wobble",
+            r#"
+import wibble
+pub type Wobble = wibble.Wibble
+"#
+        ),
+        r#"
+import wobble
+
+pub fn main(x: wobble.Wobble) {
+  Nil
+}
+"#,
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/gleam/issues/2315.

The approach taken is to look at the entire module's contents, recurse through all referenced types, and add imports for everything that's encountered.

This doesn't take the possibly preferable approach of importing the relevant type alias directly because type aliases don't appear to be tracked in the type information, and I decided not to go down the path of seeing how much work it would be to change that.

Questions:

1. Note that the original `import` statements in the Gleam code no longer get converted 1:1 to TypeScript imports. Does this seem reasonable?