### PR TITLE
Implement code action to add type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,23 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The Language Server now suggests a code action to add type annotations to
+  local variables, constants and functions:
+
+  ```gleam
+  pub fn add_int_to_float(a, b) {
+    a +. int.to_float(b)
+  }
+  ```
+
+  Becomes:
+
+  ```gleam
+  pub fn add_int_to_float(a: Float, b: Int) -> Float {
+    a +. int.to_float(b)
+  }
+  ```
+
 ### Bug Fixes
 
 - Fixed a bug in the compiler where shadowing a sized value in a bit pattern

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -694,6 +694,7 @@ impl<T> Import<T> {
 }
 
 pub type UntypedModuleConstant = ModuleConstant<(), ()>;
+pub type TypedModuleConstant = ModuleConstant<Arc<Type>, EcoString>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A certain fixed value that can be used in multiple places

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -51,7 +51,7 @@ use crate::type_::Type;
 use super::{
     AssignName, BinOp, BitArrayOption, CallArg, Definition, Pattern, SrcSpan, Statement, TodoKind,
     TypeAst, TypedArg, TypedAssignment, TypedClause, TypedDefinition, TypedExpr,
-    TypedExprBitArraySegment, TypedFunction, TypedModule, TypedPattern,
+    TypedExprBitArraySegment, TypedFunction, TypedModule, TypedModuleConstant, TypedPattern,
     TypedPatternBitArraySegment, TypedRecordUpdateArg, TypedStatement, Use,
 };
 
@@ -66,6 +66,10 @@ pub trait Visit<'ast> {
 
     fn visit_typed_function(&mut self, fun: &'ast TypedFunction) {
         visit_typed_function(self, fun);
+    }
+
+    fn visit_typed_module_constant(&mut self, constant: &'ast TypedModuleConstant) {
+        visit_typed_module_constant(self, constant);
     }
 
     fn visit_typed_expr(&mut self, expr: &'ast TypedExpr) {
@@ -463,7 +467,7 @@ where
         Definition::TypeAlias(_typealias) => { /* TODO */ }
         Definition::CustomType(_custom_type) => { /* TODO */ }
         Definition::Import(_import) => { /* TODO */ }
-        Definition::ModuleConstant(_module_constant) => { /* TODO */ }
+        Definition::ModuleConstant(constant) => v.visit_typed_module_constant(constant),
     }
 }
 pub fn visit_typed_function<'a, V>(v: &mut V, fun: &'a TypedFunction)
@@ -473,6 +477,12 @@ where
     for stmt in &fun.body {
         v.visit_typed_statement(stmt);
     }
+}
+
+pub fn visit_typed_module_constant<'a, V>(_v: &mut V, _constant: &'a TypedModuleConstant)
+where
+    V: Visit<'a> + ?Sized,
+{
 }
 
 pub fn visit_typed_expr<'a, V>(v: &mut V, node: &'a TypedExpr)

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -30,8 +30,8 @@ use std::sync::Arc;
 
 use super::{
     code_action::{
-        code_action_add_missing_patterns, code_action_import_module, CodeActionBuilder,
-        FillInMissingLabelledArgs, LabelShorthandSyntax, LetAssertToCase,
+        code_action_add_missing_patterns, code_action_import_module, AddAnnotations,
+        CodeActionBuilder, FillInMissingLabelledArgs, LabelShorthandSyntax, LetAssertToCase,
         RedundantTupleInCaseSubject,
     },
     completer::Completer,
@@ -303,6 +303,7 @@ where
             actions.extend(RedundantTupleInCaseSubject::new(module, &params).code_actions());
             actions.extend(LabelShorthandSyntax::new(module, &params).code_actions());
             actions.extend(FillInMissingLabelledArgs::new(module, &params).code_actions());
+            AddAnnotations::new(module, &params).code_action(&mut actions);
 
             Ok(if actions.is_empty() {
                 None

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_multiple_annotations.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_multiple_annotations.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub const my_constant = 20\n\npub fn add_my_constant(value) {\n  let result = value + my_constant\n  result\n}\n"
+---
+----- BEFORE ACTION
+
+pub const my_constant = 20
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn add_my_constant(value) {
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  let result = value + my_constant
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  result
+▔▔▔▔▔▔▔▔
+}
+↑
+
+
+----- AFTER ACTION
+
+pub const my_constant: Int = 20
+
+pub fn add_my_constant(value: Int) -> Int {
+  let result: Int = value + my_constant
+  result
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_correctly_prints_type_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_correctly_prints_type_variables.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn map_result(input, function) {\n  case input {\n    Ok(value) -> Ok(function(value))\n    Error(error) -> Error(error)\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn map_result(input, function) {
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔↑                  
+  case input {
+    Ok(value) -> Ok(function(value))
+    Error(error) -> Error(error)
+  }
+}
+
+
+----- AFTER ACTION
+
+pub fn map_result(input: Result(a, b), function: fn(a) -> c) -> Result(c, b) {
+  case input {
+    Ok(value) -> Ok(function(value))
+    Error(error) -> Error(error)
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type IntAlias = Int\n\npub fn main() {\n  let value = 20\n}\n"
+---
+----- BEFORE ACTION
+
+pub type IntAlias = Int
+
+pub fn main() {
+  let value = 20
+  ▔▔▔▔↑         
+}
+
+
+----- AFTER ACTION
+
+pub type IntAlias = Int
+
+pub fn main() {
+  let value: IntAlias = 20
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types2.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Result\n\npub fn main() {\n  let value = Ok(12)\n}\n"
+---
+----- BEFORE ACTION
+
+pub type Result
+
+pub fn main() {
+  let value = Ok(12)
+  ▔▔▔▔▔▔▔▔▔▔↑       
+}
+
+
+----- AFTER ACTION
+
+pub type Result
+
+pub fn main() {
+  let value: gleam.Result(Int, a) = Ok(12)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types3.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport wibble\n\npub fn main() {\n  let value = wibble.Wibble\n}\n"
+---
+----- BEFORE ACTION
+
+import wibble
+
+pub fn main() {
+  let value = wibble.Wibble
+  ▔▔▔▔▔▔▔▔▔▔↑              
+}
+
+
+----- AFTER ACTION
+
+import wibble
+
+pub fn main() {
+  let value: wibble.Wibble = wibble.Wibble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types4.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types4.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport wibble as wobble\n\npub fn main() {\n  let value = wobble.Wibble\n}\n"
+---
+----- BEFORE ACTION
+
+import wibble as wobble
+
+pub fn main() {
+  let value = wobble.Wibble
+  ▔▔▔▔▔▔▔▔▔▔↑              
+}
+
+
+----- AFTER ACTION
+
+import wibble as wobble
+
+pub fn main() {
+  let value: wobble.Wibble = wobble.Wibble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types5.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_contextual_types5.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport wibble.{type Wibble as Wobble}\n\npub fn main() {\n  let value = wibble.Wibble\n}\n"
+---
+----- BEFORE ACTION
+
+import wibble.{type Wibble as Wobble}
+
+pub fn main() {
+  let value = wibble.Wibble
+  ▔▔▔▔▔▔▔▔▔▔↑              
+}
+
+
+----- AFTER ACTION
+
+import wibble.{type Wibble as Wobble}
+
+pub fn main() {
+  let value: Wobble = wibble.Wibble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_type_variable_names.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__adding_annotations_prints_type_variable_names.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn do_generic_things(a: type_a, b: type_b) {\n  let a_value = a\n  let b_value = b\n  let other_value = a_value\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn do_generic_things(a: type_a, b: type_b) {
+  let a_value = a
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  let b_value = b
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  let other_value = a_value
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+}
+↑
+
+
+----- AFTER ACTION
+
+pub fn do_generic_things(a: type_a, b: type_b) {
+  let a_value: type_a = a
+  let b_value: type_b = b
+  let other_value: type_a = a_value
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_constant.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub const my_constant = 20\n"
+---
+----- BEFORE ACTION
+
+pub const my_constant = 20
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+
+
+----- AFTER ACTION
+
+pub const my_constant: Int = 20

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_function.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn add_one(thing) {\n  thing + 1\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn add_one(thing) {
+    ▔▔▔▔▔▔▔▔▔▔↑        
+  thing + 1
+}
+
+
+----- AFTER ACTION
+
+pub fn add_one(thing: Int) -> Int {
+  thing + 1
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_function_with_annotated_return_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_function_with_annotated_return_type.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn add_one(thing) -> Int {\n  thing + 1\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn add_one(thing) -> Int {
+    ▔▔▔▔▔▔▔▔▔▔↑               
+  thing + 1
+}
+
+
+----- AFTER ACTION
+
+pub fn add_one(thing: Int) -> Int {
+  thing + 1
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_function_with_partially_annotated_parameters.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_function_with_partially_annotated_parameters.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn add(a: Float, b) -> Float {\n  a +. b\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn add(a: Float, b) -> Float {
+    ▔▔▔▔▔▔↑                       
+  a +. b
+}
+
+
+----- AFTER ACTION
+
+pub fn add(a: Float, b: Float) -> Float {
+  a +. b
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let my_value = 10\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let my_value = 10
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let my_value: Int = 10
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable_let_assert.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable_let_assert.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn fallible() -> Result(Int, Nil) {\n  todo\n}\n\npub fn main() {\n  let assert Ok(value) = fallible()\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn fallible() -> Result(Int, Nil) {
+  todo
+}
+
+pub fn main() {
+  let assert Ok(value) = fallible()
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑           
+}
+
+
+----- AFTER ACTION
+
+pub fn fallible() -> Result(Int, Nil) {
+  todo
+}
+
+pub fn main() {
+  let assert Ok(value): Result(Int, Nil) = fallible()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable_with_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable_with_pattern.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\ntype Wibble {\n  Wibble(a: Int, b: Int, c: Int)\n}\n\npub fn main() {\n  let Wibble(a, b, c) = Wibble(1, 2, 3)\n}\n"
+---
+----- BEFORE ACTION
+
+type Wibble {
+  Wibble(a: Int, b: Int, c: Int)
+}
+
+pub fn main() {
+  let Wibble(a, b, c) = Wibble(1, 2, 3)
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑                
+}
+
+
+----- AFTER ACTION
+
+type Wibble {
+  Wibble(a: Int, b: Int, c: Int)
+}
+
+pub fn main() {
+  let Wibble(a, b, c): Wibble = Wibble(1, 2, 3)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable_with_pattern2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_local_variable_with_pattern2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main(values) {\n  let #(left, right) = values\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main(values) {
+  let #(left, right) = values
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑       
+}
+
+
+----- AFTER ACTION
+
+pub fn main(values) {
+  let #(left, right): #(a, b) = values
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__different_annotations_create_compatible_type_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__different_annotations_create_compatible_type_variables.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn do_generic_things(a, b) {\n  let a_value = a\n  let b_value = b\n  let other_value = a_value\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn do_generic_things(a, b) {
+  let a_value = a
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  let b_value = b
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  let other_value = a_value
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+}
+↑
+
+
+----- AFTER ACTION
+
+pub fn do_generic_things(a, b) {
+  let a_value: a = a
+  let b_value: b = b
+  let other_value: a = a_value
+}


### PR DESCRIPTION
Closes #2953, closes #2954
This PR adds a code action which automatically adds type annotations to functions, constants and local variables