### PR TITLE
Remove unused `allow(clippy::arc_with_non_send_sync)`

### DIFF
--- a/test-package-compiler/src/lib.rs
+++ b/test-package-compiler/src/lib.rs
@@ -1,9 +1,4 @@
 // TODO: move TestCompileOutput to a test helper crate
-#![allow(
-    // TODO: fix
-    clippy::arc_with_non_send_sync,
-)]
-
 #[cfg(test)]
 mod generated_tests;
 


### PR DESCRIPTION
This PR removes a simple `TODO` comment by removing a leftover `#![allow(clippy::arc_with_non_send_sync)]. AFAICT, the underlying issue was addressed in https://github.com/gleam-lang/gleam/pull/3615/commits/ec3fa6e973f44ef9609cf4eb2895faf82338f39b.