### PR TITLE
Fix wrong error message for values in pipe

### DIFF
--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -295,16 +295,11 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             fn_(vec![self.argument_type.clone()], return_type.clone()),
         )
         .map_err(|e| {
-            if self.check_if_pipe_function_mismatch(&e) {
-                return convert_unify_error(flip_unify_error(e), function.location());
+            if self.check_if_pipe_type_mismatch(&e) {
+                return convert_unify_error(e, function.location())
+                    .with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch);
             }
-            let is_pipe_mismatch = self.check_if_pipe_type_mismatch(&e);
-            if is_pipe_mismatch {
-                convert_unify_error(e, function.location())
-                    .with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch)
-            } else {
-                convert_unify_error(flip_unify_error(e), function.location())
-            }
+            convert_unify_error(flip_unify_error(e), function.location())
         })?;
 
         Ok(TypedExpr::Call {
@@ -330,19 +325,6 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                     _ => false,
                 }
             }
-            _ => false,
-        }
-    }
-
-    fn check_if_pipe_function_mismatch(&mut self, error: &UnifyError) -> bool {
-        match error {
-            UnifyError::CouldNotUnify {
-                situation:
-                    Some(UnifyErrorSituation::FunctionsMismatch {
-                        reason: FunctionsMismatchReason::Arity { .. },
-                    }),
-                ..
-            } => true,
             _ => false,
         }
     }

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -299,11 +299,11 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 return convert_unify_error(flip_unify_error(e), function.location());
             }
             let is_pipe_mismatch = self.check_if_pipe_type_mismatch(&e);
-            let error = convert_unify_error(e, function.location());
             if is_pipe_mismatch {
-                error.with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch)
+                convert_unify_error(e, function.location())
+                    .with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch)
             } else {
-                error
+                convert_unify_error(flip_unify_error(e), function.location())
             }
         })?;
 

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -339,6 +339,23 @@ fn pipe_mismatch_error() {
 }
 
 #[test]
+fn pipe_value_type_mismatch_error() {
+    assert_module_error!(
+        "pub fn main() -> String {
+            eat_veggie
+            |> Orange
+         }
+
+         type Fruit{ Orange }
+         type Veg{ Lettuce }
+
+         fn eat_veggie(v: Veg) -> String {
+            \"Ok\"
+         }"
+    );
+}
+
+#[test]
 fn case_tuple_guard() {
     assert_error!("case #(1, 2, 3) { x if x == #(1, 1.0) -> 1 }");
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__pipe_value_type_mismatch_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__pipe_value_type_mismatch_error.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "pub fn main() -> String {\n            eat_veggie\n            |> Orange\n         }\n\n         type Fruit{ Orange }\n         type Veg{ Lettuce }\n\n         fn eat_veggie(v: Veg) -> String {\n            \"Ok\"\n         }"
+---
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:16
+  │
+3 │             |> Orange
+  │                ^^^^^^
+
+Expected type:
+
+    fn(fn(Veg) -> String) -> a
+
+Found type:
+
+    Fruit


### PR DESCRIPTION
This PR fixes #3686.

I added a test which is very similar to the case in the reported issue. I am a bit unsure about my last commit which basically unconditionally applies the technique from https://github.com/gleam-lang/gleam/pull/3453. It seems fine since all tests still pass, but please tell me if I'm wrong ¯\\_(ツ)_/¯.