### PR TITLE
feat: check if module have type with the same name

### DIFF
--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2151,7 +2151,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         },
                         module_name: module.name.clone(),
                         value_constructors: module.public_value_names(),
-                        type_with_same_name: false,
+                        type_with_same_name: module.get_public_type(&label).is_some(),
                     })?;
 
             // Emit a warning if the value being used is deprecated.
@@ -2465,7 +2465,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         module_name: module_name.clone(),
                         name: name.clone(),
                         value_constructors: module.public_value_names(),
-                        type_with_same_name: false,
+                        type_with_same_name: module.get_public_type(name).is_some(),
                     })?
             }
         };


### PR DESCRIPTION
resolve: #3691 

the compiler already suggests something like, do we want to change it?
```
Did you mean `type Request`?

`Request` is only a type, it cannot be imported as a value.
```