### PR TITLE
Fix prelude re-export in generated TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,9 @@
   types that use a private type.
   ([Richard Viney](https://github.com/richard-viney))
 
+- Fixed the prelude re-export in generated TypeScript definitions.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -201,7 +201,11 @@ impl<'a> JavaScript<'a> {
         }
 
         if self.typescript == TypeScriptDeclarations::Emit {
-            let rexport = rexport.replace(".mjs", ".d.mts");
+            let rexport = format!(
+                "export * from \"{}\";\nexport type * from \"{}\";\n",
+                self.prelude_location,
+                self.prelude_location.as_str().replace(".mjs", ".d.mts")
+            );
             let prelude_declaration_path = &self.output_directory.join("gleam.d.mts");
 
             // Type declaration may trigger badly configured watchers

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -9,7 +9,8 @@ expression: "./cases/javascript_d_ts"
 <73 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
-export * from "../prelude.d.mts";
+export * from "../prelude.mjs";
+export type * from "../prelude.d.mts";
 
 
 //// /out/lib/the_package/gleam.mjs

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -15,7 +15,8 @@ expression: "./cases/javascript_import"
 <80 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
-export * from "../prelude.d.mts";
+export * from "../prelude.mjs";
+export type * from "../prelude.d.mts";
 
 
 //// /out/lib/the_package/gleam.mjs


### PR DESCRIPTION
When using the generated `gleam.d.mts` I was seeing this error:

```bash
gleam.d.mts:1:15 - error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file '../prelude.mjs' instead?

1 export * from "../prelude.d.mts";
 ```

The fix seems to be changing the prelude re-export to this:

```ts
export * from "../prelude.mjs";
export type * from "../prelude.d.mts";
```