### PR TITLE
Fix TypeScript definitions for records with identical structures not being branded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@
 - Fixed the prelude re-export in generated TypeScript definitions.
   ([Richard Viney](https://github.com/richard-viney))
 
+- Fixed TypeScript definitions for records with identical structures not being
+  nominally typed.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-core/src/javascript/tests/records.rs
+++ b/compiler-core/src/javascript/tests/records.rs
@@ -1,4 +1,4 @@
-use crate::assert_js;
+use crate::{assert_js, assert_ts_def};
 
 #[test]
 fn record_accessors() {
@@ -66,5 +66,26 @@ pub type Person {
 }
 pub fn get_name(person: Person) { person.name }
 pub fn get_age(person: Person) { person.age }"
+    );
+}
+
+#[test]
+fn record_with_no_variants_typescript() {
+    assert_ts_def!(
+        r#"
+pub type Dict(key, value)
+"#,
+    );
+}
+
+#[test]
+fn record_with_variants_typescript() {
+    assert_ts_def!(
+        r#"
+pub type Test {
+  Test1()
+  Test2()
+}
+"#,
     );
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil_typescript.snap
@@ -4,11 +4,17 @@ expression: "\npub type True { True False Nil }\npub fn go(x, y) {\n  let assert
 ---
 import type * as _ from "../gleam.d.mts";
 
-export class True extends _.CustomType {}
+export class True extends _.CustomType {
+  private __brand: void;
+}
 
-export class False extends _.CustomType {}
+export class False extends _.CustomType {
+  private __brand: void;
+}
 
-export class Nil extends _.CustomType {}
+export class Nil extends _.CustomType {
+  private __brand: void;
+}
 
 export type True$ = True | False | Nil;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_with_fields_typescript.snap
@@ -5,6 +5,8 @@ expression: "\npub type Mine {\n  Mine(a: Int, b: Int)\n}\n\npub const labels = 
 import type * as _ from "../gleam.d.mts";
 
 export class Mine extends _.CustomType {
+  private __brand: void;
+
   constructor(a: number, b: number);
   
   a: number;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__long_name_variant_mixed_labels_typescript.snap
@@ -5,6 +5,8 @@ expression: "\npub type TypeWithALongNameAndSeveralArguments{\n  TypeWithALongNa
 import type * as _ from "../gleam.d.mts";
 
 export class TypeWithALongNameAndSeveralArguments extends _.CustomType {
+  private __brand: void;
+
   constructor(
     argument$0: string,
     argument$1: string,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_types_typescript.snap
@@ -5,12 +5,16 @@ expression: "pub opaque type Animal {\n  Cat(goes_outside: Bool)\n  Dog(plays_fe
 import type * as _ from "../gleam.d.mts";
 
 declare class Cat extends _.CustomType {
+  private __brand: void;
+
   constructor(goes_outside: boolean);
   
   goes_outside: boolean;
 }
 
 declare class Dog extends _.CustomType {
+  private __brand: void;
+
   constructor(plays_fetch: boolean);
   
   plays_fetch: boolean;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unapplied_record_constructors_typescript.snap
@@ -5,6 +5,8 @@ expression: "pub type Cat { Cat(name: String) }\n\npub fn return_unapplied_cat()
 import type * as _ from "../gleam.d.mts";
 
 export class Cat extends _.CustomType {
+  private __brand: void;
+
   constructor(name: string);
   
   name: string;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields_typescript.snap
@@ -5,6 +5,8 @@ expression: "\npub type Ip{\n    Ip(String)\n}\n\npub const local = Ip(\"0.0.0.0
 import type * as _ from "../gleam.d.mts";
 
 export class Ip extends _.CustomType {
+  private __brand: void;
+
   constructor(argument$0: string);
   
   0: string;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__external_type_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__external_type_typescript.snap
@@ -2,6 +2,10 @@
 source: compiler-core/src/javascript/tests/externals.rs
 expression: "pub type Queue(a)\n\n@external(javascript, \"queue\", \"new\")\npub fn new() -> Queue(a)\n"
 ---
-export type Queue$<I> = any;
+declare class Queue<I> extends _.CustomType {
+  private __brand: void;
+}
+
+export type Queue$<I> = Queue<I>;
 
 export function new$(): Queue$<any>;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__tf_type_name_usage.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__tf_type_name_usage.snap
@@ -2,6 +2,10 @@
 source: compiler-core/src/javascript/tests/externals.rs
 expression: "\npub type TESTitem\n\n@external(javascript, \"it\", \"one\")\npub fn one(a: TESTitem) -> TESTitem\n"
 ---
-export type TESTitem$ = any;
+declare class TESTitem extends _.CustomType {
+  private __brand: void;
+}
+
+export type TESTitem$ = TESTitem;
 
 export function one(a: TESTitem$): TESTitem$;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__record_generics_typescript.snap
@@ -5,12 +5,16 @@ expression: "pub type Animal(t) {\n  Cat(type_: t)\n  Dog(type_: t)\n}\n\npub fn
 import type * as _ from "../gleam.d.mts";
 
 export class Cat<I> extends _.CustomType {
+  private __brand: void;
+
   constructor(type_: I);
   
   type_: I;
 }
 
 export class Dog<I> extends _.CustomType {
+  private __brand: void;
+
   constructor(type_: I);
   
   type_: I;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__task_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__task_typescript.snap
@@ -2,6 +2,10 @@
 source: compiler-core/src/javascript/tests/generics.rs
 expression: "pub type Promise(value)\n    pub type Task(a) = fn() -> Promise(a)"
 ---
-export type Promise$<I> = any;
+declare class Promise<I> extends _.CustomType {
+  private __brand: void;
+}
+
+export type Promise$<I> = Promise<I>;
 
 export type Task = () => Promise$<any>;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_with_no_variants_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_with_no_variants_typescript.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+expression: "\npub type Dict(key, value)\n"
+---
+declare class Dict<I, J> extends _.CustomType {
+  private __brand: void;
+}
+
+export type Dict$<I, J> = Dict<I, J>;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_with_variants_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__records__record_with_variants_typescript.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/javascript/tests/records.rs
+expression: "\npub type Test {\n  Test1()\n  Test2()\n}\n"
+---
+import type * as _ from "../gleam.d.mts";
+
+export class Test1 extends _.CustomType {
+  private __brand: void;
+}
+
+export class Test2 extends _.CustomType {
+  private __brand: void;
+}
+
+export type Test$ = Test1 | Test2;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__private_type_in_opaque_type.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__private_type_in_opaque_type.snap
@@ -4,11 +4,15 @@ expression: "\ntype PrivateType {\n  PrivateType\n}\n\npub opaque type OpaqueTyp
 ---
 import type * as _ from "../gleam.d.mts";
 
-declare class PrivateType extends _.CustomType {}
+declare class PrivateType extends _.CustomType {
+  private __brand: void;
+}
 
 declare type PrivateType$ = PrivateType;
 
 declare class OpaqueType extends _.CustomType {
+  private __brand: void;
+
   constructor(argument$0: PrivateType$);
   
   0: PrivateType$;

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -20,7 +20,9 @@ export * from "../prelude.mjs";
 //// /out/lib/the_package/hello.d.mts
 import type * as _ from "./gleam.d.mts";
 
-export class Woo extends _.CustomType {}
+export class Woo extends _.CustomType {
+  private __brand: void;
+}
 
 export type Wibble$ = Woo;
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -26,7 +26,9 @@ export * from "../prelude.mjs";
 //// /out/lib/the_package/one/two.d.mts
 import type * as _ from "../gleam.d.mts";
 
-export class A extends _.CustomType {}
+export class A extends _.CustomType {
+  private __brand: void;
+}
 
 export type A$ = A;
 


### PR DESCRIPTION
This PR addresses two issues with the generated TypeScript typings:

1. `pub type Dict(key, value)` generating the TypeScript `export type Dict<A, B> = any`. This isn't ideal because it uses `any` which (a) loses type information and (b) triggers downstream linters set to warn on any kind of interaction with an `any` type.

2. Gleam types with identical structure having structurally identical TypeScript types. This leads to being able to accidentally pass incorrect and invalid types to functions when relying on the TypeScript typings, with no errors or warnings being shown.

The proposed solution implemented here is to add branding to all classes in the generated TypeScript definitions. See https://www.learningtypescript.com/articles/branded-types for details.

The following Gleam code:

```gleam
pub type Foo

pub type TestWithVariants {
  TestOne
  TestTwo
}
```

now generates this TypeScript:

```typescript
declare class Foo extends _.CustomType {
  private __brand: void;
}

export type Foo$ = Foo;

export class TestOne extends _.CustomType {
  private __brand: void;
}

export class TestTwo extends _.CustomType {
  private __brand: void;
}

export type TestWithVariants$ = TestOne | TestTwo;
```