### PR TITLE
Images (and other assets) in docs

### DIFF
--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -429,6 +429,20 @@ pub fn private_files_excluding_gitignore(dir: &Utf8Path) -> impl Iterator<Item =
         .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
 }
 
+pub fn non_gleam_files_excluding_gitignore(
+    dir: &Utf8Path,
+) -> impl Iterator<Item = Utf8PathBuf> + '_ {
+    ignore::WalkBuilder::new(dir)
+        .follow_links(true)
+        .require_git(false)
+        .build()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .map(ignore::DirEntry::into_path)
+        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
+        .filter(move |d| !is_gleam_path(d, dir))
+}
+
 pub fn erlang_files(dir: &Utf8Path) -> Result<impl Iterator<Item = Utf8PathBuf> + '_> {
     Ok(read_dir(dir)?
         .flat_map(Result::ok)


### PR DESCRIPTION
Hello! Last time when I went through the [lustre/ui](https://hexdocs.pm/lustre_ui/index.html) documentation, I really wished there were some images to make choosing the right component easier. I wanted to contribute some but that is not easily possible because you can only link to externally hosted images.

I made this PR to change that. I should have probably created a Github issue first for a discussion but the change is so small I just went ahead and did it. This is my first ever PR here, let me know if I did something wrong or forgot something.

**How it works**
Any asset can be put in the `src` folder and referenced in documentation comments with a relative path.

**Example**
Let's say you have an image `example.png` and you put it under `src/example.png`.

Let's say this is `src/wibble.gleam`
```gleam
/// This is how wibble looks like ![example](./example.png).
pub fn wibble() {
  todo
}
```

After running `gleam docs build --open` you will see something like this:

<img width="774" alt="grafik" src="https://github.com/user-attachments/assets/b6d3b1db-5211-4da2-953c-846090854327">

---

Of course, you can use HTML to change the image size.

```gleam
/// This is how wibble looks like <img src="./example.png" width="150"/>
pub fn wibble() {
  todo
}
```

<img width="767" alt="grafik" src="https://github.com/user-attachments/assets/26a8818e-b66e-4071-a7dc-309ebb80e612">

