### PR TITLE
Fix bug with labelled argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@
 - Fixed the prelude re-export in generated TypeScript definitions.
   ([Richard Viney](https://github.com/richard-viney))
 
+- Fixed a bug where the compiler would incorrectly type-check and compile
+  calls to functions with labelled arguments in certain cases.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-cli/src/panic.rs
+++ b/compiler-cli/src/panic.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::unwrap_used)]
-use std::panic::PanicInfo;
+use std::panic::PanicHookInfo;
 
 pub fn add_handler() {
-    std::panic::set_hook(Box::new(move |info: &PanicInfo<'_>| {
+    std::panic::set_hook(Box::new(move |info: &PanicHookInfo<'_>| {
         print_compiler_bug_message(info)
     }));
 }
 
-fn print_compiler_bug_message(info: &PanicInfo<'_>) {
+fn print_compiler_bug_message(info: &PanicHookInfo<'_>) {
     let message = match (
         info.payload().downcast_ref::<&str>(),
         info.payload().downcast_ref::<String>(),

--- a/compiler-core/src/erlang/tests/functions.rs
+++ b/compiler-core/src/erlang/tests/functions.rs
@@ -109,3 +109,31 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn labelled_argument_ordering() {
+    // https://github.com/gleam-lang/gleam/issues/3671
+    assert_erl!(
+        "
+type A { A }
+type B { B }
+type C { C }
+type D { D }
+
+fn wibble(a a: A, b b: B, c c: C, d d: D) {
+  Nil
+}
+
+pub fn main() {
+  wibble(A, C, D, b: B)
+  wibble(A, C, D, b: B)
+  wibble(B, C, D, a: A)
+  wibble(B, C, a: A, d: D)
+  wibble(B, C, d: D, a: A)
+  wibble(B, D, a: A, c: C)
+  wibble(B, D, c: C, a: A)
+  wibble(C, D, b: B, a: A)
+}
+"
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__labelled_argument_ordering.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__labelled_argument_ordering.snap
@@ -1,0 +1,34 @@
+---
+source: compiler-core/src/erlang/tests/functions.rs
+expression: "\ntype A { A }\ntype B { B }\ntype C { C }\ntype D { D }\n\nfn wibble(a a: A, b b: B, c c: C, d d: D) {\n  Nil\n}\n\npub fn main() {\n  wibble(A, C, D, b: B)\n  wibble(A, C, D, b: B)\n  wibble(B, C, D, a: A)\n  wibble(B, C, a: A, d: D)\n  wibble(B, C, d: D, a: A)\n  wibble(B, D, a: A, c: C)\n  wibble(B, D, c: C, a: A)\n  wibble(C, D, b: B, a: A)\n}\n"
+---
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+-export_type([a/0, b/0, c/0, d/0]).
+
+-type a() :: a.
+
+-type b() :: b.
+
+-type c() :: c.
+
+-type d() :: d.
+
+-file("/root/project/test/my/mod.gleam", 7).
+-spec wibble(a(), b(), c(), d()) -> nil.
+wibble(A, B, C, D) ->
+    nil.
+
+-file("/root/project/test/my/mod.gleam", 11).
+-spec main() -> nil.
+main() ->
+    wibble(a, b, c, d),
+    wibble(a, b, c, d),
+    wibble(a, b, c, d),
+    wibble(a, b, c, d),
+    wibble(a, b, c, d),
+    wibble(a, b, c, d),
+    wibble(a, b, c, d),
+    wibble(a, b, c, d).

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -459,3 +459,31 @@ fn function_literals_get_properly_wrapped_3() {
 "#
     );
 }
+
+#[test]
+fn labelled_argument_ordering() {
+    // https://github.com/gleam-lang/gleam/issues/3671
+    assert_js!(
+        "
+type A { A }
+type B { B }
+type C { C }
+type D { D }
+
+fn wibble(a a: A, b b: B, c c: C, d d: D) {
+  Nil
+}
+
+pub fn main() {
+  wibble(A, C, D, b: B)
+  wibble(A, C, D, b: B)
+  wibble(B, C, D, a: A)
+  wibble(B, C, a: A, d: D)
+  wibble(B, C, d: D, a: A)
+  wibble(B, D, a: A, c: C)
+  wibble(B, D, c: C, a: A)
+  wibble(C, D, b: B, a: A)
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__labelled_argument_ordering.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__labelled_argument_ordering.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\ntype A { A }\ntype B { B }\ntype C { C }\ntype D { D }\n\nfn wibble(a a: A, b b: B, c c: C, d d: D) {\n  Nil\n}\n\npub fn main() {\n  wibble(A, C, D, b: B)\n  wibble(A, C, D, b: B)\n  wibble(B, C, D, a: A)\n  wibble(B, C, a: A, d: D)\n  wibble(B, C, d: D, a: A)\n  wibble(B, D, a: A, c: C)\n  wibble(B, D, c: C, a: A)\n  wibble(C, D, b: B, a: A)\n}\n"
+---
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+class A extends $CustomType {}
+
+class B extends $CustomType {}
+
+class C extends $CustomType {}
+
+class D extends $CustomType {}
+
+function wibble(a, b, c, d) {
+  return undefined;
+}
+
+export function main() {
+  wibble(new A(), new B(), new C(), new D());
+  wibble(new A(), new B(), new C(), new D());
+  wibble(new A(), new B(), new C(), new D());
+  wibble(new A(), new B(), new C(), new D());
+  wibble(new A(), new B(), new C(), new D());
+  wibble(new A(), new B(), new C(), new D());
+  wibble(new A(), new B(), new C(), new D());
+  return wibble(new A(), new B(), new C(), new D());
+}

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -2457,3 +2457,32 @@ pub fn main() {
         vec![("main", "fn() -> Int")]
     );
 }
+
+#[test]
+fn labelled_argument_ordering() {
+    // https://github.com/gleam-lang/gleam/issues/3671
+    assert_module_infer!(
+        "
+type A { A }
+type B { B }
+type C { C }
+type D { D }
+
+fn wibble(a a: A, b b: B, c c: C, d d: D) {
+  Nil
+}
+
+pub fn main() {
+  wibble(A, C, D, b: B)
+  wibble(A, C, D, b: B)
+  wibble(B, C, D, a: A)
+  wibble(B, C, a: A, d: D)
+  wibble(B, C, d: D, a: A)
+  wibble(B, D, a: A, c: C)
+  wibble(B, D, c: C, a: A)
+  wibble(C, D, b: B, a: A)
+}
+",
+        vec![("main", "fn() -> Nil")]
+    );
+}


### PR DESCRIPTION
Fixes #3671 
This fixes a bug with the reordering of arguments where reordering was just done using `[T]::swap`. This works for simple cases of argument reordering, but breaks down in quite a few cases as shown in that issue.
This implements a more complex reordering method, which removes the labelled arguments first, then reinserts them in order.

A couple of questions:
- I've just put all the erroneous cases from that issue into one test, should I separate them?
- This new method is not super efficient, since is has to iterate the arguments, remove any labelled ones, then iterate again to insert them back. I can think of a few other ways to do this, although they are a bit obscure and could make the code difficult to understand. Let me know if I should change it