### PR TITLE
TypeScript type safety on records with no variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@
   the Erlang target if any of their arguments were discarded.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Records with no variants now use the TypeScript type `unknown` instead of
+  `any`.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ### Formatter
 
 ### Language Server

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__external_type_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__external_type_typescript.snap
@@ -2,6 +2,6 @@
 source: compiler-core/src/javascript/tests/externals.rs
 expression: "pub type Queue(a)\n\n@external(javascript, \"queue\", \"new\")\npub fn new() -> Queue(a)\n"
 ---
-export type Queue$<I> = any;
+export type Queue$<I> = unknown;
 
 export function new$(): Queue$<any>;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__tf_type_name_usage.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__externals__tf_type_name_usage.snap
@@ -2,6 +2,6 @@
 source: compiler-core/src/javascript/tests/externals.rs
 expression: "\npub type TESTitem\n\n@external(javascript, \"it\", \"one\")\npub fn one(a: TESTitem) -> TESTitem\n"
 ---
-export type TESTitem$ = any;
+export type TESTitem$ = unknown;
 
 export function one(a: TESTitem$): TESTitem$;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__task_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__generics__task_typescript.snap
@@ -2,6 +2,6 @@
 source: compiler-core/src/javascript/tests/generics.rs
 expression: "pub type Promise(value)\n    pub type Task(a) = fn() -> Promise(a)"
 ---
-export type Promise$<I> = any;
+export type Promise$<I> = unknown;
 
 export type Task = () => Promise$<any>;


### PR DESCRIPTION
Currently the generated TypeScript declaration for

```gleam
pub type Dict(key, value)
```

as used by stdlib is

```ts
export type Dict$<A, B> = any;
```

Two issues arise from this:

1. The `any` loses type information and safety, e.g. in this case anything can be passed as a dict to stdlib's `dict.*` functions.
2. A TypeScript app consuming this type can't prohibit the use of `any`, which is a best-practice in strict TypeScript.

The proposed solution this PR implements is to change the generated code to be:

```ts
declare const __brand_Dict: unique symbol;
type Dict = { [__brand_Dict]: void };

export type Dict$<A, B> = Dict;
```

This code defines a type with one property named using a non-exported [unique symbol](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#unique-symbol), meaning that it can't be looked up, isn't present at runtime, and doesn't appear in editor autocomplete. This effectively creates an empty nominal type, which addresses the two issues above.

This approach is a slight variant of the 'branded types' pattern in TypeScript that's well-described here:

- https://www.learningtypescript.com/articles/branded-types
- https://blog.logrocket.com/leveraging-typescript-branded-types-stronger-type-checks/