### PR TITLE
Add ability to specify erlang node names.

### DIFF
--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -5,7 +5,9 @@ use gleam_core::{
 };
 use std::process::Command;
 
-pub fn command() -> Result<(), Error> {
+use crate::ErlangNodeName;
+
+pub fn command(erlang_node_name: Option<ErlangNodeName>, setcookie: Option<String>) -> Result<(), Error> {
     let paths = crate::find_project_paths()?;
 
     // Build project
@@ -27,6 +29,20 @@ pub fn command() -> Result<(), Error> {
 
     // Prepare the Erlang shell command
     let mut command = Command::new("erl");
+
+    match erlang_node_name {
+        Some(ErlangNodeName::Short(name)) => {
+            let _ = command.arg("-sname").arg(name);
+        }
+        Some(ErlangNodeName::Long(name)) => {
+            let _ = command.arg("-name").arg(name);
+        }
+        None => {}
+    }
+
+    if let Some(cookie) = setcookie {
+        let _ = command.arg("-setcookie").arg(cookie);
+    }
 
     // Print character lists as lists
     let _ = command.arg("-stdlib").arg("shell_strings").arg("false");

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -294,6 +294,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
         minimum_required_version: SmallVersion,
         wrongfully_allowed_version: SmallVersion,
     },
+
+    #[error("Either name or sname must be specified, but not both")]
+    ErlangNodeNameConflict,
 }
 
 /// This is to make clippy happy and not make the error variant too big by
@@ -3584,6 +3587,15 @@ or you can publish it using a different version number"),
                 location: None,
                 hint: Some("Please add the --replace flag if you want to replace the release.".into()),
             }],
+            Error::ErlangNodeNameConflict => {
+                vec![Diagnostic {
+                    title: "Erlang node name conflict".into(),
+                    text: wrap("Only either name or sname can be specified, not both."),
+                    level: Level::Error,
+                    location: None,
+                    hint: None,
+                }]
+            }
         }
     }
 }


### PR DESCRIPTION
This allows you to specify the erl cli parameters name or sname in the beam shell or run commands.

This makes it easier to attach to a running instance to launch observer, debug, inspect stuff, etc.
