### PR TITLE
Fix compiler crash on duplicate fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,10 @@
   item on its own line to make things easier to read.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would crash when pattern matching on a type
+  which was defined with duplicate fields in one of its variants.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -899,7 +899,6 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         type_parameters: &[&EcoString],
     ) -> Result<(), Error> {
         let CustomType {
-            location,
             publicity,
             opaque,
             name,
@@ -971,7 +970,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 args_types.push(t);
 
                 // Register the label for this parameter, if there is one
-                if let Some((_, label)) = label {
+                if let Some((location, label)) = label {
                     if field_map.insert(label.clone(), i as u32).is_err() {
                         self.problems.error(Error::DuplicateField {
                             label: label.clone(),

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -972,12 +972,12 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
                 // Register the label for this parameter, if there is one
                 if let Some((_, label)) = label {
-                    field_map.insert(label.clone(), i as u32).map_err(|_| {
-                        Error::DuplicateField {
+                    if field_map.insert(label.clone(), i as u32).is_err() {
+                        self.problems.error(Error::DuplicateField {
                             label: label.clone(),
                             location: *location,
-                        }
-                    })?;
+                        });
+                    };
                 }
             }
             let field_map = field_map.into_option();

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2471,3 +2471,23 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn no_crash_on_duplicate_record_fields() {
+    // https://github.com/gleam-lang/gleam/issues/3713
+    assert_module_error!(
+        "
+pub type X {
+  A
+  B(e0: Int, e0: Int)
+}
+
+fn compiler_crash(x: X) {
+  case x {
+    A -> todo
+    _ -> todo
+  }
+}
+  "
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_record_fields.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_record_fields.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type X {\n  A\n  B(e0: Int, e0: Int)\n}\n\nfn compiler_crash(x: X) {\n  case x {\n    A -> todo\n    _ -> todo\n  }\n}\n  "
+---
+error: Duplicate label
+  ┌─ /src/one/two.gleam:2:1
+  │
+2 │ pub type X {
+  │ ^^^^^^^^^^
+
+The label `e0` has already been defined. Rename this label.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_record_fields.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_record_fields.snap
@@ -3,9 +3,9 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type X {\n  A\n  B(e0: Int, e0: Int)\n}\n\nfn compiler_crash(x: X) {\n  case x {\n    A -> todo\n    _ -> todo\n  }\n}\n  "
 ---
 error: Duplicate label
-  ┌─ /src/one/two.gleam:2:1
+  ┌─ /src/one/two.gleam:4:14
   │
-2 │ pub type X {
-  │ ^^^^^^^^^^
+4 │   B(e0: Int, e0: Int)
+  │              ^^
 
 The label `e0` has already been defined. Rename this label.


### PR DESCRIPTION
Fixes #3713 
This is similar to several other bugs that arose from fault tolerance, where a type variant wouldn't be defined if it didn't have duplicate fields because the whole function would short-circuit from the `?` operator. This PR simply reports the error in `Problems` instead of returning.