### PR TITLE
Don't remove the first argument in piped functions when it has a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,34 @@
 
 ### Formatter
 
+- The formatter no longer removes the first argument from a function
+  which is part of a pipeline if the first argument is a capture
+  and it has a label. This snippet of code is left as is by the formatter:
+
+  ```gleam
+  pub fn divide(dividend a: Int, divisor b: Int) -> Int {
+    a / b
+  }
+
+  pub fn main() {
+    10 |> divide(dividend: _, divisor: 2)
+  }
+  ```
+
+  Whereas previously, the label of the capture variable would be lost:
+
+  ```gleam
+  pub fn divide(dividend a: Int, divisor b: Int) -> Int {
+    a / b
+  }
+
+  pub fn main() {
+    10 |> divide(divisor: 2)
+  }
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Language Server
 
 - The Language Server now displays correctly qualified or aliased type names

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1483,12 +1483,15 @@ impl<'comments> Formatter<'comments> {
                 ..
             }) if name == CAPTURE_VARIABLE
         );
+        let first_argument_is_labelled = args.first().is_some_and(|arg| arg.label.is_some());
         let arity = args.len();
 
-        if hole_in_first_position && args.len() == 1 {
+        // If the first argument is labelled, we don't remove it as the label adds
+        // extra information and could be used to make code more readable.
+        if hole_in_first_position && args.len() == 1 && !first_argument_is_labelled {
             // x |> fun(_)
             self.expr(fun)
-        } else if hole_in_first_position {
+        } else if hole_in_first_position && !first_argument_is_labelled {
             // x |> fun(_, 2, 3)
             let args = args
                 .iter()

--- a/compiler-core/src/format/tests/pipeline.rs
+++ b/compiler-core/src/format/tests/pipeline.rs
@@ -104,3 +104,31 @@ pub fn multiline_function_inside_pipeline_in_tuple_is_indented_properly() {
 "#,
     );
 }
+
+#[test]
+fn pipe_with_labelled_first_argument_capture() {
+    assert_format!(
+        "fn wibble(label1 a, label2 b, lots c, of d, labels e) {
+  a + b * c - d / e
+}
+
+fn main() {
+  1 |> wibble(label1: _, label2: 2, lots: 3, of: 4, labels: 5)
+}
+"
+    );
+}
+
+#[test]
+fn pipe_with_labelled_only_argument_capture() {
+    assert_format!(
+        "fn wibble(descriptive_label value) {
+  value
+}
+
+fn main() {
+  42 |> wibble(descriptive_label: _)
+}
+"
+    );
+}

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -356,12 +356,16 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         {
             if let Statement::Expression(UntypedExpr::Call { arguments, .. }) = body.first() {
                 match arguments.as_slice() {
-                    [first] | [first, ..] if first.is_capture_hole() => self
-                        .expr_typer
-                        .problems
-                        .warning(Warning::RedundantPipeFunctionCapture {
-                            location: first.location,
-                        }),
+                    // If the first argument is labelled, we don't warn the user
+                    // as they might be intentionally adding it to provide more
+                    // information about exactly which argument is being piped into.
+                    [first] | [first, ..] if first.is_capture_hole() && first.label.is_none() => {
+                        self.expr_typer
+                            .problems
+                            .warning(Warning::RedundantPipeFunctionCapture {
+                                location: first.location,
+                            })
+                    }
                     _ => (),
                 }
             }

--- a/compiler-core/src/type_/tests/pipes.rs
+++ b/compiler-core/src/type_/tests/pipes.rs
@@ -1,4 +1,4 @@
-use crate::{assert_module_error, assert_module_infer};
+use crate::{assert_module_error, assert_module_infer, assert_no_warnings};
 
 // https://github.com/gleam-lang/gleam/issues/2392
 #[test]
@@ -151,5 +151,35 @@ pub fn main() {
   let x = 1 |> callback(2)
 }
 "#
+    );
+}
+
+#[test]
+fn no_warnings_when_piping_into_labelled_capture_as_first_argument() {
+    assert_no_warnings!(
+        "
+fn wibble(label1 a, label2 b, lots c, of d, labels e) {
+  a + b * c - d / e
+}
+
+pub fn main() {
+  1 |> wibble(label1: _, label2: 2, lots: 3, of: 4, labels: 5)
+}
+"
+    );
+}
+
+#[test]
+fn no_warnings_when_piping_into_labelled_capture_as_only_argument() {
+    assert_no_warnings!(
+        "
+fn wibble(descriptive_label value) {
+  value
+}
+
+pub fn main() {
+  42 |> wibble(descriptive_label: _)
+}
+"
     );
 }


### PR DESCRIPTION
This was discussed on Discord, although it looks like no one made an issue of it.
This PR introduces a change to the formatter whereby it will no longer remove the first argument of a function in a pipeline if it is a function capture and has a label, as users may want to still annotate the label of the captured argument, even if it comes lexically first. This also removes the warning for an unnecessary capture in that case.