### PR TITLE
Consistent colouring of runtime errors on Erlang

### DIFF
--- a/compiler-core/templates/gleam@@main.erl
+++ b/compiler-core/templates/gleam@@main.erl
@@ -31,7 +31,7 @@ run_module(Module) ->
 
 print_error(Class, Error, Stacktrace) ->
     Printed = [
-        ?red, "runtime error: ", ?reset_color, error_class(Class, Error), ?reset_all,
+        ?red, "runtime error", ?reset_color, ": ", error_class(Class, Error), ?reset_all,
         "\n\n",
         error_message(Error),
         "\n\n",


### PR DESCRIPTION
Fixes #3638 with a one line change so the colon isn't coloured, which matches the compiler output:

<img width="376" alt="Screenshot 2024-10-20 at 10 36 52 PM" src="https://github.com/user-attachments/assets/00a8dae6-912a-4fbd-a21c-10e0bbe4f259">