### PR TITLE
Return error from WASM compiler when unsupported features are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,10 @@
   which was defined with duplicate fields in one of its variants.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where the WASM compiler would return incomplete JavaScript when
+  unsupported features were used. It now returns a compilation error.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -5,6 +5,7 @@ mod wasm_filesystem;
 
 use camino::Utf8PathBuf;
 use gleam_core::{
+    analyse::TargetSupport,
     build::{
         Mode, NullTelemetry, PackageCompiler, StaleTracker, Target, TargetCodegenConfiguration,
     },
@@ -203,6 +204,7 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
     compiler.write_entrypoint = false;
     compiler.write_metadata = false;
     compiler.compile_beam_bytecode = true;
+    compiler.target_support = TargetSupport::Enforced;
     compiler
         .compile(
             &warning_emitter,

--- a/compiler-wasm/src/tests.rs
+++ b/compiler-wasm/src/tests.rs
@@ -76,6 +76,23 @@ export function go() {
 }
 
 #[wasm_bindgen_test]
+fn test_compile_package_js_unsupported_feature() {
+    reset_filesystem(0);
+    write_module(
+        0,
+        "one",
+        r#"
+fn wibble() { <<0:16-native>> }
+pub fn main() { wibble() }
+"#,
+    );
+
+    assert!(compile_package(0, "javascript")
+        .unwrap_err()
+        .contains("Unsupported feature for compilation target"));
+}
+
+#[wasm_bindgen_test]
 fn test_warnings() {
     reset_filesystem(0);
     write_module(0, "one", "const x = 1");


### PR DESCRIPTION
Fixes #3310.

When tested in `gleam-lang/playground`, the correct JS compilation error is now shown:

---

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/40ef13aa-f5ed-4ca3-bffd-edb6a1adaadb">

---

It might be nice for the playground to still be able to show the Erlang output even when the JS compilation fails. Is this worth having or too niche to bother about now the JS compilation error is surfaced?