### PR TITLE
Optimise bit array creation in the JavaScript prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@
 - Improve error message for using @deprecated with no deprecation message
   ([Jiangda Wang](https://github.com/frank-iii))
 
+- Optimised creation of bit arrays on the JavaScript target.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ### Formatter
 
 - The formatter no longer removes the first argument from a function

--- a/test/javascript_prelude/main.mjs
+++ b/test/javascript_prelude/main.mjs
@@ -150,6 +150,56 @@ assertNotEqual(new UtfCodepoint(128013), new UtfCodepoint(128014));
 
 assertEqual(new BitArray(new Uint8Array([])), toBitArray([]));
 
+const testValues = [
+  { input: 0, u8: 0 },
+  { input: 1, u8: 1 },
+  { input: 127, u8: 127 },
+  { input: 128, u8: 128 },
+  { input: 129, u8: 129 },
+  { input: 255, u8: 255 },
+  { input: 256, u8: 0 },
+  { input: 257, u8: 1 },
+  { input: 2000, u8: 208 },
+  { input: 0, u8: 0 },
+  { input: -1, u8: 255 },
+  { input: -127, u8: 129 },
+  { input: -128, u8: 128 },
+  { input: -129, u8: 127 },
+  { input: -255, u8: 1 },
+  { input: -256, u8: 0 },
+  { input: -257, u8: 255 },
+  { input: -2000, u8: 48 },
+];
+
+for (const { input, u8 } of testValues) {
+  assertEqual(new BitArray(new Uint8Array([u8])), toBitArray([input]));
+}
+
+assertEqual(new BitArray(new Uint8Array([])), toBitArray([new Uint8Array([])]));
+assertEqual(
+  new BitArray(new Uint8Array([1, 2, 4, 8])),
+  toBitArray([new Uint8Array([1, 2, 4, 8])])
+);
+
+assertEqual(
+  new BitArray(new Uint8Array(testValues.map((t) => t.u8))),
+  toBitArray(testValues.map((t) => t.input))
+);
+
+assertEqual(
+  new BitArray(
+    new Uint8Array([1, 2, 4, 8, ...testValues.map((t) => t.u8), 80, 90, 100])
+  ),
+  toBitArray([
+    new Uint8Array([]),
+    new Uint8Array([1, 2, 4, 8]),
+    ...testValues.map((t) => t.input),
+    new Uint8Array([80, 90]),
+    new Uint8Array([]),
+    new Uint8Array([100]),
+  ])
+);
+
 assertEqual(
   new BitArray(new Uint8Array([97, 98, 99])),
   toBitArray([stringBits("abc")]),


### PR DESCRIPTION
### Summary

This PR makes some optimisations to the `toBitArray()` function in the JavaScript prelude.

The optimised version is between 2x and 40x faster in my benchmarks, depending on the shape of the input.

### Details

The specific changes are:

- Special case when there is exactly zero or one segment(s).
- When there is one segment and it's a `Uint8Array`, pass it straight to the `BitArray` constructor without copying.
- When there are multiple segments, if none are `Uint8Array`s then pass `segments` straight to the Uint8Array constructor without copying.
- When there are multiple segments of different types, don't use a `DataView` and instead write directly into a `Uint8Array`.

> [!NOTE]
> I didn't include a changelog entry in because it didn't seem to fit exactly under any of the headings, but can certainly add one somewhere if desired.