### PR TITLE
Improve "Add Type Annotations" Code Action

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -7,7 +7,7 @@ mod tests;
 pub mod visit;
 
 pub use self::typed::TypedExpr;
-pub use self::untyped::{UntypedExpr, Use};
+pub use self::untyped::{FunctionLiteralKind, UntypedExpr, Use};
 
 pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -47,6 +47,9 @@ pub enum TypedExpr {
 
     Fn {
         location: SrcSpan,
+        /// The location of the function head, if this function was defined
+        /// using anonymous function syntax, as opposed to a capture.
+        head_location: Option<SrcSpan>,
         type_: Arc<Type>,
         is_capture: bool,
         args: Vec<TypedArg>,

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -47,11 +47,8 @@ pub enum TypedExpr {
 
     Fn {
         location: SrcSpan,
-        /// The location of the function head, if this function was defined
-        /// using anonymous function syntax, as opposed to a capture.
-        head_location: Option<SrcSpan>,
         type_: Arc<Type>,
-        is_capture: bool,
+        kind: FunctionLiteralKind,
         args: Vec<TypedArg>,
         body: Vec1<TypedStatement>,
         return_annotation: Option<TypeAst>,

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -34,11 +34,9 @@ pub enum UntypedExpr {
         /// For anonymous functions, this is the location of the entire function including the end of the body.
         /// For named functions, this is the location of the function head.
         location: SrcSpan,
-        /// The location of the function head for anonymous functions
-        head_location: Option<SrcSpan>,
+        kind: FunctionLiteralKind,
         /// The byte location of the end of the function head before the opening bracket
         end_of_head_byte_index: u32,
-        is_capture: bool,
         arguments: Vec<UntypedArg>,
         body: Vec1<UntypedStatement>,
         return_annotation: Option<TypeAst>,
@@ -283,4 +281,20 @@ pub struct Use {
     /// The patterns on the left hand side of `<-` in a use expression.
     ///
     pub assignments: Vec<UseAssignment>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FunctionLiteralKind {
+    Capture,
+    Anonymous { head: SrcSpan },
+    Use { location: SrcSpan },
+}
+
+impl FunctionLiteralKind {
+    pub fn is_capture(&self) -> bool {
+        match self {
+            FunctionLiteralKind::Capture => true,
+            FunctionLiteralKind::Anonymous { .. } | FunctionLiteralKind::Use { .. } => false,
+        }
+    }
 }

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -34,6 +34,8 @@ pub enum UntypedExpr {
         /// For anonymous functions, this is the location of the entire function including the end of the body.
         /// For named functions, this is the location of the function head.
         location: SrcSpan,
+        /// The location of the function head for anonymous functions
+        head_location: Option<SrcSpan>,
         /// The byte location of the end of the function head before the opening bracket
         end_of_head_byte_index: u32,
         is_capture: bool,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -132,6 +132,7 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_fn(
         &mut self,
         location: &'ast SrcSpan,
+        head_location: &'ast Option<SrcSpan>,
         type_: &'ast Arc<Type>,
         is_capture: &'ast bool,
         args: &'ast [TypedArg],
@@ -141,6 +142,7 @@ pub trait Visit<'ast> {
         visit_typed_expr_fn(
             self,
             location,
+            head_location,
             type_,
             is_capture,
             args,
@@ -639,12 +641,21 @@ where
         } => v.visit_typed_expr_var(location, constructor, name),
         TypedExpr::Fn {
             location,
+            head_location,
             type_,
             is_capture,
             args,
             body,
             return_annotation,
-        } => v.visit_typed_expr_fn(location, type_, is_capture, args, body, return_annotation),
+        } => v.visit_typed_expr_fn(
+            location,
+            head_location,
+            type_,
+            is_capture,
+            args,
+            body,
+            return_annotation,
+        ),
         TypedExpr::List {
             location,
             type_,
@@ -804,6 +815,7 @@ pub fn visit_typed_expr_var<'a, V>(
 pub fn visit_typed_expr_fn<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
+    _head_location: &'a Option<SrcSpan>,
     _typ: &'a Arc<Type>,
     _is_capture: &'a bool,
     _args: &'a [TypedArg],

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -49,10 +49,10 @@ use ecow::EcoString;
 use crate::type_::Type;
 
 use super::{
-    AssignName, BinOp, BitArrayOption, CallArg, Definition, Pattern, SrcSpan, Statement, TodoKind,
-    TypeAst, TypedArg, TypedAssignment, TypedClause, TypedDefinition, TypedExpr,
-    TypedExprBitArraySegment, TypedFunction, TypedModule, TypedModuleConstant, TypedPattern,
-    TypedPatternBitArraySegment, TypedRecordUpdateArg, TypedStatement, Use,
+    untyped::FunctionLiteralKind, AssignName, BinOp, BitArrayOption, CallArg, Definition, Pattern,
+    SrcSpan, Statement, TodoKind, TypeAst, TypedArg, TypedAssignment, TypedClause, TypedDefinition,
+    TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule, TypedModuleConstant,
+    TypedPattern, TypedPatternBitArraySegment, TypedRecordUpdateArg, TypedStatement, Use,
 };
 
 pub trait Visit<'ast> {
@@ -129,27 +129,16 @@ pub trait Visit<'ast> {
         visit_typed_expr_var(self, location, constructor, name);
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn visit_typed_expr_fn(
         &mut self,
         location: &'ast SrcSpan,
-        head_location: &'ast Option<SrcSpan>,
         type_: &'ast Arc<Type>,
-        is_capture: &'ast bool,
+        kind: &'ast FunctionLiteralKind,
         args: &'ast [TypedArg],
         body: &'ast [TypedStatement],
         return_annotation: &'ast Option<TypeAst>,
     ) {
-        visit_typed_expr_fn(
-            self,
-            location,
-            head_location,
-            type_,
-            is_capture,
-            args,
-            body,
-            return_annotation,
-        );
+        visit_typed_expr_fn(self, location, type_, kind, args, body, return_annotation);
     }
 
     fn visit_typed_expr_list(
@@ -642,21 +631,12 @@ where
         } => v.visit_typed_expr_var(location, constructor, name),
         TypedExpr::Fn {
             location,
-            head_location,
             type_,
-            is_capture,
+            kind,
             args,
             body,
             return_annotation,
-        } => v.visit_typed_expr_fn(
-            location,
-            head_location,
-            type_,
-            is_capture,
-            args,
-            body,
-            return_annotation,
-        ),
+        } => v.visit_typed_expr_fn(location, type_, kind, args, body, return_annotation),
         TypedExpr::List {
             location,
             type_,
@@ -813,13 +793,11 @@ pub fn visit_typed_expr_var<'a, V>(
     /* TODO */
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn visit_typed_expr_fn<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    _head_location: &'a Option<SrcSpan>,
     _typ: &'a Arc<Type>,
-    _is_capture: &'a bool,
+    _kind: &'a FunctionLiteralKind,
     _args: &'a [TypedArg],
     body: &'a [TypedStatement],
     _return_annotation: &'a Option<TypeAst>,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -129,6 +129,7 @@ pub trait Visit<'ast> {
         visit_typed_expr_var(self, location, constructor, name);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn visit_typed_expr_fn(
         &mut self,
         location: &'ast SrcSpan,
@@ -812,6 +813,7 @@ pub fn visit_typed_expr_var<'a, V>(
     /* TODO */
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn visit_typed_expr_fn<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -665,6 +665,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         UntypedExpr::Var { location, name }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn fold_fn(
         &mut self,
         location: SrcSpan,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -250,6 +250,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
             UntypedExpr::Fn {
                 location,
+                head_location,
                 end_of_head_byte_index,
                 is_capture,
                 arguments,
@@ -257,6 +258,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 return_annotation,
             } => self.fold_fn(
                 location,
+                head_location,
                 end_of_head_byte_index,
                 is_capture,
                 arguments,
@@ -370,6 +372,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
             UntypedExpr::Fn {
                 location,
+                head_location,
                 end_of_head_byte_index,
                 is_capture,
                 arguments,
@@ -381,6 +384,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 let body = body.mapped(|s| self.fold_statement(s));
                 UntypedExpr::Fn {
                     location,
+                    head_location,
                     end_of_head_byte_index,
                     is_capture,
                     arguments,
@@ -664,6 +668,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
     fn fold_fn(
         &mut self,
         location: SrcSpan,
+        head_location: Option<SrcSpan>,
         end_of_head_byte_index: u32,
         is_capture: bool,
         arguments: Vec<UntypedArg>,
@@ -672,6 +677,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
     ) -> UntypedExpr {
         UntypedExpr::Fn {
             location,
+            head_location,
             end_of_head_byte_index,
             is_capture,
             arguments,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -4,13 +4,14 @@ use vec1::Vec1;
 use crate::{
     analyse::Inferred,
     ast::{
-        AssignName, Assignment, BinOp, CallArg, Constant, Definition, Pattern, RecordUpdateSpread,
-        SrcSpan, Statement, TargetedDefinition, TodoKind, TypeAst, TypeAstConstructor, TypeAstFn,
-        TypeAstHole, TypeAstTuple, TypeAstVar, UntypedArg, UntypedAssignment, UntypedClause,
-        UntypedConstant, UntypedConstantBitArraySegment, UntypedCustomType, UntypedDefinition,
-        UntypedExpr, UntypedExprBitArraySegment, UntypedFunction, UntypedImport, UntypedModule,
-        UntypedModuleConstant, UntypedPattern, UntypedPatternBitArraySegment,
-        UntypedRecordUpdateArg, UntypedStatement, UntypedTypeAlias, Use, UseAssignment,
+        AssignName, Assignment, BinOp, CallArg, Constant, Definition, FunctionLiteralKind, Pattern,
+        RecordUpdateSpread, SrcSpan, Statement, TargetedDefinition, TodoKind, TypeAst,
+        TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar, UntypedArg,
+        UntypedAssignment, UntypedClause, UntypedConstant, UntypedConstantBitArraySegment,
+        UntypedCustomType, UntypedDefinition, UntypedExpr, UntypedExprBitArraySegment,
+        UntypedFunction, UntypedImport, UntypedModule, UntypedModuleConstant, UntypedPattern,
+        UntypedPatternBitArraySegment, UntypedRecordUpdateArg, UntypedStatement, UntypedTypeAlias,
+        Use, UseAssignment,
     },
     build::Target,
 };
@@ -250,17 +251,15 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
             UntypedExpr::Fn {
                 location,
-                head_location,
                 end_of_head_byte_index,
-                is_capture,
+                kind,
                 arguments,
                 body,
                 return_annotation,
             } => self.fold_fn(
                 location,
-                head_location,
                 end_of_head_byte_index,
-                is_capture,
+                kind,
                 arguments,
                 body,
                 return_annotation,
@@ -372,9 +371,8 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
 
             UntypedExpr::Fn {
                 location,
-                head_location,
+                kind,
                 end_of_head_byte_index,
-                is_capture,
                 arguments,
                 body,
                 return_annotation,
@@ -384,9 +382,8 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 let body = body.mapped(|s| self.fold_statement(s));
                 UntypedExpr::Fn {
                     location,
-                    head_location,
                     end_of_head_byte_index,
-                    is_capture,
+                    kind,
                     arguments,
                     body,
                     return_annotation,
@@ -665,22 +662,19 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         UntypedExpr::Var { location, name }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn fold_fn(
         &mut self,
         location: SrcSpan,
-        head_location: Option<SrcSpan>,
         end_of_head_byte_index: u32,
-        is_capture: bool,
+        kind: FunctionLiteralKind,
         arguments: Vec<UntypedArg>,
         body: Vec1<UntypedStatement>,
         return_annotation: Option<TypeAst>,
     ) -> UntypedExpr {
         UntypedExpr::Fn {
             location,
-            head_location,
             end_of_head_byte_index,
-            is_capture,
+            kind,
             arguments,
             body,
             return_annotation,

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1616,11 +1616,7 @@ fn docs_args_call<'a>(
                 .append(args)
         }
 
-        TypedExpr::Fn {
-            is_capture: true,
-            body,
-            ..
-        } => {
+        TypedExpr::Fn { kind, body, .. } if kind.is_capture() => {
             if let Statement::Expression(TypedExpr::Call {
                 fun,
                 args: inner_args,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -957,11 +957,7 @@ impl<'comments> Formatter<'comments> {
 
             UntypedExpr::NegateBool { value, .. } => self.negate_bool(value),
 
-            UntypedExpr::Fn {
-                is_capture: true,
-                body,
-                ..
-            } => self.fn_capture(body),
+            UntypedExpr::Fn { kind, body, .. } if kind.is_capture() => self.fn_capture(body),
 
             UntypedExpr::Fn {
                 return_annotation,
@@ -1453,11 +1449,7 @@ impl<'comments> Formatter<'comments> {
         for expr in expressions.iter().skip(1) {
             let comments = self.pop_comments(expr.location().start);
             let doc = match expr {
-                UntypedExpr::Fn {
-                    is_capture: true,
-                    body,
-                    ..
-                } => {
+                UntypedExpr::Fn { kind, body, .. } if kind.is_capture() => {
                     let body = match body.first() {
                         Statement::Expression(expression) => expression,
                         Statement::Assignment(_) | Statement::Use(_) => {

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -10,7 +10,10 @@ use lsp_types::{
 use strum::IntoEnumIterator;
 
 use crate::{
-    ast::{self, Arg, CallArg, Definition, Function, Pattern, Publicity, TypedExpr},
+    ast::{
+        self, Arg, CallArg, Definition, Function, FunctionLiteralKind, Pattern, Publicity,
+        TypedExpr,
+    },
     build::Module,
     io::{BeamCompiler, CommandExecutor, FileSystemReader, FileSystemWriter},
     line_numbers::LineNumbers,
@@ -1045,9 +1048,8 @@ impl<'ast> ast::visit::Visit<'ast> for LocalCompletion<'_> {
     fn visit_typed_expr_fn(
         &mut self,
         _: &'ast ast::SrcSpan,
-        _: &'ast Option<ast::SrcSpan>,
         _: &'ast Arc<Type>,
-        _: &'ast bool,
+        _: &'ast FunctionLiteralKind,
         args: &'ast [ast::TypedArg],
         body: &'ast [ast::TypedStatement],
         _: &'ast Option<ast::TypeAst>,

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -1045,6 +1045,7 @@ impl<'ast> ast::visit::Visit<'ast> for LocalCompletion<'_> {
     fn visit_typed_expr_fn(
         &mut self,
         _: &'ast ast::SrcSpan,
+        _: &'ast Option<ast::SrcSpan>,
         _: &'ast Arc<Type>,
         _: &'ast bool,
         args: &'ast [ast::TypedArg],

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1615,6 +1615,58 @@ pub fn do_a_thing(a: Int, b: Float) -> String {
 }
 
 #[test]
+fn annotate_anonymous_function() {
+    assert_code_action!(
+        ADD_ANNOTATIONS,
+        r#"
+pub fn add_curry(a) {
+  fn(b) { a + b }
+}
+"#,
+        find_position_of("fn(").select_until(find_position_of("b)"))
+    );
+}
+
+#[test]
+fn annotate_anonymous_function_with_annotated_return_type() {
+    assert_code_action!(
+        ADD_ANNOTATION,
+        r#"
+pub fn add_curry(a) {
+  fn(b) -> Int { a + b }
+}
+"#,
+        find_position_of("fn(").select_until(find_position_of("b)"))
+    );
+}
+
+#[test]
+fn annotate_anonymous_function_with_partially_annotated_parameters() {
+    assert_code_action!(
+        ADD_ANNOTATIONS,
+        r#"
+pub fn main() {
+  fn(a, b: Int, c) { a + b + c }
+}
+"#,
+        find_position_of("fn(").select_until(find_position_of("c)"))
+    );
+}
+
+#[test]
+fn no_code_action_for_fully_annotated_anonymous_function() {
+    assert_no_code_actions!(
+        ADD_ANNOTATION | ADD_ANNOTATIONS,
+        r#"
+pub fn main() {
+  fn(a: Int, b: Int) -> Int { a - b }
+}
+"#,
+        find_position_of("fn(").select_until(find_position_of("Int)"))
+    );
+}
+
+#[test]
 fn annotate_constant() {
     assert_code_action!(
         ADD_ANNOTATION,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1749,6 +1749,22 @@ pub fn main() {
 }
 
 #[test]
+fn annotate_nested_local_variable() {
+    assert_code_action!(
+        ADD_ANNOTATION,
+        r#"
+pub fn main() {
+  let a = {
+    let b = 10
+    b + 1
+  }
+}
+"#,
+        find_position_of("let b").select_until(find_position_of("b ="))
+    );
+}
+
+#[test]
 fn no_code_action_for_annotated_local_variable() {
     assert_no_code_actions!(
         ADD_ANNOTATION | ADD_ANNOTATIONS,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1667,6 +1667,60 @@ pub fn main() {
 }
 
 #[test]
+fn annotate_use() {
+    assert_code_action!(
+        ADD_ANNOTATIONS,
+        r#"
+pub fn wibble(wobble: fn(Int, Int) -> Int) {
+  wobble(1, 2)
+}
+
+pub fn main() {
+  use a, b <- wibble
+  a + b
+}
+"#,
+        find_position_of("use").select_until(find_position_of("<-"))
+    );
+}
+
+#[test]
+fn annotate_use_with_partially_annotated_parameters() {
+    assert_code_action!(
+        ADD_ANNOTATION,
+        r#"
+pub fn wibble(wobble: fn(Int, Int) -> Int) {
+  wobble(1, 2)
+}
+
+pub fn main() {
+  use a: Int, b <- wibble
+  a + b
+}
+"#,
+        find_position_of("use").select_until(find_position_of("<-"))
+    );
+}
+
+#[test]
+fn no_code_action_for_fully_annotated_use() {
+    assert_no_code_actions!(
+        ADD_ANNOTATION | ADD_ANNOTATIONS,
+        r#"
+pub fn wibble(wobble: fn(Int, Int) -> Int) {
+  wobble(1, 2)
+}
+
+pub fn main() {
+  use a: Int, b: Int <- wibble
+  a + b
+}
+"#,
+        find_position_of("use").select_until(find_position_of("<-"))
+    );
+}
+
+#[test]
 fn annotate_constant() {
     assert_code_action!(
         ADD_ANNOTATION,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_anonymous_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_anonymous_function.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn add_curry(a) {\n  fn(b) { a + b }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn add_curry(a) {
+  fn(b) { a + b }
+  ▔▔▔↑           
+}
+
+
+----- AFTER ACTION
+
+pub fn add_curry(a) {
+  fn(b: Int) -> Int { a + b }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_anonymous_function_with_annotated_return_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_anonymous_function_with_annotated_return_type.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn add_curry(a) {\n  fn(b) -> Int { a + b }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn add_curry(a) {
+  fn(b) -> Int { a + b }
+  ▔▔▔↑                  
+}
+
+
+----- AFTER ACTION
+
+pub fn add_curry(a) {
+  fn(b: Int) -> Int { a + b }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_anonymous_function_with_partially_annotated_parameters.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_anonymous_function_with_partially_annotated_parameters.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  fn(a, b: Int, c) { a + b + c }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  fn(a, b: Int, c) { a + b + c }
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑               
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  fn(a: Int, b: Int, c: Int) -> Int { a + b + c }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_nested_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_nested_local_variable.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let a = {\n    let b = 10\n    b + 1\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let a = {
+    let b = 10
+    ▔▔▔▔↑     
+    b + 1
+  }
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let a = {
+    let b: Int = 10
+    b + 1
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_use.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_use.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn wibble(wobble: fn(Int, Int) -> Int) {\n  wobble(1, 2)\n}\n\npub fn main() {\n  use a, b <- wibble\n  a + b\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn wibble(wobble: fn(Int, Int) -> Int) {
+  wobble(1, 2)
+}
+
+pub fn main() {
+  use a, b <- wibble
+  ▔▔▔▔▔▔▔▔▔↑        
+  a + b
+}
+
+
+----- AFTER ACTION
+
+pub fn wibble(wobble: fn(Int, Int) -> Int) {
+  wobble(1, 2)
+}
+
+pub fn main() {
+  use a: Int, b: Int <- wibble
+  a + b
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_use_with_partially_annotated_parameters.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__annotate_use_with_partially_annotated_parameters.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn wibble(wobble: fn(Int, Int) -> Int) {\n  wobble(1, 2)\n}\n\npub fn main() {\n  use a: Int, b <- wibble\n  a + b\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn wibble(wobble: fn(Int, Int) -> Int) {
+  wobble(1, 2)
+}
+
+pub fn main() {
+  use a: Int, b <- wibble
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑        
+  a + b
+}
+
+
+----- AFTER ACTION
+
+pub fn wibble(wobble: fn(Int, Int) -> Int) {
+  wobble(1, 2)
+}
+
+pub fn main() {
+  use a: Int, b: Int <- wibble
+  a + b
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -673,6 +673,7 @@ where
                         ..
                     })) => UntypedExpr::Fn {
                         location: SrcSpan::new(location.start, end_position),
+                        head_location: Some(location),
                         end_of_head_byte_index: location.end,
                         is_capture: false,
                         arguments: args,
@@ -4012,6 +4013,7 @@ pub fn make_call(
         // An anon function using the capture syntax run(_, 1, 2)
         1 => Ok(UntypedExpr::Fn {
             location: call.location(),
+            head_location: None,
             end_of_head_byte_index: call.location().end,
             is_capture: true,
             arguments: vec![Arg {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -57,13 +57,13 @@ mod token;
 use crate::analyse::Inferred;
 use crate::ast::{
     Arg, ArgNames, AssignName, Assignment, AssignmentKind, BinOp, BitArrayOption, BitArraySegment,
-    CallArg, Clause, ClauseGuard, Constant, CustomType, Definition, Function, HasLocation, Import,
-    Module, ModuleConstant, Pattern, Publicity, RecordConstructor, RecordConstructorArg,
-    RecordUpdateSpread, SrcSpan, Statement, TargetedDefinition, TodoKind, TypeAlias, TypeAst,
-    TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar, UnqualifiedImport,
-    UntypedArg, UntypedClause, UntypedClauseGuard, UntypedConstant, UntypedDefinition, UntypedExpr,
-    UntypedModule, UntypedPattern, UntypedRecordUpdateArg, UntypedStatement, Use, UseAssignment,
-    CAPTURE_VARIABLE,
+    CallArg, Clause, ClauseGuard, Constant, CustomType, Definition, Function, FunctionLiteralKind,
+    HasLocation, Import, Module, ModuleConstant, Pattern, Publicity, RecordConstructor,
+    RecordConstructorArg, RecordUpdateSpread, SrcSpan, Statement, TargetedDefinition, TodoKind,
+    TypeAlias, TypeAst, TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar,
+    UnqualifiedImport, UntypedArg, UntypedClause, UntypedClauseGuard, UntypedConstant,
+    UntypedDefinition, UntypedExpr, UntypedModule, UntypedPattern, UntypedRecordUpdateArg,
+    UntypedStatement, Use, UseAssignment, CAPTURE_VARIABLE,
 };
 use crate::build::Target;
 use crate::error::wrap;
@@ -673,9 +673,8 @@ where
                         ..
                     })) => UntypedExpr::Fn {
                         location: SrcSpan::new(location.start, end_position),
-                        head_location: Some(location),
                         end_of_head_byte_index: location.end,
-                        is_capture: false,
+                        kind: FunctionLiteralKind::Anonymous { head: location },
                         arguments: args,
                         body,
                         return_annotation,
@@ -4013,9 +4012,8 @@ pub fn make_call(
         // An anon function using the capture syntax run(_, 1, 2)
         1 => Ok(UntypedExpr::Fn {
             location: call.location(),
-            head_location: None,
             end_of_head_byte_index: call.location().end,
-            is_capture: true,
+            kind: FunctionLiteralKind::Capture,
             arguments: vec![Arg {
                 location: hole_location.expect("At least a capture hole"),
                 annotation: None,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -737,6 +737,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn infer_fn(
         &mut self,
         args: Vec<UntypedArg>,
@@ -2976,6 +2977,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         (fun, args, type_)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn infer_fn_with_call_context(
         &mut self,
         args: Vec<UntypedArg>,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -333,12 +333,21 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             UntypedExpr::Fn {
                 location,
+                head_location,
                 is_capture,
                 arguments: args,
                 body,
                 return_annotation,
                 ..
-            } => self.infer_fn(args, &[], body, is_capture, return_annotation, location),
+            } => self.infer_fn(
+                args,
+                &[],
+                body,
+                is_capture,
+                return_annotation,
+                location,
+                head_location,
+            ),
 
             UntypedExpr::Case {
                 location,
@@ -645,6 +654,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let callback = UntypedExpr::Fn {
             arguments: assignments.function_arguments,
             location: SrcSpan::new(first.start, sequence_location.end),
+            head_location: None,
             end_of_head_byte_index: sequence_location.end,
             return_annotation: None,
             is_capture: false,
@@ -735,6 +745,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         is_capture: bool,
         return_annotation: Option<TypeAst>,
         location: SrcSpan,
+        head_location: Option<SrcSpan>,
     ) -> Result<TypedExpr, Error> {
         for Arg { names, .. } in args.iter() {
             check_argument_names(names, self.problems);
@@ -754,6 +765,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         Ok(TypedExpr::Fn {
             location,
+            head_location,
             type_,
             is_capture,
             args,
@@ -2933,6 +2945,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             UntypedExpr::Fn {
                 location,
+                head_location,
                 is_capture,
                 arguments,
                 body,
@@ -2945,6 +2958,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 is_capture,
                 return_annotation,
                 location,
+                head_location,
             ),
 
             fun => self.infer(fun),
@@ -2970,6 +2984,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         is_capture: bool,
         return_annotation: Option<TypeAst>,
         location: SrcSpan,
+        head_location: Option<SrcSpan>,
     ) -> Result<TypedExpr, Error> {
         let typed_call_args: Vec<Arc<Type>> = call_args
             .iter()
@@ -2988,6 +3003,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             is_capture,
             return_annotation,
             location,
+            head_location,
         )
     }
 
@@ -3238,6 +3254,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     body,
                     return_annotation,
                     location,
+                    head_location,
                     is_capture: false,
                     ..
                 },
@@ -3248,6 +3265,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 false,
                 return_annotation,
                 location,
+                head_location,
             ),
 
             // Otherwise just perform normal type inference.

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -330,25 +330,24 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
     }
 
     fn warn_if_call_first_argument_is_hole(&mut self, call: &UntypedExpr) {
-        if let UntypedExpr::Fn {
-            is_capture: true,
-            body,
-            ..
-        } = &call
-        {
-            if let Statement::Expression(UntypedExpr::Call { arguments, .. }) = body.first() {
-                match arguments.as_slice() {
-                    // If the first argument is labelled, we don't warn the user
-                    // as they might be intentionally adding it to provide more
-                    // information about exactly which argument is being piped into.
-                    [first] | [first, ..] if first.is_capture_hole() && first.label.is_none() => {
-                        self.expr_typer
-                            .problems
-                            .warning(Warning::RedundantPipeFunctionCapture {
-                                location: first.location,
-                            })
+        if let UntypedExpr::Fn { kind, body, .. } = &call {
+            if kind.is_capture() {
+                if let Statement::Expression(UntypedExpr::Call { arguments, .. }) = body.first() {
+                    match arguments.as_slice() {
+                        // If the first argument is labelled, we don't warn the user
+                        // as they might be intentionally adding it to provide more
+                        // information about exactly which argument is being piped into.
+                        [first] | [first, ..]
+                            if first.is_capture_hole() && first.label.is_none() =>
+                        {
+                            self.expr_typer.problems.warning(
+                                Warning::RedundantPipeFunctionCapture {
+                                    location: first.location,
+                                },
+                            )
+                        }
+                        _ => (),
                     }
-                    _ => (),
                 }
             }
         }


### PR DESCRIPTION
I realise that when I implemented #3682, I forgot to implement it for anonymous functions. I have now done that.
I also have limited the action to only between `let` and `=` for local variables, as it can lead to some confusing cases:
```gleam
let a = {
  let b = 10
  //  ^ Use this code action here
  b + 1
}
```
Would become:
```gleam
let a: Int = {
  let b: Int = 10
  b + 1
}
```
Which is often undesirable.