### PR TITLE
LSP Code Action: Convert to Qualified import 

### DIFF
--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1914,6 +1914,7 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
     fn edit_import(&mut self) {
         let UnqualifiedConstructor {
             import: ast::Import { location, .. },
+            is_type,
             ..
         } = self.unqualified_constructor;
         let import_code = self
@@ -1922,10 +1923,17 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
             .get(location.start as usize..location.end as usize)
             .expect("Failed to get import code");
         let constructor_import = self.unqualified_constructor.constructor_import();
-        let Some(first_char_pos) = import_code
-            .find(&constructor_import)
-            .map(|pos| location.start as usize + pos)
-        else {
+
+        // TODO: handle import module.{Constructor, type Constructor}
+        let Some(first_char_pos) = (if is_type {
+            import_code
+                .find(&constructor_import)
+                .map(|pos| location.start as usize + pos)
+        } else {
+            import_code
+                .rfind(&constructor_import)
+                .map(|pos| location.start as usize + pos)
+        }) else {
             return;
         };
         let mut last_char_pos = first_char_pos + constructor_import.len();

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1646,33 +1646,52 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
         }
     }
 
-    fn get_module_import(&mut self, module_name: &EcoString) -> Option<&'a ast::Import<EcoString>> {
+    fn get_module_import_from_value_constructor(
+        &mut self,
+        module_name: &EcoString,
+        constructor_name: &EcoString,
+    ) -> Option<(&'a ast::Import<EcoString>, EcoString, EcoString)> {
         self.module
             .ast
             .definitions
             .iter()
             .find_map(|def| match def {
-                ast::Definition::Import(import) if import.module == *module_name => Some(import),
+                ast::Definition::Import(import)
+                    if import.module == *module_name && import.used_name().is_some() =>
+                {
+                    import
+                        .unqualified_values
+                        .iter()
+                        .find(|value| value.used_name() == constructor_name)
+                        .map(|value| (import, value.name.clone(), value.used_name().clone()))
+                }
                 _ => None,
             })
     }
-    fn get_constructor_name(
-        &self,
-        import: &ast::Import<EcoString>,
-        name: &EcoString,
-        is_type: bool,
-    ) -> (EcoString, EcoString) {
-        let items = if is_type {
-            &import.unqualified_types
-        } else {
-            &import.unqualified_values
-        };
 
-        items
+    fn get_module_import_from_type_constructor(
+        &self,
+        constructor_name: &EcoString,
+    ) -> Option<(&'a ast::Import<EcoString>, EcoString, EcoString)> {
+        self.module
+            .ast
+            .definitions
             .iter()
-            .find(|item| item.used_name() == name)
-            .map(|item| (item.name.clone(), name.clone()))
-            .expect("Constructor not found in import")
+            .find_map(|def| match def {
+                ast::Definition::Import(import) => {
+                    if let Some(ty) = import
+                        .unqualified_types
+                        .iter()
+                        .find(|ty| ty.used_name() == constructor_name)
+                    {
+                        if import.used_name().is_some() {
+                            return Some((import, ty.name.clone(), ty.used_name().clone()));
+                        }
+                    }
+                    None
+                }
+                _ => None,
+            })
     }
 }
 
@@ -1730,32 +1749,12 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
                 src_span_to_lsp_range(*location, &self.line_numbers),
             )
         {
-            if let Some(import) = self
-                .module
-                .ast
-                .definitions
-                .iter()
-                .find_map(|def| match def {
-                    ast::Definition::Import(import) => {
-                        if import
-                            .unqualified_types
-                            .iter()
-                            .any(|ty| ty.used_name() == name)
-                        {
-                            return Some(import);
-                        }
-                        None
-                    }
-                    _ => None,
-                })
+            if let Some((import, constructor_name, constructor_used_name)) =
+                self.get_module_import_from_type_constructor(name)
             {
-                let (constructor_name, constructor_used_name) =
-                    self.get_constructor_name(import, name, true);
-
-                let module_alias = import.used_name();
                 self.unqualified_constructor = Some(UnqualifiedConstructor {
                     import,
-                    module_name: module_alias.unwrap_or(import.module.clone()),
+                    module_name: import.used_name().expect("Import should not be discarded"),
                     constructor_name,
                     constructor_used_name,
                     is_type: true,
@@ -1782,14 +1781,12 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
                 type_::ValueConstructorVariant::LocalVariable { .. }
                 | type_::ValueConstructorVariant::LocalConstant { .. } => None,
             } {
-                if let Some(import) = self.get_module_import(module_name) {
-                    let (constructor_name, constructor_used_name) =
-                        self.get_constructor_name(import, name, false);
-
-                    let module_alias = import.used_name();
+                if let Some((import, constructor_name, constructor_used_name)) =
+                    self.get_module_import_from_value_constructor(module_name, name)
+                {
                     self.unqualified_constructor = Some(UnqualifiedConstructor {
                         import,
-                        module_name: module_alias.unwrap_or(import.module.clone()),
+                        module_name: import.used_name().expect("Import should not be discarded"),
                         constructor_name,
                         constructor_used_name,
                         is_type: false,
@@ -1817,14 +1814,12 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
             )
         {
             if let crate::analyse::Inferred::Known(constructor) = constructor {
-                if let Some(import) = self.get_module_import(&constructor.module) {
-                    let module_alias = import.used_name();
-                    let (constructor_name, constructor_used_name) =
-                        self.get_constructor_name(import, name, false);
-
+                if let Some((import, constructor_name, constructor_used_name)) =
+                    self.get_module_import_from_value_constructor(&constructor.module, name)
+                {
                     self.unqualified_constructor = Some(UnqualifiedConstructor {
                         import,
-                        module_name: module_alias.unwrap_or(import.module.clone()),
+                        module_name: import.used_name().expect("Import should not be discarded"),
                         constructor_name,
                         constructor_used_name,
                         is_type: false,
@@ -1924,7 +1919,7 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
             .expect("Failed to get import code");
         let constructor_import = self.unqualified_constructor.constructor_import();
 
-        // TODO: handle import module.{Constructor, type Constructor}
+        // TODO: handle import module.{Constructor, type Constructor} (as alias)
         let Some(first_char_pos) = (if is_type {
             import_code
                 .find(&constructor_import)
@@ -1936,8 +1931,12 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
         }) else {
             return;
         };
+
         let mut last_char_pos = first_char_pos + constructor_import.len();
         if self.module.code.get(last_char_pos..last_char_pos + 1) == Some(",") {
+            last_char_pos += 1;
+        }
+        if self.module.code.get(last_char_pos..last_char_pos + 1) == Some(" ") {
             last_char_pos += 1;
         }
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1044,12 +1044,23 @@ impl<'a> AddAnnotations<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct QualifiedConstructor<'a> {
     import: &'a ast::Import<EcoString>,
     module_aliased: bool,
     used_name: EcoString,
     constructor: EcoString,
     is_type: bool,
+}
+
+impl<'a> QualifiedConstructor<'a> {
+    fn constructor_import(&self) -> String {
+        if self.is_type {
+            format!("type {}", self.constructor)
+        } else {
+            self.constructor.to_string()
+        }
+    }
 }
 
 pub struct QualifiedToUnqualifiedImportFirstPass<'a> {
@@ -1376,19 +1387,9 @@ impl<'a> QualifiedToUnqualifiedImportSecondPass<'a> {
     }
 
     fn determine_insert_position_and_text(&self) -> (u32, String) {
-        let QualifiedConstructor {
-            module_aliased,
-            constructor,
-            is_type,
-            ..
-        } = &self.qualified_constructor;
+        let QualifiedConstructor { module_aliased, .. } = &self.qualified_constructor;
 
-        let name = if *is_type {
-            format!("type {}", constructor)
-        } else {
-            constructor.to_string()
-        };
-
+        let name = self.qualified_constructor.constructor_import();
         let import_code = self.get_import_code();
         let has_brace = import_code.contains('}');
 
@@ -1602,6 +1603,475 @@ pub fn code_action_convert_qualified_constructor_to_unqualified(
         params,
         line_numbers,
         qualified_constructor,
+    );
+    let new_actions = second_pass.code_actions();
+    actions.extend(new_actions);
+}
+
+struct UnqualifiedConstructor<'a> {
+    import: &'a ast::Import<EcoString>,
+    module_name: EcoString,
+    constructor_name: EcoString,
+    constructor_used_name: EcoString,
+    is_type: bool,
+}
+
+impl UnqualifiedConstructor<'_> {
+    fn constructor_import(&self) -> String {
+        let prefix = if self.is_type { "type " } else { "" };
+        let base = format!("{}{}", prefix, self.constructor_name);
+
+        if self.constructor_name == self.constructor_used_name {
+            base
+        } else {
+            format!("{} as {}", base, self.constructor_used_name)
+        }
+    }
+}
+
+struct UnqualifiedToQualifiedImportFirstPass<'a> {
+    module: &'a Module,
+    params: &'a CodeActionParams,
+    line_numbers: LineNumbers,
+    unqualified_constructor: Option<UnqualifiedConstructor<'a>>,
+}
+
+impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
+    fn new(module: &'a Module, params: &'a CodeActionParams, line_numbers: LineNumbers) -> Self {
+        Self {
+            module,
+            params,
+            line_numbers,
+            unqualified_constructor: None,
+        }
+    }
+
+    fn get_module_import(&mut self, module_name: &EcoString) -> Option<&'a ast::Import<EcoString>> {
+        self.module
+            .ast
+            .definitions
+            .iter()
+            .find_map(|def| match def {
+                ast::Definition::Import(import) if import.module == *module_name => Some(import),
+                _ => None,
+            })
+    }
+    fn get_constructor_name(
+        &self,
+        import: &ast::Import<EcoString>,
+        name: &EcoString,
+        is_type: bool,
+    ) -> (EcoString, EcoString) {
+        let items = if is_type {
+            &import.unqualified_types
+        } else {
+            &import.unqualified_values
+        };
+
+        items
+            .iter()
+            .find(|item| item.used_name() == name)
+            .map(|item| (item.name.clone(), name.clone()))
+            .expect("Constructor not found in import")
+    }
+}
+
+impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'ast> {
+    fn visit_typed_expr_fn(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        is_capture: &'ast bool,
+        args: &'ast [ast::TypedArg],
+        body: &'ast [ast::TypedStatement],
+        return_annotation: &'ast Option<ast::TypeAst>,
+    ) {
+        for arg in args {
+            if let Some(annotation) = &arg.annotation {
+                self.visit_type_ast(annotation);
+            }
+        }
+        if let Some(return_) = return_annotation {
+            self.visit_type_ast(return_);
+        }
+        ast::visit::visit_typed_expr_fn(
+            self,
+            location,
+            type_,
+            is_capture,
+            args,
+            body,
+            return_annotation,
+        );
+    }
+
+    fn visit_typed_function(&mut self, fun: &'ast ast::TypedFunction) {
+        for arg in &fun.arguments {
+            if let Some(annotation) = &arg.annotation {
+                self.visit_type_ast(annotation);
+            }
+        }
+
+        if let Some(return_annotation) = &fun.return_annotation {
+            self.visit_type_ast(return_annotation);
+        }
+        ast::visit::visit_typed_function(self, fun);
+    }
+    fn visit_type_ast_constructor(
+        &mut self,
+        location: &'ast SrcSpan,
+        module: &'ast Option<(EcoString, SrcSpan)>,
+        name: &'ast EcoString,
+        arguments: &'ast Vec<ast::TypeAst>,
+    ) {
+        if module.is_none()
+            && overlaps(
+                self.params.range,
+                src_span_to_lsp_range(*location, &self.line_numbers),
+            )
+        {
+            if let Some(import) = self
+                .module
+                .ast
+                .definitions
+                .iter()
+                .find_map(|def| match def {
+                    ast::Definition::Import(import) => {
+                        if import
+                            .unqualified_types
+                            .iter()
+                            .any(|ty| ty.used_name() == name)
+                        {
+                            return Some(import);
+                        }
+                        None
+                    }
+                    _ => None,
+                })
+            {
+                let (constructor_name, constructor_used_name) =
+                    self.get_constructor_name(import, name, true);
+
+                let module_alias = import.used_name();
+                self.unqualified_constructor = Some(UnqualifiedConstructor {
+                    import,
+                    module_name: module_alias.unwrap_or(import.module.clone()),
+                    constructor_name,
+                    constructor_used_name,
+                    is_type: true,
+                });
+            }
+        }
+
+        ast::visit::visit_type_ast_constructor(self, location, module, name, arguments);
+    }
+
+    fn visit_typed_expr_var(
+        &mut self,
+        location: &'ast SrcSpan,
+        constructor: &'ast type_::ValueConstructor,
+        name: &'ast EcoString,
+    ) {
+        let range = src_span_to_lsp_range(*location, &self.line_numbers);
+        if overlaps(self.params.range, range) {
+            if let Some(module_name) = match &constructor.variant {
+                type_::ValueConstructorVariant::ModuleConstant { module, .. }
+                | type_::ValueConstructorVariant::ModuleFn { module, .. }
+                | type_::ValueConstructorVariant::Record { module, .. } => Some(module),
+
+                type_::ValueConstructorVariant::LocalVariable { .. }
+                | type_::ValueConstructorVariant::LocalConstant { .. } => None,
+            } {
+                if let Some(import) = self.get_module_import(module_name) {
+                    let (constructor_name, constructor_used_name) =
+                        self.get_constructor_name(import, name, false);
+
+                    let module_alias = import.used_name();
+                    self.unqualified_constructor = Some(UnqualifiedConstructor {
+                        import,
+                        module_name: module_alias.unwrap_or(import.module.clone()),
+                        constructor_name,
+                        constructor_used_name,
+                        is_type: false,
+                    });
+                }
+            }
+        }
+        ast::visit::visit_typed_expr_var(self, location, constructor, name);
+    }
+
+    fn visit_typed_pattern_constructor(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        arguments: &'ast Vec<CallArg<TypedPattern>>,
+        module: &'ast Option<(EcoString, SrcSpan)>,
+        constructor: &'ast crate::analyse::Inferred<type_::PatternConstructor>,
+        spread: &'ast Option<SrcSpan>,
+        type_: &'ast Arc<Type>,
+    ) {
+        if module.is_none()
+            && overlaps(
+                self.params.range,
+                src_span_to_lsp_range(*location, &self.line_numbers),
+            )
+        {
+            if let crate::analyse::Inferred::Known(constructor) = constructor {
+                if let Some(import) = self.get_module_import(&constructor.module) {
+                    let module_alias = import.used_name();
+                    let (constructor_name, constructor_used_name) =
+                        self.get_constructor_name(import, name, false);
+
+                    self.unqualified_constructor = Some(UnqualifiedConstructor {
+                        import,
+                        module_name: module_alias.unwrap_or(import.module.clone()),
+                        constructor_name,
+                        constructor_used_name,
+                        is_type: false,
+                    });
+                }
+            }
+        }
+
+        ast::visit::visit_typed_pattern_constructor(
+            self,
+            location,
+            name,
+            arguments,
+            module,
+            constructor,
+            spread,
+            type_,
+        );
+    }
+}
+
+struct UnqualifiedToQualifiedImportSecondPass<'a> {
+    module: &'a Module,
+    params: &'a CodeActionParams,
+    line_numbers: LineNumbers,
+    unqualified_constructor: UnqualifiedConstructor<'a>,
+    edits: Vec<TextEdit>,
+}
+
+impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
+    pub fn new(
+        module: &'a Module,
+        params: &'a CodeActionParams,
+        line_numbers: LineNumbers,
+        unqualified_constructor: UnqualifiedConstructor<'a>,
+    ) -> Self {
+        Self {
+            module,
+            params,
+            line_numbers,
+            unqualified_constructor,
+            edits: vec![],
+        }
+    }
+
+    fn add_module_qualifier(&mut self, location: SrcSpan) {
+        self.edits.push(TextEdit {
+            range: src_span_to_lsp_range(
+                SrcSpan::new(
+                    location.start,
+                    location.start
+                        + self.unqualified_constructor.constructor_used_name.len() as u32,
+                ),
+                &self.line_numbers,
+            ),
+            new_text: format!(
+                "{}.{}",
+                self.unqualified_constructor.module_name,
+                self.unqualified_constructor.constructor_name
+            ),
+        });
+    }
+
+    pub fn code_actions(mut self) -> Vec<CodeAction> {
+        self.visit_typed_module(&self.module.ast);
+        if self.edits.is_empty() {
+            return vec![];
+        }
+        self.edit_import();
+        let mut action = Vec::with_capacity(1);
+        CodeActionBuilder::new(&format!(
+            "Qualify {} as {}",
+            self.unqualified_constructor.constructor_used_name,
+            format!(
+                "{}.{}",
+                self.unqualified_constructor.module_name,
+                self.unqualified_constructor.constructor_name
+            )
+        ))
+        .kind(CodeActionKind::REFACTOR)
+        .changes(self.params.text_document.uri.clone(), self.edits)
+        .preferred(false)
+        .push_to(&mut action);
+        action
+    }
+
+    fn edit_import(&mut self) {
+        let UnqualifiedConstructor {
+            import: ast::Import { location, .. },
+            ..
+        } = self.unqualified_constructor;
+        let import_code = self
+            .module
+            .code
+            .get(location.start as usize..location.end as usize)
+            .expect("Failed to get import code");
+        let constructor_import = self.unqualified_constructor.constructor_import();
+        let Some(first_char_pos) = import_code
+            .find(&constructor_import)
+            .map(|pos| location.start as usize + pos)
+        else {
+            return;
+        };
+        let mut last_char_pos = first_char_pos + constructor_import.len();
+        if self.module.code.get(last_char_pos..last_char_pos + 1) == Some(",") {
+            last_char_pos += 1;
+        }
+
+        self.edits.push(TextEdit {
+            range: src_span_to_lsp_range(
+                SrcSpan::new(first_char_pos as u32, last_char_pos as u32),
+                &self.line_numbers,
+            ),
+            new_text: "".to_string(),
+        });
+    }
+}
+
+impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'ast> {
+    fn visit_typed_expr_fn(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        is_capture: &'ast bool,
+        args: &'ast [ast::TypedArg],
+        body: &'ast [ast::TypedStatement],
+        return_annotation: &'ast Option<ast::TypeAst>,
+    ) {
+        for arg in args {
+            if let Some(annotation) = &arg.annotation {
+                self.visit_type_ast(annotation);
+            }
+        }
+        if let Some(return_) = return_annotation {
+            self.visit_type_ast(return_);
+        }
+        ast::visit::visit_typed_expr_fn(
+            self,
+            location,
+            type_,
+            is_capture,
+            args,
+            body,
+            return_annotation,
+        );
+    }
+
+    fn visit_typed_function(&mut self, fun: &'ast ast::TypedFunction) {
+        for arg in &fun.arguments {
+            if let Some(annotation) = &arg.annotation {
+                self.visit_type_ast(annotation);
+            }
+        }
+
+        if let Some(return_annotation) = &fun.return_annotation {
+            self.visit_type_ast(return_annotation);
+        }
+        ast::visit::visit_typed_function(self, fun);
+    }
+
+    fn visit_type_ast_constructor(
+        &mut self,
+        location: &'ast SrcSpan,
+        module: &'ast Option<(EcoString, SrcSpan)>,
+        name: &'ast EcoString,
+        arguments: &'ast Vec<ast::TypeAst>,
+    ) {
+        if module.is_none() {
+            let UnqualifiedConstructor {
+                constructor_used_name,
+                is_type,
+                ..
+            } = &self.unqualified_constructor;
+            if *is_type && constructor_used_name == name {
+                self.add_module_qualifier(*location);
+            }
+        }
+        ast::visit::visit_type_ast_constructor(self, location, module, name, arguments);
+    }
+
+    fn visit_typed_expr_var(
+        &mut self,
+        location: &'ast SrcSpan,
+        constructor: &'ast type_::ValueConstructor,
+        name: &'ast EcoString,
+    ) {
+        let UnqualifiedConstructor {
+            constructor_used_name,
+            is_type,
+            ..
+        } = &self.unqualified_constructor;
+        if !*is_type && constructor_used_name == name {
+            self.add_module_qualifier(*location);
+        }
+        ast::visit::visit_typed_expr_var(self, location, constructor, name);
+    }
+
+    fn visit_typed_pattern_constructor(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        arguments: &'ast Vec<CallArg<TypedPattern>>,
+        module: &'ast Option<(EcoString, SrcSpan)>,
+        constructor: &'ast crate::analyse::Inferred<type_::PatternConstructor>,
+        spread: &'ast Option<SrcSpan>,
+        type_: &'ast Arc<Type>,
+    ) {
+        if module.is_none() {
+            let UnqualifiedConstructor {
+                constructor_used_name,
+                is_type,
+                ..
+            } = &self.unqualified_constructor;
+            if !*is_type && constructor_used_name == name {
+                self.add_module_qualifier(*location);
+            }
+        }
+        ast::visit::visit_typed_pattern_constructor(
+            self,
+            location,
+            name,
+            arguments,
+            module,
+            constructor,
+            spread,
+            type_,
+        );
+    }
+}
+
+pub fn code_action_convert_unqualified_constructor_to_qualified(
+    module: &Module,
+    params: &CodeActionParams,
+    actions: &mut Vec<CodeAction>,
+) {
+    let line_numbers = LineNumbers::new(&module.code);
+    let mut first_pass =
+        UnqualifiedToQualifiedImportFirstPass::new(module, params, line_numbers.clone());
+    first_pass.visit_typed_module(&module.ast);
+    let Some(unqualified_constructor) = first_pass.unqualified_constructor else {
+        return;
+    };
+    let second_pass = UnqualifiedToQualifiedImportSecondPass::new(
+        module,
+        params,
+        line_numbers,
+        unqualified_constructor,
     );
     let new_actions = second_pass.code_actions();
     actions.extend(new_actions);

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1634,57 +1634,51 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
         &mut self,
         module_name: &EcoString,
         constructor_name: &EcoString,
-    ) -> Option<UnqualifiedConstructor> {
-        self.module
-            .ast
-            .definitions
-            .iter()
-            .find_map(|def| match def {
-                ast::Definition::Import(import) if import.module == *module_name => {
-                    let Some(module_name) = import.used_name() else {
-                        return None;
-                    };
-                    import
+    ) {
+        self.unqualified_constructor =
+            self.module
+                .ast
+                .definitions
+                .iter()
+                .find_map(|def| match def {
+                    ast::Definition::Import(import) if import.module == *module_name => import
                         .unqualified_values
                         .iter()
                         .find(|value| value.used_name() == constructor_name)
-                        .map(|value| UnqualifiedConstructor {
-                            constructor: value.clone(),
-                            module_name,
-                            is_type: false,
-                        })
-                }
-                _ => None,
-            })
+                        .and_then(|value| {
+                            Some(UnqualifiedConstructor {
+                                constructor: value.clone(),
+                                module_name: import.used_name()?,
+                                is_type: false,
+                            })
+                        }),
+                    _ => None,
+                })
     }
 
-    fn get_module_import_from_type_constructor(
-        &self,
-        constructor_name: &EcoString,
-    ) -> Option<UnqualifiedConstructor> {
-        self.module
-            .ast
-            .definitions
-            .iter()
-            .find_map(|def| match def {
-                ast::Definition::Import(import) => {
-                    if let Some(ty) = import
-                        .unqualified_types
-                        .iter()
-                        .find(|ty| ty.used_name() == constructor_name)
-                    {
-                        if let Some(module_name) = import.used_name() {
+    fn get_module_import_from_type_constructor(&mut self, constructor_name: &EcoString) {
+        self.unqualified_constructor =
+            self.module
+                .ast
+                .definitions
+                .iter()
+                .find_map(|def| match def {
+                    ast::Definition::Import(import) => {
+                        if let Some(ty) = import
+                            .unqualified_types
+                            .iter()
+                            .find(|ty| ty.used_name() == constructor_name)
+                        {
                             return Some(UnqualifiedConstructor {
                                 constructor: ty.clone(),
-                                module_name,
+                                module_name: import.used_name()?,
                                 is_type: true,
                             });
                         }
+                        None
                     }
-                    None
-                }
-                _ => None,
-            })
+                    _ => None,
+                })
     }
 }
 
@@ -1742,7 +1736,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
                 src_span_to_lsp_range(*location, &self.line_numbers),
             )
         {
-            self.unqualified_constructor = self.get_module_import_from_type_constructor(name);
+            self.get_module_import_from_type_constructor(name);
         }
 
         ast::visit::visit_type_ast_constructor(self, location, module, name, arguments);
@@ -1764,8 +1758,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
                 type_::ValueConstructorVariant::LocalVariable { .. }
                 | type_::ValueConstructorVariant::LocalConstant { .. } => None,
             } {
-                self.unqualified_constructor =
-                    self.get_module_import_from_value_constructor(module_name, name);
+                self.get_module_import_from_value_constructor(module_name, name);
             }
         }
         ast::visit::visit_typed_expr_var(self, location, constructor, name);
@@ -1788,8 +1781,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
             )
         {
             if let crate::analyse::Inferred::Known(constructor) = constructor {
-                self.unqualified_constructor =
-                    self.get_module_import_from_value_constructor(&constructor.module, name);
+                self.get_module_import_from_value_constructor(&constructor.module, name);
             }
         }
 
@@ -1883,7 +1875,9 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
         } = self.unqualified_constructor;
 
         let mut last_char_pos = constructor_import_span.end as usize;
-        // TODO: handle cases like import module.{Constructor   , type Constructor}
+        while self.module.code.get(last_char_pos..last_char_pos + 1) == Some(" ") {
+            last_char_pos += 1;
+        }
         if self.module.code.get(last_char_pos..last_char_pos + 1) == Some(",") {
             last_char_pos += 1;
         }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1607,9 +1607,9 @@ pub fn code_action_convert_qualified_constructor_to_unqualified(
     actions.extend(new_actions);
 }
 
-struct UnqualifiedConstructor {
+struct UnqualifiedConstructor<'a> {
     module_name: EcoString,
-    constructor: ast::UnqualifiedImport,
+    constructor: &'a ast::UnqualifiedImport,
     is_type: bool,
 }
 
@@ -1617,7 +1617,7 @@ struct UnqualifiedToQualifiedImportFirstPass<'a> {
     module: &'a Module,
     params: &'a CodeActionParams,
     line_numbers: LineNumbers,
-    unqualified_constructor: Option<UnqualifiedConstructor>,
+    unqualified_constructor: Option<UnqualifiedConstructor<'a>>,
 }
 
 impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
@@ -1647,7 +1647,7 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
                         .find(|value| value.used_name() == constructor_name)
                         .and_then(|value| {
                             Some(UnqualifiedConstructor {
-                                constructor: value.clone(),
+                                constructor: value,
                                 module_name: import.used_name()?,
                                 is_type: false,
                             })
@@ -1670,7 +1670,7 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
                             .find(|ty| ty.used_name() == constructor_name)
                         {
                             return Some(UnqualifiedConstructor {
-                                constructor: ty.clone(),
+                                constructor: ty,
                                 module_name: import.used_name()?,
                                 is_type: true,
                             });
@@ -1802,7 +1802,7 @@ struct UnqualifiedToQualifiedImportSecondPass<'a> {
     module: &'a Module,
     params: &'a CodeActionParams,
     line_numbers: LineNumbers,
-    unqualified_constructor: UnqualifiedConstructor,
+    unqualified_constructor: UnqualifiedConstructor<'a>,
     edits: Vec<TextEdit>,
 }
 
@@ -1811,7 +1811,7 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
         module: &'a Module,
         params: &'a CodeActionParams,
         line_numbers: LineNumbers,
-        unqualified_constructor: UnqualifiedConstructor,
+        unqualified_constructor: UnqualifiedConstructor<'a>,
     ) -> Self {
         Self {
             module,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1044,7 +1044,6 @@ impl<'a> AddAnnotations<'a> {
     }
 }
 
-#[derive(Debug)]
 pub struct QualifiedConstructor<'a> {
     import: &'a ast::Import<EcoString>,
     module_aliased: bool,
@@ -1608,32 +1607,17 @@ pub fn code_action_convert_qualified_constructor_to_unqualified(
     actions.extend(new_actions);
 }
 
-struct UnqualifiedConstructor<'a> {
-    import: &'a ast::Import<EcoString>,
+struct UnqualifiedConstructor {
     module_name: EcoString,
-    constructor_name: EcoString,
-    constructor_used_name: EcoString,
+    constructor: ast::UnqualifiedImport,
     is_type: bool,
-}
-
-impl UnqualifiedConstructor<'_> {
-    fn constructor_import(&self) -> String {
-        let prefix = if self.is_type { "type " } else { "" };
-        let base = format!("{}{}", prefix, self.constructor_name);
-
-        if self.constructor_name == self.constructor_used_name {
-            base
-        } else {
-            format!("{} as {}", base, self.constructor_used_name)
-        }
-    }
 }
 
 struct UnqualifiedToQualifiedImportFirstPass<'a> {
     module: &'a Module,
     params: &'a CodeActionParams,
     line_numbers: LineNumbers,
-    unqualified_constructor: Option<UnqualifiedConstructor<'a>>,
+    unqualified_constructor: Option<UnqualifiedConstructor>,
 }
 
 impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
@@ -1650,20 +1634,25 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
         &mut self,
         module_name: &EcoString,
         constructor_name: &EcoString,
-    ) -> Option<(&'a ast::Import<EcoString>, EcoString, EcoString)> {
+    ) -> Option<UnqualifiedConstructor> {
         self.module
             .ast
             .definitions
             .iter()
             .find_map(|def| match def {
-                ast::Definition::Import(import)
-                    if import.module == *module_name && import.used_name().is_some() =>
-                {
+                ast::Definition::Import(import) if import.module == *module_name => {
+                    let Some(module_name) = import.used_name() else {
+                        return None;
+                    };
                     import
                         .unqualified_values
                         .iter()
                         .find(|value| value.used_name() == constructor_name)
-                        .map(|value| (import, value.name.clone(), value.used_name().clone()))
+                        .map(|value| UnqualifiedConstructor {
+                            constructor: value.clone(),
+                            module_name,
+                            is_type: false,
+                        })
                 }
                 _ => None,
             })
@@ -1672,7 +1661,7 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
     fn get_module_import_from_type_constructor(
         &self,
         constructor_name: &EcoString,
-    ) -> Option<(&'a ast::Import<EcoString>, EcoString, EcoString)> {
+    ) -> Option<UnqualifiedConstructor> {
         self.module
             .ast
             .definitions
@@ -1684,8 +1673,12 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
                         .iter()
                         .find(|ty| ty.used_name() == constructor_name)
                     {
-                        if import.used_name().is_some() {
-                            return Some((import, ty.name.clone(), ty.used_name().clone()));
+                        if let Some(module_name) = import.used_name() {
+                            return Some(UnqualifiedConstructor {
+                                constructor: ty.clone(),
+                                module_name,
+                                is_type: true,
+                            });
                         }
                     }
                     None
@@ -1749,17 +1742,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
                 src_span_to_lsp_range(*location, &self.line_numbers),
             )
         {
-            if let Some((import, constructor_name, constructor_used_name)) =
-                self.get_module_import_from_type_constructor(name)
-            {
-                self.unqualified_constructor = Some(UnqualifiedConstructor {
-                    import,
-                    module_name: import.used_name().expect("Import should not be discarded"),
-                    constructor_name,
-                    constructor_used_name,
-                    is_type: true,
-                });
-            }
+            self.unqualified_constructor = self.get_module_import_from_type_constructor(name);
         }
 
         ast::visit::visit_type_ast_constructor(self, location, module, name, arguments);
@@ -1781,17 +1764,8 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
                 type_::ValueConstructorVariant::LocalVariable { .. }
                 | type_::ValueConstructorVariant::LocalConstant { .. } => None,
             } {
-                if let Some((import, constructor_name, constructor_used_name)) =
-                    self.get_module_import_from_value_constructor(module_name, name)
-                {
-                    self.unqualified_constructor = Some(UnqualifiedConstructor {
-                        import,
-                        module_name: import.used_name().expect("Import should not be discarded"),
-                        constructor_name,
-                        constructor_used_name,
-                        is_type: false,
-                    });
-                }
+                self.unqualified_constructor =
+                    self.get_module_import_from_value_constructor(module_name, name);
             }
         }
         ast::visit::visit_typed_expr_var(self, location, constructor, name);
@@ -1814,17 +1788,8 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
             )
         {
             if let crate::analyse::Inferred::Known(constructor) = constructor {
-                if let Some((import, constructor_name, constructor_used_name)) =
-                    self.get_module_import_from_value_constructor(&constructor.module, name)
-                {
-                    self.unqualified_constructor = Some(UnqualifiedConstructor {
-                        import,
-                        module_name: import.used_name().expect("Import should not be discarded"),
-                        constructor_name,
-                        constructor_used_name,
-                        is_type: false,
-                    });
-                }
+                self.unqualified_constructor =
+                    self.get_module_import_from_value_constructor(&constructor.module, name);
             }
         }
 
@@ -1845,7 +1810,7 @@ struct UnqualifiedToQualifiedImportSecondPass<'a> {
     module: &'a Module,
     params: &'a CodeActionParams,
     line_numbers: LineNumbers,
-    unqualified_constructor: UnqualifiedConstructor<'a>,
+    unqualified_constructor: UnqualifiedConstructor,
     edits: Vec<TextEdit>,
 }
 
@@ -1854,7 +1819,7 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
         module: &'a Module,
         params: &'a CodeActionParams,
         line_numbers: LineNumbers,
-        unqualified_constructor: UnqualifiedConstructor<'a>,
+        unqualified_constructor: UnqualifiedConstructor,
     ) -> Self {
         Self {
             module,
@@ -1871,14 +1836,14 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
                 SrcSpan::new(
                     location.start,
                     location.start
-                        + self.unqualified_constructor.constructor_used_name.len() as u32,
+                        + self.unqualified_constructor.constructor.used_name().len() as u32,
                 ),
                 &self.line_numbers,
             ),
             new_text: format!(
                 "{}.{}",
                 self.unqualified_constructor.module_name,
-                self.unqualified_constructor.constructor_name
+                self.unqualified_constructor.constructor.name
             ),
         });
     }
@@ -1890,14 +1855,15 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
         }
         self.edit_import();
         let mut action = Vec::with_capacity(1);
+        let UnqualifiedConstructor {
+            module_name,
+            constructor,
+            ..
+        } = self.unqualified_constructor;
         CodeActionBuilder::new(&format!(
-            "Qualify {} as {}",
-            self.unqualified_constructor.constructor_used_name,
-            format!(
-                "{}.{}",
-                self.unqualified_constructor.module_name,
-                self.unqualified_constructor.constructor_name
-            )
+            "Qualify {} as {module_name}.{}",
+            constructor.used_name(),
+            constructor.name,
         ))
         .kind(CodeActionKind::REFACTOR)
         .changes(self.params.text_document.uri.clone(), self.edits)
@@ -1908,31 +1874,16 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
 
     fn edit_import(&mut self) {
         let UnqualifiedConstructor {
-            import: ast::Import { location, .. },
-            is_type,
+            constructor:
+                ast::UnqualifiedImport {
+                    location: constructor_import_span,
+                    ..
+                },
             ..
         } = self.unqualified_constructor;
-        let import_code = self
-            .module
-            .code
-            .get(location.start as usize..location.end as usize)
-            .expect("Failed to get import code");
-        let constructor_import = self.unqualified_constructor.constructor_import();
 
-        // TODO: handle import module.{Constructor, type Constructor} (as alias)
-        let Some(first_char_pos) = (if is_type {
-            import_code
-                .find(&constructor_import)
-                .map(|pos| location.start as usize + pos)
-        } else {
-            import_code
-                .rfind(&constructor_import)
-                .map(|pos| location.start as usize + pos)
-        }) else {
-            return;
-        };
-
-        let mut last_char_pos = first_char_pos + constructor_import.len();
+        let mut last_char_pos = constructor_import_span.end as usize;
+        // TODO: handle cases like import module.{Constructor   , type Constructor}
         if self.module.code.get(last_char_pos..last_char_pos + 1) == Some(",") {
             last_char_pos += 1;
         }
@@ -1942,7 +1893,7 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
 
         self.edits.push(TextEdit {
             range: src_span_to_lsp_range(
-                SrcSpan::new(first_char_pos as u32, last_char_pos as u32),
+                SrcSpan::new(constructor_import_span.start, last_char_pos as u32),
                 &self.line_numbers,
             ),
             new_text: "".to_string(),
@@ -2001,11 +1952,11 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
     ) {
         if module.is_none() {
             let UnqualifiedConstructor {
-                constructor_used_name,
+                constructor,
                 is_type,
                 ..
             } = &self.unqualified_constructor;
-            if *is_type && constructor_used_name == name {
+            if *is_type && constructor.used_name() == name {
                 self.add_module_qualifier(*location);
             }
         }
@@ -2019,11 +1970,11 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
         name: &'ast EcoString,
     ) {
         let UnqualifiedConstructor {
-            constructor_used_name,
+            constructor: wanted_constructor,
             is_type,
             ..
         } = &self.unqualified_constructor;
-        if !*is_type && constructor_used_name == name {
+        if !*is_type && wanted_constructor.used_name() == name {
             self.add_module_qualifier(*location);
         }
         ast::visit::visit_typed_expr_var(self, location, constructor, name);
@@ -2041,11 +1992,11 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
     ) {
         if module.is_none() {
             let UnqualifiedConstructor {
-                constructor_used_name,
+                constructor: wanted_constructor,
                 is_type,
                 ..
             } = &self.unqualified_constructor;
-            if !*is_type && constructor_used_name == name {
+            if !*is_type && wanted_constructor.used_name() == name {
                 self.add_module_qualifier(*location);
             }
         }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1853,8 +1853,9 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
             ..
         } = self.unqualified_constructor;
         CodeActionBuilder::new(&format!(
-            "Qualify {} as {module_name}.{}",
+            "Qualify {} as {}.{}",
             constructor.used_name(),
+            module_name,
             constructor.name,
         ))
         .kind(CodeActionKind::REFACTOR)

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -30,9 +30,7 @@ use std::sync::Arc;
 
 use super::{
     code_action::{
-        code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified,
-        code_action_import_module, AddAnnotations, CodeActionBuilder, FillInMissingLabelledArgs,
-        LabelShorthandSyntax, LetAssertToCase, RedundantTupleInCaseSubject,
+        code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified, code_action_convert_unqualified_constructor_to_qualified, code_action_import_module, AddAnnotations, CodeActionBuilder, FillInMissingLabelledArgs, LabelShorthandSyntax, LetAssertToCase, RedundantTupleInCaseSubject
     },
     completer::Completer,
     signature_help, src_span_to_lsp_range, DownloadDependencies, MakeLocker,
@@ -298,6 +296,7 @@ where
             code_action_unused_values(module, &params, &mut actions);
             code_action_unused_imports(module, &params, &mut actions);
             code_action_convert_qualified_constructor_to_unqualified(module, &params, &mut actions);
+            code_action_convert_unqualified_constructor_to_qualified(module, &params, &mut actions);
             code_action_fix_names(module, &params, &this.error, &mut actions);
             code_action_import_module(module, &params, &this.error, &mut actions);
             code_action_add_missing_patterns(module, &params, &this.error, &mut actions);

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -30,7 +30,10 @@ use std::sync::Arc;
 
 use super::{
     code_action::{
-        code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified, code_action_convert_unqualified_constructor_to_qualified, code_action_import_module, AddAnnotations, CodeActionBuilder, FillInMissingLabelledArgs, LabelShorthandSyntax, LetAssertToCase, RedundantTupleInCaseSubject
+        code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified,
+        code_action_convert_unqualified_constructor_to_qualified, code_action_import_module,
+        AddAnnotations, CodeActionBuilder, FillInMissingLabelledArgs, LabelShorthandSyntax,
+        LetAssertToCase, RedundantTupleInCaseSubject,
     },
     completer::Completer,
     signature_help, src_span_to_lsp_range, DownloadDependencies, MakeLocker,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2614,8 +2614,8 @@ pub fn create_user(name: String) -> User {
 import user.{type User, User}
 
 pub fn user_list(users: List(User)) -> List(String) {
-    User(name: "John", id: 1)
-    User(name: "Jane", id: 2)
+    [User(name: "John", id: 1),
+    User(name: "Jane", id: 2)]
 }
 
 "#;
@@ -2795,6 +2795,137 @@ pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
     );
 }
 
+#[test]
+fn test_unqualified_to_qualified_import_bad_formatted_type_constructor_with_alias() {
+    let src = r#"
+import option.{type    Option    as Maybe, Some}
+
+pub fn maybe_increment(x: Maybe(Int)) -> Maybe(Int) {
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}
+"#;
+    assert_code_action!(
+        "Qualify Maybe as option.Option",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
+        find_position_of("May")
+            .nth_occurrence(2)
+            .select_until(find_position_of("be(")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_bad_formatted_comma() {
+    let src = r#"
+import option.{type    Option    , Some}
+
+pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}
+"#;
+    assert_code_action!(
+        "Qualify Option as option.Option",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
+        find_position_of("Opt")
+            .nth_occurrence(2)
+            .select_until(find_position_of("ion(")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_in_list_and_tuple() {
+    let src = r#"
+import option.{Some}
+
+pub fn main() {
+    let list = [Some(1), option.None]
+    let tuple = #(Some(2), option.None)
+}
+"#;
+    assert_code_action!(
+        "Qualify Some as option.Some",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
+        find_position_of("Some(").select_until(find_position_of("1)")),
+    );
+}
+#[test]
+fn test_unqualified_to_qualified_import_constructor_complex_pattern() {
+    let src = r#"
+import option.{None, Some}
+
+pub fn main() {
+    case [Some(1), None] {
+        [None, ..] -> todo
+        [Some(_), ..] -> todo
+        _ -> todo
+    }
+    case Some(1), Some(2) {
+        None, Some(_) -> todo
+        Some(_), Some(val) -> todo
+        _ -> todo
+    }
+}
+"#;
+    assert_code_action!(
+        "Qualify Some as option.Some",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
+        find_position_of("Some(").select_until(find_position_of("1)")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_multiple_line_aliased() {
+    let src = r#"
+import option.{
+    type Option,
+    None,
+    Some
+} as opt
+
+pub fn main() {
+  Some(1)
+}
+"#;
+    assert_code_action!(
+        "Qualify Some as opt.Some",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
+        find_position_of("Some")
+            .nth_occurrence(2)
+            .select_until(find_position_of("(1)")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_multiple_line_bad_format_without_trailing_comma() {
+    let src = r#"
+import option.{type Option,
+    Some
+
+}
+
+pub fn main() {
+  Some(1)
+}
+"#;
+    assert_code_action!(
+        "Qualify Some as option.Some",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
+        find_position_of("Some")
+            .nth_occurrence(2)
+            .select_until(find_position_of("(1)")),
+    );
+}
 /* TODO: implement qualified unused location
 #[test]
 fn test_remove_unused_qualified_action() {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2532,6 +2532,184 @@ pub fn main() {
         find_position_of("option.").select_until(find_position_of("Some(")),
     );
 }
+
+#[test]
+fn test_unqualified_to_qualified_import_function() {
+    let src = r#"
+import list.{map}
+
+pub fn main() {
+    let identity = map([1, 2, 3], fn(x) { x })
+    let double = map([1, 2, 3], fn(x) { x * 2 })
+}
+"#;
+    assert_code_action!(
+        "Qualify map as list.map",
+        TestProject::for_source(src).add_hex_module("list", "pub fn map(list, f) { todo }"),
+        find_position_of("map(").select_until(find_position_of("[1, 2, 3]")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_constant() {
+    let src = r#"
+import mymath.{pi}
+
+pub fn circle_area(radius: Float) -> Float {
+    pi *. radius *. radius
+}
+
+pub fn circle_circumference(radius: Float) -> Float {
+    2. *. pi *. radius
+}
+"#;
+    assert_code_action!(
+        "Qualify pi as mymath.pi",
+        TestProject::for_source(src).add_hex_module("mymath", "pub const pi = 3.14159"),
+        find_position_of("pi *.").select_until(find_position_of(" radius")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_record_constructor() {
+    let src = r#"
+import user.{type User, User}
+
+pub fn create_user(name: String) -> User {
+    User(name: name, id: 1)
+}
+"#;
+    assert_code_action!(
+        "Qualify User as user.User",
+        TestProject::for_source(src)
+            .add_hex_module("user", "pub type User { User(name: String, id: Int) }"),
+        find_position_of("User(").select_until(find_position_of("name: name")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_multiple_occurrences() {
+    let src = r#"
+import list.{map, filter}
+
+pub fn process_list(items: List(Int)) -> List(Int) {
+    items
+    |> map(fn(x) { x + 1 })
+    |> map(fn(x) { x * 2 })
+}
+"#;
+    assert_code_action!(
+        "Qualify map as list.map",
+        TestProject::for_source(src).add_hex_module(
+            "list",
+            "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
+        ),
+        find_position_of("|> map").select_until(find_position_of("(fn(x)")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_in_pattern_matching() {
+    let src = r#"
+import result.{type Result, Ok, Error}
+
+pub fn process_result(res: Result(Int, String)) -> Int {
+    case res {
+        Ok(value) -> value
+        Error(_) -> 0
+    }
+}
+"#;
+    assert_code_action!(
+        "Qualify Ok as result.Ok",
+        TestProject::for_source(src)
+            .add_hex_module("result", "pub type Result(a, e) { Ok(a) Error(e) }"),
+        find_position_of("Ok(").select_until(find_position_of("value)")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_type_annotation() {
+    let src = r#"
+import option.{type Option, Some}
+
+pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}
+"#;
+    assert_code_action!(
+        "Qualify Option as option.Option",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
+        find_position_of("Option(").select_until(find_position_of("Int)")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_nested_function_call() {
+    let src = r#"
+import list.{map, flatten}
+import operation.{double}
+
+pub fn process_names(names: List(List(Int))) -> List(Int) {
+    names
+    |> flatten
+    |> map(double)
+}
+"#;
+    assert_code_action!(
+        "Qualify double as operation.double",
+        TestProject::for_source(src)
+            .add_hex_module(
+                "list",
+                "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }
+pub fn flatten(lists: List(List(a))) -> List(a) { todo }"
+            )
+            .add_hex_module("operation", "pub fn double(s: Int) -> Int { todo }"),
+        find_position_of("(dou").select_until(find_position_of("ble)")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_with_alias() {
+    let src = r#"
+import list.{map as transform}
+
+pub fn double_list(items: List(Int)) -> List(Int) {
+    transform(items, fn(x) { x * 2 })
+}
+"#;
+    assert_code_action!(
+        "Qualify transform as list.map",
+        TestProject::for_source(src).add_hex_module(
+            "list",
+            "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
+        ),
+        find_position_of("transform(").select_until(find_position_of("items,")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_with_alias_and_module_alias() {
+    let src = r#"
+import list.{map as transform} as lst
+
+pub fn double_list(items: List(Int)) -> List(Int) {
+    transform(items, fn(x) { x * 2 })
+}
+"#;
+    assert_code_action!(
+        "Qualify transform as lst.map",
+        TestProject::for_source(src).add_hex_module(
+            "list",
+            "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
+        ),
+        find_position_of("transform(").select_until(find_position_of("items,")),
+    );
+}
 /* TODO: implement qualified unused location
 #[test]
 fn test_remove_unused_qualified_action() {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2588,6 +2588,46 @@ pub fn create_user(name: String) -> User {
 }
 
 #[test]
+fn test_unqualified_to_qualified_import_after_constructor() {
+    let src = r#"
+pub fn create_user(name: String) -> User {
+    User(name: name, id: 1)
+}
+
+import user.{type User, User}
+"#;
+    assert_code_action!(
+        "Qualify User as user.User",
+        TestProject::for_source(src)
+            .add_hex_module("user", "pub type User { User(name: String, id: Int) }"),
+        find_position_of("User(").select_until(find_position_of("name: name")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_between_constructors() {
+    let src = r#"
+pub fn create_user(name: String) -> User {
+    User(name: name, id: 1)
+}
+
+import user.{type User, User}
+
+pub fn user_list(users: List(User)) -> List(String) {
+    User(name: "John", id: 1)
+    User(name: "Jane", id: 2)
+}
+
+"#;
+    assert_code_action!(
+        "Qualify User as user.User",
+        TestProject::for_source(src)
+            .add_hex_module("user", "pub type User { User(name: String, id: Int) }"),
+        find_position_of("User(").select_until(find_position_of("name: name")),
+    );
+}
+
+#[test]
 fn test_unqualified_to_qualified_import_multiple_occurrences() {
     let src = r#"
 import list.{map, filter}
@@ -2710,6 +2750,27 @@ pub fn double_list(items: List(Int)) -> List(Int) {
         find_position_of("transform(").select_until(find_position_of("items,")),
     );
 }
+
+#[test]
+fn test_unqualified_to_qualified_import_import_discarded() {
+    let src = r#"
+import list.{map as transform} as _
+
+pub fn double_list(items: List(Int)) -> List(Int) {
+    transform(items, fn(x) { x * 2 })
+}
+"#;
+    let title = "Qualify transform as list.map";
+    assert_no_code_actions!(
+        title,
+        TestProject::for_source(src).add_hex_module(
+            "list",
+            "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
+        ),
+        find_position_of("transform(").select_until(find_position_of("items,")),
+    );
+}
+
 /* TODO: implement qualified unused location
 #[test]
 fn test_remove_unused_qualified_action() {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2684,7 +2684,9 @@ pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
         "Qualify Option as option.Option",
         TestProject::for_source(src)
             .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
-        find_position_of("Option(").select_until(find_position_of("Int)")),
+        find_position_of("Opt")
+            .nth_occurrence(2)
+            .select_until(find_position_of("ion(")),
     );
 }
 
@@ -2768,6 +2770,28 @@ pub fn double_list(items: List(Int)) -> List(Int) {
             "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
         ),
         find_position_of("transform(").select_until(find_position_of("items,")),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_import_bad_formatted_type_constructor() {
+    let src = r#"
+import option.{type    Option, Some}
+
+pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}
+"#;
+    assert_code_action!(
+        "Qualify Option as option.Option",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
+        find_position_of("Opt")
+            .nth_occurrence(2)
+            .select_until(find_position_of("ion(")),
     );
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_after_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_after_constructor.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn create_user(name: String) -> User {\n    User(name: name, id: 1)\n}\n\nimport user.{type User, User}\n"
+---
+----- BEFORE ACTION
+
+pub fn create_user(name: String) -> User {
+    User(name: name, id: 1)
+    ▔▔▔▔▔↑                 
+}
+
+import user.{type User, User}
+
+
+----- AFTER ACTION
+
+pub fn create_user(name: String) -> User {
+    user.User(name: name, id: 1)
+}
+
+import user.{type User, }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_bad_formatted_comma.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_bad_formatted_comma.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option.{type    Option    , Some}\n\npub fn maybe_increment(x: Option(Int)) -> Option(Int) {\n    case x {\n        Some(value) -> Some(value + 1)\n        _ -> x\n    }\n}\n"
+---
+----- BEFORE ACTION
+
+import option.{type    Option    , Some}
+
+pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
+                          ▔▔▔↑                         
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}
+
+
+----- AFTER ACTION
+
+import option.{Some}
+
+pub fn maybe_increment(x: option.Option(Int)) -> option.Option(Int) {
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_bad_formatted_type_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_bad_formatted_type_constructor.snap
@@ -1,10 +1,10 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\nimport option.{type Option, Some}\n\npub fn maybe_increment(x: Option(Int)) -> Option(Int) {\n    case x {\n        Some(value) -> Some(value + 1)\n        _ -> x\n    }\n}\n"
+expression: "\nimport option.{type    Option, Some}\n\npub fn maybe_increment(x: Option(Int)) -> Option(Int) {\n    case x {\n        Some(value) -> Some(value + 1)\n        _ -> x\n    }\n}\n"
 ---
 ----- BEFORE ACTION
 
-import option.{type Option, Some}
+import option.{type    Option, Some}
 
 pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
                           ▔▔▔↑                         

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_bad_formatted_type_constructor_with_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_bad_formatted_type_constructor_with_alias.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option.{type    Option    as Maybe, Some}\n\npub fn maybe_increment(x: Maybe(Int)) -> Maybe(Int) {\n    case x {\n        Some(value) -> Some(value + 1)\n        _ -> x\n    }\n}\n"
+---
+----- BEFORE ACTION
+
+import option.{type    Option    as Maybe, Some}
+
+pub fn maybe_increment(x: Maybe(Int)) -> Maybe(Int) {
+                          ▔▔▔↑                       
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}
+
+
+----- AFTER ACTION
+
+import option.{Some}
+
+pub fn maybe_increment(x: option.Option(Int)) -> option.Option(Int) {
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_between_constructors.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_between_constructors.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn create_user(name: String) -> User {\n    User(name: name, id: 1)\n}\n\nimport user.{type User, User}\n\npub fn user_list(users: List(User)) -> List(String) {\n    User(name: \"John\", id: 1)\n    User(name: \"Jane\", id: 2)\n}\n\n"
+---
+----- BEFORE ACTION
+
+pub fn create_user(name: String) -> User {
+    User(name: name, id: 1)
+    ▔▔▔▔▔↑                 
+}
+
+import user.{type User, User}
+
+pub fn user_list(users: List(User)) -> List(String) {
+    User(name: "John", id: 1)
+    User(name: "Jane", id: 2)
+}
+
+
+
+----- AFTER ACTION
+
+pub fn create_user(name: String) -> User {
+    user.User(name: name, id: 1)
+}
+
+import user.{type User, }
+
+pub fn user_list(users: List(User)) -> List(String) {
+    user.User(name: "John", id: 1)
+    user.User(name: "Jane", id: 2)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_between_constructors.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_between_constructors.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\npub fn create_user(name: String) -> User {\n    User(name: name, id: 1)\n}\n\nimport user.{type User, User}\n\npub fn user_list(users: List(User)) -> List(String) {\n    User(name: \"John\", id: 1)\n    User(name: \"Jane\", id: 2)\n}\n\n"
+expression: "\npub fn create_user(name: String) -> User {\n    User(name: name, id: 1)\n}\n\nimport user.{type User, User}\n\npub fn user_list(users: List(User)) -> List(String) {\n    [User(name: \"John\", id: 1),\n    User(name: \"Jane\", id: 2)]\n}\n\n"
 ---
 ----- BEFORE ACTION
 
@@ -12,8 +12,8 @@ pub fn create_user(name: String) -> User {
 import user.{type User, User}
 
 pub fn user_list(users: List(User)) -> List(String) {
-    User(name: "John", id: 1)
-    User(name: "Jane", id: 2)
+    [User(name: "John", id: 1),
+    User(name: "Jane", id: 2)]
 }
 
 
@@ -27,6 +27,6 @@ pub fn create_user(name: String) -> User {
 import user.{type User, }
 
 pub fn user_list(users: List(User)) -> List(String) {
-    user.User(name: "John", id: 1)
-    user.User(name: "Jane", id: 2)
+    [user.User(name: "John", id: 1),
+    user.User(name: "Jane", id: 2)]
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_constant.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport mymath.{pi}\n\npub fn circle_area(radius: Float) -> Float {\n    pi *. radius *. radius\n}\n\npub fn circle_circumference(radius: Float) -> Float {\n    2. *. pi *. radius\n}\n"
+---
+----- BEFORE ACTION
+
+import mymath.{pi}
+
+pub fn circle_area(radius: Float) -> Float {
+    pi *. radius *. radius
+    ▔▔▔▔▔↑                
+}
+
+pub fn circle_circumference(radius: Float) -> Float {
+    2. *. pi *. radius
+}
+
+
+----- AFTER ACTION
+
+import mymath.{}
+
+pub fn circle_area(radius: Float) -> Float {
+    mymath.pi *. radius *. radius
+}
+
+pub fn circle_circumference(radius: Float) -> Float {
+    2. *. mymath.pi *. radius
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_constructor_complex_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_constructor_complex_pattern.snap
@@ -1,0 +1,39 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option.{None, Some}\n\npub fn main() {\n    case [Some(1), None] {\n        [None, ..] -> todo\n        [Some(_), ..] -> todo\n        _ -> todo\n    }\n    case Some(1), Some(2) {\n        None, Some(_) -> todo\n        Some(_), Some(val) -> todo\n        _ -> todo\n    }\n}\n"
+---
+----- BEFORE ACTION
+
+import option.{None, Some}
+
+pub fn main() {
+    case [Some(1), None] {
+          ▔▔▔▔▔↑          
+        [None, ..] -> todo
+        [Some(_), ..] -> todo
+        _ -> todo
+    }
+    case Some(1), Some(2) {
+        None, Some(_) -> todo
+        Some(_), Some(val) -> todo
+        _ -> todo
+    }
+}
+
+
+----- AFTER ACTION
+
+import option.{None, }
+
+pub fn main() {
+    case [option.Some(1), None] {
+        [None, ..] -> todo
+        [option.Some(_), ..] -> todo
+        _ -> todo
+    }
+    case option.Some(1), option.Some(2) {
+        None, option.Some(_) -> todo
+        option.Some(_), option.Some(val) -> todo
+        _ -> todo
+    }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_function.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport list.{map}\n\npub fn main() {\n    let identity = map([1, 2, 3], fn(x) { x })\n    let double = map([1, 2, 3], fn(x) { x * 2 })\n}\n"
+---
+----- BEFORE ACTION
+
+import list.{map}
+
+pub fn main() {
+    let identity = map([1, 2, 3], fn(x) { x })
+                   ▔▔▔▔↑                      
+    let double = map([1, 2, 3], fn(x) { x * 2 })
+}
+
+
+----- AFTER ACTION
+
+import list.{}
+
+pub fn main() {
+    let identity = list.map([1, 2, 3], fn(x) { x })
+    let double = list.map([1, 2, 3], fn(x) { x * 2 })
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_in_list_and_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_in_list_and_tuple.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option.{Some}\n\npub fn main() {\n    let list = [Some(1), option.None]\n    let tuple = #(Some(2), option.None)\n}\n"
+---
+----- BEFORE ACTION
+
+import option.{Some}
+
+pub fn main() {
+    let list = [Some(1), option.None]
+                ▔▔▔▔▔↑               
+    let tuple = #(Some(2), option.None)
+}
+
+
+----- AFTER ACTION
+
+import option.{}
+
+pub fn main() {
+    let list = [option.Some(1), option.None]
+    let tuple = #(option.Some(2), option.None)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_in_pattern_matching.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_in_pattern_matching.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport result.{type Result, Ok, Error}\n\npub fn process_result(res: Result(Int, String)) -> Int {\n    case res {\n        Ok(value) -> value\n        Error(_) -> 0\n    }\n}\n"
+---
+----- BEFORE ACTION
+
+import result.{type Result, Ok, Error}
+
+pub fn process_result(res: Result(Int, String)) -> Int {
+    case res {
+        Ok(value) -> value
+        ▔▔▔↑              
+        Error(_) -> 0
+    }
+}
+
+
+----- AFTER ACTION
+
+import result.{type Result,  Error}
+
+pub fn process_result(res: Result(Int, String)) -> Int {
+    case res {
+        result.Ok(value) -> value
+        Error(_) -> 0
+    }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_in_pattern_matching.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_in_pattern_matching.snap
@@ -17,7 +17,7 @@ pub fn process_result(res: Result(Int, String)) -> Int {
 
 ----- AFTER ACTION
 
-import result.{type Result,  Error}
+import result.{type Result, Error}
 
 pub fn process_result(res: Result(Int, String)) -> Int {
     case res {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_line_aliased.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_line_aliased.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option.{\n    type Option,\n    None,\n    Some\n} as opt\n\npub fn main() {\n  Some(1)\n}\n"
+---
+----- BEFORE ACTION
+
+import option.{
+    type Option,
+    None,
+    Some
+} as opt
+
+pub fn main() {
+  Some(1)
+  ▔▔▔▔↑  
+}
+
+
+----- AFTER ACTION
+
+import option.{
+    type Option,
+    None,
+    
+} as opt
+
+pub fn main() {
+  opt.Some(1)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_line_bad_format_without_trailing_comma.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_line_bad_format_without_trailing_comma.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option.{type Option,\n    Some\n\n}\n\npub fn main() {\n  Some(1)\n}\n"
+---
+----- BEFORE ACTION
+
+import option.{type Option,
+    Some
+
+}
+
+pub fn main() {
+  Some(1)
+  ▔▔▔▔↑  
+}
+
+
+----- AFTER ACTION
+
+import option.{type Option,
+    
+
+}
+
+pub fn main() {
+  option.Some(1)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_occurrences.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_occurrences.snap
@@ -16,7 +16,7 @@ pub fn process_list(items: List(Int)) -> List(Int) {
 
 ----- AFTER ACTION
 
-import list.{ filter}
+import list.{filter}
 
 pub fn process_list(items: List(Int)) -> List(Int) {
     items

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_occurrences.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_multiple_occurrences.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport list.{map, filter}\n\npub fn process_list(items: List(Int)) -> List(Int) {\n    items\n    |> map(fn(x) { x + 1 })\n    |> map(fn(x) { x * 2 })\n}\n"
+---
+----- BEFORE ACTION
+
+import list.{map, filter}
+
+pub fn process_list(items: List(Int)) -> List(Int) {
+    items
+    |> map(fn(x) { x + 1 })
+    ▔▔▔▔▔▔↑                
+    |> map(fn(x) { x * 2 })
+}
+
+
+----- AFTER ACTION
+
+import list.{ filter}
+
+pub fn process_list(items: List(Int)) -> List(Int) {
+    items
+    |> list.map(fn(x) { x + 1 })
+    |> list.map(fn(x) { x * 2 })
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_nested_function_call.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_nested_function_call.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport list.{map, flatten}\nimport operation.{double}\n\npub fn process_names(names: List(List(Int))) -> List(Int) {\n    names\n    |> flatten\n    |> map(double)\n}\n"
+---
+----- BEFORE ACTION
+
+import list.{map, flatten}
+import operation.{double}
+
+pub fn process_names(names: List(List(Int))) -> List(Int) {
+    names
+    |> flatten
+    |> map(double)
+          ▔▔▔▔↑   
+}
+
+
+----- AFTER ACTION
+
+import list.{map, flatten}
+import operation.{}
+
+pub fn process_names(names: List(List(Int))) -> List(Int) {
+    names
+    |> flatten
+    |> map(operation.double)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_record_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_record_constructor.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport user.{type User, User}\n\npub fn create_user(name: String) -> User {\n    User(name: name, id: 1)\n}\n"
+---
+----- BEFORE ACTION
+
+import user.{type User, User}
+
+pub fn create_user(name: String) -> User {
+    User(name: name, id: 1)
+    ▔▔▔▔▔↑                 
+}
+
+
+----- AFTER ACTION
+
+import user.{type User, }
+
+pub fn create_user(name: String) -> User {
+    user.User(name: name, id: 1)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_type_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_type_annotation.snap
@@ -17,7 +17,7 @@ pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
 
 ----- AFTER ACTION
 
-import option.{ Some}
+import option.{Some}
 
 pub fn maybe_increment(x: option.Option(Int)) -> option.Option(Int) {
     case x {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_type_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_type_annotation.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option.{type Option, Some}\n\npub fn maybe_increment(x: Option(Int)) -> Option(Int) {\n    case x {\n        Some(value) -> Some(value + 1)\n        _ -> x\n    }\n}\n"
+---
+----- BEFORE ACTION
+
+import option.{type Option, Some}
+
+pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
+                          ▔▔▔▔▔▔▔↑                     
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}
+
+
+----- AFTER ACTION
+
+import option.{ Some}
+
+pub fn maybe_increment(x: option.Option(Int)) -> option.Option(Int) {
+    case x {
+        Some(value) -> Some(value + 1)
+        _ -> x
+    }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_with_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_with_alias.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport list.{map as transform}\n\npub fn double_list(items: List(Int)) -> List(Int) {\n    transform(items, fn(x) { x * 2 })\n}\n"
+---
+----- BEFORE ACTION
+
+import list.{map as transform}
+
+pub fn double_list(items: List(Int)) -> List(Int) {
+    transform(items, fn(x) { x * 2 })
+    ▔▔▔▔▔▔▔▔▔▔↑                      
+}
+
+
+----- AFTER ACTION
+
+import list.{}
+
+pub fn double_list(items: List(Int)) -> List(Int) {
+    list.map(items, fn(x) { x * 2 })
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_with_alias_and_module_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unqualified_to_qualified_import_with_alias_and_module_alias.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport list.{map as transform} as lst\n\npub fn double_list(items: List(Int)) -> List(Int) {\n    transform(items, fn(x) { x * 2 })\n}\n"
+---
+----- BEFORE ACTION
+
+import list.{map as transform} as lst
+
+pub fn double_list(items: List(Int)) -> List(Int) {
+    transform(items, fn(x) { x * 2 })
+    ▔▔▔▔▔▔▔▔▔▔↑                      
+}
+
+
+----- AFTER ACTION
+
+import list.{} as lst
+
+pub fn double_list(items: List(Int)) -> List(Int) {
+    lst.map(items, fn(x) { x * 2 })
+}


### PR DESCRIPTION
close: #3603

also, I realize there could be two constructors with the same name, and applying the `Unqualify constructor` action could cause a conflict. Should we check that before offering the code action  or let the user check?
