### PR TITLE
fix spelling of UpdateMultiConstructorType error message

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1886,7 +1886,7 @@ assigned variables to all of them."
 so it cannot be safely updated. If this value was one of the other variants \
 then the update would be produce incorrect results.
 
-Consider pattern matching on it with a case expression and then\
+Consider pattern matching on it with a case expression and then \
 constructing a new record with its values."
                 );
 


### PR DESCRIPTION
The error message for updating a multi-constructor type is missing a space.

I haven't been able to find a GH issue for this yet.

**Issue**:
```
Diagnostics:
1. Unsafe record update
   
   I can't tell this is always the right constructor.
   
   This type has multiple constructors so it cannot be safely updated. If
   this value was one of the other variants then the update would be produce
   incorrect results.
   
   Consider pattern matching on it with a case expression and thenconstructing
   a new record with its values.
```
second-to-last line contains the mistake.