### PR TITLE
fix: check if constructor exist when offer `Unqualify` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,30 @@
 
   ([Jiangda Wang](https://github.com/Frank-III))
 
+- The Language Server now suggests a code action to convert unqualified imports to
+  qualified imports, which updates all occurrences of the unqualified name
+  throughout the module:
+
+  ```gleam
+  import list.{map}
+
+  pub fn main() {
+    map([1, 2, 3], fn(x) { x * 2 })
+  }
+  ```
+
+  Becomes:
+
+  ```gleam
+  import list.{}
+
+  pub fn main() {
+    list.map([1, 2, 3], fn(x) { x * 2 })
+  }
+  ```
+
+  ([Jiangda Wang](https://github.com/Frank-III))
+
 ### Bug Fixes
 
 - Fixed a bug in the compiler where shadowing a sized value in a bit pattern

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2661,7 +2661,7 @@ fn test_qualified_to_unqualified_import_constructor_constructor_name_exists() {
 import option.{Some}
 import opt
 
-pub fn main() {
+pub fn main() -> option.Option(opt.Option(Int)) {
     Some(opt.Some(1))
 }
 "#;
@@ -2680,7 +2680,7 @@ fn test_qualified_to_unqualified_import_constructor_constructor_name_exists_belo
     let src = r#"
 import opt
 
-pub fn main() {
+pub fn main() -> option.Option(opt.Option(Int)) {
     Some(opt.Some(1))
 }
 import option.{Some}
@@ -2701,8 +2701,8 @@ fn test_qualified_to_unqualified_import_type_constructor_constructor_name_exists
 import option.{type Option}
 import opt
 
-pub fn main() -> opt.Option(Int) {
-    opt.Some(opt.Some(1))
+pub fn main() -> Option(opt.Option(Int)) {
+    option.Some(opt.Some(1))
 }
 "#;
     let title = "Unqualify opt.Option";
@@ -2720,8 +2720,8 @@ fn test_qualified_to_unqualified_import_type_constructor_constructor_name_exists
     let src = r#"
 import opt
 
-pub fn main() -> opt.Option(Int) {
-    opt.Some(opt.Some(1))
+pub fn main() -> Option(opt.Option(Int)) {
+    option.Some(opt.Some(1))
 }
 import option.{type Option}
 "#;

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2656,6 +2656,46 @@ pub fn main() {
 }
 
 #[test]
+fn test_qualified_to_unqualified_import_constructor_constructor_name_exists() {
+    let src = r#"
+import option.{Some}
+import opt
+
+pub fn main() {
+    Some(opt.Some(1))
+}
+"#;
+    let title = "Unqualify opt.Some";
+    assert_no_code_actions!(
+        title,
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }")
+            .add_hex_module("opt", "pub type Option(v) { Some(v) None }"),
+        find_position_of("opt.").select_until(find_position_of(".Some(")),
+    );
+}
+
+#[test]
+fn test_qualified_to_unqualified_import_constructor_constructor_name_exists_below() {
+    let src = r#"
+import opt
+
+pub fn main() {
+    Some(opt.Some(1))
+}
+import option.{Some}
+"#;
+    let title = "Unqualify opt.Some";
+    assert_no_code_actions!(
+        title,
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }")
+            .add_hex_module("opt", "pub type Option(v) { Some(v) None }"),
+        find_position_of("opt.").select_until(find_position_of(".Some(")),
+    );
+}
+
+#[test]
 fn test_unqualified_to_qualified_import_function() {
     let src = r#"
 import list.{map}

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2696,6 +2696,45 @@ import option.{Some}
 }
 
 #[test]
+fn test_qualified_to_unqualified_import_type_constructor_constructor_name_exists() {
+    let src = r#"
+import option.{type Option}
+import opt
+
+pub fn main() -> opt.Option(Int) {
+    opt.Some(opt.Some(1))
+}
+"#;
+    let title = "Unqualify opt.Option";
+    assert_no_code_actions!(
+        title,
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }")
+            .add_hex_module("opt", "pub type Option(v) { Some(v) None }"),
+        find_position_of("opt.").select_until(find_position_of(".Option(")),
+    );
+}
+
+#[test]
+fn test_qualified_to_unqualified_import_type_constructor_constructor_name_exists_below() {
+    let src = r#"
+import opt
+
+pub fn main() -> opt.Option(Int) {
+    opt.Some(opt.Some(1))
+}
+import option.{type Option}
+"#;
+    let title = "Unqualify opt.Option";
+    assert_no_code_actions!(
+        title,
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }")
+            .add_hex_module("opt", "pub type Option(v) { Some(v) None }"),
+        find_position_of("opt.").select_until(find_position_of(".Option(")),
+    );
+}
+#[test]
 fn test_unqualified_to_qualified_import_function() {
     let src = r#"
 import list.{map}


### PR DESCRIPTION
as discussed in #3733