### PR TITLE
Display source code for other modules in snapshots

### DIFF
--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -40,7 +40,11 @@ macro_rules! assert_js_with_multiple_imports {
     ($(($name:literal, $module_src:literal)),+; $src:literal) => {
         let compiled =
             $crate::javascript::tests::compile_js($src, vec![$((CURRENT_PACKAGE, $name, $module_src)),*]).expect("compilation failed");
-        let output = format!("----- SOURCE CODE\n{}\n\n----- COMPILED JAVASCRIPT\n{}", $src, compiled);
+            let mut output = String::from("----- SOURCE CODE\n");
+            for (name, src) in [$(($name, $module_src)),*] {
+                output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+            }
+            output.push_str(&format!("-- main.gleam\n{}\n\n----- COMPILED JAVASCRIPT\n{compiled}", $src));
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__discarded_duplicate_import.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__discarded_duplicate_import.snap
@@ -3,6 +3,13 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport esa/rocket_ship\nimport nasa/rocket_ship as _nasa_rocket\npub fn go() { rocket_ship.go() }\n"
 ---
 ----- SOURCE CODE
+-- esa/rocket_ship.gleam
+pub fn go() { 1 }
+
+-- nasa/rocket_ship.gleam
+pub fn go() { 1 }
+
+-- main.gleam
 
 import esa/rocket_ship
 import nasa/rocket_ship as _nasa_rocket

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__discarded_duplicate_import_with_unqualified.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__discarded_duplicate_import_with_unqualified.snap
@@ -3,6 +3,13 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport esa/rocket_ship\nimport nasa/rocket_ship.{go} as _nasa_rocket\npub fn esa_go() { rocket_ship.go() }\npub fn nasa_go() { go() }\n"
 ---
 ----- SOURCE CODE
+-- esa/rocket_ship.gleam
+pub fn go() { 1 }
+
+-- nasa/rocket_ship.gleam
+pub fn go() { 1 }
+
+-- main.gleam
 
 import esa/rocket_ship
 import nasa/rocket_ship.{go} as _nasa_rocket

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -165,7 +165,18 @@ macro_rules! assert_with_module_error {
     (($name:expr, $module_src:literal), $src:expr $(,)?) => {
         let error =
             $crate::type_::tests::module_error($src, vec![("thepackage", $name, $module_src)]);
-        let output = format!("----- SOURCE CODE\n{}\n\n----- ERROR\n{}", $src, error);
+        let output = format!(
+            "----- SOURCE CODE
+-- {}.gleam
+{}
+
+-- main.gleam
+{}
+
+----- ERROR
+{}",
+            $name, $module_src, $src, error
+        );
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 
@@ -181,7 +192,21 @@ macro_rules! assert_with_module_error {
                 ("thepackage", $name2, $module_src2),
             ],
         );
-        let output = format!("----- SOURCE CODE\n{}\n\n----- ERROR\n{}", $src, error);
+        let output = format!(
+            "----- SOURCE CODE
+-- {}.gleam
+{}
+
+-- {}.gleam
+{}
+
+-- main.gleam
+{}
+
+----- ERROR
+{}",
+            $name, $module_src, $name2, $module_src2, $src, error
+        );
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }
@@ -230,7 +255,12 @@ macro_rules! assert_warnings_with_imports {
             ],
             None
         );
-        let output = format!("----- SOURCE CODE\n{}\n\n----- WARNING\n{}", $src, warning);
+
+        let mut output = String::from("----- SOURCE CODE\n");
+        for (name, src) in [$(($name, $module_src)),*] {
+            output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+        }
+        output.push_str(&format!("-- main.gleam\n{}\n\n----- WARNING\n{warning}", $src));
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/custom_types.rs
 expression: "import wibble.{type A} type A { C }"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type A { B }
+
+-- main.gleam
 import wibble.{type A} type A { C }
 
 ----- ERROR

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
@@ -3,6 +3,13 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import wibble/sub\n        import wibble2/sub\n        pub fn main() {\n            sub.wobble()\n        }\n        "
 ---
 ----- SOURCE CODE
+-- wibble/sub.gleam
+pub fn wobble() { 1 }
+
+-- wibble2/sub.gleam
+pub fn wobble() { 1 }
+
+-- main.gleam
 
         import wibble/sub
         import wibble2/sub

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
@@ -3,6 +3,13 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import wibble/sub\n        import wibble2/sub.{wobble}\n        pub fn main() {\n            sub.wobble()\n        }\n        "
 ---
 ----- SOURCE CODE
+-- wibble/sub.gleam
+pub fn wobble() { 1 }
+
+-- wibble2/sub.gleam
+pub fn wobble() { 1 }
+
+-- main.gleam
 
         import wibble/sub
         import wibble2/sub.{wobble}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_type_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_type_error.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "import wibble pub type Thing { Thing }\n        pub fn main() {\n            [Thing] == [wibble.Thing]\n        }"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Thing { Thing }
+
+-- main.gleam
 import wibble pub type Thing { Thing }
         pub fn main() {
             [Thing] == [wibble.Thing]

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_operands.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_operands.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport maths as math\npub fn add_two_vectors(a: math.Vector, b: math.Vector) {\n  a + b\n}\n"
 ---
 ----- SOURCE CODE
+-- maths.gleam
+pub type Vector { Vector(x: Float, y: Float) }
+
+-- main.gleam
 
 import maths as math
 pub fn add_two_vectors(a: math.Vector, b: math.Vector) {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_pipe_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_pipe_argument.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport mod\npub fn main() {\n  Nil |> mod.takes_wibble\n}\n"
 ---
 ----- SOURCE CODE
+-- mod.gleam
+pub type Wibble pub fn takes_wibble(value: Wibble) { value }
+
+-- main.gleam
 
 import mod
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_mismatched_type_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_mismatched_type_error.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport wibble\nconst my_wobble: wibble.Wobble = Nil\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wobble
+
+-- main.gleam
 
 import wibble
 const my_wobble: wibble.Wobble = Nil

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_function.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport wibble.{type Function as FuncWrapper}\npub fn main(f: FuncWrapper) {\n  f()\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Function { Function(fn() -> Nil) }
+
+-- main.gleam
 
 import wibble.{type Function as FuncWrapper}
 pub fn main(f: FuncWrapper) {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_tuple.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_a_tuple.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport mod.{type Pair as Duo}\npub fn first(pair: Duo(a, b)) {\n  pair.0\n}\n"
 ---
 ----- SOURCE CODE
+-- mod.gleam
+pub type Pair(a, b) { Pair(a, b) }
+
+-- main.gleam
 
 import mod.{type Pair as Duo}
 pub fn first(pair: Duo(a, b)) {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_fn_in_use.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_not_fn_in_use.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport some_mod as sm\npub fn main(func: sm.Function(Int, String, Float)) {\n  use <- func()\n}\n"
 ---
 ----- SOURCE CODE
+-- some_mod.gleam
+pub type Function(param1, param2, return)
+
+-- main.gleam
 
 import some_mod as sm
 pub fn main(func: sm.Function(Int, String, Float)) {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_similar_type_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_similar_type_name.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport wibble\nconst value: wibble.Int = 20\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Int
+
+-- main.gleam
 
 import wibble
 const value: wibble.Int = 20

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_use_fn_without_callback.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_use_fn_without_callback.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport some_mod\npub fn main() {\n  use value <- some_mod.do_a_thing(10)\n}\n"
 ---
 ----- SOURCE CODE
+-- some_mod.gleam
+pub type NotACallback pub fn do_a_thing(a: Int, _b: NotACallback) { a }
+
+-- main.gleam
 
 import some_mod
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -3,6 +3,13 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import gleam/wibble.{wobble}\n        import gleam/wibble.{zoo}\n        pub fn go() { wobble() + zoo() }\n        "
 ---
 ----- SOURCE CODE
+-- gleam/wibble.gleam
+
+            pub fn wobble() { 1 }
+            pub fn zoo() { 1 }
+            
+
+-- main.gleam
 
         import gleam/wibble.{wobble}
         import gleam/wibble.{zoo}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
@@ -3,6 +3,17 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import one\n        import two as one\n        "
 ---
 ----- SOURCE CODE
+-- one.gleam
+
+            pub fn fn1() { 1 }
+            
+
+-- two.gleam
+
+            pub fn fn2() { 1 }
+            
+
+-- main.gleam
 
         import one
         import two as one

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
@@ -3,6 +3,17 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import one as two\n        import two\n        "
 ---
 ----- SOURCE CODE
+-- one.gleam
+
+            pub fn fn1() { 1 }
+            
+
+-- two.gleam
+
+            pub fn fn2() { 1 }
+            
+
+-- main.gleam
 
         import one as two
         import two

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
@@ -3,6 +3,17 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import one as x\n        import two as x\n        "
 ---
 ----- SOURCE CODE
+-- one.gleam
+
+            pub fn fn1() { 1 }
+            
+
+-- two.gleam
+
+            pub fn fn2() { 1 }
+            
+
+-- main.gleam
 
         import one as x
         import two as x

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
@@ -3,6 +3,17 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import one.{fn1}\n        import two.{fn2} as one\n        "
 ---
 ----- SOURCE CODE
+-- one.gleam
+
+            pub fn fn1() { 1 }
+            
+
+-- two.gleam
+
+            pub fn fn2() { 1 }
+            
+
+-- main.gleam
 
         import one.{fn1}
         import two.{fn2} as one

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
@@ -3,6 +3,17 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import one.{fn1} as two\n        import two.{fn2}\n        "
 ---
 ----- SOURCE CODE
+-- one.gleam
+
+            pub fn fn1() { 1 }
+            
+
+-- two.gleam
+
+            pub fn fn2() { 1 }
+            
+
+-- main.gleam
 
         import one.{fn1} as two
         import two.{fn2}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
@@ -3,6 +3,17 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import one.{fn1} as x\n        import two.{fn2} as x\n        "
 ---
 ----- SOURCE CODE
+-- one.gleam
+
+            pub fn fn1() { 1 }
+            
+
+-- two.gleam
+
+            pub fn fn2() { 1 }
+            
+
+-- main.gleam
 
         import one.{fn1} as x
         import two.{fn2} as x

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_7.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_7.snap
@@ -3,6 +3,17 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\n        import one.{\n          fn1\n        } as x\n        import two.{\n          fn2\n        } as x\n        "
 ---
 ----- SOURCE CODE
+-- one.gleam
+
+            pub fn fn1() { 1 }
+            
+
+-- two.gleam
+
+            pub fn fn2() { 1 }
+            
+
+-- main.gleam
 
         import one.{
           fn1

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__type_imported_as_value.snap
@@ -3,6 +3,12 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "import gleam/wibble.{Wibble}"
 ---
 ----- SOURCE CODE
+-- gleam/wibble.gleam
+pub type Wibble {
+               Wobble
+             }
+
+-- main.gleam
 import gleam/wibble.{Wibble}
 
 ----- ERROR

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
@@ -3,6 +3,13 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport some_mod\npub fn main() {\n  some_mod.Wibble(1).field\n}\n"
 ---
 ----- SOURCE CODE
+-- some_mod.gleam
+pub type Wibble {
+              Wibble(field: Int)
+              Wobble(not_field: String, field: Int)
+            }
+
+-- main.gleam
 
 import some_mod
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_imported_module_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_imported_module_type.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport one/two\n\npub fn main(_x: two.Thing) {\n  Nil\n}\n"
 ---
 ----- SOURCE CODE
+-- one/two.gleam
+
+
+-- main.gleam
 
 import one/two
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_suggest_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_suggest_import.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub fn main() {\n  utils.helpful()\n}\n"
 ---
 ----- SOURCE CODE
+-- utils.gleam
+pub fn helpful() {}
+
+-- main.gleam
 
 pub fn main() {
   utils.helpful()

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_suggest_typo_for_imported_module.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_suggest_typo_for_imported_module.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport wibble\npub fn main() {\n  wible.wobble()\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub fn wobble() {}
+
+-- main.gleam
 
 import wibble
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_suggest_typo_for_unimported_module.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_suggest_typo_for_unimported_module.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub fn main() {\n  woble.wubble()\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble/wobble.gleam
+pub fn wubble() {}
+
+-- main.gleam
 
 pub fn main() {
   woble.wubble()

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__value_imported_as_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__value_imported_as_type.snap
@@ -3,6 +3,12 @@ source: compiler-core/src/type_/tests/errors.rs
 expression: "import gleam/wibble.{type Wobble}"
 ---
 ----- SOURCE CODE
+-- gleam/wibble.gleam
+pub type Wibble {
+               Wobble
+             }
+
+-- main.gleam
 import gleam/wibble.{type Wobble}
 
 ----- ERROR

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_aliased_unqualified_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_aliased_unqualified_value.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/exhaustiveness.rs
 expression: "\nimport wibble.{Wibble, Wobble as Wubble}\npub fn main() {\n    case Wibble {\n        Wibble -> Nil\n    }\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
 
 import wibble.{Wibble, Wobble as Wubble}
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_alias.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/exhaustiveness.rs
 expression: "\nimport wibble as wobble\npub fn main() {\n    case wobble.Wobble {\n        wobble.Wibble -> Nil\n    }\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
 
 import wibble as wobble
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_names.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/exhaustiveness.rs
 expression: "\nimport wibble\npub type Things { Thing1 Thing2(Int) }\npub fn main() {\n    let wobble_thing = #(wibble.Wobble, Thing2(23))\n    case wobble_thing {\n        #(wibble.Wibble, Thing1) -> Nil\n    }\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
 
 import wibble
 pub type Things { Thing1 Thing2(Int) }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_when_aliased_and_shadowed.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_when_aliased_and_shadowed.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/exhaustiveness.rs
 expression: "\nimport mod.{Wibble as Wobble}\ntype Wibble { Wobble Wubble }\npub fn main() {\n  let wibble = mod.Wibble\n  case wibble {\n    mod.Wobble -> Nil\n  }\n}\n"
 ---
 ----- SOURCE CODE
+-- mod.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
 
 import mod.{Wibble as Wobble}
 type Wibble { Wobble Wubble }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_when_shadowed.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_when_shadowed.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/exhaustiveness.rs
 expression: "\nimport mod.{Wibble}\ntype Wibble { Wibble Wobble }\npub fn main() {\n  let wibble = mod.Wibble\n  case wibble {\n    mod.Wobble -> Nil\n  }\n}\n"
 ---
 ----- SOURCE CODE
+-- mod.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
 
 import mod.{Wibble}
 type Wibble { Wibble Wobble }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_unqualifed_when_aliased.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_unqualifed_when_aliased.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/exhaustiveness.rs
 expression: "\nimport mod.{Wibble as Wobble}\ntype Wibble { Wibble Wubble }\npub fn main() {\n  let wibble = mod.Wibble\n  case wibble {\n    mod.Wobble -> Nil\n  }\n}\n"
 ---
 ----- SOURCE CODE
+-- mod.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
 
 import mod.{Wibble as Wobble}
 type Wibble { Wibble Wubble }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_unqualified_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_unqualified_value.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/exhaustiveness.rs
 expression: "\nimport wibble.{Wibble, Wobble}\npub fn main() {\n    case Wobble {\n        Wibble -> Nil\n    }\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
 
 import wibble.{Wibble, Wobble}
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__imported_javascript_only_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__imported_javascript_only_function.snap
@@ -3,6 +3,11 @@ source: compiler-core/src/type_/tests/externals.rs
 expression: "import module\npub fn main() {\n  module.javascript_only()\n}"
 ---
 ----- SOURCE CODE
+-- module.gleam
+@external(javascript, "one", "two")
+pub fn javascript_only() -> Int
+
+-- main.gleam
 import module
 pub fn main() {
   module.javascript_only()

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__javascript_only_constant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__javascript_only_constant.snap
@@ -3,6 +3,14 @@ source: compiler-core/src/type_/tests/externals.rs
 expression: "import module\npub fn main() {\n  module.javascript_only_constant()\n}"
 ---
 ----- SOURCE CODE
+-- module.gleam
+@external(javascript, "one", "two")
+fn javascript_only() -> Int
+const constant = javascript_only
+pub const javascript_only_constant = constant
+
+
+-- main.gleam
 import module
 pub fn main() {
   module.javascript_only_constant()

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__unsupported_target_for_unused_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__unsupported_target_for_unused_import.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/externals.rs
 expression: "import mod.{wobble}"
 ---
 ----- SOURCE CODE
+-- mod.gleam
+@external(javascript, "wibble", "wobble") pub fn wobble()
+
+-- main.gleam
 import mod.{wobble}
 
 ----- ERROR

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{One, type One}\n\npub fn main() -> One {\n  todo\n}\n"
 ---
 ----- SOURCE CODE
+-- one.gleam
+pub type One = Int
+
+-- main.gleam
 import one.{One, type One}
 
 pub fn main() -> One {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{type One as MyOne, type One as MyOne}\n\npub type X = One\n"
 ---
 ----- SOURCE CODE
+-- one.gleam
+pub type One = Int
+
+-- main.gleam
 import one.{type One as MyOne, type One as MyOne}
 
 pub type X = One

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as_multiline.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as_multiline.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{\n          type One as MyOne,\n          type One as MyOne\n        }\n\npub type X = One\n"
 ---
 ----- SOURCE CODE
+-- one.gleam
+pub type One = Int
+
+-- main.gleam
 import one.{
           type One as MyOne,
           type One as MyOne

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__imported_constructor_instead_of_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__imported_constructor_instead_of_type.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import module.{Wibble}\n\npub fn main(x: Wibble) {\n  todo\n}"
 ---
 ----- SOURCE CODE
+-- module.gleam
+pub type Wibble { Wibble }
+
+-- main.gleam
 import module.{Wibble}
 
 pub fn main(x: Wibble) {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__module_alias_used_as_a_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__module_alias_used_as_a_name.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "\nimport one/two\n\npub fn main() {\n  two\n}\n"
 ---
 ----- SOURCE CODE
+-- one/two.gleam
+
+
+-- main.gleam
 
 import one/two
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructo.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{Two}\n\npub fn main() {\n  Two\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+pub opaque type Two { Two }
+
+-- main.gleam
 import one.{Two}
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructo.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{Two}\n\npub fn main() {\n  Two\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type Two { Two }
+
+-- main.gleam
 import one.{Two}
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor_pattern.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{Two}\n\npub fn main(x) {\n  let Two = x\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type Two { Two }
+
+-- main.gleam
 import one.{Two}
 
 pub fn main(x) {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_function.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{two}\n\npub fn main() {\n  two\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+fn two() { 2 }
+
+-- main.gleam
 import one.{two}
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_opaque_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_opaque_constructo.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.Two\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+pub opaque type Two { Two }
+
+-- main.gleam
 import one
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructo.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructo.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.Two\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type Two { Two }
+
+-- main.gleam
 import one
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructor_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructor_pattern.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main(x) {\n  let one.Two = x\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type Two { Two }
+
+-- main.gleam
 import one
 
 pub fn main(x) {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_custom_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_custom_type.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.X\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type X { Y }
+
+-- main.gleam
 import one
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_external_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_external_type.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.X\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type X
+
+-- main.gleam
 import one
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_function.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.two\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+fn two() { 2 }
+
+-- main.gleam
 import one
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_type_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_type_alias.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one\n\npub fn main() {\n  one.X\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type X = Int
+
+-- main.gleam
 import one
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_custom_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_custom_type.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{X}\n\npub fn main() {\n  X\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type X { Y }
+
+-- main.gleam
 import one.{X}
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_external_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_external_type.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{X}\n\npub fn main() {\n  X\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type X
+
+-- main.gleam
 import one.{X}
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_type_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_type_alias.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/imports.rs
 expression: "import one.{X}\n\npub fn main() {\n  X\n}"
 ---
 ----- SOURCE CODE
+-- one.gleam
+type X = Int
+
+-- main.gleam
 import one.{X}
 
 pub fn main() {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/type_alias.rs
 expression: "import wibble.{type Wobble} type Wobble = Int"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wobble = String
+
+-- main.gleam
 import wibble.{type Wobble} type Wobble = Int
 
 ----- ERROR

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_for_duplicate_module_no_warning_for_alias_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_for_duplicate_module_no_warning_for_alias_test.snap
@@ -3,6 +3,13 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\n            import a/wibble\n            import b/wibble as wobble\n            const one = wibble.one\n        "
 ---
 ----- SOURCE CODE
+-- a/wibble.gleam
+pub const one = 1
+
+-- b/wibble.gleam
+pub const two = 2
+
+-- main.gleam
 
             import a/wibble
             import b/wibble as wobble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_warning_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_alias_warning_test.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\n            import gleam/wibble.{one} as wobble\n            const one = one\n        "
 ---
 ----- SOURCE CODE
+-- gleam/wibble.gleam
+pub const one = 1
+
+-- main.gleam
 
             import gleam/wibble.{one} as wobble
             const one = one


### PR DESCRIPTION
As discussed in #3738 
This PR prints the source code for the other modules in the `assert_with_module_error` snapshots, and other similar ones.