### PR TITLE
Fix bug with type alias printing

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1182,7 +1182,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
             environment
                 .names
-                .type_in_scope(name.clone(), type_.as_ref());
+                .type_in_scope(name.clone(), type_.as_ref(), &parameters);
 
             // Insert the alias so that it can be used by other code.
             environment.insert_type_constructor(

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -95,9 +95,11 @@ impl<'context, 'problems> Importer<'context, 'problems> {
 
         let type_info = type_info.clone().with_location(import.location);
 
-        self.environment
-            .names
-            .type_in_scope(imported_name.clone(), type_info.type_.as_ref());
+        self.environment.names.type_in_scope(
+            imported_name.clone(),
+            type_info.type_.as_ref(),
+            &type_info.parameters,
+        );
 
         if let Err(e) = self
             .environment

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1170,6 +1170,53 @@ fn do_thing() -> LocalResult {
 }
 
 #[test]
+fn hover_print_alias_when_parameters_match() {
+    let code = "
+type MyResult(a, b) = Result(a, b)
+
+fn do_thing() -> MyResult(Int, Int) {
+  Error(1)
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("do_thing").under_char('d')
+    );
+}
+
+#[test]
+fn hover_print_underlying_for_imported_alias() {
+    let code = "
+import alias.{type A}
+
+fn wibble() -> Result(Int, String) {
+  todo
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code).add_hex_module("alias", "pub type A = Result(Int, String)"),
+        find_position_of("wibble").under_char('l')
+    );
+}
+
+#[test]
+fn hover_print_aliased_imported_generic_type() {
+    let code = "
+import gleam/option.{type Option as Maybe}
+
+const none: Maybe(Int) = option.None
+";
+
+    assert_hover!(
+        TestProject::for_source(code)
+            .add_hex_module("gleam/option", "pub type Option(a) { None Some(a) }"),
+        find_position_of("none").under_char('e')
+    );
+}
+
+#[test]
 fn hover_print_qualified_prelude_type_when_shadowed_by_alias() {
     let code = "
 type Result = #(Bool, String)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_alias_when_parameters_match.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_alias_when_parameters_match.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype MyResult(a, b) = Result(a, b)\n\nfn do_thing() -> MyResult(Int, Int) {\n  Error(1)\n}\n"
+---
+type MyResult(a, b) = Result(a, b)
+
+fn do_thing() -> MyResult(Int, Int) {
+▔▔▔↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔  
+  Error(1)
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> MyResult(Int, Int)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_aliased_imported_generic_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_aliased_imported_generic_type.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport gleam/option.{type Option as Maybe}\n\nconst none: Maybe(Int) = option.None\n"
+---
+import gleam/option.{type Option as Maybe}
+
+const none: Maybe(Int) = option.None
+▔▔▔▔▔▔▔▔▔↑▔▔▔▔▔▔▔▔▔▔▔▔              
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nMaybe(Int)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_alias_with_parameters.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_alias_with_parameters.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-assertion_line: 1166
 expression: "\ntype LocalResult = Result(String, Int)\n\nfn do_thing() -> LocalResult {\n  Error(1)\n}\n"
 ---
 type LocalResult = Result(String, Int)
@@ -14,6 +13,6 @@ fn do_thing() -> LocalResult {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nfn() -> LocalResult(String, Int)\n```\n",
+        "```gleam\nfn() -> Result(String, Int)\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_imported_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_underlying_for_imported_alias.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport alias.{type A}\n\nfn wibble() -> Result(Int, String) {\n  todo\n}\n"
+---
+import alias.{type A}
+
+fn wibble() -> Result(Int, String) {
+▔▔▔▔▔▔▔↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔  
+  todo
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn() -> Result(Int, String)\n```\n",
+    ),
+)

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -119,14 +119,12 @@ pub struct Names {
 /// The `PartialEq` implementation for `Type` doesn't account for `TypeVar::Link`,
 /// so we implement an equality check that does account for it here.
 fn compare_arguments(arguments: &[Arc<Type>], parameters: &[Arc<Type>]) -> bool {
-    dbg!(arguments, parameters);
-
     if arguments.len() != parameters.len() {
         return false;
     }
 
     arguments
-        .into_iter()
+        .iter()
         .zip(parameters)
         .all(|(argument, parameter)| {
             collapse_links(argument.clone()) == collapse_links(parameter.clone())


### PR DESCRIPTION
Fixes #3749 
This PR changes the `Names` class to only register aliases when the type parameters map exactly to those of the type they alias. For example:
```gleam
type MyResult(a, b) = Result(a, b) // Result will now be printed as MyResult
type OptionalInt = option.Option(Int) // This is ignored as it doesn't map nicely
```

In future we could implement a more complex system, which could map the arguments of the type to the parameters of the alias, but I started implementing that and it got pretty complex pretty fast, so I just went with this minimal approach which fixes the bug.