### PR TITLE
Fix bug with goto definition from anonymous function annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,10 @@
   the tail of a list.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where attempting to jump to the definition of a type from the
+  annotation of a parameter of an anonymous function would do nothing.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -609,3 +609,20 @@ fn main() {
             .under_char('l')
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3758
+#[test]
+fn goto_definition_from_anonymous_function() {
+    let code = "
+pub type Wibble
+
+pub fn main() {
+  fn(w: Wibble) { todo }
+}
+";
+
+    assert_goto!(
+        TestProject::for_source(code),
+        find_position_of("w: Wibble").under_char('i')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1256,3 +1256,21 @@ pub fn main() {
 
     assert_hover!(TestProject::for_source(code), find_position_of("x"));
 }
+
+// https://github.com/gleam-lang/gleam/issues/3758
+#[test]
+fn hover_for_anonymous_function_annotation() {
+    let code = "
+/// An example type.
+pub type Wibble
+
+pub fn main() {
+  fn(w: Wibble) { todo }
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("w: Wibble").under_char('b')
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_from_anonymous_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_from_anonymous_function.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+pub type Wibble
+
+pub fn main() {
+  let anonymous = fn(w: Wibble) { todo }
+                         ↑              
+}
+
+----- Jumped to `src/app.gleam`
+
+pub type Wibble
+↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main() {
+  let anonymous = fn(w: Wibble) { todo }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_from_anonymous_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_from_anonymous_function.snap
@@ -7,8 +7,8 @@ expression: output
 pub type Wibble
 
 pub fn main() {
-  let anonymous = fn(w: Wibble) { todo }
-                         ↑              
+  fn(w: Wibble) { todo }
+         ↑              
 }
 
 ----- Jumped to `src/app.gleam`
@@ -17,5 +17,5 @@ pub type Wibble
 ↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔
 
 pub fn main() {
-  let anonymous = fn(w: Wibble) { todo }
+  fn(w: Wibble) { todo }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_anonymous_function_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_anonymous_function_annotation.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// An example type.\npub type Wibble\n\npub fn main() {\n  fn(w: Wibble) { todo }\n}\n"
+---
+/// An example type.
+pub type Wibble
+
+pub fn main() {
+  fn(w: Wibble) { todo }
+        ▔▔↑▔▔▔          
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\napp.Wibble\n```\n An example type.\n",
+    ),
+)


### PR DESCRIPTION
Fixes #3758
This PR moves the locating of annotations from function definitions to function arguments, allowing annotations to be located in the parameters of anonymous functions as well.