### PR TITLE
Warn about unsafe integer values on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,26 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- When targeting JavaScript the compiler now emits a warning for integer literals
+  and constants that lie outside JavaScript's safe integer range:
+
+  ```txt
+  warning: Int is outside the safe range on JavaScript
+    ┌─ /Users/richard/Desktop/int_test/src/int_test.gleam:1:15
+    │
+  1 │ pub const i = 9_007_199_254_740_992
+    │               ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer on JavaScript
+
+  This integer value is too large to be represented accurately by
+  JavaScript's number type. To avoid this warning integer values must be in
+  the range -(2^53 - 1) - (2^53 - 1).
+
+  See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+  properties for more information.
+  ```
+
+  ([Richard Viney](https://github.com/richard-viney))
+
 ### Formatter
 
 - The formatter no longer removes the first argument from a function

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "itertools",
  "lsp-server",
  "lsp-types",
+ "num-bigint",
  "pathdiff",
  "petgraph",
  "pretty_assertions",
@@ -1414,11 +1415,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -44,6 +44,8 @@ id-arena = "2"
 unicode-segmentation = "1.12.0"
 # Bijective (bi-directional) hashmap
 bimap = "0.6.3"
+# Parsing of arbitrary width int values
+num-bigint = "0.4.6"
 async-trait.workspace = true
 base16.workspace = true
 bytes.workspace = true

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -22,6 +22,7 @@ use crate::type_::{
 use std::sync::Arc;
 
 use ecow::EcoString;
+use num_bigint::BigInt;
 #[cfg(test)]
 use pretty_assertions::assert_eq;
 use vec1::Vec1;
@@ -1678,6 +1679,7 @@ pub enum Pattern<Type> {
     Int {
         location: SrcSpan,
         value: EcoString,
+        int_value: BigInt,
     },
 
     Float {

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -10,6 +10,7 @@ pub enum Constant<T, RecordTag> {
     Int {
         location: SrcSpan,
         value: EcoString,
+        int_value: BigInt,
     },
 
     Float {

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -223,6 +223,7 @@ wibble}"#,
     let int1 = TypedExpr::Int {
         location: SrcSpan { start: 14, end: 15 },
         value: "1".into(),
+        int_value: 1.into(),
         type_: type_::int(),
     };
 
@@ -267,16 +268,19 @@ fn find_node_list() {
         location: SrcSpan { start: 1, end: 2 },
         type_: type_::int(),
         value: "1".into(),
+        int_value: 1.into(),
     };
     let int2 = TypedExpr::Int {
         location: SrcSpan { start: 4, end: 5 },
         type_: type_::int(),
         value: "2".into(),
+        int_value: 2.into(),
     };
     let int3 = TypedExpr::Int {
         location: SrcSpan { start: 7, end: 8 },
         type_: type_::int(),
         value: "3".into(),
+        int_value: 3.into(),
     };
 
     assert_eq!(list.find_node(0), Some(Located::Expression(list)));
@@ -300,16 +304,19 @@ fn find_node_tuple() {
         location: SrcSpan { start: 2, end: 3 },
         type_: type_::int(),
         value: "1".into(),
+        int_value: 1.into(),
     };
     let int2 = TypedExpr::Int {
         location: SrcSpan { start: 5, end: 6 },
         type_: type_::int(),
         value: "2".into(),
+        int_value: 2.into(),
     };
     let int3 = TypedExpr::Int {
         location: SrcSpan { start: 8, end: 9 },
         type_: type_::int(),
         value: "3".into(),
+        int_value: 3.into(),
     };
 
     assert_eq!(tuple.find_node(0), Some(Located::Expression(tuple)));
@@ -345,6 +352,7 @@ fn find_node_tuple_index() {
     let int = TypedExpr::Int {
         location: SrcSpan { start: 2, end: 3 },
         value: "1".into(),
+        int_value: 1.into(),
         type_: type_::int(),
     };
 
@@ -386,6 +394,7 @@ fn find_node_fn() {
     let int = TypedExpr::Int {
         location: SrcSpan { start: 7, end: 8 },
         value: "1".into(),
+        int_value: 1.into(),
         type_: type_::int(),
     };
 
@@ -405,18 +414,21 @@ fn find_node_call() {
     let retrn = TypedExpr::Int {
         location: SrcSpan { start: 11, end: 12 },
         value: "1".into(),
+        int_value: 1.into(),
         type_: type_::int(),
     };
 
     let arg1 = TypedExpr::Int {
         location: SrcSpan { start: 15, end: 16 },
         value: "1".into(),
+        int_value: 1.into(),
         type_: type_::int(),
     };
 
     let arg2 = TypedExpr::Int {
         location: SrcSpan { start: 18, end: 19 },
         value: "2".into(),
+        int_value: 2.into(),
         type_: type_::int(),
     };
 
@@ -443,6 +455,7 @@ fn find_node_record_access() {
     let int = TypedExpr::Int {
         location: SrcSpan { start: 12, end: 13 },
         value: "3".into(),
+        int_value: 3.into(),
         type_: type_::int(),
     };
 
@@ -462,6 +475,7 @@ fn find_node_record_update() {
     let int = TypedExpr::Int {
         location: SrcSpan { start: 27, end: 28 },
         value: "4".into(),
+        int_value: 4.into(),
         type_: type_::int(),
     };
 
@@ -486,18 +500,21 @@ case 1, 2 {
     let int1 = TypedExpr::Int {
         location: SrcSpan { start: 6, end: 7 },
         value: "1".into(),
+        int_value: 1.into(),
         type_: type_::int(),
     };
 
     let int2 = TypedExpr::Int {
         location: SrcSpan { start: 9, end: 10 },
         value: "2".into(),
+        int_value: 2.into(),
         type_: type_::int(),
     };
 
     let int3 = TypedExpr::Int {
         location: SrcSpan { start: 23, end: 24 },
         value: "3".into(),
+        int_value: 3.into(),
         type_: type_::int(),
     };
 

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -9,6 +9,7 @@ pub enum TypedExpr {
         location: SrcSpan,
         type_: Arc<Type>,
         value: EcoString,
+        int_value: BigInt,
     },
 
     Float {

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -7,6 +7,7 @@ pub enum UntypedExpr {
     Int {
         location: SrcSpan,
         value: EcoString,
+        int_value: BigInt,
     },
 
     Float {

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -604,6 +604,7 @@ where
             location,
             type_,
             value,
+            int_value: _,
         } => v.visit_typed_expr_int(location, type_, value),
         TypedExpr::Float {
             location,
@@ -1099,7 +1100,11 @@ where
     V: Visit<'a> + ?Sized,
 {
     match pattern {
-        Pattern::Int { location, value } => v.visit_typed_pattern_int(location, value),
+        Pattern::Int {
+            location,
+            value,
+            int_value: _,
+        } => v.visit_typed_pattern_int(location, value),
         Pattern::Float { location, value } => v.visit_typed_pattern_float(location, value),
         Pattern::String { location, value } => v.visit_typed_pattern_string(location, value),
         Pattern::Variable {

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -1,4 +1,5 @@
 use ecow::EcoString;
+use num_bigint::BigInt;
 use vec1::Vec1;
 
 use crate::{
@@ -240,7 +241,11 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
     fn update_expr(&mut self, e: UntypedExpr) -> UntypedExpr {
         match e {
             UntypedExpr::Var { location, name } => self.fold_var(location, name),
-            UntypedExpr::Int { location, value } => self.fold_int(location, value),
+            UntypedExpr::Int {
+                location,
+                value,
+                int_value,
+            } => self.fold_int(location, value, int_value),
             UntypedExpr::Float { location, value } => self.fold_float(location, value),
             UntypedExpr::String { location, value } => self.fold_string(location, value),
 
@@ -639,8 +644,12 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         }
     }
 
-    fn fold_int(&mut self, location: SrcSpan, value: EcoString) -> UntypedExpr {
-        UntypedExpr::Int { location, value }
+    fn fold_int(&mut self, location: SrcSpan, value: EcoString, int_value: BigInt) -> UntypedExpr {
+        UntypedExpr::Int {
+            location,
+            value,
+            int_value,
+        }
     }
 
     fn fold_float(&mut self, location: SrcSpan, value: EcoString) -> UntypedExpr {
@@ -843,7 +852,11 @@ pub trait UntypedConstantFolder {
     /// You probably don't want to override this method.
     fn update_constant(&mut self, m: UntypedConstant) -> UntypedConstant {
         match m {
-            Constant::Int { location, value } => self.fold_constant_int(location, value),
+            Constant::Int {
+                location,
+                value,
+                int_value,
+            } => self.fold_constant_int(location, value, int_value),
 
             Constant::Float { location, value } => self.fold_constant_float(location, value),
 
@@ -892,8 +905,17 @@ pub trait UntypedConstantFolder {
         }
     }
 
-    fn fold_constant_int(&mut self, location: SrcSpan, value: EcoString) -> UntypedConstant {
-        Constant::Int { location, value }
+    fn fold_constant_int(
+        &mut self,
+        location: SrcSpan,
+        value: EcoString,
+        int_value: BigInt,
+    ) -> UntypedConstant {
+        Constant::Int {
+            location,
+            value,
+            int_value,
+        }
     }
 
     fn fold_constant_float(&mut self, location: SrcSpan, value: EcoString) -> UntypedConstant {
@@ -1077,7 +1099,11 @@ pub trait PatternFolder {
     /// You probably don't want to override this method.
     fn update_pattern(&mut self, m: UntypedPattern) -> UntypedPattern {
         match m {
-            Pattern::Int { location, value } => self.fold_pattern_int(location, value),
+            Pattern::Int {
+                location,
+                value,
+                int_value,
+            } => self.fold_pattern_int(location, value, int_value),
 
             Pattern::Float { location, value } => self.fold_pattern_float(location, value),
 
@@ -1151,8 +1177,17 @@ pub trait PatternFolder {
         }
     }
 
-    fn fold_pattern_int(&mut self, location: SrcSpan, value: EcoString) -> UntypedPattern {
-        Pattern::Int { location, value }
+    fn fold_pattern_int(
+        &mut self,
+        location: SrcSpan,
+        value: EcoString,
+        int_value: BigInt,
+    ) -> UntypedPattern {
+        Pattern::Int {
+            location,
+            value,
+            int_value,
+        }
     }
 
     fn fold_pattern_float(&mut self, location: SrcSpan, value: EcoString) -> UntypedPattern {

--- a/compiler-core/src/exhaustiveness/pattern_tests.rs
+++ b/compiler-core/src/exhaustiveness/pattern_tests.rs
@@ -11,6 +11,7 @@ fn register_int() {
     let input = TypedPattern::Int {
         location: SrcSpan::default(),
         value: "123".into(),
+        int_value: 123.into(),
     };
     let id = patterns.register(&input);
     assert_eq!(
@@ -94,6 +95,7 @@ fn register_assign() {
         location: SrcSpan::default(),
         pattern: Box::new(TypedPattern::Int {
             value: "123".into(),
+            int_value: 123.into(),
             location: SrcSpan::default(),
         }),
     };
@@ -124,6 +126,7 @@ fn register_tuple() {
         elems: vec![
             TypedPattern::Int {
                 value: "123".into(),
+                int_value: 123.into(),
                 location: SrcSpan::default(),
             },
             TypedPattern::Float {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -328,6 +328,7 @@ impl<'module> Generator<'module> {
                         location: _,
                         type_: _,
                         value,
+                        int_value: _,
                     } => value.parse().unwrap_or(0),
                     _ => 0,
                 };
@@ -1510,7 +1511,11 @@ fn sized_bit_array_segment_details<'a>(
     let size = match size {
         Some(Opt::Size { value: size, .. }) => {
             let size_int = match *size.clone() {
-                Constant::Int { location: _, value } => value.parse().unwrap_or(0),
+                Constant::Int {
+                    location: _,
+                    value,
+                    int_value: _,
+                } => value.parse().unwrap_or(0),
                 _ => 0,
             };
             if size_int > 0 && size_int % 8 != 0 {

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -262,6 +262,7 @@ impl ModuleDecoder {
         Constant::Int {
             location: Default::default(),
             value: value.into(),
+            int_value: crate::parse::parse_int_value(value).expect("int value to parse as bigint"),
         }
     }
 

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -75,6 +75,7 @@ fn bit_array_segment_option_module(option: TypedConstantBitArraySegmentOption) -
             value: Box::new(Constant::Int {
                 location: Default::default(),
                 value: "1".into(),
+                int_value: 1.into(),
             }),
             options: vec![option],
             type_: type_::int(),
@@ -834,6 +835,7 @@ fn constant_int() {
     let module = constant_module(Constant::Int {
         location: Default::default(),
         value: "100".into(),
+        int_value: 100.into(),
     });
 
     assert_eq!(roundtrip(&module), module);
@@ -867,6 +869,7 @@ fn constant_tuple() {
             Constant::Int {
                 location: Default::default(),
                 value: "1".into(),
+                int_value: 1.into(),
             },
             Constant::Float {
                 location: Default::default(),
@@ -878,6 +881,7 @@ fn constant_tuple() {
                     Constant::Int {
                         location: Default::default(),
                         value: "1".into(),
+                        int_value: 1.into(),
                     },
                     Constant::Float {
                         location: Default::default(),
@@ -900,14 +904,17 @@ fn constant_list() {
             Constant::Int {
                 location: Default::default(),
                 value: "1".into(),
+                int_value: 1.into(),
             },
             Constant::Int {
                 location: Default::default(),
                 value: "2".into(),
+                int_value: 2.into(),
             },
             Constant::Int {
                 location: Default::default(),
                 value: "3".into(),
+                int_value: 3.into(),
             },
         ],
     });
@@ -938,6 +945,7 @@ fn constant_record() {
                 value: Constant::Int {
                     location: Default::default(),
                     value: "1".into(),
+                    int_value: 1.into(),
                 },
             },
         ],
@@ -954,6 +962,7 @@ fn constant_var() {
     let one_original = Constant::Int {
         location: Default::default(),
         value: "1".into(),
+        int_value: 1.into(),
     };
 
     let one = Constant::Var {
@@ -1084,6 +1093,7 @@ fn constant_bit_array_size() {
         value: Box::new(Constant::Int {
             location: Default::default(),
             value: "1".into(),
+            int_value: 1.into(),
         }),
         short_form: false,
     });
@@ -1097,6 +1107,7 @@ fn constant_bit_array_size_short_form() {
         value: Box::new(Constant::Int {
             location: Default::default(),
             value: "1".into(),
+            int_value: 1.into(),
         }),
         short_form: true,
     });

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -565,11 +565,13 @@ where
             })
         } else {
             let value = format!("{prefix}{num}");
+            let int_value = super::parse_int_value(&value).expect("int value to parse as bigint");
             let end_pos = self.get_pos();
             Ok((
                 start_pos,
                 Token::Int {
                     value: value.into(),
+                    int_value,
                 },
                 end_pos,
             ))
@@ -621,11 +623,13 @@ where
                 end_pos,
             )
         } else {
+            let int_value = super::parse_int_value(&value).expect("int value to parse as bigint");
             let end_pos = self.get_pos();
             (
                 start_pos,
                 Token::Int {
                     value: value.into(),
+                    int_value,
                 },
                 end_pos,
             )

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
@@ -16,6 +16,7 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                         end: 7,
                     },
                     value: "2",
+                    int_value: 2,
                 },
                 Int {
                     location: SrcSpan {
@@ -23,6 +24,7 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                         end: 10,
                     },
                     value: "3",
+                    int_value: 3,
                 },
             ],
             clauses: [
@@ -85,6 +87,7 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                                         end: 35,
                                     },
                                     value: "1",
+                                    int_value: 1,
                                 },
                             ),
                         },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bare_expression.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__bare_expression.snap
@@ -10,6 +10,7 @@ expression: "1"
                 end: 1,
             },
             value: "1",
+            int_value: 1,
         },
     ),
 ]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__block_of_one.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__block_of_one.snap
@@ -17,6 +17,7 @@ expression: "{ 1 }"
                             end: 3,
                         },
                         value: "1",
+                        int_value: 1,
                     },
                 ),
             ],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__block_of_two.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__block_of_two.snap
@@ -17,6 +17,7 @@ expression: "{ 1 2 }"
                             end: 3,
                         },
                         value: "1",
+                        int_value: 1,
                     },
                 ),
                 Expression(
@@ -26,6 +27,7 @@ expression: "{ 1 2 }"
                             end: 5,
                         },
                         value: "2",
+                        int_value: 2,
                     },
                 ),
             ],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
@@ -39,6 +39,7 @@ expression: "\nlet tup = #(#(#(#(4))))\n{{{tup.0}.0}.0}.0\n"
                                                     end: 20,
                                                 },
                                                 value: "4",
+                                                int_value: 4,
                                             },
                                         ],
                                     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
@@ -39,6 +39,7 @@ expression: "\nlet tup = #(#(#(#(4))))\ntup.0.0.0.0\n"
                                                     end: 20,
                                                 },
                                                 value: "4",
+                                                int_value: 4,
                                             },
                                         ],
                                     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_block.snap
@@ -17,6 +17,7 @@ expression: "{ 1 { 1.0 2.0 } 3 }"
                             end: 3,
                         },
                         value: "1",
+                        int_value: 1,
                     },
                 ),
                 Expression(
@@ -54,6 +55,7 @@ expression: "{ 1 { 1.0 2.0 } 3 }"
                             end: 17,
                         },
                         value: "3",
+                        int_value: 3,
                     },
                 ),
             ],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
@@ -27,6 +27,7 @@ expression: "\nlet tup = #(#(5, 6))\n{tup.0}.1\n"
                                     end: 16,
                                 },
                                 value: "5",
+                                int_value: 5,
                             },
                             Int {
                                 location: SrcSpan {
@@ -34,6 +35,7 @@ expression: "\nlet tup = #(#(5, 6))\n{tup.0}.1\n"
                                     end: 19,
                                 },
                                 value: "6",
+                                int_value: 6,
                             },
                         ],
                     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
@@ -27,6 +27,7 @@ expression: "\nlet tup = #(#(5, 6))\ntup.0.1\n"
                                     end: 16,
                                 },
                                 value: "5",
+                                int_value: 5,
                             },
                             Int {
                                 location: SrcSpan {
@@ -34,6 +35,7 @@ expression: "\nlet tup = #(#(5, 6))\ntup.0.1\n"
                                     end: 19,
                                 },
                                 value: "6",
+                                int_value: 6,
                             },
                         ],
                     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3.snap
@@ -21,6 +21,7 @@ expression: "let assert [x] = [2]"
                             end: 19,
                         },
                         value: "2",
+                        int_value: 2,
                     },
                 ],
                 tail: None,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
@@ -21,6 +21,7 @@ expression: "let assert [x]: List(Int) = [2]"
                             end: 30,
                         },
                         value: "2",
+                        int_value: 2,
                     },
                 ],
                 tail: None,

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1179,10 +1179,24 @@ fn newline_tokens() {
     assert_eq!(
         make_tokenizer("1\n\n2\n").collect_vec(),
         [
-            Ok((0, Token::Int { value: "1".into() }, 1)),
+            Ok((
+                0,
+                Token::Int {
+                    value: "1".into(),
+                    int_value: 1.into()
+                },
+                1
+            )),
             Ok((1, Token::NewLine, 2)),
             Ok((2, Token::NewLine, 3)),
-            Ok((3, Token::Int { value: "2".into() }, 4)),
+            Ok((
+                3,
+                Token::Int {
+                    value: "2".into(),
+                    int_value: 2.into()
+                },
+                4
+            )),
             Ok((4, Token::NewLine, 5))
         ]
     );

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -1,3 +1,4 @@
+use num_bigint::BigInt;
 use std::fmt;
 
 use ecow::EcoString;
@@ -7,7 +8,7 @@ pub enum Token {
     Name { name: EcoString },
     UpName { name: EcoString },
     DiscardName { name: EcoString },
-    Int { value: EcoString },
+    Int { value: EcoString, int_value: BigInt },
     Float { value: EcoString },
     String { value: EcoString },
     CommentDoc { content: EcoString },
@@ -202,9 +203,12 @@ impl fmt::Display for Token {
             Token::Name { name } | Token::UpName { name } | Token::DiscardName { name } => {
                 name.as_str()
             }
-            Token::Int { value } | Token::Float { value } | Token::String { value } => {
-                value.as_str()
+            Token::Int {
+                value,
+                int_value: _,
             }
+            | Token::Float { value }
+            | Token::String { value } => value.as_str(),
             Token::AmperAmper => "&&",
             Token::As => "as",
             Token::Assert => "assert",

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -839,6 +839,13 @@ pub enum Warning {
         wrongfully_allowed_version: Version,
         feature_kind: FeatureKind,
     },
+
+    /// When targeting JavaScript and an `Int` value is specified that lies
+    /// outside the range `Number.MIN_SAFE_INTEGER` - `Number.MAX_SAFE_INTEGER`.
+    ///
+    JavaScriptIntUnsafe {
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Eq, Copy, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -1025,7 +1032,8 @@ impl Warning {
             | Warning::TodoOrPanicUsedAsFunction { location, .. }
             | Warning::UnreachableCodeAfterPanic { location, .. }
             | Warning::RedundantPipeFunctionCapture { location, .. }
-            | Warning::FeatureRequiresHigherGleamVersion { location, .. } => *location,
+            | Warning::FeatureRequiresHigherGleamVersion { location, .. }
+            | Warning::JavaScriptIntUnsafe { location, .. } => *location,
         }
     }
 

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -428,9 +428,17 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 })
             }
 
-            Pattern::Int { location, value } => {
+            Pattern::Int {
+                location,
+                value,
+                int_value,
+            } => {
                 unify(type_, int()).map_err(|e| convert_unify_error(e, location))?;
-                Ok(Pattern::Int { location, value })
+                Ok(Pattern::Int {
+                    location,
+                    value,
+                    int_value,
+                })
             }
 
             Pattern::Float { location, value } => {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_binary.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_binary.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go() {\n  [\n    0b11111111111111111111111111111111111111111111111111110,\n    0b11111111111111111111111111111111111111111111111111111,\n    0b100000000000000000000000000000000000000000000000000000,\n  ]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  [
+    0b11111111111111111111111111111111111111111111111111110,
+    0b11111111111111111111111111111111111111111111111111111,
+    0b100000000000000000000000000000000000000000000000000000,
+  ]
+}
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:6:5
+  │
+6 │     0b100000000000000000000000000000000000000000000000000000,
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_decimal.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_decimal.snap
@@ -1,0 +1,44 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go() {\n  [\n    9_007_199_254_740_990,\n    9_007_199_254_740_991,\n    9_007_199_254_740_992,\n    -9_007_199_254_740_990,\n    -9_007_199_254_740_991,\n    -9_007_199_254_740_992,\n  ]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  [
+    9_007_199_254_740_990,
+    9_007_199_254_740_991,
+    9_007_199_254_740_992,
+    -9_007_199_254_740_990,
+    -9_007_199_254_740_991,
+    -9_007_199_254_740_992,
+  ]
+}
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:6:5
+  │
+6 │     9_007_199_254_740_992,
+  │     ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.
+
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:9:5
+  │
+9 │     -9_007_199_254_740_992,
+  │     ^^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_hex.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_hex.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go() {\n  [\n    0x1FFFFFFFFFFFFE,\n    0x1FFFFFFFFFFFFF,\n    0x20000000000000,\n  ]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  [
+    0x1FFFFFFFFFFFFE,
+    0x1FFFFFFFFFFFFF,
+    0x20000000000000,
+  ]
+}
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:6:5
+  │
+6 │     0x20000000000000,
+  │     ^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_in_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_in_const.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: pub const i = 9_007_199_254_740_992
+---
+----- SOURCE CODE
+pub const i = 9_007_199_254_740_992
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:1:15
+  │
+1 │ pub const i = 9_007_199_254_740_992
+  │               ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_in_const_tuple.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_in_const_tuple.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub const i = #(9_007_199_254_740_992)"
+---
+----- SOURCE CODE
+pub const i = #(9_007_199_254_740_992)
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:1:17
+  │
+1 │ pub const i = #(9_007_199_254_740_992)
+  │                 ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_in_tuple.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_in_tuple.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go() {\n  #(9_007_199_254_740_992)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  #(9_007_199_254_740_992)
+}
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │   #(9_007_199_254_740_992)
+  │     ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_octal.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_octal.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go() {\n  [\n    0o377777777777777776,\n    0o377777777777777777,\n    0o400000000000000000,\n  ]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  [
+    0o377777777777777776,
+    0o377777777777777777,
+    0o400000000000000000,
+  ]
+}
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:6:5
+  │
+6 │     0o400000000000000000,
+  │     ^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_in_bit_array.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_in_bit_array.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go() {\n  <<9_007_199_254_740_992:64>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  <<9_007_199_254_740_992:64>>
+}
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │   <<9_007_199_254_740_992:64>>
+  │     ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_in_const_bit_array.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_in_const_bit_array.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub const i = <<9_007_199_254_740_992:64>>\n"
+---
+----- SOURCE CODE
+
+pub const i = <<9_007_199_254_740_992:64>>
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:2:17
+  │
+2 │ pub const i = <<9_007_199_254_740_992:64>>
+  │                 ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_size_in_bit_array.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_size_in_bit_array.snap
@@ -1,0 +1,40 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go() {\n  [\n    <<0:9_007_199_254_740_992>>,\n    <<0:size(9_007_199_254_740_992)>>,\n  ]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  [
+    <<0:9_007_199_254_740_992>>,
+    <<0:size(9_007_199_254_740_992)>>,
+  ]
+}
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:4:9
+  │
+4 │     <<0:9_007_199_254_740_992>>,
+  │         ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.
+
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:5:14
+  │
+5 │     <<0:size(9_007_199_254_740_992)>>,
+  │              ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_size_in_const_bit_array.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_segment_size_in_const_bit_array.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub const ints = [\n  <<0:9_007_199_254_740_992>>,\n  <<0:size(9_007_199_254_740_992)>>,\n]\n"
+---
+----- SOURCE CODE
+
+pub const ints = [
+  <<0:9_007_199_254_740_992>>,
+  <<0:size(9_007_199_254_740_992)>>,
+]
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:3:7
+  │
+3 │   <<0:9_007_199_254_740_992>>,
+  │       ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.
+
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:4:12
+  │
+4 │   <<0:size(9_007_199_254_740_992)>>,
+  │            ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    assert_no_warnings, assert_warning, assert_warnings_with_gleam_version,
+    assert_js_warning, assert_no_warnings, assert_warning, assert_warnings_with_gleam_version,
     assert_warnings_with_imports,
 };
 
@@ -2457,5 +2457,135 @@ pub fn main(wibble) {
   }
 }
 ",
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_decimal() {
+    assert_js_warning!(
+        r#"
+pub fn go() {
+  [
+    9_007_199_254_740_990,
+    9_007_199_254_740_991,
+    9_007_199_254_740_992,
+    -9_007_199_254_740_990,
+    -9_007_199_254_740_991,
+    -9_007_199_254_740_992,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_binary() {
+    assert_js_warning!(
+        r#"
+pub fn go() {
+  [
+    0b11111111111111111111111111111111111111111111111111110,
+    0b11111111111111111111111111111111111111111111111111111,
+    0b100000000000000000000000000000000000000000000000000000,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_octal() {
+    assert_js_warning!(
+        r#"
+pub fn go() {
+  [
+    0o377777777777777776,
+    0o377777777777777777,
+    0o400000000000000000,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_hex() {
+    assert_js_warning!(
+        r#"
+pub fn go() {
+  [
+    0x1FFFFFFFFFFFFE,
+    0x1FFFFFFFFFFFFF,
+    0x20000000000000,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_in_tuple() {
+    assert_js_warning!(
+        r#"
+pub fn go() {
+  #(9_007_199_254_740_992)
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_segment_in_bit_array() {
+    assert_js_warning!(
+        r#"
+pub fn go() {
+  <<9_007_199_254_740_992:64>>
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_segment_size_in_bit_array() {
+    assert_js_warning!(
+        r#"
+pub fn go() {
+  [
+    <<0:9_007_199_254_740_992>>,
+    <<0:size(9_007_199_254_740_992)>>,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_in_const() {
+    assert_js_warning!(r#"pub const i = 9_007_199_254_740_992"#);
+}
+
+#[test]
+fn javascript_unsafe_int_in_const_tuple() {
+    assert_js_warning!(r#"pub const i = #(9_007_199_254_740_992)"#);
+}
+
+#[test]
+fn javascript_unsafe_int_segment_in_const_bit_array() {
+    assert_js_warning!(
+        r#"
+pub const i = <<9_007_199_254_740_992:64>>
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_segment_size_in_const_bit_array() {
+    assert_js_warning!(
+        r#"
+pub const ints = [
+  <<0:9_007_199_254_740_992>>,
+  <<0:size(9_007_199_254_740_992)>>,
+]
+"#
     );
 }

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1061,6 +1061,29 @@ See: https://tour.gleam.run/functions/pipelines/",
                         }),
                     }
                 }
+
+                type_::Warning::JavaScriptIntUnsafe { location } => Diagnostic {
+                    title: "Int is outside JavaScript's safe integer range".into(),
+                    text: wrap(
+                        "This integer value is too large to be represented accurately by \
+JavaScript's number type. To avoid this warning integer values must be in the range \
+-(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER properties for more \
+information.",
+                    ),
+                    hint: None,
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        path: path.to_path_buf(),
+                        src: src.clone(),
+                        label: diagnostic::Label {
+                            text: Some("This is not a safe integer value on JavaScript".into()),
+                            span: *location,
+                        },
+                        extra_labels: Vec::new(),
+                    }),
+                },
             },
         }
     }


### PR DESCRIPTION
This PR adds a warning when targeting JavaScript and Int literals or constants outside JavaScript's safe range are encountered.

Fixes #3746.