### PR TITLE
Reduces compiler-wasm binary file size

### DIFF
--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -7,6 +7,7 @@ license-file = "LICENCE"
 
 [features]
 disable-erlang = []
+disable-hide-internal = []
 
 [dependencies]
 # Error message and warning formatting

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Louis Pilfold <louis@lpil.uk>"]
 edition = "2021"
 license-file = "LICENCE"
 
+[features]
+disable-erlang = []
+
 [dependencies]
 # Error message and warning formatting
 codespan-reporting = "0"

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -1,5 +1,3 @@
-use std::sync::OnceLock;
-
 use super::*;
 use crate::type_::{bool, HasType, Type, ValueConstructorVariant};
 
@@ -317,15 +315,10 @@ impl TypedExpr {
     }
 
     pub fn non_zero_compile_time_number(&self) -> bool {
-        use regex::Regex;
-        static NON_ZERO: OnceLock<Regex> = OnceLock::new();
-
         matches!(
             self,
-            Self::Int{ value, .. } | Self::Float { value, .. } if NON_ZERO.get_or_init(||
-
-
-                Regex::new(r"[1-9]").expect("NON_ZERO regex")).is_match(value)
+            Self::Int{ value, .. } | Self::Float { value, .. }
+                if matches!(value.chars().next(), Some('1'..='9'))
         )
     }
 

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -309,6 +309,8 @@ where
                 prelude_location,
             ),
             TargetCodegenConfiguration::Erlang { app_file } => {
+                #[cfg(feature = "disable-erlang")]
+                panic!("Erlang code generation is disabled.");
                 self.perform_erlang_codegen(modules, app_file.as_ref())
             }
         }

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -354,6 +354,12 @@ where
     }
 }
 
+#[cfg(feature = "disable-erlang")]
+fn ensure_gleam_module_does_not_overwrite_standard_erlang_module(input: &Input) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(not(feature = "disable-erlang"))]
 fn ensure_gleam_module_does_not_overwrite_standard_erlang_module(input: &Input) -> Result<()> {
     // We only need to check uncached modules as it's not possible for these
     // to have compiled successfully.

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -914,20 +914,17 @@ mod uri_serde_default_https {
 
 mod package_name {
     use ecow::EcoString;
-    use regex::Regex;
     use serde::Deserializer;
-    use std::sync::OnceLock;
-
-    static PACKAGE_NAME_PATTERN: OnceLock<Regex> = OnceLock::new();
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<EcoString, D::Error>
     where
         D: Deserializer<'de>,
     {
         let name: &str = serde::de::Deserialize::deserialize(deserializer)?;
-        if PACKAGE_NAME_PATTERN
-            .get_or_init(|| Regex::new("^[a-z][a-z0-9_]*$").expect("Package name regex"))
-            .is_match(name)
+        // ^[a-z][a-z0-9_]*$
+        let mut chars = name.chars();
+        if chars.next().map(|ch| ch.is_ascii_lowercase()) == Some(true)
+            && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
         {
             Ok(name.into())
         } else {

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -9,6 +9,9 @@ license-file = "LICENCE"
 # This package compiles to wasm
 crate-type = ["cdylib", "rlib"]
 
+[features]
+reduce-bin-size = ["gleam-core/disable-erlang", "gleam-core/disable-hide-internal"]
+
 [dependencies]
 gleam-core = { path = "../compiler-core" }
 console_error_panic_hook = "0"


### PR DESCRIPTION
Add the `compiler-wasm` feature `reduce-bin-size` which, when enabled, reduces the generated wasm file from 3.7 MB to 2.2 MB.

We achieved this by:
- Adding the `compiler-core` feature `disable-erlang`, which disables erlang code generation
- Replacing the use of regular expressions with iterator code
- Adding the `compiler-core` feature `disable-hide-internal`, which disables hiding of internal methods, which requires the use of the `globset` crate, which in turn requires the use of the `regex` crate

Nothing changes by default, but when the `compiler-wasm` crate is built with the `reduce-bin-size` feature enabled, the compiler do it's magic and no code from the erlang backend and the `globset` and `regex` crates appears in the wasm file.