### PR TITLE
Skip existing files when skip git option is enable

### DIFF
--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -308,7 +308,8 @@ fn validate_root_folder(creator: &Creator) -> Result<(), Error> {
 
     for t in FileToCreate::iter() {
         let full_path = t.location(creator);
-        if full_path.exists() {
+        let content = t.contents(creator);
+        if full_path.exists() && content.is_some() {
             duplicate_files.push(full_path);
         }
     }

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -297,3 +297,31 @@ fn conflict_with_existing_files() {
         })
     );
 }
+
+#[test]
+fn skip_existing_git_files_when_skip_git_is_true() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
+
+    crate::fs::mkdir(&path).unwrap();
+    let file_path = PathBuf::from(&path).join(".gitignore");
+
+    let _ = std::fs::File::create(file_path).unwrap();
+
+    let creator = super::Creator::new(
+        super::NewOptions {
+            project_root: path.to_string(),
+            template: super::Template::Erlang,
+            name: None,
+            skip_git: true,
+            skip_github: true,
+        },
+        "1.0.0-gleam",
+    )
+    .unwrap();
+
+    creator.run().unwrap();
+
+    assert!(path.join("README.md").exists());
+    assert!(path.join(".gitignore").exists());
+}


### PR DESCRIPTION
even with the --skip-git option the CLI ask to remove the files

tests ensure we can skip files that are none or without content:

```
---- new::tests::skip_existing_git_files_when_skip_git_is_true stdout ----
thread 'new::tests::skip_existing_git_files_when_skip_git_is_true' panicked at compiler-cli/src/new/tests.rs:321:6:
called `Result::unwrap()` on an `Err` value: OutputFilesAlreadyExist { file_names: ["/tmp/.tmpRvY1Nb/my_project/.gitignore"] }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```