### PR TITLE
Fix constructor functions in JavaScript guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,6 +386,10 @@
   annotation of a parameter of an anonymous function would do nothing.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where referencing record constructors in JavaScript guards but
+  not calling them could produce invalid code.
+  ([PgBiel](https://github.com/PgBiel))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1240,6 +1240,23 @@ pub(crate) fn guard_constant_expression<'a>(
                     tracker.error_used = true;
                 }
             }
+
+            // If there's no arguments and the type is a function that takes
+            // arguments then this is the constructor being referenced, not the
+            // function being called.
+            if let Some(arity) = type_.fn_arity() {
+                if args.is_empty() && arity != 0 {
+                    let arity = arity as u16;
+                    return Ok(record_constructor(
+                        type_.clone(),
+                        None,
+                        name,
+                        arity,
+                        tracker,
+                    ));
+                }
+            }
+
             let field_values: Vec<_> = args
                 .iter()
                 .map(|arg| guard_constant_expression(assignments, tracker, &arg.value))

--- a/compiler-core/src/javascript/tests/case_clause_guards.rs
+++ b/compiler-core/src/javascript/tests/case_clause_guards.rs
@@ -517,3 +517,17 @@ fn func(x) {
 "#,
     );
 }
+
+// Variant of https://github.com/lpil/decode/pull/6
+#[test]
+fn constructor_function_in_guard() {
+    assert_js!(
+        r#"fn func(x) {
+    case [] {
+        _ if [] == [ Ok ] -> True
+        _ -> False
+    }
+}
+    "#,
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/javascript/tests/case_clause_guards.rs
+expression: "fn func(x) {\n    case [] {\n        _ if [] == [ Ok ] -> True\n        _ -> False\n    }\n}\n    "
+snapshot_kind: text
+---
+----- SOURCE CODE
+fn func(x) {
+    case [] {
+        _ if [] == [ Ok ] -> True
+        _ -> False
+    }
+}
+    
+
+----- COMPILED JAVASCRIPT
+import { Ok, toList, isEqual } from "../gleam.mjs";
+
+function func(x) {
+  let $ = toList([]);
+  if (isEqual(toList([]), toList([(var0) => { return new Ok(var0); }]))) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_aliased_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_aliased_ok.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/javascript/tests/case_clause_guards.rs
 expression: "import gleam.{Ok as Y}\npub type X {\n  Ok\n}\nfn func() {\n  case Y {\n    y if y == Y -> True\n    _ -> False\n  }\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 import gleam.{Ok as Y}
@@ -23,7 +24,7 @@ export class Ok extends $CustomType {}
 
 function func() {
   let $ = (var0) => { return new Y(var0); };
-  if (isEqual($, new Y())) {
+  if (isEqual($, (var0) => { return new Y(var0); })) {
     let y = $;
     return true;
   } else {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/javascript/tests/case_clause_guards.rs
 expression: "import gleam\npub type X {\n  Ok\n}\nfn func(x) {\n  case gleam.Ok {\n    _ if [] == [ gleam.Ok ] -> True\n    _ -> False\n  }\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 import gleam
@@ -17,13 +18,13 @@ fn func(x) {
 
 ----- COMPILED JAVASCRIPT
 import * as $gleam from "../gleam.mjs";
-import { toList, CustomType as $CustomType, isEqual } from "../gleam.mjs";
+import { Ok, toList, CustomType as $CustomType, isEqual } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
 
 function func(x) {
   let $ = (var0) => { return new $gleam.Ok(var0); };
-  if (isEqual(toList([]), toList([new $gleam.Ok()]))) {
+  if (isEqual(toList([]), toList([(var0) => { return new Ok(var0); }]))) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
The fix to https://github.com/lpil/decode/pull/6 was only applied to constructor functions in constants, but not in guards. This PR fixes that.