### PR TITLE
Report duplicate label error in record updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,6 +394,10 @@
   wouldn't emit a warning when the minimum specified Gleam version was < 1.4.0.
   ([yoshi](https://github.com/joshi-monster))
 
+- Fixed a bug where no error would be reported when duplicate labelled
+  arguments were supplied in a record update.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.5.1 - 2024-09-26
 
 ### Bug Fixes

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2470,6 +2470,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             }
         }
 
+        let mut seen_labels = HashSet::new();
+
         let args: Vec<TypedRecordUpdateArg> = args
             .iter()
             .map(
@@ -2489,6 +2491,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     if arg.uses_label_shorthand() {
                         self.track_feature_usage(FeatureKind::LabelShorthandSyntax, *location);
                     }
+
+                    if seen_labels.contains(label) {
+                        return Err(Error::DuplicateArgument {
+                            location: *location,
+                            label: label.clone(),
+                        });
+                    }
+                    _ = seen_labels.insert(label.clone());
 
                     // Check that the update argument unifies with the corresponding
                     // field in the record contained within the record variable. We

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2624,3 +2624,18 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+// https://github.com/gleam-lang/gleam/issues/3783
+fn duplicate_fields_in_record_update_reports_error() {
+    assert_module_error!(
+        "
+pub type Wibble { Wibble(thing: Int, other: Int) }
+
+pub fn main() {
+  let wibble = Wibble(1, 2)
+  let wobble = Wibble(..wibble, thing: 1, thing: 2)
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fields_in_record_update_reports_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fields_in_record_update_reports_error.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble { Wibble(thing: Int, other: Int) }\n\npub fn main() {\n  let wibble = Wibble(1, 2)\n  let wobble = Wibble(..wibble, thing: 1, thing: 2)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wibble { Wibble(thing: Int, other: Int) }
+
+pub fn main() {
+  let wibble = Wibble(1, 2)
+  let wobble = Wibble(..wibble, thing: 1, thing: 2)
+}
+
+
+----- ERROR
+error: Duplicate argument
+  ┌─ /src/one/two.gleam:6:43
+  │
+6 │   let wobble = Wibble(..wibble, thing: 1, thing: 2)
+  │                                           ^^^^^^^^
+
+The labelled argument `thing` has already been supplied.


### PR DESCRIPTION
Fixes #3783
It sounds like this will be fixed when record updates are reworked anyway, but I wanted to fix it as soon as possible in case we release before that change occurs. 