### PR TITLE
Compile-time evaluate constant BitArray int segments on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   deprecated in code such as `@target`.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- When targeting JavaScript the compiler now generates faster and smaller code
+  for `Int` values in bit array expressions and patterns by evaluating them at
+  compile time where possible.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ### Build tool
 
 - Improved the error message you get when trying to add a package that doesn't

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "lsp-server",
  "lsp-types",
  "num-bigint",
+ "num-traits",
  "pathdiff",
  "petgraph",
  "pretty_assertions",
@@ -1440,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -46,6 +46,7 @@ unicode-segmentation = "1.12.0"
 bimap = "0.6.3"
 # Parsing of arbitrary width int values
 num-bigint = "0.4.6"
+num-traits = "0.2.19"
 async-trait.workspace = true
 base16.workspace = true
 bytes.workspace = true

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -1,3 +1,4 @@
+use num_bigint::BigInt;
 use std::sync::OnceLock;
 
 use super::{expression::is_js_scalar, *};
@@ -580,28 +581,49 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                     {
                         let details = Self::sized_bit_array_segment_details(segment)?;
 
-                        let start = offset.bytes;
-                        let increment = details.size / 8;
-                        let end = offset.bytes + increment;
-
-                        if segment.type_ == crate::type_::int() {
-                            if details.size == 8 && !details.is_signed {
-                                self.push_byte_at(offset.bytes);
-                            } else {
-                                self.push_int_from_slice(
-                                    start,
-                                    end,
+                        match segment.value.as_ref() {
+                            Pattern::Int { int_value, .. }
+                                if details.size <= SAFE_INT_SEGMENT_MAX_SIZE =>
+                            {
+                                let bytes = bit_array_segment_int_value_to_bytes(
+                                    (*int_value).clone(),
+                                    BigInt::from(details.size),
                                     details.endianness,
-                                    details.is_signed,
-                                );
-                            }
-                        } else {
-                            self.push_float_from_slice(start, end, details.endianness);
-                        }
+                                )?;
 
-                        self.traverse_pattern(subject, &segment.value)?;
-                        self.pop();
-                        offset.increment(increment);
+                                for byte in bytes {
+                                    self.push_byte_at(offset.bytes);
+                                    self.push_equality_check(subject.clone(), docvec![byte]);
+                                    self.pop();
+                                    offset.increment(1);
+                                }
+                            }
+
+                            _ => {
+                                let start = offset.bytes;
+                                let increment = details.size / 8;
+                                let end = offset.bytes + increment;
+
+                                if segment.type_ == crate::type_::int() {
+                                    if details.size == 8 && !details.is_signed {
+                                        self.push_byte_at(offset.bytes);
+                                    } else {
+                                        self.push_int_from_slice(
+                                            start,
+                                            end,
+                                            details.endianness,
+                                            details.is_signed,
+                                        );
+                                    }
+                                } else {
+                                    self.push_float_from_slice(start, end, details.endianness);
+                                }
+
+                                self.traverse_pattern(subject, &segment.value)?;
+                                self.pop();
+                                offset.increment(increment);
+                            }
+                        }
                     } else {
                         match segment.options.as_slice() {
                             [Opt::Bytes { .. }] => {

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -111,7 +111,7 @@ fn go() {
 }
 
 #[test]
-fn sized() {
+fn sized_constant_value() {
     assert_js!(
         r#"
 fn go() {
@@ -122,7 +122,51 @@ fn go() {
 }
 
 #[test]
-fn sized_big_endian() {
+fn sized_dynamic_value() {
+    assert_js!(
+        r#"
+fn go(i: Int) {
+  <<i:64>>
+}
+"#,
+    );
+}
+
+#[test]
+fn sized_constant_value_positive_overflow() {
+    assert_js!(
+        r#"
+fn go() {
+  <<80_000:16>>
+}
+"#,
+    );
+}
+
+#[test]
+fn sized_constant_value_negative_overflow() {
+    assert_js!(
+        r#"
+fn go() {
+  <<-80_000:16>>
+}
+"#,
+    );
+}
+
+#[test]
+fn sized_constant_value_max_size_for_compile_time_evaluation() {
+    assert_js!(
+        r#"
+fn go() {
+  <<-1:48>>
+}
+"#,
+    );
+}
+
+#[test]
+fn sized_big_endian_constant_value() {
     assert_js!(
         r#"
 fn go() {
@@ -133,7 +177,18 @@ fn go() {
 }
 
 #[test]
-fn sized_little_endian() {
+fn sized_big_endian_dynamic_value() {
+    assert_js!(
+        r#"
+fn go(i: Int) {
+  <<i:16-big>>
+}
+"#,
+    );
+}
+
+#[test]
+fn sized_little_endian_constant_value() {
     assert_js!(
         r#"
 fn go() {
@@ -144,11 +199,33 @@ fn go() {
 }
 
 #[test]
-fn explicit_sized() {
+fn sized_little_endian_dynamic_value() {
+    assert_js!(
+        r#"
+fn go(i: Int) {
+  <<i:16-little>>
+}
+"#,
+    );
+}
+
+#[test]
+fn explicit_sized_constant_value() {
     assert_js!(
         r#"
 fn go() {
-  <<256:size(64)>>
+  <<256:size(32)>>
+}
+"#,
+    );
+}
+
+#[test]
+fn explicit_sized_dynamic_value() {
+    assert_js!(
+        r#"
+fn go(i: Int) {
+  <<i:size(32)>>
 }
 "#,
     );
@@ -298,11 +375,33 @@ fn go(x) {
 }
 
 #[test]
+fn match_sized_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1234:16, 123:8>> = x
+}
+"#,
+    );
+}
+
+#[test]
 fn match_unsigned() {
     assert_js!(
         r#"
 fn go(x) {
   let assert <<a:unsigned>> = x
+}
+"#,
+    );
+}
+
+#[test]
+fn match_unsigned_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<-2:unsigned>> = x
 }
 "#,
     );
@@ -320,11 +419,33 @@ fn go(x) {
 }
 
 #[test]
+fn match_signed_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<-1:signed>> = x
+}
+"#,
+    );
+}
+
+#[test]
 fn match_sized_big_endian() {
     assert_js!(
         r#"
 fn go(x) {
   let assert <<a:16-big>> = x
+}
+"#,
+    );
+}
+
+#[test]
+fn match_sized_big_endian_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1234:16-big>> = x
 }
 "#,
     );
@@ -342,11 +463,33 @@ fn go(x) {
 }
 
 #[test]
+fn match_sized_little_endian_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1234:16-little>> = x
+}
+"#,
+    );
+}
+
+#[test]
 fn match_sized_big_endian_unsigned() {
     assert_js!(
         r#"
 fn go(x) {
   let assert <<a:16-big-unsigned>> = x
+}
+"#,
+    );
+}
+
+#[test]
+fn match_sized_big_endian_unsigned_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1234:16-big-unsigned>> = x
 }
 "#,
     );
@@ -364,6 +507,17 @@ fn go(x) {
 }
 
 #[test]
+fn match_sized_big_endian_signed_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1234:16-big-signed>> = x
+}
+"#,
+    );
+}
+
+#[test]
 fn match_sized_little_endian_unsigned() {
     assert_js!(
         r#"
@@ -375,11 +529,33 @@ fn go(x) {
 }
 
 #[test]
+fn match_sized_little_endian_unsigned_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1234:16-little-unsigned>> = x
+}
+"#,
+    );
+}
+
+#[test]
 fn match_sized_little_endian_signed() {
     assert_js!(
         r#"
 fn go(x) {
   let assert <<a:16-little-signed>> = x
+}
+"#,
+    );
+}
+
+#[test]
+fn match_sized_little_endian_signed_constant_pattern() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1234:16-little-signed>> = x
 }
 "#,
     );
@@ -422,6 +598,17 @@ fn go(x) {
 
 #[test]
 fn match_sized_value() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<i:16>> = x
+}
+"#,
+    );
+}
+
+#[test]
+fn match_sized_value_constant_pattern() {
     assert_js!(
         r#"
 fn go(x) {
@@ -555,6 +742,7 @@ fn as_module_const() {
             "Gleam":utf8,
             4.2:float,
             4.2:32-float,
+            -1:64,
             <<
               <<1, 2, 3>>:bits,
               "Gleam":utf8,
@@ -569,7 +757,18 @@ fn as_module_const() {
 fn negative_size() {
     assert_js!(
         r#"
-fn go() {
+fn go(x: Int) {
+  <<x:size(-1)>>
+}
+"#,
+    );
+}
+
+#[test]
+fn negative_size_constant_value() {
+    assert_js!(
+        r#"
+fn go(x: Int) {
   <<1:size(-1)>>
 }
 "#,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__as_module_const.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__as_module_const.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\n          pub const data = <<\n            0x1,\n            2,\n            2:size(16),\n            0x4:size(32),\n            -1:32,\n            \"Gleam\":utf8,\n            4.2:float,\n            4.2:32-float,\n            <<\n              <<1, 2, 3>>:bits,\n              \"Gleam\":utf8,\n              1024\n            >>:bits\n          >>\n        "
+expression: "\n          pub const data = <<\n            0x1,\n            2,\n            2:size(16),\n            0x4:size(32),\n            -1:32,\n            \"Gleam\":utf8,\n            4.2:float,\n            4.2:32-float,\n            -1:64,\n            <<\n              <<1, 2, 3>>:bits,\n              \"Gleam\":utf8,\n              1024\n            >>:bits\n          >>\n        "
 ---
 ----- SOURCE CODE
 
@@ -13,6 +13,7 @@ expression: "\n          pub const data = <<\n            0x1,\n            2,\n
             "Gleam":utf8,
             4.2:float,
             4.2:32-float,
+            -1:64,
             <<
               <<1, 2, 3>>:bits,
               "Gleam":utf8,
@@ -25,17 +26,18 @@ expression: "\n          pub const data = <<\n            0x1,\n            2,\n
 import { toBitArray, sizedInt, stringBits, sizedFloat } from "../gleam.mjs";
 
 export const data = /* @__PURE__ */ toBitArray([
-  0x1,
+  1,
   2,
-  sizedInt(2, 16, true),
-  sizedInt(0x4, 32, true),
-  sizedInt(-1, 32, true),
+  0, 2,
+  0, 0, 0, 4,
+  255, 255, 255, 255,
   stringBits("Gleam"),
   sizedFloat(4.2, 64, true),
   sizedFloat(4.2, 32, true),
+  sizedInt(-1, 64, true),
   /* @__PURE__ */ toBitArray([
     /* @__PURE__ */ toBitArray([1, 2, 3]).buffer,
     stringBits("Gleam"),
-    1024,
+    0,
   ]).buffer,
 ]);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__explicit_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__explicit_sized.snap
@@ -1,17 +1,19 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:size(64)>>\n}\n"
+expression: "\nfn go(i: Int) {\n  <<256:size(32)>>\n  <<i:size(32)>>\n}\n"
 ---
 ----- SOURCE CODE
 
-fn go() {
-  <<256:size(64)>>
+fn go(i: Int) {
+  <<256:size(32)>>
+  <<i:size(32)>>
 }
 
 
 ----- COMPILED JAVASCRIPT
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
-function go() {
-  return toBitArray([sizedInt(256, 64, true)]);
+function go(i) {
+  toBitArray([0, 0, 1, 0]);
+  return toBitArray([sizedInt(i, 32, true)]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__explicit_sized_constant_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__explicit_sized_constant_value.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go() {\n  <<256:size(32)>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go() {
-  <<256:int>>
+  <<256:size(32)>>
 }
 
 
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([0]);
+  return toBitArray([0, 0, 1, 0]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__explicit_sized_dynamic_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__explicit_sized_dynamic_value.snap
@@ -1,12 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(i: Int) {\n  <<256:16-little>>\n  <<i:16-little>>\n}\n"
+expression: "\nfn go(i: Int) {\n  <<i:size(32)>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(i: Int) {
-  <<256:16-little>>
-  <<i:16-little>>
+  <<i:size(32)>>
 }
 
 
@@ -14,6 +13,5 @@ fn go(i: Int) {
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
 function go(i) {
-  toBitArray([0, 1]);
-  return toBitArray([sizedInt(i, 16, false)]);
+  return toBitArray([sizedInt(i, 32, true)]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<-1:signed>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<-1:signed>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 255 || !(x.length == 1)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<1234:16-big>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<1234:16-big>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 4 || x.byteAt(1) !== 210 || !(x.length == 2)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<1234:16-big-signed>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<1234:16-big-signed>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 4 || x.byteAt(1) !== 210 || !(x.length == 2)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<1234:16-big-unsigned>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<1234:16-big-unsigned>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 4 || x.byteAt(1) !== 210 || !(x.length == 2)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<1234:16, 123:8>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<1234:16, 123:8>> = x
 }
 
 
@@ -13,7 +13,12 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (
+    x.byteAt(0) !== 4 ||
+    x.byteAt(1) !== 210 ||
+    x.byteAt(2) !== 123 ||
+    !(x.length == 3)
+  ) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +28,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<1234:16-little>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<1234:16-little>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 210 || x.byteAt(1) !== 4 || !(x.length == 2)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<1234:16-little-signed>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<1234:16-little-signed>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 210 || x.byteAt(1) !== 4 || !(x.length == 2)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<1234:16-little-unsigned>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<1234:16-little-unsigned>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 210 || x.byteAt(1) !== 4 || !(x.length == 2)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<258:16>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<258:16>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 1 || x.byteAt(1) !== 2 || !(x.length == 2)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned_constant_pattern.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(x) {\n  let assert <<i:16>> = x\n}\n"
+expression: "\nfn go(x) {\n  let assert <<-2:unsigned>> = x\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(x) {
-  let assert <<i:16>> = x
+  let assert <<-2:unsigned>> = x
 }
 
 
@@ -13,7 +13,7 @@ fn go(x) {
 import { makeError } from "../gleam.mjs";
 
 function go(x) {
-  if (!(x.length == 2)) {
+  if (x.byteAt(0) !== 254 || !(x.length == 1)) {
     throw makeError(
       "let_assert",
       "my/mod",
@@ -23,6 +23,5 @@ function go(x) {
       { value: x }
     )
   }
-  let i = x.intFromSlice(0, 2, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size.snap
@@ -1,17 +1,17 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<1:size(-1)>>\n}\n"
+expression: "\nfn go(x: Int) {\n  <<x:size(-1)>>\n}\n"
 ---
 ----- SOURCE CODE
 
-fn go() {
-  <<1:size(-1)>>
+fn go(x: Int) {
+  <<x:size(-1)>>
 }
 
 
 ----- COMPILED JAVASCRIPT
-import { toBitArray, sizedInt } from "../gleam.mjs";
+import { toBitArray } from "../gleam.mjs";
 
-function go() {
-  return toBitArray([sizedInt(1, -1, true)]);
+function go(x) {
+  return toBitArray([]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size_constant_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size_constant_value.snap
@@ -1,17 +1,17 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go(x: Int) {\n  <<1:size(-1)>>\n}\n"
 ---
 ----- SOURCE CODE
 
-fn go() {
-  <<256:int>>
+fn go(x: Int) {
+  <<1:size(-1)>>
 }
 
 
 ----- COMPILED JAVASCRIPT
 import { toBitArray } from "../gleam.mjs";
 
-function go() {
-  return toBitArray([0]);
+function go(x) {
+  return toBitArray([]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__one.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__one.snap
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([256]);
+  return toBitArray([0]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_big_endian.snap
@@ -1,17 +1,19 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:16-big>>\n}\n"
+expression: "\nfn go(i: Int) {\n  <<256:16-big>>\n  <<i:16-big>>\n}\n"
 ---
 ----- SOURCE CODE
 
-fn go() {
+fn go(i: Int) {
   <<256:16-big>>
+  <<i:16-big>>
 }
 
 
 ----- COMPILED JAVASCRIPT
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
-function go() {
-  return toBitArray([sizedInt(256, 16, true)]);
+function go(i) {
+  toBitArray([1, 0]);
+  return toBitArray([sizedInt(i, 16, true)]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_big_endian_constant_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_big_endian_constant_value.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go() {\n  <<256:16-big>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go() {
-  <<256:int>>
+  <<256:16-big>>
 }
 
 
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([0]);
+  return toBitArray([1, 0]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_big_endian_dynamic_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_big_endian_dynamic_value.snap
@@ -1,12 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(i: Int) {\n  <<256:16-little>>\n  <<i:16-little>>\n}\n"
+expression: "\nfn go(i: Int) {\n  <<i:16-big>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(i: Int) {
-  <<256:16-little>>
-  <<i:16-little>>
+  <<i:16-big>>
 }
 
 
@@ -14,6 +13,5 @@ fn go(i: Int) {
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
 function go(i) {
-  toBitArray([0, 1]);
-  return toBitArray([sizedInt(i, 16, false)]);
+  return toBitArray([sizedInt(i, 16, true)]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn go() {\n  <<256:64>>\n}\n"
+---
+----- SOURCE CODE
+
+fn go() {
+  <<256:64>>
+}
+
+
+----- COMPILED JAVASCRIPT
+import { toBitArray, sizedInt } from "../gleam.mjs";
+
+function go() {
+  return toBitArray([sizedInt(256, 64, true)]);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_max_size_for_compile_time_evaluation.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_max_size_for_compile_time_evaluation.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go() {\n  <<-1:48>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go() {
-  <<256:int>>
+  <<-1:48>>
 }
 
 
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([0]);
+  return toBitArray([255, 255, 255, 255, 255, 255]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_negative_overflow.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_negative_overflow.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go() {\n  <<-80_000:16>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go() {
-  <<256:int>>
+  <<-80_000:16>>
 }
 
 
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([0]);
+  return toBitArray([199, 128]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_positive_overflow.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_positive_overflow.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go() {\n  <<80_000:16>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go() {
-  <<256:int>>
+  <<80_000:16>>
 }
 
 
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([0]);
+  return toBitArray([56, 128]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_requiring_modulus.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_constant_value_requiring_modulus.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go() {\n  <<80_000:16>>\n  <<-80_000:16>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go() {
-  <<256:int>>
+  <<80_000:16>>
+  <<-80_000:16>>
 }
 
 
@@ -13,5 +14,6 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([0]);
+  toBitArray([56, 128]);
+  return toBitArray([199, 128]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_dynamic_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_dynamic_value.snap
@@ -1,12 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(i: Int) {\n  <<256:16-little>>\n  <<i:16-little>>\n}\n"
+expression: "\nfn go(i: Int) {\n  <<i:64>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(i: Int) {
-  <<256:16-little>>
-  <<i:16-little>>
+  <<i:64>>
 }
 
 
@@ -14,6 +13,5 @@ fn go(i: Int) {
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
 function go(i) {
-  toBitArray([0, 1]);
-  return toBitArray([sizedInt(i, 16, false)]);
+  return toBitArray([sizedInt(i, 64, true)]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_little_endian_constant_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_little_endian_constant_value.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:int>>\n}\n"
+expression: "\nfn go() {\n  <<256:16-little>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go() {
-  <<256:int>>
+  <<256:16-little>>
 }
 
 
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([0]);
+  return toBitArray([0, 1]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_little_endian_dynamic_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_little_endian_dynamic_value.snap
@@ -1,11 +1,10 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\nfn go(i: Int) {\n  <<256:16-little>>\n  <<i:16-little>>\n}\n"
+expression: "\nfn go(i: Int) {\n  <<i:16-little>>\n}\n"
 ---
 ----- SOURCE CODE
 
 fn go(i: Int) {
-  <<256:16-little>>
   <<i:16-little>>
 }
 
@@ -14,6 +13,5 @@ fn go(i: Int) {
 import { toBitArray, sizedInt } from "../gleam.mjs";
 
 function go(i) {
-  toBitArray([0, 1]);
   return toBitArray([sizedInt(i, 16, false)]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_with_compile_time_evaluation.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__sized_with_compile_time_evaluation.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn go() {\n  <<0:8>>\n  <<4000:16>>\n  <<80_000:16>>\n  <<-80_000:16>>\n  <<-1:48>>\n}\n"
+---
+----- SOURCE CODE
+
+fn go() {
+  <<0:8>>
+  <<4000:16>>
+  <<80_000:16>>
+  <<-80_000:16>>
+  <<-1:48>>
+}
+
+
+----- COMPILED JAVASCRIPT
+import { toBitArray } from "../gleam.mjs";
+
+function go() {
+  toBitArray([0]);
+  toBitArray([15, 160]);
+  toBitArray([56, 128]);
+  toBitArray([199, 128]);
+  return toBitArray([255, 255, 255, 255, 255, 255]);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__two.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__two.snap
@@ -13,5 +13,5 @@ fn go() {
 import { toBitArray } from "../gleam.mjs";
 
 function go() {
-  return toBitArray([256, 4]);
+  return toBitArray([0, 4]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__utf8.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__utf8.snap
@@ -13,5 +13,5 @@ fn go(x) {
 import { toBitArray, stringBits } from "../gleam.mjs";
 
 function go(x) {
-  return toBitArray([256, 4, x, stringBits("Gleam")]);
+  return toBitArray([0, 4, x, stringBits("Gleam")]);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__variable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__variable.snap
@@ -13,5 +13,5 @@ fn go(x) {
 import { toBitArray } from "../gleam.mjs";
 
 function go(x) {
-  return toBitArray([256, 4, x]);
+  return toBitArray([0, 4, x]);
 }

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -1021,40 +1021,87 @@ fn bit_array_target_tests() -> List(Test) {
 
 fn sized_bit_array_tests() -> List(Test) {
   [
-    "<<1>> == <<257:size(8)>>"
-    |> example(fn() { assert_equal(True, <<1>> == <<257:size(8)>>) }),
-    "<<1, 1>> == <<257:size(16)>>"
-    |> example(fn() { assert_equal(True, <<1, 1>> == <<257:size(16)>>) }),
-    "<<1, 1>> == <<257:size(24)>>"
-    |> example(fn() { assert_equal(True, <<0, 1, 1>> == <<257:size(24)>>) }),
-    "<<1, 0, 0, 0, 1>> == <<4294967297:size(40)>>"
-    |> example(fn() {
-      assert_equal(True, <<1, 0, 0, 0, 1>> == <<4_294_967_297:size(40)>>)
-    }),
+    "<<257:size(8)>> == <<1>>"
+      |> example(fn() { assert_equal(True, <<257:size(8)>> == <<1>>) }),
+    "let i = 257\n<<i:size(8)>> == <<1>>"
+      |> example(fn() {
+        let i = 257
+        assert_equal(True, <<i:size(8)>> == <<1>>)
+      }),
+    "<<257:size(16)>> == <<1, 1>>"
+      |> example(fn() { assert_equal(True, <<257:size(16)>> == <<1, 1>>) }),
+    "let i = 257\n<<i:size(16)>> == <<1, 1>>"
+      |> example(fn() {
+        let i = 257
+        assert_equal(True, <<i:size(16)>> == <<1, 1>>)
+      }),
+    "<<257:size(24)>> == <<1, 1>>"
+      |> example(fn() { assert_equal(True, <<257:size(24)>> == <<0, 1, 1>>) }),
+    "let i = 257\n<<i:size(24)>> == <<1, 1>>"
+      |> example(fn() {
+        let i = 257
+        assert_equal(True, <<i:size(24)>> == <<0, 1, 1>>)
+      }),
+    "<<4294967297:size(40)>> == <<1, 0, 0, 0, 1>>"
+      |> example(fn() {
+        assert_equal(True, <<4_294_967_297:size(40)>> == <<1, 0, 0, 0, 1>>)
+      }),
+    "let i = 4294967297\n<<i:size(40)>> == <<1, 0, 0, 0, 1>>"
+      |> example(fn() {
+        let i = 4_294_967_297
+        assert_equal(True, <<i:size(40)>> == <<1, 0, 0, 0, 1>>)
+      }),
     "<<100_000:24-little>> == <<160, 134, 1>>"
-    |> example(fn() {
-      assert_equal(True, <<100_000:24-little>> == <<160, 134, 1>>)
-    }),
+      |> example(fn() {
+        assert_equal(True, <<100_000:24-little>> == <<160, 134, 1>>)
+      }),
+    "let i = 100_000\n<<i:24-little>> == <<160, 134, 1>>"
+      |> example(fn() {
+        let i = 100_000
+        assert_equal(True, <<i:24-little>> == <<160, 134, 1>>)
+      }),
     "<<-1:32-big>> == <<255, 255, 255, 255>>"
-    |> example(fn() {
-      assert_equal(True, <<-1:32-big>> == <<255, 255, 255, 255>>)
-    }),
+      |> example(fn() {
+        assert_equal(True, <<-1:32-big>> == <<255, 255, 255, 255>>)
+      }),
+    "let i = -1\n<<i:32-big>> == <<255, 255, 255, 255>>"
+      |> example(fn() {
+        let i = -1
+        assert_equal(True, <<i:32-big>> == <<255, 255, 255, 255>>)
+      }),
     "<<100_000_000_000:32-little>> == <<0, 232, 118, 72>>"
-    |> example(fn() {
-      assert_equal(True, <<100_000_000_000:32-little>> == <<0, 232, 118, 72>>)
-    }),
-    "<<>> == <<256:size(-1)>>"
-    |> example(fn() { assert_equal(True, <<>> == <<256:size(-1)>>) }),
+      |> example(fn() {
+        assert_equal(True, <<100_000_000_000:32-little>> == <<0, 232, 118, 72>>)
+      }),
+    "let i = 100_000_000_000\n<<i:32-little>> == <<0, 232, 118, 72>>"
+      |> example(fn() {
+        let i = 100_000_000_000
+        assert_equal(True, <<i:32-little>> == <<0, 232, 118, 72>>)
+      }),
+    "<<256:size(-1)>> == <<>>"
+      |> example(fn() { assert_equal(True, <<>> == <<256:size(-1)>>) }),
+    "let i = 256\n<<i:size(-1)>> == <<>>"
+      |> example(fn() {
+        let i = 256
+        assert_equal(True, <<i:size(-1)>> == <<>>)
+      }),
     // JS Number.MAX_SAFE_INTEGER
-    "<<0, 31, 255, 255, 255, 255, 255, 255>> == <<9007199254740991:size(64)>>"
-    |> example(fn() {
-      assert_equal(
-        True,
-        <<0, 31, 255, 255, 255, 255, 255, 255>> == <<
-          9_007_199_254_740_991:size(64),
-        >>,
-      )
-    }),
+    "<<9_007_199_254_740_991:size(64)>> == <<0, 31, 255, 255, 255, 255, 255, 255>>"
+      |> example(fn() {
+        assert_equal(
+          True,
+          <<9_007_199_254_740_991:size(64)>>
+            == <<0, 31, 255, 255, 255, 255, 255, 255>>,
+        )
+      }),
+    "let i = 9_007_199_254_740_991\n<<i:size(64)>> == <<0, 31, 255, 255, 255, 255, 255, 255>>"
+      |> example(fn() {
+        let i = 9_007_199_254_740_991
+        assert_equal(
+          True,
+          <<i:size(64)>> == <<0, 31, 255, 255, 255, 255, 255, 255>>,
+        )
+      }),
   ]
 }
 


### PR DESCRIPTION
Implements https://github.com/gleam-lang/gleam/discussions/3724.

## Details

1. `Int`s in bit array expressions with a known value and size at compile time are now evaluated to bytes instead of using `sizedInt()` at runtime.

2. `Int`s in bit array patterns with a known value and size at compile time are now evaluated then matched byte-wise instead of using `intFromSlice()` at runtime.

3. The above is currently limited to `Int` sizes <= 48 bits in order to be under the JS safe integer limit, because otherwise:
   1. Code such as `<<0:8192>>` would evaluate to `[0,0,0,0, ...]`to 1024 entries, which seems undesirable (though I'm not sure if such code is commonly encountered).
   2. Code such as `let assert <<0xFFFFFFFFFFFFFFFF:64>> == <<255, 255, 255, 255, 255, 255, 255, 255>>` would change behaviour, albeit in a correct direction that would match Erlang. This may be desirable, but I've taken the conservative route initially.
   3. See discussion https://github.com/gleam-lang/gleam/discussions/3724#discussioncomment-11013077 for more details.

## Performance

Evaluating `<<-1:32>>`: 10-11x faster.

Evaluating a large lookup table of 16-bit integers: 26x faster.

Pattern matching a 32-bit signed integer: 2.7-7.1x faster, depending on how early a non-matching byte occurs.

Generated JavaScript code size is up to ~70% smaller. There are a few cases when using 40-bit and 48-bit wide integers that can see code size increases of ~20% with certain values, but the average case still sees a code size reduction on the wider integers.