### PR TITLE
Fix 3796

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.{rs, gleam, erl, hrl, ex, mjs, js, ts, sh}]
+[*.{gleam, erl, hrl, ex, mjs, js, ts, sh}]
 max_line_length = 80
 
 [*.{rs, .erl, .hrl}]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,14 @@
   no arguments.
   ([Louis Pilfold](https://github.com/lpil))
 
+- Fixed a bug where the parser would incorrectly parse a generic type
+  constructor with no arguments.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the parser would incorrectly parse a generic type definition
+  with no arguments.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where the language server wouldn't show hints when hovering over
   the tail of a list.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -316,6 +316,17 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 "I was expecting arguments here",
                 vec!["A record must be passed arguments when constructed.".into()],
             ),
+            ParseErrorType::TypeConstructorNoArguments => (
+                "I was expecting arguments here",
+                vec!["A type constructor must be passed arguments.".into()],
+            ),
+            ParseErrorType::TypeDefinitionNoArguments => (
+                "I was expecting generic parameters here",
+                vec![
+                    "A generic type must have at least a generic parameter.".into(),
+                    "Hint: If a type is not generic you should omit the `()`.".into(),
+                ],
+            ),
         }
     }
 }
@@ -385,6 +396,8 @@ pub enum ParseErrorType {
     CallInClauseGuard, // case x { _ if f() -> 1 }
     IfExpression,
     ConstantRecordConstructorNoArguments, // const x = Record()
+    TypeConstructorNoArguments,           // let a : Int()
+    TypeDefinitionNoArguments,            // pub type Wibble() { ... }
 }
 
 impl LexicalError {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_type_constructor_arguments_in_type_annotation_1.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_type_constructor_arguments_in_type_annotation_1.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "pub fn main() -> Int() {}"
+---
+----- SOURCE CODE
+pub fn main() -> Int() {}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:21
+  │
+1 │ pub fn main() -> Int() {}
+  │                     ^^ I was expecting arguments here
+
+A type constructor must be passed arguments.

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_type_constructor_arguments_in_type_annotation_2.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_type_constructor_arguments_in_type_annotation_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "pub fn main() {\n  let a: Int() = todo\n}"
+---
+----- SOURCE CODE
+pub fn main() {
+  let a: Int() = todo
+}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:13
+  │
+2 │   let a: Int() = todo
+  │             ^^ I was expecting arguments here
+
+A type constructor must be passed arguments.

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_type_constructor_arguments_in_type_definition.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_type_constructor_arguments_in_type_definition.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\npub type A() {\n  A(Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type A() {
+  A(Int)
+}
+
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:11
+  │
+2 │ pub type A() {
+  │           ^^ I was expecting generic parameters here
+
+A generic type must have at least a generic parameter.
+Hint: If a type is not generic you should omit the `()`.

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1548,3 +1548,29 @@ const a = A()
 "
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3796
+#[test]
+fn missing_type_constructor_arguments_in_type_definition() {
+    assert_module_error!(
+        "
+pub type A() {
+  A(Int)
+}
+"
+    );
+}
+
+#[test]
+fn missing_type_constructor_arguments_in_type_annotation_1() {
+    assert_module_error!("pub fn main() -> Int() {}");
+}
+
+#[test]
+fn missing_type_constructor_arguments_in_type_annotation_2() {
+    assert_module_error!(
+        "pub fn main() {
+  let a: Int() = todo
+}"
+    );
+}


### PR DESCRIPTION
This PR fixes #3796 and a similar bug where `pub type Wibble() { ... }` would be accepted (but rewritten as `pub type Wibble { ... }` by the formatter)