### PR TITLE
Escape property names with special meaning on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fixed a bug where some reserved field names were not properly escaped in
+  custom types on the JavaScript target.
+  ([yoshi](https://github.com/joshi-monster))
+
 ## v1.6.0-rc1 - 2024-11-10
 
 ### Build tool

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -293,7 +293,9 @@ impl<'a> Generator<'a> {
                 let var = parameter((i, arg));
                 match &arg.label {
                     None => docvec!["this[", i, "] = ", var, ";"],
-                    Some((_, name)) => docvec!["this.", name, " = ", var, ";"],
+                    Some((_, name)) => {
+                        docvec!["this.", maybe_escape_property_doc(name), " = ", var, ";"]
+                    }
                 }
             }),
             line(),
@@ -740,6 +742,21 @@ fn is_usable_js_identifier(word: &str) -> bool {
     )
 }
 
+fn is_usable_js_property(label: &str) -> bool {
+    !matches!(
+        label,
+        // `then` to avoid a custom type that defines a `then` function being used as a `thenable`
+        // in Javascript.
+        "then"
+            // `constructor` to avoid unintentional overriding of the constructor of records,
+            // leading to potential runtime crashes while using `withFields`.
+            | "constructor"
+            // `prototype` and `__proto__` to avoid unintentionally overriding the prototype chain
+            | "prototype"
+            | "__proto__"
+    )
+}
+
 fn maybe_escape_identifier_string(word: &str) -> EcoString {
     if is_usable_js_identifier(word) {
         EcoString::from(word)
@@ -757,6 +774,14 @@ fn maybe_escape_identifier_doc(word: &str) -> Document<'_> {
         word.to_doc()
     } else {
         escape_identifier(word).to_doc()
+    }
+}
+
+fn maybe_escape_property_doc(label: &str) -> Document<'_> {
+    if is_usable_js_property(label) {
+        label.to_doc()
+    } else {
+        escape_identifier(label).to_doc()
     }
 }
 

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -868,7 +868,7 @@ impl<'module> Generator<'module> {
             let fields = updates
                 .iter()
                 .map(|TypedRecordUpdateArg { label, value, .. }| {
-                    (label.to_doc(), gen.wrap_expression(value))
+                    (maybe_escape_property_doc(label), gen.wrap_expression(value))
                 });
             let object = try_wrap_object(fields)?;
             Ok(docvec![record, ".withFields(", object, ")"])

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -854,7 +854,7 @@ impl<'module> Generator<'module> {
     fn record_access<'a>(&mut self, record: &'a TypedExpr, label: &'a str) -> Output<'a> {
         self.not_in_tail_position(|gen| {
             let record = gen.wrap_expression(record)?;
-            Ok(docvec![record, ".", label])
+            Ok(docvec![record, ".", maybe_escape_property_doc(label)])
         })
     }
 

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -156,7 +156,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
         concat(self.path.iter().map(|segment| match segment {
             Index::Int(i) => eco_format!("[{i}]").to_doc(),
             // TODO: escape string if needed
-            Index::String(s) => docvec!(".", s),
+            Index::String(s) => docvec!(".", maybe_escape_property_doc(s)),
             Index::ByteAt(i) => docvec!(".byteAt(", i, ")"),
             Index::IntFromSlice {
                 start,
@@ -365,7 +365,11 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
             ClauseGuard::FieldAccess {
                 label, container, ..
             } => {
-                docvec!(self.guard(container)?, ".", label)
+                docvec!(
+                    self.guard(container)?,
+                    ".",
+                    maybe_escape_property_doc(label)
+                )
             }
 
             ClauseGuard::ModuleSelect {

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -728,3 +728,42 @@ pub fn main() {
 "#
     );
 }
+#[test]
+fn record_access_in_guard_with_reserved_field_name() {
+    assert_js!(
+        r#"
+pub type Thing {
+  Thing(constructor: Nil)
+}
+
+pub fn main() {
+  let a = Thing(constructor: Nil)
+  case Nil {
+      Nil if a.constructor == Nil -> a.constructor
+      _ -> Nil
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn record_access_in_pattern_with_reserved_field_name() {
+    assert_js!(
+        r#"
+pub type Thing {
+  Thing(constructor: Nil)
+}
+
+pub fn main() {
+  let a = Thing(constructor: Nil)
+  let Thing(constructor: ctor) = a
+  case a {
+      a if a.constructor == ctor -> Nil
+      Thing(constructor:) if ctor == constructor -> Nil
+      _ -> Nil
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -693,3 +693,36 @@ pub fn main() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3813
+#[test]
+fn record_with_field_named_constructor() {
+    assert_js!(
+        r#"
+pub type Thing {
+  Thing(constructor: Nil)
+}
+
+pub fn main() {
+  let a = Thing(constructor: Nil)
+  let b = Thing(..a, constructor: Nil)
+}
+"#
+    );
+}
+
+#[test]
+fn record_with_field_named_then() {
+    assert_js!(
+        r#"
+pub type Thing {
+  Thing(then: Nil)
+}
+
+pub fn main() {
+  let a = Thing(then: Nil)
+  let b = Thing(..a, then: Nil)
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -706,6 +706,7 @@ pub type Thing {
 pub fn main() {
   let a = Thing(constructor: Nil)
   let b = Thing(..a, constructor: Nil)
+  b.constructor
 }
 "#
     );
@@ -722,6 +723,7 @@ pub type Thing {
 pub fn main() {
   let a = Thing(then: Nil)
   let b = Thing(..a, then: Nil)
+  b.then
 }
 "#
     );

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_access_in_guard_with_reserved_field_name.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_access_in_guard_with_reserved_field_name.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Thing {\n  Thing(constructor: Nil)\n}\n\npub fn main() {\n  let a = Thing(constructor: Nil)\n  case Nil {\n      Nil if a.constructor == Nil -> a.constructor\n      _ -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub type Thing {
+  Thing(constructor: Nil)
+}
+
+pub fn main() {
+  let a = Thing(constructor: Nil)
+  case Nil {
+      Nil if a.constructor == Nil -> a.constructor
+      _ -> Nil
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+export class Thing extends $CustomType {
+  constructor(constructor) {
+    super();
+    this.constructor$ = constructor;
+  }
+}
+
+export function main() {
+  let a = new Thing(undefined);
+  let $ = undefined;
+  if (!$ && (a.constructor$ === undefined)) {
+    return a.constructor$;
+  } else {
+    return undefined;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_access_in_pattern_with_reserved_field_name.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_access_in_pattern_with_reserved_field_name.snap
@@ -1,0 +1,44 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Thing {\n  Thing(constructor: Nil)\n}\n\npub fn main() {\n  let a = Thing(constructor: Nil)\n  let Thing(constructor: ctor) = a\n  case a {\n      a if a.constructor == ctor -> Nil\n      Thing(constructor:) if ctor == constructor -> Nil\n      _ -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub type Thing {
+  Thing(constructor: Nil)
+}
+
+pub fn main() {
+  let a = Thing(constructor: Nil)
+  let Thing(constructor: ctor) = a
+  case a {
+      a if a.constructor == ctor -> Nil
+      Thing(constructor:) if ctor == constructor -> Nil
+      _ -> Nil
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+export class Thing extends $CustomType {
+  constructor(constructor) {
+    super();
+    this.constructor$ = constructor;
+  }
+}
+
+export function main() {
+  let a = new Thing(undefined);
+  let ctor = a.constructor$;
+  if (a.constructor$ === ctor) {
+    let a$1 = a;
+    return undefined;
+  } else if (a instanceof Thing && (ctor === a.constructor$)) {
+    let constructor = a.constructor$;
+    return undefined;
+  } else {
+    return undefined;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_constructor.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_constructor.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
-expression: "\npub type Thing {\n  Thing(constructor: Nil)\n}\n\npub fn main() {\n  let a = Thing(constructor: Nil)\n  let b = Thing(..a, constructor: Nil)\n}\n"
+expression: "\npub type Thing {\n  Thing(constructor: Nil)\n}\n\npub fn main() {\n  let a = Thing(constructor: Nil)\n  let b = Thing(..a, constructor: Nil)\n  b.constructor\n}\n"
 ---
 ----- SOURCE CODE
 
@@ -11,6 +11,7 @@ pub type Thing {
 pub fn main() {
   let a = Thing(constructor: Nil)
   let b = Thing(..a, constructor: Nil)
+  b.constructor
 }
 
 
@@ -27,5 +28,5 @@ export class Thing extends $CustomType {
 export function main() {
   let a = new Thing(undefined);
   let b = a.withFields({ constructor$: undefined });
-  return b;
+  return b.constructor$;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_constructor.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_constructor.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Thing {\n  Thing(constructor: Nil)\n}\n\npub fn main() {\n  let a = Thing(constructor: Nil)\n  let b = Thing(..a, constructor: Nil)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Thing {
+  Thing(constructor: Nil)
+}
+
+pub fn main() {
+  let a = Thing(constructor: Nil)
+  let b = Thing(..a, constructor: Nil)
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+export class Thing extends $CustomType {
+  constructor(constructor) {
+    super();
+    this.constructor$ = constructor;
+  }
+}
+
+export function main() {
+  let a = new Thing(undefined);
+  let b = a.withFields({ constructor$: undefined });
+  return b;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_then.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_then.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Thing {\n  Thing(then: Nil)\n}\n\npub fn main() {\n  let a = Thing(then: Nil)\n  let b = Thing(..a, then: Nil)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Thing {
+  Thing(then: Nil)
+}
+
+pub fn main() {
+  let a = Thing(then: Nil)
+  let b = Thing(..a, then: Nil)
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+export class Thing extends $CustomType {
+  constructor(then$) {
+    super();
+    this.then$ = then$;
+  }
+}
+
+export function main() {
+  let a = new Thing(undefined);
+  let b = a.withFields({ then$: undefined });
+  return b;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_then.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_then.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
-expression: "\npub type Thing {\n  Thing(then: Nil)\n}\n\npub fn main() {\n  let a = Thing(then: Nil)\n  let b = Thing(..a, then: Nil)\n}\n"
+expression: "\npub type Thing {\n  Thing(then: Nil)\n}\n\npub fn main() {\n  let a = Thing(then: Nil)\n  let b = Thing(..a, then: Nil)\n  b.then\n}\n"
 ---
 ----- SOURCE CODE
 
@@ -11,6 +11,7 @@ pub type Thing {
 pub fn main() {
   let a = Thing(then: Nil)
   let b = Thing(..a, then: Nil)
+  b.then
 }
 
 
@@ -27,5 +28,5 @@ export class Thing extends $CustomType {
 export function main() {
   let a = new Thing(undefined);
   let b = a.withFields({ then$: undefined });
-  return b;
+  return b.then$;
 }


### PR DESCRIPTION
Escape `constructor`, `then`, `prototype` and `__proto__`, since they all have special meaning.

fix #3813