### PR TITLE
Fix incorrect warning about unsafe ints on JS when there's an @external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   custom types on the JavaScript target.
   ([yoshi](https://github.com/joshi-monster))
 
+- Fixed a bug where a warning about unsafe integers on the JavaScript target was
+  emitted when the enclosing function has an external JavaScript implementation.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.6.0-rc1 - 2024-11-10
 
 ### Build tool

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -315,7 +315,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 int_value,
                 ..
             } => {
-                if self.environment.target == Target::JavaScript {
+                if self.environment.target == Target::JavaScript
+                    && !self.implementations.uses_javascript_externals
+                {
                     check_javascript_int_safety(&int_value, location, self.problems);
                 }
 
@@ -1309,8 +1311,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         // Ensure the pattern matches the type of the value
         let pattern_location = pattern.location();
-        let mut pattern_typer =
-            pattern::PatternTyper::new(self.environment, &self.hydrator, self.problems);
+        let mut pattern_typer = pattern::PatternTyper::new(
+            self.environment,
+            &self.implementations,
+            &self.hydrator,
+            self.problems,
+        );
         let unify_result = pattern_typer.unify(pattern, value_typ.clone(), None);
 
         let minimum_required_version = pattern_typer.minimum_required_version;
@@ -1533,8 +1539,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         subjects: &[TypedExpr],
         location: &SrcSpan,
     ) -> Result<(TypedMultiPattern, Vec<TypedMultiPattern>), Error> {
-        let mut pattern_typer =
-            pattern::PatternTyper::new(self.environment, &self.hydrator, self.problems);
+        let mut pattern_typer = pattern::PatternTyper::new(
+            self.environment,
+            &self.implementations,
+            &self.hydrator,
+            self.problems,
+        );
         let typed_pattern = pattern_typer.infer_multi_pattern(pattern, subjects, location)?;
 
         // Each case clause has one or more patterns that may match the

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 pub struct PatternTyper<'a, 'b> {
     environment: &'a mut Environment<'b>,
+    implementations: &'a Implementations,
     hydrator: &'a Hydrator,
     mode: PatternMode,
     initial_pattern_vars: HashSet<EcoString>,
@@ -36,11 +37,13 @@ enum PatternMode {
 impl<'a, 'b> PatternTyper<'a, 'b> {
     pub fn new(
         environment: &'a mut Environment<'b>,
+        implementations: &'a Implementations,
         hydrator: &'a Hydrator,
         problems: &'a mut Problems,
     ) -> Self {
         Self {
             environment,
+            implementations,
             hydrator,
             mode: PatternMode::Initial,
             initial_pattern_vars: HashSet::new(),
@@ -435,7 +438,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             } => {
                 unify(type_, int()).map_err(|e| convert_unify_error(e, location))?;
 
-                if self.environment.target == Target::JavaScript {
+                if self.environment.target == Target::JavaScript
+                    && !self.implementations.uses_javascript_externals
+                {
                     check_javascript_int_safety(&int_value, location, self.problems);
                 }
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -319,6 +319,19 @@ macro_rules! assert_js_warning {
 }
 
 #[macro_export]
+macro_rules! assert_js_no_warnings {
+    ($src:expr) => {
+        let warning = $crate::type_::tests::get_printed_warnings(
+            $src,
+            vec![],
+            crate::build::Target::JavaScript,
+            None,
+        );
+        assert!(warning.is_empty());
+    };
+}
+
+#[macro_export]
 macro_rules! assert_warnings_with_gleam_version {
     ($gleam_version:expr, $src:expr$(,)?) => {
         let warning = $crate::type_::tests::get_printed_warnings(

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_with_external_function_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_with_external_function_call.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  9_007_199_254_740_992 + helper()\n}\n\n@external(javascript, \"a\", \"b\")\nfn helper() -> Int\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  9_007_199_254_740_992 + helper()
+}
+
+@external(javascript, "a", "b")
+fn helper() -> Int
+
+
+----- WARNING
+warning: Int is outside JavaScript's safe integer range
+  ┌─ /src/warning/wrn.gleam:3:3
+  │
+3 │   9_007_199_254_740_992 + helper()
+  │   ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+
+This integer value is too large to be represented accurately by
+JavaScript's number type. To avoid this warning integer values must be in
+the range -(2^53 - 1) - (2^53 - 1).
+
+See JavaScript's Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+properties for more information.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    assert_js_warning, assert_no_warnings, assert_warning, assert_warnings_with_gleam_version,
-    assert_warnings_with_imports,
+    assert_js_no_warnings, assert_js_warning, assert_no_warnings, assert_warning,
+    assert_warnings_with_gleam_version, assert_warnings_with_imports,
 };
 
 #[test]
@@ -2668,6 +2668,44 @@ fn javascript_unsafe_int_segment_size_in_pattern() {
 pub fn go() {
   let assert <<0:9_007_199_254_740_992>> = <<>>
 }
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_with_external_implementation() {
+    assert_js_no_warnings!(
+        r#"
+@external(javascript, "./test.mjs", "go")
+pub fn go() -> Int {
+  9_007_199_254_740_992
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_segment_in_pattern_with_external_implementation() {
+    assert_js_no_warnings!(
+        r#"
+@external(javascript, "./test.mjs", "go")
+pub fn go(b: BitArray) -> BitArray {
+  let assert <<0xFFF0000000000000:64>> = b
+}
+"#
+    );
+}
+
+#[test]
+fn javascript_unsafe_int_with_external_function_call() {
+    assert_js_warning!(
+        r#"
+pub fn main() {
+  9_007_199_254_740_992 + helper()
+}
+
+@external(javascript, "a", "b")
+fn helper() -> Int
 "#
     );
 }


### PR DESCRIPTION
In v1.6.0-rc1 the following code was warning about an unsafe int on JS, but shouldn't have been because of the `@external` implementation.

```gleam
@external(javascript, "./test.mjs", "go")
pub fn go() -> Int {
  9_007_199_254_740_992
}
```
