### PR TITLE
Fix invalid TOML example in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,11 @@
   aren't located at the root of their repository:
 
   ```toml
-  repository = {
-    type = "github",
-    user = "gleam-lang",
-    repo = "gleam",
-    path = "packages/my_package"
-  }
+  [repository]
+  type = "github"
+  user = "gleam-lang"
+  repo = "gleam"
+  path = "packages/my_package"
   ```
 
   ([Richard Viney](https://github.com/richard-viney))


### PR DESCRIPTION
The example of how to use the new `repository.path` option was altered in 9e97867, but the updated version isn't actually valid TOML as inline tables have to be on one line: https://toml.io/en/v1.0.0#inline-table.

This PR switches to normal TOML table syntax, which is probably what was intended.