### PR TITLE
Specify Erlang v27 in the CI workflow for new projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Build tool
+
+- The version of Erlang used in the GitHub Actions workflow created by
+  `gleam new` has been increased from v26.0.2 to v27.1.2.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ### Bug fixes
 
 - Fixed a bug where some reserved field names were not properly escaped in

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -17,7 +17,7 @@ use crate::{fs::get_current_directory, NewOptions};
 
 const GLEAM_STDLIB_REQUIREMENT: &str = ">= 0.34.0 and < 2.0.0";
 const GLEEUNIT_REQUIREMENT: &str = ">= 1.0.0 and < 2.0.0";
-const ERLANG_OTP_VERSION: &str = "26.0.2";
+const ERLANG_OTP_VERSION: &str = "27.1.2";
 const REBAR3_VERSION: &str = "3";
 const ELIXIR_VERSION: &str = "1.15.4";
 


### PR DESCRIPTION
This increases the Erlang version used in the GitHub Actions workflow created by `gleam new` from v26.0.1 to v27.1.2.

Motivation is that lots of folks use `gleam_json`, the latest version of which needs Erlang 27, so this change will avoid them running into a CI failure.

If this is wanted, but isn't eligible for v1.6 RC 2, then just lmk and I'll rebase once v1.6 is released.