### PR TITLE
Fix #3772: Delete cached metadata if a module is stale because of it's dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   emitted when the enclosing function has an external JavaScript implementation.
   ([Richard Viney](https://github.com/richard-viney))
 
+- Fixed a bug where updating a dependency could break the build cache.
+  ([yoshi](https://github.com/joshi-monster))
+
 ## v1.6.0-rc1 - 2024-11-10
 
 ### Build tool

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -219,7 +219,7 @@ fn module_is_stale_if_deps_are_stale() {
 }
 
 #[test]
-fn loader_output_does_not_change_if_deps_are_stale() {
+fn module_continues_to_be_stale_if_deps_get_updated() {
     let fs = InMemoryFileSystem::new();
     let root = Utf8Path::new("/");
     let artefact = Utf8Path::new("/artefact");
@@ -242,14 +242,17 @@ fn loader_output_does_not_change_if_deps_are_stale() {
     write_src(&fs, "/src/three.gleam", 1, TEST_SOURCE_1);
     write_cache(&fs, "three", 2, vec![], TEST_SOURCE_1);
 
-    let loaded1 = run_loader(fs.clone(), root, artefact);
+    let _loaded1 = run_loader(fs.clone(), root, artefact);
 
     // update the dependency
     write_cache(&fs, "one", 3, vec![], TEST_SOURCE_2);
     let loaded2 = run_loader(fs, root, artefact);
 
-    assert_eq!(loaded1.to_compile, loaded2.to_compile);
-    assert_eq!(loaded1.cached, loaded2.cached);
+    assert_eq!(loaded2.to_compile, vec![EcoString::from("two")]);
+    assert_eq!(
+        loaded2.cached,
+        vec![EcoString::from("one"), EcoString::from("three")]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This fixes both caching problems described in #3772 by deleting the cache metadata if a module is found to be stale because of its dependencies.

What happened was that the dependency introduced breaking changes but otherwise compiled fine; this meant that the dependent module produced build errors but still had valid cache files. On the next run, the build cache was valid and the dependency no longer stale, so the build tool assumed everything was fine.

I copied the way the path to the `.cache_meta` file is constructed from `ModuleLoader`. I did not like putting it into `module_loader.rs` personally, but I wouldn't mind either way, please tell me if I should move stuff/make it more dry :)

~ :purple_heart: 
