### PR TITLE
fix cli update use_manifest logic

### DIFF
--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -115,7 +115,7 @@ pub enum UseManifest {
 
 pub fn update(packages: Vec<String>) -> Result<()> {
     let paths = crate::find_project_paths()?;
-    let use_manifest = if packages.is_empty() {
+    let use_manifest = if !packages.is_empty() {
         UseManifest::Yes
     } else {
         UseManifest::No


### PR DESCRIPTION
Fixes the `use_manifest` logic for the `update()` function. It is currently flipped to the opposite of what it should be.