### PR TITLE
Report unused case expressions, blocks, pipelines and function expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,10 @@
   file of same name without warning. It now produces an error.
   ([PgBiel](https://github.com/PgBiel))
 
+- The compiler now raises a warning for unused case expressions, code blocks and
+  pipelines that would be safe to remove.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.6.1 - 2024-11-19
 
 ### Bug fixed

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -2414,6 +2414,18 @@ impl TypedStatement {
             Statement::Use(use_) => use_.location,
         }
     }
+
+    fn is_pure_value_constructor(&self) -> bool {
+        match self {
+            Statement::Expression(expression) => expression.is_pure_value_constructor(),
+            Statement::Assignment(assignment) => {
+                // A let assert is not considered a pure value constructor
+                // as it could crash the program!
+                !assignment.kind.is_assert() && assignment.value.is_pure_value_constructor()
+            }
+            Statement::Use(Use { call, .. }) => call.is_pure_value_constructor(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -564,10 +564,13 @@ impl TypedExpr {
             // A pipeline is a pure value constructor if its last step is a record builder.
             // For example `wibble() |> wobble() |> Ok`
             TypedExpr::Pipeline { finally, .. } => {
-                finally.is_fn_with_pure_body() || finally.is_pure_value_constructor()
+                finally.is_fn_with_all_pure_value_constructors_in_body()
+                    || finally.is_pure_value_constructor()
             }
 
-            TypedExpr::Call { fun, .. } => fun.is_fn_with_pure_body() || fun.is_record_builder(),
+            TypedExpr::Call { fun, .. } => {
+                fun.is_fn_with_all_pure_value_constructors_in_body() || fun.is_record_builder()
+            }
 
             // A block is pure if all the statements it's made of are pure.
             // For example `{ True 1 }`
@@ -601,7 +604,7 @@ impl TypedExpr {
     }
 
     #[must_use]
-    fn is_fn_with_pure_body(&self) -> bool {
+    fn is_fn_with_all_pure_value_constructors_in_body(&self) -> bool {
         match self {
             TypedExpr::Fn { body, .. } => body.iter().all(|s| match s {
                 Statement::Expression(expression) => expression.is_pure_value_constructor(),

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -577,8 +577,7 @@ impl TypedExpr {
             TypedExpr::Block { statements, .. } => statements.iter().all(|s| match s {
                 Statement::Expression(e) => e.is_pure_value_constructor(),
                 Statement::Assignment(assignment) => assignment.value.is_pure_value_constructor(),
-                // A use is just a function call under the hood, so it's not pure.
-                Statement::Use(_) => false,
+                Statement::Use(_) => panic!("No use in typed expr"),
             }),
 
             // A case is pure if its subject and all its branches are.
@@ -609,8 +608,7 @@ impl TypedExpr {
             TypedExpr::Fn { body, .. } => body.iter().all(|s| match s {
                 Statement::Expression(expression) => expression.is_pure_value_constructor(),
                 Statement::Assignment(assignment) => assignment.value.is_pure_value_constructor(),
-                // A use is just a function call under the hood, so we don't ever consider it pure
-                Statement::Use(_) => false,
+                Statement::Use(_) => panic!("No use in typed expr"),
             }),
             _ => false,
         }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expression.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expression.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  { 1 }\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  { 1 }
+  Nil
+}
+
+
+----- WARNING
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:3:3
+  │
+3 │   { 1 }
+  │   ^^^^^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expressions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expressions.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  {\n    True\n    1\n  }\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  {
+    True
+    1
+  }
+  Nil
+}
+
+
+----- WARNING
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:3:3
+  │  
+3 │ ╭   {
+4 │ │     True
+5 │ │     1
+6 │ │   }
+  │ ╰───^ This value is never used
+
+
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:4:5
+  │
+4 │     True
+  │     ^^^^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_case_expression.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_case_expression.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n    let a = 1\n    case a {\n        1 -> a\n        _ -> 12\n    }\n    Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+    let a = 1
+    case a {
+        1 -> a
+        _ -> 12
+    }
+    Nil
+}
+
+
+----- WARNING
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:4:5
+  │  
+4 │ ╭     case a {
+5 │ │         1 -> a
+6 │ │         _ -> 12
+7 │ │     }
+  │ ╰─────^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_fn_function_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_fn_function_call.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n    fn(a) { a + 1 }(1)\n    Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+    fn(a) { a + 1 }(1)
+    Nil
+}
+
+
+----- WARNING
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │     fn(a) { a + 1 }(1)
+  │     ^^^^^^^^^^^^^^^^^^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_pure_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_pure_fn.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n    1\n    |> fn(n) { n + 1 }\n\n    Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+    1
+    |> fn(n) { n + 1 }
+
+    Nil
+}
+
+
+----- WARNING
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:3:5
+  │  
+3 │ ╭     1
+4 │ │     |> fn(n) { n + 1 }
+  │ ╰──────────────────────^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n    {\n        use _ <- fn(a) { a }\n        1\n    }\n\n    Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+    {
+        use _ <- fn(a) { a }
+        1
+    }
+
+    Nil
+}
+
+
+----- WARNING
+warning: Unused value
+  ┌─ /src/warning/wrn.gleam:3:5
+  │  
+3 │ ╭     {
+4 │ │         use _ <- fn(a) { a }
+5 │ │         1
+6 │ │     }
+  │ ╰─────^ This value is never used

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2715,8 +2715,8 @@ fn incomplete_code_block_raises_warning() {
         r#"
 pub fn main() {
     {}
-}
-"#
+    }
+    "#
     );
 }
 
@@ -2737,5 +2737,168 @@ fn deprecated_target_shorthand_javascript() {
 @target(js)
 pub fn wibble() { panic }
 "
+    );
+}
+
+#[test]
+fn unused_block_wrapping_pure_expressions() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  {
+    True
+    1
+  }
+  Nil
+}
+"#
+    );
+}
+
+#[test]
+fn unused_block_wrapping_pure_expression() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  { 1 }
+  Nil
+}
+"#
+    );
+}
+
+#[test]
+fn unused_block_wrapping_impure_expressions_is_not_reported_as_pure() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+  {
+    wibble()
+    1
+  }
+  Nil
+}
+
+fn wibble() { wibble() }
+"#
+    );
+}
+
+#[test]
+fn unused_case_expression() {
+    assert_warning!(
+        r#"
+pub fn main() {
+    let a = 1
+    case a {
+        1 -> a
+        _ -> 12
+    }
+    Nil
+}
+"#
+    );
+}
+
+#[test]
+fn impure_case_expression_is_not_marked_as_unused() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+    let a = 1
+    case a {
+        1 -> wibble()
+        _ -> 12
+    }
+    Nil
+}
+
+fn wibble() { wibble() }
+"#
+    );
+}
+
+#[test]
+fn impure_case_expression_is_not_marked_as_unused_2() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+    let a = 1
+    case wibble() {
+        1 -> a
+        _ -> 12
+    }
+    Nil
+}
+
+fn wibble() { wibble() }
+"#
+    );
+}
+
+#[test]
+fn unused_fn_function_call() {
+    assert_warning!(
+        r#"
+pub fn main() {
+    fn(a) { a + 1 }(1)
+    Nil
+}
+"#
+    );
+}
+
+#[test]
+fn impure_fn_function_call_not_mark_as_unused() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+    fn(_) { panic }(1)
+    Nil
+}
+"#
+    );
+}
+
+#[test]
+fn unused_pipeline_ending_with_pure_fn() {
+    assert_warning!(
+        r#"
+pub fn main() {
+    1
+    |> fn(n) { n + 1 }
+
+    Nil
+}
+"#
+    );
+}
+
+#[test]
+fn unused_pipeline_ending_with_impure_fn() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+    1
+    |> fn(_) { panic }
+
+    Nil
+}
+"#
+    );
+}
+
+#[test]
+fn pipeline_with_regular_function_call_is_never_marked_unused() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+    1 |> wibble
+
+    Nil
+}
+
+fn wibble(n) { n }
+"#
     );
 }

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2902,3 +2902,37 @@ fn wibble(n) { n }
 "#
     );
 }
+
+#[test]
+fn use_with_pure_fn_expression_is_marked_as_unused() {
+    assert_warning!(
+        r#"
+pub fn main() {
+    {
+        use _ <- fn(a) { a }
+        1
+    }
+
+    Nil
+}
+"#
+    );
+}
+
+#[test]
+fn use_statement_calling_regular_function_is_never_marked_unused() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+    {
+        use _ <- each([1, 2, 3])
+        1
+    }
+
+    Nil
+}
+
+fn each(list, _fun) { list }
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2715,8 +2715,8 @@ fn incomplete_code_block_raises_warning() {
         r#"
 pub fn main() {
     {}
-    }
-    "#
+}
+"#
     );
 }
 


### PR DESCRIPTION
This PR adds unused warning for pure case expressions, blocks, pipelines, function expressions and function calls

So if the compiler can understand one of those is pure and unused a warning will be raised. For example:

```gleam
fn main() {
  { 1 }
//^^^^^ Now this is reported as unused
  Nil
}
```
```gleam
fn main() {
  fn(n) { n + 1 }(1)
//^^^^^^^^^^^^^^^^^^ Now this is reported as unused
  Nil
}
```
```gleam
fn main() {
  case wibble {
    [] -> 0
    _ -> 1
  }
//^^^^^^^^^^^^^ Now this is reported as unused
  Nil
}
```