### PR TITLE
Move build locks to `build` directory so open files do not interrupt clearing old builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@
   is missing an exponent.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a crash with ENOTEMPTY (os error 39) when building on NTFS partitions
+  ([Ivan Ermakov](https://github.com/ivanjermakov))
+
 - Fixed a bug where the compiler would crash when pattern matching on multiple
   subjects and one of them being a constant record.
   ([Surya Rose](https://github.com/GearsDatapacks))


### PR DESCRIPTION
Fixes #2700 and #2680.

The cause of `Directory not empty (os error 39)` when recreating build dir within `check_gleam_version()` is that called `delete_directory` is trying to remove a directory while lock file is still open by `BuildLock::lock()`. This works ok on ext4, but fails with error on NTFS ([and perhaps BRTFS](https://github.com/gleam-lang/gleam/issues/2700#issuecomment-2317087702)) partitions.

Solution is to move lock files up in the file tree from the directory that is being removed.

New lock file paths:

```
$ROOT/build/packages/gleam.lock
$ROOT/build/gleam-dev-erlang.lock
$ROOT/build/gleam-dev-javascript.lock
$ROOT/build/gleam-prod-erlang.lock
$ROOT/build/gleam-prod-javascript.lock
$ROOT/build/gleam-lsp-erlang.lock
$ROOT/build/gleam-lsp-javascript.lock
```