### PR TITLE
Refactor code actions

### DIFF
--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -87,12 +87,12 @@ impl<'a> LineNumbersHelper<'a> {
     }
 
     fn src_span_to_lsp_range(&self, location: SrcSpan) -> Range {
-        src_span_to_lsp_range(location, &self.line_numbers)
+        src_span_to_lsp_range(location, self.line_numbers)
     }
 
     fn edit_src_span(&self, location: SrcSpan, new_text: String) -> TextEdit {
         TextEdit {
-            range: src_span_to_lsp_range(location, &self.line_numbers),
+            range: src_span_to_lsp_range(location, self.line_numbers),
             new_text,
         }
     }
@@ -327,7 +327,7 @@ impl<'ast> ast::visit::Visit<'ast> for LetAssertToCase<'_> {
         // we only check for the code action between the `let` and `=`.
         let code_action_location =
             SrcSpan::new(assignment.location.start, assignment.value.location().start);
-        let code_action_range = src_span_to_lsp_range(code_action_location, &self.line_numbers);
+        let code_action_range = src_span_to_lsp_range(code_action_location, self.line_numbers);
 
         self.visit_typed_expr(&assignment.value);
 
@@ -357,7 +357,7 @@ impl<'ast> ast::visit::Visit<'ast> for LetAssertToCase<'_> {
             .get(pattern_location.start as usize..pattern_location.end as usize)
             .expect("Location must be valid");
 
-        let range = src_span_to_lsp_range(assignment.location, &self.line_numbers);
+        let range = src_span_to_lsp_range(assignment.location, self.line_numbers);
         let indent = " ".repeat(range.start.character as usize);
 
         // Figure out which variables are assigned in the pattern
@@ -679,19 +679,15 @@ pub fn code_action_import_module(
         return;
     }
 
-    let first_import_pos = position_of_first_definition_if_import(module, &line_numbers);
+    let first_import_pos = position_of_first_definition_if_import(module, line_numbers);
     let first_is_import = first_import_pos.is_some();
     let import_location = first_import_pos.unwrap_or_default();
 
-    let after_import_newlines = add_newlines_after_import(
-        import_location,
-        first_is_import,
-        &line_numbers,
-        &module.code,
-    );
+    let after_import_newlines =
+        add_newlines_after_import(import_location, first_is_import, line_numbers, &module.code);
 
     for missing_import in missing_imports {
-        let range = src_span_to_lsp_range(missing_import.location, &line_numbers);
+        let range = src_span_to_lsp_range(missing_import.location, line_numbers);
         if !overlaps(params.range, range) {
             continue;
         }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -83,29 +83,29 @@ struct TextEdits<'a> {
 }
 
 impl<'a> TextEdits<'a> {
-    fn new(line_numbers: &'a LineNumbers) -> Self {
+    pub fn new(line_numbers: &'a LineNumbers) -> Self {
         TextEdits {
             line_numbers,
             edits: vec![],
         }
     }
 
-    fn src_span_to_lsp_range(&self, location: SrcSpan) -> Range {
+    pub fn src_span_to_lsp_range(&self, location: SrcSpan) -> Range {
         src_span_to_lsp_range(location, self.line_numbers)
     }
 
-    fn replace(&mut self, location: SrcSpan, new_text: String) {
+    pub fn replace(&mut self, location: SrcSpan, new_text: String) {
         self.edits.push(TextEdit {
             range: src_span_to_lsp_range(location, self.line_numbers),
             new_text,
         })
     }
 
-    fn insert(&mut self, at: u32, new_text: String) {
+    pub fn insert(&mut self, at: u32, new_text: String) {
         self.replace(SrcSpan { start: at, end: at }, new_text)
     }
 
-    fn delete(&mut self, location: SrcSpan) {
+    pub fn delete(&mut self, location: SrcSpan) {
         self.replace(location, "".to_string())
     }
 }

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -1031,7 +1031,7 @@ fn code_action_unused_values(
 
     for unused in unused_values {
         let SrcSpan { start, end } = *unused;
-        let hover_range = src_span_to_lsp_range(SrcSpan::new(start, end), &line_numbers);
+        let hover_range = src_span_to_lsp_range(SrcSpan::new(start, end), line_numbers);
 
         // Check if this span is contained within any previously processed span
         if processed_lsp_range
@@ -1047,7 +1047,7 @@ fn code_action_unused_values(
         }
 
         let edit = TextEdit {
-            range: src_span_to_lsp_range(SrcSpan::new(start, start), &line_numbers),
+            range: src_span_to_lsp_range(SrcSpan::new(start, start), line_numbers),
             new_text: "let _ = ".into(),
         };
 
@@ -1092,13 +1092,13 @@ fn code_action_unused_imports(
 
         // If removing an unused alias or at the beginning of the file, don't backspace
         // Otherwise, adjust the end position by 1 to ensure the entire line is deleted with the import.
-        let adjusted_end = if delete_line(unused, &line_numbers) {
+        let adjusted_end = if delete_line(unused, line_numbers) {
             end + 1
         } else {
             end
         };
 
-        let range = src_span_to_lsp_range(SrcSpan::new(start, adjusted_end), &line_numbers);
+        let range = src_span_to_lsp_range(SrcSpan::new(start, adjusted_end), line_numbers);
         // Keep track of whether any unused import has is where the cursor is
         hovered = hovered || overlaps(params.range, range);
 
@@ -1161,7 +1161,7 @@ fn code_action_fix_names(
             correction,
         } = name_correction;
 
-        let range = src_span_to_lsp_range(location, &line_numbers);
+        let range = src_span_to_lsp_range(location, line_numbers);
         // Check if the user's cursor is on the invalid name
         if overlaps(params.range, range) {
             let edit = TextEdit {

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -298,42 +298,32 @@ where
                 return Ok(None);
             };
 
-            let line_numbers = LineNumbers::new(&module.code);
+            let lines = LineNumbers::new(&module.code);
 
-            code_action_unused_values(module, &line_numbers, &params, &mut actions);
-            code_action_unused_imports(module, &line_numbers, &params, &mut actions);
+            code_action_unused_values(module, &lines, &params, &mut actions);
+            code_action_unused_imports(module, &lines, &params, &mut actions);
             code_action_convert_qualified_constructor_to_unqualified(
                 module,
-                &line_numbers,
+                &lines,
                 &params,
                 &mut actions,
             );
             code_action_convert_unqualified_constructor_to_qualified(
                 module,
-                &line_numbers,
+                &lines,
                 &params,
                 &mut actions,
             );
-            code_action_fix_names(&line_numbers, &params, &this.error, &mut actions);
-            code_action_import_module(module, &line_numbers, &params, &this.error, &mut actions);
-            code_action_add_missing_patterns(
-                module,
-                &line_numbers,
-                &params,
-                &this.error,
-                &mut actions,
-            );
-            actions.extend(LetAssertToCase::new(module, &line_numbers, &params).code_actions());
-            actions.extend(
-                RedundantTupleInCaseSubject::new(module, &line_numbers, &params).code_actions(),
-            );
+            code_action_fix_names(&lines, &params, &this.error, &mut actions);
+            code_action_import_module(module, &lines, &params, &this.error, &mut actions);
+            code_action_add_missing_patterns(module, &lines, &params, &this.error, &mut actions);
+            actions.extend(LetAssertToCase::new(module, &lines, &params).code_actions());
             actions
-                .extend(LabelShorthandSyntax::new(module, &line_numbers, &params).code_actions());
-            actions.extend(
-                FillInMissingLabelledArgs::new(module, &line_numbers, &params).code_actions(),
-            );
-            actions.extend(DesugarUse::new(module, &line_numbers, &params).code_actions());
-            AddAnnotations::new(module, &line_numbers, &params).code_action(&mut actions);
+                .extend(RedundantTupleInCaseSubject::new(module, &lines, &params).code_actions());
+            actions.extend(LabelShorthandSyntax::new(module, &lines, &params).code_actions());
+            actions.extend(FillInMissingLabelledArgs::new(module, &lines, &params).code_actions());
+            actions.extend(DesugarUse::new(module, &lines, &params).code_actions());
+            AddAnnotations::new(module, &lines, &params).code_action(&mut actions);
 
             Ok(if actions.is_empty() {
                 None


### PR DESCRIPTION
This PR does two things:
- I create a `LineNumbers` value that is passed in to all code action builders instead of rebuilding it from scratch every time. This means we will iterate through the source code just once instead of one time for each kind of code action there is
- I added a small `LineNumbersHelper` struct to make it a bit easier to produce code edits, especially ones meant to delete a specific srcspan that were quite hard to understand at a glance