### PR TITLE
Add proper hovering for patterns in `use` expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server now provides correct information when hovering over
+  patterns in use expressions.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Formatter
 
 - The formatter now adds a `todo` inside empty blocks.

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1311,3 +1311,37 @@ pub fn main() {
         find_position_of("wibble:").under_char('i')
     );
 }
+
+#[test]
+fn hover_for_pattern_in_use() {
+    let code = "
+type Wibble {
+  Wibble(Int, Float)
+}
+
+pub fn main() {
+  use Wibble(int, float) <- todo
+  todo
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("int").under_char('i')
+    );
+}
+
+#[test]
+fn hover_for_annotation_in_use() {
+    let code = "
+pub fn main() {
+  use something: Int <- todo
+  todo
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("Int").under_char('n')
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_annotation_in_use.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_annotation_in_use.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  use something: Int <- todo\n  todo\n}\n"
+---
+pub fn main() {
+  use something: Int <- todo
+                 ▔↑▔        
+  todo
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\ngleam.Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_in_use.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_pattern_in_use.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype Wibble {\n  Wibble(Int, Float)\n}\n\npub fn main() {\n  use Wibble(int, float) <- todo\n  todo\n}\n"
+---
+type Wibble {
+  Wibble(Int, Float)
+}
+
+pub fn main() {
+  use Wibble(int, float) <- todo
+             ↑▔▔                
+  todo
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n",
+    ),
+)


### PR DESCRIPTION
Fixes #3847 
This PR implements `find_node` for `use` expressions, allowing them to be used as expected with hover and goto definition (and anything else that uses `find_node`)