### PR TITLE
show latest major version available in `gleam deps update`

### DIFF
--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -1,7 +1,6 @@
 use camino::{Utf8Path, Utf8PathBuf};
 
 use gleam_core::{
-    build::Mode,
     Error, Result,
     error::{FileIoAction, FileKind},
     paths::ProjectPaths,
@@ -34,7 +33,6 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
         Some((new_package_requirements.clone(), dev)),
         Vec::new(),
         dependencies::DependencyManagerConfig {
-            mode: Mode::Dev,
             use_manifest: dependencies::UseManifest::Yes,
             check_major_versions: dependencies::CheckMajorVersions::No,
         },

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -8,7 +8,7 @@ use gleam_core::{
 
 use crate::{
     cli,
-    dependencies::{UseManifest, parse_gleam_add_specifier},
+    dependencies::{self, UseManifest, parse_gleam_add_specifier},
     fs,
 };
 
@@ -27,13 +27,13 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
 
     // Insert the new packages into the manifest and perform dependency
     // resolution to determine suitable versions
-    let manifest = crate::dependencies::download(
+    let manifest = dependencies::download(
         paths,
         cli::Reporter::new(),
         Some((new_package_requirements.clone(), dev)),
         Vec::new(),
-        UseManifest::Yes,
-        false,
+        dependencies::UseManifest::Yes,
+        dependencies::CheckMajorVersions::No,
     )?;
 
     // Read gleam.toml and manifest.toml so we can insert new deps into it

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -33,6 +33,7 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
         Some((new_package_requirements.clone(), dev)),
         Vec::new(),
         UseManifest::Yes,
+        false,
     )?;
 
     // Read gleam.toml and manifest.toml so we can insert new deps into it

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -32,8 +32,10 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
         cli::Reporter::new(),
         Some((new_package_requirements.clone(), dev)),
         Vec::new(),
-        dependencies::UseManifest::Yes,
-        dependencies::CheckMajorVersions::No,
+        dependencies::DependencyManagerConfig {
+            use_manifest: dependencies::UseManifest::Yes,
+            ..Default::default()
+        },
     )?;
 
     // Read gleam.toml and manifest.toml so we can insert new deps into it

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -1,6 +1,7 @@
 use camino::{Utf8Path, Utf8PathBuf};
 
 use gleam_core::{
+    build::Mode,
     Error, Result,
     error::{FileIoAction, FileKind},
     paths::ProjectPaths,
@@ -33,8 +34,9 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
         Some((new_package_requirements.clone(), dev)),
         Vec::new(),
         dependencies::DependencyManagerConfig {
+            mode: Mode::Dev,
             use_manifest: dependencies::UseManifest::Yes,
-            ..Default::default()
+            check_major_versions: dependencies::CheckMajorVersions::No,
         },
     )?;
 

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -8,7 +8,7 @@ use gleam_core::{
 
 use crate::{
     cli,
-    dependencies::{self, UseManifest, parse_gleam_add_specifier},
+    dependencies::{self, parse_gleam_add_specifier},
     fs,
 };
 

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -2,7 +2,7 @@ use std::{rc::Rc, time::Instant};
 
 use gleam_core::{
     Result,
-    build::{Built, Codegen, Mode, NullTelemetry, Options, ProjectCompiler, Telemetry},
+    build::{Built, Codegen, NullTelemetry, Options, ProjectCompiler, Telemetry},
     manifest::Manifest,
     paths::ProjectPaths,
     warning::WarningEmitterIO,
@@ -15,7 +15,7 @@ use crate::{
 };
 
 pub fn download_dependencies(paths: &ProjectPaths, telemetry: impl Telemetry) -> Result<Manifest> {
-    crate::dependencies::download(
+    dependencies::download(
         paths,
         telemetry,
         None,

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -20,8 +20,10 @@ pub fn download_dependencies(paths: &ProjectPaths, telemetry: impl Telemetry) ->
         telemetry,
         None,
         Vec::new(),
-        dependencies::UseManifest::Yes,
-        dependencies::CheckMajorVersions::No,
+        dependencies::DependencyManagerConfig {
+            use_manifest: dependencies::UseManifest::Yes,
+            ..Default::default()
+        },
     )
 }
 

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -21,7 +21,6 @@ pub fn download_dependencies(paths: &ProjectPaths, telemetry: impl Telemetry) ->
         None,
         Vec::new(),
         dependencies::DependencyManagerConfig {
-            mode: Mode::Dev,
             use_manifest: dependencies::UseManifest::Yes,
             check_major_versions: dependencies::CheckMajorVersions::No,
         },

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -10,13 +10,19 @@ use gleam_core::{
 
 use crate::{
     build_lock::BuildLock,
-    cli,
-    dependencies::UseManifest,
+    cli, dependencies,
     fs::{self, ConsoleWarningEmitter},
 };
 
 pub fn download_dependencies(paths: &ProjectPaths, telemetry: impl Telemetry) -> Result<Manifest> {
-    crate::dependencies::download(paths, telemetry, None, Vec::new(), UseManifest::Yes)
+    crate::dependencies::download(
+        paths,
+        telemetry,
+        None,
+        Vec::new(),
+        dependencies::UseManifest::Yes,
+        dependencies::CheckMajorVersions::No,
+    )
 }
 
 pub fn main(paths: &ProjectPaths, options: Options, manifest: Manifest) -> Result<Built> {

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -2,7 +2,7 @@ use std::{rc::Rc, time::Instant};
 
 use gleam_core::{
     Result,
-    build::{Built, Codegen, NullTelemetry, Options, ProjectCompiler, Telemetry},
+    build::{Built, Codegen, Mode, NullTelemetry, Options, ProjectCompiler, Telemetry},
     manifest::Manifest,
     paths::ProjectPaths,
     warning::WarningEmitterIO,
@@ -21,8 +21,9 @@ pub fn download_dependencies(paths: &ProjectPaths, telemetry: impl Telemetry) ->
         None,
         Vec::new(),
         dependencies::DependencyManagerConfig {
+            mode: Mode::Dev,
             use_manifest: dependencies::UseManifest::Yes,
-            ..Default::default()
+            check_major_versions: dependencies::CheckMajorVersions::No,
         },
     )
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -659,7 +659,7 @@ pub struct DependencyManagerConfig {
 }
 
 impl DependencyManagerConfig {
-    pub fn into_dependency_manager<Telem: Telemetry, P: dependency::PackageFetcher>(
+    fn into_dependency_manager<Telem: Telemetry, P: dependency::PackageFetcher>(
         self,
         runtime: tokio::runtime::Handle,
         package_fetcher: P,
@@ -678,7 +678,7 @@ impl DependencyManagerConfig {
     }
 }
 
-pub struct DependencyManager<Telem, P> {
+struct DependencyManager<Telem, P> {
     runtime: tokio::runtime::Handle,
     package_fetcher: P,
     mode: Mode,
@@ -692,7 +692,7 @@ where
     P: dependency::PackageFetcher,
     Telem: Telemetry,
 {
-    pub fn get_manifest(
+    fn get_manifest(
         &self,
         paths: &ProjectPaths,
         config: &PackageConfig,
@@ -738,7 +738,7 @@ where
         }
     }
 
-    pub fn download(
+    fn download(
         &self,
         paths: &ProjectPaths,
         new_package: Option<(Vec<(EcoString, Requirement)>, bool)>,
@@ -810,7 +810,7 @@ where
         Ok(manifest)
     }
 
-    pub fn resolve_versions(
+    fn resolve_versions(
         &self,
         project_paths: &ProjectPaths,
         config: &PackageConfig,

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -422,6 +422,12 @@ pub fn download<Telem: Telemetry>(
         .packages
         .iter()
         .map(|manifest_pkg| (manifest_pkg.name.to_string(), manifest_pkg.version.clone()))
+        .filter(|(name, _)| {
+            manifest
+                .requirements
+                .iter()
+                .any(|(required_pkg, _)| name == required_pkg)
+        })
         .collect();
     let major_versions_available = dependency::resolve_major_versions(
         PackageFetcher::boxed(runtime.handle().clone()),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -422,15 +422,25 @@ pub fn download<Telem: Telemetry>(
     let major_versions_available =
         dependency::check_for_major_version_updates(&manifest, package_fetcher);
     if !major_versions_available.is_empty() {
-        // print to stderr instead of stdout because this is not part of the standard output of this
-        // command
-        eprintln!("\nHint: the following dependencies have new major versions available...\n");
-        for (name, (v1, v2)) in major_versions_available {
-            eprintln!("{}@{} -> {}@{}", name, v1, name, v2);
-        }
+        pretty_print_major_versions_available(major_versions_available);
     }
 
     Ok(manifest)
+}
+
+fn pretty_print_major_versions_available(versions: dependency::PackageVersionDiffs) {
+    let longest_package_name_length = versions.keys().map(|name| name.len()).max().unwrap_or(10);
+
+    // print to stderr instead of stdout because this is not part of the standard output of this
+    // command
+    eprintln!("\nHint: the following dependencies have new major versions available...\n");
+    for (name, (v1, v2)) in versions {
+        let padding = " ".repeat(longest_package_name_length - name.len());
+
+        // lazily assuming the longest version could be 8 characters. eg: 1.1234.2
+        // excluding qualifiers other than x.y.z
+        eprintln!("{name}:{padding} {v1:<8} -> {v2:<8}");
+    }
 }
 
 async fn add_missing_packages<Telem: Telemetry>(

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1,3 +1,5 @@
+mod dependency_manager;
+
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -9,7 +11,6 @@ use std::{
 use camino::{Utf8Path, Utf8PathBuf};
 use ecow::{EcoString, eco_format};
 use flate2::read::GzDecoder;
-use futures::future;
 use gleam_core::{
     Error, Result,
     build::{Mode, Target, Telemetry},
@@ -26,6 +27,8 @@ use hexpm::version::Version;
 use itertools::Itertools;
 use same_file::is_same_file;
 use strum::IntoEnumIterator;
+
+pub use dependency_manager::DependencyManagerConfig;
 
 #[cfg(test)]
 mod tests;
@@ -646,237 +649,6 @@ fn same_requirements(
     };
 
     Ok(left == right)
-}
-
-pub struct DependencyManagerConfig {
-    // If `Yes` we read the manifest from disc. If not set then we ignore any
-    // manifest which will result in the latest versions of the dependency
-    // packages being resolved (not the locked ones).
-    pub use_manifest: UseManifest,
-    /// When set to `Yes`, the cli will check for major version updates of direct dependencies and
-    /// print them to the console if the major versions are not upgradeable due to constraints.
-    pub check_major_versions: CheckMajorVersions,
-}
-
-impl DependencyManagerConfig {
-    fn into_dependency_manager<Telem: Telemetry, P: dependency::PackageFetcher>(
-        self,
-        runtime: tokio::runtime::Handle,
-        package_fetcher: P,
-        telemetry: Telem,
-        mode: Mode,
-    ) -> DependencyManager<Telem, P> {
-        DependencyManager {
-            runtime,
-            package_fetcher,
-            telemetry,
-
-            mode,
-            use_manifest: self.use_manifest,
-            check_major_versions: self.check_major_versions,
-        }
-    }
-}
-
-struct DependencyManager<Telem, P> {
-    runtime: tokio::runtime::Handle,
-    package_fetcher: P,
-    mode: Mode,
-    use_manifest: UseManifest,
-    telemetry: Telem,
-    check_major_versions: CheckMajorVersions,
-}
-
-impl<Telem, P> DependencyManager<Telem, P>
-where
-    P: dependency::PackageFetcher,
-    Telem: Telemetry,
-{
-    fn get_manifest(
-        &self,
-        paths: &ProjectPaths,
-        config: &PackageConfig,
-        packages_to_update: Vec<EcoString>,
-    ) -> Result<(bool, Manifest)> {
-        // If there's no manifest (or we have been asked not to use it) then resolve
-        // the versions anew
-        let should_resolve = match self.use_manifest {
-            _ if !paths.manifest().exists() => {
-                tracing::debug!("manifest_not_present");
-                true
-            }
-            UseManifest::No => {
-                tracing::debug!("ignoring_manifest");
-                true
-            }
-            UseManifest::Yes => false,
-        };
-
-        if should_resolve {
-            let manifest = self.resolve_versions(paths, config, None, Vec::new())?;
-            return Ok((true, manifest));
-        }
-
-        let manifest = read_manifest_from_disc(paths)?;
-
-        // If there are no requested updates, and the config is unchanged
-        // since the manifest was written then it is up to date so we can return it unmodified.
-        if packages_to_update.is_empty()
-            && is_same_requirements(
-                &manifest.requirements,
-                &config.all_direct_dependencies()?,
-                paths.root(),
-            )?
-        {
-            tracing::debug!("manifest_up_to_date");
-            Ok((false, manifest))
-        } else {
-            tracing::debug!("manifest_outdated");
-            let manifest =
-                self.resolve_versions(paths, config, Some(&manifest), packages_to_update)?;
-            Ok((true, manifest))
-        }
-    }
-
-    fn download(
-        &self,
-        paths: &ProjectPaths,
-        new_package: Option<(Vec<(EcoString, Requirement)>, bool)>,
-        packages_to_update: Vec<EcoString>,
-    ) -> Result<Manifest> {
-        let span = tracing::info_span!("download_deps");
-        let _enter = span.enter();
-
-        // We do this before acquiring the build lock so that we don't create the
-        // build directory if there is no gleam.toml
-        crate::config::ensure_config_exists(paths)?;
-
-        let lock = BuildLock::new_packages(paths)?;
-        let _guard = lock.lock(&self.telemetry);
-
-        let fs = ProjectIO::boxed();
-
-        // Read the project config
-        let mut config = crate::config::read(paths.root_config())?;
-        let project_name = config.name.clone();
-
-        // Insert the new packages to add, if it exists
-        if let Some((packages, dev)) = new_package {
-            for (package, requirement) in packages {
-                if dev {
-                    _ = config.dev_dependencies.insert(package, requirement);
-                } else {
-                    _ = config.dependencies.insert(package, requirement);
-                };
-            }
-        }
-
-        // Determine what versions we need
-        let (manifest_updated, manifest) = self.get_manifest(paths, &config, packages_to_update)?;
-        let local = LocalPackages::read_from_disc(paths)?;
-
-        // Remove any packages that are no longer required due to gleam.toml changes
-        remove_extra_packages(paths, &local, &manifest, &self.telemetry)?;
-
-        // Download them from Hex to the local cache
-        self.runtime.block_on(add_missing_packages(
-            paths,
-            fs,
-            &manifest,
-            &local,
-            project_name,
-            &self.telemetry,
-        ))?;
-
-        if manifest_updated {
-            // Record new state of the packages directory
-            // TODO: test
-            tracing::debug!("writing_manifest_toml");
-            write_manifest_to_disc(paths, &manifest)?;
-        }
-        LocalPackages::from_manifest(&manifest).write_to_disc(paths)?;
-
-        if let CheckMajorVersions::Yes = self.check_major_versions {
-            let major_versions_available =
-                dependency::check_for_major_version_updates(&manifest, &self.package_fetcher);
-            if !major_versions_available.is_empty() {
-                eprintln!(
-                    "{}",
-                    pretty_print_major_versions_available(major_versions_available)
-                );
-            }
-        }
-
-        Ok(manifest)
-    }
-
-    fn resolve_versions(
-        &self,
-        project_paths: &ProjectPaths,
-        config: &PackageConfig,
-        manifest: Option<&Manifest>,
-        packages_to_update: Vec<EcoString>,
-    ) -> Result<Manifest, Error> {
-        self.telemetry.resolving_package_versions();
-        let dependencies = config.dependencies_for(self.mode)?;
-        let mut locked = config.locked(manifest)?;
-
-        if !packages_to_update.is_empty() {
-            unlock_packages(&mut locked, &packages_to_update, manifest)?;
-        }
-
-        // Packages which are provided directly instead of downloaded from hex
-        let mut provided_packages = HashMap::new();
-        // The version requires of the current project
-        let mut root_requirements = HashMap::new();
-
-        // Populate the provided_packages and root_requirements maps
-        for (name, requirement) in dependencies.into_iter() {
-            let version = match requirement {
-                Requirement::Hex { version } => version,
-                Requirement::Path { path } => provide_local_package(
-                    name.clone(),
-                    &path,
-                    project_paths.root(),
-                    project_paths,
-                    &mut provided_packages,
-                    &mut vec![],
-                )?,
-                Requirement::Git { git } => {
-                    provide_git_package(name.clone(), &git, project_paths, &mut provided_packages)?
-                }
-            };
-            let _ = root_requirements.insert(name, version);
-        }
-
-        // Convert provided packages into hex packages for pub-grub resolve
-        let provided_hex_packages = provided_packages
-            .iter()
-            .map(|(name, package)| (name.clone(), package.to_hex_package(name)))
-            .collect();
-
-        let resolved = dependency::resolve_versions(
-            &self.package_fetcher,
-            provided_hex_packages,
-            config.name.clone(),
-            root_requirements.into_iter(),
-            &locked,
-        )?;
-
-        // Convert the hex packages and local packages into manifest packages
-        let manifest_packages = self.runtime.block_on(future::try_join_all(
-            resolved
-                .into_iter()
-                .map(|(name, version)| lookup_package(name, version, &provided_packages)),
-        ))?;
-
-        let manifest = Manifest {
-            packages: manifest_packages,
-            requirements: config.all_direct_dependencies()?,
-        };
-
-        Ok(manifest)
-    }
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -646,8 +646,15 @@ fn same_requirements(
 }
 
 pub struct DependencyManagerConfig {
+    /// In `Prod` mode, dev dependencies are not considered during the executed operation.
+    /// Otherwise (`Dev` or `Lsp`), all dependencies are considered
     pub mode: Mode,
+    // If `Yes` we read the manifest from disc. If not set then we ignore any
+    // manifest which will result in the latest versions of the dependency
+    // packages being resolved (not the locked ones).
     pub use_manifest: UseManifest,
+    /// When set to `Yes`, the cli will check for major version updates of direct dependencies and
+    /// print them to the console if the major versions are not upgradeable due to constraints.
     pub check_major_versions: CheckMajorVersions,
 }
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -104,7 +104,7 @@ fn get_manifest_details(paths: &ProjectPaths) -> Result<(PackageConfig, Manifest
         cli::Reporter::new(),
         Mode::Dev,
     );
-    let (_, manifest) = dependency_manager.get_manifest(&paths, &config, Vec::new())?;
+    let (_, manifest) = dependency_manager.get_manifest(paths, &config, Vec::new())?;
     Ok((config, manifest))
 }
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1322,9 +1322,9 @@ impl PackageFetcher {
         })
     }
 
-    /// Caches the result so subsequent calls to `get_dependencies` so that we don't need to make a
-    /// network request. Currently dependencies are fetched during initial version resolution, and
-    /// then during check for major version availability.
+    /// Caches the result of `get_dependencies` so that we don't need to make a network request.
+    /// Currently dependencies are fetched during initial version resolution, and then during check
+    /// for major version availability.
     fn cache_package(&self, package: &str, result: hexpm::Package) {
         let mut runtime_cache = self.runtime_cache.borrow_mut();
         let _ = runtime_cache.insert(package.to_string(), result);

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -401,8 +401,7 @@ fn pretty_print_major_versions_available(versions: dependency::PackageVersionDif
             * total_lines,
     );
 
-    output_string
-        .push_str("\nHint: the following dependencies have new major versions available:\n\n");
+    output_string.push_str("\nThe following dependencies have new major versions available:\n\n");
     for (name, v1, v2) in versions {
         let name_padding = " ".repeat(longest_package_name_length - name.len());
         let curr_ver_padding = " ".repeat(longest_current_version_length - v1.to_string().len());

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -677,7 +677,7 @@ impl DependencyManagerConfig {
     }
 }
 
-pub struct DependencyManager<Telem: Telemetry, P: dependency::PackageFetcher> {
+pub struct DependencyManager<Telem, P> {
     runtime: tokio::runtime::Handle,
     package_fetcher: P,
     mode: Mode,

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -2,6 +2,7 @@ use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
     process::Command,
+    rc::Rc,
     time::Instant,
 };
 
@@ -1330,7 +1331,7 @@ async fn lookup_package(
 }
 
 struct PackageFetcher {
-    runtime_cache: RefCell<HashMap<String, hexpm::Package>>,
+    runtime_cache: RefCell<HashMap<String, Rc<hexpm::Package>>>,
     runtime: tokio::runtime::Handle,
     http: HttpClient,
 }
@@ -1347,7 +1348,7 @@ impl PackageFetcher {
     /// Caches the result of `get_dependencies` so that we don't need to make a network request.
     /// Currently dependencies are fetched during initial version resolution, and then during check
     /// for major version availability.
-    fn cache_package(&self, package: &str, result: hexpm::Package) {
+    fn cache_package(&self, package: &str, result: Rc<hexpm::Package>) {
         let mut runtime_cache = self.runtime_cache.borrow_mut();
         let _ = runtime_cache.insert(package.to_string(), result);
     }
@@ -1383,7 +1384,7 @@ impl dependency::PackageFetcher for PackageFetcher {
     fn get_dependencies(
         &self,
         package: &str,
-    ) -> Result<hexpm::Package, Box<dyn std::error::Error>> {
+    ) -> Result<Rc<hexpm::Package>, Box<dyn std::error::Error>> {
         {
             let runtime_cache = self.runtime_cache.borrow();
             let result = runtime_cache.get(package);
@@ -1402,9 +1403,11 @@ impl dependency::PackageFetcher for PackageFetcher {
             .map_err(Box::new)?;
 
         match hexpm::get_package_response(response, HEXPM_PUBLIC_KEY) {
-            Ok(a) => {
-                self.cache_package(package, a.clone());
-                Ok(a)
+            Ok(pkg) => {
+                let pkg = Rc::new(pkg);
+                let pkg_ref = Rc::clone(&pkg);
+                self.cache_package(package, pkg);
+                Ok(pkg_ref)
             }
             Err(e) => match e {
                 hexpm::ApiError::NotFound => {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -435,12 +435,14 @@ pub fn download<Telem: Telemetry>(
     );
 
     if !major_versions_available.is_empty() {
-        println!("Hint: the following dependencies have new major versions available...");
+        // print to stderr instead of because this is not part of the standard output of this
+        // command
+        eprintln!("Hint: the following dependencies have new major versions available...");
 
         major_versions_available
             .iter()
             .for_each(|(name, (v1, v2))| {
-                println!("{}@{} -> {}@{}", name, v1, name, v2);
+                eprintln!("{}@{} -> {}@{}", name, v1, name, v2);
             });
     }
 

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -92,8 +92,9 @@ fn get_manifest_details(paths: &ProjectPaths) -> Result<(PackageConfig, Manifest
     let config = crate::config::root_config(paths)?;
     let package_fetcher = PackageFetcher::new(runtime.handle().clone());
     let dependency_manager = DependencyManagerConfig {
+        mode: Mode::Dev,
         use_manifest: UseManifest::Yes,
-        ..Default::default()
+        check_major_versions: CheckMajorVersions::No,
     }
     .into_dependency_manager(
         runtime.handle().clone(),
@@ -228,9 +229,9 @@ pub fn update(paths: &ProjectPaths, packages: Vec<String>) -> Result<()> {
         None,
         packages.into_iter().map(EcoString::from).collect(),
         DependencyManagerConfig {
+            mode: Mode::Dev,
             use_manifest,
             check_major_versions: CheckMajorVersions::Yes,
-            ..Default::default()
         },
     )?;
 
@@ -648,16 +649,6 @@ pub struct DependencyManagerConfig {
     pub mode: Mode,
     pub use_manifest: UseManifest,
     pub check_major_versions: CheckMajorVersions,
-}
-
-impl Default for DependencyManagerConfig {
-    fn default() -> Self {
-        Self {
-            mode: Mode::Dev,
-            use_manifest: UseManifest::No,
-            check_major_versions: CheckMajorVersions::No,
-        }
-    }
 }
 
 impl DependencyManagerConfig {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -418,6 +418,26 @@ pub fn download<Telem: Telemetry>(
     }
     LocalPackages::from_manifest(&manifest).write_to_disc(paths)?;
 
+    let versions = manifest
+        .packages
+        .iter()
+        .map(|manifest_pkg| (manifest_pkg.name.to_string(), manifest_pkg.version.clone()))
+        .collect();
+    let major_versions_available = dependency::resolve_major_versions(
+        PackageFetcher::boxed(runtime.handle().clone()),
+        versions,
+    );
+
+    if !major_versions_available.is_empty() {
+        println!("Hint: the following dependencies have new major versions available...");
+
+        major_versions_available
+            .iter()
+            .for_each(|(name, (v1, v2))| {
+                println!("{}@{} -> {}@{}", name, v1, name, v2);
+            });
+    }
+
     Ok(manifest)
 }
 

--- a/compiler-cli/src/dependencies/dependency_manager.rs
+++ b/compiler-cli/src/dependencies/dependency_manager.rs
@@ -218,9 +218,14 @@ where
                     &mut provided_packages,
                     &mut vec![],
                 )?,
-                Requirement::Git { git } => {
-                    provide_git_package(name.clone(), &git, project_paths, &mut provided_packages)?
-                }
+                Requirement::Git { git, ref_ } => provide_git_package(
+                    name.clone(),
+                    &git,
+                    &ref_,
+                    project_paths,
+                    &mut provided_packages,
+                    &mut Vec::new(),
+                )?,
             };
             let _ = root_requirements.insert(name, version);
         }

--- a/compiler-cli/src/dependencies/dependency_manager.rs
+++ b/compiler-cli/src/dependencies/dependency_manager.rs
@@ -1,0 +1,256 @@
+use std::collections::HashMap;
+
+use ecow::EcoString;
+use futures::future;
+use gleam_core::{
+    build::{Mode, Telemetry},
+    config::PackageConfig,
+    dependency,
+    manifest::Manifest,
+    paths::ProjectPaths,
+    requirement::Requirement,
+    Error, Result,
+};
+
+use crate::{
+    build_lock::BuildLock,
+    dependencies::{pretty_print_major_versions_available, write_manifest_to_disc},
+    fs::ProjectIO,
+};
+
+use super::{
+    add_missing_packages, is_same_requirements, lookup_package, provide_git_package,
+    provide_local_package, read_manifest_from_disc, remove_extra_packages, unlock_packages,
+    CheckMajorVersions, LocalPackages, UseManifest,
+};
+
+pub struct DependencyManagerConfig {
+    // If `Yes` we read the manifest from disc. If not set then we ignore any
+    // manifest which will result in the latest versions of the dependency
+    // packages being resolved (not the locked ones).
+    pub use_manifest: UseManifest,
+    /// When set to `Yes`, the cli will check for major version updates of direct dependencies and
+    /// print them to the console if the major versions are not upgradeable due to constraints.
+    pub check_major_versions: CheckMajorVersions,
+}
+
+impl DependencyManagerConfig {
+    pub fn into_dependency_manager<Telem: Telemetry, P: dependency::PackageFetcher>(
+        self,
+        runtime: tokio::runtime::Handle,
+        package_fetcher: P,
+        telemetry: Telem,
+        mode: Mode,
+    ) -> DependencyManager<Telem, P> {
+        DependencyManager {
+            runtime,
+            package_fetcher,
+            telemetry,
+
+            mode,
+            use_manifest: self.use_manifest,
+            check_major_versions: self.check_major_versions,
+        }
+    }
+}
+
+pub struct DependencyManager<Telem, P> {
+    runtime: tokio::runtime::Handle,
+    package_fetcher: P,
+    mode: Mode,
+    use_manifest: UseManifest,
+    telemetry: Telem,
+    check_major_versions: CheckMajorVersions,
+}
+
+impl<Telem, P> DependencyManager<Telem, P>
+where
+    P: dependency::PackageFetcher,
+    Telem: Telemetry,
+{
+    pub fn get_manifest(
+        &self,
+        paths: &ProjectPaths,
+        config: &PackageConfig,
+        packages_to_update: Vec<EcoString>,
+    ) -> Result<(bool, Manifest)> {
+        // If there's no manifest (or we have been asked not to use it) then resolve
+        // the versions anew
+        let should_resolve = match self.use_manifest {
+            _ if !paths.manifest().exists() => {
+                tracing::debug!("manifest_not_present");
+                true
+            }
+            UseManifest::No => {
+                tracing::debug!("ignoring_manifest");
+                true
+            }
+            UseManifest::Yes => false,
+        };
+
+        if should_resolve {
+            let manifest = self.resolve_versions(paths, config, None, Vec::new())?;
+            return Ok((true, manifest));
+        }
+
+        let manifest = read_manifest_from_disc(paths)?;
+
+        // If there are no requested updates, and the config is unchanged
+        // since the manifest was written then it is up to date so we can return it unmodified.
+        if packages_to_update.is_empty()
+            && is_same_requirements(
+                &manifest.requirements,
+                &config.all_direct_dependencies()?,
+                paths.root(),
+            )?
+        {
+            tracing::debug!("manifest_up_to_date");
+            Ok((false, manifest))
+        } else {
+            tracing::debug!("manifest_outdated");
+            let manifest =
+                self.resolve_versions(paths, config, Some(&manifest), packages_to_update)?;
+            Ok((true, manifest))
+        }
+    }
+
+    pub fn download(
+        &self,
+        paths: &ProjectPaths,
+        new_package: Option<(Vec<(EcoString, Requirement)>, bool)>,
+        packages_to_update: Vec<EcoString>,
+    ) -> Result<Manifest> {
+        let span = tracing::info_span!("download_deps");
+        let _enter = span.enter();
+
+        // We do this before acquiring the build lock so that we don't create the
+        // build directory if there is no gleam.toml
+        crate::config::ensure_config_exists(paths)?;
+
+        let lock = BuildLock::new_packages(paths)?;
+        let _guard = lock.lock(&self.telemetry);
+
+        let fs = ProjectIO::boxed();
+
+        // Read the project config
+        let mut config = crate::config::read(paths.root_config())?;
+        let project_name = config.name.clone();
+
+        // Insert the new packages to add, if it exists
+        if let Some((packages, dev)) = new_package {
+            for (package, requirement) in packages {
+                if dev {
+                    _ = config.dev_dependencies.insert(package, requirement);
+                } else {
+                    _ = config.dependencies.insert(package, requirement);
+                };
+            }
+        }
+
+        // Determine what versions we need
+        let (manifest_updated, manifest) = self.get_manifest(paths, &config, packages_to_update)?;
+        let local = LocalPackages::read_from_disc(paths)?;
+
+        // Remove any packages that are no longer required due to gleam.toml changes
+        remove_extra_packages(paths, &local, &manifest, &self.telemetry)?;
+
+        // Download them from Hex to the local cache
+        self.runtime.block_on(add_missing_packages(
+            paths,
+            fs,
+            &manifest,
+            &local,
+            project_name,
+            &self.telemetry,
+        ))?;
+
+        if manifest_updated {
+            // Record new state of the packages directory
+            // TODO: test
+            tracing::debug!("writing_manifest_toml");
+            write_manifest_to_disc(paths, &manifest)?;
+        }
+        LocalPackages::from_manifest(&manifest).write_to_disc(paths)?;
+
+        if let CheckMajorVersions::Yes = self.check_major_versions {
+            let major_versions_available =
+                dependency::check_for_major_version_updates(&manifest, &self.package_fetcher);
+            if !major_versions_available.is_empty() {
+                eprintln!(
+                    "{}",
+                    pretty_print_major_versions_available(major_versions_available)
+                );
+            }
+        }
+
+        Ok(manifest)
+    }
+
+    fn resolve_versions(
+        &self,
+        project_paths: &ProjectPaths,
+        config: &PackageConfig,
+        manifest: Option<&Manifest>,
+        packages_to_update: Vec<EcoString>,
+    ) -> Result<Manifest, Error> {
+        self.telemetry.resolving_package_versions();
+        let dependencies = config.dependencies_for(self.mode)?;
+        let mut locked = config.locked(manifest)?;
+
+        if !packages_to_update.is_empty() {
+            unlock_packages(&mut locked, &packages_to_update, manifest)?;
+        }
+
+        // Packages which are provided directly instead of downloaded from hex
+        let mut provided_packages = HashMap::new();
+        // The version requires of the current project
+        let mut root_requirements = HashMap::new();
+
+        // Populate the provided_packages and root_requirements maps
+        for (name, requirement) in dependencies.into_iter() {
+            let version = match requirement {
+                Requirement::Hex { version } => version,
+                Requirement::Path { path } => provide_local_package(
+                    name.clone(),
+                    &path,
+                    project_paths.root(),
+                    project_paths,
+                    &mut provided_packages,
+                    &mut vec![],
+                )?,
+                Requirement::Git { git } => {
+                    provide_git_package(name.clone(), &git, project_paths, &mut provided_packages)?
+                }
+            };
+            let _ = root_requirements.insert(name, version);
+        }
+
+        // Convert provided packages into hex packages for pub-grub resolve
+        let provided_hex_packages = provided_packages
+            .iter()
+            .map(|(name, package)| (name.clone(), package.to_hex_package(name)))
+            .collect();
+
+        let resolved = dependency::resolve_versions(
+            &self.package_fetcher,
+            provided_hex_packages,
+            config.name.clone(),
+            root_requirements.into_iter(),
+            &locked,
+        )?;
+
+        // Convert the hex packages and local packages into manifest packages
+        let manifest_packages = self.runtime.block_on(future::try_join_all(
+            resolved
+                .into_iter()
+                .map(|(name, version)| lookup_package(name, version, &provided_packages)),
+        ))?;
+
+        let manifest = Manifest {
+            packages: manifest_packages,
+            requirements: config.all_direct_dependencies()?,
+        };
+
+        Ok(manifest)
+    }
+}

--- a/compiler-cli/src/dependencies/dependency_manager.rs
+++ b/compiler-cli/src/dependencies/dependency_manager.rs
@@ -3,13 +3,13 @@ use std::collections::HashMap;
 use ecow::EcoString;
 use futures::future;
 use gleam_core::{
+    Error, Result,
     build::{Mode, Telemetry},
     config::PackageConfig,
     dependency,
     manifest::Manifest,
     paths::ProjectPaths,
     requirement::Requirement,
-    Error, Result,
 };
 
 use crate::{
@@ -19,9 +19,9 @@ use crate::{
 };
 
 use super::{
-    add_missing_packages, is_same_requirements, lookup_package, provide_git_package,
-    provide_local_package, read_manifest_from_disc, remove_extra_packages, unlock_packages,
-    CheckMajorVersions, LocalPackages, UseManifest,
+    CheckMajorVersions, LocalPackages, UseManifest, add_missing_packages, is_same_requirements,
+    lookup_package, provide_git_package, provide_local_package, read_manifest_from_disc,
+    remove_extra_packages, unlock_packages,
 };
 
 pub struct DependencyManagerConfig {

--- a/compiler-cli/src/dependencies/snapshots/gleam__dependencies__tests__pretty_print_major_versions_available.snap
+++ b/compiler-cli/src/dependencies/snapshots/gleam__dependencies__tests__pretty_print_major_versions_available.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler-cli/src/dependencies/tests.rs
 expression: output
+snapshot_kind: text
 ---
-Hint: the following dependencies have new major versions available:
+The following dependencies have new major versions available:
 
 gleam_stdlib           0.45.0    -> 1.0.0
 short_name             1.0.0     -> 2.0.0

--- a/compiler-cli/src/dependencies/snapshots/gleam__dependencies__tests__pretty_print_major_versions_available.snap
+++ b/compiler-cli/src/dependencies/snapshots/gleam__dependencies__tests__pretty_print_major_versions_available.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-cli/src/dependencies/tests.rs
+expression: output
+---
+Hint: the following dependencies have new major versions available:
+
+gleam_stdlib           0.45.0    -> 1.0.0
+short_name             1.0.0     -> 2.0.0
+very_long_package_name 18.382.43 -> 19.0.38

--- a/compiler-cli/src/dependencies/snapshots/gleam_cli__dependencies__tests__pretty_print_major_versions_available.snap
+++ b/compiler-cli/src/dependencies/snapshots/gleam_cli__dependencies__tests__pretty_print_major_versions_available.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-cli/src/dependencies/tests.rs
+expression: output
+---
+The following dependencies have new major versions available:
+
+gleam_stdlib           0.45.0    -> 1.0.0
+short_name             1.0.0     -> 2.0.0
+very_long_package_name 18.382.43 -> 19.0.38

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -1335,3 +1335,27 @@ fn test_remove_package_that_is_also_a_transitive_dependency() {
     assert_eq!(manifest.requirements, config.dependencies);
     assert_eq!(manifest.packages, manifest_copy.packages);
 }
+
+#[test]
+fn test_pretty_print_major_versions_available() {
+    let versions = vec![
+        (
+            "very_long_package_name".to_string(),
+            (Version::new(18, 382, 43), Version::new(19, 0, 38)),
+        ),
+        (
+            "gleam_stdlib".to_string(),
+            (Version::new(0, 45, 0), Version::new(1, 0, 0)),
+        ),
+        (
+            "short_name".to_string(),
+            (Version::new(1, 0, 0), Version::new(2, 0, 0)),
+        ),
+    ]
+    .into_iter()
+    .collect();
+
+    let output = pretty_print_major_versions_available(versions);
+
+    insta::assert_snapshot!(output);
+}

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -251,8 +251,10 @@ impl DownloadDependencies for ProjectIO {
             NullTelemetry,
             None,
             Vec::new(),
-            dependencies::UseManifest::Yes,
-            dependencies::CheckMajorVersions::No,
+            dependencies::DependencyManagerConfig {
+                use_manifest: dependencies::UseManifest::Yes,
+                ..Default::default()
+            },
         )
     }
 }

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -22,7 +22,7 @@ use std::{
 
 use camino::{ReadDirUtf8, Utf8Path, Utf8PathBuf};
 
-use crate::{dependencies::UseManifest, lsp::LspLocker};
+use crate::{dependencies, lsp::LspLocker};
 
 #[cfg(test)]
 mod tests;
@@ -246,13 +246,13 @@ impl MakeLocker for ProjectIO {
 
 impl DownloadDependencies for ProjectIO {
     fn download_dependencies(&self, paths: &ProjectPaths) -> Result<Manifest> {
-        crate::dependencies::download(
+        dependencies::download(
             paths,
             NullTelemetry,
             None,
             Vec::new(),
-            UseManifest::Yes,
-            false,
+            dependencies::UseManifest::Yes,
+            dependencies::CheckMajorVersions::No,
         )
     }
 }

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -1,6 +1,6 @@
 use gleam_core::{
     Result, Warning,
-    build::{NullTelemetry, Target},
+    build::{Mode, NullTelemetry, Target},
     error::{Error, FileIoAction, FileKind, OS, ShellCommandFailureReason, parse_os},
     io::{
         BeamCompiler, Command, CommandExecutor, Content, DirEntry, FileSystemReader,
@@ -252,8 +252,9 @@ impl DownloadDependencies for ProjectIO {
             None,
             Vec::new(),
             dependencies::DependencyManagerConfig {
+                mode: Mode::Dev,
                 use_manifest: dependencies::UseManifest::Yes,
-                ..Default::default()
+                check_major_versions: dependencies::CheckMajorVersions::No,
             },
         )
     }

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -1,6 +1,6 @@
 use gleam_core::{
     Result, Warning,
-    build::{Mode, NullTelemetry, Target},
+    build::{NullTelemetry, Target},
     error::{Error, FileIoAction, FileKind, OS, ShellCommandFailureReason, parse_os},
     io::{
         BeamCompiler, Command, CommandExecutor, Content, DirEntry, FileSystemReader,

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -246,7 +246,14 @@ impl MakeLocker for ProjectIO {
 
 impl DownloadDependencies for ProjectIO {
     fn download_dependencies(&self, paths: &ProjectPaths) -> Result<Manifest> {
-        crate::dependencies::download(paths, NullTelemetry, None, Vec::new(), UseManifest::Yes)
+        crate::dependencies::download(
+            paths,
+            NullTelemetry,
+            None,
+            Vec::new(),
+            UseManifest::Yes,
+            false,
+        )
     }
 }
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -252,7 +252,6 @@ impl DownloadDependencies for ProjectIO {
             None,
             Vec::new(),
             dependencies::DependencyManagerConfig {
-                mode: Mode::Dev,
                 use_manifest: dependencies::UseManifest::Yes,
                 check_major_versions: dependencies::CheckMajorVersions::No,
             },

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -782,6 +782,7 @@ fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
         None,
         Vec::new(),
         UseManifest::Yes,
+        true,
     )?;
     Ok(())
 }

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -781,7 +781,6 @@ fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
         None,
         Vec::new(),
         dependencies::DependencyManagerConfig {
-            mode: Mode::Dev,
             use_manifest: dependencies::UseManifest::Yes,
             check_major_versions: dependencies::CheckMajorVersions::No,
         },

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -781,9 +781,9 @@ fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
         None,
         Vec::new(),
         dependencies::DependencyManagerConfig {
+            mode: Mode::Dev,
             use_manifest: dependencies::UseManifest::Yes,
-            check_major_versions: dependencies::CheckMajorVersions::Yes,
-            ..Default::default()
+            check_major_versions: dependencies::CheckMajorVersions::No,
         },
     )?;
     Ok(())

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -76,7 +76,6 @@ pub mod run;
 mod shell;
 
 use config::root_config;
-use dependencies::UseManifest;
 use fs::{get_current_directory, get_project_root};
 pub use gleam_core::error::{Error, Result};
 
@@ -781,8 +780,11 @@ fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
         cli::Reporter::new(),
         None,
         Vec::new(),
-        UseManifest::Yes,
-        dependencies::CheckMajorVersions::Yes,
+        dependencies::DependencyManagerConfig {
+            use_manifest: dependencies::UseManifest::Yes,
+            check_major_versions: dependencies::CheckMajorVersions::Yes,
+            ..Default::default()
+        },
     )?;
     Ok(())
 }

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -782,7 +782,7 @@ fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
         None,
         Vec::new(),
         UseManifest::Yes,
-        true,
+        dependencies::CheckMajorVersions::Yes,
     )?;
     Ok(())
 }

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -546,8 +546,18 @@ mod tests {
                 ],
             ),
             (
+                "depends_on_old_version_of_direct_pkg",
+                vec![(
+                    "0.1.0",
+                    vec![("direct_pkg_with_major_version", ">= 0.1.0 and < 0.3.0")],
+                )],
+            ),
+            (
                 "this_pkg_depends_on_indirect_pkg",
-                vec![("0.1.0", vec![("indirect_pkg_with_major_version", ">= 0.1.0 and < 1.0.0")])],
+                vec![(
+                    "0.1.0",
+                    vec![("indirect_pkg_with_major_version", ">= 0.1.0 and < 1.0.0")],
+                )],
             ),
             (
                 "indirect_pkg_with_major_version",
@@ -974,9 +984,15 @@ mod tests {
                 (
                     EcoString::from("direct_pkg_with_major_version"),
                     requirement::Requirement::Hex {
+                        version: Range::new("> 0.1.0 and <= 2.0.0".into()),
+                    },
+                ),
+                (
+                    EcoString::from("depends_on_old_version_of_direct_pkg"),
+                    requirement::Requirement::Hex {
                         version: Range::new("> 0.1.0 and <= 1.0.0".into()),
                     },
-                )
+                ),
             ]
             .into_iter()
             .collect(),
@@ -993,11 +1009,21 @@ mod tests {
                     },
                 },
                 ManifestPackage {
-                    name: "package_depends_on_indirect_pkg".into(),
+                    name: "depends_on_old_version_of_direct_pkg".into(),
                     version: Version::parse("0.1.0").unwrap(),
                     build_tools: ["gleam".into()].into(),
                     otp_app: None,
-                    requirements: vec!["core_package".into()],
+                    requirements: vec!["direct_pkg_with_major_version".into()],
+                    source: ManifestPackageSource::Hex {
+                        outer_checksum: Base16Checksum(vec![1, 2, 3]),
+                    },
+                },
+                ManifestPackage {
+                    name: "pkg_depends_on_indirect_pkg".into(),
+                    version: Version::parse("0.1.0").unwrap(),
+                    build_tools: ["gleam".into()].into(),
+                    otp_app: None,
+                    requirements: vec!["indirect_pkg_with_major_version".into()],
                     source: ManifestPackageSource::Hex {
                         outer_checksum: Base16Checksum(vec![1, 2, 3]),
                     },

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -80,16 +80,12 @@ fn resolve_major_versions(
                 return None;
             };
 
-            let Some(latest) = &hexpackage
+            let latest = hexpackage
                 .releases
                 .iter()
-                .map(|release| release.version.clone())
+                .map(|release| &release.version)
                 .filter(|version| !version.is_pre())
-                .sorted_by(|a, b| b.cmp(a))
-                .next()
-            else {
-                return None;
-            };
+                .max()?;
 
             if latest.major <= version.major {
                 return None;
@@ -996,7 +992,6 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-            //requirements: HashMap::new(),
             packages: vec![
                 ManifestPackage {
                     name: "direct_pkg_with_major_version".into(),

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -7,6 +7,7 @@ use hexpm::{
     Dependency, Release,
     version::{Range, ResolutionError, Version},
 };
+use itertools::Itertools;
 use pubgrub::{
     solver::{Dependencies, choose_package_with_fewest_versions},
     type_aliases::Map,
@@ -82,15 +83,17 @@ pub fn resolve_major_versions(
     versions
         .iter()
         .filter_map(|(package, version)| {
-            // TODO: find out best error type for this operation
             let Ok(hexpackage) = package_fetcher.get_dependencies(package) else {
                 return None;
             };
 
             let Some(latest) = &hexpackage
                 .releases
-                .last()
+                .iter()
                 .map(|release| release.version.clone())
+                .filter(|version| !version.is_pre())
+                .sorted_by(|a, b| b.cmp(a))
+                .next()
             else {
                 return None;
             };

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, cell::RefCell, collections::HashMap, error::Error as StdError, rc::Rc};
 
-use crate::{manifest, Error, Result};
+use crate::{Error, Result, manifest};
 
 use ecow::EcoString;
 use hexpm::{

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -100,7 +100,7 @@ fn resolve_major_versions(
 pub fn check_for_major_version_updates(
     manifest: &manifest::Manifest,
     package_fetcher: &impl PackageFetcher,
-) -> HashMap<String, (Version, Version)> {
+) -> PackageVersionDiffs {
     // get the resolved versions of the direct dependencies to check for major
     // version updates.
     let versions = manifest


### PR DESCRIPTION
This PR aims to solve #3843.
The sample output from that issue:
```bash
 % gleam deps update
  Resolving versions
Downloading packages
 Downloaded 2 packages in 0.01s
 
Hint: the following dependencies have new major versions available...

- wibble@2
- wobble@3
```

# Todos
- [x] ~~Handle Async: fireoff the checks and show the results at the end.~~ Didn't make sense to do this.
- [ ] Telemetry? Not sure it's needed for this optional part.
- [x] ~~Merge version check into a single call~~ Hexpm API doesn't have this. Went with cache instead.
- [x] Get the direct dependencies only