### PR TITLE
Refactor docs to use ExDocs search_data model for global HexDocs indexing of Gleam packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,11 @@
 
   ([Ramkarthik Krishnamurthy](https://github.com/ramkarthik))
 
+- HexDocs documentation of Gleam packages now uses the ExDocs search data model,
+  allowing for global indexing of Gleam packages in HexDocs, and
+  making Gleam packages discoverable through global search of HexDocs.
+  ([Diemo Gebhardt](https://github.com/diemogebhardt))
+
 ### Language server
 
 - The language server can now generate the definition of functions that do not

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -363,7 +363,7 @@ pub fn generate_html<IO: FileSystemReader>(
         ),
     });
 
-    // lunr.min.js, search-data.js, search-data.json and index.js
+    // lunr.min.js, search-data.js, search_data.json and index.js
 
     files.push(OutputFile {
         path: Utf8PathBuf::from("js/lunr.min.js"),
@@ -382,7 +382,7 @@ pub fn generate_html<IO: FileSystemReader>(
     });
 
     files.push(OutputFile {
-        path: Utf8PathBuf::from("search-data.json"),
+        path: Utf8PathBuf::from("search_data.json"),
         content: Content::Text(search_data_json.to_string()),
     });
 

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -517,6 +517,14 @@ fn escape_html_content(it: String) -> String {
         .replace('\'', "&#39;")
 }
 
+#[test]
+fn escape_html_content_test() {
+    assert_eq!(
+        escape_html_content("&<>\"'".to_string()),
+        "&amp;&lt;&gt;&quot;&#39;"
+    );
+}
+
 fn escape_html_contents(indexes: Vec<SearchItem>) -> Vec<SearchItem> {
     indexes
         .into_iter()

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -363,7 +363,7 @@ pub fn generate_html<IO: FileSystemReader>(
         ),
     });
 
-    // lunr.min.js, search-data.js, search_data.json and index.js
+    // lunr.min.js, search_data.json and index.js
 
     files.push(OutputFile {
         path: Utf8PathBuf::from("js/lunr.min.js"),
@@ -375,11 +375,6 @@ pub fn generate_html<IO: FileSystemReader>(
         programming_language: SearchProgrammingLanguage::Gleam,
     })
     .expect("search index serialization");
-
-    files.push(OutputFile {
-        path: Utf8PathBuf::from("search-data.js"),
-        content: Content::Text(format!("window.Gleam.initSearch({});", search_data_json)),
-    });
 
     files.push(OutputFile {
         path: Utf8PathBuf::from("search_data.json"),

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -152,8 +152,8 @@ pub fn generate_html<IO: FileSystemReader>(
             type_: SearchItemType::Page,
             parent_title: config.name.to_string(),
             title: config.name.to_string(),
-            doc: content,
-            ref_: page.path.to_string(),
+            content,
+            reference: page.path.to_string(),
         })
     }
 
@@ -218,14 +218,14 @@ pub fn generate_html<IO: FileSystemReader>(
                 type_: SearchItemType::Type,
                 parent_title: module.name.to_string(),
                 title: type_.name.to_string(),
-                doc: format!(
+                content: format!(
                     "{}\n{}\n{}\n{}",
                     type_.definition,
                     type_.text_documentation,
                     constructors,
                     import_synonyms(&module.name, type_.name)
                 ),
-                ref_: format!("{}.html#{}", module.name, type_.name),
+                reference: format!("{}.html#{}", module.name, type_.name),
             })
         });
         constants.iter().for_each(|constant| {
@@ -233,13 +233,13 @@ pub fn generate_html<IO: FileSystemReader>(
                 type_: SearchItemType::Constant,
                 parent_title: module.name.to_string(),
                 title: constant.name.to_string(),
-                doc: format!(
+                content: format!(
                     "{}\n{}\n{}",
                     constant.definition,
                     constant.text_documentation,
                     import_synonyms(&module.name, constant.name)
                 ),
-                ref_: format!("{}.html#{}", module.name, constant.name),
+                reference: format!("{}.html#{}", module.name, constant.name),
             })
         });
         functions.iter().for_each(|function| {
@@ -247,21 +247,21 @@ pub fn generate_html<IO: FileSystemReader>(
                 type_: SearchItemType::Function,
                 parent_title: module.name.to_string(),
                 title: function.name.to_string(),
-                doc: format!(
+                content: format!(
                     "{}\n{}\n{}",
                     function.signature,
                     function.text_documentation,
                     import_synonyms(&module.name, function.name)
                 ),
-                ref_: format!("{}.html#{}", module.name, function.name),
+                reference: format!("{}.html#{}", module.name, function.name),
             })
         });
         search_items.push(SearchItem {
             type_: SearchItemType::Module,
             parent_title: module.name.to_string(),
             title: module.name.to_string(),
-            doc: documentation_content,
-            ref_: format!("{}.html", module.name),
+            content: documentation_content,
+            reference: format!("{}.html", module.name),
         });
 
         let page_title = format!("{} · {} · v{}", name, config.name, config.version);
@@ -372,7 +372,7 @@ pub fn generate_html<IO: FileSystemReader>(
 
     let search_data_json = serde_to_string(&SearchData {
         items: escape_html_contents(search_items),
-        proglang: SearchProgLang::Gleam,
+        programming_language: SearchProgrammingLanguage::Gleam,
     })
     .expect("search index serialization");
 
@@ -524,8 +524,8 @@ fn escape_html_contents(indexes: Vec<SearchItem>) -> Vec<SearchItem> {
             type_: idx.type_,
             parent_title: idx.parent_title,
             title: idx.title,
-            doc: escape_html_content(idx.doc),
-            ref_: idx.ref_,
+            content: escape_html_content(idx.content),
+            reference: idx.reference,
         })
         .collect::<Vec<SearchItem>>()
 }
@@ -839,7 +839,8 @@ struct ModuleTemplate<'a> {
 #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
 struct SearchData {
     items: Vec<SearchItem>,
-    proglang: SearchProgLang,
+    #[serde(rename = "proglang")]
+    programming_language: SearchProgrammingLanguage,
 }
 
 #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -849,9 +850,10 @@ struct SearchItem {
     #[serde(rename = "parentTitle")]
     parent_title: String,
     title: String,
-    doc: String,
+    #[serde(rename = "doc")]
+    content: String,
     #[serde(rename = "ref")]
-    ref_: String,
+    reference: String,
 }
 
 #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -866,7 +868,7 @@ enum SearchItemType {
 
 #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[serde(rename_all = "lowercase")]
-enum SearchProgLang {
+enum SearchProgrammingLanguage {
     // Elixir,
     // Erlang,
     Gleam,

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMarkdownPagesOpts::default())"
+snapshot_kind: text
 ---
 //// LICENSE.html
 
@@ -313,11 +314,14 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>
 
@@ -678,11 +682,14 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>
 
@@ -1043,10 +1050,13 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       });
       hljs.highlightAll();
     </script>
+
     <script src="../../js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="../../js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="../../search-data.js?v=0"></script>
+    <script>
+      fetch("../../search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -349,10 +350,13 @@ expression: "compile(config, modules)"
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -424,10 +425,13 @@ expression: "compile(config, modules)"
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -350,10 +351,13 @@ expression: "compile(config, modules)"
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -319,10 +320,13 @@ expression: "compile(config, modules)"
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -423,10 +424,13 @@ function for a fallback value.</p>
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -353,10 +354,13 @@ expression: "compile(config, modules)"
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -323,10 +324,13 @@ expression: "compile(config, modules)"
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile_with_markdown_pages(config, vec![], pages,\nCompileWithMarkdownPagesOpts::default())"
+snapshot_kind: text
 ---
 //// one.html
 
@@ -313,10 +314,13 @@ expression: "compile_with_markdown_pages(config, vec![], pages,\nCompileWithMark
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_hex_publish.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_hex_publish.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMarkdownPagesOpts { hex_publish: Some(DocContext::Build) })"
+snapshot_kind: text
 ---
 //// LICENSE.html
 
@@ -306,11 +307,14 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>
 
@@ -664,11 +668,14 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>
 
@@ -1022,10 +1029,13 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       });
       hljs.highlightAll();
     </script>
+
     <script src="../../js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="../../js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="../../search-data.js?v=0"></script>
+    <script>
+      fetch("../../search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__output_of_search_data_js.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__output_of_search_data_js.snap
@@ -1,6 +1,0 @@
----
-source: compiler-core/src/docs/tests.rs
-expression: json_wrapped_in_js
-snapshot_kind: text
----
-window.Gleam.initSearch({"items":[{"type":"module","parentTitle":"gleam/option","title":"gleam/option","doc":"","ref":"gleam/option.html"},{"type":"type","parentTitle":"gleam/option","title":"Option","doc":"`Option` represents a value that may be present or not. `Some` means the value is present, `None` means the value is not.","ref":"gleam/option.html#Option"},{"type":"function","parentTitle":"gleam/option","title":"unwrap","doc":"Extracts the value from an `Option`, returning a default value if there is none.","ref":"gleam/option.html#unwrap"},{"type":"constant","parentTitle":"gleam/dynamic/decode","title":"bool","doc":"A decoder that decodes `Bool` values.\n\n # Examples\n\n \n let result = decode.run(dynamic.from(True), decode.bool)\n assert result == Ok(True)\n \n","ref":"gleam/dynamic/decode.html#bool"}],"proglang":"gleam"});

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__output_of_search_data_js.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__output_of_search_data_js.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: json_wrapped_in_js
+snapshot_kind: text
+---
+window.Gleam.initSearch({"items":[{"type":"module","parentTitle":"gleam/option","title":"gleam/option","doc":"","ref":"gleam/option.html"},{"type":"type","parentTitle":"gleam/option","title":"Option","doc":"`Option` represents a value that may be present or not. `Some` means the value is present, `None` means the value is not.","ref":"gleam/option.html#Option"},{"type":"function","parentTitle":"gleam/option","title":"unwrap","doc":"Extracts the value from an `Option`, returning a default value if there is none.","ref":"gleam/option.html#unwrap"},{"type":"constant","parentTitle":"gleam/dynamic/decode","title":"bool","doc":"A decoder that decodes `Bool` values.\n\n # Examples\n\n \n let result = decode.run(dynamic.from(True), decode.bool)\n assert result == Ok(True)\n \n","ref":"gleam/dynamic/decode.html#bool"}],"proglang":"gleam"});

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__output_of_search_data_json.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__output_of_search_data_json.snap
@@ -1,0 +1,6 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: json
+snapshot_kind: text
+---
+{"items":[{"type":"module","parentTitle":"gleam/option","title":"gleam/option","doc":"","ref":"gleam/option.html"},{"type":"type","parentTitle":"gleam/option","title":"Option","doc":"`Option` represents a value that may be present or not. `Some` means the value is present, `None` means the value is not.","ref":"gleam/option.html#Option"},{"type":"function","parentTitle":"gleam/option","title":"unwrap","doc":"Extracts the value from an `Option`, returning a default value if there is none.","ref":"gleam/option.html#unwrap"},{"type":"constant","parentTitle":"gleam/dynamic/decode","title":"bool","doc":"A decoder that decodes `Bool` values.\n\n # Examples\n\n \n let result = decode.run(dynamic.from(True), decode.bool)\n assert result == Ok(True)\n \n","ref":"gleam/dynamic/decode.html#bool"}],"proglang":"gleam"}

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
+snapshot_kind: text
 ---
 //// app.html
 
@@ -353,10 +354,13 @@ expression: "compile(config, modules)"
       });
       hljs.highlightAll();
     </script>
+
     <script src="./js/lunr.min.js?v=GLEAM_VERSION_HERE"></script>
     <script src="./js/index.js?v=0"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="./search-data.js?v=0"></script>
+    <script>
+      fetch("./search_data.json?v=0")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -551,3 +551,11 @@ fn output_of_search_data_json() {
     let json = serde_to_string(&data).unwrap();
     insta::assert_snapshot!(json);
 }
+
+#[test]
+fn output_of_search_data_js() {
+    let data = create_sample_search_data();
+    let json = serde_to_string(&data).unwrap();
+    let json_wrapped_in_js = format!("window.Gleam.initSearch({});", json);
+    insta::assert_snapshot!(json_wrapped_in_js);
+}

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -544,3 +544,10 @@ fn ensure_search_data_matches_exdocs_search_data_model_specification() {
         assert!(item.contains_key("ref"));
     }
 }
+
+#[test]
+fn output_of_search_data_json() {
+    let data = create_sample_search_data();
+    let json = serde_to_string(&data).unwrap();
+    insta::assert_snapshot!(json);
+}

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -551,11 +551,3 @@ fn output_of_search_data_json() {
     let json = serde_to_string(&data).unwrap();
     insta::assert_snapshot!(json);
 }
-
-#[test]
-fn output_of_search_data_js() {
-    let data = create_sample_search_data();
-    let json = serde_to_string(&data).unwrap();
-    let json_wrapped_in_js = format!("window.Gleam.initSearch({});", json);
-    insta::assert_snapshot!(json_wrapped_in_js);
-}

--- a/compiler-core/templates/documentation_layout.html
+++ b/compiler-core/templates/documentation_layout.html
@@ -302,10 +302,13 @@
       });
       hljs.highlightAll();
     </script>
+
     <script src="{{ unnest }}/js/lunr.min.js?v={{ gleam_version }}"></script>
     <script src="{{ unnest }}/js/index.js?v={{ rendering_timestamp }}"></script>
-
-    <!-- Load the search index using JSONP to avoid CORS issues -->
-    <script src="{{ unnest }}/search-data.js?v={{ rendering_timestamp }}"></script>
+    <script>
+      fetch("{{ unnest }}/search_data.json?v={{ rendering_timestamp }}")
+        .then(response => response.json())
+        .then(data => window.Gleam.initSearch(data));
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR is regarding issue https://github.com/gleam-lang/gleam/issues/3811.

## Data Model

The search data model json changed from `SearchIndex`:

```json
[
  {
    "doc": "the name of the module or page",
    "title": "the title of the item",
    "content": "the content of the item",
    "url": "the relative link of the item, like 'module.html#title'"
  }
]
```

to `SearchData`, `SearchItem`, `SearchItemType` and `SearchProgrammingLanguage`:

```json
{
  "items": [
    {
      "type": "module" | "type" | "function" | "constant" | "page",
      "parentTitle": "the name of the module or page",
      "title": "the title of the item",
      "doc": "the content of the item",
      "ref": "the relative link of the item, like 'module.html#title'"
    }
  ],
  "proglang": "gleam"
}
```

Notes:
- `parentTitle` doesn't seem to have an equivalent in ExDocs from what I have seen so far. It is being populated by:
  - either `module.name.to_string()` in the context of types `"module" | "type" | "function" | "constant"`
  - or `config.name.to_string()` in the context of type `"page"` (`README.md`)
- `doc` matches ExDocs, except for headline partitioning
- `ref` matches ExDocs, except for arity `module.html#title/arity`

Neither of those is an issue for global HexDocs indexing of Gleam packages.

## Output Files

~~As I'm still exploring how everything works in the codebase, I didn't want to change too much at once. So I added `search_data.json` in addition to `search-data.js` to keep the existing mechanism working as is for now.~~

### `search-data.js`

~~Wrapped `search_data_json` in `window.Gleam.initSearch({});` for use in `documentation_layout.html` to execute `initSearch({})` in `docs-js/index.js` which in turn uses `lunr.js`.~~

Has been removed in favor of `search_data.json`.

### `search_data.json`

Bare `search_data_json` for use in global HexDocs.