### PR TITLE
Remove hint about unwrapping Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Compiler
 
+- Removed compiler hint about pattern matching a `Result(a, b)` when being used where `a` is expected.
+  ([Kieran O'Reilly](https://github.com/SoTeKie))
+
 - Optimised code generated for record updates.
   ([yoshi](https://github.com/joshi-monster))
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::build::{Outcome, Runtime, Target};
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
-use crate::type_::collapse_links;
 use crate::type_::error::{
     MissingAnnotation, Named, UnknownField, UnknownTypeHint, UnsafeRecordUpdateReason,
 };
@@ -21,7 +20,6 @@ use std::env;
 use std::fmt::{Debug, Display};
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Arc;
 use termcolor::Buffer;
 use thiserror::Error;
 use vec1::Vec1;
@@ -1831,7 +1829,6 @@ But function expects:
                     situation,
                 } => {
                     let mut printer = Printer::new(names);
-                    let hint = hint_unwrap_result(expected, given, &mut printer);
                     let mut text = if let Some(description) = situation.as_ref().and_then(|s| s.description()) {
                         let mut text = description.to_string();
                         text.push('\n');
@@ -1844,13 +1841,10 @@ But function expects:
                     text.push_str(&printer.print_type(expected));
                     text.push_str("\n\nFound type:\n\n    ");
                     text.push_str(&printer.print_type(given));
-                    if hint.is_some() {
-                        text.push('\n');
-                    }
                     Diagnostic {
                         title: "Type mismatch".into(),
                         text,
-                        hint,
+                        hint: None,
                         level: Level::Error,
                         location: Some(Location {
                             label: Label {
@@ -3779,31 +3773,6 @@ fn hint_alternative_operator(op: &BinOp, given: &Type) -> Option<String> {
         BinOp::AddFloat if given.is_string() => Some(hint_string_message()),
 
         _ => None,
-    }
-}
-
-fn hint_unwrap_result(
-    expected: &Arc<Type>,
-    given: &Arc<Type>,
-    printer: &mut Printer<'_>,
-) -> Option<String> {
-    // If the got type is `Result(a, _)` and the expected one is
-    // `a` then we can display the hint.
-    let wrapped_type = given.result_ok_type()?;
-    let expected = collapse_links(expected.clone());
-    if collapse_links(wrapped_type) != expected {
-        None
-    } else {
-        Some(wrap_format!(
-            "If you want to get a `{}` out of a `{}` you can pattern match on it:
-
-    case result {{
-      Ok(value) -> todo
-      Error(error) -> todo
-    }}",
-            printer.print_type(&expected),
-            printer.print_type(given),
-        ))
     }
 }
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unwrapping_a_result_when_types_match.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unwrapping_a_result_when_types_match.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub fn main() {\n  let value = Ok(1)\n  add_1(value)\n}\n\nfn add_1(to x) { x + 1 }\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -26,11 +27,3 @@ Expected type:
 Found type:
 
     Result(Int, a)
-
-Hint: If you want to get a `Int` out of a `Result(Int, a)` you can pattern match
-on it:
-
-    case result {
-      Ok(value) -> todo
-      Error(error) -> todo
-    }


### PR DESCRIPTION
[Related GH issue](https://github.com/gleam-lang/gleam/issues/3835)

There's not an easy way currently to make this error hint more context specific without a decent amount of additional work, so the goal of this PR is to remove it for now.