### PR TITLE
fix: typo in indexing tuple error

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2441,7 +2441,7 @@ tuple has {} elements so the highest valid index is {}.",
 
                 TypeError::NotATupleUnbound { location } => {
                     let text = wrap("To index into a tuple we need to \
-know it size, but we don't know anything about this type yet. \
+know its size, but we don't know anything about this type yet. \
 Please add some type annotations so we can continue."
                         );
                     Diagnostic {

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity1.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__pipe_with_annonymous_unannotated_functions_wrong_arity1.snap
@@ -26,5 +26,5 @@ error: Type mismatch
 5 │      |> fn (x, y) { x.0 }
   │                     ^ What type is this?
 
-To index into a tuple we need to know it size, but we don't know anything
+To index into a tuple we need to know its size, but we don't know anything
 about this type yet. Please add some type annotations so we can continue.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__tuple_index_not_a_tuple_unbound.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__tuple_index_not_a_tuple_unbound.snap
@@ -12,5 +12,5 @@ error: Type mismatch
 1 │ fn(a) { a.2 }
   │         ^ What type is this?
 
-To index into a tuple we need to know it size, but we don't know anything
+To index into a tuple we need to know its size, but we don't know anything
 about this type yet. Please add some type annotations so we can continue.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_arg_infer_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_arg_type_to_fn_arg_infer_error.snap
@@ -16,7 +16,7 @@ error: Type mismatch
 3 │    fn(x) { x.2 }(z)
   │            ^ What type is this?
 
-To index into a tuple we need to know it size, but we don't know anything
+To index into a tuple we need to know its size, but we don't know anything
 about this type yet. Please add some type annotations so we can continue.
 
 error: Unknown variable

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_one_arg_type_to_two_args_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_one_arg_type_to_two_args_fn.snap
@@ -24,5 +24,5 @@ error: Type mismatch
 4 │    fn(x, y) { x.0 + y.1 }(a)
   │               ^ What type is this?
 
-To index into a tuple we need to know it size, but we don't know anything
+To index into a tuple we need to know its size, but we don't know anything
 about this type yet. Please add some type annotations so we can continue.


### PR DESCRIPTION
Fixed indexing tuple when size is unknown error saying `to know it size` instead of `to know its size`