### PR TITLE
Suggest valid project names on InvalidProjectName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ### Build tool
 
+- `gleam new` now has refined project name validation - rather than failing on
+  invalid project names, it suggests a valid alternative and prompts for
+  confirmation to use it.
+  ([Diemo Gebhardt](https://github.com/diemogebhardt))
+
 ### Language server
 
 - The language server can now fill in the labels of any function call, even when
@@ -54,4 +59,4 @@
 - Fixed a bug where a block expression containing a singular record update would
   produce invalid erlang.
   ([yoshi](https://github.com/joshi-monster))
-  
+

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -349,16 +349,24 @@ fn validate_name(name: &str) -> Result<(), Error> {
             name: name.to_string(),
             reason: InvalidProjectNameReason::GleamReservedModule,
         })
-    } else if !regex::Regex::new("^[a-z][a-z0-9_]*$")
-        .expect("new name regex could not be compiled")
+    } else if regex::Regex::new("^[a-z][a-z0-9_]*$")
+        .expect("failed regex to match valid name format")
+        .is_match(name)
+    {
+        Ok(())
+    } else if regex::Regex::new("^[a-zA-Z][a-zA-Z0-9_]*$")
+        .expect("failed regex to match valid but non-lowercase name format")
         .is_match(name)
     {
         Err(Error::InvalidProjectName {
             name: name.to_string(),
-            reason: InvalidProjectNameReason::Format,
+            reason: InvalidProjectNameReason::FormatNotLowercase,
         })
     } else {
-        Ok(())
+        Err(Error::InvalidProjectName {
+            name: name.to_string(),
+            reason: InvalidProjectNameReason::Format,
+        })
     }
 }
 

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -378,7 +378,7 @@ fn suggest_valid_name(invalid_name: &str, reason: &InvalidProjectNameReason) -> 
             Some(format!("{}_app", invalid_name))
         }
         InvalidProjectNameReason::GleamReservedWord => Some(format!("{}_app", invalid_name)),
-        InvalidProjectNameReason::GleamReservedModule => None,
+        InvalidProjectNameReason::GleamReservedModule => Some(format!("{}_app", invalid_name)),
         InvalidProjectNameReason::FormatNotLowercase => Some(invalid_name.to_lowercase()),
         InvalidProjectNameReason::Format => {
             let suggestion = regex::Regex::new(r"[^a-z0-9]")

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -325,3 +325,32 @@ fn skip_existing_git_files_when_skip_git_is_true() {
     assert!(path.join("README.md").exists());
     assert!(path.join(".gitignore").exists());
 }
+
+#[test]
+fn validate_name_format() {
+    assert!(crate::new::validate_name("project").is_ok());
+    assert!(crate::new::validate_name("project_name").is_ok());
+    assert!(crate::new::validate_name("project2").is_ok());
+
+    let invalid = ["Project", "PROJECT", "Project_Name"];
+    for name in invalid {
+        assert!(matches!(
+            crate::new::validate_name(name),
+            Err(Error::InvalidProjectName {
+                name: _,
+                reason: crate::new::InvalidProjectNameReason::FormatNotLowercase
+            })
+        ));
+    }
+
+    let invalid = ["0project", "_project", "project-name"];
+    for name in invalid {
+        assert!(matches!(
+            crate::new::validate_name(name),
+            Err(Error::InvalidProjectName {
+                name: _,
+                reason: crate::new::InvalidProjectNameReason::Format
+            })
+        ));
+    }
+}

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -401,7 +401,7 @@ fn suggest_valid_names() {
             "gleam",
             &crate::new::InvalidProjectNameReason::GleamReservedModule
         ),
-        None
+        Some("gleam_app".to_string())
     );
 
     assert_eq!(

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -354,3 +354,85 @@ fn validate_name_format() {
         ));
     }
 }
+
+#[test]
+fn suggest_valid_names() {
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "gleam_",
+            &crate::new::InvalidProjectNameReason::GleamPrefix
+        ),
+        None
+    );
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "gleam_project",
+            &crate::new::InvalidProjectNameReason::GleamPrefix
+        ),
+        Some("project".to_string())
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "try",
+            &crate::new::InvalidProjectNameReason::ErlangReservedWord
+        ),
+        Some("try_app".to_string())
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "erl_eval",
+            &crate::new::InvalidProjectNameReason::ErlangStandardLibraryModule
+        ),
+        Some("erl_eval_app".to_string())
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "assert",
+            &crate::new::InvalidProjectNameReason::GleamReservedWord
+        ),
+        Some("assert_app".to_string())
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "gleam",
+            &crate::new::InvalidProjectNameReason::GleamReservedModule
+        ),
+        None
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "Project_Name",
+            &crate::new::InvalidProjectNameReason::FormatNotLowercase
+        ),
+        Some("project_name".to_string())
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "Pr0ject-n4me!",
+            &crate::new::InvalidProjectNameReason::Format
+        ),
+        Some("pr0ject_n4me_".to_string())
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "Pr0ject--n4me!",
+            &crate::new::InvalidProjectNameReason::Format
+        ),
+        Some("pr0ject_n4me_".to_string())
+    );
+
+    assert_eq!(
+        crate::new::suggest_valid_name(
+            "_pr0ject-name",
+            &crate::new::InvalidProjectNameReason::Format
+        ),
+        None
+    );
+}

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -524,6 +524,7 @@ impl From<capnp::NotInSchema> for Error {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InvalidProjectNameReason {
     Format,
+    FormatNotLowercase,
     GleamPrefix,
     ErlangReservedWord,
     ErlangStandardLibraryModule,
@@ -836,6 +837,9 @@ Please try again with a different project name.",
                             "is a reserved word in Gleam.",
                         InvalidProjectNameReason::GleamReservedModule =>
                             "is a reserved module name in Gleam.",
+                        InvalidProjectNameReason::FormatNotLowercase =>
+                            "does not have the correct format. Project names \
+may only contain lowercase letters",
                         InvalidProjectNameReason::Format =>
                             "does not have the correct format. Project names \
 must start with a lowercase letter and may only contain lowercase letters, \


### PR DESCRIPTION
This PR is regarding issue https://github.com/gleam-lang/gleam/issues/1728.

Depending on the `InvalidProjectNameReason` we might suggest a valid project name.

In case of the newly added `InvalidProjectNameReason::FormatNotLowercase` it looks like so:

```sh
We were not able to create your project as `Project_Name` does not have the
correct format. Project names may only contain lowercase letters.

Would you like to name your project 'project_name' instead? [y/n]: 
```

Lets take this as a basis to discuss what valid project names we might want to suggest for which `InvalidProjectNameReason`.