### PR TITLE
Fix unsafe ints on JS not warning if an @external fn is called prior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,10 @@
    nested inside another pattern would produce invalid code on Javascript.
    ([yoshi](https://github.com/joshi-monster))
 
+- Fixed a bug where expressions which use an unsafe integer on JavaScript would
+  not emit a warning if an @external function had been referenced.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.6.1 - 2024-11-19
 
 ### Bug fixed

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -317,7 +317,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 ..
             } => {
                 if self.environment.target == Target::JavaScript
-                    && !self.implementations.uses_javascript_externals
+                    && !self.current_function_definition.has_javascript_external
                 {
                     check_javascript_int_safety(&int_value, location, self.problems);
                 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_with_external_function_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__javascript_unsafe_int_with_external_function_call.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\npub fn main() {\n  9_007_199_254_740_992 + helper()\n}\n\n@external(javascript, \"a\", \"b\")\nfn helper() -> Int\n"
+expression: "\npub fn main() {\n  helper() + 9_007_199_254_740_992\n}\n\n@external(javascript, \"a\", \"b\")\nfn helper() -> Int\n"
 ---
 ----- SOURCE CODE
 
 pub fn main() {
-  9_007_199_254_740_992 + helper()
+  helper() + 9_007_199_254_740_992
 }
 
 @external(javascript, "a", "b")
@@ -14,10 +14,10 @@ fn helper() -> Int
 
 ----- WARNING
 warning: Int is outside JavaScript's safe integer range
-  ┌─ /src/warning/wrn.gleam:3:3
+  ┌─ /src/warning/wrn.gleam:3:14
   │
-3 │   9_007_199_254_740_992 + helper()
-  │   ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
+3 │   helper() + 9_007_199_254_740_992
+  │              ^^^^^^^^^^^^^^^^^^^^^ This is not a safe integer value on JavaScript
 
 This integer value is too large to be represented accurately by
 JavaScript's number type. To avoid this warning integer values must be in

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2712,7 +2712,7 @@ fn javascript_unsafe_int_with_external_function_call() {
     assert_js_warning!(
         r#"
 pub fn main() {
-  9_007_199_254_740_992 + helper()
+  helper() + 9_007_199_254_740_992
 }
 
 @external(javascript, "a", "b")


### PR DESCRIPTION
The unsafe integer warning wasn't appearing if an @external function had already been referenced.

There was a test for this but it needed to have the external function call _prior_ to the unsafe integer, not after it.