### PR TITLE
feat(wasm): support loading precompiled dependencies in `/lib`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ version = "1.6.2"
 dependencies = [
  "camino",
  "console_error_panic_hook",
+ "ecow",
  "getrandom",
  "gleam-core",
  "hexpm",

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 termcolor.workspace = true
 tracing.workspace = true
 getrandom.workspace = true
+ecow.workspace = true
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.42"


### PR DESCRIPTION
This adds support to utilize the `/lib` path in a similar way to the `gleam-cli` compiler.

It's currently the responsiblity of the caller to populate the files with `write_file_bytes` for this to be useful.

## TODO

Because the `PackageConfig` is hard-coded and has no dependencies declared, importing anything from `/lib` will produce a "Transitive dependency imported" warning.

Added a second PR for that: https://github.com/gleam-lang/gleam/pull/3929

## Motivation

While tinkering with the idea from https://github.com/gleam-lang/playground/issues/9

Found that the current playground includes `gleam_stdlib` by pretending they're submodules in `src/gleam/io.gleam` for instance.

This approach no longer works when you're trying to use more dependencies than 1. Mainly the `import .. from` JS statements will break as they're precompiled as *siblings* rather than clobbered into a single package with submodules.