### PR TITLE
feat(wasm): support optional `/gleam.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "termcolor",
+ "toml",
  "tracing",
  "tracing-wasm",
  "wasm-bindgen",

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 termcolor.workspace = true
 tracing.workspace = true
 getrandom.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.42"

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -10,6 +10,7 @@ use gleam_core::{
         Mode, NullTelemetry, PackageCompiler, StaleTracker, Target, TargetCodegenConfiguration,
     },
     config::PackageConfig,
+    error::{FileIoAction, FileKind},
     io::{FileSystemReader, FileSystemWriter},
     uid::UniqueIdGenerator,
     warning::{VectorWarningEmitterIO, WarningEmitter},
@@ -171,11 +172,26 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
     let mut defined_modules = im::HashMap::new();
     #[allow(clippy::arc_with_non_send_sync)]
     let warning_emitter = WarningEmitter::new(Rc::new(project.warnings));
-    let config = PackageConfig {
-        name: "library".into(),
-        version: Version::new(1, 0, 0),
-        target,
-        ..Default::default()
+    let config_path = Utf8PathBuf::from("/gleam.toml");
+    let config = if project.fs.is_file(&config_path) {
+        // Try loading the config file if it exists.
+        let toml = project.fs.read(&config_path)?;
+        let config: PackageConfig = toml::from_str(&toml).map_err(|e| Error::FileIo {
+            action: FileIoAction::Parse,
+            kind: FileKind::File,
+            path: config_path,
+            err: Some(e.to_string()),
+        })?;
+        config.check_gleam_compatibility()?;
+        config
+    } else {
+        // Fallback to previous behavior when there's no config file.
+        PackageConfig {
+            name: "library".into(),
+            version: Version::new(1, 0, 0),
+            target,
+            ..Default::default()
+        }
     };
 
     let target = match target {

--- a/compiler-wasm/src/tests.rs
+++ b/compiler-wasm/src/tests.rs
@@ -26,6 +26,37 @@ fn test_write_module() {
 }
 
 #[wasm_bindgen_test]
+fn test_load_gleam_toml() {
+    reset_filesystem(0);
+    assert_eq!(read_file_bytes(0, "/gleam.toml"), None);
+    write_file(
+        0,
+        "/gleam.toml",
+        r#"
+name = "invalid-dashed-name"
+version = "0.1.0"
+"#,
+    );
+    assert!(compile_package(0, "javascript")
+        .expect_err("should fail to compile")
+        .contains("Package names may only contain"));
+
+    // TODO: config does not influence codegen yet.
+    // So we can't assert valid config had an effect here.
+
+    reset_filesystem(0);
+    write_file(
+        0,
+        "/gleam.toml",
+        r#"
+name = "testing_package"
+version = "0.1.0"
+"#,
+    );
+    assert!(compile_package(0, "javascript").is_ok());
+}
+
+#[wasm_bindgen_test]
 fn test_compile_package_bad_target() {
     reset_filesystem(0);
     assert!(compile_package(0, "ruby").is_err());


### PR DESCRIPTION
Issue: https://github.com/gleam-lang/gleam/issues/3928

Related PR: https://github.com/gleam-lang/gleam/pull/3924

Loads config if it's written to `/gleam.toml`, using the previous hard-coded config when it doesn't exist.