### PR TITLE
Replaced textwrap package with custom implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,6 @@ dependencies = [
  "strum",
  "tar",
  "termcolor",
- "textwrap",
  "thiserror",
  "toml",
  "tracing",
@@ -2133,12 +2132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
 name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,16 +2273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "test-helpers-rs"
 version = "0.1.0"
 dependencies = [
@@ -2331,18 +2314,6 @@ dependencies = [
  "test-helpers-rs",
  "toml",
  "walkdir",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-dependencies = [
- "smawk",
- "terminal_size",
- "unicode-linebreak",
- "unicode-width",
 ]
 
 [[package]]
@@ -2606,12 +2577,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -19,13 +19,13 @@ capnp = "0"
 # Template rendering
 askama = "0"
 # Markdown parsing
-pulldown-cmark = { version = "0", default-features = false, features = ["html"] }
+pulldown-cmark = { version = "0", default-features = false, features = [
+  "html",
+] }
 # Non-empty vectors
 vec1 = "1"
 # XDG directory locations
 dirs-next = "2"
-# Helper for wrapping text onto lines based upon width
-textwrap = { version = "=0.15.0", features = ["terminal_size"] }
 # SPDX license parsing
 spdx = "0"
 # Binary format de-serialization

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__no_target_supported_function_fault_tolerance.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__no_target_supported_function_fault_tolerance.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
 expression: "\n// This will error for having no support on this platform\n@external(erlang, \"one\", \"two\")\npub fn no_impl() -> Int\n\npub fn main() {\n  // This will due to no_impl not having an appropriate implementation for the\n  // target, NOT because it doesn't exist. The analyser should still know about\n  // it, even though it is invalid.\n  no_impl()\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -23,8 +24,8 @@ error: Unsupported target
 4 │ pub fn no_impl() -> Int
   │ ^^^^^^^^^^^^^^^^
 
-The `no_impl` function is public but doesn't have an implementation for
-the JavaScript target. All public functions of a package must be able to
+The `no_impl` function is public but doesn't have an implementation for the
+JavaScript target. All public functions of a package must be able to
 compile for a module to be valid.
 
 error: Unsupported target

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__type_unification_does_not_allow_different_variants_to_be_treated_as_safe.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__type_unification_does_not_allow_different_variants_to_be_treated_as_safe.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests.rs
 expression: "\npub type Wibble {\n  Wibble(a: Int, b: Int)\n  Wobble(a: Int, c: String)\n}\n\npub fn main() {\n  let a = case todo {\n    Wibble(..) as b -> Wibble(..b, b: 1)\n    Wobble(..) as b -> Wobble(..b, c: \"a\")\n  }\n\n  a.b\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -36,6 +37,6 @@ It has these accessible fields:
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_does_not_escape_clause_scope.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_does_not_escape_clause_scope.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests.rs
 expression: "\npub type Thingy {\n  A(a: Int)\n  B(x: Int, b: Int)\n}\n\npub fn fun(x) {\n  case x {\n    A(..) -> x.a\n    B(..) -> x.b\n  }\n  x.b\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -33,6 +34,6 @@ It does not have any fields shared by all variants.
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Person {\n    Teacher(name: String, title: String, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -28,6 +29,6 @@ It has these accessible fields:
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Person {\n    Teacher(title: String, age: Int, name: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -28,6 +29,6 @@ It has these accessible fields:
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_title(person: Person) { person.title }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -28,6 +29,6 @@ It has these accessible fields:
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Shape {\n    Square(x: Int, y: Int)\n    Rectangle(x: String, y: String)\n}\npub fn get_x(shape: Shape) { shape.x }\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -26,6 +27,6 @@ It does not have any fields shared by all variants.
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_bit_array_pattern_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_bit_array_pattern_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: let assert <<bitValue>> = <<73>>
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let assert <<bitValue>> = <<73>>
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ let assert <<bitValue>> = <<73>>
   │              ^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: bit_value

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_case_variable_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_case_variable_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "case 21 { twentyOne -> {Nil} }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 case 21 { twentyOne -> {Nil} }
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ case 21 { twentyOne -> {Nil} }
   │           ^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: twenty_one

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_const_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_const_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: const myInvalid_Constant = 42
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 const myInvalid_Constant = 42
@@ -12,6 +13,6 @@ error: Invalid constant name
 1 │ const myInvalid_Constant = 42
   │       ^^^^^^^^^^^^^^^^^^ This is not a valid constant name
 
-Hint: Constant names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Constant names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: my_invalid_constant

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_constructor_pattern_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_constructor_pattern_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "pub type Box { Box(Int) } pub fn main() { let Box(innerValue) = Box(203) }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Box { Box(Int) } pub fn main() { let Box(innerValue) = Box(203) }
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ pub type Box { Box(Int) } pub fn main() { let Box(innerValue) = Box(203) }
   │                                                   ^^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: inner_value

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "fn doStuff() {}"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn doStuff() {}
@@ -12,6 +13,6 @@ error: Invalid function name
 1 │ fn doStuff() {}
   │    ^^^^^^^ This is not a valid function name
 
-Hint: Function names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Function names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: do_stuff

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_type_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_type_parameter_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "fn identity(value: someType) { value }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn identity(value: someType) { value }
@@ -12,6 +13,6 @@ error: Invalid type variable name
 1 │ fn identity(value: someType) { value }
   │                    ^^^^^^^^ This is not a valid type variable name
 
-Hint: Type Variable names start with a lowercase letter and contain a-z, 0-
-9, or _.
+Hint: Type Variable names start with a lowercase letter and contain a-z,
+0-9, or _.
 Try: some_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_list_pattern_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_list_pattern_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "let assert [theElement] = [9.4]"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let assert [theElement] = [9.4]
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ let assert [theElement] = [9.4]
   │             ^^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: the_element

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_parameter_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "fn add(numA: Int, num_b: Int) { numA + num_b }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn add(numA: Int, num_b: Int) { numA + num_b }
@@ -12,6 +13,6 @@ error: Invalid argument name
 1 │ fn add(numA: Int, num_b: Int) { numA + num_b }
   │        ^^^^ This is not a valid argument name
 
-Hint: Argument names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Argument names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: num_a

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_parameter_name2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_parameter_name2.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "fn pass(label paramName: Bool) { paramName }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn pass(label paramName: Bool) { paramName }
@@ -12,6 +13,6 @@ error: Invalid argument name
 1 │ fn pass(label paramName: Bool) { paramName }
   │               ^^^^^^^^^ This is not a valid argument name
 
-Hint: Argument names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Argument names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: param_name

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_parameter_name3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_parameter_name3.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "let add = fn(numA: Int, num_b: Int) { numA + num_b }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let add = fn(numA: Int, num_b: Int) { numA + num_b }
@@ -12,6 +13,6 @@ error: Invalid argument name
 1 │ let add = fn(numA: Int, num_b: Int) { numA + num_b }
   │              ^^^^ This is not a valid argument name
 
-Hint: Argument names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Argument names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: num_a

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_pattern_assignment_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_pattern_assignment_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: let assert 42 as theAnswer = 42
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let assert 42 as theAnswer = 42
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ let assert 42 as theAnswer = 42
   │                  ^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: the_answer

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_string_prefix_pattern_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_string_prefix_pattern_alias.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "let assert \"prefix\" as thePrefix <> _suffix = \"prefix-suffix\""
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let assert "prefix" as thePrefix <> _suffix = "prefix-suffix"
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ let assert "prefix" as thePrefix <> _suffix = "prefix-suffix"
   │                        ^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: the_prefix

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_string_prefix_pattern_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_string_prefix_pattern_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "let assert \"prefix\" <> coolSuffix = \"prefix-suffix\""
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let assert "prefix" <> coolSuffix = "prefix-suffix"
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ let assert "prefix" <> coolSuffix = "prefix-suffix"
   │                        ^^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: cool_suffix

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_tuple_pattern_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_tuple_pattern_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "let #(a, secondValue) = #(1, 2)"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let #(a, secondValue) = #(1, 2)
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ let #(a, secondValue) = #(1, 2)
   │          ^^^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: second_value

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_parameter_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "type GleamOption(okType) = Result(okType, Nil)"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 type GleamOption(okType) = Result(okType, Nil)
@@ -12,6 +13,6 @@ error: Invalid type variable name
 1 │ type GleamOption(okType) = Result(okType, Nil)
   │                  ^^^^^^ This is not a valid type variable name
 
-Hint: Type Variable names start with a lowercase letter and contain a-z, 0-
-9, or _.
+Hint: Type Variable names start with a lowercase letter and contain a-z,
+0-9, or _.
 Try: ok_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_parameter_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "type Wrapper(innerType) {}"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 type Wrapper(innerType) {}
@@ -12,6 +13,6 @@ error: Invalid type variable name
 1 │ type Wrapper(innerType) {}
   │              ^^^^^^^^^ This is not a valid type variable name
 
-Hint: Type Variable names start with a lowercase letter and contain a-z, 0-
-9, or _.
+Hint: Type Variable names start with a lowercase letter and contain a-z,
+0-9, or _.
 Try: inner_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_use_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_use_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "fn use_test(f) { f(Nil) }\npub fn main() { use useVar <- use_test() }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn use_test(f) { f(Nil) }
@@ -13,6 +14,6 @@ error: Invalid argument name
 2 │ pub fn main() { use useVar <- use_test() }
   │                     ^^^^^^ This is not a valid argument name
 
-Hint: Argument names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Argument names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: use_var

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_variable_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_variable_name.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: let theAnswer = 42
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 let theAnswer = 42
@@ -12,6 +13,6 @@ error: Invalid variable name
 1 │ let theAnswer = 42
   │     ^^^^^^^^^ This is not a valid variable name
 
-Hint: Variable names start with a lowercase letter and contain a-z, 0-9,
-or _.
+Hint: Variable names start with a lowercase letter and contain a-z, 0-9, or
+_.
 Try: the_answer

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_arity_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_arity_error.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "fn go(x: List(a, b)) -> Int { 1 }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn go(x: List(a, b)) -> Int { 1 }
@@ -12,5 +13,5 @@ error: Incorrect arity
 1 │ fn go(x: List(a, b)) -> Int { 1 }
   │          ^^^^^^^^^^ Expected 1 argument, got 2
 
-Functions and constructors have to be called with their expected number
-of arguments.
+Functions and constructors have to be called with their expected number of
+arguments.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_a_variant_has_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_a_variant_has_note.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Wibble {\n  Wibble(field: Int)\n  Wobble(not_field: String, field: Int)\n}\n\npub fn main(wibble: Wibble) {\n  wibble.field\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -29,6 +30,6 @@ It does not have any fields shared by all variants.
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport some_mod\npub fn main(wibble: some_mod.Wibble) {\n  wibble.field\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 -- some_mod.gleam
@@ -32,6 +33,6 @@ It does not have any fields shared by all variants.
 
 Note: The field you are trying to access might not be consistently present
 or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same
-type in all variants, or pattern matching on it to enable direct accessor
+access. Ensure the field exists in the same position and has the same type
+in all variants, or pattern matching on it to enable direct accessor
 syntax.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unnecessary_spread_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unnecessary_spread_operator.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\ntype Triple {\n  Triple(a: Int, b: Int, c: Int)\n}\n\nfn main() {\n  let triple = Triple(1,2,3)\n  let Triple(a, b, c, ..) = triple\n}"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,5 +21,5 @@ error: Unnecessary spread operator
 8 │   let Triple(a, b, c, ..) = triple
   │                       ^^
 
-This record has 3 fields and you have already assigned variables to all
-of them.
+This record has 3 fields and you have already assigned variables to all of
+them.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__public_erlang_external.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__public_erlang_external.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/externals.rs
 expression: "@external(erlang, \"one\", \"two\")\npub fn main() -> Int\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 @external(erlang, "one", "two")
@@ -14,6 +15,6 @@ error: Unsupported target
 2 │ pub fn main() -> Int
   │ ^^^^^^^^^^^^^
 
-The `main` function is public but doesn't have an implementation for
-the JavaScript target. All public functions of a package must be able to
+The `main` function is public but doesn't have an implementation for the
+JavaScript target. All public functions of a package must be able to
 compile for a module to be valid.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_constant_segment_requires_v1_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_constant_segment_requires_v1_5.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
 expression: "pub const bits = <<\"hello\">>"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub const bits = <<"hello">>
@@ -13,8 +14,8 @@ warning: Incompatible gleam version range
   │                    ^^^^^^^ This requires a Gleam version >= 1.5.0
 
 The ability to omit the `utf8` annotation for string segments was
-introduced in version v1.5.0. But the Gleam version range specified in
-your `gleam.toml` would allow this code to run on an earlier version like
+introduced in version v1.5.0. But the Gleam version range specified in your
+`gleam.toml` would allow this code to run on an earlier version like
 v1.0.0, resulting in compilation errors!
 Hint: Remove the version constraint from your `gleam.toml` or update it to be:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_pattern_segment_requires_v1_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_pattern_segment_requires_v1_5.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
 expression: "\npub fn main(a) {\n  case a {\n    <<\"hello\">> -> Nil\n    _ -> Nil\n  }\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,8 +21,8 @@ warning: Incompatible gleam version range
   │       ^^^^^^^ This requires a Gleam version >= 1.5.0
 
 The ability to omit the `utf8` annotation for string segments was
-introduced in version v1.5.0. But the Gleam version range specified in
-your `gleam.toml` would allow this code to run on an earlier version like
+introduced in version v1.5.0. But the Gleam version range specified in your
+`gleam.toml` would allow this code to run on an earlier version like
 v1.0.0, resulting in compilation errors!
 Hint: Remove the version constraint from your `gleam.toml` or update it to be:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_segment_requires_v1_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__missing_utf_8_option_in_bit_array_segment_requires_v1_5.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
 expression: "\npub fn main() {\n  <<\"hello\">>\n}\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,8 +18,8 @@ warning: Incompatible gleam version range
   │     ^^^^^^^ This requires a Gleam version >= 1.5.0
 
 The ability to omit the `utf8` annotation for string segments was
-introduced in version v1.5.0. But the Gleam version range specified in
-your `gleam.toml` would allow this code to run on an earlier version like
+introduced in version v1.5.0. But the Gleam version range specified in your
+`gleam.toml` would allow this code to run on an earlier version like
 v1.0.0, resulting in compilation errors!
 Hint: Remove the version constraint from your `gleam.toml` or update it to be:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__todo_used_as_function_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__todo_used_as_function_2.snap
@@ -1,6 +1,7 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
 expression: "pub fn main() {\n          todo(1)\n        }"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main() {
@@ -26,8 +27,8 @@ warning: Todo used as a function
 2 │           todo(1)
   │                ^
 
-`todo` is not a function and will crash before it can do anything with
-this argument.
+`todo` is not a function and will crash before it can do anything with this
+argument.
 
 Hint: if you want to display an error message you should write
 `todo as "my error message"`


### PR DESCRIPTION
Resolves: https://github.com/gleam-lang/gleam/issues/2850 

Removes `textwrap` package in favour of custom implementation.

Personally, I'm not convinced this is better than just using `textwrap` and removing the terminal width check:
```rust 
textwrap::fill(text, 75)
```

### Issues
There are some slight differences in output between this solution and `textwrap`'s more sophisticated solution. This has caused some minor differences with some of the snapshots. I've reviewed and updated them but I want to draw attention to it.

**Question:** are we OK with these differences?