### PR TITLE
Remove dependency on `cod:del_paths`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,10 @@
   the left-hand side was a function call.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+ - Fixed a bug where Gleam would be unable to compile to BEAM bytecode on older
+   versions of Erlang/OTP.
+   ([yoshi](https://github.com/joshi-monster))
+
 ## v1.6.1 - 2024-11-19
 
 ### Bug fixed

--- a/compiler-cli/templates/gleam@@compile.erl
+++ b/compiler-cli/templates/gleam@@compile.erl
@@ -150,7 +150,11 @@ add_lib_to_erlang_path(Lib) ->
     code:add_paths(filelib:wildcard([Lib, "/*/ebin"])).
 
 del_lib_from_erlang_path(Lib) ->
-    code:del_paths(filelib:wildcard([Lib, "/*/ebin"])).
+    Paths = filelib:wildcard([Lib, "/*/ebin"]),
+    case erlang:function_exported(code, del_paths, 1) of
+        true -> code:del_paths(Paths);
+        false -> lists:foreach(fun code:del_path/1, Paths)
+    end.
 
 configure_logging() ->
     Enabled = os:getenv("GLEAM_LOG") /= false,

--- a/compiler-cli/templates/gleam@@compile.erl
+++ b/compiler-cli/templates/gleam@@compile.erl
@@ -147,14 +147,18 @@ do_compile_elixir(Modules, Out) ->
     end.
 
 add_lib_to_erlang_path(Lib) ->
-    code:add_paths(filelib:wildcard([Lib, "/*/ebin"])).
+    code:add_paths(expand_lib_paths(Lib)).
 
+-if(?OTP_RELEASE >= 26).
 del_lib_from_erlang_path(Lib) ->
-    Paths = filelib:wildcard([Lib, "/*/ebin"]),
-    case erlang:function_exported(code, del_paths, 1) of
-        true -> code:del_paths(Paths);
-        false -> lists:foreach(fun code:del_path/1, Paths)
-    end.
+    code:del_paths(expand_lib_paths(Lib)).
+-else.
+del_lib_from_erlang_path(Lib) ->
+    lists:foreach(fun code:del_path/1, expand_lib_paths(Lib)).
+-endif.
+
+expand_lib_paths(Lib) ->
+    filelib:wildcard([Lib, "/*/ebin"]).
 
 configure_logging() ->
     Enabled = os:getenv("GLEAM_LOG") /= false,


### PR DESCRIPTION
I still kept it in conditionally because the alternative `code:del_path` version sends a message to the `code` gen_server for every path. This restores compatibility with at least Erlang 25 again.

I want to apologize again for introducing that. ~ :purple_heart: 