### PR TITLE
Fix nested tuple access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,10 @@
   not emit a warning if an @external function had been referenced.
   ([Richard Viney](https://github.com/richard-viney))
 
+- Fixed a bug where nested tuple access would not be parsed correctly when
+  the left-hand side was a function call.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.6.1 - 2024-11-19
 
 ### Bug fixed

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -154,7 +154,6 @@ where
                 check_for_minus = true;
                 let name = self.lex_name()?;
                 self.emit(name);
-                self.maybe_lex_dot_access()?;
             } else if self.is_number_start(c, self.chr1) {
                 check_for_minus = true;
                 let num = self.lex_number()?;
@@ -437,6 +436,7 @@ where
                 } else {
                     let tok_end = self.get_pos();
                     self.emit((tok_start, Token::Dot, tok_end));
+                    self.maybe_lex_dot_access()?;
                 }
             }
             '#' => {
@@ -647,8 +647,7 @@ where
     fn maybe_lex_dot_access(&mut self) -> Result<(), LexicalError> {
         // It can be nested like: `tuple.1.2.3.4`
         loop {
-            if Some('.') == self.chr0 && matches!(self.chr1, Some('0'..='9')) {
-                self.eat_single_char(Token::Dot);
+            if matches!(self.chr0, Some('0'..='9')) {
                 let number = self.lex_int_number()?;
                 self.emit(number);
             } else {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuple_access_after_function.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuple_access_after_function.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: tuple().0.1
+---
+[
+    Expression(
+        TupleIndex {
+            location: SrcSpan {
+                start: 0,
+                end: 11,
+            },
+            index: 1,
+            tuple: TupleIndex {
+                location: SrcSpan {
+                    start: 0,
+                    end: 9,
+                },
+                index: 0,
+                tuple: Call {
+                    location: SrcSpan {
+                        start: 0,
+                        end: 7,
+                    },
+                    fun: Var {
+                        location: SrcSpan {
+                            start: 0,
+                            end: 5,
+                        },
+                        name: "tuple",
+                    },
+                    arguments: [],
+                },
+            },
+        },
+    ),
+]

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1676,7 +1676,5 @@ type Wibble {
 #[test]
 // https://github.com/gleam-lang/gleam/issues/3870
 fn nested_tuple_access_after_function() {
-    assert_parse!(
-        "tuple().0.1"
-    );
+    assert_parse!("tuple().0.1");
 }

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1672,3 +1672,11 @@ type Wibble {
 "#
     );
 }
+
+#[test]
+// https://github.com/gleam-lang/gleam/issues/3870
+fn nested_tuple_access_after_function() {
+    assert_parse!(
+        "tuple().0.1"
+    );
+}


### PR DESCRIPTION
Fixes #3870 
This PR moves the call to `maybe_lex_dot_access` to happen after any dot token, not just after a name token.