### PR TITLE
Fixed spelling mistake in mod package_name

### DIFF
--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -932,7 +932,7 @@ mod package_name {
             Ok(name.into())
         } else {
             let error =
-                "Package names may only container lowercase letters, numbers, and underscores";
+                "Package names may only contain lowercase letters, numbers, and underscores";
             Err(serde::de::Error::custom(error))
         }
     }
@@ -947,7 +947,7 @@ name = "one-two"
         toml::from_str::<PackageConfig>(input)
             .unwrap_err()
             .to_string(),
-        "Package names may only container lowercase letters, numbers, and underscores for key `name` at line 1 column 1"
+        "Package names may only contain lowercase letters, numbers, and underscores for key `name` at line 1 column 1"
     )
 }
 
@@ -960,6 +960,6 @@ name = "1"
         toml::from_str::<PackageConfig>(input)
             .unwrap_err()
             .to_string(),
-        "Package names may only container lowercase letters, numbers, and underscores for key `name` at line 1 column 1"
+        "Package names may only contain lowercase letters, numbers, and underscores for key `name` at line 1 column 1"
     )
 }


### PR DESCRIPTION
From issue #3955

This commit changes the phrase "package names may only container" to "package names may only contain" in all three locations.