### PR TITLE
LSP: Include braces in type import completions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,10 @@
   unused variables in certain cases.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where the completer would not include braces in type import completions
+  when it should have.
+  ([Jiangda Wang](https://github.com/Frank-III))
+
 ## v1.6.1 - 2024-11-19
 
 ### Bug fixed

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -72,6 +72,8 @@ fn sort_text(kind: CompletionKind, label: &str) -> String {
 enum TypeCompletionForm {
     // The type completion is for an unqualified import.
     UnqualifiedImport,
+    // The type completion is for an unqualified import within braces.
+    UnqualifiedImportWithinBraces,
     Default,
 }
 
@@ -211,10 +213,15 @@ where
             let importing_module_name = src.get(6..dot_index)?.trim();
             let importing_module: &ModuleInterface =
                 self.compiler.get_module_interface(importing_module_name)?;
+            let within_braces = match src.get(dot_index + 1..) {
+                Some(x) => x.trim_start().starts_with('{'),
+                None => false,
+            };
 
-            Some(Ok(Some(
-                self.unqualified_completions_from_module(importing_module),
-            )))
+            Some(Ok(Some(self.unqualified_completions_from_module(
+                importing_module,
+                within_braces,
+            ))))
         } else {
             // Find where to start and end the import completion
             let start = self.src_line_numbers.line_and_column_number(start_of_line);
@@ -233,6 +240,7 @@ where
     pub fn unqualified_completions_from_module(
         &'a self,
         module_being_imported_from: &'a ModuleInterface,
+        within_braces: bool,
     ) -> Vec<CompletionItem> {
         let insert_range = self.get_phrase_surrounding_completion_for_import();
         let mut completions = vec![];
@@ -276,7 +284,11 @@ where
                 name,
                 type_,
                 insert_range,
-                TypeCompletionForm::UnqualifiedImport,
+                if within_braces {
+                    TypeCompletionForm::UnqualifiedImportWithinBraces
+                } else {
+                    TypeCompletionForm::UnqualifiedImport
+                },
                 CompletionKind::ImportedModule,
             ));
         }
@@ -874,7 +886,8 @@ fn type_completion(
         text_edit: Some(CompletionTextEdit::Edit(TextEdit {
             range: insert_range,
             new_text: match include_type_in_completion {
-                TypeCompletionForm::UnqualifiedImport => format!("type {label}"),
+                TypeCompletionForm::UnqualifiedImport => format!("{{type {label}}}"),
+                TypeCompletionForm::UnqualifiedImportWithinBraces => format!("type {label}"),
                 TypeCompletionForm::Default => label.clone(),
             },
         })),

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -271,7 +271,7 @@ where
                     .compiler
                     .get_module_interface(import.module.as_str())
                     .map(|importing_module| {
-                        completer.unqualified_completions_from_module(importing_module)
+                        completer.unqualified_completions_from_module(importing_module, true)
                     }),
 
                 Located::ModuleStatement(Definition::ModuleConstant(_)) => None,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_type_import_completions_without_brackets.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_type_import_completions_without_brackets.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: import dep.
+---
+import dep.|
+
+
+----- Completion content -----
+Wibble
+  kind:   Class
+  detail: Type
+  sort:   3_Wibble
+  edits:
+    [0:11-0:11]: "{type Wibble}"


### PR DESCRIPTION
close: #3498

continuation of #3516, to support tests with invalid syntax. 

I am not sure if I should make it a different function. Please review it 🙏