### PR TITLE
Improve clarity of error messages for unknown record fields.

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1699,7 +1699,8 @@ Hint: Add some type annotations and try again.")
                         if variants == &UnknownField::NoFields {
                             text.push_str("\nIt does not have any fields.");
                         } else {
-                            text.push_str("\nIt does not have any fields shared by all variants.");
+                            text.push_str("\nIt does not have fields that are common \
+across all variants.");
                         }
                     } else {
                         text.push_str("\nIt has these accessible fields:\n");
@@ -1712,21 +1713,19 @@ Hint: Add some type annotations and try again.")
                     match variants {
                         UnknownField::AppearsInAVariant => {
                             let msg = wrap(
-                                "Note: The field you are trying to \
-access might not be consistently present or positioned across the custom \
-type's variants, preventing reliable access. Ensure the field exists in the \
-same position and has the same type in all variants, or pattern matching on it \
-to enable direct accessor syntax.",
+                                "Note: The field you are trying to access is \
+not defined consistently across all variants of this custom type. To fix this, \
+ensure that all variants include the field with the same name, position, and \
+type.",
                             );
                             text.push_str("\n\n");
                             text.push_str(&msg);
                         }
                         UnknownField::AppearsInAnImpossibleVariant => {
                             let msg = wrap(
-                                "Note: The field you are trying to \
-access exists, but not on the variant which this value always is. \
-A field that is not present in all variants can only be accessed when \
-the value is inferred to be one variant.",
+                                "Note: The field exists in this custom type \
+but is not defined for the current variant. Ensure that you are accessing the \
+field on a variant where it is valid.",
                             );
                             text.push_str("\n\n");
                             text.push_str(&msg);

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__type_unification_does_not_allow_different_variants_to_be_treated_as_safe.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__type_unification_does_not_allow_different_variants_to_be_treated_as_safe.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests.rs
 expression: "\npub type Wibble {\n  Wibble(a: Int, b: Int)\n  Wobble(a: Int, c: String)\n}\n\npub fn main() {\n  let a = case todo {\n    Wibble(..) as b -> Wibble(..b, b: 1)\n    Wobble(..) as b -> Wobble(..b, c: \"a\")\n  }\n\n  a.b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -35,8 +34,6 @@ It has these accessible fields:
 
     .a
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_does_not_escape_clause_scope.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_does_not_escape_clause_scope.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests.rs
 expression: "\npub type Thingy {\n  A(a: Int)\n  B(x: Int, b: Int)\n}\n\npub fn fun(x) {\n  case x {\n    A(..) -> x.a\n    B(..) -> x.b\n  }\n  x.b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -30,10 +29,8 @@ The value being accessed has this type:
 
     Thingy
 
-It does not have any fields shared by all variants.
+It does not have fields that are common across all variants.
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Person {\n    Teacher(name: String, title: String, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -27,8 +26,6 @@ It has these accessible fields:
 
     .name
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Person {\n    Teacher(title: String, age: Int, name: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -27,8 +26,6 @@ It has these accessible fields:
 
     .age
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_title(person: Person) { person.title }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -27,8 +26,6 @@ It has these accessible fields:
     .age
     .name
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Shape {\n    Square(x: Int, y: Int)\n    Rectangle(x: String, y: String)\n}\npub fn get_x(shape: Shape) { shape.x }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -23,10 +22,8 @@ The value being accessed has this type:
 
     Shape
 
-It does not have any fields shared by all variants.
+It does not have fields that are common across all variants.
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_access_on_inferred_variant_when_field_is_in_other_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_access_on_inferred_variant_when_field_is_in_other_variants.snap
@@ -30,6 +30,6 @@ It has these accessible fields:
 
     .wibble
 
-Note: The field you are trying to access exists, but not on the variant
-which this value always is. A field that is not present in all variants can
-only be accessed when the value is inferred to be one variant.
+Note: The field exists in this custom type but is not defined for the
+current variant. Ensure that you are accessing the field on a variant where
+it is valid.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_a_variant_has_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_a_variant_has_note.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\npub type Wibble {\n  Wibble(field: Int)\n  Wobble(not_field: String, field: Int)\n}\n\npub fn main(wibble: Wibble) {\n  wibble.field\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -26,10 +25,8 @@ The value being accessed has this type:
 
     Wibble
 
-It does not have any fields shared by all variants.
+It does not have fields that are common across all variants.
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "\nimport some_mod\npub fn main(wibble: some_mod.Wibble) {\n  wibble.field\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 -- some_mod.gleam
@@ -29,10 +28,8 @@ The value being accessed has this type:
 
     some_mod.Wibble
 
-It does not have any fields shared by all variants.
+It does not have fields that are common across all variants.
 
-Note: The field you are trying to access might not be consistently present
-or positioned across the custom type's variants, preventing reliable
-access. Ensure the field exists in the same position and has the same type
-in all variants, or pattern matching on it to enable direct accessor
-syntax.
+Note: The field you are trying to access is not defined consistently across
+all variants of this custom type. To fix this, ensure that all variants
+include the field with the same name, position, and type.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_does_not_appear_in_variant_has_no_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_does_not_appear_in_variant_has_no_note.snap
@@ -25,4 +25,4 @@ The value being accessed has this type:
 
     Wibble
 
-It does not have any fields shared by all variants.
+It does not have fields that are common across all variants.


### PR DESCRIPTION
Hey Louis and team.

I'm made some small changes to the error messages on Custom Types to make them clearer and more consistent.

Most importantly, inserting this one:
> The field you are trying to access is not defined consistently across all variants of this custom type. To fix this, ensure that all variants include the field with the same name, position, and type.

Instead of this one:
> The field you are trying to access exists, but not on the variant which this value always is. A field that is not present in all variants can only be accessed when the value is inferred to be one variant.

The goal was to reduce ambiguity and provide more actionable guidance. Let me know if you have any feedback!

Thanks,