### PR TITLE
Fix typo in error message for 'use'

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3121,7 +3121,7 @@ and the final one is the `use` callback function.\n"));
                         }
                     } else {
                         text.push_str("All the arguments have already been supplied, \
-so it cannot take the the `use` callback function as a final argument.\n")
+so it cannot take the `use` callback function as a final argument.\n")
                     };
 
                     text.push_str("\nSee: https://tour.gleam.run/advanced-features/use/");

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_arity_more_than_required.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_arity_more_than_required.snap
@@ -17,7 +17,7 @@ error: Incorrect arity
   │        ^^^^^^^ Expected 2 arguments, got 3
 
 The function on the right of `<-` here takes 2 arguments.
-All the arguments have already been supplied, so it cannot take the the
-`use` callback function as a final argument.
+All the arguments have already been supplied, so it cannot take the `use`
+callback function as a final argument.
 
 See: https://tour.gleam.run/advanced-features/use/

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_arity_more_than_required_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_arity_more_than_required_2.snap
@@ -17,7 +17,7 @@ error: Incorrect arity
   │        ^^^^^^^^^^ Expected 2 arguments, got 4
 
 The function on the right of `<-` here takes 2 arguments.
-All the arguments have already been supplied, so it cannot take the the
-`use` callback function as a final argument.
+All the arguments have already been supplied, so it cannot take the `use`
+callback function as a final argument.
 
 See: https://tour.gleam.run/advanced-features/use/


### PR DESCRIPTION
Stumbled across this error message and `the the` seems to be a typo?

```rust
                        text.push_str("All the arguments have already been supplied, \
so it cannot take the the `use` callback function as a final argument.\n")
```

Feel free to just close this PR, in case this isn't a typo.