### PR TITLE
Improve dependency conflict error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,27 @@
   with a local password, reducing risk of your Hex password being compromised.
   ([Louis Pilfold](https://github.com/lpil))
 
+- Improved the error message for dependency resolution failures to more clearly 
+  explain why the conflict occurs. Previously, the error message only listed the 
+  names of the conflicting packages:
+
+  ```
+  - mist
+  - server
+  - cors_builder
+  ```
+
+  Now, the message provides more detailed descriptions:
+
+  ```
+  - Package `app` requires `cors_builder` 1.0.0 <= v < 2.0.0
+  - Conflict with the `mist` package:
+      - `cors_builder` requires `mist` version 1.0.0 <= v < 2.0.0
+      - `app` requires `mist` version 3.0.0 <= v < 4.0.0
+  ```
+
+  ([dinkelspiel](https://github.com/dinkelspiel))
+
 ### Language Server
 
 - The language server now provides type information when hovering over argument

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -441,20 +441,25 @@ impl Error {
 the version constraints in your gleam.toml. \
 The conflicting packages are:
 
-{}
-{}
+{}{}{}
 ",
-                    conflicting_packages.into_iter().sorted().join("\n"),
-                from_dep_of.into_iter().map(|(dependency, conflicts)| {
-                    if conflicts.len() > 1 {
-                        format!("- Conflict with {dependency} package\n{}", conflicts.into_iter().map(|(package, dependency_version)| format!("    - {} requires {} version {}", conflict, dependency, dependency_version)).join("\n"))
-                    } else if let Some((package, dependency_version)) = conflicts.get(0) {
-                        format!("- Package {package} requires {dependency} {dependency_version}\n")
-                    } else {
-                        format!("")
+                    conflicting_packages.clone().into_iter().sorted().join("\n"),
+                    if conflicting_packages.len() > 0 {
+                        "\n"
+                    }  else {
+                        ""
+                    },
+                    from_dep_of.into_iter().map(|(dependency, conflicts)| {
+                        if conflicts.len() > 1 {
+                            format!("- Conflict with {dependency} package\n{}", conflicts.into_iter().map(|(package, dependency_version)| format!("    - {} requires {} version {}", package, dependency, dependency_version)).join("\n"))
+                        } else if let Some((package, dependency_version)) = conflicts.get(0) {
+                            format!("- Package {package} requires {dependency} {dependency_version}")
+                        } else {
+                            unreachable!("The from_dep_of hashmap can't exist with an empty vector");
+                        }
                     }
-                }
-                ).join("\n"))
+                    ).join("\n")
+                )
             }
 
             ResolutionError::ErrorRetrievingDependencies {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -380,7 +380,7 @@ impl Error {
 
     pub fn dependency_resolution_failed(error: ResolutionError) -> Error {
         fn collect_conflicting_packages<'dt, P: Package, V: Version>(
-            derivation_tree: &DerivationTree<P, V>,
+            derivation_tree: &'dt DerivationTree<P, V>,
             conflicting_packages: &mut HashSet<String>,
             from_dep_of: &mut HashMap<String, Vec<(String, String)>>,
         ) {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -379,8 +379,8 @@ impl Error {
     }
 
     pub fn dependency_resolution_failed(error: ResolutionError) -> Error {
-        fn collect_conflicting_packages<'dt, P: Package, V: Version>(
-            derivation_tree: &'dt DerivationTree<P, V>,
+        fn collect_conflicting_packages<P: Package, V: Version>(
+            derivation_tree: &DerivationTree<P, V>,
             conflicting_packages: &mut HashSet<String>,
             from_dep_of: &mut HashMap<String, Vec<(String, String)>>,
         ) {


### PR DESCRIPTION
Improved the error message for dependency resolution failures to more clearly 
explain why the conflict occurs. Previously, the error message only listed the 
names of the conflicting packages:

```
- mist
- server
- cors_builder
```

Now, the message provides more detailed descriptions:

```
- Package `app` requires `cors_builder` 1.0.0 <= v < 2.0.0
- Conflict with the `mist` package:
    - `cors_builder` requires `mist` version 1.0.0 <= v < 2.0.0
    - `app` requires `mist` version 3.0.0 <= v < 4.0.0
```
