### PR TITLE
set REBAR_SKIP_PROJECT_PLUGINS when running rebar3

### DIFF
--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -362,6 +362,7 @@ where
             ("ERL_LIBS", "../*/ebin".into()),
             ("REBAR_BARE_COMPILER_OUTPUT_DIR", package_build.to_string()),
             ("REBAR_PROFILE", "prod".into()),
+            ("REBAR_SKIP_PROJECT_PLUGINS", "true".into()),
             ("TERM", "dumb".into()),
         ];
         let args = [


### PR DESCRIPTION
This env var was added for tools like `gleam` to tell rebar3 they are using it just to build a dep and want to skip any project_plugins that might be in the configuration. Those were added specifically to not be pulled in when building a project as a dep.

Depends on https://github.com/erlang/rebar3/pull/2932 to actually have the benefit of faster builds.