### PR TITLE
Update default Elixir version in test.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,10 @@
   when it should have.
   ([Jiangda Wang](https://github.com/Frank-III))
 
+- Fixed a bug where `gleam new` would generate the github `test` workflow
+  configuration with incompatible Erlang OTP and Elixir versions.
+  ([John Strunk](https://github.com/jrstrunk))
+
 ## v1.6.1 - 2024-11-19
 
 ### Bug fixed

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -19,7 +19,7 @@ const GLEAM_STDLIB_REQUIREMENT: &str = ">= 0.44.0 and < 2.0.0";
 const GLEEUNIT_REQUIREMENT: &str = ">= 1.0.0 and < 2.0.0";
 const ERLANG_OTP_VERSION: &str = "27.1.2";
 const REBAR3_VERSION: &str = "3";
-const ELIXIR_VERSION: &str = "1.15.4";
+const ELIXIR_VERSION: &str = "1";
 
 #[derive(
     Debug, Serialize, Deserialize, Display, EnumString, VariantNames, ValueEnum, Clone, Copy,


### PR DESCRIPTION
Closes #4113, the prior Elixir version was not compatible with the Erlang OTP version provided by default, this PR fixes that. I tested the workflow with an Elixir version of `1` and it succeeded; hopefully this will prevent conflicts in the future as the Erlang OTP version is updated.