### PR TITLE
Fix trailing :bytes pattern on JS giving incorrect result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Compiler
+
+- Fixed a bug on JavaScript where a trailing `:bytes` segment would give the
+  wrong pattern match result for a sliced bit array.
+
 ## 1.7.0-rc1 - 2024-12-29
 
 ### Compiler

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -133,7 +133,8 @@ export class BitArray {
   sliceAfter(index) {
     const buffer = new Uint8Array(
       this.buffer.buffer,
-      this.buffer.byteOffset + index
+      this.buffer.byteOffset + index,
+      this.buffer.byteLength - index
     );
     return new BitArray(buffer);
   }

--- a/test/javascript_prelude/main.mjs
+++ b/test/javascript_prelude/main.mjs
@@ -438,6 +438,12 @@ assertEqual(
   new BitArray(new Uint8Array([1, 2, 3])).sliceAfter(1),
   new BitArray(new Uint8Array([2, 3])),
 );
+assertEqual(
+  new BitArray(new Uint8Array([1, 2, 3, 4, 5]))
+    .binaryFromSlice(1, 4)
+    .sliceAfter(1),
+  new BitArray(new Uint8Array([3, 4]))
+);
 
 // sizedInt()
 

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -1021,6 +1021,14 @@ fn bit_array_tests() -> List(Test) {
           _ -> False
         })
       }),
+    "pattern match using `:bytes` on a sliced bit array"
+      |> example(fn() {
+        assert_equal(<<3, 4>>, {
+          let assert <<_, b:bytes-3, _>> = <<1, 2, 3, 4, 5>>
+          let assert <<_, rest:bytes>> = b
+          rest
+        })
+      }),
   ]
 }
 


### PR DESCRIPTION
Found this regression when testing v1.7.0-rc1. It's a one line fix and new tests have been added.