### PR TITLE
Require newer stdlib version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@
   consumers.
   ([Aleksei Gurianov](https://github.com/guria))
 
-- New projects now require `gleam_stdlib` v0.44.0.
+- New projects now require `gleam_stdlib` v0.51.0.
   ([Louis Pilfold](https://github.com/lpil))
 
 - `gleam remove` no longer requires a network connection.

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -15,7 +15,7 @@ mod tests;
 
 use crate::{fs::get_current_directory, NewOptions};
 
-const GLEAM_STDLIB_REQUIREMENT: &str = ">= 0.44.0 and < 2.0.0";
+const GLEAM_STDLIB_REQUIREMENT: &str = ">= 0.51.0 and < 2.0.0";
 const GLEEUNIT_REQUIREMENT: &str = ">= 1.0.0 and < 2.0.0";
 const ERLANG_OTP_VERSION: &str = "27.1.2";
 const REBAR3_VERSION: &str = "3";

--- a/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_default_template@gleam.toml.snap
+++ b/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_default_template@gleam.toml.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-cli/src/new/tests.rs
-assertion_line: 56
 expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf()).expect(\"Non Utf8 Path\"),).unwrap()"
 ---
 name = "my_project"
@@ -18,7 +17,7 @@ version = "1.0.0"
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_stdlib = ">= 0.51.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_javascript_template@gleam.toml.snap
+++ b/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_javascript_template@gleam.toml.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-cli/src/new/tests.rs
-assertion_line: 84
 expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf()).expect(\"Non Utf8 Path\"),).unwrap()"
 ---
 name = "my_project"
@@ -19,7 +18,7 @@ target = "javascript"
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_stdlib = ">= 0.51.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"


### PR DESCRIPTION
I noticed the projects created with the RC require stdlib to be `>= 0.44`, but since we're now at `0.51` I though it would be better if we encouraged that