### PR TITLE
Stop using iifes for blocks in tail position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Compiler
 
+- Improved code generation for blocks in tail position on the Javascript target.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 ### Language server

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -511,7 +511,12 @@ impl<'module> Generator<'module> {
     }
 
     fn block<'a>(&mut self, statements: &'a Vec1<TypedStatement>) -> Output<'a> {
-        if statements.len() == 1 {
+        if self.scope_position.is_tail() {
+            // If the block is in tail position there's no need to wrap it in an
+            // immediately invoked function expression; we can just return its
+            // last expression.
+            self.statements(statements)
+        } else if statements.len() == 1 {
             match statements.first() {
                 Statement::Expression(expression) => self.child_expression(expression),
 

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -245,3 +245,17 @@ fn b() {
 "#
     );
 }
+
+#[test]
+fn block_in_tail_position_with_just_an_assignment() {
+    assert_js!(
+        r#"
+fn b() {
+  let x = 1
+  {
+    let x = x
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -215,3 +215,33 @@ fn b() {
 "#
     );
 }
+
+#[test]
+fn block_in_tail_position_is_not_an_iife() {
+    assert_js!(
+        r#"
+fn b() {
+  let x = 1
+  {
+    Nil
+    x + 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn block_in_tail_position_shadowing_variables() {
+    assert_js!(
+        r#"
+fn b() {
+  let x = 1
+  {
+    let x = 2
+    x + 1
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_is_not_an_iife.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_is_not_an_iife.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn b() {\n  let x = 1\n  {\n    Nil\n    x + 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+fn b() {
+  let x = 1
+  {
+    Nil
+    x + 1
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+function b() {
+  let x = 1;
+  undefined;
+  return x + 1;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_shadowing_variables.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_shadowing_variables.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn b() {\n  let x = 1\n  {\n    let x = 2\n    x + 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+fn b() {
+  let x = 1
+  {
+    let x = 2
+    x + 1
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+function b() {
+  let x = 1;
+  let x$1 = 2;
+  return x$1 + 1;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_with_just_an_assignment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_with_just_an_assignment.snap
@@ -1,6 +1,5 @@
 ---
 source: compiler-core/src/javascript/tests/blocks.rs
-assertion_line: 251
 expression: "\nfn b() {\n  let x = 1\n  {\n    let x = x\n  }\n}\n"
 ---
 ----- SOURCE CODE

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_with_just_an_assignment.snap.new
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__block_in_tail_position_with_just_an_assignment.snap.new
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+assertion_line: 251
+expression: "\nfn b() {\n  let x = 1\n  {\n    let x = x\n  }\n}\n"
+---
+----- SOURCE CODE
+
+fn b() {
+  let x = 1
+  {
+    let x = x
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+function b() {
+  let x = 1;
+  let x$1 = x;
+  return x$1;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks.snap
@@ -20,10 +20,8 @@ fn go() {
 function go() {
   let x = (() => {
     1;
-    return (() => {
-      2;
-      return 3;
-    })();
+    2;
+    return 3;
   })();
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks_with_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_blocks_with_case.snap
@@ -22,13 +22,11 @@ fn go() {
 function go() {
   let x = (() => {
     1;
-    return (() => {
-      2;
-      let $ = true;
-      {
-        return 3;
-      }
-    })();
+    2;
+    let $ = true;
+    {
+      return 3;
+    }
   })();
   return x;
 }


### PR DESCRIPTION
Currently the compiler wraps all blocks in iifes, but some could be dropped, for example if a block is in tail position there's no need to wrap that in an iife and we could just return its last expression.

This is only part of #3968 and doesn't addresses it completely, I've tried implementing this kind of optimisation for assignments as well but it's quite tricky to get right and couldn't get it to work properly. I'll try that again, but for the moment this is a little improvement!