### PR TITLE
Simplify pipeline assignment's internal representation

### DIFF
--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -38,7 +38,7 @@ pub enum TypedExpr {
     /// locations when showing it in error messages, etc.
     Pipeline {
         location: SrcSpan,
-        assignments: Vec<TypedAssignment>,
+        assignments: Vec<TypedPipelineAssignment>,
         finally: Box<Self>,
     },
 

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -55,7 +55,8 @@ use super::{
     untyped::FunctionLiteralKind, AssignName, BinOp, BitArrayOption, CallArg, Definition, Pattern,
     SrcSpan, Statement, TodoKind, TypeAst, TypedArg, TypedAssignment, TypedClause, TypedCustomType,
     TypedDefinition, TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule,
-    TypedModuleConstant, TypedPattern, TypedPatternBitArraySegment, TypedStatement, TypedUse,
+    TypedModuleConstant, TypedPattern, TypedPatternBitArraySegment, TypedPipelineAssignment,
+    TypedStatement, TypedUse,
 };
 
 pub trait Visit<'ast> {
@@ -121,7 +122,7 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_pipeline(
         &mut self,
         location: &'ast SrcSpan,
-        assignments: &'ast [TypedAssignment],
+        assignments: &'ast [TypedPipelineAssignment],
         finally: &'ast TypedExpr,
     ) {
         visit_typed_expr_pipeline(self, location, assignments, finally);
@@ -300,6 +301,10 @@ pub trait Visit<'ast> {
 
     fn visit_typed_use(&mut self, use_: &'ast TypedUse) {
         visit_typed_use(self, use_);
+    }
+
+    fn visit_typed_pipeline_assignment(&mut self, assignment: &'ast TypedPipelineAssignment) {
+        visit_typed_pipeline_assignment(self, assignment);
     }
 
     fn visit_typed_call_arg(&mut self, arg: &'ast TypedCallArg) {
@@ -783,16 +788,23 @@ pub fn visit_typed_expr_block<'a, V>(
 pub fn visit_typed_expr_pipeline<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    assignments: &'a [TypedAssignment],
+    assignments: &'a [TypedPipelineAssignment],
     finally: &'a TypedExpr,
 ) where
     V: Visit<'a> + ?Sized,
 {
     for assignment in assignments {
-        v.visit_typed_assignment(assignment);
+        v.visit_typed_pipeline_assignment(assignment);
     }
 
     v.visit_typed_expr(finally);
+}
+
+pub fn visit_typed_pipeline_assignment<'a, V>(v: &mut V, assignment: &'a TypedPipelineAssignment)
+where
+    V: Visit<'a> + ?Sized,
+{
+    v.visit_typed_expr(&assignment.value);
 }
 
 pub fn visit_typed_expr_var<'a, V>(

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1880,14 +1880,16 @@ fn expr<'a>(expression: &'a TypedExpr, env: &mut Env<'a>) -> Document<'a> {
 }
 
 fn pipeline<'a>(
-    assignments: &'a [TypedAssignment],
+    assignments: &'a [TypedPipelineAssignment],
     finally: &'a TypedExpr,
     env: &mut Env<'a>,
 ) -> Document<'a> {
     let mut documents = Vec::with_capacity((assignments.len() + 1) * 3);
 
     for a in assignments {
-        documents.push(assignment(a, env));
+        let body = maybe_block_expr(&a.value, env).group();
+        let name = env.next_local_var_name(&a.name);
+        documents.push(docvec![name, " = ", body]);
         documents.push(','.to_doc());
         documents.push(line());
     }

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -566,7 +566,7 @@ impl<'module> Generator<'module> {
             assignment
         };
 
-        return Ok(assignment.force_break());
+        Ok(assignment.force_break())
     }
 
     fn assignment<'a>(&mut self, assignment: &'a TypedAssignment) -> Output<'a> {

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -2,8 +2,7 @@ use self::expression::CallKind;
 
 use super::*;
 use crate::ast::{
-    Assignment, AssignmentKind, ImplicitCallArgOrigin, Statement, TypedAssignment, UntypedExpr,
-    PIPE_VARIABLE,
+    ImplicitCallArgOrigin, Statement, TypedPipelineAssignment, UntypedExpr, PIPE_VARIABLE,
 };
 use vec1::Vec1;
 
@@ -13,7 +12,7 @@ pub(crate) struct PipeTyper<'a, 'b, 'c> {
     argument_type: Arc<Type>,
     argument_location: SrcSpan,
     location: SrcSpan,
-    assignments: Vec<TypedAssignment>,
+    assignments: Vec<TypedPipelineAssignment>,
     expr_typer: &'a mut ExprTyper<'b, 'c>,
 }
 
@@ -205,16 +204,9 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             expression.type_(),
         );
         // Add the assignment to the AST
-        let assignment = Assignment {
+        let assignment = TypedPipelineAssignment {
             location,
-            annotation: None,
-            kind: AssignmentKind::Generated,
-            pattern: Pattern::Variable {
-                location,
-                name: PIPE_VARIABLE.into(),
-                type_: expression.type_(),
-                origin: VariableOrigin::Generated,
-            },
+            name: PIPE_VARIABLE.into(),
             value: Box::new(expression),
         };
         self.assignments.push(assignment);


### PR DESCRIPTION
Internally pipeline assignments are represented as regular assignments, this representation makes it a bit harder to work with those as we know that pipeline assignments are a very specific kind of assignment that will always be in the form `PipeX = Value`, with no patterns.

This change is also required by #3676 but I thought it would make sense to split it into its own PR to make that one a bit smaller and focused just on echo! Also I think this is needed to fix another recent bug <https://github.com/gleam-lang/gleam/issues/4134>, one more reason to have this in its own PR. Thanks!