### PR TITLE
Include doc comments in generated Erlang code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Improved code generation for blocks in tail position on the Javascript target.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Function documentation comments and module documentation comments are now
+  included in the generated Erlang code and can be browsed from the Erlang
+  shell starting from OTP27.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 ### Language server

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -182,10 +182,14 @@ where
             incomplete_modules,
         );
 
-        let modules = match outcome {
+        let mut modules = match outcome {
             Outcome::Ok(modules) => modules,
             Outcome::PartialFailure(_, _) | Outcome::TotalFailure(_) => return outcome,
         };
+
+        for mut module in modules.iter_mut() {
+            module.attach_doc_and_module_comments();
+        }
 
         tracing::debug!("performing_code_generation");
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -230,6 +230,10 @@ fn module_document<'a>(
         }
     }
 
+    // We're going to need the documentation directives if any of the module's
+    // functions need it, or if the module has a module comment that we want to
+    // include in the generated Erlang source.
+    let needs_function_docs = needs_function_docs || !module.documentation.is_empty();
     let documentation_directive = if needs_function_docs {
         "-if(?OTP_RELEASE >= 27).
 -define(MODULEDOC(Str), -moduledoc(Str)).

--- a/compiler-core/src/erlang/tests.rs
+++ b/compiler-core/src/erlang/tests.rs
@@ -17,6 +17,7 @@ mod case;
 mod conditional_compilation;
 mod consts;
 mod custom_types;
+mod documentation;
 mod external_fn;
 mod functions;
 mod guards;

--- a/compiler-core/src/erlang/tests/documentation.rs
+++ b/compiler-core/src/erlang/tests/documentation.rs
@@ -37,3 +37,45 @@ fn backslashes_in_documentation_are_escaped() {
 pub fn documented() { 1 }"#
     );
 }
+
+#[test]
+fn single_line_module_comment() {
+    assert_erl!(
+        r#"
+//// Hello! This is a single line module comment.
+
+pub fn main() { 1 }"#
+    );
+}
+
+#[test]
+fn multi_line_module_comment() {
+    assert_erl!(
+        r#"
+//// Hello! This is a multi-
+//// line module comment.
+////
+
+pub fn main() { 1 }"#
+    );
+}
+
+#[test]
+fn double_quotes_are_escaped_in_module_comment() {
+    assert_erl!(
+        r#"
+//// "quotes!"
+
+pub fn main() { 1 }"#
+    );
+}
+
+#[test]
+fn backslashes_are_escaped_in_module_comment() {
+    assert_erl!(
+        r#"
+//// \backslashes!\
+
+pub fn main() { 1 }"#
+    );
+}

--- a/compiler-core/src/erlang/tests/documentation.rs
+++ b/compiler-core/src/erlang/tests/documentation.rs
@@ -1,0 +1,39 @@
+use crate::assert_erl;
+
+#[test]
+fn function_with_documentation() {
+    assert_erl!(
+        r#"
+/// Function doc!
+pub fn documented() { 1 }"#
+    );
+}
+
+#[test]
+fn function_with_multiline_documentation() {
+    assert_erl!(
+        r#"
+/// Function doc!
+/// Hello!!
+///
+pub fn documented() { 1 }"#
+    );
+}
+
+#[test]
+fn quotes_in_documentation_are_escaped() {
+    assert_erl!(
+        r#"
+/// "hello"
+pub fn documented() { 1 }"#
+    );
+}
+
+#[test]
+fn backslashes_in_documentation_are_escaped() {
+    assert_erl!(
+        r#"
+/// \hello\
+pub fn documented() { 1 }"#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_are_escaped_in_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_are_escaped_in_module_comment.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n//// \\backslashes!\\\n\npub fn main() { 1 }"
+---
+----- SOURCE CODE
+
+//// \backslashes!\
+
+pub fn main() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+?MODULEDOC(" \\backslashes!\\\n").
+
+-file("/root/project/test/my/mod.gleam", 4).
+-spec main() -> integer().
+main() ->
+    1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_in_documentation_are_escaped.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_in_documentation_are_escaped.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n/// \\hello\\\npub fn documented() { 1 }"
+---
+----- SOURCE CODE
+
+/// \hello\
+pub fn documented() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([documented/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+-file("/root/project/test/my/mod.gleam", 3).
+?DOC(" \\hello\\\n").
+-spec documented() -> integer().
+documented() ->
+    1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__double_quotes_are_escaped_in_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__double_quotes_are_escaped_in_module_comment.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n//// \"quotes!\"\n\npub fn main() { 1 }"
+---
+----- SOURCE CODE
+
+//// "quotes!"
+
+pub fn main() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+?MODULEDOC(" \"quotes!\"\n").
+
+-file("/root/project/test/my/mod.gleam", 4).
+-spec main() -> integer().
+main() ->
+    1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_documentation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_documentation.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n/// Function doc!\npub fn documented() { 1 }"
+---
+----- SOURCE CODE
+
+/// Function doc!
+pub fn documented() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([documented/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+-file("/root/project/test/my/mod.gleam", 3).
+?DOC(" Function doc!\n").
+-spec documented() -> integer().
+documented() ->
+    1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_multiline_documentation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_multiline_documentation.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n/// Function doc!\n/// Hello!!\n///\npub fn documented() { 1 }"
+---
+----- SOURCE CODE
+
+/// Function doc!
+/// Hello!!
+///
+pub fn documented() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([documented/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+-file("/root/project/test/my/mod.gleam", 5).
+?DOC(
+    " Function doc!\n"
+    " Hello!!\n"
+).
+-spec documented() -> integer().
+documented() ->
+    1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__multi_line_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__multi_line_module_comment.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n//// Hello! This is a multi-\n//// line module comment.\n////\n\npub fn main() { 1 }"
+---
+----- SOURCE CODE
+
+//// Hello! This is a multi-
+//// line module comment.
+////
+
+pub fn main() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+?MODULEDOC(
+    " Hello! This is a multi-\n"
+    " line module comment.\n"
+    "\n"
+).
+
+-file("/root/project/test/my/mod.gleam", 6).
+-spec main() -> integer().
+main() ->
+    1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__quotes_in_documentation_are_escaped.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__quotes_in_documentation_are_escaped.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n/// \"hello\"\npub fn documented() { 1 }"
+---
+----- SOURCE CODE
+
+/// "hello"
+pub fn documented() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([documented/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+-file("/root/project/test/my/mod.gleam", 3).
+?DOC(" \"hello\"\n").
+-spec documented() -> integer().
+documented() ->
+    1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__single_line_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__single_line_module_comment.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n//// Hello! This is a single line module comment.\n\npub fn main() { 1 }"
+---
+----- SOURCE CODE
+
+//// Hello! This is a single line module comment.
+
+pub fn main() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+?MODULEDOC(" Hello! This is a single line module comment.\n").
+
+-file("/root/project/test/my/mod.gleam", 4).
+-spec main() -> integer().
+main() ->
+    1.

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_definition_with_docs.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_definition_with_docs.snap
@@ -13,6 +13,6 @@ fn append(x, y) {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nfn(String, String) -> String\n```\n Exciting documentation\n Maybe even multiple lines\n",
+        "```gleam\nfn(String, String) -> String\n```\n Exciting documentation\n Maybe even multiple lines",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant.snap
@@ -11,6 +11,6 @@ const one = 1
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines\n",
+        "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines",
     ),
 )

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -1,6 +1,5 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 151
 expression: "./cases/import_shadowed_name_warning"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
@@ -32,6 +31,16 @@ expression: "./cases/import_shadowed_name_warning"
 
 -export([use_type/1]).
 -export_type([shadowing/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+?MODULEDOC(" https://github.com/gleam-lang/otp/pull/22\n").
 
 -type shadowing() :: port.
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
@@ -1,6 +1,5 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 162
 expression: "./cases/imported_constants"
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
@@ -36,7 +35,19 @@ expression: "./cases/imported_constants"
 
 -export([accessors/1, destructure_qualified/1, destructure_unqualified/1, destructure_aliased/1, qualified_fn_a/0, qualified_fn_b/0, unqualified_fn_a/0, unqualified_fn_b/0, aliased_fn_a/0, aliased_fn_b/0]).
 
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
 -file("src/two.gleam", 45).
+?DOC(
+    " For these statements we use the accessors for the record from the other\n"
+    " module\n"
+).
 -spec accessors(one:user()) -> {binary(), integer()}.
 accessors(User) ->
     Name = erlang:element(2, User),
@@ -44,6 +55,7 @@ accessors(User) ->
     {Name, Score}.
 
 -file("src/two.gleam", 52).
+?DOC(" For these statements we use destructure the record\n").
 -spec destructure_qualified(one:user()) -> {binary(), integer()}.
 destructure_qualified(User) ->
     {user, Name, Score} = User,

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
@@ -35,7 +35,19 @@ expression: "./cases/imported_record_constructors"
 
 -export([accessors/1, destructure_qualified/1, destructure_qualified_aliased/1, destructure_unqualified/1, destructure_aliased/1, update_qualified/1, update_qualified_aliased/1, update_unqualified/1, update_aliased/1, qualified_fn_a/0, qualified_fn_b/0, qualified_aliased_fn_a/0, qualified_aliased_fn_b/0, unqualified_fn_a/0, unqualified_fn_b/0, aliased_fn_a/0, aliased_fn_b/0]).
 
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
 -file("src/two.gleam", 58).
+?DOC(
+    " For these statements we use the accessors for the record from the other\n"
+    " module\n"
+).
 -spec accessors(one@one:user()) -> {binary(), integer()}.
 accessors(User) ->
     Name = erlang:element(2, User),
@@ -43,6 +55,7 @@ accessors(User) ->
     {Name, Score}.
 
 -file("src/two.gleam", 65).
+?DOC(" For these statements we use destructure the record\n").
 -spec destructure_qualified(one@one:user()) -> {binary(), integer()}.
 destructure_qualified(User) ->
     {user, Name, Score} = User,
@@ -67,6 +80,7 @@ destructure_aliased(User) ->
     {Name, Score}.
 
 -file("src/two.gleam", 86).
+?DOC(" For these statements we use update the record\n").
 -spec update_qualified(one@one:user()) -> one@one:user().
 update_qualified(User) ->
     _record = User,


### PR DESCRIPTION
This PR fixes #3010!

Function and module doc comments are includ
ed in the generated Erlang code, so one can now browse Gleam's documentation from the Erlang shell, like they would with any other Erlang module:

![Screenshot 2025-01-05 alle 14 47 39](https://github.com/user-attachments/assets/1786427f-343c-4b2d-b40c-69d637e0bef8)
![Screenshot 2025-01-05 alle 14 47 52](https://github.com/user-attachments/assets/7e3f1a01-1d43-4bbf-89cf-488f1b8c3896)

