### PR TITLE
Do not show documentation for internal functions and modules in Erlang shell

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -528,7 +528,7 @@ fn hidden_module_doc<'a>() -> Document<'a> {
     doc_attribute(DocCommentKind::Module, DocCommentContent::False)
 }
 
-fn module_doc<'a, 'b>(content: &'a Vec<EcoString>) -> Document<'b> {
+fn module_doc<'a>(content: &Vec<EcoString>) -> Document<'a> {
     doc_attribute(DocCommentKind::Module, DocCommentContent::String(content))
 }
 
@@ -536,11 +536,11 @@ fn hidden_function_doc<'a>() -> Document<'a> {
     doc_attribute(DocCommentKind::Function, DocCommentContent::False)
 }
 
-fn function_doc<'a, 'b>(content: &'a Vec<EcoString>) -> Document<'b> {
+fn function_doc<'a>(content: &Vec<EcoString>) -> Document<'a> {
     doc_attribute(DocCommentKind::Function, DocCommentContent::String(content))
 }
 
-fn doc_attribute<'a, 'b>(kind: DocCommentKind, content: DocCommentContent<'b>) -> Document<'a> {
+fn doc_attribute<'a>(kind: DocCommentKind, content: DocCommentContent<'_>) -> Document<'a> {
     let prefix = match kind {
         DocCommentKind::Module => "?MODULEDOC",
         DocCommentKind::Function => "?DOC",

--- a/compiler-core/src/erlang/tests/documentation.rs
+++ b/compiler-core/src/erlang/tests/documentation.rs
@@ -79,3 +79,13 @@ fn backslashes_are_escaped_in_module_comment() {
 pub fn main() { 1 }"#
     );
 }
+
+#[test]
+fn internal_function_has_no_documentation() {
+    assert_erl!(
+        r#"
+/// hidden!
+@internal
+pub fn main() { 1 }"#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__internal_function_has_no_documentation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__internal_function_has_no_documentation.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/erlang/tests/documentation.rs
+expression: "\n/// hidden!\n@internal\npub fn main() { 1 }"
+---
+----- SOURCE CODE
+
+/// hidden!
+@internal
+pub fn main() { 1 }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+
+-file("/root/project/test/my/mod.gleam", 4).
+?DOC(false).
+-spec main() -> integer().
+main() ->
+    1.


### PR DESCRIPTION
This PR closes #4146 
If a function/module is internal a `-doc(false).` directive is added to the function so that, when someone tries to browse its documentation in the Erlang shell they'll receive a notice that it is internal:
```
%% This is the output coming from the Erlang shell
> h(module, wibble).
  -spec wibble() -> binary().

  The documentation for wibble/0 is hidden. This probably means
  that it is internal and not to be used by other applications.
```