### PR TITLE
consistently call docvec! with `[]` instead of `()`

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -132,21 +132,21 @@ pub fn record_definition(name: &str, fields: &[(&str, Arc<Type>)]) -> String {
     let type_printer = TypePrinter::new("").var_as_any();
     let fields = fields.iter().map(move |(name, type_)| {
         let type_ = type_printer.print(type_);
-        docvec!(atom_string((*name).to_string()), " :: ", type_.group())
+        docvec![atom_string((*name).to_string()), " :: ", type_.group()]
     });
     let fields = break_("", "")
         .append(join(fields, break_(",", ", ")))
         .nest(INDENT)
         .append(break_("", ""))
         .group();
-    docvec!(
+    docvec![
         "-record(",
         atom_string(name.to_string()),
         ", {",
         fields,
         "}).",
         line()
-    )
+    ]
     .to_pretty_string(MAX_COLUMNS)
 }
 
@@ -1129,7 +1129,7 @@ fn let_assert<'a>(
     let mut vars: Vec<&str> = vec![];
     let body = maybe_block_expr(value, env);
     let (subject_var, subject_definition) = if value.is_var() {
-        (body, docvec![])
+        (body, nil())
     } else {
         let var = env.next_local_var_name(ASSERT_SUBJECT_VARIABLE);
         let definition = docvec![var.clone(), " = ", body, ",", line()];

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -283,7 +283,7 @@ impl<'comments> Formatter<'comments> {
     fn imports<'a>(&mut self, imports: Vec<&'a TargetedDefinition>) -> Vec<Document<'a>> {
         let mut import_groups_docs = vec![];
         let mut current_group = vec![];
-        let mut current_group_delimiter = docvec!();
+        let mut current_group_delimiter = nil();
 
         for import in imports {
             let start = import.definition.location().start;
@@ -310,7 +310,7 @@ impl<'comments> Formatter<'comments> {
 
                 let comments = self.pop_comments(start);
                 let _ = self.pop_empty_lines(start);
-                current_group_delimiter = printed_comments(comments, true).unwrap_or(docvec!());
+                current_group_delimiter = printed_comments(comments, true).unwrap_or(nil());
             }
             // Lastly we add the import to the group.
             current_group.push(import);
@@ -1083,7 +1083,7 @@ impl<'comments> Formatter<'comments> {
         match lines.as_slice() {
             [] | [_] => string.to_doc().surround("\"", "\""),
             [first_line, lines @ ..] => {
-                let mut doc = docvec!("\"", first_line);
+                let mut doc = docvec!["\"", first_line];
                 for line in lines {
                     doc = doc
                         .append(pretty::line().set_nesting(0))
@@ -1353,8 +1353,8 @@ impl<'comments> Formatter<'comments> {
         // Otherwise those would be moved out of the case expression.
         let comments = self.pop_comments(location.end);
         let closing_bracket = match printed_comments(comments, false) {
-            None => docvec!(line(), "}"),
-            Some(comment) => docvec!(line(), comment)
+            None => docvec![line(), "}"],
+            Some(comment) => docvec![line(), comment]
                 .nest(INDENT)
                 .append(line())
                 .append("}"),
@@ -2564,9 +2564,9 @@ impl<'comments> Formatter<'comments> {
         // Otherwise those would be moved out of the call.
         let comments = self.pop_comments(location.end);
         let closing_parens = match printed_comments(comments, false) {
-            None => docvec!(break_(",", ""), ")"),
+            None => docvec![break_(",", ""), ")"],
             Some(comment) => {
-                docvec!(break_(",", "").nest(INDENT), comment, line(), ")").force_break()
+                docvec![break_(",", "").nest(INDENT), comment, line(), ")"].force_break()
             }
         };
 

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -120,12 +120,12 @@ impl<'module> Generator<'module> {
             let var = maybe_escape_identifier_doc(name);
             docvec!["let ", var, " = loop$", name, ";", line()]
         }));
-        Ok(docvec!(
+        Ok(docvec![
             "while (true) {",
-            docvec!(line(), loop_assignments, body).nest(INDENT),
+            docvec![line(), loop_assignments, body].nest(INDENT),
             line(),
             "}"
-        ))
+        ])
     }
 
     fn statement<'a>(&mut self, statement: &'a TypedStatement) -> Output<'a> {
@@ -222,7 +222,7 @@ impl<'module> Generator<'module> {
     }
 
     fn negate_with<'a>(&mut self, with: &'static str, value: &'a TypedExpr) -> Output<'a> {
-        self.not_in_tail_position(|gen| Ok(docvec!(with, gen.wrap_expression(value)?)))
+        self.not_in_tail_position(|gen| Ok(docvec![with, gen.wrap_expression(value)?]))
     }
 
     fn bit_array<'a>(&mut self, segments: &'a [TypedExprBitArraySegment]) -> Output<'a> {
@@ -253,7 +253,7 @@ impl<'module> Generator<'module> {
 
                         (Some(size_value), _) if size_value == 8.into() => Ok(value),
 
-                        (Some(size_value), _) if size_value <= 0.into() => Ok(docvec![]),
+                        (Some(size_value), _) if size_value <= 0.into() => Ok(nil()),
 
                         _ => {
                             self.tracker.sized_integer_segment_used = true;
@@ -436,7 +436,7 @@ impl<'module> Generator<'module> {
             // Here the document is a return statement: `return <expr>;`
             document
         } else {
-            docvec!("(", document, ")")
+            docvec!["(", document, ")"]
         })
     }
 
@@ -614,7 +614,7 @@ impl<'module> Generator<'module> {
         // If there is a subject name given create a variable to hold it for
         // use in patterns
         let doc = match subject_assignment {
-            Some(name) => docvec!("let ", name, " = ", value, ";", line(), compiled),
+            Some(name) => docvec!["let ", name, " = ", value, ";", line(), compiled],
             None => compiled,
         };
 
@@ -669,7 +669,7 @@ impl<'module> Generator<'module> {
                     let assignments = gen
                         .expression_generator
                         .pattern_take_assignments_doc(&mut compiled);
-                    docvec!(assignments, line(), consequence)
+                    docvec![assignments, line(), consequence]
                 } else {
                     consequence
                 };
@@ -683,14 +683,14 @@ impl<'module> Generator<'module> {
                     // render just the body as the case does nothing
                     // A block is used as it could declare variables still.
                     doc.append("{")
-                        .append(docvec!(line(), body).nest(INDENT))
+                        .append(docvec![line(), body].nest(INDENT))
                         .append(line())
                         .append("}")
                 } else if is_final_clause {
                     // If this is the final clause and there are no checks then we can
                     // render `else` instead of `else if (...)`
                     doc.append(" else {")
-                        .append(docvec!(line(), body).nest(INDENT))
+                        .append(docvec![line(), body].nest(INDENT))
                         .append(line())
                         .append("}")
                 } else {
@@ -704,7 +704,7 @@ impl<'module> Generator<'module> {
                             .pattern_take_checks_doc(&mut compiled, true),
                     )
                     .append(") {")
-                    .append(docvec!(line(), body).nest(INDENT))
+                    .append(docvec![line(), body].nest(INDENT))
                     .append(line())
                     .append("}")
                 };
@@ -719,7 +719,7 @@ impl<'module> Generator<'module> {
             .flat_map(|(assignment_name, value)| assignment_name.map(|name| (name, value)))
             .map(|(name, value)| {
                 let value = self.not_in_tail_position(|gen| gen.wrap_expression(value))?;
-                Ok(docvec!("let ", name, " = ", value, ";", line()))
+                Ok(docvec!["let ", name, " = ", value, ";", line()])
             })
             .try_collect()?;
 
@@ -830,7 +830,7 @@ impl<'module> Generator<'module> {
                     let is_fn_literal = matches!(fun, TypedExpr::Fn { .. });
                     let fun = gen.wrap_expression(fun)?;
                     if is_fn_literal {
-                        Ok(docvec!("(", fun, ")"))
+                        Ok(docvec!["(", fun, ")"])
                     } else {
                         Ok(fun)
                     }
@@ -868,18 +868,18 @@ impl<'module> Generator<'module> {
         self.current_scope_vars = scope;
         std::mem::swap(&mut self.function_name, &mut name);
 
-        Ok(docvec!(
-            docvec!(
+        Ok(docvec![
+            docvec![
                 fun_args(arguments, false),
                 " => {",
                 break_("", " "),
                 result?
-            )
+            ]
             .nest(INDENT)
             .append(break_("", " "))
             .group(),
             "}",
-        ))
+        ])
     }
 
     fn record_access<'a>(&mut self, record: &'a TypedExpr, label: &'a str) -> Output<'a> {
@@ -939,21 +939,21 @@ impl<'module> Generator<'module> {
         let left = self.not_in_tail_position(|gen| gen.child_expression(left))?;
         let right = self.not_in_tail_position(|gen| gen.child_expression(right))?;
         self.tracker.int_division_used = true;
-        Ok(docvec!("divideInt", wrap_args([left, right])))
+        Ok(docvec!["divideInt", wrap_args([left, right])])
     }
 
     fn remainder_int<'a>(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
         let left = self.not_in_tail_position(|gen| gen.child_expression(left))?;
         let right = self.not_in_tail_position(|gen| gen.child_expression(right))?;
         self.tracker.int_remainder_used = true;
-        Ok(docvec!("remainderInt", wrap_args([left, right])))
+        Ok(docvec!["remainderInt", wrap_args([left, right])])
     }
 
     fn div_float<'a>(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
         let left = self.not_in_tail_position(|gen| gen.child_expression(left))?;
         let right = self.not_in_tail_position(|gen| gen.child_expression(right))?;
         self.tracker.float_division_used = true;
-        Ok(docvec!("divideFloat", wrap_args([left, right])))
+        Ok(docvec!["divideFloat", wrap_args([left, right])])
     }
 
     fn equal<'a>(
@@ -967,7 +967,7 @@ impl<'module> Generator<'module> {
             let left_doc = self.not_in_tail_position(|gen| gen.child_expression(left))?;
             let right_doc = self.not_in_tail_position(|gen| gen.child_expression(right))?;
             let operator = if should_be_equal { " === " } else { " !== " };
-            return Ok(docvec!(left_doc, operator, right_doc));
+            return Ok(docvec![left_doc, operator, right_doc]);
         }
 
         // Other types must be compared using structural equality
@@ -991,7 +991,7 @@ impl<'module> Generator<'module> {
         } else {
             "!isEqual"
         };
-        docvec!(operator, args)
+        docvec![operator, args]
     }
 
     fn print_bin_op<'a>(
@@ -1002,7 +1002,7 @@ impl<'module> Generator<'module> {
     ) -> Output<'a> {
         let left = self.not_in_tail_position(|gen| gen.child_expression(left))?;
         let right = self.not_in_tail_position(|gen| gen.child_expression(right))?;
-        Ok(docvec!(left, " ", op, " ", right))
+        Ok(docvec![left, " ", op, " ", right])
     }
 
     fn todo<'a>(&mut self, message: Option<&'a TypedExpr>, location: &'a SrcSpan) -> Output<'a> {
@@ -1441,7 +1441,7 @@ pub(crate) fn constant_expression<'a>(
         Constant::StringConcatenation { left, right, .. } => {
             let left = constant_expression(context, tracker, left)?;
             let right = constant_expression(context, tracker, right)?;
-            Ok(docvec!(left, " + ", right))
+            Ok(docvec![left, " + ", right])
         }
 
         Constant::Invalid { .. } => panic!("invalid constants should not reach code generation"),
@@ -1480,7 +1480,7 @@ fn bit_array<'a>(
 
                     (Some(size_value), _) if size_value == 8.into() => Ok(value),
 
-                    (Some(size_value), _) if size_value <= 0.into() => Ok(docvec![]),
+                    (Some(size_value), _) if size_value <= 0.into() => Ok(nil()),
 
                     _ => {
                         tracker.sized_integer_segment_used = true;
@@ -1800,11 +1800,11 @@ fn requires_semicolon(statement: &TypedStatement) -> bool {
 
 /// Wrap a document in an immediately involked function expression
 fn immediately_invoked_function_expression_document(document: Document<'_>) -> Document<'_> {
-    docvec!(
-        docvec!("(() => {", break_("", " "), document).nest(INDENT),
+    docvec![
+        docvec!["(() => {", break_("", " "), document].nest(INDENT),
         break_("", " "),
         "})()",
-    )
+    ]
     .group()
 }
 
@@ -1840,13 +1840,13 @@ fn record_constructor<'a>(
             construct_record(qualifier, name, vars.clone()),
             ";"
         ];
-        docvec!(
-            docvec!(wrap_args(vars), " => {", break_("", " "), body)
+        docvec![
+            docvec![wrap_args(vars), " => {", break_("", " "), body]
                 .nest(INDENT)
                 .append(break_("", " "))
                 .group(),
             "}",
-        )
+        ]
     }
 }
 

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -157,14 +157,14 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
         concat(self.path.iter().map(|segment| match segment {
             Index::Int(i) => eco_format!("[{i}]").to_doc(),
             // TODO: escape string if needed
-            Index::String(s) => docvec!(".", maybe_escape_property_doc(s)),
-            Index::ByteAt(i) => docvec!(".byteAt(", i, ")"),
+            Index::String(s) => docvec![".", maybe_escape_property_doc(s)],
+            Index::ByteAt(i) => docvec![".byteAt(", i, ")"],
             Index::IntFromSlice {
                 start,
                 end,
                 endianness,
                 is_signed,
-            } => docvec!(
+            } => docvec![
                 ".intFromSlice(",
                 start,
                 ", ",
@@ -174,12 +174,12 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 ", ",
                 bool(*is_signed),
                 ")"
-            ),
+            ],
             Index::FloatFromSlice {
                 start,
                 end,
                 endianness,
-            } => docvec!(
+            } => docvec![
                 ".floatFromSlice(",
                 start,
                 ", ",
@@ -187,12 +187,12 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 ", ",
                 bool(endianness.is_big()),
                 ")"
-            ),
+            ],
             Index::BinaryFromSlice(start, end) => {
-                docvec!(".binaryFromSlice(", start, ", ", end, ")")
+                docvec![".binaryFromSlice(", start, ", ", end, ")"]
             }
-            Index::SliceAfter(i) => docvec!(".sliceAfter(", i, ")"),
-            Index::StringPrefixSlice(i) => docvec!(".slice(", i, ")"),
+            Index::SliceAfter(i) => docvec![".sliceAfter(", i, ")"],
+            Index::StringPrefixSlice(i) => docvec![".slice(", i, ")"],
         }))
     }
 
@@ -254,7 +254,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
             | ClauseGuard::RemainderInt { .. }
             | ClauseGuard::Or { .. }
             | ClauseGuard::And { .. }
-            | ClauseGuard::ModuleSelect { .. } => Ok(docvec!("(", self.guard(guard)?, ")")),
+            | ClauseGuard::ModuleSelect { .. } => Ok(docvec!["(", self.guard(guard)?, ")"]),
         }
     }
 
@@ -263,13 +263,13 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
             ClauseGuard::Equals { left, right, .. } if is_js_scalar(left.type_()) => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " === ", right)
+                docvec![left, " === ", right]
             }
 
             ClauseGuard::NotEquals { left, right, .. } if is_js_scalar(left.type_()) => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " !== ", right)
+                docvec![left, " !== ", right]
             }
 
             ClauseGuard::Equals { left, right, .. } => {
@@ -289,70 +289,70 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
             ClauseGuard::GtFloat { left, right, .. } | ClauseGuard::GtInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " > ", right)
+                docvec![left, " > ", right]
             }
 
             ClauseGuard::GtEqFloat { left, right, .. }
             | ClauseGuard::GtEqInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " >= ", right)
+                docvec![left, " >= ", right]
             }
 
             ClauseGuard::LtFloat { left, right, .. } | ClauseGuard::LtInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " < ", right)
+                docvec![left, " < ", right]
             }
 
             ClauseGuard::LtEqFloat { left, right, .. }
             | ClauseGuard::LtEqInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " <= ", right)
+                docvec![left, " <= ", right]
             }
 
             ClauseGuard::AddFloat { left, right, .. } | ClauseGuard::AddInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " + ", right)
+                docvec![left, " + ", right]
             }
 
             ClauseGuard::SubFloat { left, right, .. } | ClauseGuard::SubInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " - ", right)
+                docvec![left, " - ", right]
             }
 
             ClauseGuard::MultFloat { left, right, .. }
             | ClauseGuard::MultInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " * ", right)
+                docvec![left, " * ", right]
             }
 
             ClauseGuard::DivFloat { left, right, .. } | ClauseGuard::DivInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " / ", right)
+                docvec![left, " / ", right]
             }
 
             ClauseGuard::RemainderInt { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " % ", right)
+                docvec![left, " % ", right]
             }
 
             ClauseGuard::Or { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " || ", right)
+                docvec![left, " || ", right]
             }
 
             ClauseGuard::And { left, right, .. } => {
                 let left = self.wrapped_guard(left)?;
                 let right = self.wrapped_guard(right)?;
-                docvec!(left, " && ", right)
+                docvec![left, " && ", right]
             }
 
             ClauseGuard::Var { name, .. } => self
@@ -360,24 +360,24 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 .unwrap_or_else(|| self.local_var(name)),
 
             ClauseGuard::TupleIndex { tuple, index, .. } => {
-                docvec!(self.guard(tuple)?, "[", index, "]")
+                docvec![self.guard(tuple)?, "[", index, "]"]
             }
 
             ClauseGuard::FieldAccess {
                 label, container, ..
             } => {
-                docvec!(
+                docvec![
                     self.guard(container)?,
                     ".",
                     maybe_escape_property_doc(label)
-                )
+                ]
             }
 
             ClauseGuard::ModuleSelect {
                 module_alias,
                 label,
                 ..
-            } => docvec!("$", module_alias, ".", label),
+            } => docvec!["$", module_alias, ".", label],
 
             ClauseGuard::Not { expression, .. } => {
                 docvec!["!", self.guard(expression)?]
@@ -525,7 +525,7 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                     let var = self.next_local_var(left);
                     self.assignments.push(Assignment {
                         subject: expression::string(left_side_string),
-                        path: docvec![],
+                        path: nil(),
                         name: left,
                         var,
                     });

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -211,7 +211,7 @@ impl<'a> TypeScriptGenerator<'a> {
         }
 
         if imports.is_empty() && statements.is_empty() {
-            Ok(docvec!("export {}", line()))
+            Ok(docvec!["export {}", line()])
         } else if imports.is_empty() {
             statements.push(line());
             Ok(statements.to_doc())


### PR DESCRIPTION
I noticed that the codebase used both `docvec!()` and `docvec![]`. Since `docvec!()` was the minority I replaced those with `[]` to have a consistent style across the codebase.
I also replaced all calls to `docvec![]` with `nil()` since that seems to be the most widespread convention across the codebase!