### PR TITLE
Make pipes fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Compiler
 
+- Pipelines are now fault tolerant. A type error in the middle of a pipeline
+  won't stop the compiler from figuring out the types of the remaining pieces,
+  enabling the language server to show better suggestions for incomplete pipes.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Improved code generation for blocks in tail position on the Javascript target.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
@@ -120,4 +125,3 @@
 - Fixed a bug where a block expression containing a singular record update would
   produce invalid erlang.
   ([yoshi](https://github.com/joshi-monster))
-

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1345,3 +1345,137 @@ pub fn main() {
         find_position_of("Int").under_char('n')
     );
 }
+
+#[test]
+fn hover_on_pipe_with_invalid_step() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+",
+        find_position_of("[")
+    );
+}
+
+#[test]
+fn hover_on_pipe_with_invalid_step_1() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+",
+        find_position_of("1")
+    );
+}
+
+#[test]
+fn hover_on_pipe_with_invalid_step_2() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+",
+        find_position_of("map")
+    );
+}
+
+#[test]
+fn hover_on_pipe_with_invalid_step_3() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+",
+        find_position_of("wibble")
+    );
+}
+
+#[test]
+fn hover_on_pipe_with_invalid_step_4() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+",
+        find_position_of("filter")
+    );
+}
+
+#[test]
+fn hover_on_pipe_with_invalid_step_5() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) { todo }
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }
+",
+        find_position_of("fn(value)")
+    );
+}
+
+#[test]
+fn hover_on_pipe_with_invalid_step_6() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> wibble
+  |> filter(fn(value) { value })
+}
+
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }
+",
+        find_position_of("wibble")
+    );
+}
+
+#[test]
+fn hover_on_pipe_with_invalid_step_8() {
+    assert_hover!(
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> wibble
+  |> filter(fn(value) { value })
+}
+
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }
+",
+        find_position_of("fn(value)")
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> map(wibble)\n  |> filter(fn(value) { value })\n}\n\nfn map(list: List(a), fun: fn(a) -> b) -> List(b) {}\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}\n"
+---
+pub fn main() {
+  [1, 2, 3]
+  ↑▔▔▔▔▔▔▔▔
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nList(Int)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_1.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_1.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> map(wibble)\n  |> filter(fn(value) { value })\n}\n\nfn map(list: List(a), fun: fn(a) -> b) -> List(b) {}\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}\n"
+---
+pub fn main() {
+  [1, 2, 3]
+   ↑       
+  |> map(wibble)
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_2.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> map(wibble)\n  |> filter(fn(value) { value })\n}\n\nfn map(list: List(a), fun: fn(a) -> b) -> List(b) {}\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}\n"
+---
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+     ↑▔▔        
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(List(Int), fn(Int) -> Bool) -> List(Bool)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_3.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> map(wibble)\n  |> filter(fn(value) { value })\n}\n\nfn map(list: List(a), fun: fn(a) -> b) -> List(b) {}\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}\n"
+---
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+         ↑▔▔▔▔▔ 
+  |> filter(fn(value) { value })
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int) -> Bool\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_4.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_4.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> map(wibble)\n  |> filter(fn(value) { value })\n}\n\nfn map(list: List(a), fun: fn(a) -> b) -> List(b) {}\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}\n"
+---
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+     ↑▔▔▔▔▔                     
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {}
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) {}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(List(Bool), fn(Bool) -> Bool) -> List(Bool)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_5.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_5.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> map(wibble)\n  |> filter(fn(value) { value })\n}\n\nfn map(list: List(a), fun: fn(a) -> b) -> List(b) { todo }\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }\n"
+---
+pub fn main() {
+  [1, 2, 3]
+  |> map(wibble)
+  |> filter(fn(value) { value })
+            ↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔ 
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) { todo }
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Bool) -> Bool\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_6.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_6.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> wibble\n  |> filter(fn(value) { value })\n}\n\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }\n"
+---
+pub fn main() {
+  [1, 2, 3]
+  |> wibble
+     ↑▔▔▔▔▔
+  |> filter(fn(value) { value })
+}
+
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(List(Int)) -> List(Bool)\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_8.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_on_pipe_with_invalid_step_8.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> wibble\n  |> filter(fn(value) { value })\n}\n\nfn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }\n"
+---
+pub fn main() {
+  [1, 2, 3]
+  |> wibble
+  |> filter(fn(value) { value })
+            ↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔ 
+}
+
+fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Bool) -> Bool\n```\n",
+    ),
+)

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -341,7 +341,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location, value, ..
             } => Ok(self.infer_string(value, location)),
 
-            UntypedExpr::PipeLine { expressions } => self.infer_pipeline(expressions),
+            UntypedExpr::PipeLine { expressions } => Ok(self.infer_pipeline(expressions)),
 
             UntypedExpr::Fn {
                 location,
@@ -416,7 +416,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         }
     }
 
-    fn infer_pipeline(&mut self, expressions: Vec1<UntypedExpr>) -> Result<TypedExpr, Error> {
+    fn infer_pipeline(&mut self, expressions: Vec1<UntypedExpr>) -> TypedExpr {
         PipeTyper::infer(self, expressions)
     }
 

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -20,7 +20,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
     pub fn infer(
         expr_typer: &'a mut ExprTyper<'b, 'c>,
         expressions: Vec1<UntypedExpr>,
-    ) -> Result<TypedExpr, Error> {
+    ) -> TypedExpr {
         // The scope is reset as pipelines are rewritten into a series of
         // assignments, and we don't want these variables to leak out of the
         // pipeline.
@@ -30,14 +30,23 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         result
     }
 
-    fn run(
-        expr_typer: &'a mut ExprTyper<'b, 'c>,
-        expressions: Vec1<UntypedExpr>,
-    ) -> Result<TypedExpr, Error> {
+    fn run(expr_typer: &'a mut ExprTyper<'b, 'c>, expressions: Vec1<UntypedExpr>) -> TypedExpr {
         let size = expressions.len();
         let end = expressions.last().location().end;
         let mut expressions = expressions.into_iter();
-        let first = expr_typer.infer(expressions.next().expect("Empty pipeline in typer"))?;
+        let first = expressions.next().expect("Empty pipeline in typer");
+        let first_location = first.location();
+        let first = match expr_typer.infer(first) {
+            Ok(inferred) => inferred,
+            Err(e) => {
+                expr_typer.problems.error(e);
+                TypedExpr::Invalid {
+                    location: first_location,
+                    type_: expr_typer.new_unbound_var(),
+                }
+            }
+        };
+
         let mut typer = Self {
             size,
             expr_typer,
@@ -60,24 +69,20 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
     fn infer_expressions(
         &mut self,
         expressions: impl IntoIterator<Item = UntypedExpr>,
-    ) -> Result<TypedExpr, Error> {
+    ) -> TypedExpr {
         let finally = self.infer_each_expression(expressions);
-
-        // Return any errors after clean-up
-        let finally = finally?;
         let assignments = std::mem::take(&mut self.assignments);
-
-        Ok(TypedExpr::Pipeline {
+        TypedExpr::Pipeline {
             assignments,
             location: self.location,
             finally: Box::new(finally),
-        })
+        }
     }
 
     fn infer_each_expression(
         &mut self,
         expressions: impl IntoIterator<Item = UntypedExpr>,
-    ) -> Result<TypedExpr, Error> {
+    ) -> TypedExpr {
         let mut finally = None;
 
         for (i, call) in expressions.into_iter().enumerate() {
@@ -105,13 +110,27 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 }
 
                 // left |> right(..args)
+                //         ^^^^^ This is `fun`
                 UntypedExpr::Call {
                     fun,
                     arguments,
                     location,
                     ..
                 } => {
-                    let fun = self.expr_typer.infer(*fun)?;
+                    let fun = match self.expr_typer.infer(*fun) {
+                        Ok(fun) => fun,
+                        Err(e) => {
+                            // In case we cannot infer the function we'll
+                            // replace it with an invalid expression with an
+                            // unbound type to keep going!
+                            self.expr_typer.problems.error(e);
+                            TypedExpr::Invalid {
+                                location,
+                                type_: self.expr_typer.new_unbound_var(),
+                            }
+                        }
+                    };
+
                     match fun.type_().fn_types() {
                         // Rewrite as right(..args)(left)
                         Some((args, _)) if args.len() == arguments.len() => {
@@ -123,7 +142,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 }
 
                 // right(left)
-                call => self.infer_apply_pipe(call)?,
+                call => self.infer_apply_pipe(call),
             };
 
             if i + 2 == self.size {
@@ -133,7 +152,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             }
         }
 
-        Ok(finally.expect("Empty pipeline in typer"))
+        finally.expect("Empty pipeline in typer")
     }
 
     /// Create a call argument that can be used to refer to the value on the
@@ -279,28 +298,47 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
     }
 
     /// Attempt to infer a |> b as b(a)
-    fn infer_apply_pipe(&mut self, function: UntypedExpr) -> Result<TypedExpr, Error> {
-        let function = Box::new(self.expr_typer.infer(function)?);
+    /// b is the `function` argument.
+    fn infer_apply_pipe(&mut self, function: UntypedExpr) -> TypedExpr {
+        let function_location = function.location();
+        let function = Box::new(match self.expr_typer.infer(function) {
+            Ok(function) => function,
+            Err(error) => {
+                // If we cannot infer the function we put an invalid expression
+                // in its place so we can still keep going with the other steps.
+                self.expr_typer.problems.error(error);
+                TypedExpr::Invalid {
+                    location: function_location,
+                    type_: self.expr_typer.new_unbound_var(),
+                }
+            }
+        });
+
         let return_type = self.expr_typer.new_unbound_var();
         // Ensure that the function accepts one argument of the correct type
-        unify(
+        let unification_result = unify(
             function.type_(),
             fn_(vec![self.argument_type.clone()], return_type.clone()),
-        )
-        .map_err(|e| {
-            if self.check_if_pipe_type_mismatch(&e) {
-                return convert_unify_error(e, function.location())
-                    .with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch);
+        );
+        match unification_result {
+            Ok(_) => (),
+            Err(error) => {
+                let error = if self.check_if_pipe_type_mismatch(&error) {
+                    convert_unify_error(error, function.location())
+                        .with_unify_error_situation(UnifyErrorSituation::PipeTypeMismatch)
+                } else {
+                    convert_unify_error(flip_unify_error(error), function.location())
+                };
+                self.expr_typer.problems.error(error);
             }
-            convert_unify_error(flip_unify_error(e), function.location())
-        })?;
+        };
 
-        Ok(TypedExpr::Call {
+        TypedExpr::Call {
             location: function.location(),
             type_: return_type,
             fun: function,
             args: vec![self.typed_left_hand_value_variable_call_argument()],
-        })
+        }
     }
 
     fn check_if_pipe_type_mismatch(&mut self, error: &UnifyError) -> bool {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__pipe_value_type_mismatch_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__pipe_value_type_mismatch_error.snap
@@ -24,7 +24,7 @@ error: Type mismatch
 
 Expected type:
 
-    fn(fn(Veg) -> String) -> a
+    fn(fn(Veg) -> String) -> String
 
 Found type:
 


### PR DESCRIPTION
This PR makes pipes (and call arguments) fault tolerant.
Previously if a pipe contained an invalid step the LS would show nothing when hovering, now one can still hover on each single step and even discover what each one is supposed to have!

A small example of what it looks like now in the LS
![](https://github.com/user-attachments/assets/6b2c948e-a95f-47fc-8670-4389ad825964)

This is also a needed step to enable a "generate function" code action to also work in pipelines and generate those missing steps, which I think would be incredibly cool 