### PR TITLE
Add "generate function" code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,34 @@
 
 ### Language server
 
+- The language server can now generate the definition of functions that do not
+  exist in the current file. For example if I write the following piece of code:
+
+  ```gleam
+  import gleam/io
+
+  pub type Pokemon {
+    Pokemon(pokedex_number: Int, name: String)
+  }
+
+  pub fn main() {
+    io.println(to_string(pokemon))
+    //          ^ If you put your cursor over this function that is
+    //            not implemented yet
+  }
+  ```
+
+  Triggering the "generate function" code action, the language server will
+  generate the following function for you:
+
+  ```gleam
+  fn to_string(pokemon: Pokemon) -> String {
+    todo
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server can now fill in the labels of any function call, even when
   only some of the arguments are provided. For example:
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3760,7 +3760,25 @@ fn pretty_constructor_name(
     }
 }
 
-/// .
+/// Builder for the "generate function" code action.
+/// Whenever someone hovers an invalid expression that is inferred to have a
+/// function type the language server can generate a function definition for it.
+/// For example:
+///
+/// ```gleam
+/// pub fn main() {
+///   wibble(1, 2, "hello")
+///  //  ^ [generate function]
+/// }
+/// ```
+///
+/// Will generate the following definition:
+///
+/// ```gleam
+/// pub fn wibble(arg_0: Int, arg_1: Int, arg_2: String) -> a {
+///   todo
+/// }
+/// ```
 ///
 pub struct GenerateFunction<'a> {
     module: &'a Module,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3843,7 +3843,6 @@ impl<'a> GenerateFunction<'a> {
 
 impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
     fn visit_typed_function(&mut self, fun: &'ast ast::TypedFunction) {
-        println!("{:#?}", fun.body);
         self.last_visited_function_end = Some(fun.end_position);
         ast::visit::visit_typed_function(self, fun);
     }

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -34,8 +34,8 @@ use super::{
         code_action_convert_unqualified_constructor_to_qualified, code_action_import_module,
         code_action_inexhaustive_let_to_case, AddAnnotations, CodeActionBuilder, DesugarUse,
         ExpandFunctionCapture, ExtractVariable, FillInMissingLabelledArgs, GenerateDynamicDecoder,
-        LabelShorthandSyntax, LetAssertToCase, PatternMatchOnValue, RedundantTupleInCaseSubject,
-        TurnIntoUse,
+        GenerateFunction, LabelShorthandSyntax, LetAssertToCase, PatternMatchOnValue,
+        RedundantTupleInCaseSubject, TurnIntoUse,
     },
     completer::Completer,
     signature_help, src_span_to_lsp_range, DownloadDependencies, MakeLocker,
@@ -335,6 +335,7 @@ where
             actions.extend(TurnIntoUse::new(module, &lines, &params).code_actions());
             actions.extend(ExpandFunctionCapture::new(module, &lines, &params).code_actions());
             actions.extend(ExtractVariable::new(module, &lines, &params).code_actions());
+            actions.extend(GenerateFunction::new(module, &lines, &params).code_actions());
             actions.extend(
                 PatternMatchOnValue::new(module, &lines, &params, &this.compiler).code_actions(),
             );

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -4689,3 +4689,45 @@ fn map(list: List(a), fun: fn(a) -> b) { todo }
         find_position_of("tuple").to_selection()
     );
 }
+
+#[test]
+fn generate_function_works_with_pipeline_steps() {
+    assert_code_action!(
+        "Generate function",
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> sum
+  |> int_to_string
+}
+
+fn int_to_string(n: Int) -> String {
+  todo
+}
+",
+        find_position_of("sum").to_selection()
+    );
+}
+
+#[test]
+fn generate_function_works_with_pipeline_steps_1() {
+    assert_code_action!(
+        "Generate function",
+        "
+pub fn main() {
+  [1, 2, 3]
+  |> map(int_to_string)
+  |> join
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {
+  todo
+}
+
+fn join(n: List(String)) -> String {
+  todo
+}
+",
+        find_position_of("int_to_string").to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -73,6 +73,7 @@ const EXPAND_FUNCTION_CAPTURE: &str = "Expand function capture";
 const GENERATE_DYNAMIC_DECODER: &str = "Generate dynamic decoder";
 const PATTERN_MATCH_ON_ARGUMENT: &str = "Pattern match on argument";
 const PATTERN_MATCH_ON_VARIABLE: &str = "Pattern match on variable";
+const GENERATE_FUNCTION: &str = "Generate function";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -4691,9 +4692,22 @@ fn map(list: List(a), fun: fn(a) -> b) { todo }
 }
 
 #[test]
+fn generate_function_works_with_invalid_call() {
+    assert_code_action!(
+        GENERATE_FUNCTION,
+        "
+pub fn main() -> Bool {
+  wibble(1, True, 2.3)
+}
+",
+        find_position_of("wibble").to_selection()
+    );
+}
+
+#[test]
 fn generate_function_works_with_pipeline_steps() {
     assert_code_action!(
-        "Generate function",
+        GENERATE_FUNCTION,
         "
 pub fn main() {
   [1, 2, 3]
@@ -4712,7 +4726,7 @@ fn int_to_string(n: Int) -> String {
 #[test]
 fn generate_function_works_with_pipeline_steps_1() {
     assert_code_action!(
-        "Generate function",
+        GENERATE_FUNCTION,
         "
 pub fn main() {
   [1, 2, 3]

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_works_with_invalid_call.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_works_with_invalid_call.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() -> Bool {\n  wibble(1, True, 2.3)\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() -> Bool {
+  wibble(1, True, 2.3)
+  ↑                   
+}
+
+
+----- AFTER ACTION
+
+pub fn main() -> Bool {
+  wibble(1, True, 2.3)
+}
+
+fn wibble(arg_1: Int, arg_2: Bool, arg_3: Float) -> Bool {
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_works_with_pipeline_steps.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_works_with_pipeline_steps.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> sum\n  |> int_to_string\n}\n\nfn int_to_string(n: Int) -> String {\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  [1, 2, 3]
+  |> sum
+     ↑  
+  |> int_to_string
+}
+
+fn int_to_string(n: Int) -> String {
+  todo
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  [1, 2, 3]
+  |> sum
+  |> int_to_string
+}
+
+fn sum(list: List(Int)) -> Int {
+  todo
+}
+
+fn int_to_string(n: Int) -> String {
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_works_with_pipeline_steps_1.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_works_with_pipeline_steps_1.snap
@@ -1,0 +1,41 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  [1, 2, 3]\n  |> map(int_to_string)\n  |> join\n}\n\nfn map(list: List(a), fun: fn(a) -> b) -> List(b) {\n  todo\n}\n\nfn join(n: List(String)) -> String {\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  [1, 2, 3]
+  |> map(int_to_string)
+         ↑             
+  |> join
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {
+  todo
+}
+
+fn join(n: List(String)) -> String {
+  todo
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  [1, 2, 3]
+  |> map(int_to_string)
+  |> join
+}
+
+fn int_to_string(int: Int) -> String {
+  todo
+}
+
+fn map(list: List(a), fun: fn(a) -> b) -> List(b) {
+  todo
+}
+
+fn join(n: List(String)) -> String {
+  todo
+}


### PR DESCRIPTION
This PR adds a "generate function" code action. Here's an example showcasing it in various scenarios (function calls, pipelines, functions inside pipelines):


![](https://github.com/user-attachments/assets/dfa8069d-ef0c-445e-a343-4b5fc4671f54)


This PR is a WIP since it's based on #4167 and won't work properly until that's merged