### PR TITLE
Make case expressions fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   shell starting from OTP27.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Parsing of `case` expressions is now fault tolerant. If a `case` expressions
+  is missing its body, the compiler can still perform type inference. This also
+  allows the Language Server to provide completion hints for `case` subjects.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - `gleam new` now has refined project name validation - rather than failing on

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -69,7 +69,8 @@ pub enum UntypedExpr {
     Case {
         location: SrcSpan,
         subjects: Vec<Self>,
-        clauses: Vec<Clause<Self, (), ()>>,
+        // None if the case expression is missing a body.
+        clauses: Option<Vec<Clause<Self, (), ()>>>,
     },
 
     FieldAccess {

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -457,23 +457,25 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 clauses,
             } => {
                 let subjects = subjects.into_iter().map(|e| self.fold_expr(e)).collect();
-                let clauses = clauses
-                    .into_iter()
-                    .map(|mut c| {
-                        c.pattern = c
-                            .pattern
-                            .into_iter()
-                            .map(|p| self.fold_pattern(p))
-                            .collect();
-                        c.alternative_patterns = c
-                            .alternative_patterns
-                            .into_iter()
-                            .map(|p| p.into_iter().map(|p| self.fold_pattern(p)).collect())
-                            .collect();
-                        c.then = self.fold_expr(c.then);
-                        c
-                    })
-                    .collect();
+                let clauses = clauses.map(|clauses| {
+                    clauses
+                        .into_iter()
+                        .map(|mut c| {
+                            c.pattern = c
+                                .pattern
+                                .into_iter()
+                                .map(|p| self.fold_pattern(p))
+                                .collect();
+                            c.alternative_patterns = c
+                                .alternative_patterns
+                                .into_iter()
+                                .map(|p| p.into_iter().map(|p| self.fold_pattern(p)).collect())
+                                .collect();
+                            c.then = self.fold_expr(c.then);
+                            c
+                        })
+                        .collect()
+                });
                 UntypedExpr::Case {
                     location,
                     subjects,
@@ -742,7 +744,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         &mut self,
         location: SrcSpan,
         subjects: Vec<UntypedExpr>,
-        clauses: Vec<UntypedClause>,
+        clauses: Option<Vec<UntypedClause>>,
     ) -> UntypedExpr {
         UntypedExpr::Case {
             location,

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -278,7 +278,7 @@ impl<'a> CallGraphBuilder<'a> {
                 for subject in subjects {
                     self.expression(subject);
                 }
-                for clause in clauses {
+                for clause in clauses.as_deref().unwrap_or_default() {
                     let names = self.names.clone();
                     for pattern in &clause.pattern {
                         self.pattern(pattern);

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3066,6 +3066,27 @@ The missing patterns are:\n"
                     }
                 }
 
+                TypeError::MissingCaseBody { location } => {
+                    let text = wrap(
+                        "This case expression is missing its body."
+                        );
+                    Diagnostic {
+                        title: "Missing case body".into(),
+                        text,
+                        hint: None,
+                        level: Level::Error,
+                        location: Some(Location {
+                            src: src.clone(),
+                            path: path.to_path_buf(),
+                            label: Label {
+                                text: None,
+                                span: *location,
+                            },
+                            extra_labels: Vec::new(),
+                        }),
+                    }
+                }
+
                 TypeError::UnsupportedExpressionTarget {
                     location,
                     target: current_target,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1030,7 +1030,7 @@ impl<'comments> Formatter<'comments> {
                 subjects,
                 clauses,
                 location,
-            } => self.case(subjects, clauses, location),
+            } => self.case(subjects, clauses.as_deref().unwrap_or_default(), location),
 
             UntypedExpr::FieldAccess {
                 label, container, ..

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1886,3 +1886,18 @@ pub fn map(_, _) { [] }
         Position::new(3, 8)
     );
 }
+
+#[test]
+fn case_subject() {
+    let code = "
+pub fn main(something: Bool) {
+  case so
+}
+";
+
+    assert_apply_completion!(
+        TestProject::for_source(code),
+        "something",
+        Position::new(2, 9)
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__case_subject.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__case_subject.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\npub fn main(something: Bool) {\n  case so\n}\n"
+---
+pub fn main(something: Bool) {
+  case so|
+}
+
+
+----- After applying completion -----
+
+pub fn main(something: Bool) {
+  case something
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -701,20 +701,33 @@ where
                 self.advance();
                 let subjects =
                     Parser::series_of(self, &Parser::parse_expression, Some(&Token::Comma))?;
-                let _ = self.expect_one_following_series(&Token::LeftBrace, "an expression")?;
-                let clauses = Parser::series_of(self, &Parser::parse_case_clause, None)?;
-                let (_, end) =
-                    self.expect_one_following_series(&Token::RightBrace, "a case clause")?;
-                if subjects.is_empty() {
-                    return parse_error(
-                        ParseErrorType::ExpectedExpr,
-                        SrcSpan { start, end: case_e },
-                    );
+                if self.maybe_one(&Token::LeftBrace).is_some() {
+                    let clauses = Parser::series_of(self, &Parser::parse_case_clause, None)?;
+                    let (_, end) =
+                        self.expect_one_following_series(&Token::RightBrace, "a case clause")?;
+                    if subjects.is_empty() {
+                        return parse_error(
+                            ParseErrorType::ExpectedExpr,
+                            SrcSpan { start, end: case_e },
+                        );
+                    } else {
+                        UntypedExpr::Case {
+                            location: SrcSpan { start, end },
+                            subjects,
+                            clauses: Some(clauses),
+                        }
+                    }
                 } else {
                     UntypedExpr::Case {
-                        location: SrcSpan { start, end },
+                        location: SrcSpan::new(
+                            start,
+                            subjects
+                                .last()
+                                .map(|subject| subject.location().end)
+                                .unwrap_or(case_e),
+                        ),
                         subjects,
-                        clauses,
+                        clauses: None,
                     }
                 }
             }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
@@ -27,86 +27,88 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                     int_value: 3,
                 },
             ],
-            clauses: [
-                Clause {
-                    location: SrcSpan {
-                        start: 17,
-                        end: 43,
-                    },
-                    pattern: [
-                        Variable {
-                            location: SrcSpan {
-                                start: 17,
-                                end: 18,
-                            },
-                            name: "x",
-                            type_: (),
-                            origin: Variable(
-                                "x",
-                            ),
-                        },
-                        Variable {
-                            location: SrcSpan {
-                                start: 20,
-                                end: 21,
-                            },
-                            name: "y",
-                            type_: (),
-                            origin: Variable(
-                                "y",
-                            ),
-                        },
-                    ],
-                    alternative_patterns: [],
-                    guard: Some(
-                        Equals {
-                            location: SrcSpan {
-                                start: 25,
-                                end: 35,
-                            },
-                            left: AddInt {
-                                location: SrcSpan {
-                                    start: 25,
-                                    end: 30,
-                                },
-                                left: Var {
-                                    location: SrcSpan {
-                                        start: 25,
-                                        end: 26,
-                                    },
-                                    type_: (),
-                                    name: "x",
-                                },
-                                right: Var {
-                                    location: SrcSpan {
-                                        start: 29,
-                                        end: 30,
-                                    },
-                                    type_: (),
-                                    name: "y",
-                                },
-                            },
-                            right: Constant(
-                                Int {
-                                    location: SrcSpan {
-                                        start: 34,
-                                        end: 35,
-                                    },
-                                    value: "1",
-                                    int_value: 1,
-                                },
-                            ),
-                        },
-                    ),
-                    then: Var {
+            clauses: Some(
+                [
+                    Clause {
                         location: SrcSpan {
-                            start: 39,
+                            start: 17,
                             end: 43,
                         },
-                        name: "True",
+                        pattern: [
+                            Variable {
+                                location: SrcSpan {
+                                    start: 17,
+                                    end: 18,
+                                },
+                                name: "x",
+                                type_: (),
+                                origin: Variable(
+                                    "x",
+                                ),
+                            },
+                            Variable {
+                                location: SrcSpan {
+                                    start: 20,
+                                    end: 21,
+                                },
+                                name: "y",
+                                type_: (),
+                                origin: Variable(
+                                    "y",
+                                ),
+                            },
+                        ],
+                        alternative_patterns: [],
+                        guard: Some(
+                            Equals {
+                                location: SrcSpan {
+                                    start: 25,
+                                    end: 35,
+                                },
+                                left: AddInt {
+                                    location: SrcSpan {
+                                        start: 25,
+                                        end: 30,
+                                    },
+                                    left: Var {
+                                        location: SrcSpan {
+                                            start: 25,
+                                            end: 26,
+                                        },
+                                        type_: (),
+                                        name: "x",
+                                    },
+                                    right: Var {
+                                        location: SrcSpan {
+                                            start: 29,
+                                            end: 30,
+                                        },
+                                        type_: (),
+                                        name: "y",
+                                    },
+                                },
+                                right: Constant(
+                                    Int {
+                                        location: SrcSpan {
+                                            start: 34,
+                                            end: 35,
+                                        },
+                                        value: "1",
+                                        int_value: 1,
+                                    },
+                                ),
+                            },
+                        ),
+                        then: Var {
+                            location: SrcSpan {
+                                start: 39,
+                                end: 43,
+                            },
+                            name: "True",
+                        },
                     },
-                },
-            ],
+                ],
+            ),
         },
     ),
 ]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_expression_without_body.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_expression_without_body.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: case a
+---
+[
+    Expression(
+        Case {
+            location: SrcSpan {
+                start: 0,
+                end: 6,
+            },
+            subjects: [
+                Var {
+                    location: SrcSpan {
+                        start: 5,
+                        end: 6,
+                    },
+                    name: "a",
+                },
+            ],
+            clauses: None,
+        },
+    ),
+]

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_invalid_expression.snap
@@ -19,5 +19,4 @@ error: Syntax error
   │             ^^^^ I was not expecting this
 
 Found the keyword `type`, expected one of: 
-- `{`
-- an expression
+- `}`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_without_body.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__case_without_body.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: case a
+---
+[
+    Expression(
+        Case {
+            location: SrcSpan {
+                start: 0,
+                end: 6,
+            },
+            subjects: [
+                Var {
+                    location: SrcSpan {
+                        start: 5,
+                        end: 6,
+                    },
+                    name: "a",
+                },
+            ],
+            clauses: [],
+        },
+    ),
+]

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1678,3 +1678,8 @@ type Wibble {
 fn nested_tuple_access_after_function() {
     assert_parse!("tuple().0.1");
 }
+
+#[test]
+fn case_expression_without_body() {
+    assert_parse!("case a");
+}

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -443,6 +443,11 @@ pub enum Error {
         missing: Vec<EcoString>,
     },
 
+    /// A case expression is missing its body.
+    MissingCaseBody {
+        location: SrcSpan,
+    },
+
     /// Let assignment's pattern does not match all possible values of the type.
     InexhaustiveLetAssignment {
         location: SrcSpan,
@@ -1031,6 +1036,7 @@ impl Error {
             | Error::InvalidExternalJavascriptModule { location, .. }
             | Error::InvalidExternalJavascriptFunction { location, .. }
             | Error::InexhaustiveCaseExpression { location, .. }
+            | Error::MissingCaseBody { location }
             | Error::InexhaustiveLetAssignment { location, .. }
             | Error::UnusedTypeAliasParameter { location, .. }
             | Error::DuplicateTypeParameter { location, .. }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1463,8 +1463,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             None => {
                 self.problems.error(Error::MissingCaseBody { location });
                 return TypedExpr::Case {
-                    location: location,
-                    type_: self.new_unbound_var(),
+                    location,
+                    type_: return_type,
                     subjects: typed_subjects,
                     clauses: Vec::new(),
                 };

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2685,3 +2685,8 @@ fn negative_out_of_range_erlang_float_in_pattern() {
 fn negative_out_of_range_erlang_float_in_const() {
     assert_module_error!(r#"const x = -1.8e308"#);
 }
+
+#[test]
+fn missing_case_body() {
+    assert_error!("case True");
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__missing_case_body.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__missing_case_body.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: case True
+---
+----- SOURCE CODE
+case True
+
+----- ERROR
+error: Missing case body
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case True
+  │ ^^^^^^^^^
+
+This case expression is missing its body.


### PR DESCRIPTION
Closes #3978
This PR makes parsing of case expressions fault tolerant, allowing analysis to continue when a case expressions is missing a body. This mostly allows for LSP completions for the case subjects.