### PR TITLE
Add `deps tree` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,19 @@
   when "Cmd/Ctrl + K", "s" or "/" is pressed.
   ([Sambit Sahoo](https://github.com/soulsam480))
 
+- `gleam deps` now supports `tree` operation that lists the dependency tree.
+
+  ```markdown
+  Usage: gleam deps tree [OPTIONS]
+
+  Options:
+    -p, --package <PACKAGE>  Package to be used as the root of the tree
+    -i, --invert <PACKAGE>   Invert the tree direction and focus on the given package
+    -h, --help               Print help
+  ```
+
+  ([Ramkarthik Krishnamurthy](https://github.com/ramkarthik))
+
 ### Language server
 
 - The language server can now generate the definition of functions that do not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,31 @@
     -h, --help               Print help
   ```
 
+  For example, if the root project (`project_a`) depends on `package_b` and `package_c`, and `package_c` also depends on `package_b`, the output will be:
+
+
+  ```markdown
+  $ gleam deps tree
+
+  project_a v1.0.0
+  ├── package_b v0.52.0
+  └── package_c v1.2.0
+      └── package_b v0.52.0
+
+  $ gleam deps tree --package package_c
+
+  package_c v1.2.0
+  └── package_b v0.52.0
+
+  $ gleam deps tree --invert package_b
+
+  package_b v0.52.0
+  ├── package_c v1.2.0
+  │   └── project_a v1.0.0
+  └── project_a v1.0.0
+
+  ```
+
   ([Ramkarthik Krishnamurthy](https://github.com/ramkarthik))
 
 ### Language server

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -84,9 +84,7 @@ pub fn tree(options: TreeOptions) -> Result<()> {
         Some(&root_package)
     };
 
-    list_package_and_dependencies_tree(std::io::stdout(), package, packages.clone(), invert)?;
-
-    Ok(())
+    list_package_and_dependencies_tree(std::io::stdout(), package, packages.clone(), invert)
 }
 
 fn get_manifest_details() -> Result<(Utf8PathBuf, PackageConfig, Manifest)> {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -73,18 +73,7 @@ pub fn tree(options: TreeOptions) -> Result<()> {
     let mut packages = manifest.packages.iter().cloned().collect_vec();
     packages.append(&mut vec![root_package.clone()]);
 
-    let mut invert = false;
-
-    let package: Option<&ManifestPackage> = if let Some(input_package_name) = options.package {
-        packages.iter().find(|p| p.name == input_package_name)
-    } else if let Some(input_package_name) = options.invert {
-        invert = true;
-        packages.iter().find(|p| p.name == input_package_name)
-    } else {
-        Some(&root_package)
-    };
-
-    list_package_and_dependencies_tree(std::io::stdout(), package, packages.clone(), invert)
+    list_package_and_dependencies_tree(std::io::stdout(), options, packages.clone(), config.name)
 }
 
 fn get_manifest_details() -> Result<(Utf8PathBuf, PackageConfig, Manifest)> {
@@ -117,10 +106,21 @@ fn list_manifest_packages<W: std::io::Write>(mut buffer: W, manifest: Manifest) 
 
 fn list_package_and_dependencies_tree<W: std::io::Write>(
     mut buffer: W,
-    package: Option<&ManifestPackage>,
+    options: TreeOptions,
     packages: Vec<ManifestPackage>,
-    invert: bool,
+    root_package_name: EcoString,
 ) -> Result<()> {
+    let mut invert = false;
+
+    let package: Option<&ManifestPackage> = if let Some(input_package_name) = options.package {
+        packages.iter().find(|p| p.name == input_package_name)
+    } else if let Some(input_package_name) = options.invert {
+        invert = true;
+        packages.iter().find(|p| p.name == input_package_name)
+    } else {
+        packages.iter().find(|p| p.name == root_package_name)
+    };
+
     if let Some(package) = package {
         let tree = Vec::from([eco_format!("{0} v{1}", package.name, package.version)]);
         let tree = list_dependencies_tree(

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -64,6 +64,163 @@ zzz 0.4.0
 }
 
 #[test]
+fn list_tree_format() {
+    let mut buffer = vec![];
+    let manifest = Manifest {
+        requirements: HashMap::new(),
+        packages: vec![
+            ManifestPackage {
+                name: "deps_proj".into(),
+                version: Version::parse("1.0.0").unwrap(),
+                build_tools: [].into(),
+                otp_app: None,
+                requirements: vec!["gleam_regexp".into(), "gleam_stdlib".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![1, 2, 3, 4]),
+                },
+            },
+            ManifestPackage {
+                name: "gleam_stdlib".into(),
+                version: Version::new(0, 52, 0),
+                build_tools: ["rebar3".into(), "make".into()].into(),
+                otp_app: Some("aaa_app".into()),
+                requirements: vec![],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+            ManifestPackage {
+                name: "gleam_regexp".into(),
+                version: Version::new(1, 0, 0),
+                build_tools: ["mix".into()].into(),
+                otp_app: None,
+                requirements: vec!["gleam_stdlib".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+        ],
+    };
+    list_package_and_dependencies_tree(
+        &mut buffer,
+        manifest.packages.first(),
+        manifest.packages.clone(),
+        false,
+    )
+    .unwrap();
+    assert_eq!(
+        std::str::from_utf8(&buffer).unwrap(),
+        r#"deps_proj v1.0.0
+├── gleam_regexp v1.0.0
+│   └── gleam_stdlib v0.52.0
+└── gleam_stdlib v0.52.0
+"#
+    )
+}
+
+#[test]
+fn list_tree_invert_format() {
+    let mut buffer = vec![];
+    let manifest = Manifest {
+        requirements: HashMap::new(),
+        packages: vec![
+            ManifestPackage {
+                name: "gleam_stdlib".into(),
+                version: Version::new(0, 52, 0),
+                build_tools: ["rebar3".into(), "make".into()].into(),
+                otp_app: Some("aaa_app".into()),
+                requirements: vec![],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+            ManifestPackage {
+                name: "deps_proj".into(),
+                version: Version::parse("1.0.0").unwrap(),
+                build_tools: [].into(),
+                otp_app: None,
+                requirements: vec!["gleam_stdlib".into(), "gleam_regexp".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![1, 2, 3, 4]),
+                },
+            },
+            ManifestPackage {
+                name: "gleam_regexp".into(),
+                version: Version::new(1, 0, 0),
+                build_tools: ["mix".into()].into(),
+                otp_app: None,
+                requirements: vec!["gleam_stdlib".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+        ],
+    };
+    list_package_and_dependencies_tree(
+        &mut buffer,
+        manifest.packages.first(),
+        manifest.packages.clone(),
+        true,
+    )
+    .unwrap();
+    assert_eq!(
+        std::str::from_utf8(&buffer).unwrap(),
+        r#"gleam_stdlib v0.52.0
+├── deps_proj v1.0.0
+└── gleam_regexp v1.0.0
+    └── deps_proj v1.0.0
+"#
+    )
+}
+
+#[test]
+fn list_tree_invalid_package_format() {
+    let mut buffer = vec![];
+    let manifest = Manifest {
+        requirements: HashMap::new(),
+        packages: vec![
+            ManifestPackage {
+                name: "gleam_stdlib".into(),
+                version: Version::new(0, 52, 0),
+                build_tools: ["rebar3".into(), "make".into()].into(),
+                otp_app: Some("aaa_app".into()),
+                requirements: vec![],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+            ManifestPackage {
+                name: "gleam_regexp".into(),
+                version: Version::new(1, 0, 0),
+                build_tools: ["mix".into()].into(),
+                otp_app: None,
+                requirements: vec!["gleam_stdlib".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+            ManifestPackage {
+                name: "root".into(),
+                version: Version::parse("1.0.0").unwrap(),
+                build_tools: [].into(),
+                otp_app: None,
+                requirements: vec!["gleam_regexp".into(), "gleam_stdlib".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![1, 2, 3, 4]),
+                },
+            },
+        ],
+    };
+    list_package_and_dependencies_tree(&mut buffer, None, manifest.packages.clone(), false)
+        .unwrap();
+    assert_eq!(
+        std::str::from_utf8(&buffer).unwrap(),
+        r#"Package not found. Please check the package name.
+"#
+    )
+}
+
+#[test]
 fn parse_gleam_add_specifier_invalid_semver() {
     assert!(parse_gleam_add_specifier("some_package@1.2.3.4").is_err());
 }

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -64,7 +64,7 @@ zzz 0.4.0
 }
 
 #[test]
-fn list_tree_format() {
+fn tree_format() {
     let mut buffer = vec![];
     let manifest = Manifest {
         requirements: HashMap::new(),
@@ -101,11 +101,19 @@ fn list_tree_format() {
             },
         ],
     };
+
+    let options = TreeOptions {
+        package: None,
+        invert: None,
+    };
+
+    let root_package_name = EcoString::from("deps_proj");
+
     list_package_and_dependencies_tree(
         &mut buffer,
-        manifest.packages.first(),
+        options,
         manifest.packages.clone(),
-        false,
+        root_package_name,
     )
     .unwrap();
     assert_eq!(
@@ -119,7 +127,7 @@ fn list_tree_format() {
 }
 
 #[test]
-fn list_tree_invert_format() {
+fn tree_package_format() {
     let mut buffer = vec![];
     let manifest = Manifest {
         requirements: HashMap::new(),
@@ -156,11 +164,78 @@ fn list_tree_invert_format() {
             },
         ],
     };
+    let options = TreeOptions {
+        package: Some("gleam_regexp".to_string()),
+        invert: None,
+    };
+
+    let root_package_name = EcoString::from("deps_proj");
+
     list_package_and_dependencies_tree(
         &mut buffer,
-        manifest.packages.first(),
+        options,
         manifest.packages.clone(),
-        true,
+        root_package_name,
+    )
+    .unwrap();
+    assert_eq!(
+        std::str::from_utf8(&buffer).unwrap(),
+        r#"gleam_regexp v1.0.0
+└── gleam_stdlib v0.52.0
+"#
+    )
+}
+
+#[test]
+fn tree_invert_format() {
+    let mut buffer = vec![];
+    let manifest = Manifest {
+        requirements: HashMap::new(),
+        packages: vec![
+            ManifestPackage {
+                name: "gleam_stdlib".into(),
+                version: Version::new(0, 52, 0),
+                build_tools: ["rebar3".into(), "make".into()].into(),
+                otp_app: Some("aaa_app".into()),
+                requirements: vec![],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+            ManifestPackage {
+                name: "deps_proj".into(),
+                version: Version::parse("1.0.0").unwrap(),
+                build_tools: [].into(),
+                otp_app: None,
+                requirements: vec!["gleam_stdlib".into(), "gleam_regexp".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![1, 2, 3, 4]),
+                },
+            },
+            ManifestPackage {
+                name: "gleam_regexp".into(),
+                version: Version::new(1, 0, 0),
+                build_tools: ["mix".into()].into(),
+                otp_app: None,
+                requirements: vec!["gleam_stdlib".into()],
+                source: ManifestPackageSource::Hex {
+                    outer_checksum: Base16Checksum(vec![3, 22]),
+                },
+            },
+        ],
+    };
+    let options = TreeOptions {
+        package: None,
+        invert: Some("gleam_stdlib".to_string()),
+    };
+
+    let root_package_name = EcoString::from("deps_proj");
+
+    list_package_and_dependencies_tree(
+        &mut buffer,
+        options,
+        manifest.packages.clone(),
+        root_package_name,
     )
     .unwrap();
     assert_eq!(
@@ -211,8 +286,20 @@ fn list_tree_invalid_package_format() {
             },
         ],
     };
-    list_package_and_dependencies_tree(&mut buffer, None, manifest.packages.clone(), false)
-        .unwrap();
+    let options = TreeOptions {
+        package: Some("zzzzzz".to_string()),
+        invert: None,
+    };
+
+    let root_package_name = EcoString::from("deps_proj");
+
+    list_package_and_dependencies_tree(
+        &mut buffer,
+        options,
+        manifest.packages.clone(),
+        root_package_name,
+    )
+    .unwrap();
     assert_eq!(
         std::str::from_utf8(&buffer).unwrap(),
         r#"Package not found. Please check the package name.

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -101,6 +101,27 @@ struct UpdateOptions {
     packages: Vec<String>,
 }
 
+#[derive(Args, Debug, Clone)]
+struct TreeOptions {
+    /// (optional) Name of the package to get the dependency tree for
+    #[arg(
+        short,
+        long,
+        ignore_case = true,
+        help = "Package to be used as the root of the tree"
+    )]
+    package: Option<String>,
+    /// (optional) Name of the package to get the inverted dependency tree for
+    #[arg(
+        short,
+        long,
+        ignore_case = true,
+        help = "Invert the tree direction and focus on the given package",
+        value_name = "PACKAGE"
+    )]
+    invert: Option<String>,
+}
+
 #[derive(Parser, Debug)]
 #[command(
     version,
@@ -355,6 +376,9 @@ enum Dependencies {
 
     /// Update dependency packages to their latest versions
     Update(UpdateOptions),
+
+    /// Tree of all the dependency packages
+    Tree(TreeOptions),
 }
 
 #[derive(Subcommand, Debug)]
@@ -484,6 +508,8 @@ fn main() {
         Command::Deps(Dependencies::Download) => download_dependencies(),
 
         Command::Deps(Dependencies::Update(options)) => dependencies::update(options.packages),
+
+        Command::Deps(Dependencies::Tree(options)) => dependencies::tree(options),
 
         Command::Hex(Hex::Authenticate) => hex::authenticate(),
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -103,7 +103,7 @@ struct UpdateOptions {
 
 #[derive(Args, Debug, Clone)]
 struct TreeOptions {
-    /// (optional) Name of the package to get the dependency tree for
+    /// Name of the package to get the dependency tree for
     #[arg(
         short,
         long,
@@ -111,7 +111,7 @@ struct TreeOptions {
         help = "Package to be used as the root of the tree"
     )]
     package: Option<String>,
-    /// (optional) Name of the package to get the inverted dependency tree for
+    /// Name of the package to get the inverted dependency tree for-878904231
     #[arg(
         short,
         long,

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -111,7 +111,7 @@ struct TreeOptions {
         help = "Package to be used as the root of the tree"
     )]
     package: Option<String>,
-    /// Name of the package to get the inverted dependency tree for-878904231
+    /// Name of the package to get the inverted dependency tree for
     #[arg(
         short,
         long,


### PR DESCRIPTION
Related to #3267.

Modified it to `gleam deps tree` based on the conversation in #3408 to make it more inline with how `cargo tree` works.

Currently supports `gleam deps tree`, `gleam deps tree --package PACKAGE_NAME`, and `gleam deps tree --invert PACKAGE_NAME`

Sample output (project name: deps_list):

1. `gleam deps tree`

```
deps_list v1.0.0
├── gleam_regexp v1.0.0
│   └── gleam_stdlib v0.52.0
├── gleam_stdlib v0.52.0
├── gleeunit v1.2.0
│   └── gleam_stdlib v0.52.0
└── pog v3.1.1
    ├── gleam_stdlib v0.52.0
    └── pgo v0.14.0
        ├── backoff v1.1.6
        ├── opentelemetry_api v1.4.0
        └── pg_types v0.4.0
```

2. `gleam deps tree --package pog`

```
pog v3.1.1
├── gleam_stdlib v0.52.0
└── pgo v0.14.0
    ├── backoff v1.1.6
    ├── opentelemetry_api v1.4.0
    └── pg_types v0.4.0
```

3. `gleam deps tree --invert gleam_stdlib`

```
gleam_stdlib v0.52.0
├── deps_list v1.0.0
├── gleam_regexp v1.0.0
│   └── deps_list v1.0.0
├── gleeunit v1.2.0
│   └── deps_list v1.0.0
└── pog v3.1.1
    └── deps_list v1.0.0
```

Please let me know if I should change anything.