### PR TITLE
Improve error message on types used as vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,18 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler now shows an improved error message when using an unknown type as a
+  variable name
+
+  ```txt
+  error: Unknown variable
+    ┌─ /src/one/two.gleam:4:3
+    │
+  4 │   X
+    │   ^
+  The custom type variant constructor `X` is not in scope here.
+  ```
+
 ### Build tool
 
 - `gleam new` now has refined project name validation - rather than failing on

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2259,7 +2259,13 @@ but no type in scope with that name."
                     let text = if *type_with_name_in_scope {
                         wrap_format!("`{name}` is a type, it cannot be used as a value.")
                     } else {
-                        wrap_format!("The name `{name}` is not in scope here.")
+                        let is_first_char_uppercase = name.chars().next().is_some_and(char::is_uppercase);
+
+                        if is_first_char_uppercase {
+                            wrap_format!("The custom type variant constructor `{name}` is not in scope here.")
+                        } else {
+                            wrap_format!("The name `{name}` is not in scope here.")
+                        }
                     };
                     Diagnostic {
                         title: "Unknown variable".into(),

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_are_local_with_annotation.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_are_local_with_annotation.snap
@@ -43,4 +43,4 @@ error: Unknown variable
 2 │ const tpl: String = #(Ok(1), MyInvalidType, 3)
   │                              ^^^^^^^^^^^^^
 
-The name `MyInvalidType` is not in scope here.
+The custom type variant constructor `MyInvalidType` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_are_local_with_unbound_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_are_local_with_unbound_value.snap
@@ -37,4 +37,4 @@ error: Unknown variable
 2 │ const unbound: MyInvalidType = MyInvalidType
   │                                ^^^^^^^^^^^^^
 
-The name `MyInvalidType` is not in scope here.
+The custom type variant constructor `MyInvalidType` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_annotation.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_annotation.snap
@@ -21,4 +21,4 @@ error: Unknown variable
 2 │ const invalid_value: String = MyInvalidValue
   │                               ^^^^^^^^^^^^^^
 
-The name `MyInvalidValue` is not in scope here.
+The custom type variant constructor `MyInvalidValue` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_annotation_and_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_annotation_and_value.snap
@@ -21,7 +21,7 @@ error: Unknown variable
 1 │ const invalid_everything: MyInvalidType = MyInvalidValue
   │                                           ^^^^^^^^^^^^^^
 
-The name `MyInvalidValue` is not in scope here.
+The custom type variant constructor `MyInvalidValue` is not in scope here.
 
 error: Type mismatch
   ┌─ /src/one/two.gleam:2:34

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_unannotated_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_unannotated_value.snap
@@ -35,4 +35,4 @@ error: Unknown variable
 2 │ const invalid_everything: MyInvalidType = MyInvalidValue
   │                                           ^^^^^^^^^^^^^^
 
-The name `MyInvalidValue` is not in scope here.
+The custom type variant constructor `MyInvalidValue` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__const_multiple_errors_invalid_value.snap
@@ -13,7 +13,7 @@ error: Unknown variable
 1 │ const invalid_value: String = MyInvalidValue
   │                               ^^^^^^^^^^^^^^
 
-The name `MyInvalidValue` is not in scope here.
+The custom type variant constructor `MyInvalidValue` is not in scope here.
 
 error: Type mismatch
   ┌─ /src/one/two.gleam:2:39

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_constructor_update.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_constructor_update.snap
@@ -18,4 +18,4 @@ error: Unknown variable
 6 │    NotAPerson(..person)
   │    ^^^^^^^^^^ Did you mean `Person`?
 
-The name `NotAPerson` is not in scope here.
+The custom type variant constructor `NotAPerson` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_guard_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_guard_fault_tolerance.snap
@@ -21,7 +21,7 @@ error: Unknown variable
 5 │     a if a == Wibble -> 0
   │               ^^^^^^ Did you mean `wibble`?
 
-The name `Wibble` is not in scope here.
+The custom type variant constructor `Wibble` is not in scope here.
 
 error: Unknown variable
   ┌─ /src/one/two.gleam:6:15
@@ -29,4 +29,4 @@ error: Unknown variable
 6 │     b if b == Wibble -> 0
   │               ^^^^^^ Did you mean `wibble`?
 
-The name `Wibble` is not in scope here.
+The custom type variant constructor `Wibble` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_pattern_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_pattern_fault_tolerance.snap
@@ -22,7 +22,7 @@ error: Unknown variable
 6 │     Wibble -> 1
   │     ^^^^^^ Did you mean `wibble`?
 
-The name `Wibble` is not in scope here.
+The custom type variant constructor `Wibble` is not in scope here.
 
 error: Unknown variable
   ┌─ /src/one/two.gleam:7:5
@@ -30,4 +30,4 @@ error: Unknown variable
 7 │     Wibble2 -> 2
   │     ^^^^^^^ Did you mean `wibble`?
 
-The name `Wibble2` is not in scope here.
+The custom type variant constructor `Wibble2` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_annotation_fault_tolerance2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_annotation_fault_tolerance2.snap
@@ -19,7 +19,7 @@ error: Unknown variable
 4 │   let a: Int = Junk
   │                ^^^^
 
-The name `Junk` is not in scope here.
+The custom type variant constructor `Junk` is not in scope here.
 
 error: Type mismatch
   ┌─ /src/one/two.gleam:5:19

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_pattern_fault_tolerance2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_pattern_fault_tolerance2.snap
@@ -20,7 +20,7 @@ error: Unknown variable
 4 │   let Junk(a) = 7
   │       ^^^^^^^
 
-The name `Junk` is not in scope here.
+The custom type variant constructor `Junk` is not in scope here.
 
 error: Type mismatch
   ┌─ /src/one/two.gleam:6:7

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_opaque_constructor.snap
@@ -28,4 +28,4 @@ error: Unknown variable
 4 │   Two
   │   ^^^
 
-The name `Two` is not in scope here.
+The custom type variant constructor `Two` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor.snap
@@ -28,4 +28,4 @@ error: Unknown variable
 4 │   Two
   │   ^^^
 
-The name `Two` is not in scope here.
+The custom type variant constructor `Two` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__unqualified_using_private_constructor_pattern.snap
@@ -28,4 +28,4 @@ error: Unknown variable
 4 │   let Two = x
   │       ^^^
 
-The name `Two` is not in scope here.
+The custom type variant constructor `Two` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_custom_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_custom_type.snap
@@ -28,4 +28,4 @@ error: Unknown variable
 4 │   X
   │   ^
 
-The name `X` is not in scope here.
+The custom type variant constructor `X` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_external_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_external_type.snap
@@ -28,4 +28,4 @@ error: Unknown variable
 4 │   X
   │   ^
 
-The name `X` is not in scope here.
+The custom type variant constructor `X` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_type_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_unqualified_type_alias.snap
@@ -28,4 +28,4 @@ error: Unknown variable
 4 │   X
   │   ^
 
-The name `X` is not in scope here.
+The custom type variant constructor `X` is not in scope here.


### PR DESCRIPTION
Closes https://github.com/gleam-lang/gleam/issues/4112

This is the simplest fix to improve the error message when using a type instead of a value (when it's not in scope).
Another approach could be to create a new error type, but that will lead to more code duplication and "tribal" knowledge (you have to check the variable's name before **every** creation of the error), WDYT?