### PR TITLE
Implement renaming for local variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,30 @@
   better names using the type of the code it's generating.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The Language Server now provides the ability to rename local variables.
+  For example:
+
+  ```gleam
+  pub fn main() {
+    let wibble = 10
+    //  ^ If you put your cursor here, and trigger a rename
+    wibble + 1
+  }
+  ```
+
+  Triggering a rename and entering `my_number` results in this code:
+
+
+  ```gleam
+  pub fn main() {
+    let my_number = 10
+    my_number + 1
+  }
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+
 ### Formatter
 
 ### Bug fixes

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1951,7 +1951,6 @@ impl TypedPattern {
             | Pattern::VarUsage { .. }
             | Pattern::Assign { .. }
             | Pattern::Discard { .. }
-            | Pattern::BitArray { .. }
             | Pattern::StringPrefix { .. }
             | Pattern::Invalid { .. } => Some(Located::Pattern(self)),
 
@@ -1973,6 +1972,11 @@ impl TypedPattern {
                 .or_else(|| tail.as_ref().and_then(|p| p.find_node(byte_index))),
 
             Pattern::Tuple { elems, .. } => elems.iter().find_map(|p| p.find_node(byte_index)),
+
+            Pattern::BitArray { segments, .. } => segments
+                .iter()
+                .find_map(|segment| segment.find_node(byte_index))
+                .or(Some(Located::Pattern(self))),
         }
         .or(Some(Located::Pattern(self)))
     }
@@ -2046,6 +2050,16 @@ pub struct BitArraySegment<Value, Type> {
 impl TypedExprBitArraySegment {
     pub fn find_node(&self, byte_index: u32) -> Option<Located<'_>> {
         self.value.find_node(byte_index)
+    }
+}
+
+impl TypedPatternBitArraySegment {
+    pub fn find_node(&self, byte_index: u32) -> Option<Located<'_>> {
+        self.value.find_node(byte_index).or_else(|| {
+            self.options
+                .iter()
+                .find_map(|option| option.find_node(byte_index))
+        })
     }
 }
 
@@ -2174,6 +2188,30 @@ impl<A> BitArrayOption<A> {
             BitArrayOption::Native { .. } => "native".into(),
             BitArrayOption::Size { .. } => "size".into(),
             BitArrayOption::Unit { .. } => "unit".into(),
+        }
+    }
+}
+
+impl BitArrayOption<TypedPattern> {
+    pub fn find_node(&self, byte_index: u32) -> Option<Located<'_>> {
+        match self {
+            BitArrayOption::Bytes { .. }
+            | BitArrayOption::Int { .. }
+            | BitArrayOption::Float { .. }
+            | BitArrayOption::Bits { .. }
+            | BitArrayOption::Utf8 { .. }
+            | BitArrayOption::Utf16 { .. }
+            | BitArrayOption::Utf32 { .. }
+            | BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. }
+            | BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. }
+            | BitArrayOption::Unit { .. } => None,
+            BitArrayOption::Size { value, .. } => value.find_node(byte_index),
         }
     }
 }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1524,6 +1524,7 @@ pub enum ClauseGuard<Type, RecordTag> {
         location: SrcSpan,
         type_: Type,
         name: EcoString,
+        definition_location: SrcSpan,
     },
 
     TupleIndex {

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -6,6 +6,7 @@ use crate::analyse::TargetSupport;
 use crate::build::Target;
 use crate::config::PackageConfig;
 use crate::line_numbers::LineNumbers;
+use crate::type_::error::VariableOrigin;
 use crate::type_::expression::FunctionDefinition;
 use crate::type_::{Deprecation, Problems, PRELUDE_MODULE_NAME};
 use crate::warning::WarningEmitter;
@@ -234,6 +235,7 @@ wibble}"#,
             publicity: Publicity::Private,
             variant: ValueConstructorVariant::LocalVariable {
                 location: SrcSpan { start: 5, end: 11 },
+                origin: VariableOrigin::Variable("wibble".into()),
             },
             type_: type_::int(),
         },

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -486,6 +486,10 @@ pub trait Visit<'ast> {
         visit_typed_pattern_bit_array(self, location, segments);
     }
 
+    fn visit_typed_pattern_bit_array_option(&mut self, option: &'ast BitArrayOption<TypedPattern>) {
+        visit_typed_pattern_bit_array_option(self, option);
+    }
+
     fn visit_typed_pattern_string_prefix(
         &mut self,
         location: &'ast SrcSpan,
@@ -1582,6 +1586,45 @@ pub fn visit_typed_pattern_bit_array<'a, V>(
 {
     for segment in segments {
         v.visit_typed_pattern(&segment.value);
+        for option in segment.options.iter() {
+            v.visit_typed_pattern_bit_array_option(option);
+        }
+    }
+}
+
+pub fn visit_typed_pattern_bit_array_option<'a, V>(
+    v: &mut V,
+    option: &'a BitArrayOption<TypedPattern>,
+) where
+    V: Visit<'a> + ?Sized,
+{
+    match option {
+        BitArrayOption::Bytes { location: _ } => { /* TODO */ }
+        BitArrayOption::Int { location: _ } => { /* TODO */ }
+        BitArrayOption::Float { location: _ } => { /* TODO */ }
+        BitArrayOption::Bits { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf8 { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf16 { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf32 { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf8Codepoint { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf16Codepoint { location: _ } => { /* TODO */ }
+        BitArrayOption::Utf32Codepoint { location: _ } => { /* TODO */ }
+        BitArrayOption::Signed { location: _ } => { /* TODO */ }
+        BitArrayOption::Unsigned { location: _ } => { /* TODO */ }
+        BitArrayOption::Big { location: _ } => { /* TODO */ }
+        BitArrayOption::Little { location: _ } => { /* TODO */ }
+        BitArrayOption::Native { location: _ } => { /* TODO */ }
+        BitArrayOption::Size {
+            location: _,
+            value,
+            short_form: _,
+        } => {
+            v.visit_typed_pattern(value);
+        }
+        BitArrayOption::Unit {
+            location: _,
+            value: _,
+        } => { /* TODO */ }
     }
 }
 

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -325,8 +325,9 @@ pub trait Visit<'ast> {
         location: &'ast SrcSpan,
         name: &'ast EcoString,
         type_: &'ast Arc<Type>,
+        definition_location: &'ast SrcSpan,
     ) {
-        visit_typed_clause_guard_var(self, location, name, type_);
+        visit_typed_clause_guard_var(self, location, name, type_, definition_location);
     }
 
     fn visit_typed_clause_guard_tuple_index(
@@ -1250,7 +1251,8 @@ where
             location,
             type_,
             name,
-        } => v.visit_typed_clause_guard_var(location, name, type_),
+            definition_location,
+        } => v.visit_typed_clause_guard_var(location, name, type_, definition_location),
         super::ClauseGuard::TupleIndex {
             location,
             index,
@@ -1288,6 +1290,7 @@ pub fn visit_typed_clause_guard_var<'a, V>(
     _location: &'a SrcSpan,
     _name: &'a EcoString,
     _type_: &'a Arc<Type>,
+    _definition_location: &'a SrcSpan,
 ) where
     V: Visit<'a> + ?Sized,
 {

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -31,7 +31,7 @@ use super::{
     compiler::LspProjectCompiler,
     edits::{add_newlines_after_import, get_import_edit, position_of_first_definition_if_import},
     engine::{overlaps, within},
-    src_span_to_lsp_range,
+    src_span_to_lsp_range, TextEdits,
 };
 
 #[derive(Debug)]
@@ -77,48 +77,6 @@ impl CodeActionBuilder {
 
     pub fn push_to(self, actions: &mut Vec<CodeAction>) {
         actions.push(self.action);
-    }
-}
-
-/// A little wrapper around LineNumbers to make it easier to build text edits.
-///
-struct TextEdits<'a> {
-    line_numbers: &'a LineNumbers,
-    edits: Vec<TextEdit>,
-}
-
-impl<'a> TextEdits<'a> {
-    pub fn new(line_numbers: &'a LineNumbers) -> Self {
-        TextEdits {
-            line_numbers,
-            edits: vec![],
-        }
-    }
-
-    pub fn src_span_to_lsp_range(&self, location: SrcSpan) -> Range {
-        src_span_to_lsp_range(location, self.line_numbers)
-    }
-
-    pub fn replace(&mut self, location: SrcSpan, new_text: String) {
-        self.edits.push(TextEdit {
-            range: src_span_to_lsp_range(location, self.line_numbers),
-            new_text,
-        })
-    }
-
-    pub fn insert(&mut self, at: u32, new_text: String) {
-        self.replace(SrcSpan { start: at, end: at }, new_text)
-    }
-
-    pub fn delete(&mut self, location: SrcSpan) {
-        self.replace(location, "".to_string())
-    }
-
-    fn delete_range(&mut self, range: Range) {
-        self.edits.push(TextEdit {
-            range,
-            new_text: "".into(),
-        })
     }
 }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -537,7 +537,6 @@ where
 
             Ok(match found {
                 Located::Expression(TypedExpr::Var {
-                    location,
                     constructor:
                         ValueConstructor {
                             variant:
@@ -547,9 +546,7 @@ where
                             ..
                         },
                     ..
-                }) => {
-                    rename_local_variable(module, &lines, &params, *location, *definition_location)
-                }
+                }) => rename_local_variable(module, &lines, &params, *definition_location),
                 _ => None,
             })
         })

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -547,9 +547,9 @@ where
                         },
                     ..
                 })
-                | Located::Pattern(Pattern::Variable { location, .. }) => {
-                    rename_local_variable(module, &lines, &params, *location)
-                }
+                | Located::Pattern(
+                    Pattern::Variable { location, .. } | Pattern::Assign { location, .. },
+                ) => rename_local_variable(module, &lines, &params, *location),
                 Located::Arg(arg) => match &arg.names {
                     ArgNames::Named { location, .. }
                     | ArgNames::NamedLabelled {

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -514,9 +514,12 @@ where
                             ..
                         },
                     ..
-                }) => Some(PrepareRenameResponse::DefaultBehavior {
-                    default_behavior: true,
-                }),
+                })
+                | Located::Pattern(Pattern::Variable { .. }) => {
+                    Some(PrepareRenameResponse::DefaultBehavior {
+                        default_behavior: true,
+                    })
+                }
                 _ => None,
             })
         })

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -1,8 +1,8 @@
 use crate::{
     analyse::name::correct_name_case,
     ast::{
-        CustomType, Definition, ModuleConstant, SrcSpan, TypedArg, TypedExpr, TypedFunction,
-        TypedModule, TypedPattern,
+        CustomType, Definition, ModuleConstant, Pattern, SrcSpan, TypedArg, TypedExpr,
+        TypedFunction, TypedModule, TypedPattern,
     },
     build::{type_constructor_from_modules, Located, Module, UnqualifiedImport},
     config::PackageConfig,
@@ -547,6 +547,9 @@ where
                         },
                     ..
                 }) => rename_local_variable(module, &lines, &params, *definition_location),
+                Located::Pattern(Pattern::Variable { location, .. }) => {
+                    rename_local_variable(module, &lines, &params, *location)
+                }
                 _ => None,
             })
         })

--- a/compiler-core/src/language_server/messages.rs
+++ b/compiler-core/src/language_server/messages.rs
@@ -8,7 +8,7 @@ use lsp_types::{
     notification::{DidChangeTextDocument, DidCloseTextDocument, DidSaveTextDocument},
     request::{
         CodeActionRequest, Completion, DocumentSymbolRequest, Formatting, HoverRequest,
-        SignatureHelpRequest,
+        PrepareRenameRequest, Rename, SignatureHelpRequest,
     },
 };
 use std::time::Duration;
@@ -28,6 +28,8 @@ pub enum Request {
     CodeAction(lsp::CodeActionParams),
     SignatureHelp(lsp::SignatureHelpParams),
     DocumentSymbol(lsp::DocumentSymbolParams),
+    PrepareRename(lsp::TextDocumentPositionParams),
+    Rename(lsp::RenameParams),
 }
 
 impl Request {
@@ -61,6 +63,14 @@ impl Request {
             "textDocument/documentSymbol" => {
                 let params = cast_request::<DocumentSymbolRequest>(request);
                 Some(Message::Request(id, Request::DocumentSymbol(params)))
+            }
+            "textDocument/rename" => {
+                let params = cast_request::<Rename>(request);
+                Some(Message::Request(id, Request::Rename(params)))
+            }
+            "textDocument/prepareRename" => {
+                let params = cast_request::<PrepareRenameRequest>(request);
+                Some(Message::Request(id, Request::PrepareRename(params)))
             }
             _ => None,
         }

--- a/compiler-core/src/language_server/rename.rs
+++ b/compiler-core/src/language_server/rename.rs
@@ -117,4 +117,26 @@ impl<'ast> Visit<'ast> for RenameLocalVariable {
             self.references.push(*location)
         }
     }
+
+    fn visit_typed_pattern_var_usage(
+        &mut self,
+        location: &'ast SrcSpan,
+        _name: &'ast EcoString,
+        constructor: &'ast Option<ValueConstructor>,
+        _type_: &'ast std::sync::Arc<crate::type_::Type>,
+    ) {
+        let variant = match constructor {
+            Some(constructor) => &constructor.variant,
+            None => return,
+        };
+        match variant {
+            ValueConstructorVariant::LocalVariable {
+                location: definition_location,
+                ..
+            } if *definition_location == self.definition_location => {
+                self.references.push(*location)
+            }
+            _ => {}
+        }
+    }
 }

--- a/compiler-core/src/language_server/rename.rs
+++ b/compiler-core/src/language_server/rename.rs
@@ -81,4 +81,16 @@ impl<'ast> Visit<'ast> for RenameLocalVariable {
             _ => {}
         }
     }
+
+    fn visit_typed_clause_guard_var(
+        &mut self,
+        location: &'ast SrcSpan,
+        _name: &'ast EcoString,
+        _type_: &'ast std::sync::Arc<crate::type_::Type>,
+        definition_location: &'ast SrcSpan,
+    ) {
+        if *definition_location == self.definition_location {
+            self.references.push(*location)
+        }
+    }
 }

--- a/compiler-core/src/language_server/rename.rs
+++ b/compiler-core/src/language_server/rename.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+use lsp_types::{RenameParams, TextEdit, Url, WorkspaceEdit};
+
+use crate::{ast::SrcSpan, build::Module, line_numbers::LineNumbers};
+
+use super::TextEdits;
+
+fn workspace_edit(uri: Url, edits: Vec<TextEdit>) -> WorkspaceEdit {
+    let mut changes = HashMap::new();
+    let _ = changes.insert(uri, edits);
+
+    WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    }
+}
+
+pub fn rename_local_variable(
+    _module: &Module,
+    line_numbers: &LineNumbers,
+    params: &RenameParams,
+    location: SrcSpan,
+    definition_location: SrcSpan,
+) -> Option<WorkspaceEdit> {
+    let uri = params.text_document_position.text_document.uri.clone();
+    let mut edits = TextEdits::new(line_numbers);
+
+    edits.replace(location, params.new_name.clone());
+    edits.replace(definition_location, params.new_name.clone());
+
+    Some(workspace_edit(uri, edits.edits))
+}

--- a/compiler-core/src/language_server/rename.rs
+++ b/compiler-core/src/language_server/rename.rs
@@ -4,10 +4,11 @@ use ecow::EcoString;
 use lsp_types::{RenameParams, TextEdit, Url, WorkspaceEdit};
 
 use crate::{
+    analyse::name,
     ast::{self, visit::Visit, SrcSpan, TypedModule},
     build::Module,
     line_numbers::LineNumbers,
-    type_::{ValueConstructor, ValueConstructorVariant},
+    type_::{error::Named, ValueConstructor, ValueConstructorVariant},
 };
 
 use super::TextEdits;
@@ -29,6 +30,16 @@ pub fn rename_local_variable(
     params: &RenameParams,
     definition_location: SrcSpan,
 ) -> Option<WorkspaceEdit> {
+    if name::check_name_case(
+        Default::default(),
+        &params.new_name.as_str().into(),
+        Named::Variable,
+    )
+    .is_err()
+    {
+        return None;
+    }
+
     let uri = params.text_document_position.text_document.uri.clone();
     let mut edits = TextEdits::new(line_numbers);
 

--- a/compiler-core/src/language_server/rename.rs
+++ b/compiler-core/src/language_server/rename.rs
@@ -1,8 +1,14 @@
 use std::collections::HashMap;
 
+use ecow::EcoString;
 use lsp_types::{RenameParams, TextEdit, Url, WorkspaceEdit};
 
-use crate::{ast::SrcSpan, build::Module, line_numbers::LineNumbers};
+use crate::{
+    ast::{self, visit::Visit, SrcSpan, TypedModule},
+    build::Module,
+    line_numbers::LineNumbers,
+    type_::{ValueConstructor, ValueConstructorVariant},
+};
 
 use super::TextEdits;
 
@@ -18,17 +24,61 @@ fn workspace_edit(uri: Url, edits: Vec<TextEdit>) -> WorkspaceEdit {
 }
 
 pub fn rename_local_variable(
-    _module: &Module,
+    module: &Module,
     line_numbers: &LineNumbers,
     params: &RenameParams,
-    location: SrcSpan,
     definition_location: SrcSpan,
 ) -> Option<WorkspaceEdit> {
     let uri = params.text_document_position.text_document.uri.clone();
     let mut edits = TextEdits::new(line_numbers);
 
-    edits.replace(location, params.new_name.clone());
+    let references = RenameLocalVariable::new(definition_location).references(&module.ast);
+
     edits.replace(definition_location, params.new_name.clone());
+    references
+        .into_iter()
+        .for_each(|location| edits.replace(location, params.new_name.clone()));
 
     Some(workspace_edit(uri, edits.edits))
+}
+
+struct RenameLocalVariable {
+    definition_location: SrcSpan,
+    references: Vec<SrcSpan>,
+}
+
+impl RenameLocalVariable {
+    fn new(definition_location: SrcSpan) -> Self {
+        Self {
+            references: Vec::new(),
+            definition_location,
+        }
+    }
+
+    fn references(mut self, ast: &TypedModule) -> Vec<SrcSpan> {
+        self.visit_typed_module(ast);
+        self.references
+    }
+}
+
+impl<'ast> Visit<'ast> for RenameLocalVariable {
+    fn visit_typed_function(&mut self, fun: &'ast ast::TypedFunction) {
+        if fun.full_location().contains(self.definition_location.start) {
+            ast::visit::visit_typed_function(self, fun);
+        }
+    }
+
+    fn visit_typed_expr_var(
+        &mut self,
+        location: &'ast SrcSpan,
+        constructor: &'ast ValueConstructor,
+        _name: &'ast EcoString,
+    ) {
+        match constructor.variant {
+            ValueConstructorVariant::LocalVariable {
+                location: definition_location,
+            } if definition_location == self.definition_location => self.references.push(*location),
+            _ => {}
+        }
+    }
 }

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -4,6 +4,7 @@ mod completion;
 mod definition;
 mod document_symbols;
 mod hover;
+mod rename;
 mod signature_help;
 
 use std::{

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -183,6 +183,36 @@ pub fn main() {
 }
 
 #[test]
+fn rename_local_variable_assignment_pattern() {
+    assert_rename!(
+        "
+pub fn main() {
+  let assert Error(12 as something) = Error(12)
+  something
+}
+",
+        "the_error",
+        find_position_of("something")
+            .nth_occurrence(2)
+            .to_selection()
+    );
+}
+
+#[test]
+fn rename_local_variable_from_definition_assignment_pattern() {
+    assert_rename!(
+        "
+pub fn main() {
+  let assert Error(12 as something) = Error(12)
+  something
+}
+",
+        "the_error",
+        find_position_of("something)").to_selection()
+    );
+}
+
+#[test]
 fn rename_local_variable_argument() {
     assert_rename!(
         "

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -163,3 +163,17 @@ pub fn main() {}
         find_position_of("fn").to_selection(),
     );
 }
+
+#[test]
+fn no_rename_invalid_name() {
+    assert_no_rename!(
+        "
+pub fn main() {
+  let wibble = 10
+  wibble
+}
+",
+        "Not_AValid_Name",
+        find_position_of("wibble").nth_occurrence(2).to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -239,6 +239,42 @@ pub fn wibble(wibble: Float) {
 }
 
 #[test]
+fn rename_local_variable_label_shorthand() {
+    assert_rename!(
+        "
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let Wibble(wibble:) = todo
+  wibble + 1
+}
+",
+        "wobble",
+        find_position_of("wibble +").to_selection()
+    );
+}
+
+#[test]
+fn rename_local_variable_label_shorthand_from_definition() {
+    assert_rename!(
+        "
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let Wibble(wibble:) = todo
+  wibble + 1
+}
+",
+        "wobble",
+        find_position_of("wibble:)").to_selection()
+    );
+}
+
+#[test]
 fn no_rename_keyword() {
     assert_no_rename!(
         "

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -283,6 +283,42 @@ pub fn main() {
 }
 
 #[test]
+fn rename_local_variable_in_bit_array_pattern() {
+    assert_rename!(
+        "
+pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
+  let prefix_size = bit_size(prefix)
+
+  case bits {
+    <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True
+    _ -> False
+  }
+}
+",
+        "size_of_prefix",
+        find_position_of("prefix_size =").to_selection()
+    );
+}
+
+#[test]
+fn rename_local_variable_from_bit_array_pattern() {
+    assert_rename!(
+        "
+pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
+  let prefix_size = bit_size(prefix)
+
+  case bits {
+    <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True
+    _ -> False
+  }
+}
+",
+        "size_of_prefix",
+        find_position_of("prefix_size)").to_selection()
+    );
+}
+
+#[test]
 fn no_rename_keyword() {
     assert_no_rename!(
         "

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -11,6 +11,14 @@ fn rename(
     new_name: &str,
     position: Position,
 ) -> Option<lsp_types::WorkspaceEdit> {
+    let _ = tester.at(position, |engine, params, _| {
+        let params = TextDocumentPositionParams {
+            text_document: params.text_document,
+            position,
+        };
+        engine.prepare_rename(params).result.unwrap()
+    })?;
+
     tester.at(position, |engine, params, _| {
         let params = RenameParams {
             text_document_position: TextDocumentPositionParams {

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -183,6 +183,32 @@ pub fn main() {
 }
 
 #[test]
+fn rename_local_variable_argument() {
+    assert_rename!(
+        "
+pub fn add(first_number: Int, x: Int) -> Int {
+  x + first_number
+}
+",
+        "second_number",
+        find_position_of("x +").to_selection()
+    );
+}
+
+#[test]
+fn rename_local_variable_argument_from_definition() {
+    assert_rename!(
+        "
+pub fn wibble(wibble: Float) {
+  wibble /. 0.3
+}
+",
+        "wobble",
+        find_position_of("wibble:").to_selection()
+    );
+}
+
+#[test]
 fn no_rename_keyword() {
     assert_no_rename!(
         "

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -154,6 +154,35 @@ pub fn main() {
 }
 
 #[test]
+fn rename_local_variable_from_definition() {
+    assert_rename!(
+        "
+pub fn main() {
+  let wibble = 10
+  let wobble = wibble + 1
+  wobble - wibble
+}
+",
+        "some_value",
+        find_position_of("wibble =").to_selection()
+    );
+}
+
+#[test]
+fn rename_local_variable_from_definition_nested_pattern() {
+    assert_rename!(
+        "
+pub fn main() {
+  let assert Ok([_, wibble, ..]) = Error(12)
+  wibble
+}
+",
+        "second_element",
+        find_position_of("wibble,").to_selection()
+    );
+}
+
+#[test]
 fn no_rename_keyword() {
     assert_no_rename!(
         "

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+
+use lsp_types::{Position, RenameParams, TextDocumentPositionParams, Url, WorkDoneProgressParams};
+
+use crate::language_server::tests::{find_position_of, TestProject};
+
+use super::hover;
+
+fn rename(
+    tester: TestProject<'_>,
+    new_name: &str,
+    position: Position,
+) -> Option<lsp_types::WorkspaceEdit> {
+    tester.at(position, |engine, params, _| {
+        let params = RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: params.text_document,
+                position,
+            },
+            new_name: new_name.to_string(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+        engine.rename(params).result.unwrap()
+    })
+}
+
+fn apply_rename(tester: TestProject<'_>, new_name: &str, position: Position) -> String {
+    let src = tester.src;
+    let changes = rename(tester, new_name, position)
+        .expect("Rename failed")
+        .changes
+        .expect("No text edit found");
+    apply_code_edit(src, changes)
+}
+
+fn apply_code_edit(src: &str, changes: HashMap<Url, Vec<lsp_types::TextEdit>>) -> String {
+    let mut result = src.to_string();
+    for (_, change) in changes {
+        result = super::apply_code_edit(result.as_str(), change);
+    }
+    result
+}
+
+macro_rules! assert_rename {
+    ($code:literal, $new_name:literal, $range:expr $(,)?) => {
+        let project = TestProject::for_source($code);
+        assert_rename!(project, $new_name, $range);
+    };
+
+    ($project:expr, $new_name:literal, $range:expr $(,)?) => {
+        let src = $project.src;
+        let range = $range.find_range(src);
+        let result = apply_rename($project, $new_name, range.start);
+        let output = format!(
+            "----- BEFORE RENAME\n{}\n\n----- AFTER RENAME\n{}",
+            hover::show_hover(src, range, range.start),
+            result
+        );
+        insta::assert_snapshot!(insta::internals::AutoName, output, src);
+    };
+}
+
+macro_rules! assert_no_rename {
+    ($code:literal, $new_name:literal, $range:expr $(,)?) => {
+        let project = TestProject::for_source($code);
+        assert_no_rename!(project, $new_name, $range);
+    };
+
+    ($project:expr, $new_name:literal, $range:expr $(,)?) => {
+        let src = $project.src;
+        let range = $range.find_range(src);
+        let result = rename($project, $new_name, range.start);
+        assert_eq!(result, None);
+    };
+}
+
+#[test]
+fn rename_local_variable() {
+    assert_rename!(
+        "
+pub fn main() {
+  let wibble = 10
+  wibble
+}
+",
+        "wobble",
+        find_position_of("wibble").nth_occurrence(2).to_selection(),
+    );
+}
+
+#[test]
+fn no_rename_keyword() {
+    assert_no_rename!(
+        "
+pub fn main() {}
+",
+        "wibble",
+        find_position_of("fn").to_selection(),
+    );
+}

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -89,6 +89,71 @@ pub fn main() {
 }
 
 #[test]
+fn rename_shadowed_local_variable() {
+    assert_rename!(
+        "
+pub fn main() {
+  let wibble = 10
+  let wibble = wibble / 2
+  wibble
+}
+",
+        "wobble",
+        find_position_of("wibble /").to_selection(),
+    );
+}
+
+#[test]
+fn rename_shadowing_local_variable() {
+    assert_rename!(
+        "
+pub fn main() {
+  let wibble = 10
+  let wibble = wibble / 2
+  wibble
+}
+",
+        "wobble",
+        find_position_of("wibble").nth_occurrence(4).to_selection(),
+    );
+}
+
+#[test]
+fn rename_local_variable_record_access() {
+    assert_rename!(
+        "
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(wibble: 1)
+  wibble.wibble
+}
+",
+        "wobble",
+        find_position_of("wibble.").to_selection(),
+    );
+}
+#[test]
+fn rename_local_variable_guard_clause() {
+    assert_rename!(
+        "
+pub fn main() {
+  let wibble = True
+  case Nil {
+    Nil if wibble -> todo
+    _ -> panic
+  }
+  wibble || False
+}
+",
+        "wobble",
+        find_position_of("wibble ||").to_selection(),
+    );
+}
+
+#[test]
 fn no_rename_keyword() {
     assert_no_rename!(
         "

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  wibble\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let wibble = 10
+  wibble
+  ↑     
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let wobble = 10
+  wobble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_argument.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_argument.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn add(first_number: Int, x: Int) -> Int {\n  x + first_number\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn add(first_number: Int, x: Int) -> Int {
+  x + first_number
+  ↑               
+}
+
+
+----- AFTER RENAME
+
+pub fn add(first_number: Int, second_number: Int) -> Int {
+  second_number + first_number
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_argument_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_argument_from_definition.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn wibble(wibble: Float) {\n  wibble /. 0.3\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn wibble(wibble: Float) {
+              ↑               
+  wibble /. 0.3
+}
+
+
+----- AFTER RENAME
+
+pub fn wibble(wobble: Float) {
+  wobble /. 0.3
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_assignment_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_assignment_pattern.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() {\n  let assert Error(12 as something) = Error(12)\n  something\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let assert Error(12 as something) = Error(12)
+  something
+  ↑        
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let assert Error(12 as the_error) = Error(12)
+  the_error
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_bit_array_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_bit_array_pattern.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {\n  let prefix_size = bit_size(prefix)\n\n  case bits {\n    <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True\n    _ -> False\n  }\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
+  let prefix_size = bit_size(prefix)
+
+  case bits {
+    <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True
+                     ↑                                               
+    _ -> False
+  }
+}
+
+
+----- AFTER RENAME
+
+pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
+  let size_of_prefix = bit_size(prefix)
+
+  case bits {
+    <<pref:bits-size(size_of_prefix), _:bits>> if pref == prefix -> True
+    _ -> False
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  let wobble = wibble + 1\n  wobble - wibble\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let wibble = 10
+      ↑          
+  let wobble = wibble + 1
+  wobble - wibble
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let some_value = 10
+  let wobble = some_value + 1
+  wobble - some_value
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_assignment_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_assignment_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/rename.rs
-assertion_line: 203
 expression: "\npub fn main() {\n  let assert Error(12 as something) = Error(12)\n  something\n}\n"
-snapshot_kind: text
 ---
 ----- BEFORE RENAME
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_assignment_pattern.snap.new
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_assignment_pattern.snap.new
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+assertion_line: 203
+expression: "\npub fn main() {\n  let assert Error(12 as something) = Error(12)\n  something\n}\n"
+snapshot_kind: text
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let assert Error(12 as something) = Error(12)
+                         ↑                     
+  something
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let assert Error(12 as the_error) = Error(12)
+  the_error
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_nested_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_nested_pattern.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() {\n  let assert Ok([_, wibble, ..]) = Error(12)\n  wibble\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let assert Ok([_, wibble, ..]) = Error(12)
+                    ↑                       
+  wibble
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let assert Ok([_, second_element, ..]) = Error(12)
+  second_element
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_guard_clause.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_guard_clause.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+assertion_line: 140
+expression: "\npub fn main() {\n  let wibble = True\n  case Nil {\n    Nil if wibble -> todo\n    _ -> panic\n  }\n  wibble || False\n}\n"
+snapshot_kind: text
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let wibble = True
+  case Nil {
+    Nil if wibble -> todo
+    _ -> panic
+  }
+  wibble || False
+  ↑
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let wobble = True
+  case Nil {
+    Nil if wobble -> todo
+    _ -> panic
+  }
+  wobble || False
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_guard_clause.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_guard_clause.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/rename.rs
-assertion_line: 140
 expression: "\npub fn main() {\n  let wibble = True\n  case Nil {\n    Nil if wibble -> todo\n    _ -> panic\n  }\n  wibble || False\n}\n"
-snapshot_kind: text
 ---
 ----- BEFORE RENAME
 
@@ -13,7 +11,7 @@ pub fn main() {
     _ -> panic
   }
   wibble || False
-  ↑
+  ↑              
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_in_bit_array_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_in_bit_array_pattern.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {\n  let prefix_size = bit_size(prefix)\n\n  case bits {\n    <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True\n    _ -> False\n  }\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
+  let prefix_size = bit_size(prefix)
+      ↑                             
+
+  case bits {
+    <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True
+    _ -> False
+  }
+}
+
+
+----- AFTER RENAME
+
+pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
+  let size_of_prefix = bit_size(prefix)
+
+  case bits {
+    <<pref:bits-size(size_of_prefix), _:bits>> if pref == prefix -> True
+    _ -> False
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\ntype Wibble {\n  Wibble(wibble: Int)\n}\n\npub fn main() {\n  let Wibble(wibble:) = todo\n  wibble + 1\n}\n"
+---
+----- BEFORE RENAME
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let Wibble(wibble:) = todo
+  wibble + 1
+  ↑         
+}
+
+
+----- AFTER RENAME
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let Wibble(wibble: wobble) = todo
+  wobble + 1
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand_from_definition.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\ntype Wibble {\n  Wibble(wibble: Int)\n}\n\npub fn main() {\n  let Wibble(wibble:) = todo\n  wibble + 1\n}\n"
+---
+----- BEFORE RENAME
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let Wibble(wibble:) = todo
+             ↑              
+  wibble + 1
+}
+
+
+----- AFTER RENAME
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let Wibble(wibble: wobble) = todo
+  wobble + 1
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_record_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_record_access.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\ntype Wibble {\n  Wibble(wibble: Int)\n}\n\npub fn main() {\n  let wibble = Wibble(wibble: 1)\n  wibble.wibble\n}\n"
+---
+----- BEFORE RENAME
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(wibble: 1)
+  wibble.wibble
+  ↑            
+}
+
+
+----- AFTER RENAME
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let wobble = Wibble(wibble: 1)
+  wobble.wibble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowed_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowed_local_variable.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  let wibble = wibble / 2\n  wibble\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let wibble = 10
+  let wibble = wibble / 2
+               ↑         
+  wibble
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let wobble = 10
+  let wibble = wobble / 2
+  wibble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowing_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowing_local_variable.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  let wibble = wibble / 2\n  wibble\n}\n"
+---
+----- BEFORE RENAME
+
+pub fn main() {
+  let wibble = 10
+  let wibble = wibble / 2
+  wibble
+  ↑     
+}
+
+
+----- AFTER RENAME
+
+pub fn main() {
+  let wibble = 10
+  let wobble = wibble / 2
+  wobble
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1595,6 +1595,7 @@ where
                         location: SrcSpan { start, end },
                         type_: (),
                         name,
+                        definition_location: SrcSpan::default(),
                     }
                 };
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
@@ -77,6 +77,10 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                                         },
                                         type_: (),
                                         name: "x",
+                                        definition_location: SrcSpan {
+                                            start: 0,
+                                            end: 0,
+                                        },
                                     },
                                     right: Var {
                                         location: SrcSpan {
@@ -85,6 +89,10 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                                         },
                                         type_: (),
                                         name: "y",
+                                        definition_location: SrcSpan {
+                                            start: 0,
+                                            end: 0,
+                                        },
                                     },
                                 },
                                 right: Constant(

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -620,7 +620,10 @@ pub struct RecordAccessor {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValueConstructorVariant {
     /// A locally defined variable or function parameter
-    LocalVariable { location: SrcSpan },
+    LocalVariable {
+        location: SrcSpan,
+        origin: VariableOrigin,
+    },
 
     /// A module constant
     ModuleConstant {
@@ -737,7 +740,7 @@ impl ValueConstructorVariant {
 
     pub fn definition_location(&self) -> SrcSpan {
         match self {
-            ValueConstructorVariant::LocalVariable { location }
+            ValueConstructorVariant::LocalVariable { location, .. }
             | ValueConstructorVariant::ModuleConstant { location, .. }
             | ValueConstructorVariant::ModuleFn { location, .. }
             | ValueConstructorVariant::Record { location, .. } => *location,
@@ -1274,7 +1277,7 @@ impl ValueConstructor {
                 span: literal.location(),
             },
 
-            ValueConstructorVariant::LocalVariable { location } => DefinitionLocation {
+            ValueConstructorVariant::LocalVariable { location, .. } => DefinitionLocation {
                 module: None,
                 span: *location,
             },

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -218,13 +218,19 @@ impl Environment<'_> {
 
     /// Insert a variable in the current scope.
     ///
-    pub fn insert_local_variable(&mut self, name: EcoString, location: SrcSpan, type_: Arc<Type>) {
+    pub fn insert_local_variable(
+        &mut self,
+        name: EcoString,
+        location: SrcSpan,
+        origin: VariableOrigin,
+        type_: Arc<Type>,
+    ) {
         let _ = self.scope.insert(
             name,
             ValueConstructor {
                 deprecation: Deprecation::NotDeprecated,
                 publicity: Publicity::Private,
-                variant: ValueConstructorVariant::LocalVariable { location },
+                variant: ValueConstructorVariant::LocalVariable { location, origin },
                 type_,
             },
         );

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1653,8 +1653,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 let constructor = self.infer_value_constructor(&None, &name, &location)?;
 
                 // We cannot support all values in guard expressions as the BEAM does not
-                match &constructor.variant {
-                    ValueConstructorVariant::LocalVariable { .. } => (),
+                let definition_location = match &constructor.variant {
+                    ValueConstructorVariant::LocalVariable { location } => *location,
                     ValueConstructorVariant::ModuleFn { .. }
                     | ValueConstructorVariant::Record { .. } => {
                         return Err(Error::NonLocalClauseGuardVariable { location, name });
@@ -1670,6 +1670,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     location,
                     name,
                     type_: constructor.type_,
+                    definition_location,
                 })
             }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -3671,7 +3671,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             for (arg, t) in args.iter().zip(args.iter().map(|arg| arg.type_.clone())) {
                 match &arg.names {
-                    ArgNames::Named { name, .. } | ArgNames::NamedLabelled { name, .. } => {
+                    ArgNames::Named { name, location }
+                    | ArgNames::NamedLabelled {
+                        name,
+                        name_location: location,
+                        ..
+                    } => {
                         // Check that this name has not already been used for
                         // another argument
                         if !argument_names.insert(name) {
@@ -3684,7 +3689,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         // Insert a variable for the argument into the environment
                         body_typer
                             .environment
-                            .insert_local_variable(name.clone(), arg.location, t);
+                            .insert_local_variable(name.clone(), *location, t);
 
                         if !body.first().is_placeholder() {
                             // Register the variable in the usage tracker so that we

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1654,7 +1654,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
                 // We cannot support all values in guard expressions as the BEAM does not
                 let definition_location = match &constructor.variant {
-                    ValueConstructorVariant::LocalVariable { location } => *location,
+                    ValueConstructorVariant::LocalVariable { location, .. } => *location,
                     ValueConstructorVariant::ModuleFn { .. }
                     | ValueConstructorVariant::Record { .. } => {
                         return Err(Error::NonLocalClauseGuardVariable { location, name });
@@ -2467,6 +2467,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 type_: record_type,
                 variant: ValueConstructorVariant::LocalVariable {
                     location: record_location,
+                    origin: VariableOrigin::Generated,
                 },
             },
             name: RECORD_UPDATE_VARIABLE.into(),
@@ -3687,9 +3688,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         }
 
                         // Insert a variable for the argument into the environment
-                        body_typer
-                            .environment
-                            .insert_local_variable(name.clone(), *location, t);
+                        body_typer.environment.insert_local_variable(
+                            name.clone(),
+                            *location,
+                            VariableOrigin::Variable(name.clone()),
+                            t,
+                        );
 
                         if !body.first().is_placeholder() {
                             // Register the variable in the usage tracker so that we

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -67,7 +67,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 // Register usage for the unused variable detection
                 self.environment.init_usage(
                     name.into(),
-                    EntityKind::Variable { origin },
+                    EntityKind::Variable {
+                        origin: origin.clone(),
+                    },
                     location,
                     self.problems,
                 );
@@ -85,7 +87,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 // And now insert the variable for use in the code that comes
                 // after the pattern.
                 self.environment
-                    .insert_local_variable(name.into(), location, type_);
+                    .insert_local_variable(name.into(), location, origin, type_);
                 Ok(())
             }
 
@@ -133,8 +135,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     .insert(name.clone(), variant_index);
                 // This variable is only inferred in this branch of the case expression
                 self.environment.insert_local_variable(
-                    name,
+                    name.clone(),
                     variable.definition_location().span,
+                    VariableOrigin::Variable(name),
                     type_,
                 );
             }

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -193,6 +193,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 type_: self.argument_type.clone(),
                 variant: ValueConstructorVariant::LocalVariable {
                     location: self.argument_location,
+                    origin: VariableOrigin::Generated,
                 },
             },
         }
@@ -220,6 +221,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         self.expr_typer.environment.insert_local_variable(
             PIPE_VARIABLE.into(),
             location,
+            VariableOrigin::Generated,
             expression.type_(),
         );
         // Add the assignment to the AST


### PR DESCRIPTION
Closes #2956
This PR implements renaming of local variables in the Language Server including:
- Setting up the new route and server capability
- Setting up a test environment for testing renaming
- Tree walking to find references to the variable
- Rejecting renames if an invalid name is provided (e.g. renaming a variable to `SomeVar`)

A few things I did while implementing this:
- I used definition location to decide whether two variables were the same. That's mainly because since variable shadowing exists in Gleam, two variables with the same name don't necessarily refer to the same variable.
- To allow renaming to also rename references to variables in clause guards, I added a `definition_location` field to the `ClauseGuard::Var` variant. Since `ClauseGuard` is just one type for both typed and untyped versions, this field has to be present in the untyped AST, where it has no meaning (we don't know where the variable is defined yet). That was the most straightforward solution I could find for the time being.
- Similarly, I added clause guards to the AST visitor. I only really implemented the bare-bones for what this PR needs; it seemed a bit wasteful to implement it all. I'll probably open a separate PR to implement the full visitor for it