### PR TITLE
LSP: Allow unqualifying constructor when hovering over the module name bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,17 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- `Unqualify` Action now get triggered when hovering over the module name
+  for record value constructor.
+  For example:
+
+  ```gleam
+  pub fn main() {
+    let my_option = option.Some(1)
+    //                 ^ would trigger "Unqualify option.Some"
+  }
+  ```
+  ([Jiangda Wang](https://github.com/Frank-III))
 
 ### Formatter
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1367,7 +1367,14 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass<'as
         module_alias: &'ast EcoString,
         constructor: &'ast ModuleValueConstructor,
     ) {
-        let range = src_span_to_lsp_range(*location, &self.line_numbers);
+        // When hovering over a Record Value Constructor, we want to expand the source span to
+        // include the module name:
+        // option.Some
+        //  ↑
+        // This allows us to offer a code action when hovering over the module name.
+        let expanded_location =
+            SrcSpan::new(location.start - module_name.len() as u32, location.end);
+        let range = src_span_to_lsp_range(expanded_location, &self.line_numbers);
         if overlaps(self.params.range, range) {
             if let ModuleValueConstructor::Record {
                 name: constructor_name,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2108,6 +2108,23 @@ pub fn identity(x: wobble.Wobble) -> wobble.Wobble {
 }
 
 #[test]
+fn test_qualified_to_unqualified_record_value_constructor_module_name() {
+    let src = r#"
+import option
+
+pub fn main() {
+  option.Some(1)
+}
+"#;
+    assert_code_action!(
+        "Unqualify option.Some",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
+        find_position_of("option").nth_occurrence(2).to_selection()
+    );
+}
+
+#[test]
 fn test_qualified_to_unqualified_import_basic_multiple() {
     let src = r#"
 import option

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__qualified_to_unqualified_record_value_constructor_module_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__qualified_to_unqualified_record_value_constructor_module_name.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport option\n\npub fn main() {\n  option.Some(1)\n}\n"
+---
+----- BEFORE ACTION
+
+import option
+
+pub fn main() {
+  option.Some(1)
+  ↑             
+}
+
+
+----- AFTER ACTION
+
+import option.{Some}
+
+pub fn main() {
+  Some(1)
+}


### PR DESCRIPTION
close: #4189 