### PR TITLE
Fix bug with scoping in let assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,3 +266,7 @@
 - Fixed a bug where the "Extract variable" code action would erroneously extract
   a pipeline step as a variable.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where variables bound in `let assert` assignments would be allowed
+  to be used in the custom panic message.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1325,6 +1325,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let value_typ = value.type_();
 
+        let kind = match self.infer_assignment_kind(kind) {
+            Ok(kind) => kind,
+            Err(error) => {
+                self.problems.error(error);
+                AssignmentKind::Generated
+            }
+        };
+
         // Ensure the pattern matches the type of the value
         let pattern_location = pattern.location();
         let mut pattern_typer = pattern::PatternTyper::new(
@@ -1380,14 +1388,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             }
             (AssignmentKind::Assert { .. }, _) => {}
         }
-
-        let kind = match self.infer_assignment_kind(kind) {
-            Ok(kind) => kind,
-            Err(error) => {
-                self.problems.error(error);
-                AssignmentKind::Generated
-            }
-        };
 
         Assignment {
             location,

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2849,3 +2849,15 @@ pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
 "
     );
 }
+
+#[test]
+// https://github.com/gleam-lang/gleam/issues/4195
+fn let_assert_binding_cannot_be_used_in_panic_message() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  let assert Ok(message) = Error("Not Message") as { "Uh oh: " <> message }
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__let_assert_binding_cannot_be_used_in_panic_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__let_assert_binding_cannot_be_used_in_panic_message.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  let assert Ok(message) = Error(\"Not Message\") as { \"Uh oh: \" <> message }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let assert Ok(message) = Error("Not Message") as { "Uh oh: " <> message }
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:67
+  │
+3 │   let assert Ok(message) = Error("Not Message") as { "Uh oh: " <> message }
+  │                                                                   ^^^^^^^
+
+The name `message` is not in scope here.


### PR DESCRIPTION
Fixes #4195 
This PR fixes the scoping issue by analysing the panic message before bringing the variable binding into scope.