### PR TITLE
Warn if the same operand is on either side of the equality operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,33 @@
   The custom type variant constructor `X` is not in scope here.
   ```
 
+- The compiler now warns when using the same operand on either side of the equality operator:
+
+  ```gleam
+  type Wibble {
+    Wibble(id: Int)
+  }
+
+  pub fn main() {
+    let wibble = Wibble(1)
+    case wibble.id == wibble.id {
+      True -> Nil
+      False -> Nil
+    }
+  }
+  ```
+
+  Results in the following warning:
+
+  ```
+    warning: Same operand on either side of the equality operator
+    ┌─ /app.gleam:7:8
+    │
+  7 │   case wibble.id == wibble.id {
+    │        ^^^^^^^^^^^^^^^^^^^^^^ This will always be true
+  ```
+  ([Ramkarthik Krishnamurthy](https://github.com/ramkarthik))
+
 ### Build tool
 
 - `gleam new` now has refined project name validation - rather than failing on

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -910,6 +910,11 @@ pub enum Warning {
     JavaScriptIntUnsafe {
         location: SrcSpan,
     },
+
+    EqualityOnSameOperands {
+        location: SrcSpan,
+        result: EcoString,
+    },
 }
 
 #[derive(Debug, Eq, Copy, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -1113,7 +1118,8 @@ impl Warning {
             | Warning::UnreachableCodeAfterPanic { location, .. }
             | Warning::RedundantPipeFunctionCapture { location, .. }
             | Warning::FeatureRequiresHigherGleamVersion { location, .. }
-            | Warning::JavaScriptIntUnsafe { location, .. } => *location,
+            | Warning::JavaScriptIntUnsafe { location, .. }
+            | Warning::EqualityOnSameOperands { location, .. } => *location,
         }
     }
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_field_access_on_either_side_of_equal_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_field_access_on_either_side_of_equal_equal_operator.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\ntype Wibble {\n  Wibble(a: Int)\n}\n\npub fn main() {\n  let wibble = Wibble(1)\n  case wibble.a == wibble.a {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble(a: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(1)
+  case wibble.a == wibble.a {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:8:8
+  │
+8 │   case wibble.a == wibble.a {
+  │        ^^^^^^^^^^^^^^^^^^^^ This will always be true

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_field_access_on_either_side_of_not_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_field_access_on_either_side_of_not_equal_operator.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\ntype Wibble {\n  Wibble(a: Int)\n}\n\npub fn main() {\n  let wibble = Wibble(1)\n  case wibble.a != wibble.a {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble(a: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(1)
+  case wibble.a != wibble.a {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:8:8
+  │
+8 │   case wibble.a != wibble.a {
+  │        ^^^^^^^^^^^^^^^^^^^^ This will always be false

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_float_on_either_side_of_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_float_on_either_side_of_equal_operator.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case 1.00 == 1.00 {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case 1.00 == 1.00 {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:3:8
+  │
+3 │   case 1.00 == 1.00 {
+  │        ^^^^^^^^^^^^ This will always be true

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_float_on_either_side_of_not_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_float_on_either_side_of_not_equal_operator.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case 10.0 != 10.0 {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case 10.0 != 10.0 {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:3:8
+  │
+3 │   case 10.0 != 10.0 {
+  │        ^^^^^^^^^^^^ This will always be false

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_int_on_either_side_of_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_int_on_either_side_of_equal_operator.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case 10 == 10 {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case 10 == 10 {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:3:8
+  │
+3 │   case 10 == 10 {
+  │        ^^^^^^^^ This will always be true

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_int_on_either_side_of_not_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_int_on_either_side_of_not_equal_operator.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case 15 != 15 {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case 15 != 15 {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:3:8
+  │
+3 │   case 15 != 15 {
+  │        ^^^^^^^^ This will always be false

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_string_on_either_side_of_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_string_on_either_side_of_equal_operator.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case \"hi\" == \"hi\" {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case "hi" == "hi" {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:3:8
+  │
+3 │   case "hi" == "hi" {
+  │        ^^^^^^^^^^^^ This will always be true

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_string_on_either_side_of_not_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_string_on_either_side_of_not_equal_operator.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  case \"hi\" != \"hi\" {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  case "hi" != "hi" {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:3:8
+  │
+3 │   case "hi" != "hi" {
+  │        ^^^^^^^^^^^^ This will always be false

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_variable_on_either_side_of_equal_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_variable_on_either_side_of_equal_equal_operator.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  let greeting = \"hi\"\n  case greeting == greeting {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let greeting = "hi"
+  case greeting == greeting {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:4:8
+  │
+4 │   case greeting == greeting {
+  │        ^^^^^^^^^^^^^^^^^^^^ This will always be true

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_variable_on_either_side_of_not_equal_operator.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__same_variable_on_either_side_of_not_equal_operator.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  let greeting = \"hi\"\n  case greeting != greeting {\n    True -> Nil\n    False -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let greeting = "hi"
+  case greeting != greeting {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Same operand on either side of the equality operator
+  ┌─ /src/warning/wrn.gleam:4:8
+  │
+4 │   case greeting != greeting {
+  │        ^^^^^^^^^^^^^^^^^^^^ This will always be false

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2989,3 +2989,155 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn same_variable_on_either_side_of_equal_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  let greeting = "hi"
+  case greeting == greeting {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn same_variable_on_either_side_of_not_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  let greeting = "hi"
+  case greeting != greeting {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn same_field_access_on_either_side_of_equal_equal_operator() {
+    assert_warning!(
+        r#"
+type Wibble {
+  Wibble(a: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(1)
+  case wibble.a == wibble.a {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn same_field_access_on_either_side_of_not_equal_operator() {
+    assert_warning!(
+        r#"
+type Wibble {
+  Wibble(a: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(1)
+  case wibble.a != wibble.a {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn same_int_on_either_side_of_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  case 10 == 10 {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+);
+}
+
+#[test]
+fn same_int_on_either_side_of_not_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  case 15 != 15 {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+);
+}
+
+#[test]
+fn same_float_on_either_side_of_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  case 1.00 == 1.00 {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+);
+}
+
+#[test]
+fn same_float_on_either_side_of_not_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  case 10.0 != 10.0 {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+);
+}
+
+#[test]
+fn same_string_on_either_side_of_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  case "hi" == "hi" {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+);
+}
+
+#[test]
+fn same_string_on_either_side_of_not_equal_operator() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  case "hi" != "hi" {
+    True -> Nil
+    False -> Nil
+  }
+}
+"#
+);
+}

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1134,6 +1134,22 @@ information.",
                         extra_labels: Vec::new(),
                     }),
                 },
+
+                type_::Warning::EqualityOnSameOperands { location, result } => Diagnostic {
+                    title: "Same operand on either side of the equality operator".into(),
+                    text: "".into(),
+                    hint: None,
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        label: diagnostic::Label {
+                            text: Some(format!("This will always be {result}")),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
             },
         }
     }


### PR DESCRIPTION
Closes #4205 

Based on the conversation in the comments thread of the mentioned issue, I have implemented this for variables, field access, and literals. I'm not sure about module selects. @giacomocavalieri Could you please share an example for module select? (I'm still fairly new to Gleam)

Currently, it only checks for the same operand. In the case of literals, it doesn't warn if the check is `1 == 2` (which is always `false`). Do we want to handle those cases? If yes, I will likely have to rename the `Warning::EqualityOnSameOperands` variant and change the warning title. Any equality check for literals on both sides of the operator is always going to be the same result, so maybe we want to warn?

This PR also doesn't handle `gt`, `gte`, `lt`, and `lte` for Int and Float literals (based on the discussion in the issue thread).

If there's a better way to phrase the warning (title, hint, etc), please let me know.

Currently, the warning message template is:

```
warning: Same operand on either side of the equality operator
   ┌─ /code/gleam/gleam/test/equality/src/equality.gleam:10:8
   │
10 │   case name == name {
   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This will always be true
```

Not related: It looks like the person who added this particular changelog entry missed adding their name/link - https://github.com/gleam-lang/gleam/commit/65d7bb554609d8ff3b0f2ba7c6ad86ffc48ed6aa