### PR TITLE
Fix formatting of cases used as last argument in function calls

### DIFF
--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1338,6 +1338,7 @@ impl<'comments> Formatter<'comments> {
             .nest(INDENT)
             .append(break_("", " "))
             .append("{")
+            .next_break_fits(NextBreakFitsMode::Disabled)
             .group();
 
         let clauses_doc = concat(

--- a/compiler-core/src/format/tests/cases.rs
+++ b/compiler-core/src/format/tests/cases.rs
@@ -163,3 +163,33 @@ fn subjects_are_not_split_if_not_necessary() {
 "#
     );
 }
+
+#[test]
+fn case_in_call_gets_broken_if_it_goes_over_the_limit_with_subject() {
+    assert_format!(
+        r#"fn main() {
+  do_diff_attributes(
+    dict.delete(prev, attr.name),
+    rest,
+    case attr.value == old.value {
+      True -> added
+      False -> [attr, ..added]
+    },
+  )
+}
+"#
+    );
+}
+
+#[test]
+fn case_in_call_is_not_broken_if_it_goes_over_the_limit_with_branches() {
+    assert_format!(
+        r#"fn main() {
+  do_diff_attributes(rest, case attr.value == old.value {
+    True -> added
+    False -> [attr, ..added]
+  })
+}
+"#
+    );
+}


### PR DESCRIPTION
This PR fixes the formatting of case expressions used as the last argument of a function call. Right now the formatting for a case that goes over the line limit with its subjects becomes:
```gleam
function_call(wibble, wobble, case
  subjects
{
  True -> todo
  False -> todo
})
```
With this update it would be formatted as:
```gleam
function_call(wibble, wobble, case subjects {
  True -> todo
  False -> todo
})
```