### PR TITLE
Make constructor arguments fit better on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   making Gleam packages discoverable through global search of HexDocs.
   ([Diemo Gebhardt](https://github.com/diemogebhardt))
 
+- Improved the styling of constructor argument descriptions in the generated
+  documentation. ([Nicd](https://git.ahlcode.fi/nicd))
+
 - Allow users to set the `GLEAM_CACERTS_PATH` environment variable to specify a
   path to a directory containing CA certificates to install Hex packages.
   ([winstxnhdw](https://github.com/winstxnhdw))

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/docs/tests.rs
 expression: "compile(config, modules)"
-snapshot_kind: text
 ---
 //// app.html
 
@@ -298,21 +297,17 @@ snapshot_kind: text
               Arguments
             </h4>
 
-            <ul class="constructor-argument-list">
+            <dl class="constructor-argument-list">
             
-              <li>
-                <div class="constructor-argument-item">
-                  <p class="constructor-argument-label">
-                    <i>wabble</i>
-                  </p>
-                  <div class="constructor-argument-doc">
-                    <p>Documentation!!</p>
+              <dt class="constructor-argument-label">
+                wabble
+              </dt>
+              <dd class="constructor-argument-doc">
+                <p>Documentation!!</p>
 
-                  </div>
-                </div>
-              </li>
+              </dd>
             
-            </ul>
+            </dl>
             
           </div>
         </li>

--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -565,16 +565,8 @@ body.drawer-open .label-closed {
   margin-bottom: var(--small-gap);
 }
 
-.constructor-argument-item {
-  display: flex;
-}
-
 .constructor-argument-label {
-  flex-shrink: 0;
-}
-
-.constructor-argument-doc {
-  margin-left: var(--gap);
+  font-style: italic;
 }
 
 .constructor-argument-list {

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -85,20 +85,16 @@
               Arguments
             </h4>
 
-            <ul class="constructor-argument-list">
+            <dl class="constructor-argument-list">
             {% for argument in constructor.arguments %}
-              <li>
-                <div class="constructor-argument-item">
-                  <p class="constructor-argument-label">
-                    <i>{{ argument.name }}</i>
-                  </p>
-                  <div class="constructor-argument-doc">
-                    {{ argument.doc|safe }}
-                  </div>
-                </div>
-              </li>
+              <dt class="constructor-argument-label">
+                {{ argument.name }}
+              </dt>
+              <dd class="constructor-argument-doc">
+                {{ argument.doc|safe }}
+              </dd>
             {% endfor %}
-            </ul>
+            </dl>
             {% endif %}
           </div>
         </li>


### PR DESCRIPTION
This is a minor change to the styling of constructor arguments in generated documentation. Currently they are indented quite a lot and waste space especially on small screens. With this change, the indentation is lessened and the argument name and description can overlap, allowing for better wrapping even with long argument names. Before and after:

<img width="250" alt="Screenshot 2025-02-11 at 19 28 36" src="https://github.com/user-attachments/assets/7a5191a5-1b7a-4e7c-82b5-ab8f73a168f3" /> <img width="250" alt="Screenshot 2025-02-11 at 19 41 21" src="https://github.com/user-attachments/assets/b983b21f-8675-47a2-9a89-7ea1e1ea07db" />

## Technical details

This uses the [description list](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl) (dl) element which is both stylistically and semantically appropriate. Argument names are description terms (dt) and their descriptions are... descriptions (dd).

I kept the argument name as italic to match the previous style.

An alternative would be to use a regular list (as before) but remove the flexbox alignment and align it similar to this with CSS.

## Accessibility

Screen reader support seems to be adequate: https://adrianroselli.com/2025/01/updated-brief-note-on-description-list-support.html -- At the least the situation is mostly similar to how it is now.

## Browser support

Tested on macOS using Vivaldi (Chrome based), Safari, and Firefox. Looks the same on each one. The element is very old so support should be good.
