### PR TITLE
Fix convert to call

### DIFF
--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -366,12 +366,12 @@ fn find_node_tuple_index() {
 #[test]
 fn find_node_module_select() {
     let expr = TypedExpr::ModuleSelect {
-        location: SrcSpan { start: 1, end: 3 },
+        location: SrcSpan { start: 1, end: 4 },
+        field_start: 2,
         type_: type_::int(),
         label: "label".into(),
         module_name: "name".into(),
         module_alias: "alias".into(),
-        module_location: SrcSpan { start: 0, end: 0 },
         constructor: ModuleValueConstructor::Fn {
             module: "module".into(),
             name: "function".into(),
@@ -384,7 +384,7 @@ fn find_node_module_select() {
     };
 
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(Located::Expression(&expr)));
+    assert_eq!(expr.find_node(1), None);
     assert_eq!(expr.find_node(2), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(3), Some(Located::Expression(&expr)));
 }

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -371,6 +371,7 @@ fn find_node_module_select() {
         label: "label".into(),
         module_name: "name".into(),
         module_alias: "alias".into(),
+        module_location: SrcSpan { start: 0, end: 0 },
         constructor: ModuleValueConstructor::Fn {
             module: "module".into(),
             name: "function".into(),

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -97,11 +97,27 @@ pub enum TypedExpr {
     },
 
     ModuleSelect {
+        /// The location of the selected value coming after the `.` (including
+        /// it):
+        ///
+        /// ```gleam
+        ///    wibble.wobble
+        /// //       ^^^^^^^ location
+        /// ```
+        ///
         location: SrcSpan,
         type_: Arc<Type>,
         label: EcoString,
         module_name: EcoString,
         module_alias: EcoString,
+        /// The location of the module before the `.`:
+        ///
+        /// ```gleam
+        ///    wibble.wobble
+        /// // ^^^^^^ module_location
+        /// ```
+        ///
+        module_location: SrcSpan,
         constructor: ModuleValueConstructor,
     },
 

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -78,9 +78,9 @@ pub enum UntypedExpr {
         //   user.name
         //   ^^^^^^^^^
         location: SrcSpan,
-        // This is the location of just the field access
+        // This is the location of just the field access (ignoring the `.`)
         //   user.name
-        //       ^^^^^
+        //        ^^^^
         label_location: SrcSpan,
         label: EcoString,
         container: Box<Self>,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -214,21 +214,21 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_module_select(
         &mut self,
         location: &'ast SrcSpan,
+        field_start: &'ast u32,
         type_: &'ast Arc<Type>,
         label: &'ast EcoString,
         module_name: &'ast EcoString,
         module_alias: &'ast EcoString,
-        module_location: &'ast SrcSpan,
         constructor: &'ast ModuleValueConstructor,
     ) {
         visit_typed_expr_module_select(
             self,
             location,
+            field_start,
             type_,
             label,
             module_name,
             module_alias,
-            module_location,
             constructor,
         );
     }
@@ -761,19 +761,19 @@ where
         } => v.visit_typed_expr_record_access(location, type_, label, index, record),
         TypedExpr::ModuleSelect {
             location,
+            field_start,
             type_,
             label,
             module_name,
             module_alias,
-            module_location,
             constructor,
         } => v.visit_typed_expr_module_select(
             location,
+            field_start,
             type_,
             label,
             module_name,
             module_alias,
-            module_location,
             constructor,
         ),
         TypedExpr::Tuple {
@@ -993,11 +993,11 @@ pub fn visit_typed_expr_record_access<'a, V>(
 pub fn visit_typed_expr_module_select<'a, V>(
     _v: &mut V,
     _location: &'a SrcSpan,
+    _field_start: &'a u32,
     _typ: &'a Arc<Type>,
     _label: &'a EcoString,
     _module_name: &'a EcoString,
     _module_alias: &'a EcoString,
-    _module_location: &'a SrcSpan,
     _constructor: &'a ModuleValueConstructor,
 ) where
     V: Visit<'a> + ?Sized,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -218,6 +218,7 @@ pub trait Visit<'ast> {
         label: &'ast EcoString,
         module_name: &'ast EcoString,
         module_alias: &'ast EcoString,
+        module_location: &'ast SrcSpan,
         constructor: &'ast ModuleValueConstructor,
     ) {
         visit_typed_expr_module_select(
@@ -227,6 +228,7 @@ pub trait Visit<'ast> {
             label,
             module_name,
             module_alias,
+            module_location,
             constructor,
         );
     }
@@ -763,6 +765,7 @@ where
             label,
             module_name,
             module_alias,
+            module_location,
             constructor,
         } => v.visit_typed_expr_module_select(
             location,
@@ -770,6 +773,7 @@ where
             label,
             module_name,
             module_alias,
+            module_location,
             constructor,
         ),
         TypedExpr::Tuple {
@@ -993,6 +997,7 @@ pub fn visit_typed_expr_module_select<'a, V>(
     _label: &'a EcoString,
     _module_name: &'a EcoString,
     _module_alias: &'a EcoString,
+    _module_location: &'a SrcSpan,
     _constructor: &'a ModuleValueConstructor,
 ) where
     V: Visit<'a> + ?Sized,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -211,6 +211,7 @@ pub trait Visit<'ast> {
         visit_typed_expr_record_access(self, location, type_, label, index, record);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn visit_typed_expr_module_select(
         &mut self,
         location: &'ast SrcSpan,
@@ -990,6 +991,7 @@ pub fn visit_typed_expr_record_access<'a, V>(
     v.visit_typed_expr(record);
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn visit_typed_expr_module_select<'a, V>(
     _v: &mut V,
     _location: &'a SrcSpan,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -5116,6 +5116,32 @@ fn filter(list: List(a), fun: fn(a) -> Bool) -> List(b) { todo }
 }
 
 #[test]
+fn convert_to_function_call_works_with_labelled_argument() {
+    assert_code_action!(
+        CONVERT_TO_FUNCTION_CALL,
+        "
+pub fn main() {
+  [1, 2, 3] |> wibble(wobble: _, woo:)
+}
+",
+        find_position_of("wibble").to_selection()
+    );
+}
+
+#[test]
+fn convert_to_function_call_works_with_labelled_argument_2() {
+    assert_code_action!(
+        CONVERT_TO_FUNCTION_CALL,
+        "
+pub fn main() {
+  [1, 2, 3] |> wibble(wobble:, woo: _)
+}
+",
+        find_position_of("wibble").to_selection()
+    );
+}
+
+#[test]
 fn no_code_action_to_generate_json_encoder_for_type_without_labels() {
     assert_no_code_actions!(
         GENERATE_JSON_ENCODER,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -4085,8 +4085,8 @@ fn map(list, fun) { todo }
 #[test]
 fn extract_variable_2() {
     let src = r#"
-import list
-import int
+import gleam/list
+import gleam/int
 
 pub fn main() {
   list.map([1, 2, 3], int.add(1, _))
@@ -4095,8 +4095,8 @@ pub fn main() {
     assert_code_action!(
         EXTRACT_VARIABLE,
         TestProject::for_source(src)
-            .add_module("int", "pub fn add(n, m) { todo }")
-            .add_module("list", "pub fn map(l, f) { todo }"),
+            .add_module("gleam/int", "pub fn add(n, m) { todo }")
+            .add_module("gleam/list", "pub fn map(l, f) { todo }"),
         find_position_of("int.").select_until(find_position_of("add"))
     );
 }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -5142,6 +5142,19 @@ pub fn main() {
 }
 
 #[test]
+fn convert_to_function_call_works_when_piping_a_module_select() {
+    assert_code_action!(
+        CONVERT_TO_FUNCTION_CALL,
+        "
+pub fn main() {
+  wibble.wobble |> woo(_)
+}
+",
+        find_position_of("woo").to_selection()
+    );
+}
+
+#[test]
 fn no_code_action_to_generate_json_encoder_for_type_without_labels() {
     assert_no_code_actions!(
         GENERATE_JSON_ENCODER,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -4084,11 +4084,19 @@ fn map(list, fun) { todo }
 
 #[test]
 fn extract_variable_2() {
+    let src = r#"
+import list
+import int
+
+pub fn main() {
+  list.map([1, 2, 3], int.add(1, _))
+}"#;
+
     assert_code_action!(
         EXTRACT_VARIABLE,
-        r#"pub fn main() {
-  list.map([1, 2, 3], int.add(1, _))
-}"#,
+        TestProject::for_source(src)
+            .add_module("int", "pub fn add(n, m) { todo }")
+            .add_module("list", "pub fn map(l, f) { todo }"),
         find_position_of("int.").select_until(find_position_of("add"))
     );
 }
@@ -5142,7 +5150,7 @@ pub fn main() {
 }
 
 #[test]
-fn convert_to_function_call_works_when_piping_a_module_select() {
+fn convert_to_function_call_works_when_piping_an_invalid_module_select() {
     assert_code_action!(
         CONVERT_TO_FUNCTION_CALL,
         "
@@ -5150,6 +5158,25 @@ pub fn main() {
   wibble.wobble |> woo(_)
 }
 ",
+        find_position_of("woo").to_selection()
+    );
+}
+
+#[test]
+fn convert_to_function_call_works_when_piping_a_module_select() {
+    let src = "
+import wibble
+
+pub fn main() {
+  wibble.wobble |> woo(_)
+}
+
+fn woo(n) { todo }
+";
+
+    assert_code_action!(
+        CONVERT_TO_FUNCTION_CALL,
+        TestProject::for_source(src).add_module("wibble", "pub const wobble = 1"),
         find_position_of("woo").to_selection()
     );
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_when_piping_a_module_select.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_when_piping_a_module_select.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  wibble.wobble |> woo(_)\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  wibble.wobble |> woo(_)
+                   ↑     
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  woo(wibble.wobble)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_when_piping_an_invalid_module_select.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_when_piping_an_invalid_module_select.snap
@@ -1,25 +1,17 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\nimport wibble\n\npub fn main() {\n  wibble.wobble |> woo(_)\n}\n\nfn woo(n) { todo }\n"
+expression: "\npub fn main() {\n  wibble.wobble |> woo(_)\n}\n"
 ---
 ----- BEFORE ACTION
-
-import wibble
 
 pub fn main() {
   wibble.wobble |> woo(_)
                    ↑     
 }
 
-fn woo(n) { todo }
-
 
 ----- AFTER ACTION
-
-import wibble
 
 pub fn main() {
   woo(wibble.wobble)
 }
-
-fn woo(n) { todo }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_with_labelled_argument.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_with_labelled_argument.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  [1, 2, 3] |> wibble(wobble: _, woo:)\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  [1, 2, 3] |> wibble(wobble: _, woo:)
+               ↑                      
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  wibble(wobble: [1, 2, 3], woo:)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_with_labelled_argument_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_function_call_works_with_labelled_argument_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  [1, 2, 3] |> wibble(wobble:, woo: _)\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  [1, 2, 3] |> wibble(wobble:, woo: _)
+               ↑                      
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  wibble(wobble:, woo: [1, 2, 3])
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__extract_variable_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__extract_variable_2.snap
@@ -1,8 +1,12 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "pub fn main() {\n  list.map([1, 2, 3], int.add(1, _))\n}"
+expression: "\nimport gleam/list\nimport gleam/int\n\npub fn main() {\n  list.map([1, 2, 3], int.add(1, _))\n}"
 ---
 ----- BEFORE ACTION
+
+import gleam/list
+import gleam/int
+
 pub fn main() {
   list.map([1, 2, 3], int.add(1, _))
                       ▔▔▔▔↑         
@@ -10,6 +14,10 @@ pub fn main() {
 
 
 ----- AFTER ACTION
+
+import gleam/list
+import gleam/int
+
 pub fn main() {
   let value = int.add(1, _)
   list.map([1, 2, 3], value)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_expression.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_expression.snap
@@ -6,7 +6,7 @@ import wibble/wobble
 
 pub fn main() {
   let wibble = wobble.Wibble
-                     ▔▔▔▔▔↑▔
+               ▔▔▔▔▔▔▔▔▔▔▔↑▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
@@ -5,7 +5,7 @@ expression: "\nimport example_module\nfn main() {\n  example_module.my_const\n}\
 import example_module
 fn main() {
   example_module.my_const
-                ▔▔▔↑▔▔▔▔▔
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑▔▔▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
@@ -5,7 +5,7 @@ expression: "\nimport example_module\nfn main() {\n    example_module.my_fn\n}\n
 import example_module
 fn main() {
     example_module.my_fn
-                  ▔▔▔▔↑▔
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function.snap
@@ -5,7 +5,7 @@ expression: "\nimport example_module\nfn main() {\n  example_module.my_fn\n}\n"
 import example_module
 fn main() {
   example_module.my_fn
-                ▔▔▔↑▔▔
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_nested_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_nested_module.snap
@@ -5,7 +5,7 @@ expression: "\nimport my/nested/example_module\nfn main() {\n    example_module.
 import my/nested/example_module
 fn main() {
     example_module.my_fn
-                  ▔▔▔▔↑▔
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_renamed_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_function_renamed_module.snap
@@ -5,7 +5,7 @@ expression: "\nimport example_module as renamed_module\nfn main() {\n    renamed
 import example_module as renamed_module
 fn main() {
     renamed_module.my_fn
-                  ▔▔▔▔↑▔
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
@@ -6,7 +6,7 @@ import a/example_module as _
 import b/example_module
 fn main() {
     example_module.my_const
-                  ▔▔▔▔↑▔▔▔▔
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑▔▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_imported_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_imported_function.snap
@@ -5,7 +5,7 @@ expression: "\nimport example_module\nfn main() {\n  example_module.my_fn\n}\n"
 import example_module
 fn main() {
   example_module.my_fn
-                ▔▔▔↑▔▔
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑▔▔
 }
 
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -820,12 +820,12 @@ where
                         }
                     }
 
-                    Some((_, Token::Name { name: label }, end)) => {
+                    Some((label_start, Token::Name { name: label }, end)) => {
                         self.advance();
                         expr = UntypedExpr::FieldAccess {
                             location: SrcSpan { start, end },
                             label_location: SrcSpan {
-                                start: dot_start,
+                                start: label_start,
                                 end,
                             },
                             label,
@@ -833,12 +833,12 @@ where
                         }
                     }
 
-                    Some((_, Token::UpName { name: label }, end)) => {
+                    Some((label_start, Token::UpName { name: label }, end)) => {
                         self.advance();
                         expr = UntypedExpr::FieldAccess {
                             location: SrcSpan { start, end },
                             label_location: SrcSpan {
-                                start: dot_start,
+                                start: label_start,
                                 end,
                             },
                             label,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -4144,7 +4144,7 @@ pub fn make_call(
                     return parse_error(ParseErrorType::TooManyArgHoles, SrcSpan { start, end });
                 }
 
-                hole_location = Some(arg_location);
+                hole_location = Some(discard_location);
                 if name != "_" {
                     return parse_error(
                         ParseErrorType::UnexpectedToken {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -976,8 +976,22 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     fn infer_field_access(
         &mut self,
         container: UntypedExpr,
+
+        // The SrcSpan of the entire field access:
+        // ```gleam
+        //    wibble.wobble
+        // // ^^^^^^^^^^^^^ This
+        // ```
+        //
         location: SrcSpan,
         label: EcoString,
+
+        // The SrcSpan of the selection label:
+        // ```gleam
+        //    wibble.wobble
+        // // ^^^^^^ This
+        // ```
+        //
         label_location: SrcSpan,
         usage: FieldAccessUsage,
     ) -> TypedExpr {
@@ -2183,6 +2197,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     label,
                     module_name,
                     module_alias,
+                    module_location: _,
                     constructor,
                 } => match constructor {
                     ModuleValueConstructor::Constant { literal, .. } => {
@@ -2284,6 +2299,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Ok(TypedExpr::ModuleSelect {
             label,
             type_: Arc::clone(&type_),
+            module_location: *module_location,
             location: select_location,
             module_name,
             module_alias: module_alias.clone(),
@@ -2994,7 +3010,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 // TODO: resvisit this. It is rather awkward at present how we
                 // have to convert to this other data structure.
                 let fun = match &module {
-                    Some((module_alias, _)) => {
+                    Some((module_alias, module_location)) => {
                         let type_ = Arc::clone(&constructor.type_);
                         let module_name = self
                             .environment
@@ -3018,6 +3034,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             label: name.clone(),
                             module_alias: module_alias.clone(),
                             module_name,
+                            module_location: *module_location,
                             type_,
                             constructor: module_value_constructor,
                             location,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -384,9 +384,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 label_location,
                 label,
                 container,
-                ..
+                location,
             } => Ok(self.infer_field_access(
                 *container,
+                location,
                 label,
                 label_location,
                 FieldAccessUsage::Other,
@@ -975,6 +976,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     fn infer_field_access(
         &mut self,
         container: UntypedExpr,
+        location: SrcSpan,
         label: EcoString,
         label_location: SrcSpan,
         usage: FieldAccessUsage,
@@ -1011,7 +1013,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             (_, Some((Err(module_access_err), false))) => {
                 self.problems.error(module_access_err);
                 TypedExpr::Invalid {
-                    location: label_location,
+                    location,
                     type_: self.new_unbound_var(),
                 }
             }
@@ -1030,7 +1032,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         record: Box::new(record),
                     },
                     Err(_) => TypedExpr::Invalid {
-                        location: label_location,
+                        location,
                         type_: self.new_unbound_var(),
                     },
                 }
@@ -3282,9 +3284,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 label,
                 container,
                 label_location,
-                ..
+                location,
             } => Ok(self.infer_field_access(
                 *container,
+                location,
                 label,
                 label_location,
                 FieldAccessUsage::MethodCall,

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__type_unification_does_not_allow_different_variants_to_be_treated_as_safe.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__type_unification_does_not_allow_different_variants_to_be_treated_as_safe.snap
@@ -21,10 +21,10 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown record field
-   ┌─ /src/one/two.gleam:13:4
+   ┌─ /src/one/two.gleam:13:5
    │
 13 │   a.b
-   │    ^^ Did you mean `a`?
+   │     ^ Did you mean `a`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_does_not_escape_clause_scope.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_does_not_escape_clause_scope.snap
@@ -20,10 +20,10 @@ pub fn fun(x) {
 
 ----- ERROR
 error: Unknown record field
-   ┌─ /src/one/two.gleam:12:4
+   ┌─ /src/one/two.gleam:12:5
    │
 12 │   x.b
-   │    ^^ This field does not exist
+   │     ^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__access_int.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__access_int.snap
@@ -7,10 +7,10 @@ let x = 1 x.whatever
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:1:12
+  ┌─ /src/one/two.gleam:1:13
   │
 1 │ let x = 1 x.whatever
-  │            ^^^^^^^^^ This field does not exist
+  │             ^^^^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions.snap
@@ -13,10 +13,10 @@ pub fn get_age(person: Person) { person.age }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:7:40
+  ┌─ /src/one/two.gleam:7:41
   │
 7 │ pub fn get_age(person: Person) { person.age }
-  │                                        ^^^^ Did you mean `name`?
+  │                                         ^^^ Did you mean `name`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__accessor_multiple_variants_multiple_positions2.snap
@@ -13,10 +13,10 @@ pub fn get_age(person: Person) { person.age }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:41
+  ┌─ /src/one/two.gleam:6:42
   │
 6 │ pub fn get_name(person: Person) { person.name }
-  │                                         ^^^^^ Did you mean `age`?
+  │                                          ^^^^ Did you mean `age`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_all_variants.snap
@@ -12,10 +12,10 @@ pub fn get_title(person: Person) { person.title }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:42
+  ┌─ /src/one/two.gleam:6:43
   │
 6 │ pub fn get_title(person: Person) { person.title }
-  │                                          ^^^^^^ This field does not exist
+  │                                           ^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_any_variant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_not_in_any_variant.snap
@@ -12,10 +12,10 @@ pub fn get_height(person: Person) { person.height }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:43
+  ┌─ /src/one/two.gleam:6:44
   │
 6 │ pub fn get_height(person: Person) { person.height }
-  │                                           ^^^^^^^ This field does not exist
+  │                                            ^^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__field_type_different_between_variants.snap
@@ -13,10 +13,10 @@ pub fn get_x(shape: Shape) { shape.x }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:6:35
+  ┌─ /src/one/two.gleam:6:36
   │
 6 │ pub fn get_x(shape: Shape) { shape.x }
-  │                                   ^^ This field does not exist
+  │                                    ^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__hint_for_method_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__hint_for_method_call.snap
@@ -15,10 +15,10 @@ pub fn main(user: User) {
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:7:7
+  ┌─ /src/one/two.gleam:7:8
   │
 7 │   user.login()
-  │       ^^^^^^ This field does not exist
+  │        ^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_hint_for_non_method_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_hint_for_non_method_call.snap
@@ -19,10 +19,10 @@ pub fn main(user: User) {
 
 ----- ERROR
 error: Unknown record field
-   ┌─ /src/one/two.gleam:11:13
+   ┌─ /src/one/two.gleam:11:14
    │
 11 │   login(user.wibble)
-   │             ^^^^^^^ This field does not exist
+   │              ^^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_note_about_reliable_access_if_the_accessed_type_has_a_single_variant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_note_about_reliable_access_if_the_accessed_type_has_a_single_variant.snap
@@ -15,10 +15,10 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:7:14
+  ┌─ /src/one/two.gleam:7:15
   │
 7 │   User("Jak").nam
-  │              ^^^^ Did you mean `name`?
+  │               ^^^ Did you mean `name`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_pipe_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_invalid_pipe_argument.snap
@@ -16,10 +16,10 @@ pub fn main() {
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:4:13
+  ┌─ /src/one/two.gleam:4:10
   │
 4 │   Nil |> mod.takes_wibble
-  │             ^^^^^^^^^^^^^ This function does not accept the piped type
+  │          ^^^^^^^^^^^^^^^^ This function does not accept the piped type
 
 The argument is:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_unknown_field.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_unknown_field.snap
@@ -16,10 +16,10 @@ pub fn main(not_a_record: gleam.Int) {
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:8:15
+  ┌─ /src/one/two.gleam:8:16
   │
 8 │   not_a_record.bits
-  │               ^^^^^ This field does not exist
+  │                ^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_access_on_inferred_variant_when_field_is_in_other_variants.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_access_on_inferred_variant_when_field_is_in_other_variants.snap
@@ -17,10 +17,10 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:9:16
+  ┌─ /src/one/two.gleam:9:17
   │
 9 │   always_wibble.wobble
-  │                ^^^^^^^ Did you mean `wibble`?
+  │                 ^^^^^^ Did you mean `wibble`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field.snap
@@ -7,10 +7,10 @@ fn(a: a) { a.field }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:1:13
+  ┌─ /src/one/two.gleam:1:14
   │
 1 │ fn(a: a) { a.field }
-  │             ^^^^^^ This field does not exist
+  │              ^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_a_variant_has_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_a_variant_has_note.snap
@@ -16,10 +16,10 @@ pub fn main(wibble: Wibble) {
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:8:9
+  ┌─ /src/one/two.gleam:8:10
   │
 8 │   wibble.field
-  │         ^^^^^^ This field does not exist
+  │          ^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_appears_in_an_imported_variant_has_note.snap
@@ -19,10 +19,10 @@ pub fn main(wibble: some_mod.Wibble) {
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:4:9
+  ┌─ /src/one/two.gleam:4:10
   │
 4 │   wibble.field
-  │         ^^^^^^ This field does not exist
+  │          ^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_does_not_appear_in_variant_has_no_note.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_field_that_does_not_appear_in_variant_has_no_note.snap
@@ -16,10 +16,10 @@ pub fn main(wibble: Wibble) {
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:8:9
+  ┌─ /src/one/two.gleam:8:10
   │
 8 │   wibble.wibble
-  │         ^^^^^^^ This field does not exist
+  │          ^^^^^^ This field does not exist
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field.snap
@@ -10,10 +10,10 @@ pub fn main(box: Box(Int)) { box.unknown }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:3:33
+  ┌─ /src/one/two.gleam:3:34
   │
 3 │ pub fn main(box: Box(Int)) { box.unknown }
-  │                                 ^^^^^^^^ Did you mean `inner`?
+  │                                  ^^^^^^^ Did you mean `inner`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_record_field_2.snap
@@ -9,10 +9,10 @@ pub fn main(box: Box(Box(Int))) { box.inner.unknown }
 
 ----- ERROR
 error: Unknown record field
-  ┌─ /src/one/two.gleam:3:44
+  ┌─ /src/one/two.gleam:3:45
   │
 3 │ pub fn main(box: Box(Box(Int))) { box.inner.unknown }
-  │                                            ^^^^^^^^ Did you mean `inner`?
+  │                                             ^^^^^^^ Did you mean `inner`?
 
 The value being accessed has this type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__imported_javascript_only_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__imported_javascript_only_function.snap
@@ -15,10 +15,10 @@ pub fn main() {
 
 ----- ERROR
 error: Unsupported target
-  ┌─ /src/one/two.gleam:3:9
+  ┌─ /src/one/two.gleam:3:10
   │
 3 │   module.javascript_only()
-  │         ^^^^^^^^^^^^^^^^
+  │          ^^^^^^^^^^^^^^^
 
 This value is not available as it is defined using externals, and there is
 no implementation for the Erlang target.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__javascript_only_constant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__externals__javascript_only_constant.snap
@@ -18,10 +18,10 @@ pub fn main() {
 
 ----- ERROR
 error: Unsupported target
-  ┌─ /src/one/two.gleam:3:9
+  ┌─ /src/one/two.gleam:3:10
   │
 3 │   module.javascript_only_constant()
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+  │          ^^^^^^^^^^^^^^^^^^^^^^^^
 
 This value is not available as it is defined using externals, and there is
 no implementation for the Erlang target.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_opaque_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_opaque_constructor.snap
@@ -15,9 +15,9 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown module value
-  ┌─ /src/one/two.gleam:4:6
+  ┌─ /src/one/two.gleam:4:7
   │
 4 │   one.Two
-  │      ^^^^
+  │       ^^^
 
 one.Two is a type constructor, it cannot be used as a value

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_constructor.snap
@@ -15,9 +15,9 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown module value
-  ┌─ /src/one/two.gleam:4:6
+  ┌─ /src/one/two.gleam:4:7
   │
 4 │   one.Two
-  │      ^^^^
+  │       ^^^
 
 The module `one` does not have a `Two` value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_custom_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_custom_type.snap
@@ -15,9 +15,9 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown module value
-  ┌─ /src/one/two.gleam:4:6
+  ┌─ /src/one/two.gleam:4:7
   │
 4 │   one.X
-  │      ^^
+  │       ^
 
 The module `one` does not have a `X` value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_external_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_external_type.snap
@@ -15,9 +15,9 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown module value
-  ┌─ /src/one/two.gleam:4:6
+  ┌─ /src/one/two.gleam:4:7
   │
 4 │   one.X
-  │      ^^
+  │       ^
 
 The module `one` does not have a `X` value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_function.snap
@@ -15,9 +15,9 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown module value
-  ┌─ /src/one/two.gleam:4:6
+  ┌─ /src/one/two.gleam:4:7
   │
 4 │   one.two
-  │      ^^^^
+  │       ^^^
 
 The module `one` does not have a `two` value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_type_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__using_private_type_alias.snap
@@ -15,9 +15,9 @@ pub fn main() {
 
 ----- ERROR
 error: Unknown module value
-  ┌─ /src/one/two.gleam:4:6
+  ┌─ /src/one/two.gleam:4:7
   │
 4 │   one.X
-  │      ^^
+  │       ^
 
 The module `one` does not have a `X` value.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_imported_call_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_imported_call_function.snap
@@ -13,9 +13,9 @@ pub fn a() {
 
 ----- WARNING
 warning: Deprecated value used
-  ┌─ /src/warning/wrn.gleam:5:9
+  ┌─ /src/warning/wrn.gleam:5:10
   │
 5 │   module.a()
-  │         ^^ This value has been deprecated
+  │          ^ This value has been deprecated
 
 It was deprecated with this message: Don't use this!

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_imported_constant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_imported_constant.snap
@@ -13,9 +13,9 @@ pub fn a() {
 
 ----- WARNING
 warning: Deprecated value used
-  ┌─ /src/warning/wrn.gleam:5:9
+  ┌─ /src/warning/wrn.gleam:5:10
   │
 5 │   module.a
-  │         ^^ This value has been deprecated
+  │          ^ This value has been deprecated
 
 It was deprecated with this message: Don't use this!

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_imported_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_imported_function.snap
@@ -13,9 +13,9 @@ pub fn a() {
 
 ----- WARNING
 warning: Deprecated value used
-  ┌─ /src/warning/wrn.gleam:5:9
+  ┌─ /src/warning/wrn.gleam:5:10
   │
 5 │   module.a
-  │         ^^ This value has been deprecated
+  │          ^ This value has been deprecated
 
 It was deprecated with this message: Don't use this!

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__record_access_variant_inference_requires_v1_6.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__record_access_variant_inference_requires_v1_6.snap
@@ -19,10 +19,10 @@ pub fn main(wibble) {
 
 ----- WARNING
 warning: Incompatible gleam version range
-  ┌─ /src/warning/wrn.gleam:9:25
+  ┌─ /src/warning/wrn.gleam:9:26
   │
 9 │     Wibble(..) -> wibble.b
-  │                         ^^ This requires a Gleam version >= 1.6.0
+  │                          ^ This requires a Gleam version >= 1.6.0
 
 Field access on custom types when the variant is known was introduced in
 version v1.6.0. But the Gleam version range specified in your `gleam.toml`
@@ -33,10 +33,10 @@ Hint: Remove the version constraint from your `gleam.toml` or update it to be:
     gleam = ">= 1.6.0"
 
 warning: Incompatible gleam version range
-   ┌─ /src/warning/wrn.gleam:10:25
+   ┌─ /src/warning/wrn.gleam:10:26
    │
 10 │     Wobble(..) -> wibble.c
-   │                         ^^ This requires a Gleam version >= 1.6.0
+   │                          ^ This requires a Gleam version >= 1.6.0
 
 Field access on custom types when the variant is known was introduced in
 version v1.6.0. But the Gleam version range specified in your `gleam.toml`

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
@@ -14,7 +14,7 @@ pub fn main() {
 
 ----- WARNING
 warning: Unused value
-  ┌─ /src/warning/wrn.gleam:5:9
+  ┌─ /src/warning/wrn.gleam:5:3
   │
 5 │   wibble.a
-  │         ^^ This value is never used
+  │   ^^^^^^^^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
@@ -14,7 +14,7 @@ pub fn main() {
 
 ----- WARNING
 warning: Unused value
-  ┌─ /src/warning/wrn.gleam:5:9
+  ┌─ /src/warning/wrn.gleam:5:3
   │
 5 │   wibble.Wibble
-  │         ^^^^^^^ This value is never used
+  │   ^^^^^^^^^^^^^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
@@ -14,7 +14,7 @@ pub fn main() {
 
 ----- WARNING
 warning: Unused value
-  ┌─ /src/warning/wrn.gleam:5:9
+  ┌─ /src/warning/wrn.gleam:5:3
   │
 5 │   wibble.println
-  │         ^^^^^^^^ This value is never used
+  │   ^^^^^^^^^^^^^^ This value is never used

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
@@ -17,7 +17,7 @@ pub fn main() {
 
 ----- WARNING
 warning: Unused value
-  ┌─ /src/warning/wrn.gleam:8:8
+  ┌─ /src/warning/wrn.gleam:8:9
   │
 8 │   thing.value
-  │        ^^^^^^ This value is never used
+  │         ^^^^^ This value is never used

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_accessor.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_accessor.snap
@@ -3,10 +3,10 @@ source: test-package-compiler/src/generated_tests.rs
 expression: "./cases/opaque_type_accessor"
 ---
 error: Unknown record field
-  ┌─ src/two.gleam:7:18
+  ┌─ src/two.gleam:7:19
   │
 7 │   let name = user.name
-  │                  ^ This field does not exist
+  │                   ^ This field does not exist
 
 The value being accessed has this type:
 
@@ -15,10 +15,10 @@ The value being accessed has this type:
 It does not have any fields.
 
 error: Unknown record field
-  ┌─ src/two.gleam:8:19
+  ┌─ src/two.gleam:8:20
   │
 8 │   let score = user.score
-  │                   ^ This field does not exist
+  │                    ^ This field does not exist
 
 The value being accessed has this type:
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_expression.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__unknown_module_field_in_expression.snap
@@ -3,9 +3,9 @@ source: test-package-compiler/src/generated_tests.rs
 expression: "./cases/unknown_module_field_in_expression"
 ---
 error: Unknown module value
-  ┌─ src/two.gleam:4:6
+  ┌─ src/two.gleam:4:7
   │
 4 │   one.B
-  │      ^ Did you mean `A`?
+  │       ^ Did you mean `A`?
 
 The module `one` does not have a `B` value.


### PR DESCRIPTION
I found a couple of bugs in the "convert to call" code action testing it out on some real code:
- It wouldn't work with module selects, moving only the bit after the `.`
- It wouldn't work with module selects that cannot be inferred, moving only the bit after `.`
- It would remove labels when piping into a capture with explicit labels written down

This PR fixes all of those issues