### PR TITLE
Fix `gleam new` README.md formatting

### DIFF
--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -93,6 +93,7 @@ impl FileToCreate {
 ```sh
 gleam add {project_name}@1
 ```
+
 ```gleam
 import {project_name}
 

--- a/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_default_template@README.md.snap
+++ b/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_default_template@README.md.snap
@@ -10,6 +10,7 @@ expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf())
 ```sh
 gleam add my_project@1
 ```
+
 ```gleam
 import my_project
 

--- a/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_javascript_template@README.md.snap
+++ b/compiler-cli/src/new/snapshots/gleam__new__tests__new_with_javascript_template@README.md.snap
@@ -10,6 +10,7 @@ expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf())
 ```sh
 gleam add my_project@1
 ```
+
 ```gleam
 import my_project
 


### PR DESCRIPTION
Not sure if this is something you care about:

The current `README.md` generated by `gleam new` violates rule [MD031 - Fenced code blocks should be surrounded by blank lines](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines) of `markdownlint`.