### PR TITLE
Fix generation of package interface when modules are cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,10 @@
   private type used in the same module it's defined in.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where `gleam export package-interface` would not properly generate
+  the package interface file if some modules were cached.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.8.1 - 2025-02-11
 
 ### Bug fixes

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -143,7 +143,11 @@ pub fn package_interface(paths: &ProjectPaths, out: Utf8PathBuf) -> Result<()> {
     )?;
     built.root_package.attach_doc_and_module_comments();
 
-    let out = gleam_core::docs::generate_json_package_interface(out, &built.root_package);
+    let out = gleam_core::docs::generate_json_package_interface(
+        out,
+        &built.root_package,
+        &built.module_interfaces,
+    );
     crate::fs::write_outputs_under(&[out], paths.root())?;
     Ok(())
 }

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -2058,11 +2058,15 @@ pub mod types_variant_constructors {
     pub fn has_type_parameters_ids(&self) -> bool {
       !self.reader.get_pointer_field(1).is_null()
     }
+    #[inline]
+    pub fn get_opaque(self) -> bool {
+      self.reader.get_bool_field(0)
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 2 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -2144,6 +2148,14 @@ pub mod types_variant_constructors {
     pub fn has_type_parameters_ids(&self) -> bool {
       !self.builder.is_pointer_field_null(1)
     }
+    #[inline]
+    pub fn get_opaque(self) -> bool {
+      self.builder.get_bool_field(0)
+    }
+    #[inline]
+    pub fn set_opaque(&mut self, value: bool)  {
+      self.builder.set_bool_field(0, value);
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -2155,17 +2167,17 @@ pub mod types_variant_constructors {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 60] = [
+    pub static ENCODED_NODE: [::capnp::Word; 75] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(242, 117, 25, 190, 73, 132, 187, 199),
-      ::capnp::word(13, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 50, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 119, 0, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 175, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -2174,21 +2186,28 @@ pub mod types_variant_constructors {
       ::capnp::word(116, 67, 111, 110, 115, 116, 114, 117),
       ::capnp::word(99, 116, 111, 114, 115, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(41, 0, 0, 0, 74, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(68, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(65, 0, 0, 0, 146, 0, 0, 0),
+      ::capnp::word(69, 0, 0, 0, 74, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
       ::capnp::word(96, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(93, 0, 0, 0, 146, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(124, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(121, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(116, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(128, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(118, 97, 114, 105, 97, 110, 116, 115),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
@@ -2216,11 +2235,20 @@ pub mod types_variant_constructors {
       ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(111, 112, 97, 113, 117, 101, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
         0 => <::capnp::struct_list::Owned<crate::schema_capnp::type_value_constructor::Owned> as ::capnp::introspect::Introspect>::introspect(),
         1 => <::capnp::primitive_list::Owned<u16> as ::capnp::introspect::Introspect>::introspect(),
+        2 => <bool as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -2233,9 +2261,9 @@ pub mod types_variant_constructors {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[1,0];
+    pub static MEMBERS_BY_NAME : &[u16] = &[2,1,0];
     pub const TYPE_ID: u64 = 0xc7bb_8449_be19_75f2;
   }
 }
@@ -2903,15 +2931,11 @@ pub mod type_constructor {
     pub fn has_documentation(&self) -> bool {
       !self.reader.get_pointer_field(6).is_null()
     }
-    #[inline]
-    pub fn get_opaque(self) -> bool {
-      self.reader.get_bool_field(0)
-    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 7 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 7 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -3073,14 +3097,6 @@ pub mod type_constructor {
     pub fn has_documentation(&self) -> bool {
       !self.builder.is_pointer_field_null(6)
     }
-    #[inline]
-    pub fn get_opaque(self) -> bool {
-      self.builder.get_bool_field(0)
-    }
-    #[inline]
-    pub fn set_opaque(&mut self, value: bool)  {
-      self.builder.set_bool_field(0, value);
-    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -3101,17 +3117,17 @@ pub mod type_constructor {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 146] = [
+    pub static ENCODED_NODE: [::capnp::Word; 131] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(122, 109, 11, 224, 98, 109, 251, 177),
-      ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(13, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
       ::capnp::word(7, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 234, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(29, 0, 0, 0, 199, 1, 0, 0),
+      ::capnp::word(29, 0, 0, 0, 143, 1, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -3119,63 +3135,56 @@ pub mod type_constructor {
       ::capnp::word(101, 67, 111, 110, 115, 116, 114, 117),
       ::capnp::word(99, 116, 111, 114, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(32, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(28, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(209, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(181, 0, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(204, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(216, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(176, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(188, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(213, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(185, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(212, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(240, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(184, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(212, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(237, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(209, 0, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(232, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(244, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(204, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(216, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(241, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(213, 0, 0, 0, 82, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(240, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(252, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(212, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(224, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(4, 0, 0, 0, 4, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(249, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(221, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(248, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(4, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(220, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(232, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(5, 0, 0, 0, 5, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(1, 1, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(229, 0, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(252, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(8, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(224, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(236, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(6, 0, 0, 0, 6, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(5, 1, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(233, 0, 0, 0, 114, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(4, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(16, 1, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(7, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 7, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(13, 1, 0, 0, 58, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(8, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(20, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(232, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(244, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
       ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
@@ -3240,14 +3249,6 @@ pub mod type_constructor {
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(111, 112, 97, 113, 117, 101, 0, 0),
-      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
@@ -3258,7 +3259,6 @@ pub mod type_constructor {
         4 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         5 => <crate::schema_capnp::src_span::Owned as ::capnp::introspect::Introspect>::introspect(),
         6 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-        7 => <bool as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -3271,9 +3271,9 @@ pub mod type_constructor {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6,7];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[4,6,2,7,5,1,3,0];
+    pub static MEMBERS_BY_NAME : &[u16] = &[4,6,2,5,1,3,0];
     pub const TYPE_ID: u64 = 0xb1fb_6d62_e00b_6d7a;
   }
 }

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -688,11 +688,27 @@ pub mod module {
     pub fn has_required_version(&self) -> bool {
       !self.reader.get_pointer_field(8).is_null()
     }
+    #[inline]
+    pub fn get_type_aliases(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::type_alias_constructor::Owned>>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(9), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_type_aliases(&self) -> bool {
+      !self.reader.get_pointer_field(9).is_null()
+    }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text_list::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(10), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.reader.get_pointer_field(10).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 9 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 11 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -894,6 +910,38 @@ pub mod module {
     pub fn has_required_version(&self) -> bool {
       !self.builder.is_pointer_field_null(8)
     }
+    #[inline]
+    pub fn get_type_aliases(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::type_alias_constructor::Owned>>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(9), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_type_aliases(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::property::Owned<crate::schema_capnp::type_alias_constructor::Owned>>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(9), value, false)
+    }
+    #[inline]
+    pub fn init_type_aliases(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::type_alias_constructor::Owned>> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(9), size)
+    }
+    #[inline]
+    pub fn has_type_aliases(&self) -> bool {
+      !self.builder.is_pointer_field_null(9)
+    }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text_list::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(10), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_documentation(&mut self, value: impl ::capnp::traits::SetterInput<::capnp::text_list::Owned>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(10), value, false)
+    }
+    #[inline]
+    pub fn init_documentation(self, size: u32) -> ::capnp::text_list::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(10), size)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.builder.is_pointer_field_null(10)
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -911,94 +959,108 @@ pub mod module {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 237] = [
+    pub static ENCODED_NODE: [::capnp::Word; 289] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(129, 5, 219, 80, 68, 149, 82, 154),
       ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
-      ::capnp::word(9, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(11, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 162, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(25, 0, 0, 0, 55, 2, 0, 0),
+      ::capnp::word(25, 0, 0, 0, 167, 2, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
       ::capnp::word(97, 112, 110, 112, 58, 77, 111, 100),
       ::capnp::word(117, 108, 101, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(40, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(48, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(9, 1, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(65, 1, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(4, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(16, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(60, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(72, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(13, 1, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(69, 1, 0, 0, 50, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(8, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(84, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(64, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(140, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(81, 1, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(137, 1, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(76, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(152, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(132, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(208, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(149, 1, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(205, 1, 0, 0, 82, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(148, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(224, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(204, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(24, 2, 0, 0, 2, 0, 1, 0),
       ::capnp::word(4, 0, 0, 0, 4, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(221, 1, 0, 0, 66, 0, 0, 0),
+      ::capnp::word(21, 2, 0, 0, 66, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(216, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(228, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(16, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(28, 2, 0, 0, 2, 0, 1, 0),
       ::capnp::word(5, 0, 0, 0, 5, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(225, 1, 0, 0, 146, 0, 0, 0),
+      ::capnp::word(25, 2, 0, 0, 146, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(228, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(48, 2, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(28, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(104, 2, 0, 0, 2, 0, 1, 0),
       ::capnp::word(6, 0, 0, 0, 6, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(45, 2, 0, 0, 98, 0, 0, 0),
+      ::capnp::word(101, 2, 0, 0, 98, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(44, 2, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(56, 2, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(100, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(112, 2, 0, 0, 2, 0, 1, 0),
       ::capnp::word(7, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(53, 2, 0, 0, 66, 0, 0, 0),
+      ::capnp::word(109, 2, 0, 0, 66, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(48, 2, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(60, 2, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(104, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(116, 2, 0, 0, 2, 0, 1, 0),
       ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 8, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(57, 2, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(113, 2, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(56, 2, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(68, 2, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(112, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(124, 2, 0, 0, 2, 0, 1, 0),
       ::capnp::word(9, 0, 0, 0, 8, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 9, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(65, 2, 0, 0, 130, 0, 0, 0),
+      ::capnp::word(121, 2, 0, 0, 130, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(64, 2, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(76, 2, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(120, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(132, 2, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(10, 0, 0, 0, 9, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 10, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(129, 2, 0, 0, 98, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(128, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(204, 2, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(11, 0, 0, 0, 10, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 11, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(201, 2, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(200, 2, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(228, 2, 0, 0, 2, 0, 1, 0),
       ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1149,6 +1211,44 @@ pub mod module {
       ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(116, 121, 112, 101, 65, 108, 105, 97),
+      ::capnp::word(115, 101, 115, 0, 0, 0, 0, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(106, 29, 126, 201, 93, 118, 154, 200),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 1, 0),
+      ::capnp::word(1, 0, 0, 0, 31, 0, 0, 0),
+      ::capnp::word(4, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(106, 29, 126, 201, 93, 118, 154, 200),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 23, 0, 0, 0),
+      ::capnp::word(4, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(77, 68, 194, 176, 34, 71, 88, 172),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(100, 111, 99, 117, 109, 101, 110, 116),
+      ::capnp::word(97, 116, 105, 111, 110, 0, 0, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
@@ -1162,6 +1262,8 @@ pub mod module {
         7 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         8 => <bool as ::capnp::introspect::Introspect>::introspect(),
         9 => <crate::schema_capnp::version::Owned as ::capnp::introspect::Introspect>::introspect(),
+        10 => <::capnp::struct_list::Owned<crate::schema_capnp::property::Owned<crate::schema_capnp::type_alias_constructor::Owned>> as ::capnp::introspect::Introspect>::introspect(),
+        11 => <::capnp::text_list::Owned as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -1174,10 +1276,458 @@ pub mod module {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6,7,8,9];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6,7,8,9,10,11];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[3,8,6,0,4,9,7,1,5,2];
+    pub static MEMBERS_BY_NAME : &[u16] = &[3,11,8,6,0,4,9,7,10,1,5,2];
     pub const TYPE_ID: u64 = 0x9a52_9544_50db_0581;
+  }
+}
+
+pub mod type_alias_constructor {
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  impl <> ::core::marker::Copy for Reader<'_,>  {}
+  impl <> ::core::clone::Clone for Reader<'_,>  {
+    fn clone(&self) -> Self { *self }
+  }
+
+  impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+    fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+      Self { reader,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+    fn from(reader: Reader<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <> ::core::fmt::Debug for Reader<'_,>  {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+      core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(reader.get_struct(default)?.into())
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Self { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_publicity(&self) -> bool {
+      !self.reader.get_pointer_field(0).is_null()
+    }
+    #[inline]
+    pub fn get_module(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_module(&self) -> bool {
+      !self.reader.get_pointer_field(1).is_null()
+    }
+    #[inline]
+    pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_type(&self) -> bool {
+      !self.reader.get_pointer_field(2).is_null()
+    }
+    #[inline]
+    pub fn get_arity(self) -> u32 {
+      self.reader.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn get_deprecation(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_deprecation(&self) -> bool {
+      !self.reader.get_pointer_field(3).is_null()
+    }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.reader.get_pointer_field(4).is_null()
+    }
+    #[inline]
+    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_origin(&self) -> bool {
+      !self.reader.get_pointer_field(5).is_null()
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 6 };
+  }
+  impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+    fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+      Self { builder,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+    fn from(builder: Builder<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+      builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+    }
+  }
+
+  impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      self.builder.into_reader().into()
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { builder: self.builder.reborrow() }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      self.builder.as_reader().into()
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.as_reader().total_size()
+    }
+    #[inline]
+    pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_publicity(&mut self, value: crate::schema_capnp::publicity::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
+    }
+    #[inline]
+    pub fn init_publicity(self, ) -> crate::schema_capnp::publicity::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+    }
+    #[inline]
+    pub fn has_publicity(&self) -> bool {
+      !self.builder.is_pointer_field_null(0)
+    }
+    #[inline]
+    pub fn get_module(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_module(&mut self, value: impl ::capnp::traits::SetterInput<::capnp::text::Owned>)  {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(1), value, false).unwrap()
+    }
+    #[inline]
+    pub fn init_module(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(1).init_text(size)
+    }
+    #[inline]
+    pub fn has_module(&self) -> bool {
+      !self.builder.is_pointer_field_null(1)
+    }
+    #[inline]
+    pub fn get_type(self) -> ::capnp::Result<crate::schema_capnp::type_::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_type(&mut self, value: crate::schema_capnp::type_::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(2), value, false)
+    }
+    #[inline]
+    pub fn init_type(self, ) -> crate::schema_capnp::type_::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
+    }
+    #[inline]
+    pub fn has_type(&self) -> bool {
+      !self.builder.is_pointer_field_null(2)
+    }
+    #[inline]
+    pub fn get_arity(self) -> u32 {
+      self.builder.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn set_arity(&mut self, value: u32)  {
+      self.builder.set_data_field::<u32>(0, value);
+    }
+    #[inline]
+    pub fn get_deprecation(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_deprecation(&mut self, value: impl ::capnp::traits::SetterInput<::capnp::text::Owned>)  {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(3), value, false).unwrap()
+    }
+    #[inline]
+    pub fn init_deprecation(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(3).init_text(size)
+    }
+    #[inline]
+    pub fn has_deprecation(&self) -> bool {
+      !self.builder.is_pointer_field_null(3)
+    }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_documentation(&mut self, value: impl ::capnp::traits::SetterInput<::capnp::text::Owned>)  {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(4), value, false).unwrap()
+    }
+    #[inline]
+    pub fn init_documentation(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(4).init_text(size)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.builder.is_pointer_field_null(4)
+    }
+    #[inline]
+    pub fn get_origin(self) -> ::capnp::Result<crate::schema_capnp::src_span::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_origin(&mut self, value: crate::schema_capnp::src_span::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(5), value, false)
+    }
+    #[inline]
+    pub fn init_origin(self, ) -> crate::schema_capnp::src_span::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), 0)
+    }
+    #[inline]
+    pub fn has_origin(&self) -> bool {
+      !self.builder.is_pointer_field_null(5)
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+      Self { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+    pub fn get_publicity(&self) -> crate::schema_capnp::publicity::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+    }
+    pub fn get_type(&self) -> crate::schema_capnp::type_::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+    }
+    pub fn get_origin(&self) -> crate::schema_capnp::src_span::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(5))
+    }
+  }
+  mod _private {
+    pub static ENCODED_NODE: [::capnp::Word; 127] = [
+      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      ::capnp::word(77, 68, 194, 176, 34, 71, 88, 172),
+      ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
+      ::capnp::word(6, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
+      ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 143, 1, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
+      ::capnp::word(97, 112, 110, 112, 58, 84, 121, 112),
+      ::capnp::word(101, 65, 108, 105, 97, 115, 67, 111),
+      ::capnp::word(110, 115, 116, 114, 117, 99, 116, 111),
+      ::capnp::word(114, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(28, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(181, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(180, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(192, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(189, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(184, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(196, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(193, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(188, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(200, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(3, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(197, 0, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(192, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(204, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(4, 0, 0, 0, 3, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(201, 0, 0, 0, 98, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(200, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(212, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(5, 0, 0, 0, 4, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(209, 0, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(208, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(220, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(6, 0, 0, 0, 5, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(217, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(212, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(224, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(112, 117, 98, 108, 105, 99, 105, 116),
+      ::capnp::word(121, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(102, 28, 233, 33, 200, 211, 73, 197),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(109, 111, 100, 117, 108, 101, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(97, 114, 105, 116, 121, 0, 0, 0),
+      ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(100, 101, 112, 114, 101, 99, 97, 116),
+      ::capnp::word(105, 111, 110, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(100, 111, 99, 117, 109, 101, 110, 116),
+      ::capnp::word(97, 116, 105, 111, 110, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(111, 114, 105, 103, 105, 110, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(176, 122, 119, 83, 72, 147, 59, 230),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+    ];
+    pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+      match index {
+        0 => <crate::schema_capnp::publicity::Owned as ::capnp::introspect::Introspect>::introspect(),
+        1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        2 => <crate::schema_capnp::type_::Owned as ::capnp::introspect::Introspect>::introspect(),
+        3 => <u32 as ::capnp::introspect::Introspect>::introspect(),
+        4 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        5 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        6 => <crate::schema_capnp::src_span::Owned as ::capnp::introspect::Introspect>::introspect(),
+        _ => panic!("invalid field index {}", index),
+      }
+    }
+    pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+      panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+    }
+    pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+      encoded_node: &ENCODED_NODE,
+      nonunion_members: NONUNION_MEMBERS,
+      members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+      members_by_name: MEMBERS_BY_NAME,
+    };
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6];
+    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
+    pub static MEMBERS_BY_NAME : &[u16] = &[3,4,5,1,6,0,2];
+    pub const TYPE_ID: u64 = 0xac58_4722_b0c2_444d;
   }
 }
 
@@ -2012,11 +2562,19 @@ pub mod type_value_constructor_parameter {
     pub fn has_type(&self) -> bool {
       !self.reader.get_pointer_field(0).is_null()
     }
+    #[inline]
+    pub fn get_label(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_label(&self) -> bool {
+      !self.reader.get_pointer_field(1).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 2 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -2082,6 +2640,22 @@ pub mod type_value_constructor_parameter {
     pub fn has_type(&self) -> bool {
       !self.builder.is_pointer_field_null(0)
     }
+    #[inline]
+    pub fn get_label(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_label(&mut self, value: impl ::capnp::traits::SetterInput<::capnp::text::Owned>)  {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(1), value, false).unwrap()
+    }
+    #[inline]
+    pub fn init_label(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(1).init_text(size)
+    }
+    #[inline]
+    pub fn has_label(&self) -> bool {
+      !self.builder.is_pointer_field_null(1)
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -2096,17 +2670,17 @@ pub mod type_value_constructor_parameter {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 35] = [
+    pub static ENCODED_NODE: [::capnp::Word; 50] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(234, 83, 193, 19, 176, 48, 149, 161),
       ::capnp::word(13, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
-      ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 90, 1, 0, 0),
       ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
+      ::capnp::word(37, 0, 0, 0, 119, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -2116,14 +2690,21 @@ pub mod type_value_constructor_parameter {
       ::capnp::word(114, 80, 97, 114, 97, 109, 101, 116),
       ::capnp::word(101, 114, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(13, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(41, 0, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(36, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(48, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(45, 0, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
       ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
@@ -2132,10 +2713,19 @@ pub mod type_value_constructor_parameter {
       ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(108, 97, 98, 101, 108, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
         0 => <crate::schema_capnp::type_::Owned as ::capnp::introspect::Introspect>::introspect(),
+        1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -2148,9 +2738,9 @@ pub mod type_value_constructor_parameter {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[0];
+    pub static MEMBERS_BY_NAME : &[u16] = &[1,0];
     pub const TYPE_ID: u64 = 0xa195_30b0_13c1_53ea;
   }
 }
@@ -2272,11 +2862,15 @@ pub mod type_constructor {
     pub fn has_documentation(&self) -> bool {
       !self.reader.get_pointer_field(6).is_null()
     }
+    #[inline]
+    pub fn get_opaque(self) -> bool {
+      self.reader.get_bool_field(0)
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 7 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 7 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -2438,6 +3032,14 @@ pub mod type_constructor {
     pub fn has_documentation(&self) -> bool {
       !self.builder.is_pointer_field_null(6)
     }
+    #[inline]
+    pub fn get_opaque(self) -> bool {
+      self.builder.get_bool_field(0)
+    }
+    #[inline]
+    pub fn set_opaque(&mut self, value: bool)  {
+      self.builder.set_bool_field(0, value);
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -2458,17 +3060,17 @@ pub mod type_constructor {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 131] = [
+    pub static ENCODED_NODE: [::capnp::Word; 146] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(122, 109, 11, 224, 98, 109, 251, 177),
-      ::capnp::word(13, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
       ::capnp::word(7, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 234, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(29, 0, 0, 0, 143, 1, 0, 0),
+      ::capnp::word(29, 0, 0, 0, 199, 1, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -2476,56 +3078,63 @@ pub mod type_constructor {
       ::capnp::word(101, 67, 111, 110, 115, 116, 114, 117),
       ::capnp::word(99, 116, 111, 114, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(28, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(32, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(181, 0, 0, 0, 42, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(176, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(188, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(185, 0, 0, 0, 90, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(184, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(212, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(209, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(209, 0, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(204, 0, 0, 0, 3, 0, 1, 0),
       ::capnp::word(216, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(213, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(213, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(212, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(224, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(4, 0, 0, 0, 4, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
+      ::capnp::word(240, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(221, 0, 0, 0, 90, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(220, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(232, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(5, 0, 0, 0, 5, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(229, 0, 0, 0, 58, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(224, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(236, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(6, 0, 0, 0, 6, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(233, 0, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(237, 0, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(232, 0, 0, 0, 3, 0, 1, 0),
       ::capnp::word(244, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(241, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(240, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(252, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(4, 0, 0, 0, 4, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(249, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(248, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(4, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(5, 0, 0, 0, 5, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(1, 1, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(252, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(8, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(6, 0, 0, 0, 6, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(5, 1, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(4, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(16, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(7, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 7, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(13, 1, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(8, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(20, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
       ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
@@ -2590,6 +3199,14 @@ pub mod type_constructor {
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(111, 112, 97, 113, 117, 101, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
@@ -2600,6 +3217,7 @@ pub mod type_constructor {
         4 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         5 => <crate::schema_capnp::src_span::Owned as ::capnp::introspect::Introspect>::introspect(),
         6 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        7 => <bool as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -2612,9 +3230,9 @@ pub mod type_constructor {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6,7];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[4,6,2,5,1,3,0];
+    pub static MEMBERS_BY_NAME : &[u16] = &[4,6,2,7,5,1,3,0];
     pub const TYPE_ID: u64 = 0xb1fb_6d62_e00b_6d7a;
   }
 }

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -2317,11 +2317,19 @@ pub mod type_value_constructor {
     pub fn has_parameters(&self) -> bool {
       !self.reader.get_pointer_field(1).is_null()
     }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.reader.get_pointer_field(2).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 2 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 3 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -2403,6 +2411,22 @@ pub mod type_value_constructor {
     pub fn has_parameters(&self) -> bool {
       !self.builder.is_pointer_field_null(1)
     }
+    #[inline]
+    pub fn get_documentation(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_documentation(&mut self, value: impl ::capnp::traits::SetterInput<::capnp::text::Owned>)  {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(2), value, false).unwrap()
+    }
+    #[inline]
+    pub fn init_documentation(self, size: u32) -> ::capnp::text::Builder<'a> {
+      self.builder.get_pointer_field(2).init_text(size)
+    }
+    #[inline]
+    pub fn has_documentation(&self) -> bool {
+      !self.builder.is_pointer_field_null(2)
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -2414,17 +2438,17 @@ pub mod type_value_constructor {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 54] = [
+    pub static ENCODED_NODE: [::capnp::Word; 70] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(219, 85, 99, 173, 224, 242, 6, 232),
       ::capnp::word(13, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
-      ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 119, 0, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 175, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -2433,21 +2457,28 @@ pub mod type_value_constructor {
       ::capnp::word(110, 115, 116, 114, 117, 99, 116, 111),
       ::capnp::word(114, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(41, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(69, 0, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(36, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(48, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(45, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(73, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(44, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(72, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(100, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(97, 0, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2469,11 +2500,21 @@ pub mod type_value_constructor {
       ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(100, 111, 99, 117, 109, 101, 110, 116),
+      ::capnp::word(97, 116, 105, 111, 110, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
         0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         1 => <::capnp::struct_list::Owned<crate::schema_capnp::type_value_constructor_parameter::Owned> as ::capnp::introspect::Introspect>::introspect(),
+        2 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -2486,9 +2527,9 @@ pub mod type_value_constructor {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[0,1];
+    pub static MEMBERS_BY_NAME : &[u16] = &[2,0,1];
     pub const TYPE_ID: u64 = 0xe806_f2e0_ad63_55db;
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -58,6 +58,7 @@ struct TypesVariantConstructors {
 struct TypeValueConstructor {
   name @0 :Text;
   parameters @1 :List(TypeValueConstructorParameter);
+  documentation @2 :Text;
 }
 
 struct TypeValueConstructorParameter {

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -53,6 +53,7 @@ struct Version {
 struct TypesVariantConstructors {
   variants @0 :List(TypeValueConstructor);
   typeParametersIds @1 :List(UInt16);
+  opaque @2 :Bool;
 }
 
 struct TypeValueConstructor {
@@ -77,7 +78,6 @@ struct TypeConstructor {
   deprecated @4 :Text;
   origin @5 :SrcSpan;
   documentation @6 :Text;
-  opaque @7 :Bool;
 }
 
 struct AccessorsMap {

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -30,6 +30,18 @@ struct Module {
   srcPath @7 :Text;
   isInternal @8 :Bool;
   requiredVersion @9 :Version;
+  typeAliases @10 :List(Property(TypeAliasConstructor));
+  documentation @11 :List(Text);
+}
+
+struct TypeAliasConstructor {
+    publicity @0 :Publicity;
+    module @1 :Text;
+    type @2 :Type;
+    arity @3 :UInt32;
+    deprecation @4 :Text;
+    documentation @5 :Text;
+    origin @6 :SrcSpan;
 }
 
 struct Version {
@@ -50,6 +62,7 @@ struct TypeValueConstructor {
 
 struct TypeValueConstructorParameter {
   type @0 :Type;
+  label @1 :Text;
 }
 
 struct TypeConstructor {
@@ -63,6 +76,7 @@ struct TypeConstructor {
   deprecated @4 :Text;
   origin @5 :SrcSpan;
   documentation @6 :Text;
+  opaque @7 :Bool;
 }
 
 struct AccessorsMap {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1088,6 +1088,10 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             constructors_data.push(TypeValueConstructor {
                 name: constructor.name.clone(),
                 parameters: fields,
+                documentation: constructor
+                    .documentation
+                    .as_ref()
+                    .map(|(_, documentation)| documentation.clone()),
             });
             environment.insert_variable(
                 constructor.name.clone(),

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -21,9 +21,10 @@ use crate::{
     line_numbers::LineNumbers,
     parse::SpannedString,
     type_::{
-        self, AccessorsMap, Deprecation, ModuleInterface, PatternConstructor, RecordAccessor, Type,
-        TypeAliasConstructor, TypeConstructor, TypeValueConstructor, TypeValueConstructorField,
-        TypeVariantConstructors, ValueConstructor, ValueConstructorVariant, Warning,
+        self, AccessorsMap, Deprecation, ModuleInterface, Opaque, PatternConstructor,
+        RecordAccessor, Type, TypeAliasConstructor, TypeConstructor, TypeValueConstructor,
+        TypeValueConstructorField, TypeVariantConstructors, ValueConstructor,
+        ValueConstructorVariant, Warning,
         environment::*,
         error::{Error, FeatureKind, MissingAnnotation, Named, Problems, convert_unify_error},
         expression::{ExprTyper, FunctionDefinition, Implementations},
@@ -1108,10 +1109,15 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             );
         }
 
+        let opaque = if *opaque {
+            Opaque::Opaque
+        } else {
+            Opaque::NotOpaque
+        };
         // Now record the constructors for the type.
         environment.insert_type_to_constructors(
             name.clone(),
-            TypeVariantConstructors::new(constructors_data, type_parameters, hydrator),
+            TypeVariantConstructors::new(constructors_data, type_parameters, opaque, hydrator),
         );
 
         Ok(())
@@ -1185,7 +1191,6 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                     publicity,
                     type_,
                     documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
-                    opaque: *opaque,
                 },
             )
             .expect("name uniqueness checked above");
@@ -1260,7 +1265,6 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                     deprecation: deprecation.clone(),
                     publicity: *publicity,
                     documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
-                    opaque: false,
                 },
             )?;
 

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -215,6 +215,7 @@ fn mode_includes_tests() {
 pub struct Package {
     pub config: PackageConfig,
     pub modules: Vec<Module>,
+    pub module_names: Vec<EcoString>,
 }
 
 impl Package {

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -269,6 +269,8 @@ impl Module {
             .map(|span| Comment::from((span, self.code.as_str())).content.into())
             .collect();
 
+        self.ast.type_info.documentation = self.ast.documentation.clone();
+
         // Order statements to avoid misassociating doc comments after the
         // order has changed during compilation.
         let mut statements: Vec<_> = self.ast.definitions.iter_mut().collect();

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -215,7 +215,7 @@ fn mode_includes_tests() {
 pub struct Package {
     pub config: PackageConfig,
     pub modules: Vec<Module>,
-    pub module_names: Vec<EcoString>,
+    pub cached_module_names: Vec<EcoString>,
 }
 
 impl Package {

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -202,7 +202,7 @@ where
                         cached_module_names,
                     },
                     error,
-                )
+                );
             }
             Outcome::TotalFailure(error) => return Outcome::TotalFailure(error),
         };

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -31,8 +31,10 @@ use camino::{Utf8Path, Utf8PathBuf};
 use super::{ErlangAppCodegenConfiguration, TargetCodegenConfiguration, Telemetry};
 
 pub struct Compiled {
+    /// The modules which were just compiled
     pub modules: Vec<Module>,
-    pub module_names: Vec<EcoString>,
+    /// The names of all cached modules, which are not present in the `modules` field.
+    pub cached_module_names: Vec<EcoString>,
 }
 
 #[derive(Debug)]
@@ -150,7 +152,7 @@ where
             Loaded::empty()
         };
 
-        let mut module_names = Vec::new();
+        let mut cached_module_names = Vec::new();
 
         // Load the cached modules that have previously been compiled
         for module in loaded.cached.into_iter() {
@@ -161,7 +163,7 @@ where
                 return e.into();
             }
 
-            module_names.push(module.name.clone());
+            cached_module_names.push(module.name.clone());
 
             // Register the cached module so its type information etc can be
             // used for compiling futher modules.
@@ -197,7 +199,7 @@ where
                 return Outcome::PartialFailure(
                     Compiled {
                         modules,
-                        module_names,
+                        cached_module_names,
                     },
                     error,
                 )
@@ -221,7 +223,7 @@ where
 
         Outcome::Ok(Compiled {
             modules,
-            module_names,
+            cached_module_names,
         })
     }
 

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -61,6 +61,8 @@ fn write_cache(
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),
         warnings: vec![],
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: Default::default(),
+        documentation: Default::default(),
     };
     let path = Utf8Path::new("/artefact").join(format!("{name}.cache"));
     fs.write_bytes(

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -215,11 +215,11 @@ where
             .map(
                 |Compiled {
                      modules,
-                     module_names,
+                     cached_module_names,
                  }| Package {
                     config,
                     modules,
-                    module_names,
+                    cached_module_names,
                 },
             )
     }

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -18,7 +18,7 @@ use crate::{
     package_interface::PackageInterface,
     paths::ProjectPaths,
     pretty,
-    type_::Deprecation,
+    type_::{self, Deprecation},
     version::COMPILER_VERSION,
 };
 use askama::Template;
@@ -465,11 +465,15 @@ pub fn generate_html<IO: FileSystemReader>(
     files
 }
 
-pub fn generate_json_package_interface(path: Utf8PathBuf, package: &Package) -> OutputFile {
+pub fn generate_json_package_interface(
+    path: Utf8PathBuf,
+    package: &Package,
+    cached_modules: &im::HashMap<EcoString, type_::ModuleInterface>,
+) -> OutputFile {
     OutputFile {
         path,
         content: Content::Text(
-            serde_json::to_string(&PackageInterface::from_package(package))
+            serde_json::to_string(&PackageInterface::from_package(package, cached_modules))
                 .expect("JSON module interface serialisation"),
         ),
     }

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -69,7 +69,8 @@ fn compile_with_markdown_pages(
             &mut HashSet::new(),
             &NullTelemetry,
         )
-        .unwrap();
+        .unwrap()
+        .modules;
 
     for module in &mut modules {
         module.attach_doc_and_module_comments();

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -989,7 +989,11 @@ impl ConstructorSpecialiser {
     }
 
     fn specialise_type_value_constructor(&self, v: &TypeValueConstructor) -> TypeValueConstructor {
-        let TypeValueConstructor { name, parameters } = v;
+        let TypeValueConstructor {
+            name,
+            parameters,
+            documentation,
+        } = v;
         let parameters = parameters
             .iter()
             .map(|p| TypeValueConstructorField {
@@ -1000,6 +1004,7 @@ impl ConstructorSpecialiser {
         TypeValueConstructor {
             name: name.clone(),
             parameters,
+            documentation: documentation.clone(),
         }
     }
 

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -994,6 +994,7 @@ impl ConstructorSpecialiser {
             .iter()
             .map(|p| TypeValueConstructorField {
                 type_: self.specialise_type(p.type_.as_ref()),
+                label: p.label.clone(),
             })
             .collect_vec();
         TypeValueConstructor {

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -246,6 +246,7 @@ impl ModuleDecoder {
                 self,
                 type_value_constructor_parameter
             ),
+            documentation: self.optional_string(self.str(reader.get_documentation()?)?),
         })
     }
 

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -14,7 +14,7 @@ use crate::{
     line_numbers::LineNumbers,
     schema_capnp::{self as schema, *},
     type_::{
-        self, AccessorsMap, Deprecation, FieldMap, ModuleInterface, RecordAccessor, Type,
+        self, AccessorsMap, Deprecation, FieldMap, ModuleInterface, Opaque, RecordAccessor, Type,
         TypeAliasConstructor, TypeConstructor, TypeValueConstructor, TypeValueConstructorField,
         TypeVariantConstructors, ValueConstructor, ValueConstructorVariant,
         expression::Implementations,
@@ -128,7 +128,6 @@ impl ModuleDecoder {
             type_,
             deprecation,
             documentation: self.optional_string(self.str(reader.get_documentation()?)?),
-            opaque: reader.get_opaque(),
         })
     }
 
@@ -225,9 +224,16 @@ impl ModuleDecoder {
             self,
             type_variant_constructor_type_parameter_id
         );
+        let opaque = if reader.get_opaque() {
+            Opaque::Opaque
+        } else {
+            Opaque::NotOpaque
+        };
+
         Ok(TypeVariantConstructors {
             variants,
             type_parameters_ids,
+            opaque,
         })
     }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -252,6 +252,7 @@ impl<'a> ModuleEncoder<'a> {
         constructor: &TypeValueConstructor,
     ) {
         builder.set_name(&constructor.name);
+        builder.set_documentation(constructor.documentation.as_deref().unwrap_or_default());
         let mut builder = builder.init_parameters(constructor.parameters.len() as u32);
         for (i, parameter) in constructor.parameters.iter().enumerate() {
             self.build_type_value_constructor_parameter(

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -7,9 +7,10 @@ use crate::{
     },
     schema_capnp::{self as schema, *},
     type_::{
-        self, AccessorsMap, Deprecation, FieldMap, RecordAccessor, Type, TypeAliasConstructor,
-        TypeConstructor, TypeValueConstructor, TypeVar, TypeVariantConstructors, ValueConstructor,
-        ValueConstructorVariant, expression::Implementations,
+        self, AccessorsMap, Deprecation, FieldMap, Opaque, RecordAccessor, Type,
+        TypeAliasConstructor, TypeConstructor, TypeValueConstructor, TypeVar,
+        TypeVariantConstructors, ValueConstructor, ValueConstructorVariant,
+        expression::Implementations,
     },
 };
 use std::{collections::HashMap, ops::Deref, sync::Arc};
@@ -167,6 +168,10 @@ impl<'a> ModuleEncoder<'a> {
         mut builder: types_variant_constructors::Builder<'_>,
         data: &TypeVariantConstructors,
     ) {
+        match data.opaque {
+            Opaque::Opaque => builder.set_opaque(true),
+            Opaque::NotOpaque => builder.set_opaque(false),
+        }
         {
             let mut builder = builder
                 .reborrow()
@@ -225,7 +230,6 @@ impl<'a> ModuleEncoder<'a> {
                 .map(EcoString::as_str)
                 .unwrap_or_default(),
         );
-        builder.set_opaque(constructor.opaque);
     }
 
     fn build_type_alias_constructor(

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -64,6 +64,8 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     }
 }
 
@@ -98,6 +100,8 @@ fn empty_module() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -121,6 +125,8 @@ fn with_line_numbers() {
         ),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -143,6 +149,7 @@ fn module_with_private_type() {
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
                 documentation: None,
+                opaque: false,
             },
         )]
         .into(),
@@ -152,6 +159,8 @@ fn module_with_private_type() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -174,6 +183,7 @@ fn module_with_app_type() {
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
                 documentation: None,
+                opaque: false,
             },
         )]
         .into(),
@@ -183,6 +193,8 @@ fn module_with_app_type() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -205,6 +217,7 @@ fn module_with_fn_type() {
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
                 documentation: None,
+                opaque: false,
             },
         )]
         .into(),
@@ -214,6 +227,8 @@ fn module_with_fn_type() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -236,6 +251,7 @@ fn module_with_tuple_type() {
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
                 documentation: None,
+                opaque: false,
             },
         )]
         .into(),
@@ -245,6 +261,8 @@ fn module_with_tuple_type() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -273,6 +291,7 @@ fn module_with_generic_type() {
                     parameters: vec![t1, t2],
                     deprecation: Deprecation::NotDeprecated,
                     documentation: None,
+                    opaque: false,
                 },
             )]
             .into(),
@@ -282,6 +301,8 @@ fn module_with_generic_type() {
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
             minimum_required_version: Version::new(0, 1, 0),
+            type_aliases: HashMap::new(),
+            documentation: Vec::new(),
         }
     }
 
@@ -310,6 +331,7 @@ fn module_with_type_links() {
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
                     documentation: None,
+                    opaque: false,
                 },
             )]
             .into(),
@@ -319,6 +341,8 @@ fn module_with_type_links() {
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
             minimum_required_version: Version::new(0, 1, 0),
+            type_aliases: HashMap::new(),
+            documentation: Vec::new(),
         }
     }
 
@@ -347,6 +371,7 @@ fn module_with_type_constructor_documentation() {
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
                     documentation: Some("type documentation".into()),
+                    opaque: false,
                 },
             )]
             .into(),
@@ -356,6 +381,8 @@ fn module_with_type_constructor_documentation() {
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
             minimum_required_version: Version::new(0, 1, 0),
+            type_aliases: HashMap::new(),
+            documentation: Vec::new(),
         }
     }
 
@@ -387,6 +414,7 @@ fn module_with_type_constructor_origin() {
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
                     documentation: None,
+                    opaque: false,
                 },
             )]
             .into(),
@@ -396,6 +424,8 @@ fn module_with_type_constructor_origin() {
             line_numbers: LineNumbers::new(""),
             src_path: "some_path".into(),
             minimum_required_version: Version::new(0, 1, 0),
+            type_aliases: HashMap::new(),
+            documentation: Vec::new(),
         }
     }
 
@@ -427,6 +457,8 @@ fn module_type_to_constructors_mapping() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -475,6 +507,8 @@ fn module_fn_value() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -524,6 +558,8 @@ fn deprecated_module_fn_value() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -571,6 +607,8 @@ fn private_module_fn_value() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -620,6 +658,8 @@ fn module_fn_value_regression() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -668,6 +708,8 @@ fn module_fn_value_with_field_map() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -711,6 +753,8 @@ fn record_value() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -758,6 +802,8 @@ fn record_value_with_field_map() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -826,6 +872,8 @@ fn accessors() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -894,6 +942,8 @@ fn private_accessors() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1116,6 +1166,8 @@ fn constant_var() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1299,6 +1351,7 @@ fn deprecated_type() {
                     message: "oh no".into(),
                 },
                 documentation: None,
+                opaque: false,
             },
         )]
         .into(),
@@ -1308,6 +1361,8 @@ fn deprecated_type() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }
@@ -1355,6 +1410,8 @@ fn module_fn_value_with_external_implementations() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1405,6 +1462,8 @@ fn internal_module_fn() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1458,6 +1517,8 @@ fn internal_annotated_module_fn() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     assert_eq!(roundtrip(&module), module);
@@ -1482,12 +1543,15 @@ fn type_variable_ids_in_constructors_are_shared() {
                     parameters: vec![
                         TypeValueConstructorField {
                             type_: type_::generic_var(6),
+                            label: None,
                         },
                         TypeValueConstructorField {
                             type_: type_::int(),
+                            label: None,
                         },
                         TypeValueConstructorField {
                             type_: type_::tuple(vec![type_::generic_var(4), type_::generic_var(5)]),
+                            label: None,
                         },
                     ],
                 }],
@@ -1498,6 +1562,8 @@ fn type_variable_ids_in_constructors_are_shared() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     let expected = HashMap::from([(
@@ -1509,12 +1575,15 @@ fn type_variable_ids_in_constructors_are_shared() {
                 parameters: vec![
                     TypeValueConstructorField {
                         type_: type_::generic_var(0),
+                        label: None,
                     },
                     TypeValueConstructorField {
                         type_: type_::int(),
+                        label: None,
                     },
                     TypeValueConstructorField {
                         type_: type_::tuple(vec![type_::generic_var(1), type_::generic_var(2)]),
+                        label: None,
                     },
                 ],
             }],
@@ -1549,6 +1618,7 @@ fn type_with_inferred_variant() {
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
                 documentation: None,
+                opaque: false,
             },
         )]
         .into(),
@@ -1558,6 +1628,8 @@ fn type_with_inferred_variant() {
         line_numbers: LineNumbers::new(""),
         src_path: "some_path".into(),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
     assert_eq!(roundtrip(&module), module);
 }

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -448,6 +448,7 @@ fn module_type_to_constructors_mapping() {
                 variants: vec![TypeValueConstructor {
                     name: "One".into(),
                     parameters: vec![],
+                    documentation: Some("Some documentation".into()),
                 }],
             },
         )]
@@ -1554,6 +1555,7 @@ fn type_variable_ids_in_constructors_are_shared() {
                             label: None,
                         },
                     ],
+                    documentation: None,
                 }],
             },
         )]),
@@ -1586,6 +1588,7 @@ fn type_variable_ids_in_constructors_are_shared() {
                         label: None,
                     },
                 ],
+                documentation: None,
             }],
         },
     )]);

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -428,8 +428,7 @@ impl ModuleInterface {
                                 .variants
                                 .iter()
                                 .map(|constructor| TypeConstructorInterface {
-                                    // TODO: Find documentation
-                                    documentation: None,
+                                    documentation: constructor.documentation.clone(),
                                     name: constructor.name.clone(),
                                     parameters: constructor
                                         .parameters

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -1,19 +1,20 @@
 use std::{collections::HashMap, ops::Deref};
 
 use ecow::EcoString;
-use itertools::Itertools;
 use serde::Serialize;
 
 #[cfg(test)]
 mod tests;
 
 use crate::{
-    ast::{CustomType, Definition, Function, ModuleConstant, Publicity, TypeAlias},
     io::ordered_map,
-    type_::{Deprecation, Type, TypeVar, expression::Implementations},
+    type_::{
+        self, Deprecation, Type, TypeConstructor, TypeVar, ValueConstructorVariant,
+        expression::Implementations,
+    },
 };
 
-use crate::build::{Module, Package};
+use crate::build::Package;
 
 /// The public interface of a package that gets serialised as a json object.
 #[derive(Serialize, Debug)]
@@ -358,7 +359,10 @@ pub struct ParameterInterface {
 }
 
 impl PackageInterface {
-    pub fn from_package(package: &Package) -> PackageInterface {
+    pub fn from_package(
+        package: &Package,
+        cached_modules: &im::HashMap<EcoString, type_::ModuleInterface>,
+    ) -> PackageInterface {
         PackageInterface {
             name: package.config.name.clone(),
             version: package.config.version.to_string().into(),
@@ -370,183 +374,169 @@ impl PackageInterface {
             modules: package
                 .modules
                 .iter()
+                .map(|module| &module.ast.type_info)
+                .chain(
+                    package
+                        .module_names
+                        .iter()
+                        .filter_map(|name| cached_modules.get(name)),
+                )
                 .filter(|module| !package.config.is_internal_module(module.name.as_str()))
-                .map(|module| (module.name.clone(), ModuleInterface::from_module(module)))
+                .map(|module| (module.name.clone(), ModuleInterface::from_interface(module)))
                 .collect(),
         }
     }
 }
 
 impl ModuleInterface {
-    fn from_module(module: &Module) -> ModuleInterface {
+    pub fn from_interface(interface: &type_::ModuleInterface) -> ModuleInterface {
         let mut types = HashMap::new();
         let mut type_aliases = HashMap::new();
         let mut constants = HashMap::new();
         let mut functions = HashMap::new();
-        for statement in &module.ast.definitions {
-            match statement {
-                // A public type definition.
-                Definition::CustomType(CustomType {
-                    publicity: Publicity::Public,
-                    name,
-                    constructors,
-                    documentation,
-                    opaque,
-                    deprecation,
-                    typed_parameters,
-                    parameters: _,
-                    location: _,
-                    name_location: _,
-                    end_position: _,
-                }) => {
+        for (name, constructor) in interface
+            .types
+            .iter()
+            .filter(|(_, c)| c.publicity.is_public())
+        {
+            let mut id_map = IdMap::new();
+
+            let TypeConstructor {
+                deprecation,
+                documentation,
+                ..
+            } = constructor;
+
+            for typed_parameter in &constructor.parameters {
+                id_map.add_type_variable_id(typed_parameter.as_ref());
+            }
+
+            let _ = types.insert(
+                name.clone(),
+                TypeDefinitionInterface {
+                    documentation: documentation.clone(),
+                    deprecation: DeprecationInterface::from_deprecation(&deprecation),
+                    parameters: interface
+                        .types
+                        .get(&name.clone())
+                        .map_or(vec![], |t| t.parameters.clone())
+                        .len(),
+                    constructors: if constructor.opaque {
+                        vec![]
+                    } else {
+                        match interface.types_value_constructors.get(&name.clone()) {
+                            Some(constructors) => constructors
+                                .variants
+                                .iter()
+                                .map(|constructor| TypeConstructorInterface {
+                                    // TODO: Find documentation
+                                    documentation: None,
+                                    name: constructor.name.clone(),
+                                    parameters: constructor
+                                        .parameters
+                                        .iter()
+                                        .map(|arg| ParameterInterface {
+                                            label: arg.label.clone(),
+                                            // We share the same id_map between each step so that the
+                                            // incremental ids assigned are consisten with each other
+                                            type_: from_type_helper(
+                                                arg.type_.as_ref(),
+                                                &mut id_map,
+                                            ),
+                                        })
+                                        .collect(),
+                                })
+                                .collect(),
+                            None => vec![],
+                        }
+                    },
+                },
+            );
+        }
+
+        for (name, alias) in interface
+            .type_aliases
+            .iter()
+            .filter(|(_, v)| v.publicity.is_public())
+        {
+            let _ = type_aliases.insert(
+                name.clone(),
+                TypeAliasInterface {
+                    documentation: alias.documentation.clone(),
+                    deprecation: DeprecationInterface::from_deprecation(&alias.deprecation),
+                    parameters: alias.arity,
+                    alias: TypeInterface::from_type(&alias.type_),
+                },
+            );
+        }
+
+        for (name, value) in interface
+            .values
+            .iter()
+            .filter(|(_, v)| v.publicity.is_public())
+        {
+            match (value.type_.as_ref(), value.variant.clone()) {
+                (
+                    Type::Fn {
+                        args: arguments,
+                        retrn: return_type,
+                    },
+                    ValueConstructorVariant::ModuleFn {
+                        documentation,
+                        implementations,
+                        ..
+                    },
+                ) => {
                     let mut id_map = IdMap::new();
 
-                    // Let's first add all the types that appear in the type parameters so those are
-                    // taken into account when assigning incremental numbers to the constructor's
-                    // type variables.
-                    for typed_parameter in typed_parameters {
-                        id_map.add_type_variable_id(typed_parameter.as_ref());
-                    }
-
-                    let _ = types.insert(
-                        name.clone(),
-                        TypeDefinitionInterface {
-                            documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
-                            deprecation: DeprecationInterface::from_deprecation(deprecation),
-                            parameters: typed_parameters.len(),
-                            constructors: if *opaque {
-                                vec![]
-                            } else {
-                                constructors
-                                    .iter()
-                                    .map(|constructor| TypeConstructorInterface {
-                                        documentation: constructor
-                                            .documentation
-                                            .as_ref()
-                                            .map(|(_, doc)| doc.clone()),
-                                        name: constructor.name.clone(),
-                                        parameters: constructor
-                                            .arguments
-                                            .iter()
-                                            .map(|arg| ParameterInterface {
-                                                label: arg
-                                                    .label
-                                                    .as_ref()
-                                                    .map(|(_, label)| label.clone()),
-                                                // We share the same id_map between each step so that the
-                                                // incremental ids assigned are consisten with each other
-                                                type_: from_type_helper(&arg.type_, &mut id_map),
-                                            })
-                                            .collect_vec(),
-                                    })
-                                    .collect()
-                            },
-                        },
-                    );
-                }
-
-                // A public type alias definition
-                Definition::TypeAlias(TypeAlias {
-                    publicity: Publicity::Public,
-                    alias,
-                    parameters,
-                    type_,
-                    documentation,
-                    deprecation,
-                    location: _,
-                    name_location: _,
-                    type_ast: _,
-                }) => {
-                    let _ = type_aliases.insert(
-                        alias.clone(),
-                        TypeAliasInterface {
-                            documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
-                            deprecation: DeprecationInterface::from_deprecation(deprecation),
-                            parameters: parameters.len(),
-                            alias: TypeInterface::from_type(type_.as_ref()),
-                        },
-                    );
-                }
-
-                // A public module constant.
-                Definition::ModuleConstant(ModuleConstant {
-                    publicity: Publicity::Public,
-                    name,
-                    type_,
-                    documentation,
-                    implementations,
-                    deprecation,
-                    location: _,
-                    name_location: _,
-                    annotation: _,
-                    value: _,
-                }) => {
-                    let _ = constants.insert(
-                        name.clone(),
-                        ConstantInterface {
-                            implementations: ImplementationsInterface::from_implementations(
-                                implementations,
-                            ),
-                            type_: TypeInterface::from_type(type_.as_ref()),
-                            deprecation: DeprecationInterface::from_deprecation(deprecation),
-                            documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
-                        },
-                    );
-                }
-
-                // A public top-level function.
-                Definition::Function(Function {
-                    publicity: Publicity::Public,
-                    name,
-                    arguments,
-                    deprecation,
-                    return_type,
-                    documentation,
-                    implementations,
-                    location: _,
-                    end_position: _,
-                    body: _,
-                    return_annotation: _,
-                    external_erlang: _,
-                    external_javascript: _,
-                }) => {
-                    let mut id_map = IdMap::new();
-                    let (_, name) = name
-                        .as_ref()
-                        .expect("Function in a definition must be named");
                     let _ = functions.insert(
                         name.clone(),
                         FunctionInterface {
                             implementations: ImplementationsInterface::from_implementations(
-                                implementations,
+                                &implementations,
                             ),
-                            deprecation: DeprecationInterface::from_deprecation(deprecation),
-                            documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
+                            deprecation: DeprecationInterface::from_deprecation(&value.deprecation),
+                            documentation,
                             parameters: arguments
                                 .iter()
                                 .map(|arg| ParameterInterface {
-                                    label: arg.names.get_label().cloned(),
-                                    type_: from_type_helper(arg.type_.as_ref(), &mut id_map),
+                                    // TODO: fixme
+                                    label: None,
+                                    type_: from_type_helper(arg, &mut id_map),
                                 })
                                 .collect(),
-                            return_: from_type_helper(return_type, &mut id_map),
+                            return_: from_type_helper(&return_type, &mut id_map),
                         },
                     );
                 }
 
-                // Private or internal definitions are not included.
-                Definition::Function(_) => {}
-                Definition::CustomType(_) => {}
-                Definition::ModuleConstant(_) => {}
-                Definition::TypeAlias(_) => {}
+                (
+                    type_,
+                    ValueConstructorVariant::ModuleConstant {
+                        documentation,
+                        implementations,
+                        ..
+                    },
+                ) => {
+                    let _ = constants.insert(
+                        name.clone(),
+                        ConstantInterface {
+                            implementations: ImplementationsInterface::from_implementations(
+                                &implementations,
+                            ),
+                            type_: TypeInterface::from_type(type_),
+                            deprecation: DeprecationInterface::from_deprecation(&value.deprecation),
+                            documentation,
+                        },
+                    );
+                }
 
-                // Imports are ignored.
-                Definition::Import(_) => {}
+                _ => {}
             }
         }
 
         ModuleInterface {
-            documentation: module.ast.documentation.clone(),
+            documentation: interface.documentation.clone(),
             types,
             type_aliases,
             constants,

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -389,16 +389,15 @@ impl PackageInterface {
 }
 
 impl ModuleInterface {
-    pub fn from_interface(interface: &type_::ModuleInterface) -> ModuleInterface {
+    fn from_interface(interface: &type_::ModuleInterface) -> ModuleInterface {
         let mut types = HashMap::new();
         let mut type_aliases = HashMap::new();
         let mut constants = HashMap::new();
         let mut functions = HashMap::new();
-        for (name, constructor) in interface
-            .types
-            .iter()
-            .filter(|(_, c)| c.publicity.is_public())
-        {
+        for (name, constructor) in interface.types.iter().filter(|(name, c)| {
+            // Aliases are stored separately
+            c.publicity.is_public() && !interface.type_aliases.contains_key(*name)
+        }) {
             let mut id_map = IdMap::new();
 
             let TypeConstructor {

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -483,10 +483,15 @@ impl ModuleInterface {
                     ValueConstructorVariant::ModuleFn {
                         documentation,
                         implementations,
+                        field_map,
                         ..
                     },
                 ) => {
                     let mut id_map = IdMap::new();
+
+                    let reverse_field_map = field_map
+                        .map(|field_map| field_map.indices_to_labels())
+                        .unwrap_or_default();
 
                     let _ = functions.insert(
                         name.clone(),
@@ -498,10 +503,10 @@ impl ModuleInterface {
                             documentation,
                             parameters: arguments
                                 .iter()
-                                .map(|arg| ParameterInterface {
-                                    // TODO: fixme
-                                    label: None,
-                                    type_: from_type_helper(arg, &mut id_map),
+                                .enumerate()
+                                .map(|(index, type_)| ParameterInterface {
+                                    label: reverse_field_map.get(&(index as u32)).cloned(),
+                                    type_: from_type_helper(type_, &mut id_map),
                                 })
                                 .collect(),
                             return_: from_type_helper(&return_type, &mut id_map),

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -414,7 +414,7 @@ impl ModuleInterface {
                 name.clone(),
                 TypeDefinitionInterface {
                     documentation: documentation.clone(),
-                    deprecation: DeprecationInterface::from_deprecation(&deprecation),
+                    deprecation: DeprecationInterface::from_deprecation(deprecation),
                     parameters: interface
                         .types
                         .get(&name.clone())
@@ -508,7 +508,7 @@ impl ModuleInterface {
                                     type_: from_type_helper(type_, &mut id_map),
                                 })
                                 .collect(),
-                            return_: from_type_helper(&return_type, &mut id_map),
+                            return_: from_type_helper(return_type, &mut id_map),
                         },
                     );
                 }

--- a/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__constructors_with_documentation.snap
+++ b/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__constructors_with_documentation.snap
@@ -1,0 +1,58 @@
+---
+source: compiler-core/src/package_interface/tests.rs
+expression: "\npub type Wibble {\n  /// This is the Wibble variant. It contains some example data.\n  Wibble(Int)\n  /// This is the Wobble variant. It is a recursive type.\n  Wobble(Wibble)\n}\n"
+---
+{
+  "name": "my_package",
+  "version": "11.10.9-1.wibble+build",
+  "gleam-version-constraint": "1.0.0",
+  "modules": {
+    "my/module": {
+      "documentation": [],
+      "type-aliases": {},
+      "types": {
+        "Wibble": {
+          "documentation": null,
+          "deprecation": null,
+          "parameters": 0,
+          "constructors": [
+            {
+              "documentation": " This is the Wibble variant. It contains some example data.\n",
+              "name": "Wibble",
+              "parameters": [
+                {
+                  "label": null,
+                  "type": {
+                    "kind": "named",
+                    "name": "Int",
+                    "package": "",
+                    "module": "gleam",
+                    "parameters": []
+                  }
+                }
+              ]
+            },
+            {
+              "documentation": " This is the Wobble variant. It is a recursive type.\n",
+              "name": "Wobble",
+              "parameters": [
+                {
+                  "label": null,
+                  "type": {
+                    "kind": "named",
+                    "name": "Wibble",
+                    "package": "my_package",
+                    "module": "my/module",
+                    "parameters": []
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "constants": {},
+      "functions": {}
+    }
+  }
+}

--- a/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__labelled_function_parameters.snap
+++ b/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__labelled_function_parameters.snap
@@ -1,0 +1,78 @@
+---
+source: compiler-core/src/package_interface/tests.rs
+expression: "\npub fn fold(list: List(a), from acc: b, with f: fn(a, b) -> b) -> b {\n  todo\n}\n"
+---
+{
+  "name": "my_package",
+  "version": "11.10.9-1.wibble+build",
+  "gleam-version-constraint": "1.0.0",
+  "modules": {
+    "my/module": {
+      "documentation": [],
+      "type-aliases": {},
+      "types": {},
+      "constants": {},
+      "functions": {
+        "fold": {
+          "documentation": null,
+          "deprecation": null,
+          "implementations": {
+            "gleam": true,
+            "uses-erlang-externals": false,
+            "uses-javascript-externals": false,
+            "can-run-on-erlang": true,
+            "can-run-on-javascript": true
+          },
+          "parameters": [
+            {
+              "label": null,
+              "type": {
+                "kind": "named",
+                "name": "List",
+                "package": "",
+                "module": "gleam",
+                "parameters": [
+                  {
+                    "kind": "variable",
+                    "id": 0
+                  }
+                ]
+              }
+            },
+            {
+              "label": "from",
+              "type": {
+                "kind": "variable",
+                "id": 1
+              }
+            },
+            {
+              "label": "with",
+              "type": {
+                "kind": "fn",
+                "parameters": [
+                  {
+                    "kind": "variable",
+                    "id": 0
+                  },
+                  {
+                    "kind": "variable",
+                    "id": 1
+                  }
+                ],
+                "return": {
+                  "kind": "variable",
+                  "id": 1
+                }
+              }
+            }
+          ],
+          "return": {
+            "kind": "variable",
+            "id": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__type_definition.snap
+++ b/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__type_definition.snap
@@ -12,7 +12,7 @@ expression: "\n/// Wibble's documentation\npub type Wibble(a, b) {\n  Wibble\n  
       "type-aliases": {},
       "types": {
         "Wibble": {
-          "documentation": " Wibble's documentation",
+          "documentation": " Wibble's documentation\n",
           "deprecation": null,
           "parameters": 2,
           "constructors": [

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -312,3 +312,14 @@ pub type Box(a, b) {
 pub fn internal_modules_are_not_exported() {
     assert_package_interface_with_name!("internals/internal_module", "pub fn main() { 1 }");
 }
+
+#[test]
+pub fn labelled_function_parameters() {
+    assert_package_interface!(
+        r#"
+pub fn fold(list: List(a), from acc: b, with f: fn(a, b) -> b) -> b {
+  todo
+}
+"#
+    );
+}

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -323,3 +323,17 @@ pub fn fold(list: List(a), from acc: b, with f: fn(a, b) -> b) -> b {
 "#
     );
 }
+
+#[test]
+pub fn constructors_with_documentation() {
+    assert_package_interface!(
+        r#"
+pub type Wibble {
+  /// This is the Wibble variant. It contains some example data.
+  Wibble(Int)
+  /// This is the Wobble variant. It is a recursive type.
+  Wobble(Wibble)
+}
+"#
+    );
+}

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -177,7 +177,7 @@ fn package_from_module(module: Module) -> Package {
                     .expect("internals glob"),
             ]),
         },
-        module_names: vec![module.name.clone()],
+        cached_module_names: Vec::new(),
         modules: vec![module],
     }
 }

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -135,7 +135,11 @@ pub fn compile_package(
     };
     module.attach_doc_and_module_comments();
     let package: Package = package_from_module(module);
-    serde_json::to_string_pretty(&PackageInterface::from_package(&package)).expect("to json")
+    serde_json::to_string_pretty(&PackageInterface::from_package(
+        &package,
+        &Default::default(),
+    ))
+    .expect("to json")
 }
 
 fn package_from_module(module: Module) -> Package {
@@ -173,6 +177,7 @@ fn package_from_module(module: Module) -> Package {
                     .expect("internals glob"),
             ]),
         },
+        module_names: vec![module.name.clone()],
         modules: vec![module],
     }
 }

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -896,6 +896,12 @@ impl ModuleInterface {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Opaque {
+    Opaque,
+    NotOpaque,
+}
+
 /// Information on the constructors of a custom type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeVariantConstructors {
@@ -913,6 +919,7 @@ pub struct TypeVariantConstructors {
     /// and `a` is a Generic type variable with id 1, then this field will be `[1]`.
     ///
     pub type_parameters_ids: Vec<u64>,
+    pub opaque: Opaque,
     pub variants: Vec<TypeValueConstructor>,
 }
 
@@ -920,6 +927,7 @@ impl TypeVariantConstructors {
     pub(crate) fn new(
         variants: Vec<TypeValueConstructor>,
         type_parameters: &[&EcoString],
+        opaque: Opaque,
         hydrator: Hydrator,
     ) -> TypeVariantConstructors {
         let named_types = hydrator.named_type_variables();
@@ -942,6 +950,7 @@ impl TypeVariantConstructors {
         Self {
             type_parameters_ids: type_parameters,
             variants,
+            opaque,
         }
     }
 }
@@ -1212,7 +1221,6 @@ impl TypeVar {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeConstructor {
     pub publicity: Publicity,
-    pub opaque: bool,
     pub origin: SrcSpan,
     pub module: EcoString,
     pub parameters: Vec<Arc<Type>>,

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -886,6 +886,8 @@ pub struct ModuleInterface {
     pub warnings: Vec<Warning>,
     /// The minimum Gleam version needed to use this module.
     pub minimum_required_version: Version,
+    pub type_aliases: HashMap<EcoString, TypeAliasConstructor>,
+    pub documentation: Vec<EcoString>,
 }
 
 impl ModuleInterface {
@@ -954,6 +956,7 @@ pub struct TypeValueConstructor {
 pub struct TypeValueConstructorField {
     /// This type of this parameter
     pub type_: Arc<Type>,
+    pub label: Option<EcoString>,
 }
 
 impl ModuleInterface {
@@ -1208,6 +1211,7 @@ impl TypeVar {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeConstructor {
     pub publicity: Publicity,
+    pub opaque: bool,
     pub origin: SrcSpan,
     pub module: EcoString,
     pub parameters: Vec<Arc<Type>>,
@@ -1302,8 +1306,11 @@ impl ValueConstructor {
 pub struct TypeAliasConstructor {
     pub publicity: Publicity,
     pub module: EcoString,
-    pub type_: Type,
+    pub type_: Arc<Type>,
     pub arity: usize,
+    pub deprecation: Deprecation,
+    pub documentation: Option<EcoString>,
+    pub origin: SrcSpan,
 }
 
 impl ValueConstructor {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -950,6 +950,7 @@ impl TypeVariantConstructors {
 pub struct TypeValueConstructor {
     pub name: EcoString,
     pub parameters: Vec<TypeValueConstructorField>,
+    pub documentation: Option<EcoString>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -47,6 +47,8 @@ pub struct Environment<'a> {
     /// Mapping from types to constructor names in the current module (or the prelude)
     pub module_types_constructors: HashMap<EcoString, TypeVariantConstructors>,
 
+    pub module_type_aliases: HashMap<EcoString, TypeAliasConstructor>,
+
     /// Values defined in the current module (or the prelude)
     pub module_values: HashMap<EcoString, ValueConstructor>,
 
@@ -115,6 +117,7 @@ impl<'a> Environment<'a> {
             entity_usages: vec![HashMap::new()],
             target_support,
             names,
+            module_type_aliases: HashMap::new(),
         }
     }
 }
@@ -311,6 +314,28 @@ impl Environment<'_> {
         let name = type_name.clone();
         let location = info.origin;
         match self.module_types.insert(type_name, info) {
+            None => Ok(()),
+            Some(prelude_type) if is_prelude_module(&prelude_type.module) => Ok(()),
+            Some(previous) => Err(Error::DuplicateTypeName {
+                name,
+                location,
+                previous_location: previous.origin,
+            }),
+        }
+    }
+
+    /// Map a type alias in the current scope.
+    /// Errors if the module already has a type with that name, unless the type is from the
+    /// prelude.
+    ///
+    pub fn insert_type_alias(
+        &mut self,
+        type_name: EcoString,
+        info: TypeAliasConstructor,
+    ) -> Result<(), Error> {
+        let name = type_name.clone();
+        let location = info.origin;
+        match self.module_type_aliases.insert(type_name, info) {
             None => Ok(()),
             Some(prelude_type) if is_prelude_module(&prelude_type.module) => Ok(()),
             Some(previous) => Err(Error::DuplicateTypeName {

--- a/compiler-core/src/type_/fields.rs
+++ b/compiler-core/src/type_/fields.rs
@@ -202,10 +202,10 @@ impl FieldMap {
             .collect_vec()
     }
 
-    pub fn indices_to_labels(&self) -> HashMap<u32, EcoString> {
+    pub fn indices_to_labels(&self) -> HashMap<u32, &EcoString> {
         self.fields
             .iter()
-            .map(|(name, index)| (*index, name.clone()))
+            .map(|(name, index)| (*index, name))
             .collect()
     }
 }

--- a/compiler-core/src/type_/fields.rs
+++ b/compiler-core/src/type_/fields.rs
@@ -201,6 +201,13 @@ impl FieldMap {
             .map(|(label, _position)| label.clone())
             .collect_vec()
     }
+
+    pub fn indices_to_labels(&self) -> HashMap<u32, EcoString> {
+        self.fields
+            .iter()
+            .map(|(name, index)| (*index, name.clone()))
+            .collect()
+    }
 }
 
 #[derive(Debug)]

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -270,10 +270,12 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                             TypeValueConstructor {
                                 name: "True".into(),
                                 parameters: vec![],
+                                documentation: None,
                             },
                             TypeValueConstructor {
                                 name: "False".into(),
                                 parameters: vec![],
+                                documentation: None,
                             },
                         ],
                     },
@@ -411,6 +413,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         variants: vec![TypeValueConstructor {
                             name: "Nil".into(),
                             parameters: vec![],
+                            documentation: None,
                         }],
                     },
                 );
@@ -445,6 +448,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                                     type_: result_value,
                                     label: None,
                                 }],
+                                documentation: None,
                             },
                             TypeValueConstructor {
                                 name: "Error".into(),
@@ -452,6 +456,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                                     type_: result_error,
                                     label: None,
                                 }],
+                                documentation: None,
                             },
                         ],
                     },

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -9,8 +9,9 @@ use crate::{
 };
 
 use super::{
-    ModuleInterface, Type, TypeConstructor, TypeValueConstructor, TypeValueConstructorField,
-    TypeVar, TypeVariantConstructors, ValueConstructor, ValueConstructorVariant,
+    ModuleInterface, Opaque, Type, TypeConstructor, TypeValueConstructor,
+    TypeValueConstructorField, TypeVar, TypeVariantConstructors, ValueConstructor,
+    ValueConstructorVariant,
 };
 use crate::type_::Deprecation::NotDeprecated;
 use std::{cell::RefCell, collections::HashMap, sync::Arc};
@@ -256,7 +257,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     publicity: Publicity::Public,
                     deprecation: NotDeprecated,
                     documentation: None,
-                    opaque: false,
                 };
                 let _ = prelude.types.insert(BIT_ARRAY.into(), v.clone());
             }
@@ -278,6 +278,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                                 documentation: None,
                             },
                         ],
+                        opaque: Opaque::NotOpaque,
                     },
                 );
                 let _ = prelude.values.insert(
@@ -322,7 +323,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
             }
@@ -338,7 +338,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
             }
@@ -354,7 +353,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
             }
@@ -371,7 +369,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
             }
@@ -403,7 +400,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
                 let _ = prelude.types_value_constructors.insert(
@@ -415,6 +411,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                             parameters: vec![],
                             documentation: None,
                         }],
+                        opaque: Opaque::NotOpaque,
                     },
                 );
             }
@@ -434,7 +431,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
                 let _ = prelude.types_value_constructors.insert(
@@ -459,6 +455,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                                 documentation: None,
                             },
                         ],
+                        opaque: Opaque::NotOpaque,
                     },
                 );
                 let ok = generic_var(ids.next());
@@ -510,7 +507,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
             }
@@ -526,7 +522,6 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
-                        opaque: false,
                     },
                 );
             }

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -241,6 +241,8 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         // prelude doesn't have real line numbers
         line_numbers: LineNumbers::new(""),
         minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
     };
 
     for t in PreludeType::iter() {
@@ -254,6 +256,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     publicity: Publicity::Public,
                     deprecation: NotDeprecated,
                     documentation: None,
+                    opaque: false,
                 };
                 let _ = prelude.types.insert(BIT_ARRAY.into(), v.clone());
             }
@@ -317,6 +320,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
             }
@@ -332,6 +336,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
             }
@@ -347,6 +352,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
             }
@@ -363,6 +369,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
             }
@@ -394,6 +401,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
                 let _ = prelude.types_value_constructors.insert(
@@ -423,6 +431,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
                 let _ = prelude.types_value_constructors.insert(
@@ -434,12 +443,14 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                                 name: "Ok".into(),
                                 parameters: vec![TypeValueConstructorField {
                                     type_: result_value,
+                                    label: None,
                                 }],
                             },
                             TypeValueConstructor {
                                 name: "Error".into(),
                                 parameters: vec![TypeValueConstructorField {
                                     type_: result_error,
+                                    label: None,
                                 }],
                             },
                         ],
@@ -494,6 +505,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
             }
@@ -509,6 +521,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
                         documentation: None,
+                        opaque: false,
                     },
                 );
             }

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -835,7 +835,8 @@ fn infer_module_type_retention_test() {
                                 parameters: vec![],
                                 documentation: None,
                             }
-                        ]
+                        ],
+                        opaque: Opaque::NotOpaque,
                     }
                 ),
                 (
@@ -859,7 +860,8 @@ fn infer_module_type_retention_test() {
                                 }],
                                 documentation: None,
                             }
-                        ]
+                        ],
+                        opaque: Opaque::NotOpaque,
                     }
                 ),
                 (
@@ -870,7 +872,8 @@ fn infer_module_type_retention_test() {
                             name: "Nil".into(),
                             parameters: vec![],
                             documentation: None,
-                        }]
+                        }],
+                        opaque: Opaque::NotOpaque,
                     }
                 )
             ]),

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -818,7 +818,6 @@ fn infer_module_type_retention_test() {
             package: "thepackage".into(),
             name: "ok".into(),
             is_internal: false,
-            // Core type constructors like String and Int are not included
             types: HashMap::new(),
             types_value_constructors: HashMap::from([
                 (
@@ -846,12 +845,14 @@ fn infer_module_type_retention_test() {
                                 name: "Ok".into(),
                                 parameters: vec![TypeValueConstructorField {
                                     type_: generic_var(1),
+                                    label: None,
                                 }]
                             },
                             TypeValueConstructor {
                                 name: "Error".into(),
                                 parameters: vec![TypeValueConstructorField {
                                     type_: generic_var(2),
+                                    label: None,
                                 }]
                             }
                         ]
@@ -873,6 +874,8 @@ fn infer_module_type_retention_test() {
             line_numbers: LineNumbers::new(""),
             src_path: "".into(),
             minimum_required_version: Version::new(0, 1, 0),
+            type_aliases: HashMap::new(),
+            documentation: Vec::new(),
         }
     );
 }

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -828,10 +828,12 @@ fn infer_module_type_retention_test() {
                             TypeValueConstructor {
                                 name: "True".into(),
                                 parameters: vec![],
+                                documentation: None,
                             },
                             TypeValueConstructor {
                                 name: "False".into(),
                                 parameters: vec![],
+                                documentation: None,
                             }
                         ]
                     }
@@ -846,14 +848,16 @@ fn infer_module_type_retention_test() {
                                 parameters: vec![TypeValueConstructorField {
                                     type_: generic_var(1),
                                     label: None,
-                                }]
+                                }],
+                                documentation: None,
                             },
                             TypeValueConstructor {
                                 name: "Error".into(),
                                 parameters: vec![TypeValueConstructorField {
                                     type_: generic_var(2),
                                     label: None,
-                                }]
+                                }],
+                                documentation: None,
                             }
                         ]
                     }
@@ -864,7 +868,8 @@ fn infer_module_type_retention_test() {
                         type_parameters_ids: vec![],
                         variants: vec![TypeValueConstructor {
                             name: "Nil".into(),
-                            parameters: vec![]
+                            parameters: vec![],
+                            documentation: None,
                         }]
                     }
                 )


### PR DESCRIPTION
This PR follows on from #3669 and fixes #2898.
It uses partly the same approach of using the `ModuleInterface` (the part which is cached) to generate the package interface, rather than the AST. However, this is implemented in such a way that the cached modules do not need to be cloned when doing so.