### PR TITLE
Use `ProjectPaths` instead of the current directory

### DIFF
--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -2,6 +2,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use gleam_core::{
     error::{FileIoAction, FileKind},
+    paths::ProjectPaths,
     Error, Result,
 };
 
@@ -11,9 +12,7 @@ use crate::{
     fs,
 };
 
-pub fn command(packages_to_add: Vec<String>, dev: bool) -> Result<()> {
-    let paths = crate::find_project_paths()?;
-
+pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) -> Result<()> {
     let mut new_package_requirements = Vec::with_capacity(packages_to_add.len());
     for specifier in packages_to_add {
         new_package_requirements.push(parse_gleam_add_specifier(&specifier)?);

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -30,8 +30,8 @@ pub fn command(packages_to_add: Vec<String>, dev: bool) -> Result<()> {
     )?;
 
     // Read gleam.toml and manifest.toml so we can insert new deps into it
-    let mut gleam_toml = read_toml_edit("gleam.toml")?;
-    let mut manifest_toml = read_toml_edit("manifest.toml")?;
+    let mut gleam_toml = read_toml_edit(paths.root_config().as_str())?;
+    let mut manifest_toml = read_toml_edit(paths.manifest().as_str())?;
 
     // Insert the new deps
     for (added_package, _) in new_package_requirements {
@@ -74,8 +74,14 @@ pub fn command(packages_to_add: Vec<String>, dev: bool) -> Result<()> {
     }
 
     // Write the updated config
-    fs::write(Utf8Path::new("gleam.toml"), &gleam_toml.to_string())?;
-    fs::write(Utf8Path::new("manifest.toml"), &manifest_toml.to_string())?;
+    fs::write(
+        Utf8Path::new(paths.root_config().as_str()),
+        &gleam_toml.to_string(),
+    )?;
+    fs::write(
+        Utf8Path::new(paths.manifest().as_str()),
+        &manifest_toml.to_string(),
+    )?;
 
     Ok(())
 }

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -21,7 +21,7 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
     // Insert the new packages into the manifest and perform dependency
     // resolution to determine suitable versions
     let manifest = crate::dependencies::download(
-        &paths,
+        paths,
         cli::Reporter::new(),
         Some((new_package_requirements.clone(), dev)),
         Vec::new(),

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -30,7 +30,7 @@ pub(crate) fn main_with_warnings(
     warnings: Rc<dyn WarningEmitterIO>,
 ) -> Result<Built> {
     let perform_codegen = options.codegen;
-    let root_config = crate::config::root_config(&paths)?;
+    let root_config = crate::config::root_config(paths)?;
     let telemetry: &'static dyn Telemetry = if options.no_print_progress {
         &NullTelemetry
     } else {
@@ -39,7 +39,7 @@ pub(crate) fn main_with_warnings(
     let io = fs::ProjectIO::new();
     let start = Instant::now();
     let lock = BuildLock::new_target(
-        &paths,
+        paths,
         options.mode,
         options.target.unwrap_or(root_config.target),
     )?;

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -3,6 +3,7 @@ use std::{rc::Rc, time::Instant};
 use gleam_core::{
     build::{Built, Codegen, NullTelemetry, Options, ProjectCompiler, Telemetry},
     manifest::Manifest,
+    paths::ProjectPaths,
     warning::WarningEmitterIO,
     Result,
 };
@@ -14,21 +15,20 @@ use crate::{
     fs::{self, ConsoleWarningEmitter},
 };
 
-pub fn download_dependencies(telemetry: impl Telemetry) -> Result<Manifest> {
-    let paths = crate::find_project_paths()?;
-    crate::dependencies::download(&paths, telemetry, None, Vec::new(), UseManifest::Yes)
+pub fn download_dependencies(paths: &ProjectPaths, telemetry: impl Telemetry) -> Result<Manifest> {
+    crate::dependencies::download(paths, telemetry, None, Vec::new(), UseManifest::Yes)
 }
 
-pub fn main(options: Options, manifest: Manifest) -> Result<Built> {
-    main_with_warnings(options, manifest, Rc::new(ConsoleWarningEmitter))
+pub fn main(paths: &ProjectPaths, options: Options, manifest: Manifest) -> Result<Built> {
+    main_with_warnings(paths, options, manifest, Rc::new(ConsoleWarningEmitter))
 }
 
 pub(crate) fn main_with_warnings(
+    paths: &ProjectPaths,
     options: Options,
     manifest: Manifest,
     warnings: Rc<dyn WarningEmitterIO>,
 ) -> Result<Built> {
-    let paths = crate::find_project_paths()?;
     let perform_codegen = options.codegen;
     let root_config = crate::config::root_config(&paths)?;
     let telemetry: &'static dyn Telemetry = if options.no_print_progress {
@@ -53,7 +53,7 @@ pub(crate) fn main_with_warnings(
             manifest.packages,
             telemetry,
             warnings,
-            paths,
+            paths.clone(),
             io,
         );
         compiler.compile()?

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -7,14 +7,6 @@ use gleam_core::{
     paths::ProjectPaths,
 };
 
-use crate::fs::{get_current_directory, get_project_root};
-
-pub fn root_config() -> Result<PackageConfig, Error> {
-    let dir = get_project_root(get_current_directory()?)?;
-    let paths = ProjectPaths::new(dir);
-    read(paths.root_config())
-}
-
 #[derive(Debug, Clone, Copy)]
 pub enum PackageKind {
     Dependency,
@@ -47,7 +39,7 @@ pub fn find_package_config_for_module(
         return Ok((configuration, PackageKind::Dependency));
     }
 
-    Ok((root_config()?, PackageKind::Root))
+    Ok((root_config(project_paths)?, PackageKind::Root))
 }
 
 fn package_root(package: &ManifestPackage, project_paths: &ProjectPaths) -> Utf8PathBuf {
@@ -58,6 +50,10 @@ fn package_root(package: &ManifestPackage, project_paths: &ProjectPaths) -> Utf8
             project_paths.build_packages_package(&package.name)
         }
     }
+}
+
+pub fn root_config(paths: &ProjectPaths) -> Result<PackageConfig, Error> {
+    read(paths.root_config())
 }
 
 pub fn read(config_path: Utf8PathBuf) -> Result<PackageConfig, Error> {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -50,12 +50,12 @@ static UTF8_SYMBOLS: Symbols = Symbols {
 };
 
 pub fn list(paths: &ProjectPaths) -> Result<()> {
-    let (_, manifest) = get_manifest_details(&paths)?;
+    let (_, manifest) = get_manifest_details(paths)?;
     list_manifest_packages(std::io::stdout(), manifest)
 }
 
 pub fn tree(paths: &ProjectPaths, options: TreeOptions) -> Result<()> {
-    let (config, manifest) = get_manifest_details(&paths)?;
+    let (config, manifest) = get_manifest_details(paths)?;
 
     // Initialize the root package since it is not part of the manifest
     let root_package = ManifestPackage {
@@ -78,9 +78,9 @@ pub fn tree(paths: &ProjectPaths, options: TreeOptions) -> Result<()> {
 
 fn get_manifest_details(paths: &ProjectPaths) -> Result<(PackageConfig, Manifest)> {
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
-    let config = crate::config::root_config(&paths)?;
+    let config = crate::config::root_config(paths)?;
     let (_, manifest) = get_manifest(
-        &paths,
+        paths,
         runtime.handle().clone(),
         Mode::Dev,
         &config,
@@ -210,7 +210,7 @@ pub fn update(paths: &ProjectPaths, packages: Vec<String>) -> Result<()> {
 
     // Update specific packages
     _ = download(
-        &paths,
+        paths,
         cli::Reporter::new(),
         None,
         packages.into_iter().map(EcoString::from).collect(),

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -49,14 +49,12 @@ static UTF8_SYMBOLS: Symbols = Symbols {
     right: "─",
 };
 
-pub fn list() -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn list(paths: &ProjectPaths) -> Result<()> {
     let (_, manifest) = get_manifest_details(&paths)?;
     list_manifest_packages(std::io::stdout(), manifest)
 }
 
-pub fn tree(options: TreeOptions) -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn tree(paths: &ProjectPaths, options: TreeOptions) -> Result<()> {
     let (config, manifest) = get_manifest_details(&paths)?;
 
     // Initialize the root package since it is not part of the manifest
@@ -203,8 +201,7 @@ pub enum UseManifest {
     No,
 }
 
-pub fn update(packages: Vec<String>) -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn update(paths: &ProjectPaths, packages: Vec<String>) -> Result<()> {
     let use_manifest = if packages.is_empty() {
         UseManifest::No
     } else {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -80,7 +80,7 @@ fn get_manifest_details() -> Result<(Utf8PathBuf, PackageConfig, Manifest)> {
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
     let project = fs::get_project_root(fs::get_current_directory()?)?;
     let paths = ProjectPaths::new(project.clone());
-    let config = crate::config::root_config()?;
+    let config = crate::config::root_config(&paths)?;
     let (_, manifest) = get_manifest(
         &paths,
         runtime.handle().clone(),

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -41,7 +41,7 @@ pub struct BuildOptions {
 
 pub fn build(options: BuildOptions) -> Result<()> {
     let paths = crate::find_project_paths()?;
-    let config = crate::config::root_config()?;
+    let config = crate::config::root_config(&paths)?;
 
     // Reset the build directory so we know the state of the project
     crate::fs::delete_directory(&paths.build_directory_for_target(Mode::Prod, config.target))?;
@@ -127,7 +127,7 @@ pub(crate) fn build_documentation(
 
 pub fn publish() -> Result<()> {
     let paths = crate::find_project_paths()?;
-    let config = crate::config::root_config()?;
+    let config = crate::config::root_config(&paths)?;
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
     let hex_config = hexpm::Config::new();

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -11,6 +11,7 @@ use gleam_core::{
     error::Error,
     hex,
     io::HttpClient as _,
+    paths::ProjectPaths,
     Result,
 };
 
@@ -48,6 +49,7 @@ pub fn build(options: BuildOptions) -> Result<()> {
 
     let out = paths.build_documentation_directory(&config.name);
     let mut built = crate::build::main(
+        &paths,
         Options {
             mode: Mode::Prod,
             target: options.target,
@@ -57,9 +59,9 @@ pub fn build(options: BuildOptions) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
             no_print_progress: false,
         },
-        crate::build::download_dependencies(cli::Reporter::new())?,
+        crate::build::download_dependencies(&paths, cli::Reporter::new())?,
     )?;
-    let outputs = build_documentation(&config, &mut built.root_package, DocContext::Build)?;
+    let outputs = build_documentation(&paths, &config, &mut built.root_package, DocContext::Build)?;
 
     // Write
     crate::fs::delete_directory(&out)?;
@@ -95,13 +97,13 @@ fn open_docs(path: &Utf8Path) -> Result<()> {
 }
 
 pub(crate) fn build_documentation(
+    paths: &ProjectPaths,
     config: &PackageConfig,
     compiled: &mut Package,
     is_hex_publish: DocContext,
 ) -> Result<Vec<gleam_core::io::OutputFile>, Error> {
     compiled.attach_doc_and_module_comments();
     cli::print_generating_documentation();
-    let paths = crate::find_project_paths()?;
     let mut pages = vec![DocsPage {
         title: "README".into(),
         path: "index.html".into(),
@@ -138,6 +140,7 @@ pub fn publish() -> Result<()> {
     crate::fs::delete_directory(&paths.build_directory_for_target(Mode::Prod, config.target))?;
 
     let mut built = crate::build::main(
+        &paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -147,9 +150,14 @@ pub fn publish() -> Result<()> {
             target: None,
             no_print_progress: false,
         },
-        crate::build::download_dependencies(cli::Reporter::new())?,
+        crate::build::download_dependencies(&paths, cli::Reporter::new())?,
     )?;
-    let outputs = build_documentation(&config, &mut built.root_package, DocContext::HexPublish)?;
+    let outputs = build_documentation(
+        &paths,
+        &config,
+        &mut built.root_package,
+        DocContext::HexPublish,
+    )?;
     let archive = crate::fs::create_tar_archive(outputs)?;
 
     let start = Instant::now();

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -41,14 +41,14 @@ pub struct BuildOptions {
 }
 
 pub fn build(paths: &ProjectPaths, options: BuildOptions) -> Result<()> {
-    let config = crate::config::root_config(&paths)?;
+    let config = crate::config::root_config(paths)?;
 
     // Reset the build directory so we know the state of the project
     crate::fs::delete_directory(&paths.build_directory_for_target(Mode::Prod, config.target))?;
 
     let out = paths.build_documentation_directory(&config.name);
     let mut built = crate::build::main(
-        &paths,
+        paths,
         Options {
             mode: Mode::Prod,
             target: options.target,
@@ -58,9 +58,9 @@ pub fn build(paths: &ProjectPaths, options: BuildOptions) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
             no_print_progress: false,
         },
-        crate::build::download_dependencies(&paths, cli::Reporter::new())?,
+        crate::build::download_dependencies(paths, cli::Reporter::new())?,
     )?;
-    let outputs = build_documentation(&paths, &config, &mut built.root_package, DocContext::Build)?;
+    let outputs = build_documentation(paths, &config, &mut built.root_package, DocContext::Build)?;
 
     // Write
     crate::fs::delete_directory(&out)?;
@@ -110,7 +110,7 @@ pub(crate) fn build_documentation(
     }];
     pages.extend(config.documentation.pages.iter().cloned());
     let mut outputs = gleam_core::docs::generate_html(
-        &paths,
+        paths,
         config,
         compiled.modules.as_slice(),
         &pages,
@@ -127,7 +127,7 @@ pub(crate) fn build_documentation(
 }
 
 pub fn publish(paths: &ProjectPaths) -> Result<()> {
-    let config = crate::config::root_config(&paths)?;
+    let config = crate::config::root_config(paths)?;
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
     let hex_config = hexpm::Config::new();
@@ -138,7 +138,7 @@ pub fn publish(paths: &ProjectPaths) -> Result<()> {
     crate::fs::delete_directory(&paths.build_directory_for_target(Mode::Prod, config.target))?;
 
     let mut built = crate::build::main(
-        &paths,
+        paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -148,10 +148,10 @@ pub fn publish(paths: &ProjectPaths) -> Result<()> {
             target: None,
             no_print_progress: false,
         },
-        crate::build::download_dependencies(&paths, cli::Reporter::new())?,
+        crate::build::download_dependencies(paths, cli::Reporter::new())?,
     )?;
     let outputs = build_documentation(
-        &paths,
+        paths,
         &config,
         &mut built.root_package,
         DocContext::HexPublish,

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -40,8 +40,7 @@ pub struct BuildOptions {
     pub target: Option<Target>,
 }
 
-pub fn build(options: BuildOptions) -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn build(paths: &ProjectPaths, options: BuildOptions) -> Result<()> {
     let config = crate::config::root_config(&paths)?;
 
     // Reset the build directory so we know the state of the project
@@ -127,8 +126,7 @@ pub(crate) fn build_documentation(
     Ok(outputs)
 }
 
-pub fn publish() -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn publish(paths: &ProjectPaths) -> Result<()> {
     let config = crate::config::root_config(&paths)?;
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -41,7 +41,7 @@ pub(crate) fn erlang_shipment(paths: &ProjectPaths) -> Result<()> {
 
     // Build project in production mode
     let built = crate::build::main(
-        &paths,
+        paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -51,7 +51,7 @@ pub(crate) fn erlang_shipment(paths: &ProjectPaths) -> Result<()> {
             target: Some(target),
             no_print_progress: false,
         },
-        crate::build::download_dependencies(&paths, crate::cli::Reporter::new())?,
+        crate::build::download_dependencies(paths, crate::cli::Reporter::new())?,
     )?;
 
     for entry in crate::fs::read_dir(&build)?.filter_map(Result::ok) {
@@ -102,8 +102,8 @@ the {ENTRYPOINT_FILENAME} script.
 }
 
 pub fn hex_tarball(paths: &ProjectPaths) -> Result<()> {
-    let mut config = crate::config::root_config(&paths)?;
-    let data: Vec<u8> = crate::publish::build_hex_tarball(&paths, &mut config)?;
+    let mut config = crate::config::root_config(paths)?;
+    let data: Vec<u8> = crate::publish::build_hex_tarball(paths, &mut config)?;
 
     let path = paths.build_export_hex_tarball(&config.name, &config.version.to_string());
     crate::fs::write_bytes(&path, &data)?;
@@ -129,7 +129,7 @@ pub fn typescript_prelude() -> Result<()> {
 pub fn package_interface(paths: &ProjectPaths, out: Utf8PathBuf) -> Result<()> {
     // Build the project
     let mut built = crate::build::main(
-        &paths,
+        paths,
         Options {
             mode: Mode::Prod,
             target: None,
@@ -139,7 +139,7 @@ pub fn package_interface(paths: &ProjectPaths, out: Utf8PathBuf) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
             no_print_progress: false,
         },
-        crate::build::download_dependencies(&paths, crate::cli::Reporter::new())?,
+        crate::build::download_dependencies(paths, crate::cli::Reporter::new())?,
     )?;
     built.root_package.attach_doc_and_module_comments();
 

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -102,7 +102,7 @@ the {ENTRYPOINT_FILENAME} script.
 
 pub fn hex_tarball() -> Result<()> {
     let paths = crate::find_project_paths()?;
-    let mut config = crate::config::root_config()?;
+    let mut config = crate::config::root_config(&paths)?;
     let data: Vec<u8> = crate::publish::build_hex_tarball(&paths, &mut config)?;
 
     let path = paths.build_export_hex_tarball(&config.name, &config.version.to_string());

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -27,8 +27,7 @@ static ENTRYPOINT_TEMPLATE: &str = include_str!("../templates/erlang-shipment-en
 /// - ebin
 /// - include
 /// - priv
-pub(crate) fn erlang_shipment() -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub(crate) fn erlang_shipment(paths: &ProjectPaths) -> Result<()> {
     let target = Target::Erlang;
     let mode = Mode::Prod;
     let build = paths.build_directory_for_target(mode, target);
@@ -102,8 +101,7 @@ the {ENTRYPOINT_FILENAME} script.
     Ok(())
 }
 
-pub fn hex_tarball() -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn hex_tarball(paths: &ProjectPaths) -> Result<()> {
     let mut config = crate::config::root_config(&paths)?;
     let data: Vec<u8> = crate::publish::build_hex_tarball(&paths, &mut config)?;
 
@@ -146,6 +144,6 @@ pub fn package_interface(paths: &ProjectPaths, out: Utf8PathBuf) -> Result<()> {
     built.root_package.attach_doc_and_module_comments();
 
     let out = gleam_core::docs::generate_json_package_interface(out, &built.root_package);
-    crate::fs::write_outputs_under(&[out], crate::find_project_paths()?.root())?;
+    crate::fs::write_outputs_under(&[out], paths.root())?;
     Ok(())
 }

--- a/compiler-cli/src/fix.rs
+++ b/compiler-cli/src/fix.rs
@@ -13,8 +13,7 @@ use hexpm::version::Version;
 
 use crate::{build, cli};
 
-pub fn run() -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn run(paths: &ProjectPaths) -> Result<()> {
     // When running gleam fix we want all the compilation warnings to be hidden,
     // at the same time we need to access those to apply the fixes: so we
     // accumulate those into a vector.

--- a/compiler-cli/src/fix.rs
+++ b/compiler-cli/src/fix.rs
@@ -14,11 +14,13 @@ use hexpm::version::Version;
 use crate::{build, cli};
 
 pub fn run() -> Result<()> {
+    let paths = crate::find_project_paths()?;
     // When running gleam fix we want all the compilation warnings to be hidden,
     // at the same time we need to access those to apply the fixes: so we
     // accumulate those into a vector.
     let warnings = Rc::new(VectorWarningEmitterIO::new());
     let _built = build::main_with_warnings(
+        &paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -28,7 +30,7 @@ pub fn run() -> Result<()> {
             target: None,
             no_print_progress: false,
         },
-        build::download_dependencies(cli::Reporter::new())?,
+        build::download_dependencies(&paths, cli::Reporter::new())?,
         warnings.clone(),
     )?;
     let warnings = warnings.take();

--- a/compiler-cli/src/fix.rs
+++ b/compiler-cli/src/fix.rs
@@ -19,7 +19,7 @@ pub fn run(paths: &ProjectPaths) -> Result<()> {
     // accumulate those into a vector.
     let warnings = Rc::new(VectorWarningEmitterIO::new());
     let _built = build::main_with_warnings(
-        &paths,
+        paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -29,12 +29,12 @@ pub fn run(paths: &ProjectPaths) -> Result<()> {
             target: None,
             no_print_progress: false,
         },
-        build::download_dependencies(&paths, cli::Reporter::new())?,
+        build::download_dependencies(paths, cli::Reporter::new())?,
         warnings.clone(),
     )?;
     let warnings = warnings.take();
 
-    fix_minimum_required_version(&paths, warnings)?;
+    fix_minimum_required_version(paths, warnings)?;
 
     println!("Done!");
     Ok(())

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -4,6 +4,7 @@ use crate::{cli, http::HttpClient};
 use gleam_core::{
     hex::{self, RetirementReason},
     io::HttpClient as _,
+    paths::ProjectPaths,
     Error, Result,
 };
 
@@ -48,10 +49,14 @@ pub fn unretire(package: String, version: String) -> Result<()> {
     Ok(())
 }
 
-pub fn revert(package: Option<String>, version: Option<String>) -> Result<()> {
+pub fn revert(
+    paths: &ProjectPaths,
+    package: Option<String>,
+    version: Option<String>,
+) -> Result<()> {
     let (package, version) = match (package, version) {
         (Some(pkg), Some(ver)) => (pkg, ver),
-        (None, Some(ver)) => (crate::config::root_config()?.name.to_string(), ver),
+        (None, Some(ver)) => (crate::config::root_config(&paths)?.name.to_string(), ver),
         (Some(pkg), None) => {
             let query = format!("Which version of package {pkg} do you want to revert?");
             let ver = cli::ask(&query)?;
@@ -59,7 +64,7 @@ pub fn revert(package: Option<String>, version: Option<String>) -> Result<()> {
         }
         (None, None) => {
             // Only want to access root_config once rather than twice
-            let config = crate::config::root_config()?;
+            let config = crate::config::root_config(&paths)?;
             (config.name.to_string(), config.version.to_string())
         }
     };

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -56,7 +56,7 @@ pub fn revert(
 ) -> Result<()> {
     let (package, version) = match (package, version) {
         (Some(pkg), Some(ver)) => (pkg, ver),
-        (None, Some(ver)) => (crate::config::root_config(&paths)?.name.to_string(), ver),
+        (None, Some(ver)) => (crate::config::root_config(paths)?.name.to_string(), ver),
         (Some(pkg), None) => {
             let query = format!("Which version of package {pkg} do you want to revert?");
             let ver = cli::ask(&query)?;
@@ -64,7 +64,7 @@ pub fn revert(
         }
         (None, None) => {
             // Only want to access root_config once rather than twice
-            let config = crate::config::root_config(&paths)?;
+            let config = crate::config::root_config(paths)?;
             (config.name.to_string(), config.version.to_string())
         }
     };

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -739,7 +739,7 @@ fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
 
 fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
     _ = dependencies::download(
-        &paths,
+        paths,
         cli::Reporter::new(),
         None,
         Vec::new(),

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -493,22 +493,30 @@ fn main() {
 }
 
 fn parse_and_run_command() -> Result<(), Error> {
-    let paths = find_project_paths()?;
-
     match Command::parse() {
         Command::Build {
             target,
             warnings_as_errors,
             no_print_progress,
-        } => command_build(&paths, target, warnings_as_errors, no_print_progress),
-
-        Command::Check { target } => command_check(&paths, target),
-
-        Command::Docs(Docs::Build { open, target }) => {
-            docs::build(docs::BuildOptions { open, target })
+        } => {
+            let paths = find_project_paths()?;
+            command_build(&paths, target, warnings_as_errors, no_print_progress)
         }
 
-        Command::Docs(Docs::Publish) => docs::publish(),
+        Command::Check { target } => {
+            let paths = find_project_paths()?;
+            command_check(&paths, target)
+        }
+
+        Command::Docs(Docs::Build { open, target }) => {
+            let paths = find_project_paths()?;
+            docs::build(&paths, docs::BuildOptions { open, target })
+        }
+
+        Command::Docs(Docs::Publish) => {
+            let paths = find_project_paths()?;
+            docs::publish(&paths)
+        }
 
         Command::Docs(Docs::Remove { package, version }) => docs::remove(package, version),
 
@@ -518,21 +526,39 @@ fn parse_and_run_command() -> Result<(), Error> {
             check,
         } => format::run(stdin, check, files),
 
-        Command::Fix => fix::run(),
+        Command::Fix => {
+            let paths = find_project_paths()?;
+            fix::run(&paths)
+        }
 
-        Command::Deps(Dependencies::List) => dependencies::list(),
+        Command::Deps(Dependencies::List) => {
+            let paths = find_project_paths()?;
+            dependencies::list(&paths)
+        }
 
-        Command::Deps(Dependencies::Download) => download_dependencies(),
+        Command::Deps(Dependencies::Download) => {
+            let paths = find_project_paths()?;
+            download_dependencies(&paths)
+        }
 
-        Command::Deps(Dependencies::Update(options)) => dependencies::update(options.packages),
+        Command::Deps(Dependencies::Update(options)) => {
+            let paths = find_project_paths()?;
+            dependencies::update(&paths, options.packages)
+        }
 
-        Command::Deps(Dependencies::Tree(options)) => dependencies::tree(options),
+        Command::Deps(Dependencies::Tree(options)) => {
+            let paths = find_project_paths()?;
+            dependencies::tree(&paths, options)
+        }
 
         Command::Hex(Hex::Authenticate) => hex::authenticate(),
 
         Command::New(options) => new::create(options, COMPILER_VERSION),
 
-        Command::Shell => shell::command(),
+        Command::Shell => {
+            let paths = find_project_paths()?;
+            shell::command(&paths)
+        }
 
         Command::Run {
             target,
@@ -540,26 +566,47 @@ fn parse_and_run_command() -> Result<(), Error> {
             runtime,
             module,
             no_print_progress,
-        } => run::command(
-            arguments,
-            target,
-            runtime,
-            module,
-            run::Which::Src,
-            no_print_progress,
-        ),
+        } => {
+            let paths = find_project_paths()?;
+            run::command(
+                &paths,
+                arguments,
+                target,
+                runtime,
+                module,
+                run::Which::Src,
+                no_print_progress,
+            )
+        }
 
         Command::Test {
             target,
             arguments,
             runtime,
-        } => run::command(arguments, target, runtime, None, run::Which::Test, false),
+        } => {
+            let paths = find_project_paths()?;
+            run::command(
+                &paths,
+                arguments,
+                target,
+                runtime,
+                None,
+                run::Which::Test,
+                false,
+            )
+        }
 
         Command::CompilePackage(opts) => compile_package::command(opts),
 
-        Command::Publish { replace, yes } => publish::command(replace, yes),
+        Command::Publish { replace, yes } => {
+            let paths = find_project_paths()?;
+            publish::command(&paths, replace, yes)
+        }
 
-        Command::PrintConfig => print_config(&paths),
+        Command::PrintConfig => {
+            let paths = find_project_paths()?;
+            print_config(&paths)
+        }
 
         Command::Hex(Hex::Retire {
             package,
@@ -570,23 +617,45 @@ fn parse_and_run_command() -> Result<(), Error> {
 
         Command::Hex(Hex::Unretire { package, version }) => hex::unretire(package, version),
 
-        Command::Hex(Hex::Revert { package, version }) => hex::revert(&paths, package, version),
+        Command::Hex(Hex::Revert { package, version }) => {
+            let paths = find_project_paths()?;
+            hex::revert(&paths, package, version)
+        }
 
-        Command::Add { packages, dev } => add::command(packages, dev),
+        Command::Add { packages, dev } => {
+            let paths = find_project_paths()?;
+            add::command(&paths, packages, dev)
+        }
 
-        Command::Remove { packages } => remove::command(&paths, packages),
+        Command::Remove { packages } => {
+            let paths = find_project_paths()?;
+            remove::command(&paths, packages)
+        }
 
-        Command::Update(options) => dependencies::update(options.packages),
+        Command::Update(options) => {
+            let paths = find_project_paths()?;
+            dependencies::update(&paths, options.packages)
+        }
 
-        Command::Clean => clean(),
+        Command::Clean => {
+            let paths = find_project_paths()?;
+            clean(&paths)
+        }
 
         Command::LanguageServer => lsp::main(),
 
-        Command::Export(ExportTarget::ErlangShipment) => export::erlang_shipment(),
-        Command::Export(ExportTarget::HexTarball) => export::hex_tarball(),
+        Command::Export(ExportTarget::ErlangShipment) => {
+            let paths = find_project_paths()?;
+            export::erlang_shipment(&paths)
+        }
+        Command::Export(ExportTarget::HexTarball) => {
+            let paths = find_project_paths()?;
+            export::hex_tarball(&paths)
+        }
         Command::Export(ExportTarget::JavascriptPrelude) => export::javascript_prelude(),
         Command::Export(ExportTarget::TypescriptPrelude) => export::typescript_prelude(),
         Command::Export(ExportTarget::PackageInterface { output }) => {
+            let paths = find_project_paths()?;
             export::package_interface(&paths, output)
         }
     }
@@ -642,8 +711,7 @@ fn print_config(paths: &ProjectPaths) -> Result<()> {
     Ok(())
 }
 
-fn clean() -> Result<()> {
-    let paths = find_project_paths()?;
+fn clean(paths: &ProjectPaths) -> Result<()> {
     fs::delete_directory(&paths.build_directory())
 }
 
@@ -669,8 +737,7 @@ fn project_paths_at_current_directory_without_toml() -> ProjectPaths {
     ProjectPaths::new(current_dir)
 }
 
-fn download_dependencies() -> Result<()> {
-    let paths = find_project_paths()?;
+fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
     _ = dependencies::download(
         &paths,
         cli::Reporter::new(),

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -574,7 +574,7 @@ fn parse_and_run_command() -> Result<(), Error> {
 
         Command::Add { packages, dev } => add::command(packages, dev),
 
-        Command::Remove { packages } => remove::command(packages),
+        Command::Remove { packages } => remove::command(&paths, packages),
 
         Command::Update(options) => dependencies::update(options.packages),
 

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -500,9 +500,9 @@ fn parse_and_run_command() -> Result<(), Error> {
             target,
             warnings_as_errors,
             no_print_progress,
-        } => command_build(target, warnings_as_errors, no_print_progress),
+        } => command_build(&paths, target, warnings_as_errors, no_print_progress),
 
-        Command::Check { target } => command_check(target),
+        Command::Check { target } => command_check(&paths, target),
 
         Command::Docs(Docs::Build { open, target }) => {
             docs::build(docs::BuildOptions { open, target })
@@ -587,13 +587,14 @@ fn parse_and_run_command() -> Result<(), Error> {
         Command::Export(ExportTarget::JavascriptPrelude) => export::javascript_prelude(),
         Command::Export(ExportTarget::TypescriptPrelude) => export::typescript_prelude(),
         Command::Export(ExportTarget::PackageInterface { output }) => {
-            export::package_interface(output)
+            export::package_interface(&paths, output)
         }
     }
 }
 
-fn command_check(target: Option<Target>) -> Result<()> {
+fn command_check(paths: &ProjectPaths, target: Option<Target>) -> Result<()> {
     let _ = build::main(
+        paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -603,22 +604,24 @@ fn command_check(target: Option<Target>) -> Result<()> {
             target,
             no_print_progress: false,
         },
-        build::download_dependencies(cli::Reporter::new())?,
+        build::download_dependencies(paths, cli::Reporter::new())?,
     )?;
     Ok(())
 }
 
 fn command_build(
+    paths: &ProjectPaths,
     target: Option<Target>,
     warnings_as_errors: bool,
     no_print_progress: bool,
 ) -> Result<()> {
     let manifest = if no_print_progress {
-        build::download_dependencies(NullTelemetry)?
+        build::download_dependencies(paths, NullTelemetry)?
     } else {
-        build::download_dependencies(cli::Reporter::new())?
+        build::download_dependencies(paths, cli::Reporter::new())?
     };
     let _ = build::main(
+        paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors,

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -18,8 +18,7 @@ use std::{io::Write, path::PathBuf, time::Instant};
 
 use crate::{build, cli, docs, fs, http::HttpClient};
 
-pub fn command(replace: bool, i_am_sure: bool) -> Result<()> {
-    let paths = crate::find_project_paths()?;
+pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<()> {
     let mut config = crate::config::root_config(&paths)?;
 
     let should_publish = check_for_gleam_prefix(&config)?

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -20,7 +20,7 @@ use crate::{build, cli, docs, fs, http::HttpClient};
 
 pub fn command(replace: bool, i_am_sure: bool) -> Result<()> {
     let paths = crate::find_project_paths()?;
-    let mut config = crate::config::root_config()?;
+    let mut config = crate::config::root_config(&paths)?;
 
     let should_publish = check_for_gleam_prefix(&config)?
         && check_for_version_zero(&config)?

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -43,6 +43,7 @@ pub fn command(replace: bool, i_am_sure: bool) -> Result<()> {
 
     // Build HTML documentation
     let docs_tarball = fs::create_tar_archive(docs::build_documentation(
+        &paths,
         &config,
         &mut compile_result,
         DocContext::HexPublish,
@@ -275,6 +276,7 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
 
     // Build the project to check that it is valid
     let built = build::main(
+        paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -284,7 +286,7 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
             compile: Compile::All,
             no_print_progress: false,
         },
-        build::download_dependencies(cli::Reporter::new())?,
+        build::download_dependencies(paths, cli::Reporter::new())?,
     )?;
 
     let minimum_required_version = built.minimum_required_version();

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -19,7 +19,7 @@ use std::{io::Write, path::PathBuf, time::Instant};
 use crate::{build, cli, docs, fs, http::HttpClient};
 
 pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<()> {
-    let mut config = crate::config::root_config(&paths)?;
+    let mut config = crate::config::root_config(paths)?;
 
     let should_publish = check_for_gleam_prefix(&config)?
         && check_for_version_zero(&config)?
@@ -35,14 +35,14 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
         data: package_tarball,
         src_files_added,
         generated_files_added,
-    } = do_build_hex_tarball(&paths, &mut config)?;
+    } = do_build_hex_tarball(paths, &mut config)?;
 
     check_for_name_squatting(&compile_result)?;
     check_for_multiple_top_level_modules(&compile_result, i_am_sure)?;
 
     // Build HTML documentation
     let docs_tarball = fs::create_tar_archive(docs::build_documentation(
-        &paths,
+        paths,
         &config,
         &mut compile_result,
         DocContext::HexPublish,

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -44,7 +44,7 @@ pub fn command(paths: &ProjectPaths, packages: Vec<String>) -> Result<()> {
 
     // Write the updated config
     fs::write(root_config.as_path(), &toml.to_string())?;
-    _ = crate::dependencies::cleanup(&paths, cli::Reporter::new())?;
+    _ = crate::dependencies::cleanup(paths, cli::Reporter::new())?;
 
     for package_to_remove in packages {
         cli::print_removed(&package_to_remove);

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -48,9 +48,9 @@ pub fn command(
 
     // Download dependencies
     let manifest = if no_print_progress {
-        crate::build::download_dependencies(NullTelemetry)?
+        crate::build::download_dependencies(&paths, NullTelemetry)?
     } else {
-        crate::build::download_dependencies(crate::cli::Reporter::new())?
+        crate::build::download_dependencies(&paths, crate::cli::Reporter::new())?
     };
 
     // Get the config for the module that is being run to check the target.
@@ -97,7 +97,7 @@ pub fn command(
         no_print_progress,
     };
 
-    let built = crate::build::main(options, manifest)?;
+    let built = crate::build::main(&paths, options, manifest)?;
 
     // A module can not be run if it does not exist or does not have a public main function.
     let main_function = get_or_suggest_main_function(built, &module, target)?;

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -22,6 +22,7 @@ pub enum Which {
 
 // TODO: test
 pub fn command(
+    paths: &ProjectPaths,
     arguments: Vec<String>,
     target: Option<Target>,
     runtime: Option<Runtime>,
@@ -29,8 +30,6 @@ pub fn command(
     which: Which,
     no_print_progress: bool,
 ) -> Result<(), Error> {
-    let paths = crate::find_project_paths()?;
-
     // Validate the module path
     if let Some(mod_path) = &module {
         if !is_gleam_module(mod_path) {

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -47,9 +47,9 @@ pub fn command(
 
     // Download dependencies
     let manifest = if no_print_progress {
-        crate::build::download_dependencies(&paths, NullTelemetry)?
+        crate::build::download_dependencies(paths, NullTelemetry)?
     } else {
-        crate::build::download_dependencies(&paths, crate::cli::Reporter::new())?
+        crate::build::download_dependencies(paths, crate::cli::Reporter::new())?
     };
 
     // Get the config for the module that is being run to check the target.
@@ -57,13 +57,13 @@ pub fn command(
     // belongs to a dependency or to the root package.
     let (mod_config, package_kind) = match &module {
         Some(mod_path) => {
-            crate::config::find_package_config_for_module(mod_path, &manifest, &paths)?
+            crate::config::find_package_config_for_module(mod_path, &manifest, paths)?
         }
-        _ => (crate::config::root_config(&paths)?, PackageKind::Root),
+        _ => (crate::config::root_config(paths)?, PackageKind::Root),
     };
 
     // The root config is required to run the project.
-    let root_config = crate::config::root_config(&paths)?;
+    let root_config = crate::config::root_config(paths)?;
 
     // Determine which module to run
     let module = module.unwrap_or(match which {
@@ -96,7 +96,7 @@ pub fn command(
         no_print_progress,
     };
 
-    let built = crate::build::main(&paths, options, manifest)?;
+    let built = crate::build::main(paths, options, manifest)?;
 
     // A module can not be run if it does not exist or does not have a public main function.
     let main_function = get_or_suggest_main_function(built, &module, target)?;
@@ -113,20 +113,20 @@ pub fn command(
                 target: Target::Erlang,
                 invalid_runtime: r,
             }),
-            _ => run_erlang(&paths, &root_config.name, &module, arguments),
+            _ => run_erlang(paths, &root_config.name, &module, arguments),
         },
         Target::JavaScript => match runtime.unwrap_or(mod_config.javascript.runtime) {
             Runtime::Deno => run_javascript_deno(
-                &paths,
+                paths,
                 &root_config,
                 &main_function.package,
                 &module,
                 arguments,
             ),
             Runtime::NodeJs => {
-                run_javascript_node(&paths, &main_function.package, &module, arguments)
+                run_javascript_node(paths, &main_function.package, &module, arguments)
             }
-            Runtime::Bun => run_javascript_bun(&paths, &main_function.package, &module, arguments),
+            Runtime::Bun => run_javascript_bun(paths, &main_function.package, &module, arguments),
         },
     }?;
 

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -60,11 +60,11 @@ pub fn command(
         Some(mod_path) => {
             crate::config::find_package_config_for_module(mod_path, &manifest, &paths)?
         }
-        _ => (crate::config::root_config()?, PackageKind::Root),
+        _ => (crate::config::root_config(&paths)?, PackageKind::Root),
     };
 
     // The root config is required to run the project.
-    let root_config = crate::config::root_config()?;
+    let root_config = crate::config::root_config(&paths)?;
 
     // Determine which module to run
     let module = module.unwrap_or(match which {

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -10,6 +10,7 @@ pub fn command() -> Result<(), Error> {
 
     // Build project
     let _ = crate::build::main(
+        &paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -19,7 +20,7 @@ pub fn command() -> Result<(), Error> {
             target: Some(Target::Erlang),
             no_print_progress: false,
         },
-        crate::build::download_dependencies(crate::cli::Reporter::new())?,
+        crate::build::download_dependencies(&paths, crate::cli::Reporter::new())?,
     )?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 pub fn command(paths: &ProjectPaths) -> Result<(), Error> {
     // Build project
     let _ = crate::build::main(
-        &paths,
+        paths,
         Options {
             root_target_support: TargetSupport::Enforced,
             warnings_as_errors: false,
@@ -19,7 +19,7 @@ pub fn command(paths: &ProjectPaths) -> Result<(), Error> {
             target: Some(Target::Erlang),
             no_print_progress: false,
         },
-        crate::build::download_dependencies(&paths, crate::cli::Reporter::new())?,
+        crate::build::download_dependencies(paths, crate::cli::Reporter::new())?,
     )?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell

--- a/compiler-cli/src/shell.rs
+++ b/compiler-cli/src/shell.rs
@@ -2,12 +2,11 @@ use gleam_core::{
     analyse::TargetSupport,
     build::{Codegen, Compile, Mode, Options, Target},
     error::Error,
+    paths::ProjectPaths,
 };
 use std::process::Command;
 
-pub fn command() -> Result<(), Error> {
-    let paths = crate::find_project_paths()?;
-
+pub fn command(paths: &ProjectPaths) -> Result<(), Error> {
     // Build project
     let _ = crate::build::main(
         &paths,


### PR DESCRIPTION
In this PR I've changed all gleam commands that need to access project's files to use `ProjectPaths` passed in as an argument. This means that the `ProjectPaths` only gets built once per command and reused everywhere, instead of building it from scratch in multiple places by looking at the current working directory.
This also means it will be easier to test each command, being able to feed it the path where a test project is located, instead of relying on the current working directory.