### PR TITLE
introduce `Command` struct and split `run` to make it easier to test

### DIFF
--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -11,7 +11,7 @@ use crate::{
     config::PackageConfig,
     dep_tree,
     error::{FileIoAction, FileKind, ShellCommandFailureReason},
-    io::{BeamCompiler, CommandExecutor, FileSystemReader, FileSystemWriter, Stdio},
+    io::{BeamCompiler, Command, CommandExecutor, FileSystemReader, FileSystemWriter, Stdio},
     manifest::{ManifestPackage, ManifestPackageSource},
     metadata,
     paths::{self, ProjectPaths},
@@ -361,27 +361,30 @@ where
         self.io.mkdir(&package_build)?;
         self.io.copy_dir(&package, &package_build)?;
 
-        let env = [
-            ("ERL_LIBS", "../*/ebin".into()),
-            ("REBAR_BARE_COMPILER_OUTPUT_DIR", package_build.to_string()),
-            ("REBAR_PROFILE", "prod".into()),
-            ("REBAR_SKIP_PROJECT_PLUGINS", "true".into()),
-            ("TERM", "dumb".into()),
+        let env = vec![
+            ("ERL_LIBS".to_string(), "../*/ebin".to_string()),
+            (
+                "REBAR_BARE_COMPILER_OUTPUT_DIR".to_string(),
+                package_build.to_string(),
+            ),
+            ("REBAR_PROFILE".to_string(), "prod".to_string()),
+            ("REBAR_SKIP_PROJECT_PLUGINS".to_string(), "true".to_string()),
+            ("TERM".to_string(), "dumb".to_string()),
         ];
-        let args = [
+        let args = vec![
             "bare".into(),
             "compile".into(),
             "--paths".into(),
             "../*/ebin".into(),
         ];
 
-        let status = self.io.exec(
-            REBAR_EXECUTABLE,
-            &args,
-            &env,
-            Some(&package_build),
-            self.subprocess_stdio,
-        )?;
+        let status = self.io.exec(Command {
+            program: REBAR_EXECUTABLE.into(),
+            args,
+            env,
+            cwd: Some(package_build),
+            stdio: self.subprocess_stdio,
+        })?;
 
         if status == 0 {
             Ok(())
@@ -451,29 +454,30 @@ where
             }
         }
 
-        let env = [
-            ("MIX_BUILD_PATH", mix_path(&mix_build_dir)),
-            ("MIX_ENV", mix_target.into()),
-            ("MIX_QUIET", "1".into()),
-            ("TERM", "dumb".into()),
+        let env = vec![
+            ("MIX_BUILD_PATH".to_string(), mix_path(&mix_build_dir)),
+            ("MIX_ENV".to_string(), mix_target.to_string()),
+            ("MIX_QUIET".to_string(), "1".to_string()),
+            ("TERM".to_string(), "dumb".to_string()),
         ];
-        let args = [
-            "-pa".into(),
+        let args = vec![
+            "-pa".to_string(),
             mix_path(&ebins),
-            "-S".into(),
-            "mix".into(),
-            "compile".into(),
-            "--no-deps-check".into(),
-            "--no-load-deps".into(),
-            "--no-protocol-consolidation".into(),
+            "-S".to_string(),
+            "mix".to_string(),
+            "compile".to_string(),
+            "--no-deps-check".to_string(),
+            "--no-load-deps".to_string(),
+            "--no-protocol-consolidation".to_string(),
         ];
-        let status = self.io.exec(
-            ELIXIR_EXECUTABLE,
-            &args,
-            &env,
-            Some(&project_dir),
-            self.subprocess_stdio,
-        )?;
+
+        let status = self.io.exec(Command {
+            program: ELIXIR_EXECUTABLE.into(),
+            args,
+            env,
+            cwd: Some(project_dir),
+            stdio: self.subprocess_stdio,
+        })?;
 
         if status == 0 {
             // TODO: unit test

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -307,14 +307,17 @@ fn files_with_extension<'a>(
 
 /// A trait used to run other programs.
 pub trait CommandExecutor {
-    fn exec(
-        &self,
-        program: &str,
-        args: &[String],
-        env: &[(&str, String)],
-        cwd: Option<&Utf8Path>,
-        stdio: Stdio,
-    ) -> Result<i32, Error>;
+    fn exec(&self, command: Command) -> Result<i32, Error>;
+}
+
+/// A command one can run with a `CommandExecutor`
+#[derive(Debug, Eq, PartialEq)]
+pub struct Command {
+    pub program: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub cwd: Option<Utf8PathBuf>,
+    pub stdio: Stdio,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -424,14 +424,7 @@ impl io::Write for InMemoryFile {
 }
 
 impl CommandExecutor for InMemoryFileSystem {
-    fn exec(
-        &self,
-        _program: &str,
-        _args: &[String],
-        _env: &[(&str, String)],
-        _cwd: Option<&Utf8Path>,
-        _stdio: Stdio,
-    ) -> Result<i32, Error> {
+    fn exec(&self, _command: Command) -> Result<i32, Error> {
         Ok(0) // Always succeed.
     }
 }

--- a/compiler-core/src/language_server/files.rs
+++ b/compiler-core/src/language_server/files.rs
@@ -6,7 +6,7 @@ use debug_ignore::DebugIgnore;
 use crate::{
     error::Error,
     io::{
-        memory::InMemoryFileSystem, BeamCompiler, CommandExecutor, FileSystemReader,
+        memory::InMemoryFileSystem, BeamCompiler, Command, CommandExecutor, FileSystemReader,
         FileSystemWriter, ReadDir, Stdio, WrappedReader,
     },
     Result,
@@ -157,14 +157,7 @@ impl<IO> CommandExecutor for FileSystemProxy<IO>
 where
     IO: CommandExecutor,
 {
-    fn exec(
-        &self,
-        _program: &str,
-        _args: &[String],
-        _env: &[(&str, String)],
-        _cwd: Option<&Utf8Path>,
-        _stdio: Stdio,
-    ) -> Result<i32> {
+    fn exec(&self, _command: Command) -> Result<i32> {
         panic!("The language server is not permitted to create subprocesses")
     }
 }

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -23,7 +23,7 @@ use lsp_types::{Position, TextDocumentIdentifier, TextDocumentPositionParams, Ur
 use crate::{
     config::PackageConfig,
     io::{
-        memory::InMemoryFileSystem, BeamCompiler, CommandExecutor, FileSystemReader,
+        memory::InMemoryFileSystem, BeamCompiler, Command, CommandExecutor, FileSystemReader,
         FileSystemWriter, ReadDir, WrappedReader,
     },
     language_server::{
@@ -209,14 +209,14 @@ impl DownloadDependencies for LanguageServerTestIO {
 }
 
 impl CommandExecutor for LanguageServerTestIO {
-    fn exec(
-        &self,
-        program: &str,
-        args: &[String],
-        env: &[(&str, String)],
-        cwd: Option<&Utf8Path>,
-        stdio: crate::io::Stdio,
-    ) -> Result<i32> {
+    fn exec(&self, command: Command) -> Result<i32> {
+        let Command {
+            program,
+            args,
+            env,
+            cwd,
+            stdio,
+        } = command;
         panic!("exec({program:?}, {args:?}, {env:?}, {cwd:?}, {stdio:?}) is not implemented")
     }
 }

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -1,7 +1,7 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use gleam_core::{
     io::{
-        memory::InMemoryFileSystem, BeamCompiler, CommandExecutor, FileSystemReader,
+        memory::InMemoryFileSystem, BeamCompiler, Command, CommandExecutor, FileSystemReader,
         FileSystemWriter, ReadDir, Stdio, WrappedReader,
     },
     Error, Result,
@@ -20,14 +20,7 @@ impl WasmFileSystem {
 }
 
 impl CommandExecutor for WasmFileSystem {
-    fn exec(
-        &self,
-        _program: &str,
-        _args: &[String],
-        _env: &[(&str, String)],
-        _cwd: Option<&Utf8Path>,
-        _stdio: Stdio,
-    ) -> Result<i32, Error> {
+    fn exec(&self, _command: Command) -> Result<i32, Error> {
         Ok(0) // Always succeed.
     }
 }


### PR DESCRIPTION
To make it easier to test the `run` command I've split it into a `setup` function separate from the command running: so we will be able to reuse that command in tests with a different project runner (I'll need this in the echo PR to write integration tests to capture a project's output once it's run)