### PR TITLE
Add missing comma

### DIFF
--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3371,7 +3371,7 @@ impl<'a> GenerateJsonEncoder<'a> {
 {encoders},
 {indent}])",
             tag = variant_tag
-                .map(|tag| eco_format!("\n{indent}  #(\"type\", {json_module}.string(\"{tag}\"))"))
+                .map(|tag| eco_format!("\n{indent}  #(\"type\", {json_module}.string(\"{tag}\")),"))
                 .unwrap_or_default()
         ))
     }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_json_encoder_for_multi_variant_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_json_encoder_for_multi_variant_type.snap
@@ -22,12 +22,12 @@ pub type Wibble {
 fn encode_wibble(wibble: Wibble) -> json.Json {
   case wibble {
     Wibble(..) -> json.object([
-      #("type", json.string("wibble"))
+      #("type", json.string("wibble")),
       #("wibble", json.int(wibble.wibble)),
       #("next", encode_wibble(wibble.next)),
     ])
     Wobble(..) -> json.object([
-      #("type", json.string("wobble"))
+      #("type", json.string("wobble")),
       #("wobble", json.float(wibble.wobble)),
       #("text", json.string(wibble.text)),
       #("values", json.array(wibble.values, json.bool)),

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_json_encoder_for_multi_variant_type_multi_word_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_json_encoder_for_multi_variant_type_multi_word_name.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-assertion_line: 5134
 expression: "\npub type Wibble {\n  OneTwoThree(wibble: Int, next: Wibble)\n  FourFive(wobble: Float, text: String, values: List(Bool))\n  SixSevenEight(one_two: Float)\n}\n"
-snapshot_kind: text
 ---
 ----- BEFORE ACTION
 
@@ -26,18 +24,18 @@ pub type Wibble {
 fn encode_wibble(wibble: Wibble) -> json.Json {
   case wibble {
     OneTwoThree(..) -> json.object([
-      #("type", json.string("one_two_three"))
+      #("type", json.string("one_two_three")),
       #("wibble", json.int(wibble.wibble)),
       #("next", encode_wibble(wibble.next)),
     ])
     FourFive(..) -> json.object([
-      #("type", json.string("four_five"))
+      #("type", json.string("four_five")),
       #("wobble", json.float(wibble.wobble)),
       #("text", json.string(wibble.text)),
       #("values", json.array(wibble.values, json.bool)),
     ])
     SixSevenEight(..) -> json.object([
-      #("type", json.string("six_seven_eight"))
+      #("type", json.string("six_seven_eight")),
       #("one_two", json.float(wibble.one_two)),
     ])
   }


### PR DESCRIPTION
I noticed when using the "Generate JSON Encoder" code action that I had missed a comma and the syntax was invalid. This PR fixes that small error