### PR TITLE
Fix pattern match on arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,11 @@
   provided labels.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the "Pattern match on argument" and
+  "Pattern match on variable" code actions would not allow to pattern match on a
+  private type used in the same module it's defined in.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.8.1 - 2025-02-11
 
 ### Bug fixes

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -4547,6 +4547,41 @@ pub fn main(arg: Wibble) {
 }
 
 #[test]
+fn pattern_match_on_argument_with_private_type_from_same_module() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_ARGUMENT,
+        "
+type Wibble {
+  Wobble(Int, String)
+}
+
+pub fn main(arg: Wibble) {
+  todo
+}
+",
+        find_position_of("arg").select_until(find_position_of("Wibble").nth_occurrence(2))
+    );
+}
+
+#[test]
+fn pattern_match_on_value_with_private_type_from_same_module() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_VARIABLE,
+        "
+type Wibble {
+  Wobble(Int, String)
+}
+
+pub fn main() {
+  let wibble = Wobble(1, \"Hello\")
+  todo
+}
+",
+        find_position_of("wibble").to_selection()
+    );
+}
+
+#[test]
 fn pattern_match_on_argument_will_use_qualified_name() {
     let src = "
 import wibble

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__pattern_match_on_argument_with_private_type_from_same_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__pattern_match_on_argument_with_private_type_from_same_module.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\ntype Wibble {\n  Wobble(Int, String)\n}\n\npub fn main(arg: Wibble) {\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+type Wibble {
+  Wobble(Int, String)
+}
+
+pub fn main(arg: Wibble) {
+            ▔▔▔▔▔↑        
+  todo
+}
+
+
+----- AFTER ACTION
+
+type Wibble {
+  Wobble(Int, String)
+}
+
+pub fn main(arg: Wibble) {
+  let Wobble(int, string) = arg
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__pattern_match_on_value_with_private_type_from_same_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__pattern_match_on_value_with_private_type_from_same_module.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\ntype Wibble {\n  Wobble(Int, String)\n}\n\npub fn main() {\n  let wibble = Wobble(1, \"Hello\")\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+type Wibble {
+  Wobble(Int, String)
+}
+
+pub fn main() {
+  let wibble = Wobble(1, "Hello")
+      ↑                          
+  todo
+}
+
+
+----- AFTER ACTION
+
+type Wibble {
+  Wobble(Int, String)
+}
+
+pub fn main() {
+  let wibble = Wobble(1, "Hello")
+  let Wobble(int, string) = wibble
+  todo
+}


### PR DESCRIPTION
This PR fixes a bug with the "pattern match on argument/value" code actions that prevented them from pattern matching on private types in the same module they're defined in.