### PR TITLE
Increase version to 1.9.0-pre so nightlies support `gleam = ">= 1.9"`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "gleam"
-version = "1.8.1"
+version = "1.9.0-pre"
 dependencies = [
  "async-trait",
  "base16",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "gleam-core"
-version = "1.8.1"
+version = "1.9.0-pre"
 dependencies = [
  "age",
  "askama",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "gleam-wasm"
-version = "1.8.1"
+version = "1.9.0-pre"
 dependencies = [
  "camino",
  "console_error_panic_hook",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "test-package-compiler"
-version = "1.8.1"
+version = "1.9.0-pre"
 dependencies = [
  "camino",
  "gleam-core",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "test-project-compiler"
-version = "1.8.1"
+version = "1.9.0-pre"
 dependencies = [
  "camino",
  "gleam-core",

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "1.8.1"
+version = "1.9.0-pre"
 authors = ["Louis Pilfold <louis@lpil.uk>"]
 edition = "2021"
 license-file = "LICENCE"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam-core"
-version = "1.8.1"
+version = "1.9.0-pre"
 authors = ["Louis Pilfold <louis@lpil.uk>"]
 edition = "2021"
 license-file = "LICENCE"

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam-wasm"
-version = "1.8.1"
+version = "1.9.0-pre"
 authors = ["Louis Pilfold <louis@lpil.uk>"]
 edition = "2021"
 license-file = "LICENCE"

--- a/test-package-compiler/Cargo.toml
+++ b/test-package-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-package-compiler"
-version = "1.8.1"
+version = "1.9.0-pre"
 authors = ["Louis Pilfold <louis@lpil.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/test-project-compiler/Cargo.toml
+++ b/test-project-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-project-compiler"
-version = "1.8.1"
+version = "1.9.0-pre"
 authors = ["Louis Pilfold <louis@lpil.uk>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Not sure if this change aligns with the version bumping approach, but it allows https://github.com/gleam-lang/stdlib/pull/761 to specify `gleam = ">= 1.9"` when run against nightly.