### PR TITLE
Implement LSP Hover for module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,10 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The Language Server now shows module documentation when hovering over a module
+  name.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Formatter
 
 - Redundant function captures that take no additional arguments are now

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -419,7 +419,9 @@ impl TypeAst {
                     None
                 })
                 .or(Some(Located::Annotation(self.location(), type_))),
-            TypeAst::Constructor(TypeAstConstructor { arguments, .. }) => type_
+            TypeAst::Constructor(TypeAstConstructor {
+                arguments, module, ..
+            }) => type_
                 .constructor_types()
                 .and_then(|arg_types| {
                     if let Some(arg) = arguments
@@ -432,6 +434,13 @@ impl TypeAst {
 
                     None
                 })
+                .or(module.as_ref().and_then(|(name, location)| {
+                    if location.contains(byte_index) {
+                        Some(Located::ModuleName(*location, name))
+                    } else {
+                        None
+                    }
+                }))
                 .or(Some(Located::Annotation(self.location(), type_))),
             TypeAst::Tuple(TypeAstTuple { elems, .. }) => type_
                 .tuple_types()

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -436,7 +436,11 @@ impl TypeAst {
                 })
                 .or(module.as_ref().and_then(|(name, location)| {
                     if location.contains(byte_index) {
-                        Some(Located::ModuleName(*location, name))
+                        Some(Located::ModuleName {
+                            location: *location,
+                            name,
+                            layer: Layer::Type,
+                        })
                     } else {
                         None
                     }

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -384,7 +384,14 @@ fn find_node_module_select() {
     };
 
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), None);
+    assert_eq!(
+        expr.find_node(1),
+        Some(Located::ModuleName {
+            location: SrcSpan::new(1, 1),
+            name: &"name".into(),
+            layer: super::Layer::Value
+        })
+    );
     assert_eq!(expr.find_node(2), Some(Located::Expression(&expr)));
     assert_eq!(expr.find_node(3), Some(Located::Expression(&expr)));
 }

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -200,6 +200,7 @@ impl TypedExpr {
             Self::ModuleSelect {
                 location,
                 field_start,
+                module_name,
                 ..
             } => {
                 // We want to return the `ModuleSelect` only when we're hovering
@@ -209,8 +210,13 @@ impl TypedExpr {
                     end: location.end,
                 };
 
+                // We subtract 1 so the location doesn't include the `.` character.
+                let module_span = SrcSpan::new(location.start, field_start - 1);
+
                 if field_span.contains(byte_index) {
                     Some(self.into())
+                } else if module_span.contains(byte_index) {
+                    Some(Located::ModuleName(module_span, module_name))
                 } else {
                     None
                 }

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -216,7 +216,11 @@ impl TypedExpr {
                 if field_span.contains(byte_index) {
                     Some(self.into())
                 } else if module_span.contains(byte_index) {
-                    Some(Located::ModuleName(module_span, module_name))
+                    Some(Located::ModuleName {
+                        location: module_span,
+                        name: module_name,
+                        layer: Layer::Value,
+                    })
                 } else {
                     None
                 }

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -344,6 +344,7 @@ pub enum Located<'a> {
     Annotation(SrcSpan, std::sync::Arc<Type>),
     UnqualifiedImport(UnqualifiedImport<'a>),
     Label(SrcSpan, std::sync::Arc<Type>),
+    ModuleName(SrcSpan, &'a EcoString),
 }
 
 impl<'a> Located<'a> {
@@ -398,6 +399,10 @@ impl<'a> Located<'a> {
             Self::Arg(_) => None,
             Self::Annotation(_, type_) => self.type_location(importable_modules, type_.clone()),
             Self::Label(_, _) => None,
+            Self::ModuleName(_, name) => Some(DefinitionLocation {
+                module: Some((*name).clone()),
+                span: SrcSpan::new(0, 0),
+            }),
         }
     }
 
@@ -413,6 +418,7 @@ impl<'a> Located<'a> {
             Located::ModuleStatement(definition) => None,
             Located::FunctionBody(function) => None,
             Located::UnqualifiedImport(unqualified_import) => None,
+            Located::ModuleName(_, _) => None,
         }
     }
 

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -17,7 +17,7 @@ pub use self::project_compiler::{Built, Options, ProjectCompiler};
 pub use self::telemetry::{NullTelemetry, Telemetry};
 
 use crate::ast::{
-    CallArg, CustomType, DefinitionLocation, Pattern, TypeAst, TypedArg, TypedDefinition,
+    self, CallArg, CustomType, DefinitionLocation, Pattern, TypeAst, TypedArg, TypedDefinition,
     TypedExpr, TypedFunction, TypedPattern, TypedStatement,
 };
 use crate::type_::Type;
@@ -344,7 +344,11 @@ pub enum Located<'a> {
     Annotation(SrcSpan, std::sync::Arc<Type>),
     UnqualifiedImport(UnqualifiedImport<'a>),
     Label(SrcSpan, std::sync::Arc<Type>),
-    ModuleName(SrcSpan, &'a EcoString),
+    ModuleName {
+        location: SrcSpan,
+        name: &'a EcoString,
+        layer: ast::Layer,
+    },
 }
 
 impl<'a> Located<'a> {
@@ -399,7 +403,7 @@ impl<'a> Located<'a> {
             Self::Arg(_) => None,
             Self::Annotation(_, type_) => self.type_location(importable_modules, type_.clone()),
             Self::Label(_, _) => None,
-            Self::ModuleName(_, name) => Some(DefinitionLocation {
+            Self::ModuleName { name, .. } => Some(DefinitionLocation {
                 module: Some((*name).clone()),
                 span: SrcSpan::new(0, 0),
             }),
@@ -418,7 +422,7 @@ impl<'a> Located<'a> {
             Located::ModuleStatement(definition) => None,
             Located::FunctionBody(function) => None,
             Located::UnqualifiedImport(unqualified_import) => None,
-            Located::ModuleName(_, _) => None,
+            Located::ModuleName { .. } => None,
         }
     }
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1333,19 +1333,15 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass<'as
     ) {
         let range = src_span_to_lsp_range(*location, &self.line_numbers);
         if overlaps(self.params.range, range) {
-            if let Some((module_alias, module_location)) = module {
-                if let Some(import) =
-                    self.module
-                        .find_node(module_location.start)
-                        .and_then(|node| {
-                            if let Located::Annotation(_, ty) = node {
-                                if let Some((module, _)) = ty.named_type_name() {
-                                    return self.get_module_import(&module, name, ast::Layer::Type);
-                                }
-                            }
-                            None
-                        })
-                {
+            if let Some((module_alias, _)) = module {
+                if let Some(import) = self.module.find_node(location.end).and_then(|node| {
+                    if let Located::Annotation(_, ty) = node {
+                        if let Some((module, _)) = ty.named_type_name() {
+                            return self.get_module_import(&module, name, ast::Layer::Type);
+                        }
+                    }
+                    None
+                }) {
                     self.qualified_constructor = Some(QualifiedConstructor {
                         import,
                         module_aliased: import.as_name.is_some(),

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -322,6 +322,8 @@ where
                 Located::Annotation(_, _) => Some(completer.completion_types()),
 
                 Located::Label(_, _) => None,
+
+                Located::ModuleName(_, _) => None,
             };
 
             Ok(completions)
@@ -827,6 +829,17 @@ Unused labelled fields:
                 }
                 Located::Label(location, type_) => {
                     Some(hover_for_label(location, type_, lines, module))
+                }
+                Located::ModuleName(location, name) => {
+                    let Some(module) = this.compiler.modules.get(name) else {
+                        return Ok(None);
+                    };
+                    Some(Hover {
+                        contents: HoverContents::Scalar(MarkedString::String(
+                            module.ast.documentation.join("\n"),
+                        )),
+                        range: Some(src_span_to_lsp_range(location, &lines)),
+                    })
                 }
             })
         })

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -834,10 +834,15 @@ Unused labelled fields:
                     let Some(module) = this.compiler.modules.get(name) else {
                         return Ok(None);
                     };
+                    let contents = format!(
+                        "```gleam
+{name}
+```
+{}",
+                        module.ast.documentation.join("\n")
+                    );
                     Some(Hover {
-                        contents: HoverContents::Scalar(MarkedString::String(
-                            module.ast.documentation.join("\n"),
-                        )),
+                        contents: HoverContents::Scalar(MarkedString::String(contents)),
                         range: Some(src_span_to_lsp_range(location, &lines)),
                     })
                 }

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -2,8 +2,8 @@ use crate::{
     Error, Result, Warning,
     analyse::name::correct_name_case,
     ast::{
-        ArgNames, CustomType, Definition, DefinitionLocation, ModuleConstant, Pattern, SrcSpan,
-        TypedArg, TypedExpr, TypedFunction, TypedModule, TypedPattern,
+        self, ArgNames, CustomType, Definition, DefinitionLocation, ModuleConstant, Pattern,
+        SrcSpan, TypedArg, TypedExpr, TypedFunction, TypedModule, TypedPattern,
     },
     build::{Located, Module, UnqualifiedImport, type_constructor_from_modules},
     config::PackageConfig,
@@ -323,7 +323,14 @@ where
 
                 Located::Label(_, _) => None,
 
-                Located::ModuleName(_, _) => None,
+                Located::ModuleName {
+                    layer: ast::Layer::Type,
+                    ..
+                } => Some(completer.completion_types()),
+                Located::ModuleName {
+                    layer: ast::Layer::Value,
+                    ..
+                } => Some(completer.completion_values()),
             };
 
             Ok(completions)
@@ -830,7 +837,7 @@ Unused labelled fields:
                 Located::Label(location, type_) => {
                     Some(hover_for_label(location, type_, lines, module))
                 }
-                Located::ModuleName(location, name) => {
+                Located::ModuleName { location, name, .. } => {
                     let Some(module) = this.compiler.modules.get(name) else {
                         return Ok(None);
                     };

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -791,3 +791,19 @@ pub fn main() {
         find_position_of("w: Wibble").under_char('i')
     );
 }
+
+#[test]
+fn goto_definition_module() {
+    let code = "
+import wibble
+
+pub fn main() {
+  wibble.wibble()
+}
+";
+
+    assert_goto!(
+        TestProject::for_source(code).add_module("wibble", "pub fn wibble() {}"),
+        find_position_of("wibble.").under_char('i')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1507,6 +1507,30 @@ pub fn wibble() {
 }
 
 #[test]
+fn hover_over_module_with_path() {
+    let src = "
+import wibble/wobble
+
+pub fn main() {
+  wobble.wibble()
+}
+";
+    assert_hover!(
+        TestProject::for_source(src).add_module(
+            "wibble/wobble",
+            "
+//// The module documentation
+
+pub fn wibble() {
+  todo
+}
+"
+        ),
+        find_position_of("wobble.")
+    );
+}
+
+#[test]
 fn hover_over_module_name_in_annotation() {
     let src = "
 import wibble

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1505,3 +1505,27 @@ pub fn wibble() {
         find_position_of("wibble.")
     );
 }
+
+#[test]
+fn hover_over_module_name_in_annotation() {
+    let src = "
+import wibble
+
+pub fn main(w: wibble.Wibble) {
+  todo
+}
+";
+    assert_hover!(
+        TestProject::for_source(src).add_module(
+            "wibble",
+            "
+//// This is the wibble module.
+//// Here is some documentation about it.
+//// This module does stuff
+
+pub type Wibble
+"
+        ),
+        find_position_of("wibble.")
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1553,3 +1553,21 @@ pub type Wibble
         find_position_of("wibble.")
     );
 }
+
+#[test]
+fn hover_over_imported_module() {
+    let src = "
+import wibble
+";
+    assert_hover!(
+        TestProject::for_source(src).add_module(
+            "wibble",
+            "
+//// This is the wibble module.
+//// Here is some documentation about it.
+//// This module does stuff
+"
+        ),
+        find_position_of("wibble")
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1490,7 +1490,7 @@ pub fn main() {
 }
 ";
     assert_hover!(
-        TestProject::for_source(src).add_module(
+        TestProject::for_source(src).add_hex_module(
             "wibble",
             "
 //// This is the wibble module.
@@ -1516,7 +1516,7 @@ pub fn main() {
 }
 ";
     assert_hover!(
-        TestProject::for_source(src).add_module(
+        TestProject::for_source(src).add_hex_module(
             "wibble/wobble",
             "
 //// The module documentation
@@ -1540,7 +1540,7 @@ pub fn main(w: wibble.Wibble) {
 }
 ";
     assert_hover!(
-        TestProject::for_source(src).add_module(
+        TestProject::for_source(src).add_hex_module(
             "wibble",
             "
 //// This is the wibble module.
@@ -1556,6 +1556,24 @@ pub type Wibble
 
 #[test]
 fn hover_over_imported_module() {
+    let src = "
+import wibble
+";
+    assert_hover!(
+        TestProject::for_source(src).add_hex_module(
+            "wibble",
+            "
+//// This is the wibble module.
+//// Here is some documentation about it.
+//// This module does stuff
+"
+        ),
+        find_position_of("wibble")
+    );
+}
+
+#[test]
+fn no_hexdocs_link_when_hovering_over_local_module() {
     let src = "
 import wibble
 ";

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1479,3 +1479,29 @@ fn filter(list: List(a), fun: fn(a) -> Bool) -> List(a) { todo }
         find_position_of("fn(value)")
     );
 }
+
+#[test]
+fn hover_over_module_name() {
+    let src = "
+import wibble
+
+pub fn main() {
+  wibble.wibble()
+}
+";
+    assert_hover!(
+        TestProject::for_source(src).add_module(
+            "wibble",
+            "
+//// This is the wibble module.
+//// Here is some documentation about it.
+//// This module does stuff
+
+pub fn wibble() {
+  todo
+}
+"
+        ),
+        find_position_of("wibble.")
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1069,7 +1069,7 @@ fn make_wibble() -> wobble.Wibble { wobble.Wibble }
 
     assert_hover!(
         TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
-        find_position_of("-> wobble").under_char('o')
+        find_position_of("-> wobble.Wibble").under_char('i')
     );
 }
 
@@ -1131,7 +1131,7 @@ fn main(wibble: wubble.Wibble) {
 
     assert_hover!(
         TestProject::for_source(code).add_hex_module("wibble/wobble", "pub type Wibble { Wibble }"),
-        find_position_of(": wubble").under_char('e')
+        find_position_of(": wubble.Wibble").under_char('W')
     );
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_module.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+import wibble
+
+pub fn main() {
+  wibble.wibble()
+   ↑             
+}
+
+----- Jumped to `src/wibble.gleam`
+pub fn wibble() {}
+↑

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation.snap
@@ -5,7 +5,7 @@ expression: "\nimport wibble/wobble\n\nfn make_wibble() -> wobble.Wibble { wobbl
 import wibble/wobble
 
 fn make_wibble() -> wobble.Wibble { wobble.Wibble }
-                    ▔↑▔▔▔▔▔▔▔▔▔▔▔                  
+                    ▔▔▔▔▔▔▔▔↑▔▔▔▔                  
 
 
 ----- Hover content -----

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_aliased_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_annotation_aliased_module.snap
@@ -5,7 +5,7 @@ expression: "\nimport wibble/wobble as wubble\n\nfn main(wibble: wubble.Wibble) 
 import wibble/wobble as wubble
 
 fn main(wibble: wubble.Wibble) {
-                ▔▔▔▔▔↑▔▔▔▔▔▔▔   
+                ▔▔▔▔▔▔▔↑▔▔▔▔▔   
   wibble
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_imported_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_imported_module.snap
@@ -1,13 +1,9 @@
 ---
 source: compiler-core/src/language_server/tests/hover.rs
-expression: "\nimport wibble\n\npub fn main() {\n  wibble.wibble()\n}\n"
+expression: "\nimport wibble\n"
 ---
 import wibble
-
-pub fn main() {
-  wibble.wibble()
-  ↑▔▔▔▔▔         
-}
+▔▔▔▔▔▔▔↑▔▔▔▔▔
 
 
 ----- Hover content -----

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name.snap
@@ -13,6 +13,6 @@ pub fn main() {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff\nView on [HexDocs](https://hexdocs.pm/app/wibble.html)",
+        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff\n\nView on [HexDocs](https://hexdocs.pm/hex/wibble.html)",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name.snap
@@ -13,6 +13,6 @@ pub fn main() {
 ----- Hover content -----
 Scalar(
     String(
-        " This is the wibble module.\n Here is some documentation about it.\n This module does stuff",
+        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble\n\npub fn main() {\n  wibble.wibble()\n}\n"
+---
+import wibble
+
+pub fn main() {
+  wibble.wibble()
+  ↑▔▔▔▔▔         
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        " This is the wibble module.\n Here is some documentation about it.\n This module does stuff",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
@@ -13,6 +13,6 @@ pub fn main(w: wibble.Wibble) {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff",
+        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff\nView on [HexDocs](https://hexdocs.pm/app/wibble.html)",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble\n\npub fn main(w: wibble.Wibble) {\n  todo\n}\n"
+---
+import wibble
+
+pub fn main(w: wibble.Wibble) {
+               ↑▔▔▔▔▔          
+  todo
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        " This is the wibble module.\n Here is some documentation about it.\n This module does stuff",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
@@ -13,6 +13,6 @@ pub fn main(w: wibble.Wibble) {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff\nView on [HexDocs](https://hexdocs.pm/app/wibble.html)",
+        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff\n\nView on [HexDocs](https://hexdocs.pm/hex/wibble.html)",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_name_in_annotation.snap
@@ -13,6 +13,6 @@ pub fn main(w: wibble.Wibble) {
 ----- Hover content -----
 Scalar(
     String(
-        " This is the wibble module.\n Here is some documentation about it.\n This module does stuff",
+        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_with_path.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_with_path.snap
@@ -13,6 +13,6 @@ pub fn main() {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwibble/wobble\n```\n The module documentation\nView on [HexDocs](https://hexdocs.pm/app/wibble/wobble.html)",
+        "```gleam\nwibble/wobble\n```\n The module documentation\n\nView on [HexDocs](https://hexdocs.pm/hex/wibble/wobble.html)",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_with_path.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_with_path.snap
@@ -13,6 +13,6 @@ pub fn main() {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwibble/wobble\n```\n The module documentation",
+        "```gleam\nwibble/wobble\n```\n The module documentation\nView on [HexDocs](https://hexdocs.pm/app/wibble/wobble.html)",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_with_path.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_over_module_with_path.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble/wobble\n\npub fn main() {\n  wobble.wibble()\n}\n"
+---
+import wibble/wobble
+
+pub fn main() {
+  wobble.wibble()
+  ↑▔▔▔▔▔         
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nwibble/wobble\n```\n The module documentation",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__no_hexdocs_link_when_hovering_over_local_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__no_hexdocs_link_when_hovering_over_local_module.snap
@@ -9,6 +9,6 @@ import wibble
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff\n\nView on [HexDocs](https://hexdocs.pm/hex/wibble.html)",
+        "```gleam\nwibble\n```\n This is the wibble module.\n Here is some documentation about it.\n This module does stuff\n",
     ),
 )


### PR DESCRIPTION
Closes #3451 
This PR implements the ability to hover over a module name and see the documentation for it.
I've had to edit a couple of existing tests to account for the change in behaviour when hovering the module part of a module select.