### PR TITLE
Make JavaScript BitArray deprecation warnings more compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Compiler
+
+- Made runtime warnings regarding the use of deprecated BitArray properties in
+  JavaScript FFI code more compact. They are now one line instead of three.
+  ([Richard Viney](https://github.com/richard-viney))
+
 ## v1.9.0-rc1 - 2025-03-04
 
 ### Compiler

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -338,9 +338,9 @@ function bitArrayPrintDeprecationWarning(name, message) {
     return;
   }
 
-  console.warn(`Deprecated BitArray property used`);
-  console.warn(`  Name: BitArray.${name}`);
-  console.warn(`  Message: ${message}`);
+  console.warn(
+    `Deprecated BitArray.${name} property used in JavaScript FFI code. ${message}.`,
+  );
 
   isBitArrayDeprecationMessagePrinted[name] = true;
 }


### PR DESCRIPTION
Each warning is now one line instead of three.