### PR TITLE
Implement the `unit` option for bit arrays on the Javascript target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Compiler
 
+- On the JavaScript target, bit arrays can now use the `unit` option to control
+  the units of the `size` option.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 ### Language server

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -385,10 +385,19 @@ impl<'module> Generator<'module> {
             .iter()
             .find(|x| matches!(x, Opt::Size { .. }));
 
+        let unit = segment
+            .options
+            .iter()
+            .find_map(|option| match option {
+                Opt::Unit { value, .. } => Some(*value),
+                _ => None,
+            })
+            .unwrap_or(1);
+
         let (size_value, size) = match size {
             Some(Opt::Size { value: size, .. }) => {
                 let size_value = match *size.clone() {
-                    TypedExpr::Int { int_value, .. } => Some(int_value),
+                    TypedExpr::Int { int_value, .. } => Some(int_value * unit as usize),
                     _ => None,
                 };
 
@@ -409,7 +418,7 @@ impl<'module> Generator<'module> {
         };
 
         Ok(SizedBitArraySegmentDetails {
-            size,
+            size: size.group().append(" * ".to_doc().append(unit.to_doc())),
             size_value,
             endianness,
         })
@@ -1689,6 +1698,15 @@ fn sized_bit_array_segment_details<'a>(
         Endianness::Big
     };
 
+    let unit = segment
+        .options
+        .iter()
+        .find_map(|option| match option {
+            Opt::Unit { value, .. } => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(1);
+
     let size = segment
         .options
         .iter()
@@ -1697,7 +1715,7 @@ fn sized_bit_array_segment_details<'a>(
     let (size_value, size) = match size {
         Some(Opt::Size { value: size, .. }) => {
             let size_value = match *size.clone() {
-                Constant::Int { int_value, .. } => Some(int_value),
+                Constant::Int { int_value, .. } => Some(int_value * unit as usize),
                 _ => None,
             };
 
@@ -1715,7 +1733,7 @@ fn sized_bit_array_segment_details<'a>(
     };
 
     Ok(SizedBitArraySegmentDetails {
-        size,
+        size: size.group().append(" * ".to_doc().append(unit.to_doc())),
         size_value,
         endianness,
     })

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -1048,3 +1048,49 @@ pub fn main() {
 }"#
     );
 }
+
+#[test]
+fn with_unit() {
+    assert_js!(
+        r#"
+fn main() {
+  <<1:size(2)-unit(2), 2:size(3)-unit(4)>>
+}
+"#,
+    );
+}
+
+#[test]
+fn dynamic_size_with_unit() {
+    assert_js!(
+        r#"
+fn main() {
+  let size = 3
+  <<1:size(size)-unit(2)>>
+}
+"#,
+    );
+}
+
+#[test]
+fn pattern_with_unit() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let assert <<1:size(2)-unit(2), 2:size(3)-unit(4)>> = x
+}
+"#,
+    );
+}
+
+#[test]
+fn dynamic_size_pattern_with_unit() {
+    assert_js!(
+        r#"
+fn go(x) {
+  let size = 3
+  let assert <<1:size(size)-unit(2)>> = x
+}
+"#,
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn go(x) {\n  let size = 3\n  let assert <<1:size(size)-unit(2)>> = x\n}\n"
+---
+----- SOURCE CODE
+
+fn go(x) {
+  let size = 3
+  let assert <<1:size(size)-unit(2)>> = x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError, bitArraySliceToInt } from "../gleam.mjs";
+
+function go(x) {
+  let size = 3;
+  if (
+    bitArraySliceToInt(x, 0, size * 2, true, false) !== 1 ||
+    !(x.bitSize == size * 2)
+  ) {
+    throw makeError(
+      "let_assert",
+      "my/mod",
+      4,
+      "go",
+      "Pattern match failed, no pattern matched the value.",
+      { value: x }
+    )
+  }
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_with_unit.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn main() {\n  let size = 3\n  <<1:size(size)-unit(2)>>\n}\n"
+---
+----- SOURCE CODE
+
+fn main() {
+  let size = 3
+  <<1:size(size)-unit(2)>>
+}
+
+
+----- COMPILED JAVASCRIPT
+import { toBitArray, sizedInt } from "../gleam.mjs";
+
+function main() {
+  let size = 3;
+  return toBitArray([sizedInt(1, size * 2, true)]);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_with_unit.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn go(x) {\n  let assert <<1:size(2)-unit(2), 2:size(3)-unit(4)>> = x\n}\n"
+---
+----- SOURCE CODE
+
+fn go(x) {
+  let assert <<1:size(2)-unit(2), 2:size(3)-unit(4)>> = x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError, bitArraySliceToInt } from "../gleam.mjs";
+
+function go(x) {
+  if (
+    bitArraySliceToInt(x, 0, 4, true, false) !== 1 ||
+    bitArraySliceToInt(x, 4, 16, true, false) !== 2 ||
+    !(x.bitSize == 16)
+  ) {
+    throw makeError(
+      "let_assert",
+      "my/mod",
+      3,
+      "go",
+      "Pattern match failed, no pattern matched the value.",
+      { value: x }
+    )
+  }
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__with_unit.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\nfn main() {\n  <<1:size(2)-unit(2), 2:size(3)-unit(4)>>\n}\n"
+---
+----- SOURCE CODE
+
+fn main() {
+  <<1:size(2)-unit(2), 2:size(3)-unit(4)>>
+}
+
+
+----- COMPILED JAVASCRIPT
+import { toBitArray, sizedInt } from "../gleam.mjs";
+
+function main() {
+  return toBitArray([sizedInt(1, 4, true), sizedInt(2, 12, true)]);
+}

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -1137,6 +1137,19 @@ fn sized_bit_array_tests() -> List(Test) {
           <<i:size(64)>> == <<0, 31, 255, 255, 255, 255, 255, 255>>,
         )
       }),
+    "let i = 9_007_199_254_740_991\n<<i:size(4)-unit(16)>> == <<0, 31, 255, 255, 255, 255, 255, 255>>"
+      |> example(fn() {
+        let i = 9_007_199_254_740_991
+        assert_equal(
+          True,
+          <<i:size(4)-unit(16)>> == <<0, 31, 255, 255, 255, 255, 255, 255>>,
+        )
+      }),
+    "let size = 5\n<<405:size(size)-unit(2)>> == <<101, 1:2>>"
+      |> example(fn() {
+        let size = 5
+        assert_equal(True, <<405:size(size)-unit(2)>> == <<101, 1:2>>)
+      }),
   ]
 }
 


### PR DESCRIPTION
Leaving this as a draft until 1.9 is released.