### PR TITLE
1.9-RC1 - fix command line name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   JavaScript FFI code more compact. They are now one line instead of three.
   ([Richard Viney](https://github.com/richard-viney))
 
+### Bug fixes
+
+- Fixed a bug that would result in displaying the wrong name when running
+  `gleam --version`.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.9.0-rc1 - 2025-03-04
 
 ### Compiler

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -129,6 +129,7 @@ struct TreeOptions {
 #[derive(Parser, Debug)]
 #[command(
     version,
+    name = "gleam",
     next_display_order = None,
     help_template = "\
 {before-help}{name} {version}


### PR DESCRIPTION
This PR fixes #4310 