### PR TITLE
Improve the error message when echo tests fail on missing target executable

### DIFF
--- a/test-output/src/tests/echo.rs
+++ b/test-output/src/tests/echo.rs
@@ -71,7 +71,7 @@ fn run_and_capture_output(
         .envs(env.iter().map(|pair| (&pair.0, &pair.1)))
         .current_dir(paths.root())
         .spawn()
-        .expect("spawn run process");
+        .unwrap_or_else(|e| panic!("Failed to spawn process '{}': {}", &program, &e));
 
     let mut stderr = process.stderr.take().expect("take stderr");
     let mut output = String::new();


### PR DESCRIPTION
If you don't have an executable required by the echo tests installed, you'd get a somewhat cryptic error along the lines of:
```
thread 'tests::echo::echo_dict' panicked at test-output/src/tests/echo.rs:74:10:
spawn run process: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

It will now be this instead (if you don't have bun installed):
```
thread 'tests::echo::echo_dict' panicked at test-output/src/tests/echo.rs:74:29:
Failed to spawn process 'bun': No such file or directory (os error 2)
```