### PR TITLE
Update local development dependencies documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,8 @@ Code changes to Gleam are welcomed via the process below.
 
 ## Local development
 
-To run the compiler tests. This will require a recent stable version of Rust
-to be installed.
+To run the compiler tests. This will require a recent stable version of Rust,
+Erlang, NodeJS, Deno, and Bun to be installed.
 
 If you are using the Nix package manager, there's a [gleam-nix flake](https://github.com/vic/gleam-nix)
 you can use for running any Gleam version or quickly obtaining a development environment for Gleam.


### PR DESCRIPTION
The `echo` tests now have more dependencies during runtime. (See also #4315) 