### PR TITLE
Fix echo code generation on the Erlang target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,11 @@
 
 ### Formatter
 
+- Improved the formatting of pipelines printed with `echo`.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug fixes
+
+- Fixed a bug where `echo` used before a pipeline would generate invalid code
+  for the Erlang target.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1988,7 +1988,7 @@ fn expr<'a>(expression: &'a TypedExpr, env: &mut Env<'a>) -> Document<'a> {
             let expression = expression
                 .as_ref()
                 .expect("echo with no expression outside of pipe");
-            echo(expr(expression, env), location, env)
+            echo(maybe_block_expr(expression, env), location, env)
         }
 
         TypedExpr::Int { value, .. } => int(value),

--- a/compiler-core/src/erlang/tests/echo.rs
+++ b/compiler-core/src/erlang/tests/echo.rs
@@ -106,3 +106,33 @@ pub fn wibble(n) { n }
 "#
     )
 }
+
+#[test]
+pub fn pipeline_printed_by_echo_is_wrapped_in_begin_end_block() {
+    assert_erl!(
+        r#"
+pub fn main() {
+  echo
+    123
+    |> wibble
+    |> wibble
+}
+
+pub fn wibble(n) { n }
+"#
+    )
+}
+
+#[test]
+pub fn record_update_printed_by_echo_is_wrapped_in_begin_end_block() {
+    assert_erl!(
+        r#"
+pub type Wobble { Wobble(id: Int, name: String) }
+
+pub fn main() {
+  let wobble = Wobble(1, "wobble")
+  echo Wobble(..wobble, id: 1)
+}
+"#
+    )
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__pipeline_printed_by_echo_is_wrapped_in_begin_end_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__pipeline_printed_by_echo_is_wrapped_in_begin_end_block.snap
@@ -1,0 +1,41 @@
+---
+source: compiler-core/src/erlang/tests/echo.rs
+expression: "\npub fn main() {\n  echo\n    123\n    |> wibble\n    |> wibble\n}\n\npub fn wibble(n) { n }\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  echo
+    123
+    |> wibble
+    |> wibble
+}
+
+pub fn wibble(n) { n }
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([wibble/1, main/0]).
+
+-file("project/test/my/mod.gleam", 9).
+-spec wibble(J) -> J.
+wibble(N) ->
+    N.
+
+-file("project/test/my/mod.gleam", 2).
+-spec main() -> integer().
+main() ->
+    echo(
+        begin
+            _pipe = 123,
+            _pipe@1 = wibble(_pipe),
+            wibble(_pipe@1)
+        end,
+        "project/test/my/mod.gleam",
+        3
+    ).
+
+% ...omitted code from `templates/echo.erl`...

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__record_update_printed_by_echo_is_wrapped_in_begin_end_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__record_update_printed_by_echo_is_wrapped_in_begin_end_block.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/erlang/tests/echo.rs
+expression: "\npub type Wobble { Wobble(id: Int, name: String) }\n\npub fn main() {\n  let wobble = Wobble(1, \"wobble\")\n  echo Wobble(..wobble, id: 1)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wobble { Wobble(id: Int, name: String) }
+
+pub fn main() {
+  let wobble = Wobble(1, "wobble")
+  echo Wobble(..wobble, id: 1)
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+-export_type([wobble/0]).
+
+-type wobble() :: {wobble, integer(), binary()}.
+
+-file("project/test/my/mod.gleam", 4).
+-spec main() -> wobble().
+main() ->
+    Wobble = {wobble, 1, <<"wobble"/utf8>>},
+    echo(
+        begin
+            _record = Wobble,
+            {wobble, 1, erlang:element(3, _record)}
+        end,
+        "project/test/my/mod.gleam",
+        6
+    ).
+
+% ...omitted code from `templates/echo.erl`...

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2730,8 +2730,7 @@ impl<'comments> Formatter<'comments> {
             // it's nested onto a new line:
             //
             // ```gleam
-            // echo
-            //   first
+            // echo first
             //   |> wobble
             //   |> wibble
             // ```
@@ -2745,13 +2744,7 @@ impl<'comments> Formatter<'comments> {
             // |> wibble
             // ```
             //
-            UntypedExpr::PipeLine { .. } => docvec![
-                "echo",
-                break_("", " ").nest(INDENT),
-                self.expr(expression).nest(INDENT)
-            ]
-            .group(),
-
+            UntypedExpr::PipeLine { .. } => docvec!["echo ", self.expr(expression).nest(INDENT)],
             _ => docvec!["echo ", self.expr(expression)],
         }
     }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6523,8 +6523,7 @@ fn echo_printing_multiline_pipeline() {
 }
 "#,
         r#"fn main() {
-  echo
-    first
+  echo first
     |> wibble
     |> wobble
 }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6512,3 +6512,32 @@ fn echo_with_following_value_in_a_pipeline() {
 "#
     );
 }
+
+#[test]
+fn echo_printing_multiline_pipeline() {
+    assert_format_rewrite!(
+        r#"fn main() {
+  echo first
+  |> wibble
+  |> wobble
+}
+"#,
+        r#"fn main() {
+  echo
+    first
+    |> wibble
+    |> wobble
+}
+"#
+    );
+}
+
+#[test]
+fn echo_printing_one_line_pipeline() {
+    assert_format!(
+        r#"fn main() {
+  echo first |> wibble |> wobble
+}
+"#
+    );
+}

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__echo_at_start_of_pipeline_wraps_the_whole_thing.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__echo_at_start_of_pipeline_wraps_the_whole_thing.snap
@@ -1,0 +1,42 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: echo 1 |> wibble |> wobble
+---
+[
+    Expression(
+        Echo {
+            location: SrcSpan {
+                start: 0,
+                end: 26,
+            },
+            expression: Some(
+                PipeLine {
+                    expressions: [
+                        Int {
+                            location: SrcSpan {
+                                start: 5,
+                                end: 6,
+                            },
+                            value: "1",
+                            int_value: 1,
+                        },
+                        Var {
+                            location: SrcSpan {
+                                start: 10,
+                                end: 16,
+                            },
+                            name: "wibble",
+                        },
+                        Var {
+                            location: SrcSpan {
+                                start: 20,
+                                end: 26,
+                            },
+                            name: "wobble",
+                        },
+                    ],
+                },
+            ),
+        },
+    ),
+]

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -520,6 +520,11 @@ fn repeated_echos() {
 }
 
 #[test]
+fn echo_at_start_of_pipeline_wraps_the_whole_thing() {
+    assert_parse!("echo 1 |> wibble |> wobble");
+}
+
+#[test]
 fn no_let_binding_snapshot_1() {
     assert_error!("wibble = 4");
 }


### PR DESCRIPTION
This PR fixes #4322 
- I fixed a bug in code generation that meant using echo to print an entire pipeline or record update would end up generating invalid erlang code, sorry for missing this! 🙇
- Since I was there I made a small change to the formatter to make sure it's easier to see echo is printing an entire pipeline if used at the beginning of it