### PR TITLE
Fix and clarify cache file handling

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -12,7 +12,7 @@ pub use self::untyped::{FunctionLiteralKind, UntypedExpr};
 pub use self::constant::{Constant, TypedConstant, UntypedConstant};
 
 use crate::analyse::Inferred;
-use crate::build::{Located, Target};
+use crate::build::{Located, Target, module_erlang_name};
 use crate::parse::SpannedString;
 use crate::type_::error::VariableOrigin;
 use crate::type_::expression::Implementations;
@@ -50,6 +50,12 @@ pub struct Module<Info, Statements> {
     pub type_info: Info,
     pub definitions: Vec<Statements>,
     pub names: Names,
+}
+
+impl<Info, Statements> Module<Info, Statements> {
+    pub fn erlang_name(&self) -> EcoString {
+        module_erlang_name(&self.name)
+    }
 }
 
 impl TypedModule {

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -246,10 +246,14 @@ pub struct Module {
 }
 
 impl Module {
+    pub fn erlang_name(&self) -> EcoString {
+        module_erlang_name(&self.name)
+    }
+
     pub fn compiled_erlang_path(&self) -> Utf8PathBuf {
-        let mut path = self.name.replace("/", "@");
-        path.push_str(".erl");
-        Utf8PathBuf::from(path.as_ref())
+        let mut path = Utf8PathBuf::from(&module_erlang_name(&self.name));
+        assert!(path.set_extension("erl"), "Couldn't set file extension");
+        path
     }
 
     pub fn is_test(&self) -> bool {
@@ -319,6 +323,10 @@ impl Module {
             }
         }
     }
+}
+
+pub fn module_erlang_name(gleam_name: &EcoString) -> EcoString {
+    gleam_name.replace("/", "@")
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     Mode, Origin, SourceFingerprint, Target,
-    package_compiler::{CacheMetadata, CachedModule, Input, UncompiledModule, module_name},
+    package_compiler::{CacheMetadata, CachedModule, Input, UncompiledModule},
     package_loader::{CodegenRequired, GleamFile},
 };
 use crate::{

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -594,25 +594,6 @@ fn analyse(
     Outcome::Ok(modules)
 }
 
-pub(crate) fn module_name(package_path: &Utf8Path, full_module_path: &Utf8Path) -> EcoString {
-    // /path/to/project/_build/default/lib/the_package/src/my/module.gleam
-
-    // my/module.gleam
-    let mut module_path = full_module_path
-        .strip_prefix(package_path)
-        .expect("Stripping package prefix from module path")
-        .to_path_buf();
-
-    // my/module
-    let _ = module_path.set_extension("");
-
-    // Stringify
-    let name = module_path.to_string();
-
-    // normalise windows paths
-    name.replace("\\", "/").into()
-}
-
 #[derive(Debug)]
 pub(crate) enum Input {
     New(UncompiledModule),

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -1,4 +1,5 @@
 use crate::analyse::{ModuleAnalyzerConstructor, TargetSupport};
+use crate::io::files_with_extension;
 use crate::line_numbers::{self, LineNumbers};
 use crate::type_::PRELUDE_MODULE_NAME;
 use crate::{

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -1,4 +1,5 @@
 use crate::analyse::{ModuleAnalyzerConstructor, TargetSupport};
+use crate::build::package_loader::CacheFiles;
 use crate::io::files_with_extension;
 use crate::line_numbers::{self, LineNumbers};
 use crate::type_::PRELUDE_MODULE_NAME;
@@ -286,17 +287,13 @@ where
 
         tracing::debug!("writing_module_caches");
         for module in modules {
-            let module_name = module.name.replace("/", "@");
+            let cache_files = CacheFiles::new(&artefact_dir, &module.name);
 
-            // Write metadata file
-            let name = format!("{}.cache", &module_name);
-            let path = artefact_dir.join(name);
+            // Write cache file
             let bytes = ModuleEncoder::new(&module.ast.type_info).encode()?;
-            self.io.write_bytes(&path, &bytes)?;
+            self.io.write_bytes(&cache_files.cache_path, &bytes)?;
 
-            // Write cache info
-            let name = format!("{}.cache_meta", &module_name);
-            let path = artefact_dir.join(name);
+            // Write cache metadata
             let info = CacheMetadata {
                 mtime: module.mtime,
                 codegen_performed: self.perform_codegen,
@@ -304,18 +301,17 @@ where
                 fingerprint: SourceFingerprint::new(&module.code),
                 line_numbers: module.ast.type_info.line_numbers.clone(),
             };
-            self.io.write_bytes(&path, &info.to_binary())?;
+            self.io
+                .write_bytes(&cache_files.meta_path, &info.to_binary())?;
 
             // Write warnings.
             // Dependency packages don't get warnings persisted as the
             // programmer doesn't want to be told every time about warnings they
             // cannot fix directly.
             if self.cached_warnings.should_use() {
-                let name = format!("{}.cache_warnings", &module_name);
-                let path = artefact_dir.join(name);
                 let warnings = &module.ast.type_info.warnings;
                 let data = bincode::serialize(warnings).expect("Serialise warnings");
-                self.io.write_bytes(&path, &data)?;
+                self.io.write_bytes(&cache_files.warnings_path, &data)?;
             }
         }
         Ok(())

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -1805,23 +1805,19 @@ impl CacheFiles {
         files_with_extension(io, dir, "cache_meta").map(move |path| Self::module_name(&dir, &path))
     }
 
-    // TODO: This is not correct! Will TDD it later.
     fn module_name(dir: &Utf8Path, path: &Utf8Path) -> EcoString {
-        // /path/to/project/_build/default/lib/the_package/src/my/module.gleam
+        // /path/to/artefact/dir/my@module.cache_meta
 
-        // my/module.gleam
+        // my@module.cache_meta
         let mut module_path = path
             .strip_prefix(dir)
             .expect("Stripping package prefix from module path")
             .to_path_buf();
 
-        // my/module
+        // my@module
         let _ = module_path.set_extension("");
 
-        // Stringify
-        let name = module_path.to_string();
-
-        // normalise windows paths
-        name.replace("\\", "/").into()
+        // my/module
+        module_path.to_string().replace("@", "/").into()
     }
 }

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -362,3 +362,17 @@ fn invalid_nested_module_name_in_test() {
         }],
     );
 }
+
+#[test]
+fn cache_files_are_removed_when_source_removed() {
+    let fs = InMemoryFileSystem::new();
+    let root = Utf8Path::new("/");
+    let artefact = Utf8Path::new("/artefact");
+
+    // Source is removed, cache is present
+    write_cache(&fs, "nested/one", 0, vec![], TEST_SOURCE_1);
+
+    _ = run_loader(fs.clone(), root, artefact);
+
+    assert_eq!(fs.files().len(), 0);
+}

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -45,7 +45,9 @@ fn write_cache(
         fingerprint: SourceFingerprint::new(src),
         line_numbers: line_numbers.clone(),
     };
-    let path = Utf8Path::new("/artefact").join(format!("{name}.cache_meta"));
+
+    let artefact_name = name.replace("/", "@");
+    let path = Utf8Path::new("/artefact").join(format!("{artefact_name}.cache_meta"));
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();
 
     let cache = crate::type_::ModuleInterface {
@@ -65,7 +67,7 @@ fn write_cache(
         documentation: Default::default(),
         contains_echo: false,
     };
-    let path = Utf8Path::new("/artefact").join(format!("{name}.cache"));
+    let path = Utf8Path::new("/artefact").join(format!("{artefact_name}.cache"));
     fs.write_bytes(
         &path,
         &metadata::ModuleEncoder::new(&cache).encode().unwrap(),
@@ -228,7 +230,7 @@ fn module_is_stale_if_deps_removed() {
     let artefact = Utf8Path::new("/artefact");
 
     // Source is removed, cache is present
-    write_cache(&fs, "one", 0, vec![], TEST_SOURCE_1);
+    write_cache(&fs, "nested/one", 0, vec![], TEST_SOURCE_1);
 
     // Cache is fresh but dep is removed
     write_src(&fs, "/src/two.gleam", 1, "import one");
@@ -236,8 +238,8 @@ fn module_is_stale_if_deps_removed() {
         &fs,
         "two",
         2,
-        vec![(EcoString::from("one"), SrcSpan { start: 0, end: 0 })],
-        "import one",
+        vec![(EcoString::from("nested/one"), SrcSpan { start: 0, end: 0 })],
+        "import nested/one",
     );
 
     let loaded = run_loader(fs, root, artefact);

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -1,7 +1,9 @@
 use crate::{
     Result,
     analyse::TargetSupport,
-    build::{ErlangAppCodegenConfiguration, Module, package_compiler::StdlibPackage},
+    build::{
+        ErlangAppCodegenConfiguration, Module, module_erlang_name, package_compiler::StdlibPackage,
+    },
     config::PackageConfig,
     erlang,
     io::FileSystemWriter,
@@ -38,7 +40,7 @@ impl<'a> Erlang<'a> {
         root: &Utf8Path,
     ) -> Result<()> {
         for module in modules {
-            let erl_name = module.name.replace("/", "@");
+            let erl_name = module.erlang_name();
             self.erlang_module(&writer, module, &erl_name, root)?;
             self.erlang_record_headers(&writer, module, &erl_name)?;
         }
@@ -107,12 +109,12 @@ impl<'a> ErlangApp<'a> {
             .erlang
             .application_start_module
             .as_ref()
-            .map(|module| tuple("mod", &format!("{{'{}', []}}", module.replace("/", "@"))))
+            .map(|module| tuple("mod", &format!("{{'{}', []}}", module_erlang_name(module))))
             .unwrap_or_default();
 
         let modules = modules
             .iter()
-            .map(|m| m.name.replace("/", "@"))
+            .map(|m| m.erlang_name())
             .chain(native_modules)
             .unique()
             .sorted()

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -6,7 +6,7 @@ mod pattern;
 #[cfg(test)]
 mod tests;
 
-use crate::build::Target;
+use crate::build::{Target, module_erlang_name};
 use crate::strings::convert_string_escape_chars;
 use crate::type_::is_prelude_module;
 use crate::{
@@ -182,7 +182,7 @@ fn module_document<'a>(
 
     let header = "-module("
         .to_doc()
-        .append(module.name.replace("/", "@"))
+        .append(module.erlang_name())
         .append(").")
         .append(line());
 
@@ -1779,7 +1779,7 @@ fn docs_args_call<'a>(
             // This also enables an optimisation in the Erlang compiler in which
             // some Erlang BIFs can be replaced with literals if their arguments
             // are literals, such as `binary_to_atom`.
-            atom_string(module.replace("/", "@").to_string())
+            atom_string(module_erlang_name(module).to_string())
                 .append(":")
                 .append(atom_string(name.to_string()))
                 .append(args)

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -274,16 +274,6 @@ pub trait FileSystemReader {
     fn canonicalise(&self, path: &Utf8Path) -> Result<Utf8PathBuf, Error>;
 }
 
-/// Iterates over Gleam cache files (`.cache`) in a certain directory.
-/// Symlinks are followed.
-pub fn gleam_cache_files<'a>(
-    io: &'a impl FileSystemReader,
-    dir: &'a Utf8Path,
-) -> impl Iterator<Item = Utf8PathBuf> + 'a {
-    tracing::trace!("gleam_cache_files {:?}", dir);
-    files_with_extension(io, dir, "cache")
-}
-
 /// Iterates over files with the given extension in a certain directory.
 /// Symlinks are followed.
 pub fn files_with_extension<'a>(

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -274,16 +274,6 @@ pub trait FileSystemReader {
     fn canonicalise(&self, path: &Utf8Path) -> Result<Utf8PathBuf, Error>;
 }
 
-/// Iterates over Gleam source files (`.gleam`) in a certain directory.
-/// Symlinks are followed.
-pub fn gleam_source_files<'a>(
-    io: &'a impl FileSystemReader,
-    dir: &'a Utf8Path,
-) -> impl Iterator<Item = Utf8PathBuf> + 'a {
-    tracing::trace!("gleam_source_files {:?}", dir);
-    files_with_extension(io, dir, "gleam")
-}
-
 /// Iterates over Gleam cache files (`.cache`) in a certain directory.
 /// Symlinks are followed.
 pub fn gleam_cache_files<'a>(
@@ -294,7 +284,9 @@ pub fn gleam_cache_files<'a>(
     files_with_extension(io, dir, "cache")
 }
 
-fn files_with_extension<'a>(
+/// Iterates over files with the given extension in a certain directory.
+/// Symlinks are followed.
+pub fn files_with_extension<'a>(
     io: &'a impl FileSystemReader,
     dir: &'a Utf8Path,
     extension: &'a str,

--- a/compiler-core/src/language_server/tests/compilation.rs
+++ b/compiler-core/src/language_server/tests/compilation.rs
@@ -119,7 +119,7 @@ fn compile_recompile() {
     // This time it does not compile the module again, instead using the
     // cache from the previous run.
     let response = engine.compile_please();
-    assert!(response.result.is_ok());
+    assert_eq!(response.result, Ok(()));
     assert!(response.warnings.is_empty());
     assert_eq!(response.compilation, Compilation::Yes(vec![]));
 


### PR DESCRIPTION
Functional changes:
* Delete cache files when we detect that the source file for a module has been deleted. Resolves #4320
* Delete *all* cache files when loading a stale module
* Handles the detection of deleted *nested* modules properly. I messed this up in #3873 so I decided to do some related refactoring to clarify the related code.

Refactoring:
* Remove very repetitive use of `replace("/", "@")`. Add two versions of it: One for erlang module names, and one for cache file names. My understanding is that they just happen to do the same thing, so I duplicated it. If there's some reason the cache file names must match the erlang module names, then we should probably change it further.
* For the use of `replace("/", "@")` related to cache files, group these operations together as `CacheFiles`, as there was further duplication of the same logic in different parts of the code base.
* Group logic related to discovery, validation, and module name derivation from gleam source files under `GleamFile`

I was originally going to refactor first separately, but it was hard to keep doing the wrong thing, and since the actual fixes are quite small, I thought it might be better if I just outlined them in the PR.