### PR TITLE
Add labels when showing a hovered function type

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -18,7 +18,7 @@ use crate::type_::error::VariableOrigin;
 use crate::type_::expression::Implementations;
 use crate::type_::printer::Names;
 use crate::type_::{
-    self, Deprecation, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
+    self, Deprecation, FieldMap, ModuleValueConstructor, PatternConstructor, Type, ValueConstructor,
 };
 use std::sync::Arc;
 
@@ -745,6 +745,23 @@ pub struct ModuleConstant<T, ConstantRecordTag> {
     pub type_: T,
     pub deprecation: Deprecation,
     pub implementations: Implementations,
+}
+
+impl TypedModuleConstant {
+    pub(crate) fn field_map(&self) -> Option<&FieldMap> {
+        match self.value.as_ref() {
+            Constant::Record { field_map, .. } => field_map.as_ref(),
+            Constant::Int { .. }
+            | Constant::Float { .. }
+            | Constant::String { .. }
+            | Constant::Tuple { .. }
+            | Constant::List { .. }
+            | Constant::BitArray { .. }
+            | Constant::Var { .. }
+            | Constant::StringConcatenation { .. }
+            | Constant::Invalid { .. } => None,
+        }
+    }
 }
 
 pub type UntypedCustomType = CustomType<()>;

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -70,6 +70,96 @@ macro_rules! assert_hover {
 }
 
 #[test]
+fn hover_function_with_labelled_arguments() {
+    let code = "
+pub fn main() {
+  labelled
+}
+
+pub fn labelled(a: Int, label b: String) -> Int { 1 }
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("labelled").under_char('b')
+    );
+}
+
+#[test]
+fn hover_constructor_with_labelled_arguments() {
+    let code = "
+pub fn main() {
+    Labelled
+}
+
+pub type Labelled {
+  Labelled(Int, label: String)
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("Labelled").under_char('b')
+    );
+}
+
+#[test]
+fn hover_constant_with_labelled_constructor() {
+    let code = "
+pub const wibble = Labelled
+
+pub type Labelled {
+  Labelled(Int, label: String)
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("wibble").under_char('i')
+    );
+}
+
+#[test]
+fn hover_imported_labelled_function() {
+    let code = "
+import wibble.{wobble}
+";
+
+    assert_hover!(
+        TestProject::for_source(code)
+            .add_dep_module("wibble", "pub fn wobble(a: Int, label b: String) {}"),
+        find_position_of("wobble").under_char('i')
+    );
+}
+
+#[test]
+fn hover_imported_labelled_constructor() {
+    let code = "
+import wibble.{Wobble}
+";
+
+    assert_hover!(
+        TestProject::for_source(code)
+            .add_dep_module("wibble", "pub type Wobble { Wobble(Int, label: String) }"),
+        find_position_of("Wobble").under_char('i')
+    );
+}
+
+#[test]
+fn hover_labelled_function_head() {
+    let code = "
+pub fn main(a, label b) {
+  a + b
+}
+";
+
+    assert_hover!(
+        TestProject::for_source(code),
+        find_position_of("main").under_char('i')
+    );
+}
+
+#[test]
 fn hover_function_definition() {
     assert_hover!(
         "

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_constant_with_labelled_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_constant_with_labelled_constructor.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub const wibble = Labelled\n\npub type Labelled {\n  Labelled(Int, label: String)\n}\n"
+---
+pub const wibble = Labelled
+▔▔▔▔▔▔▔▔▔▔▔↑▔▔▔▔           
+
+pub type Labelled {
+  Labelled(Int, label: String)
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int, label: String) -> Labelled\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_constructor_with_labelled_arguments.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_constructor_with_labelled_arguments.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n    Labelled\n}\n\npub type Labelled {\n  Labelled(Int, label: String)\n}\n"
+---
+pub fn main() {
+    Labelled
+    ▔▔↑▔▔▔▔▔
+}
+
+pub type Labelled {
+  Labelled(Int, label: String)
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int, label: String) -> Labelled\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_with_labelled_arguments.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_function_with_labelled_arguments.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main() {\n  labelled\n}\n\npub fn labelled(a: Int, label b: String) -> Int { 1 }\n"
+---
+pub fn main() {
+  labelled
+  ▔▔↑▔▔▔▔▔
+}
+
+pub fn labelled(a: Int, label b: String) -> Int { 1 }
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int, label: String) -> Int\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_imported_labelled_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_imported_labelled_constructor.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble.{Wobble}\n"
+---
+import wibble.{Wobble}
+               ↑▔▔▔▔▔ 
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int, label: String) -> wibble.Wobble\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_imported_labelled_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_imported_labelled_function.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nimport wibble.{wobble}\n"
+---
+import wibble.{wobble}
+               ↑▔▔▔▔▔ 
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int, label: String) -> a\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_labelled_function_head.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_labelled_function_head.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\npub fn main(a, label b) {\n  a + b\n}\n"
+---
+pub fn main(a, label b) {
+▔▔▔▔▔▔▔▔▔↑▔▔▔▔▔▔▔▔▔▔▔▔▔  
+  a + b
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nfn(Int, label: Int) -> Int\n```\n",
+    ),
+)


### PR DESCRIPTION
This PR closes #3507 by adding labels to function types that are displayed when hovering on something. This works for constructors, imported functions, functions and function heads!