### PR TITLE
Improve error message when giving the wrong password for a local token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
   project's `gleam.toml` as a JSON file.
   ([Rodrigo Álvarez](https://github.com/Papipo))
 
+- Improve error message when giving the wrong password for a local token.
+  ([Samuel Cristobal](https://github.com/scristobal))
+
 ### Language server
 
 - The language server now allows renaming of functions, constants,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
   project's `gleam.toml` as a JSON file.
   ([Rodrigo Álvarez](https://github.com/Papipo))
 
-- Improve error message when giving the wrong password for a local token.
+- Improve error messages when encrypting and decrypting local Hex AIP key.
   ([Samuel Cristobal](https://github.com/scristobal))
 
 ### Language server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
   project's `gleam.toml` as a JSON file.
   ([Rodrigo Álvarez](https://github.com/Papipo))
 
-- Improve error messages when encrypting and decrypting local Hex AIP key.
+- Improve error messages when encrypting and decrypting local Hex API key.
   ([Samuel Cristobal](https://github.com/scristobal))
 
 ### Language server

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -111,7 +111,10 @@ encrypt your Hex API key.
             return Ok(None);
         };
         let password = self.ask_local_password()?;
-        let unencrypted = encryption::decrypt_with_passphrase(encrypted.as_bytes(), &password)?;
+        let unencrypted = encryption::decrypt_with_passphrase(encrypted.as_bytes(), &password)
+            .map_err(|e| Error::FailedToDecryptApiKey {
+                detail: e.to_string(),
+            })?;
         Ok(Some(UnencryptedApiKey { unencrypted }))
     }
 

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -62,7 +62,10 @@ encrypt your Hex API key.
             );
         }
         let password = self.ask_local_password()?;
-        let encrypted = encryption::encrypt_with_passphrase(api_key.as_bytes(), &password)?;
+        let encrypted = encryption::encrypt_with_passphrase(api_key.as_bytes(), &password)
+            .map_err(|e| Error::FailedToEncryptLocalHexApiKey {
+                detail: e.to_string(),
+            })?;
 
         crate::fs::write(&path, &format!("{name}\n{encrypted}"))?;
         println!("Encrypted Hex API key written to {path}");
@@ -110,11 +113,13 @@ encrypt your Hex API key.
         let Some(EncryptedApiKey { encrypted, .. }) = self.read_stored_api_key()? else {
             return Ok(None);
         };
+
         let password = self.ask_local_password()?;
         let unencrypted = encryption::decrypt_with_passphrase(encrypted.as_bytes(), &password)
-            .map_err(|e| Error::FailedToDecryptApiKey {
+            .map_err(|e| Error::FailedToDecryptLocalHexApiKey {
                 detail: e.to_string(),
             })?;
+
         Ok(Some(UnencryptedApiKey { unencrypted }))
     }
 

--- a/compiler-core/src/encryption.rs
+++ b/compiler-core/src/encryption.rs
@@ -1,24 +1,37 @@
-use crate::{Error, Result};
+use thiserror::Error;
 
-pub fn encrypt_with_passphrase(message: &[u8], passphrase: &str) -> Result<String> {
+pub fn encrypt_with_passphrase(
+    message: &[u8],
+    passphrase: &str,
+) -> Result<String, age::EncryptError> {
     let passphrase = age::secrecy::SecretString::from(passphrase);
     let recipient = age::scrypt::Recipient::new(passphrase.clone());
-    let encrypted =
-        age::encrypt_and_armor(&recipient, message).map_err(|e| Error::FailedToEncrypt {
-            detail: e.to_string(),
-        })?;
+
+    let encrypted = age::encrypt_and_armor(&recipient, message)?;
+
     Ok(encrypted)
 }
 
-pub fn decrypt_with_passphrase(encrypted_message: &[u8], passphrase: &str) -> Result<String> {
+// the function `decrypt_with_passphrase` has two possible failure cases:
+// - when decryption fails
+// - when the data was decrypted succesfully but the result is not UTF-8 valid
+#[derive(Error, Debug)]
+pub enum DecryptError {
+    #[error("unable to decrypt message: {0}")]
+    Decrypt(#[from] age::DecryptError),
+    #[error("decrypted message is not UTF-8 valid: {0}")]
+    Io(#[from] std::string::FromUtf8Error),
+}
+
+pub fn decrypt_with_passphrase(
+    encrypted_message: &[u8],
+    passphrase: &str,
+) -> Result<String, DecryptError> {
     let passphrase = age::secrecy::SecretString::from(passphrase);
     let identity = age::scrypt::Identity::new(passphrase);
-    let decrypted =
-        age::decrypt(&identity, encrypted_message).map_err(|e| Error::FailedToDecrypt {
-            detail: e.to_string(),
-        })?;
-    let decrypted = String::from_utf8(decrypted).map_err(|e| Error::FailedToDecrypt {
-        detail: e.to_string(),
-    })?;
+
+    let decrypted = age::decrypt(&identity, encrypted_message)?;
+    let decrypted = String::from_utf8(decrypted)?;
+
     Ok(decrypted)
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -321,6 +321,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
 
     #[error("Failed to decrypt data")]
     FailedToDecrypt { detail: String },
+
+    #[error("Failed to decrypt API key")]
+    FailedToDecryptApiKey { detail: String },
 }
 
 /// This is to make clippy happy and not make the error variant too big by
@@ -1480,6 +1483,21 @@ The error from the encryption library was:
 );
                 vec![Diagnostic {
                     title: "Failed to decrypt data".into(),
+                    text,
+                    hint: None,
+                    level: Level::Error,
+                    location: None,
+                }]
+            }
+
+            Error::FailedToDecryptApiKey { detail } => {
+                let text = wrap_format!("Unable to decrypt the local Hex token with the given password.
+The error from the encryption library was:
+
+    {detail}"
+);
+                vec![Diagnostic {
+                    title: "Failed to decrypt Hex token".into(),
                     text,
                     hint: None,
                     level: Level::Error,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -316,7 +316,7 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
         wrongfully_allowed_version: SmallVersion,
     },
 
-    #[error("Failed to encrypt local Hex APIT key")]
+    #[error("Failed to encrypt local Hex API key")]
     FailedToEncryptLocalHexApiKey { detail: String },
 
     #[error("Failed to decrypt local Hex API key")]

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -316,14 +316,11 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
         wrongfully_allowed_version: SmallVersion,
     },
 
-    #[error("Failed to encrypt data")]
-    FailedToEncrypt { detail: String },
+    #[error("Failed to encrypt local Hex APIT key")]
+    FailedToEncryptLocalHexApiKey { detail: String },
 
-    #[error("Failed to decrypt data")]
-    FailedToDecrypt { detail: String },
-
-    #[error("Failed to decrypt API key")]
-    FailedToDecryptApiKey { detail: String },
+    #[error("Failed to decrypt local Hex API key")]
+    FailedToDecryptLocalHexApiKey { detail: String },
 }
 
 /// This is to make clippy happy and not make the error variant too big by
@@ -1460,8 +1457,8 @@ https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-fo
             }
 
 
-            Error::FailedToEncrypt { detail } => {
-                let text = wrap_format!("A problem was encountered encrypting data.
+            Error::FailedToEncryptLocalHexApiKey { detail } => {
+                let text = wrap_format!("A problem was encountered encrypting the local Hex API key with the given password.
 The error from the encryption library was:
 
     {detail}"
@@ -1475,29 +1472,14 @@ The error from the encryption library was:
                 }]
             }
 
-            Error::FailedToDecrypt { detail } => {
-                let text = wrap_format!("A problem was encountered decrypting data.
+            Error::FailedToDecryptLocalHexApiKey { detail }=> {
+                let text = wrap_format!("Unable to decrypt the local Hex API key with the given password.
 The error from the encryption library was:
 
     {detail}"
 );
                 vec![Diagnostic {
-                    title: "Failed to decrypt data".into(),
-                    text,
-                    hint: None,
-                    level: Level::Error,
-                    location: None,
-                }]
-            }
-
-            Error::FailedToDecryptApiKey { detail } => {
-                let text = wrap_format!("Unable to decrypt the local Hex token with the given password.
-The error from the encryption library was:
-
-    {detail}"
-);
-                vec![Diagnostic {
-                    title: "Failed to decrypt Hex token".into(),
+                    title: "Failed to decrypt local Hex API key".into(),
                     text,
                     hint: None,
                     level: Level::Error,


### PR DESCRIPTION
Adds a new error variant `Error::FailedToDecryptApiKey` specifically to handle the case when the decryption of the Hex API token fails. 

Hopefully, the changes will make the error message a bit more friendly and possibly more useful. 

resolves #4317 