### PR TITLE
Fix renaming of aliased and nested modules

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -342,7 +342,11 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 documentation,
                 contains_echo: echo_found,
                 references: References {
-                    imported_modules: env.imported_modules.into_keys().collect(),
+                    imported_modules: env
+                        .imported_modules
+                        .values()
+                        .map(|(_location, module)| module.name.clone())
+                        .collect(),
                     value_references: env.references.into_locations(),
                 },
             },

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -1073,3 +1073,49 @@ pub fn main() {
         find_position_of("Wibble").to_selection()
     );
 }
+
+#[test]
+fn rename_value_in_nested_module() {
+    assert_rename!(
+        (
+            "sub/mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import sub/mod
+
+pub fn main() {
+  mod.wibble()
+}
+",
+        "some_function",
+        find_position_of("wibble").to_selection()
+    );
+}
+
+#[test]
+fn rename_value_in_aliased_module() {
+    assert_rename!(
+        (
+            "mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import mod as the_module
+
+pub fn main() {
+  the_module.wibble()
+}
+",
+        "some_function",
+        find_position_of("wibble").to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_aliased_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_aliased_module.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport mod as the_module\n\npub fn main() {\n  the_module.wibble()\n}\n"
+---
+----- BEFORE RENAME
+-- mod.gleam
+
+pub fn wibble() {
+  wibble()
+}
+
+
+-- app.gleam
+
+import mod as the_module
+
+pub fn main() {
+  the_module.wibble()
+             ↑       
+}
+
+
+----- AFTER RENAME
+-- mod.gleam
+
+pub fn some_function() {
+  some_function()
+}
+
+
+-- app.gleam
+
+import mod as the_module
+
+pub fn main() {
+  the_module.some_function()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_nested_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_nested_module.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport sub/mod\n\npub fn main() {\n  mod.wibble()\n}\n"
+---
+----- BEFORE RENAME
+-- sub/mod.gleam
+
+pub fn wibble() {
+  wibble()
+}
+
+
+-- app.gleam
+
+import sub/mod
+
+pub fn main() {
+  mod.wibble()
+      ↑       
+}
+
+
+----- AFTER RENAME
+-- sub/mod.gleam
+
+pub fn some_function() {
+  some_function()
+}
+
+
+-- app.gleam
+
+import sub/mod
+
+pub fn main() {
+  mod.some_function()
+}


### PR DESCRIPTION
Fixes #4344 
Turns out `imported_modules` stores the locally used names of the modules, not the fully qualified ones.