### PR TITLE
Check if string patterns are unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,36 @@
   the units of the `size` option.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- On the JavaScript target, blocks and various other expressions no longer compile to
-  immediately invoked function expressions.
+- The compiler can now tell if string branches are unreachable. For example, the
+  following code:
+
+  ```gleam
+  case a_string {
+    "Hello, " <> name -> name
+    "Hello, Jak" -> "Jak"
+    _ -> "Stranger"
+  }
+  ```
+
+  Will raise the following warning:
+
+  ```
+  warning: Unreachable case clause
+    ┌─ /src/greet.gleam:7:5
+    │
+  7 │     "Hello, Jak" -> "Jak"
+    │     ^^^^^^^^^^^^^^^^^^^^^
+
+  This case clause cannot be reached as a previous clause matches the same
+  values.
+
+  Hint: It can be safely removed.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- On the JavaScript target, blocks and various other expressions no longer
+  compile to immediately invoked function expressions.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
 - On the JavaScript target, bit arrays can now use 16-bit floats in expressions
@@ -116,7 +144,6 @@
 - Fixed a bug where using the "Convert to pipe" code action on a function or
   record capture produces invalid code.
   ([Matias Carlander](https://github.com/matiascr))
-
 
 ## v1.9.1 - 2025-03-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1123,7 @@ dependencies = [
  "pretty_assertions",
  "pubgrub",
  "pulldown-cmark",
+ "radix_trie",
  "rand",
  "regex",
  "serde",
@@ -1854,6 +1861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +2295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -49,6 +49,7 @@ num-bigint = "0.4.6"
 num-traits = "0.2.19"
 # Encryption
 age = { version = "0.11", features = ["armor"] }
+radix_trie = "0.2.1"
 
 async-trait.workspace = true
 base16.workspace = true

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -504,6 +504,16 @@ impl Variable {
         Self { id, type_ }
     }
 
+    /// Builds a `PatternCheck` that checks this variable matches the given pattern.
+    /// So we can build pattern checks the same way we informally describe them:
+    /// ```text
+    /// var is pattern
+    /// ```
+    /// With this builder method would become:
+    /// ```rs
+    /// var.is(pattern)
+    /// ```
+    ///
     fn is(&self, pattern: Id<Pattern>) -> PatternCheck {
         PatternCheck {
             var: self.clone(),

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -536,11 +536,11 @@ impl Variable {
 /// performing a `PatternCheck` on a variable with a specific type.
 ///
 enum BranchMode {
-    /// This covers numbers, functions, variables, bitarrays and strings.
+    /// This covers numbers, functions, variables, and bitarrays.
     ///
-    /// TODO)) In the future it won't be the case: strings and bitarrays will be
-    /// special cased to improve on exhaustiveness checking and to be used for
-    /// code generation.
+    /// TODO)) In the future it won't be the case: bitarrays will be special
+    /// cased to improve on exhaustiveness checking and to be used for code
+    /// generation.
     ///
     Infinite,
     Tuple {

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -313,7 +313,7 @@ pub enum Pattern {
         name: EcoString,
     },
     Tuple {
-        elems: Vec<Id<Pattern>>,
+        elements: Vec<Id<Pattern>>,
     },
     Variant {
         index: usize,
@@ -353,7 +353,9 @@ impl Pattern {
             Pattern::StringPrefix { prefix, .. } => RuntimeCheckKind::StringPrefix {
                 prefix: prefix.clone(),
             },
-            Pattern::Tuple { elems } => RuntimeCheckKind::Tuple { size: elems.len() },
+            Pattern::Tuple { elements } => RuntimeCheckKind::Tuple {
+                size: elements.len(),
+            },
             Pattern::Variant { index, .. } => RuntimeCheckKind::Variant { index: *index },
             Pattern::BitArray { value } => RuntimeCheckKind::BitArray {
                 value: value.clone(),
@@ -1070,14 +1072,11 @@ impl<'a> Compiler<'a> {
             // pattern: `a is #(1, _)` will result in the following checks
             // `a0 is 1, a1 is _` (where `a0` and `a1` are fresh variable names we use to
             // refer to each of the tuple's elements).
-            (
-                Pattern::Tuple {
-                    elems: elems_patterns,
-                },
-                RuntimeCheck::Tuple { args, .. },
-            ) => (args.iter().zip(elems_patterns))
-                .map(|(arg, pattern)| arg.is(*pattern))
-                .collect_vec(),
+            (Pattern::Tuple { elements }, RuntimeCheck::Tuple { args, .. }) => {
+                (args.iter().zip(elements))
+                    .map(|(arg, pattern)| arg.is(*pattern))
+                    .collect_vec()
+            }
 
             // Strings are quite fun: if we've checked at runtime a string starts with a given
             // prefix and we want to check that it's some overlapping literal value we'll still
@@ -1630,8 +1629,8 @@ impl CaseToCompile {
             }
 
             TypedPattern::Tuple { elems, .. } => {
-                let elems = elems.iter().map(|elem| self.register(elem)).collect_vec();
-                self.insert(Pattern::Tuple { elems })
+                let elements = elems.iter().map(|elem| self.register(elem)).collect_vec();
+                self.insert(Pattern::Tuple { elements })
             }
 
             TypedPattern::List { elements, tail, .. } => {

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -546,7 +546,7 @@ enum BranchMode {
     ///
     Infinite,
     Tuple {
-        elems: Vec<Arc<Type>>,
+        elements: Vec<Arc<Type>>,
     },
     List {
         inner_type: Arc<Type>,
@@ -589,7 +589,7 @@ impl Variable {
             },
 
             Type::Tuple { elems } => BranchMode::Tuple {
-                elems: elems.clone(),
+                elements: elems.clone(),
             },
 
             Type::Named {
@@ -878,7 +878,7 @@ impl<'a> Compiler<'a> {
 
             // If the type is a tuple there's only one runtime check we could
             // perform that actually makes sense.
-            BranchMode::Tuple { elems } => vec![self.is_tuple_check(elems)],
+            BranchMode::Tuple { elements } => vec![self.is_tuple_check(elements)],
 
             // If the type being matched on is a list we know the resulting
             // decision tree node is only ever going to have two different paths:
@@ -995,8 +995,8 @@ impl<'a> Compiler<'a> {
                 prefix: prefix.clone(),
                 rest_arg: self.fresh_variable(string()),
             },
-            (RuntimeCheckKind::Tuple { .. }, BranchMode::Tuple { elems }) => {
-                self.is_tuple_check(elems)
+            (RuntimeCheckKind::Tuple { .. }, BranchMode::Tuple { elements }) => {
+                self.is_tuple_check(elements)
             }
             (RuntimeCheckKind::Variant { index }, BranchMode::NamedType { constructors, .. }) => {
                 self.is_variant_check(
@@ -1163,10 +1163,10 @@ impl<'a> Compiler<'a> {
     /// Builds an `IsTuple` runtime check, coming up with fresh variable
     /// names for its arguments.
     ///
-    fn is_tuple_check(&mut self, elems: &[Arc<Type>]) -> RuntimeCheck {
+    fn is_tuple_check(&mut self, elements: &[Arc<Type>]) -> RuntimeCheck {
         RuntimeCheck::Tuple {
-            size: elems.len(),
-            args: elems
+            size: elements.len(),
+            args: elements
                 .iter()
                 .map(|type_| self.fresh_variable(type_.clone()))
                 .collect_vec(),

--- a/compiler-core/src/exhaustiveness/missing_patterns.rs
+++ b/compiler-core/src/exhaustiveness/missing_patterns.rs
@@ -31,11 +31,11 @@ pub enum Term {
         variable: Variable,
         name: EcoString,
         module: EcoString,
-        arguments: Vec<Variable>,
+        fields: Vec<Variable>,
     },
     Tuple {
         variable: Variable,
-        arguments: Vec<Variable>,
+        elements: Vec<Variable>,
     },
     Infinite {
         variable: Variable,
@@ -136,12 +136,12 @@ fn check_to_term(variable: Variable, check: &RuntimeCheck, env: &Environment<'_>
         | RuntimeCheck::BitArray { .. }
         | RuntimeCheck::StringPrefix { .. } => Term::Infinite { variable },
 
-        RuntimeCheck::Tuple { args, .. } => Term::Tuple {
+        RuntimeCheck::Tuple { elements, .. } => Term::Tuple {
             variable,
-            arguments: args.clone(),
+            elements: elements.clone(),
         },
 
-        RuntimeCheck::Variant { index, args } => {
+        RuntimeCheck::Variant { index, fields } => {
             let (module, name) = variable
                 .type_
                 .named_type_name()
@@ -160,17 +160,14 @@ fn check_to_term(variable: Variable, check: &RuntimeCheck, env: &Environment<'_>
                 variable,
                 name,
                 module,
-                arguments: args.clone(),
+                fields: fields.clone(),
             }
         }
 
-        RuntimeCheck::NonEmptyList {
-            first_arg,
-            rest_arg,
-        } => Term::List {
+        RuntimeCheck::NonEmptyList { first, rest } => Term::List {
             variable,
-            first: first_arg.clone(),
-            rest: rest_arg.clone(),
+            first: first.clone(),
+            rest: rest.clone(),
         },
 
         RuntimeCheck::EmptyList => Term::EmptyList { variable },

--- a/compiler-core/src/exhaustiveness/missing_patterns.rs
+++ b/compiler-core/src/exhaustiveness/missing_patterns.rs
@@ -164,7 +164,7 @@ fn check_to_term(variable: Variable, check: &RuntimeCheck, env: &Environment<'_>
             }
         }
 
-        RuntimeCheck::List {
+        RuntimeCheck::NonEmptyList {
             first_arg,
             rest_arg,
         } => Term::List {

--- a/compiler-core/src/exhaustiveness/missing_patterns.rs
+++ b/compiler-core/src/exhaustiveness/missing_patterns.rs
@@ -164,7 +164,7 @@ fn check_to_term(variable: Variable, check: &RuntimeCheck, env: &Environment<'_>
             }
         }
 
-        RuntimeCheck::NonEmptyList {
+        RuntimeCheck::List {
             first_arg,
             rest_arg,
         } => Term::List {

--- a/compiler-core/src/exhaustiveness/printer.rs
+++ b/compiler-core/src/exhaustiveness/printer.rs
@@ -50,7 +50,7 @@ impl<'a> Printer<'a> {
             Term::Variant {
                 name,
                 module,
-                arguments,
+                fields,
                 ..
             } => {
                 let (module, name) = match self.names.named_constructor(module, name) {
@@ -67,11 +67,11 @@ impl<'a> Printer<'a> {
                 }
                 buffer.push_str(name);
 
-                if arguments.is_empty() {
+                if fields.is_empty() {
                     return;
                 }
                 buffer.push('(');
-                for (i, variable) in arguments.iter().enumerate() {
+                for (i, variable) in fields.iter().enumerate() {
                     if i != 0 {
                         buffer.push_str(", ");
                     }
@@ -89,9 +89,9 @@ impl<'a> Printer<'a> {
                 }
                 buffer.push(')');
             }
-            Term::Tuple { arguments, .. } => {
+            Term::Tuple { elements, .. } => {
                 buffer.push_str("#(");
-                for (i, variable) in arguments.iter().enumerate() {
+                for (i, variable) in elements.iter().enumerate() {
                     if i != 0 {
                         buffer.push_str(", ");
                     }
@@ -201,7 +201,7 @@ mod tests {
             variable: subjects[0].clone(),
             name: "Wibble".into(),
             module: "module".into(),
-            arguments: Vec::new(),
+            fields: Vec::new(),
         };
 
         let terms = &[term];
@@ -227,7 +227,7 @@ mod tests {
             variable: subjects[0].clone(),
             name: "Wibble".into(),
             module: "module".into(),
-            arguments: vec![var1.clone(), var2.clone()],
+            fields: vec![var1.clone(), var2.clone()],
         };
 
         let terms = &[
@@ -256,7 +256,7 @@ mod tests {
             variable: subjects[0].clone(),
             name: "Rectangle".into(),
             module: "mod".into(),
-            arguments: Vec::new(),
+            fields: Vec::new(),
         };
 
         let terms = &[term];
@@ -283,7 +283,7 @@ mod tests {
             variable: subjects[0].clone(),
             name: "Regex".into(),
             module: "regex".into(),
-            arguments: vec![arg.clone()],
+            fields: vec![arg.clone()],
         };
 
         let terms = &[term, Term::Infinite { variable: arg }];
@@ -308,7 +308,7 @@ mod tests {
             variable: subjects[0].clone(),
             name: "Regex".into(),
             module: "regex".into(),
-            arguments: vec![arg.clone()],
+            fields: vec![arg.clone()],
         };
 
         let terms = &[
@@ -317,7 +317,7 @@ mod tests {
                 variable: arg,
                 name: "None".into(),
                 module: "gleam".into(),
-                arguments: vec![],
+                fields: vec![],
             },
         ];
         let mapping = get_mapping(terms);
@@ -350,7 +350,7 @@ mod tests {
                 variable: var1,
                 name: "Type".into(),
                 module: "module".into(),
-                arguments: Vec::new(),
+                fields: Vec::new(),
             },
             Term::List {
                 variable: var2,
@@ -383,13 +383,13 @@ mod tests {
                 variable: subjects[0].clone(),
                 name: "Ok".into(),
                 module: "gleam".into(),
-                arguments: vec![make_variable(3)],
+                fields: vec![make_variable(3)],
             },
             Term::Variant {
                 variable: subjects[2].clone(),
                 name: "False".into(),
                 module: "gleam".into(),
-                arguments: Vec::new(),
+                fields: Vec::new(),
             },
         ];
         let mapping = get_mapping(terms);

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1371,3 +1371,117 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn unreachable_string_pattern_after_prefix() {
+    assert_warning!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest -> rest
+    "wibble" -> "a"
+    _ -> "b"
+  }
+}"#
+    );
+}
+
+#[test]
+fn reachable_string_pattern_after_prefix() {
+    assert_no_warnings!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest if True -> rest
+    "wibble" -> "a"
+    _ -> "b"
+  }
+}"#
+    );
+}
+
+#[test]
+fn reachable_string_pattern_after_prefix_1() {
+    assert_no_warnings!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wibble" <> rest -> rest
+    "wib" -> "a"
+    _ -> "b"
+  }
+}"#
+    );
+}
+
+#[test]
+fn unreachable_prefix_pattern_after_prefix() {
+    assert_warning!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest -> rest
+    "wibble" <> rest -> rest
+    _ -> "a"
+  }
+}"#
+    );
+}
+
+#[test]
+fn reachable_prefix_pattern_after_prefix() {
+    assert_no_warnings!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest if True -> rest
+    "wibble" <> rest -> rest
+    _ -> "a"
+  }
+}"#
+    );
+}
+
+#[test]
+fn reachable_prefix_pattern_after_prefix_1() {
+    assert_no_warnings!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wibble" <> rest -> rest
+    "wib" <> rest -> rest
+    _ -> "a"
+  }
+}"#
+    );
+}
+
+#[test]
+fn multiple_unreachable_prefix_patterns() {
+    assert_warning!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest -> rest
+    "wibble" <> rest -> rest
+    "wibblest" <> rest -> rest
+    _ -> "a"
+  }
+}"#
+    );
+}
+
+#[test]
+fn multiple_unreachable_prefix_patterns_1() {
+    assert_warning!(
+        r#"pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest if True -> rest
+    "wibble" <> rest -> rest
+    "wibblest" <> rest -> rest
+    _ -> "a"
+  }
+}"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "pub fn main() {\n  let string = \"\"\n  case string {\n    \"wib\" <> rest -> rest\n    \"wibble\" <> rest -> rest\n    \"wibblest\" <> rest -> rest\n    _ -> \"a\"\n  }\n}"
+---
+----- SOURCE CODE
+pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest -> rest
+    "wibble" <> rest -> rest
+    "wibblest" <> rest -> rest
+    _ -> "a"
+  }
+}
+
+----- WARNING
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:5:5
+  │
+5 │     "wibble" <> rest -> rest
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches the same
+values.
+
+Hint: It can be safely removed.
+
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:6:5
+  │
+6 │     "wibblest" <> rest -> rest
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches the same
+values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns_1.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "pub fn main() {\n  let string = \"\"\n  case string {\n    \"wib\" <> rest if True -> rest\n    \"wibble\" <> rest -> rest\n    \"wibblest\" <> rest -> rest\n    _ -> \"a\"\n  }\n}"
+---
+----- SOURCE CODE
+pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest if True -> rest
+    "wibble" <> rest -> rest
+    "wibblest" <> rest -> rest
+    _ -> "a"
+  }
+}
+
+----- WARNING
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:6:5
+  │
+6 │     "wibblest" <> rest -> rest
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches the same
+values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_prefix_pattern_after_prefix.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_prefix_pattern_after_prefix.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "pub fn main() {\n  let string = \"\"\n  case string {\n    \"wib\" <> rest -> rest\n    \"wibble\" <> rest -> rest\n    _ -> \"a\"\n  }\n}"
+---
+----- SOURCE CODE
+pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest -> rest
+    "wibble" <> rest -> rest
+    _ -> "a"
+  }
+}
+
+----- WARNING
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:5:5
+  │
+5 │     "wibble" <> rest -> rest
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches the same
+values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_string_pattern_after_prefix.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_string_pattern_after_prefix.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "pub fn main() {\n  let string = \"\"\n  case string {\n    \"wib\" <> rest -> rest\n    \"wibble\" -> \"a\"\n    _ -> \"b\"\n  }\n}"
+---
+----- SOURCE CODE
+pub fn main() {
+  let string = ""
+  case string {
+    "wib" <> rest -> rest
+    "wibble" -> "a"
+    _ -> "b"
+  }
+}
+
+----- WARNING
+warning: Unreachable case clause
+  ┌─ /src/warning/wrn.gleam:5:5
+  │
+5 │     "wibble" -> "a"
+  │     ^^^^^^^^^^^^^^^
+
+This case clause cannot be reached as a previous clause matches the same
+values.
+
+Hint: It can be safely removed.


### PR DESCRIPTION
This PR expands the pattern matching decision tree to properly deal with string patterns and check if they are reachable or not. It also lays the foundation to properly do efficient code generation for string patterns, after this I'll start working on the code get part!