### PR TITLE
LSP: Show references to values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The language server now supports finding references to values, both within
+  a module and across multiple modules.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Formatter
 
 ### Bug fixes

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -2158,7 +2158,7 @@ pub mod reference {
 }
 
 pub mod reference_kind {
-  pub use self::Which::{Qualified,Unqualified,Import,Definition};
+  pub use self::Which::{Qualified,Unqualified,Import,Definition,Alias};
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
@@ -2243,6 +2243,11 @@ pub mod reference_kind {
             ()
           ))
         }
+        4 => {
+          ::core::result::Result::Ok(Alias(
+            ()
+          ))
+        }
         x => ::core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
@@ -2317,6 +2322,10 @@ pub mod reference_kind {
       self.builder.set_data_field::<u16>(0, 3);
     }
     #[inline]
+    pub fn set_alias(&mut self, _value: ())  {
+      self.builder.set_data_field::<u16>(0, 4);
+    }
+    #[inline]
     pub fn which(self) -> ::core::result::Result<WhichBuilder, ::capnp::NotInSchema> {
       match self.builder.get_data_field::<u16>(0) {
         0 => {
@@ -2339,6 +2348,11 @@ pub mod reference_kind {
             ()
           ))
         }
+        4 => {
+          ::core::result::Result::Ok(Alias(
+            ()
+          ))
+        }
         x => ::core::result::Result::Err(::capnp::NotInSchema(x))
       }
     }
@@ -2353,17 +2367,17 @@ pub mod reference_kind {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 81] = [
+    pub static ENCODED_NODE: [::capnp::Word; 96] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(201, 38, 14, 81, 37, 76, 28, 166),
       ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
-      ::capnp::word(0, 0, 7, 0, 0, 0, 4, 0),
+      ::capnp::word(0, 0, 7, 0, 0, 0, 5, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 218, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(29, 0, 0, 0, 231, 0, 0, 0),
+      ::capnp::word(29, 0, 0, 0, 31, 1, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -2371,35 +2385,42 @@ pub mod reference_kind {
       ::capnp::word(101, 114, 101, 110, 99, 101, 75, 105),
       ::capnp::word(110, 100, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(20, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 255, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(97, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(125, 0, 0, 0, 82, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(124, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(136, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(1, 0, 254, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(105, 0, 0, 0, 98, 0, 0, 0),
+      ::capnp::word(133, 0, 0, 0, 98, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(132, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(144, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(2, 0, 253, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(113, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(141, 0, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(108, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(120, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(136, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(148, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(3, 0, 252, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(117, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(145, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(116, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(128, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(144, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(156, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(4, 0, 251, 255, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(153, 0, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(148, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(160, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(113, 117, 97, 108, 105, 102, 105, 101),
       ::capnp::word(100, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2435,6 +2456,14 @@ pub mod reference_kind {
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(97, 108, 105, 97, 115, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
@@ -2442,6 +2471,7 @@ pub mod reference_kind {
         1 => <() as ::capnp::introspect::Introspect>::introspect(),
         2 => <() as ::capnp::introspect::Introspect>::introspect(),
         3 => <() as ::capnp::introspect::Introspect>::introspect(),
+        4 => <() as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -2455,8 +2485,8 @@ pub mod reference_kind {
       members_by_name: MEMBERS_BY_NAME,
     };
     pub static NONUNION_MEMBERS : &[u16] = &[];
-    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[0,1,2,3];
-    pub static MEMBERS_BY_NAME : &[u16] = &[3,2,0,1];
+    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[0,1,2,3,4];
+    pub static MEMBERS_BY_NAME : &[u16] = &[4,3,2,0,1];
     pub const TYPE_ID: u64 = 0xa61c_4c25_510e_26c9;
   }
   pub enum Which {
@@ -2464,6 +2494,7 @@ pub mod reference_kind {
     Unqualified(()),
     Import(()),
     Definition(()),
+    Alias(()),
   }
   pub type WhichReader = Which;
   pub type WhichBuilder = Which;

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -58,6 +58,7 @@ struct ReferenceKind {
     unqualified @1 :Void;
     import @2 :Void;
     definition @3 :Void;
+    alias @4 :Void;
   }
 }
 

--- a/compiler-core/src/language_server.rs
+++ b/compiler-core/src/language_server.rs
@@ -7,6 +7,7 @@ mod feedback;
 mod files;
 mod messages;
 mod progress;
+mod reference;
 mod rename;
 mod router;
 mod server;

--- a/compiler-core/src/language_server.rs
+++ b/compiler-core/src/language_server.rs
@@ -114,3 +114,26 @@ fn path(uri: &Url) -> Utf8PathBuf {
     #[cfg(not(any(unix, windows, target_os = "redox", target_os = "wasi")))]
     return Utf8PathBuf::from_path_buf(uri.path().into()).expect("Non Utf8 Path");
 }
+
+fn url_from_path(path: &str) -> Option<Url> {
+    // The targets for which `from_file_path` is defined
+    #[cfg(any(
+        unix,
+        windows,
+        target_os = "redox",
+        target_os = "wasi",
+        target_os = "hermit"
+    ))]
+    let uri = Url::from_file_path(path).ok();
+
+    #[cfg(not(any(
+        unix,
+        windows,
+        target_os = "redox",
+        target_os = "wasi",
+        target_os = "hermit"
+    )))]
+    let uri = Url::parse(&format!("file://{path}")).ok();
+
+    uri
+}

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -31,7 +31,7 @@ use super::{
     compiler::LspProjectCompiler,
     edits::{add_newlines_after_import, get_import_edit, position_of_first_definition_if_import},
     engine::{overlaps, within},
-    rename::find_variable_references,
+    reference::find_variable_references,
     src_span_to_lsp_range,
 };
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -715,14 +715,17 @@ where
                             .collect(),
                     ),
                 },
-                Some(Referenced::ModuleValue { module, name, .. }) => {
-                    Some(find_module_value_references(
-                        module,
-                        name,
-                        this.compiler.project_compiler.get_importable_modules(),
-                        &this.compiler.sources,
-                    ))
-                }
+                Some(Referenced::ModuleValue {
+                    module,
+                    name,
+                    location,
+                    ..
+                }) if location.contains(byte_index) => Some(find_module_value_references(
+                    module,
+                    name,
+                    this.compiler.project_compiler.get_importable_modules(),
+                    &this.compiler.sources,
+                )),
                 _ => None,
             })
         })

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -931,6 +931,13 @@ where
         })
     }
 
+    pub fn find_references(
+        &mut self,
+        _params: lsp::ReferenceParams,
+    ) -> Response<Option<Vec<SrcSpan>>> {
+        self.respond(|_this| Ok(None))
+    }
+
     fn respond<T>(&mut self, handler: impl FnOnce(&mut Self) -> Result<T>) -> Response<T> {
         let result = handler(self);
         let warnings = self.take_warnings();

--- a/compiler-core/src/language_server/messages.rs
+++ b/compiler-core/src/language_server/messages.rs
@@ -8,7 +8,7 @@ use lsp_types::{
     notification::{DidChangeTextDocument, DidCloseTextDocument, DidSaveTextDocument},
     request::{
         CodeActionRequest, Completion, DocumentSymbolRequest, Formatting, GotoTypeDefinition,
-        HoverRequest, PrepareRenameRequest, Rename, SignatureHelpRequest,
+        HoverRequest, PrepareRenameRequest, References, Rename, SignatureHelpRequest,
     },
 };
 use std::time::Duration;
@@ -31,6 +31,7 @@ pub enum Request {
     DocumentSymbol(lsp::DocumentSymbolParams),
     PrepareRename(lsp::TextDocumentPositionParams),
     Rename(lsp::RenameParams),
+    FindReferences(lsp::ReferenceParams),
 }
 
 impl Request {
@@ -76,6 +77,10 @@ impl Request {
             "textDocument/typeDefinition" => {
                 let params = cast_request::<GotoTypeDefinition>(request);
                 Some(Message::Request(id, Request::GoToTypeDefinition(params)))
+            }
+            "textDocument/references" => {
+                let params = cast_request::<References>(request);
+                Some(Message::Request(id, Request::FindReferences(params)))
             }
             _ => None,
         }

--- a/compiler-core/src/language_server/reference.rs
+++ b/compiler-core/src/language_server/reference.rs
@@ -1,0 +1,200 @@
+use ecow::EcoString;
+
+use crate::{
+    analyse,
+    ast::{
+        ArgNames, Definition, Function, ModuleConstant, Pattern, RecordConstructor, SrcSpan,
+        TypedExpr,
+    },
+    build::Located,
+    type_::{
+        ModuleValueConstructor, ValueConstructor, ValueConstructorVariant,
+        error::{Named, VariableOrigin},
+    },
+};
+
+use super::rename::RenameTarget;
+
+pub enum Referenced {
+    LocalVariable {
+        definition_location: SrcSpan,
+        location: SrcSpan,
+        origin: Option<VariableOrigin>,
+    },
+    ModuleValue {
+        module: EcoString,
+        name: EcoString,
+        location: SrcSpan,
+        name_kind: Named,
+        target_kind: RenameTarget,
+    },
+}
+
+pub fn reference_for_ast_node(
+    found: Located<'_>,
+    current_module: &EcoString,
+) -> Option<Referenced> {
+    match found {
+        Located::Expression(TypedExpr::Var {
+            constructor:
+                ValueConstructor {
+                    variant:
+                        ValueConstructorVariant::LocalVariable {
+                            location: definition_location,
+                            origin,
+                        },
+                    ..
+                },
+            location,
+            ..
+        }) => Some(Referenced::LocalVariable {
+            definition_location: *definition_location,
+            location: *location,
+            origin: Some(origin.clone()),
+        }),
+        Located::Pattern(Pattern::Variable {
+            location, origin, ..
+        }) => Some(Referenced::LocalVariable {
+            definition_location: *location,
+            location: *location,
+            origin: Some(origin.clone()),
+        }),
+        Located::Pattern(Pattern::VarUsage {
+            constructor,
+            location,
+            ..
+        }) => constructor
+            .as_ref()
+            .and_then(|constructor| match &constructor.variant {
+                ValueConstructorVariant::LocalVariable {
+                    location: definition_location,
+                    origin,
+                } => Some(Referenced::LocalVariable {
+                    definition_location: *definition_location,
+                    location: *location,
+                    origin: Some(origin.clone()),
+                }),
+                _ => None,
+            }),
+        Located::Pattern(Pattern::Assign { location, .. }) => Some(Referenced::LocalVariable {
+            definition_location: *location,
+            location: *location,
+            origin: None,
+        }),
+        Located::Arg(arg) => match &arg.names {
+            ArgNames::Named { location, .. }
+            | ArgNames::NamedLabelled {
+                name_location: location,
+                ..
+            } => Some(Referenced::LocalVariable {
+                definition_location: *location,
+                location: *location,
+                origin: None,
+            }),
+            ArgNames::Discard { .. } | ArgNames::LabelledDiscard { .. } => None,
+        },
+        Located::Expression(TypedExpr::Var {
+            constructor:
+                ValueConstructor {
+                    variant:
+                        ValueConstructorVariant::ModuleConstant { module, .. }
+                        | ValueConstructorVariant::ModuleFn { module, .. },
+                    ..
+                },
+            name,
+            location,
+            ..
+        }) => Some(Referenced::ModuleValue {
+            module: module.clone(),
+            name: name.clone(),
+            location: *location,
+            name_kind: Named::Function,
+            target_kind: RenameTarget::Unqualified,
+        }),
+
+        Located::Expression(TypedExpr::ModuleSelect {
+            module_name,
+            label,
+            constructor: ModuleValueConstructor::Fn { .. } | ModuleValueConstructor::Constant { .. },
+            location,
+            ..
+        }) => Some(Referenced::ModuleValue {
+            module: module_name.clone(),
+            name: label.clone(),
+            location: *location,
+            name_kind: Named::Function,
+            target_kind: RenameTarget::Qualified,
+        }),
+        Located::ModuleStatement(
+            Definition::Function(Function {
+                name: Some((location, name)),
+                ..
+            })
+            | Definition::ModuleConstant(ModuleConstant {
+                name,
+                name_location: location,
+                ..
+            }),
+        ) => Some(Referenced::ModuleValue {
+            module: current_module.clone(),
+            name: name.clone(),
+            location: *location,
+            name_kind: Named::Function,
+            target_kind: RenameTarget::Definition,
+        }),
+        Located::Expression(TypedExpr::Var {
+            constructor:
+                ValueConstructor {
+                    variant: ValueConstructorVariant::Record { module, name, .. },
+                    ..
+                },
+            location,
+            ..
+        }) => Some(Referenced::ModuleValue {
+            module: module.clone(),
+            name: name.clone(),
+            location: *location,
+            name_kind: Named::CustomTypeVariant,
+            target_kind: RenameTarget::Unqualified,
+        }),
+        Located::Expression(TypedExpr::ModuleSelect {
+            module_name,
+            label,
+            constructor: ModuleValueConstructor::Record { .. },
+            location,
+            ..
+        }) => Some(Referenced::ModuleValue {
+            module: module_name.clone(),
+            name: label.clone(),
+            location: *location,
+            name_kind: Named::CustomTypeVariant,
+            target_kind: RenameTarget::Qualified,
+        }),
+        Located::VariantConstructorDefinition(RecordConstructor { name, location, .. }) => {
+            Some(Referenced::ModuleValue {
+                module: current_module.clone(),
+                name: name.clone(),
+                location: *location,
+                name_kind: Named::CustomTypeVariant,
+                target_kind: RenameTarget::Definition,
+            })
+        }
+        Located::Pattern(Pattern::Constructor {
+            constructor: analyse::Inferred::Known(constructor),
+            module: module_select,
+            name_location: location,
+            ..
+        }) => Some(Referenced::ModuleValue {
+            module: constructor.module.clone(),
+            name: constructor.name.clone(),
+            location: *location,
+            name_kind: Named::CustomTypeVariant,
+            target_kind: if module_select.is_some() {
+                RenameTarget::Qualified
+            } else {
+                RenameTarget::Unqualified
+            },
+        }),
+        _ => None,
+    }
+}

--- a/compiler-core/src/language_server/rename.rs
+++ b/compiler-core/src/language_server/rename.rs
@@ -163,7 +163,14 @@ fn rename_references_in_module(
     let mut edits = TextEdits::new(&source_information.line_numbers);
 
     for reference in references {
-        edits.replace(reference.location, new_name.clone());
+        match reference.kind {
+            // If the reference is an alias, the alias name will remain unchanged.
+            ReferenceKind::Alias => {}
+            ReferenceKind::Qualified
+            | ReferenceKind::Unqualified
+            | ReferenceKind::Import
+            | ReferenceKind::Definition => edits.replace(reference.location, new_name.clone()),
+        }
     }
 
     let Some(uri) = url_from_path(source_information.path.as_str()) else {
@@ -193,7 +200,7 @@ fn alias_references_in_module(
     for reference in references {
         match reference.kind {
             ReferenceKind::Qualified => {}
-            ReferenceKind::Unqualified => {
+            ReferenceKind::Unqualified | ReferenceKind::Alias => {
                 edits.replace(reference.location, params.new_name.clone())
             }
             ReferenceKind::Import => {

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -4,6 +4,7 @@ mod completion;
 mod definition;
 mod document_symbols;
 mod hover;
+mod reference;
 mod rename;
 mod signature_help;
 

--- a/compiler-core/src/language_server/tests/reference.rs
+++ b/compiler-core/src/language_server/tests/reference.rs
@@ -519,3 +519,27 @@ pub fn wibble() {
         find_position_of("fn")
     );
 }
+
+#[test]
+fn references_for_aliased_value() {
+    assert_references!(
+        (
+            "mod",
+            "
+import app.{Wibble as Wobble}
+
+fn wobble() {
+  Wobble
+}
+"
+        ),
+        "
+pub type Wibble { Wibble }
+
+pub fn main() {
+  Wibble
+}
+",
+        find_position_of("Wibble").nth_occurrence(2),
+    );
+}

--- a/compiler-core/src/language_server/tests/reference.rs
+++ b/compiler-core/src/language_server/tests/reference.rs
@@ -1,0 +1,521 @@
+use std::collections::HashMap;
+
+use lsp_types::{
+    PartialResultParams, Position, Range, ReferenceContext, ReferenceParams,
+    TextDocumentPositionParams, WorkDoneProgressParams,
+};
+
+use crate::language_server::tests::{TestProject, find_position_of};
+
+fn find_references(
+    tester: &TestProject<'_>,
+    position: Position,
+) -> Option<HashMap<String, Vec<Range>>> {
+    let locations = tester.at(position, |engine, params, _| {
+        let params = ReferenceParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: params.text_document,
+                position,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+            context: ReferenceContext {
+                include_declaration: true,
+            },
+        };
+        engine.find_references(params).result.unwrap()
+    })?;
+    let mut references: HashMap<String, Vec<Range>> = HashMap::new();
+
+    for location in locations {
+        let module_name = tester
+            .module_name_from_url(&location.uri)
+            .expect("Valid uri");
+        _ = references
+            .entry(module_name)
+            .or_default()
+            .push(location.range);
+    }
+
+    Some(references)
+}
+
+fn show_references(code: &str, position: Option<Position>, ranges: &[Range]) -> String {
+    let mut buffer = String::new();
+
+    for (line_number, line) in code.lines().enumerate() {
+        let mut underline = String::new();
+        let mut underline_empty = true;
+        let line_number = line_number as u32;
+
+        if let Some(Range { start, end }) = ranges
+            .iter()
+            .find(|range| range.start.line == line_number && range.end.line == line_number)
+        {
+            for (column_number, _) in line.chars().enumerate() {
+                let current_position = Position::new(line_number, column_number as u32);
+                if Some(current_position) == position {
+                    underline_empty = false;
+                    underline.push('↑');
+                } else if start.le(&current_position) && current_position.lt(&end) {
+                    underline_empty = false;
+                    underline.push('▔');
+                } else {
+                    underline.push(' ');
+                }
+            }
+        }
+
+        buffer.push_str(line);
+        if !underline_empty {
+            buffer.push('\n');
+            buffer.push_str(&underline);
+        }
+        buffer.push('\n');
+    }
+
+    buffer
+}
+
+macro_rules! assert_references {
+    ($code:literal, $position:expr $(,)?) => {
+        assert_references!(TestProject::for_source($code), $position);
+    };
+
+    (($module_name:literal, $module_src:literal), $code:literal, $position:expr $(,)?) => {
+        assert_references!(
+            TestProject::for_source($code).add_module($module_name, $module_src),
+            $position
+        );
+    };
+
+    ($project:expr, $position:expr $(,)?) => {
+        let project = $project;
+        let src = project.src;
+        let position = $position.find_position(src);
+        let result = dbg!(find_references(&project, position)).expect("References not found");
+
+        let mut output = String::new();
+        for (name, src) in project.root_package_modules.iter() {
+            output.push_str(&format!(
+                "-- {name}.gleam\n{}\n\n",
+                show_references(src, None, result.get(*name).unwrap_or(&Vec::new()))
+            ));
+        }
+        output.push_str(&format!(
+            "-- app.gleam\n{}",
+            show_references(
+                src,
+                Some(position),
+                result.get("app").unwrap_or(&Vec::new())
+            )
+        ));
+
+        insta::assert_snapshot!(insta::internals::AutoName, output, src);
+    };
+}
+
+macro_rules! assert_no_references {
+    ($code:literal, $position:expr $(,)?) => {
+        let project = TestProject::for_source($code);
+        assert_no_references!(&project, $position);
+    };
+
+    ($project:expr, $position:expr $(,)?) => {
+        let src = $project.src;
+        let position = $position.find_position(src);
+        let result = find_references($project, position);
+        assert_eq!(result, None);
+    };
+}
+
+#[test]
+fn references_for_local_variable() {
+    assert_references!(
+        "
+pub fn main() {
+  let wibble = 10
+  let wobble = wibble + 1
+  wibble + wobble
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn references_for_local_variable_from_definition() {
+    assert_references!(
+        "
+pub fn main() {
+  let wibble = 10
+  let wobble = wibble + 1
+  wibble + wobble
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn references_for_private_function() {
+    assert_references!(
+        "
+fn wibble() {
+  wibble()
+}
+
+pub fn main() {
+  let _ = wibble()
+  wibble() + 4
+}
+
+fn wobble() {
+  wibble() || wobble()
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn references_for_private_function_from_reference() {
+    assert_references!(
+        "
+fn wibble() {
+  wibble()
+}
+
+pub fn main() {
+  let _ = wibble()
+  wibble() + 4
+}
+
+fn wobble() {
+  wibble() || wobble()
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn references_for_public_function() {
+    assert_references!(
+        (
+            "mod",
+            "
+import app.{wibble}
+
+fn wobble() {
+  app.wibble()
+}
+
+fn other() {
+  wibble()
+}
+"
+        ),
+        "
+pub fn wibble() {
+  wibble()
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn references_for_function_from_qualified_reference() {
+    assert_references!(
+        (
+            "mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import mod
+
+pub fn main() {
+  let value = mod.wibble()
+  mod.wibble()
+  value
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn references_for_function_from_unqualified_reference() {
+    assert_references!(
+        (
+            "mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import mod.{wibble}
+
+pub fn main() {
+  let value = wibble()
+  mod.wibble()
+  value
+}
+",
+        find_position_of("wibble()"),
+    );
+}
+
+#[test]
+fn references_for_private_constant() {
+    assert_references!(
+        "
+const wibble = 10
+
+pub fn main() {
+  let _ = wibble
+  wibble + 4
+}
+
+fn wobble() {
+  wibble + wobble()
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn references_for_private_constant_from_reference() {
+    assert_references!(
+        "
+const wibble = 10
+
+pub fn main() {
+  let _ = wibble
+  wibble + 4
+}
+
+fn wobble() {
+  wibble + wobble()
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn references_for_public_constant() {
+    assert_references!(
+        (
+            "mod",
+            "
+import app.{wibble}
+
+fn wobble() {
+  app.wibble
+}
+
+fn other() {
+  wibble
+}
+"
+        ),
+        "
+pub const wibble = 10
+
+pub fn main() {
+  wibble
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn references_for_constant_from_qualified_reference() {
+    assert_references!(
+        (
+            "mod",
+            "
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+"
+        ),
+        "
+import mod
+
+pub fn main() {
+  let value = mod.wibble
+  mod.wibble + value
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn references_for_constant_from_unqualified_reference() {
+    assert_references!(
+        (
+            "mod",
+            "
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+"
+        ),
+        "
+import mod.{wibble}
+
+pub fn main() {
+  let value = mod.wibble
+  wibble + value
+}
+",
+        find_position_of("wibble +"),
+    );
+}
+
+#[test]
+fn references_for_private_type_variant() {
+    assert_references!(
+        "
+type Wibble { Wibble }
+
+fn main() {
+  let _ = Wibble
+  Wibble
+}
+
+fn wobble() {
+  Wibble
+  wobble()
+}
+",
+        find_position_of("Wibble }"),
+    );
+}
+
+#[test]
+fn references_for_private_type_variant_from_reference() {
+    assert_references!(
+        "
+type Wibble { Wibble }
+
+fn main() {
+  let _ = Wibble
+  Wibble
+}
+
+fn wobble() {
+  Wibble
+  wobble()
+}
+",
+        find_position_of(" = Wibble").under_char('W'),
+    );
+}
+
+#[test]
+fn references_for_public_type_variant() {
+    assert_references!(
+        (
+            "mod",
+            "
+import app.{Wibble}
+
+fn wobble() {
+  app.Wibble
+}
+
+fn other() {
+  Wibble
+}
+"
+        ),
+        "
+pub type Wibble { Wibble }
+
+pub fn main() {
+  Wibble
+}
+",
+        find_position_of("Wibble }"),
+    );
+}
+
+#[test]
+fn references_for_type_variant_from_qualified_reference() {
+    assert_references!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+"
+        ),
+        "
+import mod
+
+pub fn main() {
+  let value = mod.Wibble
+  mod.Wibble
+  value
+}
+",
+        find_position_of("Wibble"),
+    );
+}
+
+#[test]
+fn references_for_type_variant_from_unqualified_reference() {
+    assert_references!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+"
+        ),
+        "
+import mod.{Wibble}
+
+pub fn main() {
+  let value = mod.Wibble
+  Wibble
+}
+",
+        find_position_of("Wibble").nth_occurrence(3),
+    );
+}
+
+#[test]
+fn no_references_for_keyword() {
+    assert_no_references!(
+        "
+pub fn wibble() {
+  todo
+}
+",
+        find_position_of("fn")
+    );
+}

--- a/compiler-core/src/language_server/tests/reference.rs
+++ b/compiler-core/src/language_server/tests/reference.rs
@@ -543,3 +543,53 @@ pub fn main() {
         find_position_of("Wibble").nth_occurrence(2),
     );
 }
+
+#[test]
+fn references_for_aliased_const() {
+    assert_references!(
+        (
+            "mod",
+            "
+import app.{wibble as other}
+
+fn wobble() {
+  other
+}
+"
+        ),
+        "
+pub const wibble = 123
+
+pub fn main() {
+  wibble
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn references_for_aliased_function() {
+    assert_references!(
+        (
+            "mod",
+            "
+import app.{wibble as other}
+
+fn wobble() {
+  other()
+}
+"
+        ),
+        "
+pub fn wibble() {
+  123
+}
+
+pub fn main() {
+  wibble()
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -1119,3 +1119,28 @@ pub fn main() {
         find_position_of("wibble").to_selection()
     );
 }
+
+#[test]
+fn rename_aliased_value() {
+    assert_rename!(
+        (
+            "mod",
+            "
+import app.{Wibble as Wobble}
+
+fn wobble() {
+  Wobble
+}
+"
+        ),
+        "
+pub type Wibble { Wibble }
+
+pub fn main() {
+  Wibble
+}
+",
+        "Wubble",
+        find_position_of("Wibble }").to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_aliased_const.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_aliased_const.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+assertion_line: 549
+expression: "\npub const wibble = 123\n\npub fn main() {\n  wibble\n}\n"
+snapshot_kind: text
+---
+-- mod.gleam
+
+import app.{wibble as other}
+            ▔▔▔▔▔▔          
+
+fn wobble() {
+  other
+  ▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+pub const wibble = 123
+          ▔▔▔▔▔▔      
+
+pub fn main() {
+  wibble
+  ↑▔▔▔▔▔
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_aliased_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_aliased_function.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+assertion_line: 573
+expression: "\npub fn wibble() {\n  123\n}\n\npub fn main() {\n  wibble()\n}\n"
+snapshot_kind: text
+---
+-- mod.gleam
+
+import app.{wibble as other}
+            ▔▔▔▔▔▔          
+
+fn wobble() {
+  other()
+  ▔▔▔▔▔  
+}
+
+
+-- app.gleam
+
+pub fn wibble() {
+       ▔▔▔▔▔▔    
+  123
+}
+
+pub fn main() {
+  wibble()
+  ↑▔▔▔▔▔  
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_aliased_value.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_aliased_value.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\npub type Wibble { Wibble }\n\npub fn main() {\n  Wibble\n}\n"
+---
+-- mod.gleam
+
+import app.{Wibble as Wobble}
+            ▔▔▔▔▔▔           
+
+fn wobble() {
+  Wobble
+  ▔▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+pub type Wibble { Wibble }
+                  ↑▔▔▔▔▔  
+
+pub fn main() {
+  Wibble
+  ▔▔▔▔▔▔
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_constant_from_qualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_constant_from_qualified_reference.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nimport mod\n\npub fn main() {\n  let value = mod.wibble\n  mod.wibble + value\n}\n"
+---
+-- mod.gleam
+
+pub const wibble = 10
+          ▔▔▔▔▔▔     
+
+fn wobble() {
+  wibble
+  ▔▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() {
+  let value = mod.wibble
+                  ↑▔▔▔▔▔
+  mod.wibble + value
+      ▔▔▔▔▔▔        
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_constant_from_unqualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_constant_from_unqualified_reference.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nimport mod.{wibble}\n\npub fn main() {\n  let value = mod.wibble\n  wibble + value\n}\n"
+---
+-- mod.gleam
+
+pub const wibble = 10
+          ▔▔▔▔▔▔     
+
+fn wobble() {
+  wibble
+  ▔▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+import mod.{wibble}
+            ▔▔▔▔▔▔ 
+
+pub fn main() {
+  let value = mod.wibble
+                  ▔▔▔▔▔▔
+  wibble + value
+  ↑▔▔▔▔▔        
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_function_from_qualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_function_from_qualified_reference.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nimport mod\n\npub fn main() {\n  let value = mod.wibble()\n  mod.wibble()\n  value\n}\n"
+---
+-- mod.gleam
+
+pub fn wibble() {
+       ▔▔▔▔▔▔    
+  wibble()
+  ▔▔▔▔▔▔  
+}
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() {
+  let value = mod.wibble()
+                  ↑▔▔▔▔▔  
+  mod.wibble()
+      ▔▔▔▔▔▔  
+  value
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_function_from_unqualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_function_from_unqualified_reference.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nimport mod.{wibble}\n\npub fn main() {\n  let value = wibble()\n  mod.wibble()\n  value\n}\n"
+---
+-- mod.gleam
+
+pub fn wibble() {
+       ▔▔▔▔▔▔    
+  wibble()
+  ▔▔▔▔▔▔  
+}
+
+
+-- app.gleam
+
+import mod.{wibble}
+            ▔▔▔▔▔▔ 
+
+pub fn main() {
+  let value = wibble()
+              ↑▔▔▔▔▔  
+  mod.wibble()
+      ▔▔▔▔▔▔  
+  value
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_local_variable.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  let wobble = wibble + 1\n  wibble + wobble\n}\n"
+---
+-- app.gleam
+
+pub fn main() {
+  let wibble = 10
+      ▔▔▔▔▔▔     
+  let wobble = wibble + 1
+               ↑▔▔▔▔▔    
+  wibble + wobble
+  ▔▔▔▔▔▔         
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_local_variable_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_local_variable_from_definition.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  let wobble = wibble + 1\n  wibble + wobble\n}\n"
+---
+-- app.gleam
+
+pub fn main() {
+  let wibble = 10
+      ↑▔▔▔▔▔     
+  let wobble = wibble + 1
+               ▔▔▔▔▔▔    
+  wibble + wobble
+  ▔▔▔▔▔▔         
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_constant.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nconst wibble = 10\n\npub fn main() {\n  let _ = wibble\n  wibble + 4\n}\n\nfn wobble() {\n  wibble + wobble()\n}\n"
+---
+-- app.gleam
+
+const wibble = 10
+      ↑▔▔▔▔▔     
+
+pub fn main() {
+  let _ = wibble
+          ▔▔▔▔▔▔
+  wibble + 4
+  ▔▔▔▔▔▔    
+}
+
+fn wobble() {
+  wibble + wobble()
+  ▔▔▔▔▔▔           
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_constant_from_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_constant_from_reference.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nconst wibble = 10\n\npub fn main() {\n  let _ = wibble\n  wibble + 4\n}\n\nfn wobble() {\n  wibble + wobble()\n}\n"
+---
+-- app.gleam
+
+const wibble = 10
+      ▔▔▔▔▔▔     
+
+pub fn main() {
+  let _ = wibble
+          ↑▔▔▔▔▔
+  wibble + 4
+  ▔▔▔▔▔▔    
+}
+
+fn wobble() {
+  wibble + wobble()
+  ▔▔▔▔▔▔           
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_function.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nfn wibble() {\n  wibble()\n}\n\npub fn main() {\n  let _ = wibble()\n  wibble() + 4\n}\n\nfn wobble() {\n  wibble() || wobble()\n}\n"
+---
+-- app.gleam
+
+fn wibble() {
+   ↑▔▔▔▔▔    
+  wibble()
+  ▔▔▔▔▔▔  
+}
+
+pub fn main() {
+  let _ = wibble()
+          ▔▔▔▔▔▔  
+  wibble() + 4
+  ▔▔▔▔▔▔      
+}
+
+fn wobble() {
+  wibble() || wobble()
+  ▔▔▔▔▔▔              
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_function_from_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_function_from_reference.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nfn wibble() {\n  wibble()\n}\n\npub fn main() {\n  let _ = wibble()\n  wibble() + 4\n}\n\nfn wobble() {\n  wibble() || wobble()\n}\n"
+---
+-- app.gleam
+
+fn wibble() {
+   ▔▔▔▔▔▔    
+  wibble()
+  ↑▔▔▔▔▔  
+}
+
+pub fn main() {
+  let _ = wibble()
+          ▔▔▔▔▔▔  
+  wibble() + 4
+  ▔▔▔▔▔▔      
+}
+
+fn wobble() {
+  wibble() || wobble()
+  ▔▔▔▔▔▔              
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_type_variant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_type_variant.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\ntype Wibble { Wibble }\n\nfn main() {\n  let _ = Wibble\n  Wibble\n}\n\nfn wobble() {\n  Wibble\n  wobble()\n}\n"
+---
+-- app.gleam
+
+type Wibble { Wibble }
+              ↑▔▔▔▔▔  
+
+fn main() {
+  let _ = Wibble
+          ▔▔▔▔▔▔
+  Wibble
+  ▔▔▔▔▔▔
+}
+
+fn wobble() {
+  Wibble
+  ▔▔▔▔▔▔
+  wobble()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_type_variant_from_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_private_type_variant_from_reference.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\ntype Wibble { Wibble }\n\nfn main() {\n  let _ = Wibble\n  Wibble\n}\n\nfn wobble() {\n  Wibble\n  wobble()\n}\n"
+---
+-- app.gleam
+
+type Wibble { Wibble }
+              ▔▔▔▔▔▔  
+
+fn main() {
+  let _ = Wibble
+          ↑▔▔▔▔▔
+  Wibble
+  ▔▔▔▔▔▔
+}
+
+fn wobble() {
+  Wibble
+  ▔▔▔▔▔▔
+  wobble()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_public_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_public_constant.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\npub const wibble = 10\n\npub fn main() {\n  wibble\n}\n"
+---
+-- mod.gleam
+
+import app.{wibble}
+            ▔▔▔▔▔▔ 
+
+fn wobble() {
+  app.wibble
+      ▔▔▔▔▔▔
+}
+
+fn other() {
+  wibble
+  ▔▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+pub const wibble = 10
+          ▔▔▔▔▔▔     
+
+pub fn main() {
+  wibble
+  ↑▔▔▔▔▔
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_public_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_public_function.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\npub fn wibble() {\n  wibble()\n}\n"
+---
+-- mod.gleam
+
+import app.{wibble}
+            ▔▔▔▔▔▔ 
+
+fn wobble() {
+  app.wibble()
+      ▔▔▔▔▔▔  
+}
+
+fn other() {
+  wibble()
+  ▔▔▔▔▔▔  
+}
+
+
+-- app.gleam
+
+pub fn wibble() {
+       ▔▔▔▔▔▔    
+  wibble()
+  ↑▔▔▔▔▔  
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_public_type_variant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_public_type_variant.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\npub type Wibble { Wibble }\n\npub fn main() {\n  Wibble\n}\n"
+---
+-- mod.gleam
+
+import app.{Wibble}
+            ▔▔▔▔▔▔ 
+
+fn wobble() {
+  app.Wibble
+      ▔▔▔▔▔▔
+}
+
+fn other() {
+  Wibble
+  ▔▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+pub type Wibble { Wibble }
+                  ↑▔▔▔▔▔  
+
+pub fn main() {
+  Wibble
+  ▔▔▔▔▔▔
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_type_variant_from_qualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_type_variant_from_qualified_reference.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nimport mod\n\npub fn main() {\n  let value = mod.Wibble\n  mod.Wibble\n  value\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+                  ▔▔▔▔▔▔  
+
+fn wobble() {
+  Wibble
+  ▔▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() {
+  let value = mod.Wibble
+                  ↑▔▔▔▔▔
+  mod.Wibble
+      ▔▔▔▔▔▔
+  value
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_type_variant_from_unqualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__reference__references_for_type_variant_from_unqualified_reference.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/reference.rs
+expression: "\nimport mod.{Wibble}\n\npub fn main() {\n  let value = mod.Wibble\n  Wibble\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+                  ▔▔▔▔▔▔  
+
+fn wobble() {
+  Wibble
+  ▔▔▔▔▔▔
+}
+
+
+-- app.gleam
+
+import mod.{Wibble}
+            ▔▔▔▔▔▔ 
+
+pub fn main() {
+  let value = mod.Wibble
+                  ▔▔▔▔▔▔
+  Wibble
+  ↑▔▔▔▔▔
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_value.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_value.snap
@@ -1,0 +1,41 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub type Wibble { Wibble }\n\npub fn main() {\n  Wibble\n}\n"
+---
+----- BEFORE RENAME
+-- mod.gleam
+
+import app.{Wibble as Wobble}
+
+fn wobble() {
+  Wobble
+}
+
+
+-- app.gleam
+
+pub type Wibble { Wibble }
+                  ↑       
+
+pub fn main() {
+  Wibble
+}
+
+
+----- AFTER RENAME
+-- mod.gleam
+
+import app.{Wubble as Wobble}
+
+fn wobble() {
+  Wobble
+}
+
+
+-- app.gleam
+
+pub type Wibble { Wubble }
+
+pub fn main() {
+  Wubble
+}

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -153,6 +153,7 @@ impl ModuleDecoder {
             Which::Unqualified(_) => ReferenceKind::Unqualified,
             Which::Import(_) => ReferenceKind::Import,
             Which::Definition(_) => ReferenceKind::Definition,
+            Which::Alias(_) => ReferenceKind::Alias,
         })
     }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -232,6 +232,7 @@ impl<'a> ModuleEncoder<'a> {
             ReferenceKind::Unqualified => kind.set_unqualified(()),
             ReferenceKind::Import => kind.set_import(()),
             ReferenceKind::Definition => kind.set_definition(()),
+            ReferenceKind::Alias => kind.set_alias(()),
         }
         self.build_src_span(builder.init_location(), reference.location);
     }

--- a/compiler-core/src/reference.rs
+++ b/compiler-core/src/reference.rs
@@ -13,6 +13,7 @@ pub enum ReferenceKind {
     Unqualified,
     Import,
     Definition,
+    Alias,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -3042,18 +3042,26 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         kind: ReferenceKind,
     ) {
         match variant {
-            // If the referenced name is different to the name of the original
-            // value, that means we are referencing it via an alias and don't
-            // want to track this reference.
             ValueConstructorVariant::ModuleFn {
-                name: value_name, ..
+                module,
+                name: value_name,
+                ..
             }
             | ValueConstructorVariant::Record {
-                name: value_name, ..
+                module,
+                name: value_name,
+                ..
             }
             | ValueConstructorVariant::ModuleConstant {
-                name: value_name, ..
-            } if value_name != referenced_name => {}
+                module,
+                name: value_name,
+                ..
+            } if value_name != referenced_name => self.environment.references.register_reference(
+                module.clone(),
+                value_name.clone(),
+                location,
+                ReferenceKind::Alias,
+            ),
             ValueConstructorVariant::ModuleFn { name, module, .. }
             | ValueConstructorVariant::Record { name, module, .. }
             | ValueConstructorVariant::ModuleConstant { name, module, .. } => self


### PR DESCRIPTION
Closes #1541
This PR uses the infrastructure introduced for value renaming to allow finding value references.
I've extracted the shared `match` expression in `prepare_rename` and `rename` into a new function, so the same long pattern match wouldn't need to be repeated a third time for this.