### PR TITLE
Fix rename range for type variant definitions

### DIFF
--- a/compiler-core/src/language_server/reference.rs
+++ b/compiler-core/src/language_server/reference.rs
@@ -122,11 +122,13 @@ pub fn reference_for_ast_node(
             label,
             constructor: ModuleValueConstructor::Fn { .. } | ModuleValueConstructor::Constant { .. },
             location,
+            field_start,
             ..
         }) => Some(Referenced::ModuleValue {
             module: module_name.clone(),
             name: label.clone(),
-            location: *location,
+
+            location: SrcSpan::new(*field_start, location.end),
             name_kind: Named::Function,
             target_kind: RenameTarget::Qualified,
         }),
@@ -167,23 +169,26 @@ pub fn reference_for_ast_node(
             label,
             constructor: ModuleValueConstructor::Record { .. },
             location,
+            field_start,
             ..
         }) => Some(Referenced::ModuleValue {
             module: module_name.clone(),
             name: label.clone(),
-            location: *location,
+            location: SrcSpan::new(*field_start, location.end),
             name_kind: Named::CustomTypeVariant,
             target_kind: RenameTarget::Qualified,
         }),
-        Located::VariantConstructorDefinition(RecordConstructor { name, location, .. }) => {
-            Some(Referenced::ModuleValue {
-                module: current_module.clone(),
-                name: name.clone(),
-                location: *location,
-                name_kind: Named::CustomTypeVariant,
-                target_kind: RenameTarget::Definition,
-            })
-        }
+        Located::VariantConstructorDefinition(RecordConstructor {
+            name,
+            name_location,
+            ..
+        }) => Some(Referenced::ModuleValue {
+            module: current_module.clone(),
+            name: name.clone(),
+            location: *name_location,
+            name_kind: Named::CustomTypeVariant,
+            target_kind: RenameTarget::Definition,
+        }),
         Located::Pattern(Pattern::Constructor {
             constructor: analyse::Inferred::Known(constructor),
             module: module_select,

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -1141,6 +1141,6 @@ pub fn main() {
 }
 ",
         "Wubble",
-        find_position_of("Wibble }").to_selection()
+        find_position_of("Wibble }")
     );
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_constant.snap
@@ -15,7 +15,7 @@ fn wibble() {
 -- app.gleam
 
 pub const something = 10
-          ↑             
+          ↑▔▔▔▔▔▔▔▔     
 
 pub fn main() {
   something + { 4 * something }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_function.snap
@@ -15,7 +15,7 @@ fn wibble() {
 -- app.gleam
 
 pub fn something() {
-       ↑            
+       ↑▔▔▔▔▔▔▔▔    
   something()
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_type_variant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_type_variant.snap
@@ -16,7 +16,7 @@ fn wibble() {
 
 pub type Wibble {
   Constructor(Int)
-  ↑               
+  ↑▔▔▔▔▔▔▔▔▔▔     
 }
 
 pub fn main() {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_value.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_aliased_value.snap
@@ -15,7 +15,7 @@ fn wobble() {
 -- app.gleam
 
 pub type Wibble { Wibble }
-                  ↑       
+                  ↑▔▔▔▔▔  
 
 pub fn main() {
   Wibble

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_definition.snap
@@ -15,7 +15,7 @@ fn wibble() {
 -- app.gleam
 
 pub const something = 10
-          ↑             
+          ↑▔▔▔▔▔▔▔▔     
 
 pub fn main() {
   something + { 4 * something }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_qualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_qualified_reference.snap
@@ -18,7 +18,7 @@ import mod
 
 pub fn main() {
   mod.something
-      ↑        
+      ↑▔▔▔▔▔▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_reference.snap
@@ -18,7 +18,7 @@ pub const something = 10
 
 pub fn main() {
   something + { 4 * something }
-  ↑                            
+  ↑▔▔▔▔▔▔▔▔                    
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_unqualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_from_unqualified_reference.snap
@@ -18,7 +18,7 @@ import mod.{something}
 
 pub fn main() {
   something + mod.something
-  ↑                        
+  ↑▔▔▔▔▔▔▔▔                
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_shadowed_by_field_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_shadowed_by_field_access.snap
@@ -20,7 +20,7 @@ pub fn main() {
 -- app.gleam
 
 pub const something = 10
-          ↑             
+          ↑▔▔▔▔▔▔▔▔     
 
 
 ----- AFTER RENAME

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_shadowing_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_constant_shadowing_module.snap
@@ -8,7 +8,7 @@ expression: "\nimport gleam/list\n\nconst list = []\n\npub fn main() {\n  list.m
 import gleam/list
 
 const list = []
-      ↑        
+      ↑▔▔▔     
 
 pub fn main() {
   list.map(todo, todo)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_definition.snap
@@ -15,7 +15,7 @@ fn wibble() {
 -- app.gleam
 
 pub fn something() {
-       ↑            
+       ↑▔▔▔▔▔▔▔▔    
   something()
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_qualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_qualified_reference.snap
@@ -16,7 +16,7 @@ import mod
 
 pub fn main() {
   mod.wibble()
-      ↑       
+      ↑▔▔▔▔▔  
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_reference.snap
@@ -16,7 +16,7 @@ fn wibble() {
 
 pub fn something() {
   something()
-  ↑          
+  ↑▔▔▔▔▔▔▔▔  
 }
 
 fn something_else() {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_unqualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_from_unqualified_reference.snap
@@ -16,7 +16,7 @@ import mod.{wibble}
 
 pub fn main() {
   wibble()
-  ↑       
+  ↑▔▔▔▔▔  
   mod.wibble()
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_shadowed_by_field_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_shadowed_by_field_access.snap
@@ -20,7 +20,7 @@ pub fn main() {
 -- app.gleam
 
 pub fn something() {
-       ↑            
+       ↑▔▔▔▔▔▔▔▔    
   todo
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_shadowing_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_function_shadowing_module.snap
@@ -8,7 +8,7 @@ expression: "\nimport gleam/list\n\npub fn list() {\n  []\n}\n\npub fn main() {\
 import gleam/list
 
 pub fn list() {
-       ↑       
+       ↑▔▔▔    
   []
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable.snap
@@ -8,7 +8,7 @@ expression: "\npub fn main() {\n  let wibble = 10\n  wibble\n}\n"
 pub fn main() {
   let wibble = 10
   wibble
-  ↑     
+  ↑▔▔▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_argument_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_argument_from_definition.snap
@@ -6,7 +6,7 @@ expression: "\npub fn wibble(wibble: Float) {\n  wibble /. 0.3\n}\n"
 -- app.gleam
 
 pub fn wibble(wibble: Float) {
-              ↑               
+              ↑▔▔▔▔▔          
   wibble /. 0.3
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_assignment_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_assignment_pattern.snap
@@ -8,7 +8,7 @@ expression: "\npub fn main() {\n  let assert Error(12 as something) = Error(12)\
 pub fn main() {
   let assert Error(12 as something) = Error(12)
   something
-  ↑        
+  ↑▔▔▔▔▔▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_bit_array_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_bit_array_pattern.snap
@@ -10,7 +10,7 @@ pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
 
   case bits {
     <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True
-                     ↑                                               
+                     ↑▔▔▔▔▔▔▔▔▔▔                                     
     _ -> False
   }
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition.snap
@@ -7,7 +7,7 @@ expression: "\npub fn main() {\n  let wibble = 10\n  let wobble = wibble + 1\n  
 
 pub fn main() {
   let wibble = 10
-      ↑          
+      ↑▔▔▔▔▔     
   let wobble = wibble + 1
   wobble - wibble
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_assignment_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_assignment_pattern.snap
@@ -7,7 +7,7 @@ expression: "\npub fn main() {\n  let assert Error(12 as something) = Error(12)\
 
 pub fn main() {
   let assert Error(12 as something) = Error(12)
-                         ↑                     
+                         ↑▔▔▔▔▔▔▔▔             
   something
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_nested_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_definition_nested_pattern.snap
@@ -7,7 +7,7 @@ expression: "\npub fn main() {\n  let assert Ok([_, wibble, ..]) = Error(12)\n  
 
 pub fn main() {
   let assert Ok([_, wibble, ..]) = Error(12)
-                    ↑                       
+                    ↑▔▔▔▔▔                  
   wibble
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_guard_clause.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_guard_clause.snap
@@ -12,7 +12,7 @@ pub fn main() {
     _ -> panic
   }
   wibble || False
-  ↑              
+  ↑▔▔▔▔▔         
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_in_bit_array_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_in_bit_array_pattern.snap
@@ -7,7 +7,7 @@ expression: "\npub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {\n 
 
 pub fn starts_with(bits: BitArray, prefix: BitArray) -> Bool {
   let prefix_size = bit_size(prefix)
-      ↑                             
+      ↑▔▔▔▔▔▔▔▔▔▔                   
 
   case bits {
     <<pref:bits-size(prefix_size), _:bits>> if pref == prefix -> True

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand.snap
@@ -12,7 +12,7 @@ type Wibble {
 pub fn main() {
   let Wibble(wibble:) = todo
   wibble + 1
-  ↑         
+  ↑▔▔▔▔▔    
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand_from_definition.snap
@@ -11,7 +11,7 @@ type Wibble {
 
 pub fn main() {
   let Wibble(wibble:) = todo
-             ↑              
+             ↑▔▔▔▔▔▔        
   wibble + 1
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_record_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_record_access.snap
@@ -12,7 +12,7 @@ type Wibble {
 pub fn main() {
   let wibble = Wibble(wibble: 1)
   wibble.wibble
-  ↑            
+  ↑▔▔▔▔▔       
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowed_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowed_local_variable.snap
@@ -8,7 +8,7 @@ expression: "\npub fn main() {\n  let wibble = 10\n  let wibble = wibble / 2\n  
 pub fn main() {
   let wibble = 10
   let wibble = wibble / 2
-               ↑         
+               ↑▔▔▔▔▔    
   wibble
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowing_local_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_shadowing_local_variable.snap
@@ -9,7 +9,7 @@ pub fn main() {
   let wibble = 10
   let wibble = wibble / 2
   wibble
-  ↑     
+  ↑▔▔▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_definition.snap
@@ -16,7 +16,7 @@ fn wibble() {
 
 pub type Wibble {
   Constructor(Int)
-  ↑               
+  ↑▔▔▔▔▔▔▔▔▔▔     
 }
 
 pub fn main() {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_qualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_qualified_reference.snap
@@ -20,7 +20,7 @@ import mod
 
 pub fn main() {
   mod.Constructor
-      ↑          
+      ↑▔▔▔▔▔▔▔▔▔▔
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_reference.snap
@@ -20,7 +20,7 @@ pub type Wibble {
 
 pub fn main() {
   Constructor(10)
-  ↑              
+  ↑▔▔▔▔▔▔▔▔▔▔    
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_unqualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_from_unqualified_reference.snap
@@ -20,7 +20,7 @@ import mod.{Constructor}
 
 pub fn main() {
   #(Constructor(75), mod.Constructor(57))
-    ↑                                    
+    ↑▔▔▔▔▔▔▔▔▔▔                          
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_pattern_with_arguments.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_variant_pattern_with_arguments.snap
@@ -12,7 +12,7 @@ pub type Wibble {
 
 fn wibble() {
   case Wibble(10) {
-       ↑           
+       ↑▔▔▔▔▔      
     Wibble(20) -> todo
     Wibble(_) -> panic
   }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_aliased_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_aliased_module.snap
@@ -16,7 +16,7 @@ import mod as the_module
 
 pub fn main() {
   the_module.wibble()
-             ↑       
+             ↑▔▔▔▔▔  
 }
 
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_nested_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_value_in_nested_module.snap
@@ -16,7 +16,7 @@ import sub/mod
 
 pub fn main() {
   mod.wibble()
-      ↑       
+      ↑▔▔▔▔▔  
 }
 
 


### PR DESCRIPTION
Fixes #4356 
I've fixed that bug, and also added the rename location to the test snapshots to hopefully make these bugs easier to catch in future.