### PR TITLE
Remove many abbreviations

### DIFF
--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -397,12 +397,17 @@ pub fn gleam_files(dir: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
     ignore::WalkBuilder::new(dir)
         .follow_links(true)
         .standard_filters(false)
-        .filter_entry(|e| !is_gleam_build_dir(e))
+        .filter_entry(|entry| !is_gleam_build_dir(entry))
         .build()
         .filter_map(Result::ok)
-        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|entry| {
+            entry
+                .file_type()
+                .map(|type_| type_.is_file())
+                .unwrap_or(false)
+        })
         .map(ignore::DirEntry::into_path)
-        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
+        .map(|path| Utf8PathBuf::from_path_buf(path).expect("Non Utf-8 Path"))
         .filter(move |d| is_gleam_path(d, dir))
 }
 
@@ -412,12 +417,17 @@ pub fn native_files(dir: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
     ignore::WalkBuilder::new(dir)
         .follow_links(true)
         .standard_filters(false)
-        .filter_entry(|e| !is_gleam_build_dir(e))
+        .filter_entry(|entry| !is_gleam_build_dir(entry))
         .build()
         .filter_map(Result::ok)
-        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|entry| {
+            entry
+                .file_type()
+                .map(|type_| type_.is_file())
+                .unwrap_or(false)
+        })
         .map(ignore::DirEntry::into_path)
-        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
+        .map(|path| Utf8PathBuf::from_path_buf(path).expect("Non Utf-8 Path"))
         .filter(|path| {
             let extension = path.extension().unwrap_or_default();
             is_native_file_extension(extension)
@@ -431,9 +441,14 @@ pub fn private_files(dir: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
         .standard_filters(false)
         .build()
         .filter_map(Result::ok)
-        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|entry| {
+            entry
+                .file_type()
+                .map(|type_| type_.is_file())
+                .unwrap_or(false)
+        })
         .map(ignore::DirEntry::into_path)
-        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
+        .map(|path| Utf8PathBuf::from_path_buf(path).expect("Non Utf-8 Path"))
 }
 
 /// Walks through all `.erl` and `.hrl` files in the directory, even if ignored.
@@ -443,9 +458,14 @@ pub fn erlang_files(dir: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
         .standard_filters(false)
         .build()
         .filter_map(Result::ok)
-        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|entry| {
+            entry
+                .file_type()
+                .map(|type_| type_.is_file())
+                .unwrap_or(false)
+        })
         .map(ignore::DirEntry::into_path)
-        .map(|pb| Utf8PathBuf::from_path_buf(pb).expect("Non Utf-8 Path"))
+        .map(|path| Utf8PathBuf::from_path_buf(path).expect("Non Utf-8 Path"))
         .filter(|path| {
             let extension = path.extension().unwrap_or_default();
             extension == "erl" || extension == "hrl"

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1933,9 +1933,9 @@ fn get_type_dependencies(type_: &TypeAst) -> Vec<EcoString> {
             }
             deps.extend(get_type_dependencies(return_))
         }
-        TypeAst::Tuple(TypeAstTuple { elems, .. }) => {
-            for elem in elems {
-                deps.extend(get_type_dependencies(elem))
+        TypeAst::Tuple(TypeAstTuple { elements, .. }) => {
+            for element in elements {
+                deps.extend(get_type_dependencies(element))
             }
         }
     }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1848,7 +1848,7 @@ pub enum Pattern<Type> {
 
     Tuple {
         location: SrcSpan,
-        elems: Vec<Self>,
+        elements: Vec<Self>,
     },
 
     BitArray {
@@ -2004,7 +2004,9 @@ impl TypedPattern {
 
             Pattern::Discard { type_, .. } => type_.clone(),
 
-            Pattern::Tuple { elems, .. } => type_::tuple(elems.iter().map(|p| p.type_()).collect()),
+            Pattern::Tuple { elements, .. } => {
+                type_::tuple(elements.iter().map(|p| p.type_()).collect())
+            }
         }
     }
 
@@ -2048,7 +2050,9 @@ impl TypedPattern {
                 .find_map(|p| p.find_node(byte_index))
                 .or_else(|| tail.as_ref().and_then(|p| p.find_node(byte_index))),
 
-            Pattern::Tuple { elems, .. } => elems.iter().find_map(|p| p.find_node(byte_index)),
+            Pattern::Tuple { elements, .. } => {
+                elements.iter().find_map(|p| p.find_node(byte_index))
+            }
 
             Pattern::BitArray { segments, .. } => segments
                 .iter()

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -475,8 +475,8 @@ impl TypeAst {
             TypeAst::Hole(hole) => buffer.push_str(&hole.name),
             TypeAst::Tuple(tuple) => {
                 buffer.push_str("#(");
-                for (i, elem) in tuple.elements.iter().enumerate() {
-                    elem.print(buffer);
+                for (i, element) in tuple.elements.iter().enumerate() {
+                    element.print(buffer);
                     if i < tuple.elements.len() - 1 {
                         buffer.push_str(", ");
                     }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -291,7 +291,7 @@ pub struct TypeAstVar {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeAstTuple {
     pub location: SrcSpan,
-    pub elems: Vec<TypeAst>,
+    pub elements: Vec<TypeAst>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -372,15 +372,18 @@ impl TypeAst {
                 }) => name == o_name,
                 _ => false,
             },
-            TypeAst::Tuple(TypeAstTuple { elems, location: _ }) => match other {
+            TypeAst::Tuple(TypeAstTuple {
+                elements,
+                location: _,
+            }) => match other {
                 TypeAst::Tuple(TypeAstTuple {
-                    elems: o_elems,
+                    elements: other_elements,
                     location: _,
                 }) => {
-                    elems.len() == o_elems.len()
-                        && elems
+                    elements.len() == other_elements.len()
+                        && elements
                             .iter()
-                            .zip(o_elems)
+                            .zip(other_elements)
                             .all(|a| a.0.is_logically_equal(a.1))
                 }
                 _ => false,
@@ -447,10 +450,10 @@ impl TypeAst {
                     }
                 }))
                 .or(Some(Located::Annotation(self.location(), type_))),
-            TypeAst::Tuple(TypeAstTuple { elems, .. }) => type_
+            TypeAst::Tuple(TypeAstTuple { elements, .. }) => type_
                 .tuple_types()
                 .and_then(|elem_types| {
-                    if let Some(e) = elems
+                    if let Some(e) = elements
                         .iter()
                         .zip(elem_types)
                         .find_map(|(e, e_type)| e.find_node(byte_index, e_type.clone()))
@@ -472,9 +475,9 @@ impl TypeAst {
             TypeAst::Hole(hole) => buffer.push_str(&hole.name),
             TypeAst::Tuple(tuple) => {
                 buffer.push_str("#(");
-                for (i, elem) in tuple.elems.iter().enumerate() {
+                for (i, elem) in tuple.elements.iter().enumerate() {
                     elem.print(buffer);
-                    if i < tuple.elems.len() - 1 {
+                    if i < tuple.elements.len() - 1 {
                         buffer.push_str(", ");
                     }
                 }
@@ -564,7 +567,7 @@ fn type_ast_print_tuple() {
     let mut buffer = EcoString::new();
     let ast = TypeAst::Tuple(TypeAstTuple {
         location: SrcSpan { start: 1, end: 1 },
-        elems: vec![
+        elements: vec![
             TypeAst::Constructor(TypeAstConstructor {
                 name: "SomeType".into(),
                 module: Some(("some_module".into(), SrcSpan { start: 1, end: 1 })),

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -79,7 +79,7 @@ impl TypedConstant {
             Constant::String { .. } | Constant::StringConcatenation { .. } => type_::string(),
             Constant::BitArray { .. } => type_::bits(),
             Constant::Tuple { elements, .. } => {
-                type_::tuple(elements.iter().map(|e| e.type_()).collect())
+                type_::tuple(elements.iter().map(|element| element.type_()).collect())
             }
             Constant::List { type_, .. }
             | Constant::Record { type_, .. }

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -421,7 +421,7 @@ fn find_node_call() {
     let statement = compile_expression("fn(_, _) { 1 }(1, 2)");
     let expr = get_bare_expression(&statement);
 
-    let retrn = TypedExpr::Int {
+    let return_ = TypedExpr::Int {
         location: SrcSpan { start: 11, end: 12 },
         value: "1".into(),
         int_value: 1.into(),
@@ -442,7 +442,7 @@ fn find_node_call() {
         type_: type_::int(),
     };
 
-    assert_eq!(expr.find_node(11), Some(Located::Expression(&retrn)));
+    assert_eq!(expr.find_node(11), Some(Located::Expression(&return_)));
     assert_eq!(expr.find_node(15), Some(Located::Expression(&arg1)));
     assert_eq!(expr.find_node(16), Some(Located::Expression(&arg1)));
     assert_eq!(expr.find_node(17), Some(Located::Expression(expr)));

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -109,7 +109,7 @@ pub enum TypedExpr {
     Tuple {
         location: SrcSpan,
         type_: Arc<Type>,
-        elems: Vec<Self>,
+        elements: Vec<Self>,
     },
 
     TupleIndex {
@@ -281,7 +281,8 @@ impl TypedExpr {
             // if during iteration, an element is encountered with a start index
             // beyond the index under search.
             Self::Tuple {
-                elems: expressions, ..
+                elements: expressions,
+                ..
             } => {
                 for expression in expressions {
                     if expression.location().start > byte_index {
@@ -415,7 +416,8 @@ impl TypedExpr {
             // if during iteration, an element is encountered with a start index
             // beyond the index under search.
             Self::Tuple {
-                elems: expressions, ..
+                elements: expressions,
+                ..
             } => {
                 for expression in expressions {
                     if expression.location().start > byte_index {

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -234,7 +234,7 @@ impl TypedExpr {
 
             Self::Echo { expression, .. } => expression
                 .as_ref()
-                .and_then(|e| e.find_node(byte_index))
+                .and_then(|expression| expression.find_node(byte_index))
                 .or_else(|| self.self_if_contains_location(byte_index)),
 
             Self::Todo { kind, .. } => match kind {
@@ -490,7 +490,7 @@ impl TypedExpr {
 
             Self::Echo { expression, .. } => expression
                 .as_ref()
-                .and_then(|e| e.find_statement(byte_index)),
+                .and_then(|expression| expression.find_statement(byte_index)),
 
             Self::BitArray { segments, .. } => segments
                 .iter()

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -88,7 +88,7 @@ pub enum UntypedExpr {
 
     Tuple {
         location: SrcSpan,
-        elems: Vec<Self>,
+        elements: Vec<Self>,
     },
 
     TupleIndex {

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -671,8 +671,8 @@ pub fn visit_type_ast_tuple<'a, V>(v: &mut V, _location: &'a SrcSpan, elements: 
 where
     V: Visit<'a> + ?Sized,
 {
-    for elem in elements {
-        v.visit_type_ast(elem);
+    for element in elements {
+        v.visit_type_ast(element);
     }
 }
 
@@ -1032,8 +1032,8 @@ pub fn visit_typed_expr_tuple<'a, V>(
 ) where
     V: Visit<'a> + ?Sized,
 {
-    for elem in elements {
-        v.visit_typed_expr(elem);
+    for element in elements {
+        v.visit_typed_expr(element);
     }
 }
 
@@ -1626,8 +1626,8 @@ pub fn visit_typed_pattern_tuple<'a, V>(
 ) where
     V: Visit<'a> + ?Sized,
 {
-    for elem in elements {
-        v.visit_typed_pattern(elem);
+    for element in elements {
+        v.visit_typed_pattern(element);
     }
 }
 

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -1492,7 +1492,7 @@ where
             spread,
             type_,
         ),
-        Pattern::Tuple { location, elems } => v.visit_typed_pattern_tuple(location, elems),
+        Pattern::Tuple { location, elements } => v.visit_typed_pattern_tuple(location, elements),
         Pattern::BitArray { location, segments } => {
             v.visit_typed_pattern_bit_array(location, segments)
         }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -792,8 +792,8 @@ where
         TypedExpr::Tuple {
             location,
             type_,
-            elems,
-        } => v.visit_typed_expr_tuple(location, type_, elems),
+            elements,
+        } => v.visit_typed_expr_tuple(location, type_, elements),
         TypedExpr::TupleIndex {
             location,
             type_,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -623,8 +623,8 @@ where
         TypeAst::Var(super::TypeAstVar { location, name }) => {
             v.visit_type_ast_var(location, name);
         }
-        TypeAst::Tuple(super::TypeAstTuple { location, elems }) => {
-            v.visit_type_ast_tuple(location, elems);
+        TypeAst::Tuple(super::TypeAstTuple { location, elements }) => {
+            v.visit_type_ast_tuple(location, elements);
         }
         TypeAst::Hole(super::TypeAstHole { location, name }) => {
             v.visit_type_ast_hole(location, name);

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -248,9 +248,9 @@ pub trait Visit<'ast> {
         &mut self,
         location: &'ast SrcSpan,
         type_: &'ast Arc<Type>,
-        elems: &'ast [TypedExpr],
+        elements: &'ast [TypedExpr],
     ) {
-        visit_typed_expr_tuple(self, location, type_, elems);
+        visit_typed_expr_tuple(self, location, type_, elements);
     }
 
     fn visit_typed_expr_tuple_index(
@@ -497,9 +497,9 @@ pub trait Visit<'ast> {
     fn visit_typed_pattern_tuple(
         &mut self,
         location: &'ast SrcSpan,
-        elems: &'ast Vec<TypedPattern>,
+        elements: &'ast Vec<TypedPattern>,
     ) {
-        visit_typed_pattern_tuple(self, location, elems);
+        visit_typed_pattern_tuple(self, location, elements);
     }
 
     fn visit_typed_pattern_bit_array(
@@ -561,8 +561,8 @@ pub trait Visit<'ast> {
         visit_type_ast_var(self, location, name);
     }
 
-    fn visit_type_ast_tuple(&mut self, location: &'ast SrcSpan, elems: &'ast Vec<TypeAst>) {
-        visit_type_ast_tuple(self, location, elems);
+    fn visit_type_ast_tuple(&mut self, location: &'ast SrcSpan, elements: &'ast Vec<TypeAst>) {
+        visit_type_ast_tuple(self, location, elements);
     }
 
     fn visit_type_ast_hole(&mut self, location: &'ast SrcSpan, name: &'ast EcoString) {
@@ -667,11 +667,11 @@ where
     // No further traversal needed for variables
 }
 
-pub fn visit_type_ast_tuple<'a, V>(v: &mut V, _location: &'a SrcSpan, elems: &'a Vec<TypeAst>)
+pub fn visit_type_ast_tuple<'a, V>(v: &mut V, _location: &'a SrcSpan, elements: &'a Vec<TypeAst>)
 where
     V: Visit<'a> + ?Sized,
 {
-    for elem in elems {
+    for elem in elements {
         v.visit_type_ast(elem);
     }
 }
@@ -1028,11 +1028,11 @@ pub fn visit_typed_expr_tuple<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
     _type_: &'a Arc<Type>,
-    elems: &'a [TypedExpr],
+    elements: &'a [TypedExpr],
 ) where
     V: Visit<'a> + ?Sized,
 {
-    for elem in elems {
+    for elem in elements {
         v.visit_typed_expr(elem);
     }
 }
@@ -1622,11 +1622,11 @@ where
 pub fn visit_typed_pattern_tuple<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    elems: &'a Vec<TypedPattern>,
+    elements: &'a Vec<TypedPattern>,
 ) where
     V: Visit<'a> + ?Sized,
 {
-    for elem in elems {
+    for elem in elements {
         v.visit_typed_pattern(elem);
     }
 }

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -1189,7 +1189,7 @@ pub trait PatternFolder {
                 spread,
             ),
 
-            Pattern::Tuple { location, elems } => self.fold_pattern_tuple(location, elems),
+            Pattern::Tuple { location, elements } => self.fold_pattern_tuple(location, elements),
 
             Pattern::BitArray { location, segments } => {
                 self.fold_pattern_bit_array(location, segments)
@@ -1318,9 +1318,9 @@ pub trait PatternFolder {
     fn fold_pattern_tuple(
         &mut self,
         location: SrcSpan,
-        elems: Vec<UntypedPattern>,
+        elements: Vec<UntypedPattern>,
     ) -> UntypedPattern {
-        Pattern::Tuple { location, elems }
+        Pattern::Tuple { location, elements }
     }
 
     fn fold_pattern_bit_array(
@@ -1427,9 +1427,9 @@ pub trait PatternFolder {
                 }
             }
 
-            Pattern::Tuple { location, elems } => {
-                let elems = elems.into_iter().map(|p| self.fold_pattern(p)).collect();
-                Pattern::Tuple { location, elems }
+            Pattern::Tuple { location, elements } => {
+                let elements = elements.into_iter().map(|p| self.fold_pattern(p)).collect();
+                Pattern::Tuple { location, elements }
             }
 
             Pattern::BitArray { location, segments } => {

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -305,7 +305,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 container,
             } => self.fold_field_access(location, label_location, label, container),
 
-            UntypedExpr::Tuple { location, elems } => self.fold_tuple(location, elems),
+            UntypedExpr::Tuple { location, elements } => self.fold_tuple(location, elements),
 
             UntypedExpr::TupleIndex {
                 location,
@@ -511,9 +511,9 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 }
             }
 
-            UntypedExpr::Tuple { location, elems } => {
-                let elems = elems.into_iter().map(|e| self.fold_expr(e)).collect();
-                UntypedExpr::Tuple { location, elems }
+            UntypedExpr::Tuple { location, elements } => {
+                let elements = elements.into_iter().map(|e| self.fold_expr(e)).collect();
+                UntypedExpr::Tuple { location, elements }
             }
 
             UntypedExpr::TupleIndex {
@@ -781,8 +781,8 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         }
     }
 
-    fn fold_tuple(&mut self, location: SrcSpan, elems: Vec<UntypedExpr>) -> UntypedExpr {
-        UntypedExpr::Tuple { location, elems }
+    fn fold_tuple(&mut self, location: SrcSpan, elements: Vec<UntypedExpr>) -> UntypedExpr {
+        UntypedExpr::Tuple { location, elements }
     }
 
     fn fold_tuple_index(

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -512,7 +512,10 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             }
 
             UntypedExpr::Tuple { location, elements } => {
-                let elements = elements.into_iter().map(|e| self.fold_expr(e)).collect();
+                let elements = elements
+                    .into_iter()
+                    .map(|element| self.fold_expr(element))
+                    .collect();
                 UntypedExpr::Tuple { location, elements }
             }
 
@@ -1053,7 +1056,7 @@ pub trait UntypedConstantFolder {
             } => {
                 let elements = elements
                     .into_iter()
-                    .map(|e| self.fold_constant(e))
+                    .map(|element| self.fold_constant(element))
                     .collect();
                 Constant::List {
                     location,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -414,7 +414,10 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 elements,
                 tail,
             } => {
-                let elements = elements.into_iter().map(|e| self.fold_expr(e)).collect();
+                let elements = elements
+                    .into_iter()
+                    .map(|element| self.fold_expr(element))
+                    .collect();
                 let tail = tail.map(|e| Box::new(self.fold_expr(*e)));
                 UntypedExpr::List {
                     location,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -192,7 +192,7 @@ pub trait TypeAstFolder {
             }
 
             TypeAst::Tuple(mut t) => {
-                t.elems = self.fold_all_types(t.elems);
+                t.elements = self.fold_all_types(t.elements);
                 TypeAst::Tuple(t)
             }
 

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -490,11 +490,11 @@ fn type_to_definition_locations<'a>(
         // For fn types we just get the locations of their arguments and return
         // type.
         //
-        Type::Fn { args, retrn } => args
+        Type::Fn { args, return_ } => args
             .iter()
             .flat_map(|arg| type_to_definition_locations(arg.clone(), importable_modules))
             .chain(type_to_definition_locations(
-                retrn.clone(),
+                return_.clone(),
                 importable_modules,
             ))
             .collect_vec(),

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -511,9 +511,9 @@ fn type_to_definition_locations<'a>(
 
         // In case of tuples we get the locations of the wrapped types.
         //
-        Type::Tuple { elems } => elems
+        Type::Tuple { elements } => elements
             .iter()
-            .flat_map(|elem| type_to_definition_locations(elem.clone(), importable_modules))
+            .flat_map(|element| type_to_definition_locations(element.clone(), importable_modules))
             .collect_vec(),
     }
 }

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -323,7 +323,7 @@ impl<'a> CallGraphBuilder<'a> {
             }
 
             Pattern::Tuple {
-                elems: patterns, ..
+                elements: patterns, ..
             } => {
                 for pattern in patterns {
                     self.pattern(pattern);

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -206,8 +206,8 @@ impl<'a> CallGraphBuilder<'a> {
                 }
             }
 
-            UntypedExpr::Tuple { elems, .. } => {
-                for expression in elems {
+            UntypedExpr::Tuple { elements, .. } => {
+                for expression in elements {
                     self.expression(expression);
                 }
             }

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -551,7 +551,10 @@ fn manifest_package(
         version: Version::parse(version).unwrap(),
         build_tools: vec![],
         otp_app: None,
-        requirements: requirements.iter().map(|e| (*e).into()).collect(),
+        requirements: requirements
+            .iter()
+            .map(|requirement| (*requirement).into())
+            .collect(),
         source: crate::manifest::ManifestPackageSource::Hex {
             outer_checksum: Base16Checksum(vec![]),
         },

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2063,7 +2063,9 @@ fn expr<'a>(expression: &'a TypedExpr, env: &mut Env<'a>) -> Document<'a> {
             name, left, right, ..
         } => bin_op(name, left, right, env),
 
-        TypedExpr::Tuple { elems, .. } => tuple(elems.iter().map(|e| maybe_block_expr(e, env))),
+        TypedExpr::Tuple { elements, .. } => {
+            tuple(elements.iter().map(|e| maybe_block_expr(e, env)))
+        }
 
         TypedExpr::BitArray { segments, .. } => bit_array(
             segments

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2414,9 +2414,9 @@ fn type_var_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
             }
             type_var_ids(retrn, ids);
         }
-        Type::Tuple { elems } => {
-            for elem in elems {
-                type_var_ids(elem, ids)
+        Type::Tuple { elements } => {
+            for element in elements {
+                type_var_ids(element, ids)
             }
         }
     }
@@ -2506,7 +2506,7 @@ impl<'a> TypePrinter<'a> {
 
             Type::Fn { args, retrn } => self.print_fn(args, retrn),
 
-            Type::Tuple { elems } => tuple(elems.iter().map(|e| self.print(e))),
+            Type::Tuple { elements } => tuple(elements.iter().map(|e| self.print(e))),
         }
     }
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1245,10 +1245,15 @@ fn expr_list<'a>(
     env: &mut Env<'a>,
 ) -> Document<'a> {
     let elements = join(
-        elements.iter().map(|e| maybe_block_expr(e, env)),
+        elements
+            .iter()
+            .map(|element| maybe_block_expr(element, env)),
         break_(",", ", "),
     );
-    list(elements, tail.as_ref().map(|e| maybe_block_expr(e, env)))
+    list(
+        elements,
+        tail.as_ref().map(|element| maybe_block_expr(element, env)),
+    )
 }
 
 fn list<'a>(elements: Document<'a>, tail: Option<Document<'a>>) -> Document<'a> {
@@ -1340,10 +1345,12 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
         Constant::Int { value, .. } => int(value),
         Constant::Float { value, .. } => float(value),
         Constant::String { value, .. } => string(value),
-        Constant::Tuple { elements, .. } => tuple(elements.iter().map(|e| const_inline(e, env))),
+        Constant::Tuple { elements, .. } => {
+            tuple(elements.iter().map(|element| const_inline(element, env)))
+        }
 
         Constant::List { elements, .. } => join(
-            elements.iter().map(|e| const_inline(e, env)),
+            elements.iter().map(|element| const_inline(element, env)),
             break_(",", ", "),
         )
         .nest(INDENT)
@@ -1656,7 +1663,11 @@ fn case<'a>(subjects: &'a [TypedExpr], cs: &'a [TypedClause], env: &mut Env<'a>)
             .expect("erl case printing of single subject");
         maybe_block_expr(subject, env).group()
     } else {
-        tuple(subjects.iter().map(|e| maybe_block_expr(e, env)))
+        tuple(
+            subjects
+                .iter()
+                .map(|element| maybe_block_expr(element, env)),
+        )
     };
     "case "
         .to_doc()
@@ -2063,9 +2074,11 @@ fn expr<'a>(expression: &'a TypedExpr, env: &mut Env<'a>) -> Document<'a> {
             name, left, right, ..
         } => bin_op(name, left, right, env),
 
-        TypedExpr::Tuple { elements, .. } => {
-            tuple(elements.iter().map(|e| maybe_block_expr(e, env)))
-        }
+        TypedExpr::Tuple { elements, .. } => tuple(
+            elements
+                .iter()
+                .map(|element| maybe_block_expr(element, env)),
+        ),
 
         TypedExpr::BitArray { segments, .. } => bit_array(
             segments
@@ -2506,7 +2519,7 @@ impl<'a> TypePrinter<'a> {
 
             Type::Fn { args, retrn } => self.print_fn(args, retrn),
 
-            Type::Tuple { elements } => tuple(elements.iter().map(|e| self.print(e))),
+            Type::Tuple { elements } => tuple(elements.iter().map(|element| self.print(element))),
         }
     }
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -723,17 +723,17 @@ fn string_length_utf8_bytes(str: &EcoString) -> usize {
     convert_string_escape_chars(str).len()
 }
 
-fn tuple<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
-    join(elems, break_(",", ", "))
+fn tuple<'a>(elements: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
+    join(elements, break_(",", ", "))
         .nest(INDENT)
         .surround("{", "}")
         .group()
 }
 
 fn const_string_concatenate_bit_array<'a>(
-    elems: impl IntoIterator<Item = Document<'a>>,
+    elements: impl IntoIterator<Item = Document<'a>>,
 ) -> Document<'a> {
-    join(elems, break_(",", ", "))
+    join(elements, break_(",", ", "))
         .nest(INDENT)
         .surround("<<", ">>")
         .group()
@@ -834,8 +834,8 @@ fn string_concatenate_argument<'a>(value: &'a TypedExpr, env: &mut Env<'a>) -> D
     }
 }
 
-fn bit_array<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
-    join(elems, break_(",", ", "))
+fn bit_array<'a>(elements: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
+    join(elements, break_(",", ", "))
         .nest(INDENT)
         .surround("<<", ">>")
         .group()
@@ -1251,16 +1251,16 @@ fn expr_list<'a>(
     list(elements, tail.as_ref().map(|e| maybe_block_expr(e, env)))
 }
 
-fn list<'a>(elems: Document<'a>, tail: Option<Document<'a>>) -> Document<'a> {
-    let elems = match tail {
-        Some(tail) if elems.is_empty() => return tail.to_doc(),
+fn list<'a>(elements: Document<'a>, tail: Option<Document<'a>>) -> Document<'a> {
+    let elements = match tail {
+        Some(tail) if elements.is_empty() => return tail.to_doc(),
 
-        Some(tail) => elems.append(break_(" |", " | ")).append(tail),
+        Some(tail) => elements.append(break_(" |", " | ")).append(tail),
 
-        None => elems,
+        None => elements,
     };
 
-    elems.to_doc().nest(INDENT).surround("[", "]").group()
+    elements.to_doc().nest(INDENT).surround("[", "]").group()
 }
 
 fn var<'a>(name: &'a str, constructor: &'a ValueConstructor, env: &mut Env<'a>) -> Document<'a> {

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -643,14 +643,14 @@ where
 fn fun_spec<'a>(
     name: &'a str,
     args: impl IntoIterator<Item = Document<'a>>,
-    retrn: Document<'a>,
+    return_: Document<'a>,
 ) -> Document<'a> {
     "-spec "
         .to_doc()
         .append(atom(name))
         .append(wrap_args(args))
         .append(" -> ")
-        .append(retrn)
+        .append(return_)
         .append(".")
         .append(line())
         .group()
@@ -2421,11 +2421,11 @@ fn type_var_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
                 }
             }
         },
-        Type::Fn { args, retrn } => {
+        Type::Fn { args, return_ } => {
             for arg in args {
                 type_var_ids(arg, ids)
             }
-            type_var_ids(retrn, ids);
+            type_var_ids(return_, ids);
         }
         Type::Tuple { elements } => {
             for element in elements {
@@ -2517,7 +2517,7 @@ impl<'a> TypePrinter<'a> {
                 name, module, args, ..
             } => self.print_type_app(module, name, args),
 
-            Type::Fn { args, retrn } => self.print_fn(args, retrn),
+            Type::Fn { args, return_ } => self.print_fn(args, return_),
 
             Type::Tuple { elements } => tuple(elements.iter().map(|element| self.print(element))),
         }
@@ -2576,14 +2576,14 @@ impl<'a> TypePrinter<'a> {
         }
     }
 
-    fn print_fn(&self, args: &[Arc<Type>], retrn: &Type) -> Document<'static> {
+    fn print_fn(&self, args: &[Arc<Type>], return_: &Type) -> Document<'static> {
         let args = join(args.iter().map(|a| self.print(a)), ", ".to_doc());
-        let retrn = self.print(retrn);
+        let return_ = self.print(return_);
         "fun(("
             .to_doc()
             .append(args)
             .append(") -> ")
-            .append(retrn)
+            .append(return_)
             .append(")")
     }
 

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -251,7 +251,7 @@ fn pattern_list<'a>(
     let elements = join(
         elements
             .iter()
-            .map(|e| print(e, vars, define_variables, env, guards)),
+            .map(|element| print(element, vars, define_variables, env, guards)),
         break_(",", ", "),
     );
     let tail = tail.map(|tail| print(tail, vars, define_variables, env, guards));

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -86,8 +86,8 @@ fn print<'a>(
             panic!("Erlang generation performed with uninferred pattern constructor")
         }
 
-        Pattern::Tuple { elems, .. } => tuple(
-            elems
+        Pattern::Tuple { elements, .. } => tuple(
+            elements
                 .iter()
                 .map(|p| print(p, vars, define_variables, env, guards)),
         ),

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -702,8 +702,8 @@ pub fn edit_distance(a: &str, b: &str, limit: usize) -> Option<usize> {
 
     // row by row
     for i in 1..=a.len() {
-        if let Some(elem) = current.get_mut(0) {
-            *elem = i;
+        if let Some(element) = current.get_mut(0) {
+            *element = i;
         }
         let a_idx = i - 1;
 

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -1458,9 +1458,9 @@ impl ConstructorSpecialiser {
                 inferred_variant: *inferred_variant,
             },
 
-            Type::Fn { args, retrn } => Type::Fn {
+            Type::Fn { args, return_ } => Type::Fn {
                 args: args.iter().map(|a| self.specialise_type(a)).collect(),
-                retrn: retrn.clone(),
+                return_: return_.clone(),
             },
 
             Type::Var { type_ } => Type::Var {

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -1468,7 +1468,10 @@ impl ConstructorSpecialiser {
             },
 
             Type::Tuple { elements } => Type::Tuple {
-                elements: elements.iter().map(|e| self.specialise_type(e)).collect(),
+                elements: elements
+                    .iter()
+                    .map(|element| self.specialise_type(element))
+                    .collect(),
             },
         })
     }
@@ -1633,7 +1636,7 @@ impl CaseToCompile {
             TypedPattern::Tuple { elements, .. } => {
                 let elements = elements
                     .iter()
-                    .map(|elem| self.register(elem))
+                    .map(|element| self.register(element))
                     .collect_vec();
                 self.insert(Pattern::Tuple { elements })
             }

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -1630,8 +1630,11 @@ impl CaseToCompile {
                 self.insert(Pattern::Assign { name, pattern })
             }
 
-            TypedPattern::Tuple { elems, .. } => {
-                let elements = elems.iter().map(|elem| self.register(elem)).collect_vec();
+            TypedPattern::Tuple { elements, .. } => {
+                let elements = elements
+                    .iter()
+                    .map(|elem| self.register(elem))
+                    .collect_vec();
                 self.insert(Pattern::Tuple { elements })
             }
 

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -584,8 +584,8 @@ impl Variable {
                 inner_type: args.first().expect("list has a type argument").clone(),
             },
 
-            Type::Tuple { elems } => BranchMode::Tuple {
-                elements: elems.clone(),
+            Type::Tuple { elements } => BranchMode::Tuple {
+                elements: elements.clone(),
             },
 
             Type::Named {
@@ -1467,8 +1467,8 @@ impl ConstructorSpecialiser {
                 type_: Arc::new(RefCell::new(self.specialise_var(type_))),
             },
 
-            Type::Tuple { elems } => Type::Tuple {
-                elems: elems.iter().map(|e| self.specialise_type(e)).collect(),
+            Type::Tuple { elements } => Type::Tuple {
+                elements: elements.iter().map(|e| self.specialise_type(e)).collect(),
             },
         })
     }

--- a/compiler-core/src/exhaustiveness/printer.rs
+++ b/compiler-core/src/exhaustiveness/printer.rs
@@ -175,7 +175,9 @@ mod tests {
     fn make_variable(id: usize) -> Variable {
         Variable {
             id,
-            type_: Arc::new(Type::Tuple { elems: Vec::new() }),
+            type_: Arc::new(Type::Tuple {
+                elements: Vec::new(),
+            }),
         }
     }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -599,7 +599,10 @@ impl<'comments> Formatter<'comments> {
             Some(_) | None => flex_break(",", ", "),
         };
 
-        let elements = join(elements.iter().map(|e| self.const_expr(e)), comma);
+        let elements = join(
+            elements.iter().map(|element| self.const_expr(element)),
+            comma,
+        );
 
         let doc = break_("[", "[").append(elements).nest(INDENT);
 
@@ -647,7 +650,7 @@ impl<'comments> Formatter<'comments> {
             };
         }
 
-        let args_docs = elements.iter().map(|e| self.const_expr(e));
+        let args_docs = elements.iter().map(|element| self.const_expr(element));
         let tuple_doc = break_("#(", "#(")
             .append(join(args_docs, break_(",", ", ")).next_break_fits(NextBreakFitsMode::Disabled))
             .nest(INDENT);
@@ -2178,7 +2181,10 @@ impl<'comments> Formatter<'comments> {
             Pattern::Tuple {
                 elements, location, ..
             } => {
-                let args = elements.iter().map(|e| self.pattern(e)).collect_vec();
+                let args = elements
+                    .iter()
+                    .map(|element| self.pattern(element))
+                    .collect_vec();
                 "#".to_doc()
                     .append(self.wrap_args(args, location.end))
                     .group()
@@ -2228,7 +2234,10 @@ impl<'comments> Formatter<'comments> {
                 None => "[]".to_doc(),
             };
         }
-        let elements = join(elements.iter().map(|e| self.pattern(e)), break_(",", ", "));
+        let elements = join(
+            elements.iter().map(|element| self.pattern(element)),
+            break_(",", ", "),
+        );
         let doc = break_("[", "[").append(elements);
         match tail {
             None => doc.nest(INDENT).append(break_(",", "")),

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2176,9 +2176,9 @@ impl<'comments> Formatter<'comments> {
             } => self.pattern_constructor(name, args, module, *spread, location),
 
             Pattern::Tuple {
-                elems, location, ..
+                elements, location, ..
             } => {
-                let args = elems.iter().map(|e| self.pattern(e)).collect_vec();
+                let args = elements.iter().map(|e| self.pattern(e)).collect_vec();
                 "#".to_doc()
                     .append(self.wrap_args(args, location.end))
                     .group()

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -750,7 +750,7 @@ impl<'comments> Formatter<'comments> {
     }
 
     fn type_arguments<'a>(&mut self, args: &'a [TypeAst], location: &SrcSpan) -> Document<'a> {
-        let args = args.iter().map(|t| self.type_ast(t)).collect_vec();
+        let args = args.iter().map(|type_| self.type_ast(type_)).collect_vec();
         self.wrap_args(args, location.end)
     }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -739,8 +739,8 @@ impl<'comments> Formatter<'comments> {
 
             TypeAst::Var(TypeAstVar { name, .. }) => name.to_doc(),
 
-            TypeAst::Tuple(TypeAstTuple { elems, location }) => {
-                "#".to_doc().append(self.type_arguments(elems, location))
+            TypeAst::Tuple(TypeAstTuple { elements, location }) => {
+                "#".to_doc().append(self.type_arguments(elements, location))
             }
         }
         .group()

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -394,11 +394,11 @@ impl<'comments> Formatter<'comments> {
                     let unqualified_types = unqualified_types
                         .iter()
                         .sorted_by(|a, b| a.name.cmp(&b.name))
-                        .map(|e| docvec!["type ", e]);
+                        .map(|type_| docvec!["type ", type_]);
                     let unqualified_values = unqualified_values
                         .iter()
                         .sorted_by(|a, b| a.name.cmp(&b.name))
-                        .map(|e| e.to_doc());
+                        .map(|value| value.to_doc());
                     let unqualified = join(
                         unqualified_types.chain(unqualified_values),
                         flex_break(",", ", "),
@@ -475,7 +475,7 @@ impl<'comments> Formatter<'comments> {
             } => {
                 let segment_docs = segments
                     .iter()
-                    .map(|s| bit_array_segment(s, |e| self.const_expr(e)))
+                    .map(|segment| bit_array_segment(segment, |e| self.const_expr(e)))
                     .collect_vec();
 
                 self.bit_array(
@@ -802,7 +802,7 @@ impl<'comments> Formatter<'comments> {
         let args = function
             .arguments
             .iter()
-            .map(|e| self.fn_arg(e))
+            .map(|argument| self.fn_arg(argument))
             .collect_vec();
         let signature = pub_(function.publicity)
             .append("fn ")
@@ -853,7 +853,7 @@ impl<'comments> Formatter<'comments> {
         location: &SrcSpan,
         end_of_head_byte_index: &u32,
     ) -> Document<'a> {
-        let args_docs = args.iter().map(|e| self.fn_arg(e)).collect_vec();
+        let args_docs = args.iter().map(|arg| self.fn_arg(arg)).collect_vec();
         let args = self
             .wrap_args(args_docs, *end_of_head_byte_index)
             .group()
@@ -1063,7 +1063,7 @@ impl<'comments> Formatter<'comments> {
             } => {
                 let segment_docs = segments
                     .iter()
-                    .map(|s| bit_array_segment(s, |e| self.bit_array_segment_expr(e)))
+                    .map(|segment| bit_array_segment(segment, |e| self.bit_array_segment_expr(e)))
                     .collect_vec();
 
                 self.bit_array(
@@ -2195,7 +2195,7 @@ impl<'comments> Formatter<'comments> {
             } => {
                 let segment_docs = segments
                     .iter()
-                    .map(|s| bit_array_segment(s, |e| self.pattern(e)))
+                    .map(|segment| bit_array_segment(segment, |pattern| self.pattern(pattern)))
                     .collect_vec();
 
                 self.bit_array(segment_docs, false, location)
@@ -2909,7 +2909,9 @@ where
         BitArraySegment { value, options, .. } if options.is_empty() => to_doc(value),
 
         BitArraySegment { value, options, .. } => to_doc(value).append(":").append(join(
-            options.iter().map(|o| segment_option(o, |e| to_doc(e))),
+            options
+                .iter()
+                .map(|option| segment_option(option, |value| to_doc(value))),
             "-".to_doc(),
         )),
     }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1053,7 +1053,7 @@ impl<'comments> Formatter<'comments> {
             .append(".")
             .append(label.as_str()),
 
-            UntypedExpr::Tuple { elems, location } => self.tuple(elems, location),
+            UntypedExpr::Tuple { elements, location } => self.tuple(elements, location),
 
             UntypedExpr::BitArray {
                 segments, location, ..

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -731,14 +731,14 @@ impl<'comments> Formatter<'comments> {
 
             TypeAst::Fn(TypeAstFn {
                 arguments: args,
-                return_: retrn,
+                return_,
                 location,
             }) => "fn"
                 .to_doc()
                 .append(self.type_arguments(args, location))
                 .group()
                 .append(" ->")
-                .append(break_("", " ").append(self.type_ast(retrn)).nest(INDENT)),
+                .append(break_("", " ").append(self.type_ast(return_)).nest(INDENT)),
 
             TypeAst::Var(TypeAstVar { name, .. }) => name.to_doc(),
 

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -244,7 +244,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                 })
             }
 
-            TypedExpr::Tuple { elems, .. } => self.tuple(elems),
+            TypedExpr::Tuple { elements, .. } => self.tuple(elements),
             TypedExpr::TupleIndex { tuple, index, .. } => self.tuple_index(tuple, *index),
 
             TypedExpr::Case {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -235,11 +235,20 @@ impl<'module, 'a> Generator<'module, 'a> {
                     Some(tail) => {
                         r#gen.tracker.prepend_used = true;
                         let tail = r#gen.wrap_expression(tail)?;
-                        prepend(elements.iter().map(|e| r#gen.wrap_expression(e)), tail)
+                        prepend(
+                            elements
+                                .iter()
+                                .map(|element| r#gen.wrap_expression(element)),
+                            tail,
+                        )
                     }
                     None => {
                         r#gen.tracker.list_used = true;
-                        list(elements.iter().map(|e| r#gen.wrap_expression(e)))
+                        list(
+                            elements
+                                .iter()
+                                .map(|element| r#gen.wrap_expression(element)),
+                        )
                     }
                 })
             }
@@ -1531,7 +1540,7 @@ pub(crate) fn guard_constant_expression<'a>(
         Constant::Tuple { elements, .. } => array(
             elements
                 .iter()
-                .map(|e| guard_constant_expression(assignments, tracker, e)),
+                .map(|element| guard_constant_expression(assignments, tracker, element)),
         ),
 
         Constant::List { elements, .. } => {
@@ -1539,7 +1548,7 @@ pub(crate) fn guard_constant_expression<'a>(
             list(
                 elements
                     .iter()
-                    .map(|e| guard_constant_expression(assignments, tracker, e)),
+                    .map(|element| guard_constant_expression(assignments, tracker, element)),
             )
         }
         Constant::Record { type_, name, .. } if type_.is_bool() && name == "True" => {
@@ -1631,7 +1640,7 @@ pub(crate) fn constant_expression<'a>(
         Constant::Tuple { elements, .. } => array(
             elements
                 .iter()
-                .map(|e| constant_expression(context, tracker, e)),
+                .map(|element| constant_expression(context, tracker, element)),
         ),
 
         Constant::List { elements, .. } => {
@@ -1639,7 +1648,7 @@ pub(crate) fn constant_expression<'a>(
             let list = list(
                 elements
                     .iter()
-                    .map(|e| constant_expression(context, tracker, e)),
+                    .map(|element| constant_expression(context, tracker, element)),
             )?;
 
             match context {

--- a/compiler-core/src/javascript/pattern.rs
+++ b/compiler-core/src/javascript/pattern.rs
@@ -583,10 +583,10 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                 Ok(())
             }
 
-            Pattern::Tuple { elems, .. } => {
+            Pattern::Tuple { elements, .. } => {
                 // We don't check the length because type system ensures it's a
                 // tuple of the correct size
-                for (index, pattern) in elems.iter().enumerate() {
+                for (index, pattern) in elements.iter().enumerate() {
                     self.push_int(index);
                     self.traverse_pattern(subject, pattern)?;
                     self.pop();

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -650,9 +650,11 @@ impl<'a> TypeScriptGenerator<'a> {
 
             Type::Fn { args, retrn } => self.print_fn(args, retrn, generic_usages),
 
-            Type::Tuple { elements } => {
-                tuple(elements.iter().map(|e| self.do_print(e, generic_usages)))
-            }
+            Type::Tuple { elements } => tuple(
+                elements
+                    .iter()
+                    .map(|element| self.do_print(element, generic_usages)),
+            ),
         }
     }
 
@@ -670,7 +672,9 @@ impl<'a> TypeScriptGenerator<'a> {
 
             Type::Fn { args, retrn } => self.print_fn(args, retrn, None),
 
-            Type::Tuple { elements } => tuple(elements.iter().map(|e| self.do_print(e, None))),
+            Type::Tuple { elements } => {
+                tuple(elements.iter().map(|element| self.do_print(element, None)))
+            }
         }
     }
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -110,9 +110,9 @@ fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
             }
             generic_ids(retrn, ids);
         }
-        Type::Tuple { elems } => {
-            for elem in elems {
-                generic_ids(elem, ids)
+        Type::Tuple { elements } => {
+            for element in elements {
+                generic_ids(element, ids)
             }
         }
     }
@@ -309,9 +309,9 @@ impl<'a> TypeScriptGenerator<'a> {
                 }
                 self.collect_imports_for_type(retrn, imports);
             }
-            Type::Tuple { elems } => {
-                for elem in elems {
-                    self.collect_imports_for_type(elem, imports);
+            Type::Tuple { elements } => {
+                for element in elements {
+                    self.collect_imports_for_type(element, imports);
                 }
             }
             Type::Var { type_ } => {
@@ -650,7 +650,9 @@ impl<'a> TypeScriptGenerator<'a> {
 
             Type::Fn { args, retrn } => self.print_fn(args, retrn, generic_usages),
 
-            Type::Tuple { elems } => tuple(elems.iter().map(|e| self.do_print(e, generic_usages))),
+            Type::Tuple { elements } => {
+                tuple(elements.iter().map(|e| self.do_print(e, generic_usages)))
+            }
         }
     }
 
@@ -668,7 +670,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
             Type::Fn { args, retrn } => self.print_fn(args, retrn, None),
 
-            Type::Tuple { elems } => tuple(elems.iter().map(|e| self.do_print(e, None))),
+            Type::Tuple { elements } => tuple(elements.iter().map(|e| self.do_print(e, None))),
         }
     }
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -104,11 +104,11 @@ fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
                 generic_ids(arg, ids)
             }
         }
-        Type::Fn { args, retrn } => {
+        Type::Fn { args, return_ } => {
             for arg in args {
                 generic_ids(arg, ids)
             }
-            generic_ids(retrn, ids);
+            generic_ids(return_, ids);
         }
         Type::Tuple { elements } => {
             for element in elements {
@@ -303,11 +303,11 @@ impl<'a> TypeScriptGenerator<'a> {
                     self.collect_imports_for_type(arg, imports);
                 }
             }
-            Type::Fn { args, retrn } => {
+            Type::Fn { args, return_ } => {
                 for arg in args {
                     self.collect_imports_for_type(arg, imports);
                 }
-                self.collect_imports_for_type(retrn, imports);
+                self.collect_imports_for_type(return_, imports);
             }
             Type::Tuple { elements } => {
                 for element in elements {
@@ -648,7 +648,7 @@ impl<'a> TypeScriptGenerator<'a> {
                 name, args, module, ..
             } => self.print_type_app(name, args, module, generic_usages),
 
-            Type::Fn { args, retrn } => self.print_fn(args, retrn, generic_usages),
+            Type::Fn { args, return_ } => self.print_fn(args, return_, generic_usages),
 
             Type::Tuple { elements } => tuple(
                 elements
@@ -670,7 +670,7 @@ impl<'a> TypeScriptGenerator<'a> {
                 name, args, module, ..
             } => self.print_type_app(name, args, module, None),
 
-            Type::Fn { args, retrn } => self.print_fn(args, retrn, None),
+            Type::Fn { args, return_ } => self.print_fn(args, return_, None),
 
             Type::Tuple { elements } => {
                 tuple(elements.iter().map(|element| self.do_print(element, None)))
@@ -782,7 +782,7 @@ impl<'a> TypeScriptGenerator<'a> {
     fn print_fn(
         &mut self,
         args: &[Arc<Type>],
-        retrn: &Type,
+        return_: &Type,
         generic_usages: Option<&HashMap<u64, u64>>,
     ) -> Document<'static> {
         docvec![
@@ -793,7 +793,7 @@ impl<'a> TypeScriptGenerator<'a> {
                 self.do_print(a, generic_usages)
             ])),
             " => ",
-            self.do_print(retrn, generic_usages)
+            self.do_print(return_, generic_usages)
         ]
     }
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -120,9 +120,9 @@ fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
 
 /// Prints a Gleam tuple in the TypeScript equivalent syntax
 ///
-fn tuple<'a>(elems: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
+fn tuple<'a>(elements: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
     break_("", "")
-        .append(join(elems, break_(",", ", ")))
+        .append(join(elements, break_(",", ", ")))
         .nest(INDENT)
         .append(break_("", ""))
         .surround("[", "]")

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -166,8 +166,10 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
 
             for clause in clauses {
                 match clause.pattern.get(subject_idx) {
-                    Some(Pattern::Tuple { location, elems }) => self
-                        .delete_tuple_tokens(*location, elems.last().map(|elem| elem.location())),
+                    Some(Pattern::Tuple { location, elements }) => self.delete_tuple_tokens(
+                        *location,
+                        elements.last().map(|elem| elem.location()),
+                    ),
                     Some(Pattern::Discard { location, .. }) => {
                         self.discard_tuple_items(*location, elements.len())
                     }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -162,13 +162,13 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
                 continue;
             }
 
-            self.delete_tuple_tokens(*location, elements.last().map(|elem| elem.location()));
+            self.delete_tuple_tokens(*location, elements.last().map(|element| element.location()));
 
             for clause in clauses {
                 match clause.pattern.get(subject_idx) {
                     Some(Pattern::Tuple { location, elements }) => self.delete_tuple_tokens(
                         *location,
-                        elements.last().map(|elem| elem.location()),
+                        elements.last().map(|element| element.location()),
                     ),
                     Some(Pattern::Discard { location, .. }) => {
                         self.discard_tuple_items(*location, elements.len())

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -135,14 +135,14 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
     ) {
         for (subject_idx, subject) in subjects.iter().enumerate() {
             let TypedExpr::Tuple {
-                location, elems, ..
+                location, elements, ..
             } = subject
             else {
                 continue;
             };
 
             // Ignore empty tuple
-            if elems.is_empty() {
+            if elements.is_empty() {
                 continue;
             }
 
@@ -162,14 +162,14 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
                 continue;
             }
 
-            self.delete_tuple_tokens(*location, elems.last().map(|elem| elem.location()));
+            self.delete_tuple_tokens(*location, elements.last().map(|elem| elem.location()));
 
             for clause in clauses {
                 match clause.pattern.get(subject_idx) {
                     Some(Pattern::Tuple { location, elems }) => self
                         .delete_tuple_tokens(*location, elems.last().map(|elem| elem.location())),
                     Some(Pattern::Discard { location, .. }) => {
-                        self.discard_tuple_items(*location, elems.len())
+                        self.discard_tuple_items(*location, elements.len())
                     }
                     _ => panic!("safe: we've just checked all patterns must be discards/tuples"),
                 }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3972,10 +3972,10 @@ where
             }
             // We don't want to suggest this action for empty tuple as it
             // doesn't make a lot of sense to match on those.
-            Type::Tuple { elems } if elems.is_empty() => None,
-            Type::Tuple { elems } => Some(vec1![eco_format!(
+            Type::Tuple { elements } if elements.is_empty() => None,
+            Type::Tuple { elements } => Some(vec1![eco_format!(
                 "#({})",
-                (0..elems.len() as u32)
+                (0..elements.len() as u32)
                     .map(|i| format!("value_{i}"))
                     .join(", ")
             )]),

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -1085,7 +1085,7 @@ fn hover_for_pattern(pattern: &TypedPattern, line_numbers: LineNumbers, module: 
 fn get_function_type(fun: &TypedFunction) -> Type {
     Type::Fn {
         args: fun.arguments.iter().map(|arg| arg.type_.clone()).collect(),
-        retrn: fun.return_type.clone(),
+        return_: fun.return_type.clone(),
     }
 }
 

--- a/compiler-core/src/language_server/server.rs
+++ b/compiler-core/src/language_server/server.rs
@@ -386,7 +386,7 @@ where
         let mut accumulator = Feedback::none();
         let projects = std::mem::take(&mut self.changed_projects);
         for path in projects {
-            let (_, feedback) = self.respond_with_engine(path, |e| e.compile_please());
+            let (_, feedback) = self.respond_with_engine(path, |this| this.compile_please());
             accumulator.append_feedback(feedback);
         }
         accumulator

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -239,8 +239,8 @@ impl ModuleDecoder {
     }
 
     fn type_tuple(&mut self, reader: &schema::type_::tuple::Reader<'_>) -> Result<Arc<Type>> {
-        let elems = read_vec!(&reader.get_elements()?, self, type_);
-        Ok(Arc::new(Type::Tuple { elems }))
+        let elements = read_vec!(&reader.get_elements()?, self, type_);
+        Ok(Arc::new(Type::Tuple { elements }))
     }
 
     fn type_var(&mut self, reader: &schema::type_::var::Reader<'_>) -> Result<Arc<Type>> {

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -233,9 +233,9 @@ impl ModuleDecoder {
     }
 
     fn type_fn(&mut self, reader: &schema::type_::fn_::Reader<'_>) -> Result<Arc<Type>> {
-        let retrn = self.type_(&reader.get_return()?)?;
+        let return_ = self.type_(&reader.get_return()?)?;
         let args = read_vec!(&reader.get_arguments()?, self, type_);
-        Ok(Arc::new(Type::Fn { args, retrn }))
+        Ok(Arc::new(Type::Fn { args, return_ }))
     }
 
     fn type_tuple(&mut self, reader: &schema::type_::tuple::Reader<'_>) -> Result<Arc<Type>> {

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -626,9 +626,9 @@ impl<'a> ModuleEncoder<'a> {
                 self.build_types(app.reborrow().init_parameters(args.len() as u32), args);
             }
 
-            Type::Tuple { elems } => self.build_types(
-                builder.init_tuple().init_elements(elems.len() as u32),
-                elems,
+            Type::Tuple { elements } => self.build_types(
+                builder.init_tuple().init_elements(elements.len() as u32),
+                elements,
             ),
 
             Type::Var { type_ } => match type_.borrow().deref() {

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -600,10 +600,10 @@ impl<'a> ModuleEncoder<'a> {
 
     fn build_type(&mut self, builder: schema::type_::Builder<'_>, type_: &Type) {
         match type_ {
-            Type::Fn { args, retrn } => {
+            Type::Fn { args, return_ } => {
                 let mut fun = builder.init_fn();
                 self.build_types(fun.reborrow().init_arguments(args.len() as u32), args);
-                self.build_type(fun.init_return(), retrn)
+                self.build_type(fun.init_return(), return_)
             }
 
             Type::Named {

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -473,7 +473,7 @@ impl ModuleInterface {
                 (
                     Type::Fn {
                         args: arguments,
-                        retrn: return_type,
+                        return_: return_type,
                     },
                     ValueConstructorVariant::ModuleFn {
                         documentation,
@@ -559,12 +559,12 @@ impl TypeInterface {
 /// have the same id will also have the same incremental number in the end).
 fn from_type_helper(type_: &Type, id_map: &mut IdMap) -> TypeInterface {
     match type_ {
-        Type::Fn { args, retrn } => TypeInterface::Fn {
+        Type::Fn { args, return_ } => TypeInterface::Fn {
             parameters: args
                 .iter()
                 .map(|arg| from_type_helper(arg.as_ref(), id_map))
                 .collect(),
-            return_: Box::new(from_type_helper(retrn, id_map)),
+            return_: Box::new(from_type_helper(return_, id_map)),
         },
 
         Type::Tuple { elements } => TypeInterface::Tuple {

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -567,10 +567,10 @@ fn from_type_helper(type_: &Type, id_map: &mut IdMap) -> TypeInterface {
             return_: Box::new(from_type_helper(retrn, id_map)),
         },
 
-        Type::Tuple { elems } => TypeInterface::Tuple {
-            elements: elems
+        Type::Tuple { elements } => TypeInterface::Tuple {
+            elements: elements
                 .iter()
-                .map(|elem| from_type_helper(elem.as_ref(), id_map))
+                .map(|element| from_type_helper(element.as_ref(), id_map))
                 .collect(),
         },
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2537,14 +2537,14 @@ where
                     Parser::series_of(self, &|x| Parser::parse_type(x), Some(&Token::Comma))?;
                 let _ = self.expect_one_following_series(&Token::RightParen, "a type")?;
                 let (arr_s, arr_e) = self.expect_one(&Token::RArrow)?;
-                let retrn = self.parse_type()?;
-                match retrn {
-                    Some(retrn) => Ok(Some(TypeAst::Fn(TypeAstFn {
+                let return_ = self.parse_type()?;
+                match return_ {
+                    Some(return_) => Ok(Some(TypeAst::Fn(TypeAstFn {
                         location: SrcSpan {
                             start,
-                            end: retrn.location().end,
+                            end: return_.location().end,
                         },
-                        return_: Box::new(retrn),
+                        return_: Box::new(return_),
                         arguments: args,
                     }))),
                     _ => parse_error(

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2625,8 +2625,8 @@ where
 
     // For parsing a comma separated "list" of types, for tuple, constructor, and function
     fn parse_types(&mut self) -> Result<Vec<TypeAst>, ParseError> {
-        let elems = Parser::series_of(self, &|p| Parser::parse_type(p), Some(&Token::Comma))?;
-        Ok(elems)
+        let elements = Parser::series_of(self, &|p| Parser::parse_type(p), Some(&Token::Comma))?;
+        Ok(elements)
     }
 
     //

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1304,11 +1304,12 @@ where
             Some((start, Token::Hash, _)) => {
                 self.advance();
                 let _ = self.expect_one(&Token::LeftParen)?;
-                let elems = Parser::series_of(self, &Parser::parse_pattern, Some(&Token::Comma))?;
+                let elements =
+                    Parser::series_of(self, &Parser::parse_pattern, Some(&Token::Comma))?;
                 let (_, end) = self.expect_one_following_series(&Token::RightParen, "a pattern")?;
                 Pattern::Tuple {
                     location: SrcSpan { start, end },
-                    elems,
+                    elements,
                 }
             }
             // BitArray

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -580,13 +580,13 @@ where
             Some((start, Token::Hash, _)) => {
                 self.advance();
                 let _ = self.expect_one(&Token::LeftParen)?;
-                let elems =
+                let elements =
                     Parser::series_of(self, &Parser::parse_expression, Some(&Token::Comma))?;
                 let (_, end) =
                     self.expect_one_following_series(&Token::RightParen, "an expression")?;
                 UntypedExpr::Tuple {
                     location: SrcSpan { start, end },
-                    elems,
+                    elements,
                 }
             }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -2520,11 +2520,11 @@ where
             Some((start, Token::Hash, _)) => {
                 self.advance();
                 let _ = self.expect_one(&Token::LeftParen)?;
-                let elems = self.parse_types()?;
+                let elements = self.parse_types()?;
                 let (_, end) = self.expect_one(&Token::RightParen)?;
                 Ok(Some(TypeAst::Tuple(TypeAstTuple {
                     location: SrcSpan { start, end },
-                    elems,
+                    elements,
                 })))
             }
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
@@ -14,25 +14,25 @@ expression: "\nlet tup = #(#(#(#(4))))\n{{{tup.0}.0}.0}.0\n"
                     start: 11,
                     end: 24,
                 },
-                elems: [
+                elements: [
                     Tuple {
                         location: SrcSpan {
                             start: 13,
                             end: 23,
                         },
-                        elems: [
+                        elements: [
                             Tuple {
                                 location: SrcSpan {
                                     start: 15,
                                     end: 22,
                                 },
-                                elems: [
+                                elements: [
                                     Tuple {
                                         location: SrcSpan {
                                             start: 17,
                                             end: 21,
                                         },
-                                        elems: [
+                                        elements: [
                                             Int {
                                                 location: SrcSpan {
                                                     start: 19,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
@@ -14,25 +14,25 @@ expression: "\nlet tup = #(#(#(#(4))))\ntup.0.0.0.0\n"
                     start: 11,
                     end: 24,
                 },
-                elems: [
+                elements: [
                     Tuple {
                         location: SrcSpan {
                             start: 13,
                             end: 23,
                         },
-                        elems: [
+                        elements: [
                             Tuple {
                                 location: SrcSpan {
                                     start: 15,
                                     end: 22,
                                 },
-                                elems: [
+                                elements: [
                                     Tuple {
                                         location: SrcSpan {
                                             start: 17,
                                             end: 21,
                                         },
-                                        elems: [
+                                        elements: [
                                             Int {
                                                 location: SrcSpan {
                                                     start: 19,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
@@ -14,13 +14,13 @@ expression: "\nlet tup = #(#(5, 6))\n{tup.0}.1\n"
                     start: 11,
                     end: 21,
                 },
-                elems: [
+                elements: [
                     Tuple {
                         location: SrcSpan {
                             start: 13,
                             end: 20,
                         },
-                        elems: [
+                        elements: [
                             Int {
                                 location: SrcSpan {
                                     start: 15,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
@@ -14,13 +14,13 @@ expression: "\nlet tup = #(#(5, 6))\ntup.0.1\n"
                     start: 11,
                     end: 21,
                 },
-                elems: [
+                elements: [
                     Tuple {
                         location: SrcSpan {
                             start: 13,
                             end: 20,
                         },
-                        elems: [
+                        elements: [
                             Int {
                                 location: SrcSpan {
                                     start: 15,

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -255,8 +255,8 @@ fn nest_if_broken_test() {
 
 #[test]
 fn let_left_side_fits_test() {
-    let elems = break_("", "").append("1").nest(2).append(break_("", ""));
-    let list = "[".to_doc().append(elems).append("]").group();
+    let elements = break_("", "").append("1").nest(2).append(break_("", ""));
+    let list = "[".to_doc().append(elements).append("]").group();
     let doc = list.clone().append(" = ").append(list);
 
     assert_eq!(

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -98,7 +98,7 @@ pub enum Type {
     ///
     Fn {
         args: Vec<Arc<Type>>,
-        retrn: Arc<Type>,
+        return_: Arc<Type>,
     },
 
     /// A type variable. See the contained `TypeVar` enum for more information.
@@ -115,7 +115,7 @@ pub enum Type {
 impl Type {
     pub fn is_result_constructor(&self) -> bool {
         match self {
-            Type::Fn { retrn, .. } => retrn.is_result(),
+            Type::Fn { return_, .. } => return_.is_result(),
             Type::Var { type_ } => type_.borrow().is_result(),
             _ => false,
         }
@@ -174,7 +174,7 @@ impl Type {
 
     pub fn return_type(&self) -> Option<Arc<Self>> {
         match self {
-            Self::Fn { retrn, .. } => Some(retrn.clone()),
+            Self::Fn { return_, .. } => Some(return_.clone()),
             Self::Var { type_ } => type_.borrow().return_type(),
             _ => None,
         }
@@ -182,7 +182,7 @@ impl Type {
 
     pub fn fn_types(&self) -> Option<(Vec<Arc<Self>>, Arc<Self>)> {
         match self {
-            Self::Fn { args, retrn, .. } => Some((args.clone(), retrn.clone())),
+            Self::Fn { args, return_, .. } => Some((args.clone(), return_.clone())),
             Self::Var { type_ } => type_.borrow().fn_types(),
             _ => None,
         }
@@ -344,11 +344,11 @@ impl Type {
                     Arc::make_mut(element).generalise_custom_type_variant();
                 }
             }
-            Type::Fn { args, retrn } => {
+            Type::Fn { args, return_ } => {
                 for argument in args {
                     Arc::make_mut(argument).generalise_custom_type_variant();
                 }
-                Arc::make_mut(retrn).generalise_custom_type_variant();
+                Arc::make_mut(return_).generalise_custom_type_variant();
             }
         }
     }
@@ -442,7 +442,7 @@ impl Type {
 
             Self::Tuple { elements, .. } => elements.iter().find_map(|t| t.find_private_type()),
 
-            Self::Fn { retrn, args, .. } => retrn
+            Self::Fn { return_, args, .. } => return_
                 .find_private_type()
                 .or_else(|| args.iter().find_map(|t| t.find_private_type())),
 
@@ -464,7 +464,7 @@ impl Type {
 
             Self::Tuple { elements, .. } => elements.iter().find_map(|t| t.find_internal_type()),
 
-            Self::Fn { retrn, args, .. } => retrn
+            Self::Fn { return_, args, .. } => return_
                 .find_internal_type()
                 .or_else(|| args.iter().find_map(|t| t.find_internal_type())),
 
@@ -526,10 +526,10 @@ impl Type {
                 type_.as_ref().borrow().same_as_other_type(one)
             }
             (
-                Type::Fn { args, retrn },
+                Type::Fn { args, return_ },
                 Type::Fn {
                     args: other_args,
-                    retrn: other_retrn,
+                    return_: other_return,
                 },
             ) => {
                 args.len() == other_args.len()
@@ -537,7 +537,7 @@ impl Type {
                         .iter()
                         .zip(other_args)
                         .all(|(one, other)| one.same_as(other))
-                    && retrn.same_as(other_retrn)
+                    && return_.same_as(other_return)
             }
 
             (Type::Var { type_ }, other) => type_.as_ref().borrow().same_as_other_type(other),
@@ -1409,11 +1409,11 @@ fn unify_unbound_type(type_: Arc<Type>, own_id: u64) -> Result<(), UnifyError> {
             Ok(())
         }
 
-        Type::Fn { args, retrn } => {
+        Type::Fn { args, return_ } => {
             for arg in args {
                 unify_unbound_type(arg.clone(), own_id)?;
             }
-            unify_unbound_type(retrn.clone(), own_id)
+            unify_unbound_type(return_.clone(), own_id)
         }
 
         Type::Tuple { elements, .. } => {
@@ -1440,31 +1440,31 @@ fn match_fun_type(
 
             TypeVar::Unbound { .. } => {
                 let args: Vec<_> = (0..arity).map(|_| environment.new_unbound_var()).collect();
-                let retrn = environment.new_unbound_var();
-                Some((args, retrn))
+                let return_ = environment.new_unbound_var();
+                Some((args, return_))
             }
 
             TypeVar::Generic { .. } => None,
         };
 
-        if let Some((args, retrn)) = new_value {
+        if let Some((args, return_)) = new_value {
             *type_.borrow_mut() = TypeVar::Link {
-                type_: fn_(args.clone(), retrn.clone()),
+                type_: fn_(args.clone(), return_.clone()),
             };
-            return Ok((args, retrn));
+            return Ok((args, return_));
         }
     }
 
-    if let Type::Fn { args, retrn } = type_.deref() {
+    if let Type::Fn { args, return_ } = type_.deref() {
         return if args.len() != arity {
             Err(MatchFunTypeError::IncorrectArity {
                 expected: args.len(),
                 given: arity,
                 args: args.clone(),
-                return_type: retrn.clone(),
+                return_type: return_.clone(),
             })
         } else {
-            Ok((args.clone(), retrn.clone()))
+            Ok((args.clone(), return_.clone()))
         };
     }
 
@@ -1500,9 +1500,9 @@ pub fn generalise(t: Arc<Type>) -> Arc<Type> {
             })
         }
 
-        Type::Fn { args, retrn } => fn_(
+        Type::Fn { args, return_ } => fn_(
             args.iter().map(|t| generalise(t.clone())).collect(),
-            generalise(retrn.clone()),
+            generalise(return_.clone()),
         ),
 
         Type::Tuple { elements } => tuple(elements.iter().map(|t| generalise(t.clone())).collect()),

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -109,7 +109,7 @@ pub enum Type {
     /// can have a different type, so the `tuple` type is the sum of all the
     /// contained types.
     ///
-    Tuple { elems: Vec<Arc<Type>> },
+    Tuple { elements: Vec<Arc<Type>> },
 }
 
 impl Type {
@@ -191,7 +191,7 @@ impl Type {
     /// Gets the types inside of a tuple. Returns `None` if the type is not a tuple.
     pub fn tuple_types(&self) -> Option<Vec<Arc<Self>>> {
         match self {
-            Self::Tuple { elems } => Some(elems.clone()),
+            Self::Tuple { elements } => Some(elements.clone()),
             Self::Var { type_, .. } => type_.borrow().tuple_types(),
             _ => None,
         }
@@ -339,8 +339,8 @@ impl Type {
                 inferred_variant, ..
             } => *inferred_variant = None,
             Type::Var { type_ } => type_.borrow_mut().generalise_custom_type_variant(),
-            Type::Tuple { elems } => {
-                for element in elems {
+            Type::Tuple { elements } => {
+                for element in elements {
                     Arc::make_mut(element).generalise_custom_type_variant();
                 }
             }
@@ -440,7 +440,7 @@ impl Type {
 
             Self::Named { args, .. } => args.iter().find_map(|t| t.find_private_type()),
 
-            Self::Tuple { elems, .. } => elems.iter().find_map(|t| t.find_private_type()),
+            Self::Tuple { elements, .. } => elements.iter().find_map(|t| t.find_private_type()),
 
             Self::Fn { retrn, args, .. } => retrn
                 .find_private_type()
@@ -462,7 +462,7 @@ impl Type {
 
             Self::Named { args, .. } => args.iter().find_map(|t| t.find_internal_type()),
 
-            Self::Tuple { elems, .. } => elems.iter().find_map(|t| t.find_internal_type()),
+            Self::Tuple { elements, .. } => elements.iter().find_map(|t| t.find_internal_type()),
 
             Self::Fn { retrn, args, .. } => retrn
                 .find_internal_type()
@@ -546,11 +546,16 @@ impl Type {
             (one @ Type::Tuple { .. }, Type::Var { type_ }) => {
                 type_.as_ref().borrow().same_as_other_type(one)
             }
-            (Type::Tuple { elems }, Type::Tuple { elems: other_elems }) => {
-                elems.len() == other_elems.len()
-                    && elems
+            (
+                Type::Tuple { elements },
+                Type::Tuple {
+                    elements: other_elements,
+                },
+            ) => {
+                elements.len() == other_elements.len()
+                    && elements
                         .iter()
-                        .zip(other_elems)
+                        .zip(other_elements)
                         .all(|(one, other)| one.same_as(other))
             }
         }
@@ -1411,9 +1416,9 @@ fn unify_unbound_type(type_: Arc<Type>, own_id: u64) -> Result<(), UnifyError> {
             unify_unbound_type(retrn.clone(), own_id)
         }
 
-        Type::Tuple { elems, .. } => {
-            for elem in elems {
-                unify_unbound_type(elem.clone(), own_id)?
+        Type::Tuple { elements, .. } => {
+            for element in elements {
+                unify_unbound_type(element.clone(), own_id)?
             }
             Ok(())
         }
@@ -1500,7 +1505,7 @@ pub fn generalise(t: Arc<Type>) -> Arc<Type> {
             generalise(retrn.clone()),
         ),
 
-        Type::Tuple { elems } => tuple(elems.iter().map(|t| generalise(t.clone())).collect()),
+        Type::Tuple { elements } => tuple(elements.iter().map(|t| generalise(t.clone())).collect()),
     }
 }
 

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -558,7 +558,7 @@ impl Environment<'_> {
             } => {
                 let args = args
                     .iter()
-                    .map(|t| self.instantiate(t.clone(), ids, hydrator))
+                    .map(|type_| self.instantiate(type_.clone(), ids, hydrator))
                     .collect();
                 Arc::new(Type::Named {
                     publicity: *publicity,
@@ -601,7 +601,7 @@ impl Environment<'_> {
 
             Type::Fn { args, return_, .. } => fn_(
                 args.iter()
-                    .map(|t| self.instantiate(t.clone(), ids, hydrator))
+                    .map(|type_| self.instantiate(type_.clone(), ids, hydrator))
                     .collect(),
                 self.instantiate(return_.clone(), ids, hydrator),
             ),
@@ -609,7 +609,7 @@ impl Environment<'_> {
             Type::Tuple { elements } => tuple(
                 elements
                     .iter()
-                    .map(|t| self.instantiate(t.clone(), ids, hydrator))
+                    .map(|type_| self.instantiate(type_.clone(), ids, hydrator))
                     .collect(),
             ),
         }

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -606,8 +606,8 @@ impl Environment<'_> {
                 self.instantiate(retrn.clone(), ids, hydrator),
             ),
 
-            Type::Tuple { elems } => tuple(
-                elems
+            Type::Tuple { elements } => tuple(
+                elements
                     .iter()
                     .map(|t| self.instantiate(t.clone(), ids, hydrator))
                     .collect(),
@@ -912,10 +912,17 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
             Ok(())
         }
 
-        (Type::Tuple { elems: elems1, .. }, Type::Tuple { elems: elems2, .. })
-            if elems1.len() == elems2.len() =>
-        {
-            for (a, b) in elems1.iter().zip(elems2) {
+        (
+            Type::Tuple {
+                elements: elements1,
+                ..
+            },
+            Type::Tuple {
+                elements: elements2,
+                ..
+            },
+        ) if elements1.len() == elements2.len() => {
+            for (a, b) in elements1.iter().zip(elements2) {
                 unify_enclosed_type(t1.clone(), t2.clone(), unify(a.clone(), b.clone()))?;
             }
             Ok(())

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -599,11 +599,11 @@ impl Environment<'_> {
                 })
             }
 
-            Type::Fn { args, retrn, .. } => fn_(
+            Type::Fn { args, return_, .. } => fn_(
                 args.iter()
                     .map(|t| self.instantiate(t.clone(), ids, hydrator))
                     .collect(),
-                self.instantiate(retrn.clone(), ids, hydrator),
+                self.instantiate(return_.clone(), ids, hydrator),
             ),
 
             Type::Tuple { elements } => tuple(
@@ -931,12 +931,12 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
         (
             Type::Fn {
                 args: args1,
-                retrn: retrn1,
+                return_: return1,
                 ..
             },
             Type::Fn {
                 args: args2,
-                retrn: retrn2,
+                return_: return2,
                 ..
             },
         ) => {
@@ -949,8 +949,8 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
                     .map_err(|_| unify_wrong_arguments(&t1, a, &t2, b, i))?;
             }
 
-            unify(retrn1.clone(), retrn2.clone())
-                .map_err(|_| unify_wrong_returns(&t1, retrn1, &t2, retrn2))
+            unify(return1.clone(), return2.clone())
+                .map_err(|_| unify_wrong_returns(&t1, return1, &t2, return2))
         }
 
         _ => Err(UnifyError::CouldNotUnify {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -939,14 +939,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
     fn infer_tuple(
         &mut self,
-        elems: Vec<UntypedExpr>,
+        elements: Vec<UntypedExpr>,
         location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
-        let elems: Vec<_> = elems.into_iter().map(|e| self.infer(e)).try_collect()?;
-        let type_ = tuple(elems.iter().map(HasType::type_).collect());
+        let elements: Vec<_> = elements.into_iter().map(|e| self.infer(e)).try_collect()?;
+        let type_ = tuple(elements.iter().map(HasType::type_).collect());
         Ok(TypedExpr::Tuple {
             location,
-            elems,
+            elements,
             type_,
         })
     }
@@ -4127,7 +4127,7 @@ fn check_subject_for_redundant_match(
     case_used_like_if: bool,
 ) -> Option<Warning> {
     match subject {
-        TypedExpr::Tuple { elems, .. } if !elems.is_empty() => {
+        TypedExpr::Tuple { elements, .. } if !elements.is_empty() => {
             Some(Warning::CaseMatchOnLiteralCollection {
                 kind: LiteralCollectionKind::Tuple,
                 location: subject.location(),

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -835,7 +835,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         } = arg;
         let type_ = annotation
             .clone()
-            .map(|t| self.type_from_ast(&t))
+            .map(|type_| self.type_from_ast(&type_))
             .unwrap_or_else(|| Ok(self.new_unbound_var()))?;
 
         // If we know the expected type of the argument from its contextual
@@ -1503,7 +1503,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         if let Some(annotation) = &annotation {
             match self
                 .type_from_ast(annotation)
-                .map(|t| self.instantiate(t, &mut hashmap![]))
+                .map(|type_| self.instantiate(type_, &mut hashmap![]))
             {
                 Ok(ann_typ) => {
                     if let Err(error) = unify(ann_typ, value_typ.clone())

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -329,8 +329,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             } => self.infer_block(statements, location),
 
             UntypedExpr::Tuple {
-                location, elems, ..
-            } => self.infer_tuple(elems, location),
+                location, elements, ..
+            } => self.infer_tuple(elements, location),
 
             UntypedExpr::Float {
                 location, value, ..

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1162,8 +1162,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         let tuple = self.infer(tuple)?;
         match collapse_links(tuple.type_()).as_ref() {
-            Type::Tuple { elems } => {
-                let type_ = elems
+            Type::Tuple { elements } => {
+                let type_ = elements
                     .get(index as usize)
                     .ok_or_else(|| Error::OutOfBoundsTupleIndex {
                         location: SrcSpan {
@@ -1171,7 +1171,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             end: location.end,
                         },
                         index,
-                        size: elems.len(),
+                        size: elements.len(),
                     })?
                     .clone();
                 Ok(TypedExpr::TupleIndex {
@@ -1829,13 +1829,13 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             } => {
                 let tuple = self.infer_clause_guard(*tuple)?;
                 match tuple.type_().as_ref() {
-                    Type::Tuple { elems } => {
-                        let type_ = elems
+                    Type::Tuple { elements } => {
+                        let type_ = elements
                             .get(index as usize)
                             .ok_or(Error::OutOfBoundsTupleIndex {
                                 location,
                                 index,
-                                size: elems.len(),
+                                size: elements.len(),
                             })?
                             .clone();
                         Ok(ClauseGuard::TupleIndex {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -681,7 +681,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // it consumes everything that comes below it and returns a single value.
         let last_statement_location = statements
             .iter()
-            .find_or_last(|e| e.is_use())
+            .find_or_last(|statement| statement.is_use())
             .expect("safe: iter from non empty vec")
             .location();
 
@@ -942,7 +942,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         elements: Vec<UntypedExpr>,
         location: SrcSpan,
     ) -> Result<TypedExpr, Error> {
-        let elements: Vec<_> = elements.into_iter().map(|e| self.infer(e)).try_collect()?;
+        let elements: Vec<_> = elements
+            .into_iter()
+            .map(|element| self.infer(element))
+            .try_collect()?;
         let type_ = tuple(elements.iter().map(HasType::type_).collect());
         Ok(TypedExpr::Tuple {
             location,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2785,7 +2785,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let record_type = record.type_();
         // The record constructor needs to be a function.
         let (args_types, return_type) = match constructor.type_().as_ref() {
-            Type::Fn { args, retrn } => (args.clone(), retrn.clone()),
+            Type::Fn { args, return_ } => (args.clone(), return_.clone()),
             _ => {
                 return Err(Error::RecordUpdateInvalidConstructor {
                     location: constructor.location(),
@@ -2813,7 +2813,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // not some unrelated other type. This should not affect our returned type, so we
         // instantiate a new copy of the generic return type for our value constructor.
         let return_type_copy = match value_constructor.type_.as_ref() {
-            Type::Fn { retrn, .. } => self.instantiate(retrn.clone(), &mut hashmap![]),
+            Type::Fn { return_, .. } => self.instantiate(return_.clone(), &mut hashmap![]),
             _ => {
                 return Err(Error::RecordUpdateInvalidConstructor {
                     location: constructor.location(),

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -193,7 +193,7 @@ impl Hydrator {
             TypeAst::Tuple(TypeAstTuple { elements, .. }) => Ok(tuple(
                 elements
                     .iter()
-                    .map(|t| self.type_from_ast(t, environment, problems))
+                    .map(|type_| self.type_from_ast(type_, environment, problems))
                     .try_collect()?,
             )),
 
@@ -204,7 +204,7 @@ impl Hydrator {
             }) => {
                 let args = args
                     .iter()
-                    .map(|t| self.type_from_ast(t, environment, problems))
+                    .map(|type_| self.type_from_ast(type_, environment, problems))
                     .try_collect()?;
                 let return_ = self.type_from_ast(return_, environment, problems)?;
                 Ok(fn_(args, return_))

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -199,15 +199,15 @@ impl Hydrator {
 
             TypeAst::Fn(TypeAstFn {
                 arguments: args,
-                return_: retrn,
+                return_,
                 ..
             }) => {
                 let args = args
                     .iter()
                     .map(|t| self.type_from_ast(t, environment, problems))
                     .try_collect()?;
-                let retrn = self.type_from_ast(retrn, environment, problems)?;
-                Ok(fn_(args, retrn))
+                let return_ = self.type_from_ast(return_, environment, problems)?;
+                Ok(fn_(args, return_))
             }
 
             TypeAst::Var(TypeAstVar { name, location }) => {

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -190,8 +190,8 @@ impl Hydrator {
                 Ok(return_type)
             }
 
-            TypeAst::Tuple(TypeAstTuple { elems, .. }) => Ok(tuple(
-                elems
+            TypeAst::Tuple(TypeAstTuple { elements, .. }) => Ok(tuple(
+                elements
                     .iter()
                     .map(|t| self.type_from_ast(t, environment, problems))
                     .try_collect()?,

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -835,7 +835,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     self.environment
                         .instantiate(constructor_typ, &mut hashmap![], self.hydrator);
                 match instantiated_constructor_type.deref() {
-                    Type::Fn { args, retrn } => {
+                    Type::Fn { args, return_ } => {
                         if args.len() == pattern_args.len() {
                             let pattern_args = pattern_args
                                 .into_iter()
@@ -863,11 +863,11 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                     })
                                 })
                                 .try_collect()?;
-                            unify(type_.clone(), retrn.clone())
+                            unify(type_.clone(), return_.clone())
                                 .map_err(|e| convert_unify_error(e, location))?;
 
                             if let Some((variable_to_infer, inferred_variant)) =
-                                subject_variable.zip(retrn.custom_type_inferred_variant())
+                                subject_variable.zip(return_.custom_type_inferred_variant())
                             {
                                 self.set_subject_variable_variant(
                                     variable_to_infer,
@@ -883,7 +883,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                 arguments: pattern_args,
                                 constructor: Inferred::Known(constructor),
                                 spread,
-                                type_: retrn.clone(),
+                                type_: return_.clone(),
                             })
                         } else {
                             Err(Error::IncorrectArity {

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -594,46 +594,46 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 }),
             },
 
-            Pattern::Tuple { elems, location } => match collapse_links(type_.clone()).deref() {
+            Pattern::Tuple { elements, location } => match collapse_links(type_.clone()).deref() {
                 Type::Tuple { elems: type_elems } => {
-                    if elems.len() != type_elems.len() {
+                    if elements.len() != type_elems.len() {
                         return Err(Error::IncorrectArity {
                             labels: vec![],
                             location,
                             expected: type_elems.len(),
-                            given: elems.len(),
+                            given: elements.len(),
                         });
                     }
 
-                    let elems = elems
+                    let elements = elements
                         .into_iter()
                         .zip(type_elems)
                         .map(|(pattern, type_)| self.unify(pattern, type_.clone(), None))
                         .try_collect()?;
-                    Ok(Pattern::Tuple { elems, location })
+                    Ok(Pattern::Tuple { elements, location })
                 }
 
                 Type::Var { .. } => {
-                    let elems_types: Vec<_> = (0..(elems.len()))
+                    let elems_types: Vec<_> = (0..(elements.len()))
                         .map(|_| self.environment.new_unbound_var())
                         .collect();
                     unify(tuple(elems_types.clone()), type_)
                         .map_err(|e| convert_unify_error(e, location))?;
-                    let elems = elems
+                    let elements = elements
                         .into_iter()
                         .zip(elems_types)
                         .map(|(pattern, type_)| self.unify(pattern, type_, None))
                         .try_collect()?;
-                    Ok(Pattern::Tuple { elems, location })
+                    Ok(Pattern::Tuple { elements, location })
                 }
 
                 _ => {
-                    let elems_types = (0..(elems.len()))
+                    let elements_types = (0..(elements.len()))
                         .map(|_| self.environment.new_unbound_var())
                         .collect();
 
                     Err(Error::CouldNotUnify {
-                        given: tuple(elems_types),
+                        given: tuple(elements_types),
                         expected: type_,
                         situation: None,
                         location,

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -595,19 +595,21 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             },
 
             Pattern::Tuple { elements, location } => match collapse_links(type_.clone()).deref() {
-                Type::Tuple { elems: type_elems } => {
-                    if elements.len() != type_elems.len() {
+                Type::Tuple {
+                    elements: type_elements,
+                } => {
+                    if elements.len() != type_elements.len() {
                         return Err(Error::IncorrectArity {
                             labels: vec![],
                             location,
-                            expected: type_elems.len(),
+                            expected: type_elements.len(),
                             given: elements.len(),
                         });
                     }
 
                     let elements = elements
                         .into_iter()
-                        .zip(type_elems)
+                        .zip(type_elements)
                         .map(|(pattern, type_)| self.unify(pattern, type_.clone(), None))
                         .try_collect()?;
                     Ok(Pattern::Tuple { elements, location })

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -616,14 +616,14 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 }
 
                 Type::Var { .. } => {
-                    let elems_types: Vec<_> = (0..(elements.len()))
+                    let elements_types: Vec<_> = (0..(elements.len()))
                         .map(|_| self.environment.new_unbound_var())
                         .collect();
-                    unify(tuple(elems_types.clone()), type_)
+                    unify(tuple(elements_types.clone()), type_)
                         .map_err(|e| convert_unify_error(e, location))?;
                     let elements = elements
                         .into_iter()
-                        .zip(elems_types)
+                        .zip(elements_types)
                         .map(|(pattern, type_)| self.unify(pattern, type_, None))
                         .try_collect()?;
                     Ok(Pattern::Tuple { elements, location })

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -153,8 +153,8 @@ fn result_with_variant(a: Arc<Type>, e: Arc<Type>, variant_index: Option<u16>) -
     })
 }
 
-pub fn tuple(elems: Vec<Arc<Type>>) -> Arc<Type> {
-    Arc::new(Type::Tuple { elems })
+pub fn tuple(elements: Vec<Arc<Type>>) -> Arc<Type> {
+    Arc::new(Type::Tuple { elements })
 }
 
 pub fn fn_(args: Vec<Arc<Type>>, retrn: Arc<Type>) -> Arc<Type> {

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -157,8 +157,8 @@ pub fn tuple(elements: Vec<Arc<Type>>) -> Arc<Type> {
     Arc::new(Type::Tuple { elements })
 }
 
-pub fn fn_(args: Vec<Arc<Type>>, retrn: Arc<Type>) -> Arc<Type> {
-    Arc::new(Type::Fn { retrn, args })
+pub fn fn_(args: Vec<Arc<Type>>, return_: Arc<Type>) -> Arc<Type> {
+    Arc::new(Type::Fn { return_, args })
 }
 
 pub fn named(

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -83,7 +83,7 @@ impl Printer {
 
             Type::Var { type_, .. } => self.type_var_doc(&type_.borrow()),
 
-            Type::Tuple { elems, .. } => self.args_to_gleam_doc(elems).surround("#(", ")"),
+            Type::Tuple { elements, .. } => self.args_to_gleam_doc(elements).surround("#(", ")"),
         }
     }
 

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -70,13 +70,13 @@ impl Printer {
                 }
             }
 
-            Type::Fn { args, retrn } => "fn("
+            Type::Fn { args, return_ } => "fn("
                 .to_doc()
                 .append(self.args_to_gleam_doc(args))
                 .append(") ->")
                 .append(
                     break_("", " ")
-                        .append(self.print(retrn))
+                        .append(self.print(return_))
                         .nest(INDENT)
                         .group(),
                 ),
@@ -311,7 +311,7 @@ fn pretty_print_test() {
                     inferred_variant: None,
                 }),
             ],
-            retrn: Arc::new(Type::Named {
+            return_: Arc::new(Type::Named {
                 args: vec![],
                 module: "whatever".into(),
                 package: "whatever".into(),

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -145,7 +145,7 @@ impl Printer {
         }
 
         let args = join(
-            args.iter().map(|t| self.print(t).group()),
+            args.iter().map(|type_| self.print(type_).group()),
             break_(",", ", "),
         );
         break_("", "")

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -375,9 +375,9 @@ impl<'a> Printer<'a> {
                 }
             },
 
-            Type::Tuple { elems, .. } => {
+            Type::Tuple { elements, .. } => {
                 buffer.push_str("#(");
-                self.print_arguments(elems, buffer, print_mode);
+                self.print_arguments(elements, buffer, print_mode);
                 buffer.push(')');
             }
         }
@@ -548,7 +548,7 @@ fn test_tuple_type() {
     let mut printer = Printer::new(&names);
 
     let type_ = Type::Tuple {
-        elems: vec![
+        elements: vec![
             Arc::new(Type::Named {
                 name: "Int".into(),
                 args: vec![],

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -401,13 +401,13 @@ impl<'a> Printer<'a> {
     fn print_arguments(
         &mut self,
         args: &[Arc<Type>],
-        typ_str: &mut EcoString,
+        type_str: &mut EcoString,
         print_mode: PrintMode,
     ) {
         for (i, arg) in args.iter().enumerate() {
-            self.print(arg, typ_str, print_mode);
+            self.print(arg, type_str, print_mode);
             if i < args.len() - 1 {
-                typ_str.push_str(", ");
+                type_str.push_str(", ");
             }
         }
     }

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -361,11 +361,11 @@ impl<'a> Printer<'a> {
                 }
             }
 
-            Type::Fn { args, retrn } => {
+            Type::Fn { args, return_ } => {
                 buffer.push_str("fn(");
                 self.print_arguments(args, buffer, print_mode);
                 buffer.push_str(") -> ");
-                self.print(retrn, buffer, print_mode);
+                self.print(return_, buffer, print_mode);
             }
 
             Type::Var { type_, .. } => match *type_.borrow() {
@@ -597,7 +597,7 @@ fn test_fn_type() {
                 inferred_variant: None,
             }),
         ],
-        retrn: Arc::new(Type::Named {
+        return_: Arc::new(Type::Named {
             name: "Bool".into(),
             args: vec![],
             module: "gleam".into(),

--- a/test-helpers-rs/src/lib.rs
+++ b/test-helpers-rs/src/lib.rs
@@ -79,8 +79,8 @@ pub fn to_in_memory_filesystem(path: &Utf8Path) -> InMemoryFileSystem {
         .follow_links(true)
         .into_iter()
         .filter_map(Result::ok)
-        .filter(|e| e.file_type().is_file())
-        .map(|d| d.into_path());
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| entry.into_path());
 
     for fullpath in files {
         let content = std::fs::read(&fullpath).unwrap();


### PR DESCRIPTION
This PR removes the use of various abbreviations:
- `r#gen` was renamed to `this` to follow an already existing convention in the codebase
- `elems` was renamed everywhere to `elements`
- when iterating over `elements` the loop variable is now consistently called `element` instead of `elem` or `e`
- there was one stray occurrence of `typ` that I renamed to `type_` to follow the already existing convention
- `retrn` was renamed to `return_` to be consistent with the choice of adding an underscore after names that would otherwise be Rust keywords
- `t` has been renamed to `type_` when it references a type
- I've renamed a couple other single-letter lambda arguments to use more descriptive names
- I did quite a bit of renaming for the arguments of the functions is `ast_folder`, previously a lot of those were single letter names