### PR TITLE
Do not loose information about definition groups

### DIFF
--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -135,13 +135,15 @@ fn check_for_name_squatting(package: &Package) -> Result<(), Error> {
         return Ok(());
     }
 
-    let definitions = &module.ast.definitions;
-
-    if definitions.len() > 2 {
+    if module.ast.total_definitions() > 2 {
         return Ok(());
     }
 
-    let Some(main) = definitions.iter().find_map(|d| d.main_function()) else {
+    let Some(main) = module
+        .ast
+        .iter_definitions()
+        .find_map(|definition| definition.main_function())
+    else {
         return Ok(());
     };
 

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -575,8 +575,8 @@ pub fn visit_typed_module<'a, V>(v: &mut V, module: &'a TypedModule)
 where
     V: Visit<'a> + ?Sized,
 {
-    for def in &module.definitions {
-        v.visit_typed_definition(def);
+    for definition in module.iter_definitions() {
+        v.visit_typed_definition(definition);
     }
 }
 

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -21,46 +21,51 @@ use crate::{
 #[allow(dead_code)]
 pub trait UntypedModuleFolder: TypeAstFolder + UntypedExprFolder {
     /// You probably don't want to override this method.
-    fn fold_module(&mut self, mut m: UntypedModule) -> UntypedModule {
-        m.definitions = m
-            .definitions
+    fn fold_module(&mut self, mut module: UntypedModule) -> UntypedModule {
+        module.groups = module
+            .groups
             .into_iter()
-            .map(|d| {
-                let TargetedDefinition { definition, target } = d;
-                match definition {
-                    Definition::Function(f) => {
-                        let f = self.fold_function_definition(f, target);
-                        let definition = self.walk_function_definition(f);
-                        TargetedDefinition { definition, target }
-                    }
+            .map(|group| {
+                group
+                    .into_iter()
+                    .map(|d| {
+                        let TargetedDefinition { definition, target } = d;
+                        match definition {
+                            Definition::Function(f) => {
+                                let f = self.fold_function_definition(f, target);
+                                let definition = self.walk_function_definition(f);
+                                TargetedDefinition { definition, target }
+                            }
 
-                    Definition::TypeAlias(a) => {
-                        let a = self.fold_type_alias(a, target);
-                        let definition = self.walk_type_alias(a);
-                        TargetedDefinition { definition, target }
-                    }
+                            Definition::TypeAlias(a) => {
+                                let a = self.fold_type_alias(a, target);
+                                let definition = self.walk_type_alias(a);
+                                TargetedDefinition { definition, target }
+                            }
 
-                    Definition::CustomType(t) => {
-                        let t = self.fold_custom_type(t, target);
-                        let definition = self.walk_custom_type(t);
-                        TargetedDefinition { definition, target }
-                    }
+                            Definition::CustomType(t) => {
+                                let t = self.fold_custom_type(t, target);
+                                let definition = self.walk_custom_type(t);
+                                TargetedDefinition { definition, target }
+                            }
 
-                    Definition::Import(i) => {
-                        let i = self.fold_import(i, target);
-                        let definition = self.walk_import(i);
-                        TargetedDefinition { definition, target }
-                    }
+                            Definition::Import(i) => {
+                                let i = self.fold_import(i, target);
+                                let definition = self.walk_import(i);
+                                TargetedDefinition { definition, target }
+                            }
 
-                    Definition::ModuleConstant(c) => {
-                        let c = self.fold_module_constant(c, target);
-                        let definition = self.walk_module_constant(c);
-                        TargetedDefinition { definition, target }
-                    }
-                }
+                            Definition::ModuleConstant(c) => {
+                                let c = self.fold_module_constant(c, target);
+                                let definition = self.walk_module_constant(c);
+                                TargetedDefinition { definition, target }
+                            }
+                        }
+                    })
+                    .collect()
             })
             .collect();
-        m
+        module
     }
 
     /// You probably don't want to override this method.

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -271,26 +271,26 @@ impl Module {
 
         self.ast.type_info.documentation = self.ast.documentation.clone();
 
-        // Order statements to avoid misassociating doc comments after the
+        // Order definitions to avoid misassociating doc comments after the
         // order has changed during compilation.
-        let mut statements: Vec<_> = self.ast.definitions.iter_mut().collect();
-        statements.sort_by(|a, b| a.location().start.cmp(&b.location().start));
+        let mut definitions: Vec<_> = self.ast.iter_mut_definitions().collect();
+        definitions.sort_by(|a, b| a.location().start.cmp(&b.location().start));
 
         // Doc Comments
         let mut doc_comments = self.extra.doc_comments.iter().peekable();
-        for statement in &mut statements {
+        for definition in &mut definitions {
             let (docs_start, docs): (u32, Vec<&str>) = doc_comments_before(
                 &mut doc_comments,
                 &self.extra,
-                statement.location().start,
+                definition.location().start,
                 &self.code,
             );
             if !docs.is_empty() {
                 let doc = docs.join("\n").into();
-                statement.put_doc((docs_start, doc));
+                definition.put_doc((docs_start, doc));
             }
 
-            if let Definition::CustomType(CustomType { constructors, .. }) = statement {
+            if let Definition::CustomType(CustomType { constructors, .. }) = definition {
                 for constructor in constructors {
                     let (docs_start, docs): (u32, Vec<&str>) = doc_comments_before(
                         &mut doc_comments,

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -171,28 +171,25 @@ pub fn generate_html<IO: FileSystemReader>(
 
         let functions: Vec<DocsFunction<'_>> = module
             .ast
-            .definitions
-            .iter()
-            .filter(|statement| !statement.is_internal())
-            .flat_map(|statement| function(&source_links, statement))
+            .iter_definitions()
+            .filter(|definition| !definition.is_internal())
+            .flat_map(|definition| function(&source_links, definition))
             .sorted()
             .collect();
 
         let types: Vec<Type<'_>> = module
             .ast
-            .definitions
-            .iter()
-            .filter(|statement| !statement.is_internal())
-            .flat_map(|statement| type_(&source_links, statement))
+            .iter_definitions()
+            .filter(|definition| !definition.is_internal())
+            .flat_map(|definition| type_(&source_links, definition))
             .sorted()
             .collect();
 
         let constants: Vec<Constant<'_>> = module
             .ast
-            .definitions
-            .iter()
-            .filter(|statement| !statement.is_internal())
-            .flat_map(|statement| constant(&source_links, statement))
+            .iter_definitions()
+            .filter(|definition| !definition.is_internal())
+            .flat_map(|definition| constant(&source_links, definition))
             .sorted()
             .collect();
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -209,8 +209,7 @@ impl<'comments> Formatter<'comments> {
         // Here we take consecutive groups of imports so that they can be sorted
         // alphabetically.
         for (is_import_group, definitions) in &module
-            .definitions
-            .iter()
+            .iter_definitions()
             .chunk_by(|definition| definition.definition.is_import())
         {
             if is_import_group {

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -111,9 +111,8 @@ impl<'a> Generator<'a> {
         // Generate JavaScript code for each statement
         let statements = self.collect_definitions().into_iter().chain(
             self.module
-                .definitions
-                .iter()
-                .flat_map(|s| self.statement(s)),
+                .iter_definitions()
+                .flat_map(|definition| self.statement(definition)),
         );
 
         // Two lines between each statement
@@ -366,9 +365,8 @@ impl<'a> Generator<'a> {
 
     fn collect_definitions(&mut self) -> Vec<Output<'a>> {
         self.module
-            .definitions
-            .iter()
-            .flat_map(|statement| match statement {
+            .iter_definitions()
+            .flat_map(|definition| match definition {
                 Definition::CustomType(CustomType {
                     publicity,
                     constructors,
@@ -387,8 +385,8 @@ impl<'a> Generator<'a> {
     fn collect_imports(&mut self) -> Imports<'a> {
         let mut imports = Imports::new();
 
-        for statement in &self.module.definitions {
-            match statement {
+        for definition in self.module.iter_definitions() {
+            match definition {
                 Definition::Import(Import {
                     module,
                     as_name,
@@ -586,8 +584,8 @@ impl<'a> Generator<'a> {
     }
 
     fn register_module_definitions_in_scope(&mut self) {
-        for statement in self.module.definitions.iter() {
-            match statement {
+        for definition in self.module.iter_definitions() {
+            match definition {
                 Definition::ModuleConstant(ModuleConstant { name, .. }) => {
                     self.register_in_scope(name)
                 }

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -195,9 +195,8 @@ impl<'a> TypeScriptGenerator<'a> {
         let mut imports = self.collect_imports();
         let statements = self
             .module
-            .definitions
-            .iter()
-            .flat_map(|s| self.statement(s));
+            .iter_definitions()
+            .flat_map(|definition| self.statement(definition));
 
         // Two lines between each statement
         let mut statements: Vec<_> =
@@ -230,8 +229,8 @@ impl<'a> TypeScriptGenerator<'a> {
     fn collect_imports(&mut self) -> Imports<'a> {
         let mut imports = Imports::new();
 
-        for statement in &self.module.definitions {
-            match statement {
+        for definition in self.module.iter_definitions() {
+            match definition {
                 Definition::Function(Function {
                     arguments,
                     return_type,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1269,8 +1269,8 @@ impl<'a> QualifiedToUnqualifiedImportFirstPass<'a> {
     ) -> Option<&'a ast::Import<EcoString>> {
         let mut matching_import = None;
 
-        for def in &self.module.ast.definitions {
-            if let ast::Definition::Import(import) = def {
+        for definition in self.module.ast.iter_definitions() {
+            if let ast::Definition::Import(import) = definition {
                 let imported = if layer.is_value() {
                     &import.unqualified_values
                 } else {
@@ -1818,9 +1818,8 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
         self.unqualified_constructor =
             self.module
                 .ast
-                .definitions
-                .iter()
-                .find_map(|def| match def {
+                .iter_definitions()
+                .find_map(|definition| match definition {
                     ast::Definition::Import(import) if import.module == *module_name => import
                         .unqualified_values
                         .iter()
@@ -1840,17 +1839,16 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
         self.unqualified_constructor =
             self.module
                 .ast
-                .definitions
-                .iter()
-                .find_map(|def| match def {
+                .iter_definitions()
+                .find_map(|definition| match definition {
                     ast::Definition::Import(import) => {
-                        if let Some(ty) = import
-                            .unqualified_types
-                            .iter()
-                            .find(|ty| ty.used_name() == constructor_name)
+                        if let Some(unqualified_import) =
+                            import.unqualified_types.iter().find(|unqualified_import| {
+                                unqualified_import.used_name() == constructor_name
+                            })
                         {
                             return Some(UnqualifiedConstructor {
-                                constructor: ty,
+                                constructor: unqualified_import,
                                 module_name: import.used_name()?,
                                 layer: ast::Layer::Type,
                             });

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -251,7 +251,7 @@ where
         let mut already_imported_values = std::collections::HashSet::new();
 
         // Search the ast for import statements
-        for import in self.module.ast.definitions.iter().filter_map(get_import) {
+        for import in self.module.ast.iter_definitions().filter_map(get_import) {
             // Find the import that matches the module being imported from
             if import.module == module_being_imported_from.name {
                 // Add the values and types that have already been imported
@@ -432,7 +432,7 @@ where
         }
 
         // Imported modules
-        for import in self.module.ast.definitions.iter().filter_map(get_import) {
+        for import in self.module.ast.iter_definitions().filter_map(get_import) {
             // The module may not be known of yet if it has not previously
             // compiled yet in this editor session.
             let Some(module) = self.compiler.get_module_interface(&import.module) else {
@@ -595,12 +595,21 @@ where
 
             // Find the function that the cursor is in and push completions for
             // its arguments and local variables.
-            if let Some(fun) = self.module.ast.definitions.iter().find_map(|d| match d {
-                Definition::Function(f) if f.full_location().contains(cursor) => Some(f),
-                _ => None,
-            }) {
+            if let Some(function) =
+                self.module
+                    .ast
+                    .iter_definitions()
+                    .find_map(|definition| match definition {
+                        Definition::Function(function)
+                            if function.full_location().contains(cursor) =>
+                        {
+                            Some(function)
+                        }
+                        _ => None,
+                    })
+            {
                 completions.extend(
-                    LocalCompletion::new(mod_name, insert_range, cursor).fn_completions(fun),
+                    LocalCompletion::new(mod_name, insert_range, cursor).fn_completions(function),
                 );
             }
 
@@ -620,7 +629,7 @@ where
         }
 
         // Imported modules
-        for import in self.module.ast.definitions.iter().filter_map(get_import) {
+        for import in self.module.ast.iter_definitions().filter_map(get_import) {
             // The module may not be known of yet if it has not previously
             // compiled yet in this editor session.
             let Some(module) = self.compiler.get_module_interface(&import.module) else {

--- a/compiler-core/src/language_server/edits.rs
+++ b/compiler-core/src/language_server/edits.rs
@@ -17,8 +17,7 @@ pub fn position_of_first_definition_if_import(
     // As "self.module.ast.definitions"  could be sorted, let's find the actual first definition by position.
     let first_definition = module
         .ast
-        .definitions
-        .iter()
+        .iter_definitions()
         .min_by(|a, b| a.location().start.cmp(&b.location().start));
     let import = first_definition.and_then(get_import);
     import.map(|import| src_span_to_lsp_range(import.location, line_numbers).start)

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -420,7 +420,7 @@ where
             };
             let line_numbers = LineNumbers::new(&module.code);
 
-            for definition in &module.ast.definitions {
+            for definition in module.ast.iter_definitions() {
                 match definition {
                     // Typically, imports aren't considered document symbols.
                     Definition::Import(_) => {}
@@ -1564,12 +1564,16 @@ fn get_hexdocs_link_section(
     ast: &TypedModule,
     hex_deps: &HashSet<EcoString>,
 ) -> Option<String> {
-    let package_name = ast.definitions.iter().find_map(|def| match def {
-        Definition::Import(p) if p.module == module_name && hex_deps.contains(&p.package) => {
-            Some(&p.package)
-        }
-        _ => None,
-    })?;
+    let package_name = ast
+        .iter_definitions()
+        .find_map(|definition| match definition {
+            Definition::Import(import)
+                if import.module == module_name && hex_deps.contains(&import.package) =>
+            {
+                Some(&import.package)
+            }
+            _ => None,
+        })?;
 
     Some(format_hexdocs_link_section(
         package_name,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -241,7 +241,7 @@ where
             name: "".into(),
             documentation: vec![],
             type_info: (),
-            definitions,
+            groups: vec![definitions],
             names: Default::default(),
         };
         Ok(Parsed {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -7,93 +7,95 @@ Parsed {
         name: "",
         documentation: [],
         type_info: (),
-        definitions: [
-            TargetedDefinition {
-                definition: ModuleConstant(
-                    ModuleConstant {
-                        documentation: None,
-                        location: SrcSpan {
-                            start: 1,
-                            end: 11,
-                        },
-                        publicity: Private,
-                        name: "cute",
-                        name_location: SrcSpan {
-                            start: 7,
-                            end: 11,
-                        },
-                        annotation: None,
-                        value: String {
+        groups: [
+            [
+                TargetedDefinition {
+                    definition: ModuleConstant(
+                        ModuleConstant {
+                            documentation: None,
                             location: SrcSpan {
-                                start: 14,
-                                end: 20,
+                                start: 1,
+                                end: 11,
                             },
-                            value: "cute",
+                            publicity: Private,
+                            name: "cute",
+                            name_location: SrcSpan {
+                                start: 7,
+                                end: 11,
+                            },
+                            annotation: None,
+                            value: String {
+                                location: SrcSpan {
+                                    start: 14,
+                                    end: 20,
+                                },
+                                value: "cute",
+                            },
+                            type_: (),
+                            deprecation: NotDeprecated,
+                            implementations: Implementations {
+                                gleam: true,
+                                can_run_on_erlang: true,
+                                can_run_on_javascript: true,
+                                uses_erlang_externals: false,
+                                uses_javascript_externals: false,
+                            },
                         },
-                        type_: (),
-                        deprecation: NotDeprecated,
-                        implementations: Implementations {
-                            gleam: true,
-                            can_run_on_erlang: true,
-                            can_run_on_javascript: true,
-                            uses_erlang_externals: false,
-                            uses_javascript_externals: false,
-                        },
-                    },
-                ),
-                target: None,
-            },
-            TargetedDefinition {
-                definition: ModuleConstant(
-                    ModuleConstant {
-                        documentation: None,
-                        location: SrcSpan {
-                            start: 21,
-                            end: 35,
-                        },
-                        publicity: Private,
-                        name: "cute_bee",
-                        name_location: SrcSpan {
-                            start: 27,
-                            end: 35,
-                        },
-                        annotation: None,
-                        value: StringConcatenation {
+                    ),
+                    target: None,
+                },
+                TargetedDefinition {
+                    definition: ModuleConstant(
+                        ModuleConstant {
+                            documentation: None,
                             location: SrcSpan {
-                                start: 38,
-                                end: 51,
+                                start: 21,
+                                end: 35,
                             },
-                            left: Var {
+                            publicity: Private,
+                            name: "cute_bee",
+                            name_location: SrcSpan {
+                                start: 27,
+                                end: 35,
+                            },
+                            annotation: None,
+                            value: StringConcatenation {
                                 location: SrcSpan {
                                     start: 38,
-                                    end: 42,
-                                },
-                                module: None,
-                                name: "cute",
-                                constructor: None,
-                                type_: (),
-                            },
-                            right: String {
-                                location: SrcSpan {
-                                    start: 46,
                                     end: 51,
                                 },
-                                value: "bee",
+                                left: Var {
+                                    location: SrcSpan {
+                                        start: 38,
+                                        end: 42,
+                                    },
+                                    module: None,
+                                    name: "cute",
+                                    constructor: None,
+                                    type_: (),
+                                },
+                                right: String {
+                                    location: SrcSpan {
+                                        start: 46,
+                                        end: 51,
+                                    },
+                                    value: "bee",
+                                },
+                            },
+                            type_: (),
+                            deprecation: NotDeprecated,
+                            implementations: Implementations {
+                                gleam: true,
+                                can_run_on_erlang: true,
+                                can_run_on_javascript: true,
+                                uses_erlang_externals: false,
+                                uses_javascript_externals: false,
                             },
                         },
-                        type_: (),
-                        deprecation: NotDeprecated,
-                        implementations: Implementations {
-                            gleam: true,
-                            can_run_on_erlang: true,
-                            can_run_on_javascript: true,
-                            uses_erlang_externals: false,
-                            uses_javascript_externals: false,
-                        },
-                    },
-                ),
-                target: None,
-            },
+                    ),
+                    target: None,
+                },
+            ],
         ],
         names: Names {
             local_types: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
@@ -7,62 +7,64 @@ Parsed {
         name: "",
         documentation: [],
         type_info: (),
-        definitions: [
-            TargetedDefinition {
-                definition: CustomType(
-                    CustomType {
-                        location: SrcSpan {
-                            start: 1,
-                            end: 12,
-                        },
-                        end_position: 61,
-                        name: "Wibble",
-                        name_location: SrcSpan {
-                            start: 6,
-                            end: 12,
-                        },
-                        publicity: Private,
-                        constructors: [
-                            RecordConstructor {
-                                location: SrcSpan {
-                                    start: 40,
-                                    end: 47,
-                                },
-                                name_location: SrcSpan {
-                                    start: 40,
-                                    end: 47,
-                                },
-                                name: "Wibble1",
-                                arguments: [],
-                                documentation: None,
-                                deprecation: Deprecated {
-                                    message: "1",
-                                },
+        groups: [
+            [
+                TargetedDefinition {
+                    definition: CustomType(
+                        CustomType {
+                            location: SrcSpan {
+                                start: 1,
+                                end: 12,
                             },
-                            RecordConstructor {
-                                location: SrcSpan {
-                                    start: 52,
-                                    end: 59,
-                                },
-                                name_location: SrcSpan {
-                                    start: 52,
-                                    end: 59,
-                                },
-                                name: "Wibble2",
-                                arguments: [],
-                                documentation: None,
-                                deprecation: NotDeprecated,
+                            end_position: 61,
+                            name: "Wibble",
+                            name_location: SrcSpan {
+                                start: 6,
+                                end: 12,
                             },
-                        ],
-                        documentation: None,
-                        deprecation: NotDeprecated,
-                        opaque: false,
-                        parameters: [],
-                        typed_parameters: [],
-                    },
-                ),
-                target: None,
-            },
+                            publicity: Private,
+                            constructors: [
+                                RecordConstructor {
+                                    location: SrcSpan {
+                                        start: 40,
+                                        end: 47,
+                                    },
+                                    name_location: SrcSpan {
+                                        start: 40,
+                                        end: 47,
+                                    },
+                                    name: "Wibble1",
+                                    arguments: [],
+                                    documentation: None,
+                                    deprecation: Deprecated {
+                                        message: "1",
+                                    },
+                                },
+                                RecordConstructor {
+                                    location: SrcSpan {
+                                        start: 52,
+                                        end: 59,
+                                    },
+                                    name_location: SrcSpan {
+                                        start: 52,
+                                        end: 59,
+                                    },
+                                    name: "Wibble2",
+                                    arguments: [],
+                                    documentation: None,
+                                    deprecation: NotDeprecated,
+                                },
+                            ],
+                            documentation: None,
+                            deprecation: NotDeprecated,
+                            opaque: false,
+                            parameters: [],
+                            typed_parameters: [],
+                        },
+                    ),
+                    target: None,
+                },
+            ],
         ],
         names: Names {
             local_types: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -7,62 +7,64 @@ Parsed {
         name: "",
         documentation: [],
         type_info: (),
-        definitions: [
-            TargetedDefinition {
-                definition: Import(
-                    Import {
-                        documentation: None,
-                        location: SrcSpan {
-                            start: 0,
-                            end: 48,
+        groups: [
+            [
+                TargetedDefinition {
+                    definition: Import(
+                        Import {
+                            documentation: None,
+                            location: SrcSpan {
+                                start: 0,
+                                end: 48,
+                            },
+                            module: "wibble",
+                            as_name: None,
+                            unqualified_values: [
+                                UnqualifiedImport {
+                                    location: SrcSpan {
+                                        start: 28,
+                                        end: 34,
+                                    },
+                                    imported_name_location: SrcSpan {
+                                        start: 28,
+                                        end: 34,
+                                    },
+                                    name: "Wobble",
+                                    as_name: None,
+                                },
+                            ],
+                            unqualified_types: [
+                                UnqualifiedImport {
+                                    location: SrcSpan {
+                                        start: 15,
+                                        end: 26,
+                                    },
+                                    imported_name_location: SrcSpan {
+                                        start: 20,
+                                        end: 26,
+                                    },
+                                    name: "Wobble",
+                                    as_name: None,
+                                },
+                                UnqualifiedImport {
+                                    location: SrcSpan {
+                                        start: 36,
+                                        end: 47,
+                                    },
+                                    imported_name_location: SrcSpan {
+                                        start: 41,
+                                        end: 47,
+                                    },
+                                    name: "Wabble",
+                                    as_name: None,
+                                },
+                            ],
+                            package: (),
                         },
-                        module: "wibble",
-                        as_name: None,
-                        unqualified_values: [
-                            UnqualifiedImport {
-                                location: SrcSpan {
-                                    start: 28,
-                                    end: 34,
-                                },
-                                imported_name_location: SrcSpan {
-                                    start: 28,
-                                    end: 34,
-                                },
-                                name: "Wobble",
-                                as_name: None,
-                            },
-                        ],
-                        unqualified_types: [
-                            UnqualifiedImport {
-                                location: SrcSpan {
-                                    start: 15,
-                                    end: 26,
-                                },
-                                imported_name_location: SrcSpan {
-                                    start: 20,
-                                    end: 26,
-                                },
-                                name: "Wobble",
-                                as_name: None,
-                            },
-                            UnqualifiedImport {
-                                location: SrcSpan {
-                                    start: 36,
-                                    end: 47,
-                                },
-                                imported_name_location: SrcSpan {
-                                    start: 41,
-                                    end: 47,
-                                },
-                                name: "Wabble",
-                                as_name: None,
-                            },
-                        ],
-                        package: (),
-                    },
-                ),
-                target: None,
-            },
+                    ),
+                    target: None,
+                },
+            ],
         ],
         names: Names {
             local_types: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -7,160 +7,162 @@ Parsed {
         name: "",
         documentation: [],
         type_info: (),
-        definitions: [
-            TargetedDefinition {
-                definition: CustomType(
-                    CustomType {
-                        location: SrcSpan {
-                            start: 1,
-                            end: 12,
-                        },
-                        end_position: 43,
-                        name: "Wibble",
-                        name_location: SrcSpan {
-                            start: 6,
-                            end: 12,
-                        },
-                        publicity: Private,
-                        constructors: [
-                            RecordConstructor {
-                                location: SrcSpan {
-                                    start: 19,
-                                    end: 41,
-                                },
-                                name_location: SrcSpan {
-                                    start: 19,
-                                    end: 25,
-                                },
-                                name: "Wibble",
-                                arguments: [
-                                    RecordConstructorArg {
-                                        label: Some(
-                                            (
-                                                SrcSpan {
-                                                    start: 26,
-                                                    end: 32,
-                                                },
-                                                "wibble",
-                                            ),
-                                        ),
-                                        ast: Constructor(
-                                            TypeAstConstructor {
-                                                location: SrcSpan {
-                                                    start: 34,
-                                                    end: 40,
-                                                },
-                                                name_location: SrcSpan {
-                                                    start: 34,
-                                                    end: 40,
-                                                },
-                                                module: None,
-                                                name: "String",
-                                                arguments: [],
-                                            },
-                                        ),
-                                        location: SrcSpan {
-                                            start: 26,
-                                            end: 40,
-                                        },
-                                        type_: (),
-                                        doc: None,
-                                    },
-                                ],
-                                documentation: None,
-                                deprecation: NotDeprecated,
+        groups: [
+            [
+                TargetedDefinition {
+                    definition: CustomType(
+                        CustomType {
+                            location: SrcSpan {
+                                start: 1,
+                                end: 12,
                             },
-                        ],
-                        documentation: None,
-                        deprecation: NotDeprecated,
-                        opaque: false,
-                        parameters: [],
-                        typed_parameters: [],
-                    },
-                ),
-                target: None,
-            },
-            TargetedDefinition {
-                definition: Function(
-                    Function {
-                        location: SrcSpan {
-                            start: 45,
-                            end: 56,
-                        },
-                        end_position: 75,
-                        name: Some(
-                            (
-                                SrcSpan {
-                                    start: 48,
-                                    end: 54,
-                                },
-                                "wobble",
-                            ),
-                        ),
-                        arguments: [],
-                        body: [
-                            Expression(
-                                FieldAccess {
+                            end_position: 43,
+                            name: "Wibble",
+                            name_location: SrcSpan {
+                                start: 6,
+                                end: 12,
+                            },
+                            publicity: Private,
+                            constructors: [
+                                RecordConstructor {
                                     location: SrcSpan {
-                                        start: 61,
-                                        end: 73,
+                                        start: 19,
+                                        end: 41,
                                     },
-                                    label_location: SrcSpan {
-                                        start: 72,
-                                        end: 73,
+                                    name_location: SrcSpan {
+                                        start: 19,
+                                        end: 25,
                                     },
-                                    label: "",
-                                    container: Call {
+                                    name: "Wibble",
+                                    arguments: [
+                                        RecordConstructorArg {
+                                            label: Some(
+                                                (
+                                                    SrcSpan {
+                                                        start: 26,
+                                                        end: 32,
+                                                    },
+                                                    "wibble",
+                                                ),
+                                            ),
+                                            ast: Constructor(
+                                                TypeAstConstructor {
+                                                    location: SrcSpan {
+                                                        start: 34,
+                                                        end: 40,
+                                                    },
+                                                    name_location: SrcSpan {
+                                                        start: 34,
+                                                        end: 40,
+                                                    },
+                                                    module: None,
+                                                    name: "String",
+                                                    arguments: [],
+                                                },
+                                            ),
+                                            location: SrcSpan {
+                                                start: 26,
+                                                end: 40,
+                                            },
+                                            type_: (),
+                                            doc: None,
+                                        },
+                                    ],
+                                    documentation: None,
+                                    deprecation: NotDeprecated,
+                                },
+                            ],
+                            documentation: None,
+                            deprecation: NotDeprecated,
+                            opaque: false,
+                            parameters: [],
+                            typed_parameters: [],
+                        },
+                    ),
+                    target: None,
+                },
+                TargetedDefinition {
+                    definition: Function(
+                        Function {
+                            location: SrcSpan {
+                                start: 45,
+                                end: 56,
+                            },
+                            end_position: 75,
+                            name: Some(
+                                (
+                                    SrcSpan {
+                                        start: 48,
+                                        end: 54,
+                                    },
+                                    "wobble",
+                                ),
+                            ),
+                            arguments: [],
+                            body: [
+                                Expression(
+                                    FieldAccess {
                                         location: SrcSpan {
                                             start: 61,
-                                            end: 72,
+                                            end: 73,
                                         },
-                                        fun: Var {
+                                        label_location: SrcSpan {
+                                            start: 72,
+                                            end: 73,
+                                        },
+                                        label: "",
+                                        container: Call {
                                             location: SrcSpan {
                                                 start: 61,
-                                                end: 67,
+                                                end: 72,
                                             },
-                                            name: "Wibble",
-                                        },
-                                        arguments: [
-                                            CallArg {
-                                                label: None,
+                                            fun: Var {
                                                 location: SrcSpan {
-                                                    start: 68,
-                                                    end: 71,
+                                                    start: 61,
+                                                    end: 67,
                                                 },
-                                                value: String {
+                                                name: "Wibble",
+                                            },
+                                            arguments: [
+                                                CallArg {
+                                                    label: None,
                                                     location: SrcSpan {
                                                         start: 68,
                                                         end: 71,
                                                     },
-                                                    value: "a",
+                                                    value: String {
+                                                        location: SrcSpan {
+                                                            start: 68,
+                                                            end: 71,
+                                                        },
+                                                        value: "a",
+                                                    },
+                                                    implicit: None,
                                                 },
-                                                implicit: None,
-                                            },
-                                        ],
+                                            ],
+                                        },
                                     },
-                                },
-                            ),
-                        ],
-                        publicity: Private,
-                        deprecation: NotDeprecated,
-                        return_annotation: None,
-                        return_type: (),
-                        documentation: None,
-                        external_erlang: None,
-                        external_javascript: None,
-                        implementations: Implementations {
-                            gleam: true,
-                            can_run_on_erlang: true,
-                            can_run_on_javascript: true,
-                            uses_erlang_externals: false,
-                            uses_javascript_externals: false,
+                                ),
+                            ],
+                            publicity: Private,
+                            deprecation: NotDeprecated,
+                            return_annotation: None,
+                            return_type: (),
+                            documentation: None,
+                            external_erlang: None,
+                            external_javascript: None,
+                            implementations: Implementations {
+                                gleam: true,
+                                can_run_on_erlang: true,
+                                can_run_on_javascript: true,
+                                uses_erlang_externals: false,
+                                uses_javascript_externals: false,
+                            },
                         },
-                    },
-                ),
-                target: None,
-            },
+                    ),
+                    target: None,
+                },
+            ],
         ],
         names: Names {
             local_types: {},

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -1438,8 +1438,9 @@ fn first_parsed_docstring(src: &str) -> EcoString {
 
     parsed
         .module
-        .definitions
-        .first()
+        .iter_definitions()
+        .peekable()
+        .peek()
         .expect("parsed a definition")
         .definition
         .get_doc()

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -783,7 +783,7 @@ fn infer_module_type_retention_test() {
     let module: UntypedModule = crate::ast::Module {
         documentation: vec![],
         name: "ok".into(),
-        definitions: vec![],
+        groups: vec![],
         type_info: (),
         names: Default::default(),
     };


### PR DESCRIPTION
This will be needed to implement mutual recursion TCO on the JS target. At the moment we throw away the different definitions groupings after analysis by flattening all the groups when storing those in the typed module. In this PR I change the internal module representation to make sure we store each group separately; this way code generation will be able to work with groups of related functions!

As a side note I've also done quite some renaming here: the codebase was calling a module's definitions `statements` despite those being definitions (and their type is indeed `Un/TypedDefinition`). And the `Statement` type and `statement` name is already widely used to refer to the statements that are part of a function's body, so now we use distinct names to refer to module definitions and statements