### PR TITLE
Improve error message for invalid target in attribute

### DIFF
--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3482,14 +3482,17 @@ functions are declared separately from types.";
         }
     }
 
-    // Expect a target name. e.g. `javascript` or `erlang`
-    fn expect_target(&mut self) -> Result<Target, ParseError> {
+    // Expect a target name. e.g. `javascript` or `erlang`.
+    // The location of the preceding left parenthesis is required
+    // to give the correct error span in case the target name is missing.
+    fn expect_target(&mut self, paren_location: SrcSpan) -> Result<Target, ParseError> {
         let (start, t, end) = match self.next_tok() {
             Some(t) => t,
             None => {
                 return parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 });
             }
         };
+        let location = SrcSpan::new(start, end);
         match t {
             Token::Name { name } => match name.as_str() {
                 "javascript" => Ok(Target::JavaScript),
@@ -3497,7 +3500,7 @@ functions are declared separately from types.";
                 "js" => {
                     self.warnings
                         .push(DeprecatedSyntaxWarning::DeprecatedTargetShorthand {
-                            location: SrcSpan { start, end },
+                            location,
                             target: Target::JavaScript,
                         });
                     Ok(Target::JavaScript)
@@ -3505,14 +3508,14 @@ functions are declared separately from types.";
                 "erl" => {
                     self.warnings
                         .push(DeprecatedSyntaxWarning::DeprecatedTargetShorthand {
-                            location: SrcSpan { start, end },
+                            location,
                             target: Target::Erlang,
                         });
                     Ok(Target::Erlang)
                 }
-                _ => parse_error(ParseErrorType::UnknownTarget, SrcSpan::new(start, end)),
+                _ => parse_error(ParseErrorType::UnknownTarget, location),
             },
-            _ => self.next_tok_unexpected(Target::variant_strings()),
+            _ => parse_error(ParseErrorType::ExpectedTargetName, paren_location),
         }
     }
 
@@ -3761,10 +3764,7 @@ functions are declared separately from types.";
                 let _ = self.expect_one(&Token::LeftParen)?;
                 self.parse_external_attribute(start, end, attributes)
             }
-            "target" => {
-                let _ = self.expect_one(&Token::LeftParen)?;
-                self.parse_target_attribute(start, end, attributes)
-            }
+            "target" => self.parse_target_attribute(start, end, attributes),
             "deprecated" => {
                 let _ = self.expect_one(&Token::LeftParen)?;
                 self.parse_deprecated_attribute(start, end, attributes)
@@ -3782,7 +3782,8 @@ functions are declared separately from types.";
         end: u32,
         attributes: &mut Attributes,
     ) -> Result<u32, ParseError> {
-        let target = self.expect_target()?;
+        let (paren_start, paren_end) = self.expect_one(&Token::LeftParen)?;
+        let target = self.expect_target(SrcSpan::new(paren_start, paren_end))?;
         if attributes.target.is_some() {
             return parse_error(ParseErrorType::DuplicateAttribute, SrcSpan { start, end });
         }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3510,7 +3510,7 @@ functions are declared separately from types.";
                         });
                     Ok(Target::Erlang)
                 }
-                _ => self.next_tok_unexpected(Target::variant_strings()),
+                _ => parse_error(ParseErrorType::UnknownTarget, SrcSpan::new(start, end)),
             },
             _ => self.next_tok_unexpected(Target::variant_strings()),
         }

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -60,6 +60,10 @@ impl ParseError {
             ParseErrorType::ExpectedFunctionDefinition => {
                 ("I was expecting a function definition after this", vec![])
             }
+            ParseErrorType::ExpectedTargetName => (
+                "I was expecting a target name after this",
+                vec!["Try `erlang`, `javascript`.".into()],
+            ),
             ParseErrorType::ExtraSeparator => (
                 "This is an extra delimiter",
                 vec!["Hint: Try removing it?".into()],
@@ -351,6 +355,7 @@ pub enum ParseErrorType {
     ExpectedDefinition,         // after attributes
     ExpectedDeprecationMessage, // after "deprecated"
     ExpectedFunctionDefinition, // after function-only attributes
+    ExpectedTargetName,         // after "@target("
     ExprLparStart,              // it seems "(" was used to start an expression
     ExtraSeparator,             // #(1,,) <- the 2nd comma is an extra separator
     IncorrectName,              // UpName or DiscardName used when Name was expected

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_target.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_target.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\n@target()\npub fn one() {}"
+---
+----- SOURCE CODE
+
+@target()
+pub fn one() {}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:8
+  │
+2 │ @target()
+  │        ^ I was expecting a target name after this
+
+Try `erlang`, `javascript`.

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_target_and_bracket.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_target_and_bracket.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\n@target(\npub fn one() {}"
+---
+----- SOURCE CODE
+
+@target(
+pub fn one() {}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:8
+  │
+2 │ @target(
+  │        ^ I was expecting a target name after this
+
+Try `erlang`, `javascript`.

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__unknown_target.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__unknown_target.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\n@target(abc)\npub fn one() {}"
+---
+----- SOURCE CODE
+
+@target(abc)
+pub fn one() {}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:9
+  │
+2 │ @target(abc)
+  │         ^^^ I don't recognise this target
+
+Try `erlang`, `javascript`.

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -669,6 +669,24 @@ pub fn one() {}"#
 }
 
 #[test]
+fn missing_target() {
+    assert_module_error!(
+        r#"
+@target()
+pub fn one() {}"#
+    );
+}
+
+#[test]
+fn missing_target_and_bracket() {
+    assert_module_error!(
+        r#"
+@target(
+pub fn one() {}"#
+    );
+}
+
+#[test]
 fn unknown_attribute() {
     assert_module_error!(
         r#"@go_faster()

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -660,6 +660,15 @@ pub fn one(x: Int) -> Int {
 }
 
 #[test]
+fn unknown_target() {
+    assert_module_error!(
+        r#"
+@target(abc)
+pub fn one() {}"#
+    );
+}
+
+#[test]
 fn unknown_attribute() {
     assert_module_error!(
         r#"@go_faster()


### PR DESCRIPTION
Resolves Issue #4362.
- Return `UnknownTarget` error in case the target name is neither `javascript` nor `erlang`
- Return new `ExpectedTargetName` error in case the target is missing
- Hand down the location of the parenthesis for the error span
- Add snapshot tests for the new error messages