### PR TITLE
Simplify test macros

### DIFF
--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -37,10 +37,10 @@ mod use_;
 pub static CURRENT_PACKAGE: &str = "thepackage";
 
 #[macro_export]
-macro_rules! assert_js_with_multiple_imports {
-    ($(($name:literal, $module_src:literal)),+; $src:literal) => {
+macro_rules! assert_js {
+    ($(($name:literal, $module_src:literal)),+, $src:literal $(,)?) => {
         let compiled =
-            $crate::javascript::tests::compile_js($src, vec![$((CURRENT_PACKAGE, $name, $module_src)),*]).expect("compilation failed");
+            $crate::javascript::tests::compile_js($src, vec![$(($crate::javascript::tests::CURRENT_PACKAGE, $name, $module_src)),*]).expect("compilation failed");
             let mut output = String::from("----- SOURCE CODE\n");
             for (name, src) in [$(($name, $module_src)),*] {
                 output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
@@ -48,10 +48,7 @@ macro_rules! assert_js_with_multiple_imports {
             output.push_str(&format!("-- main.gleam\n{}\n\n----- COMPILED JAVASCRIPT\n{compiled}", $src));
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
-}
 
-#[macro_export]
-macro_rules! assert_js {
     (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr $(,)?) => {{
         let compiled =
             $crate::javascript::tests::compile_js($src, vec![($dep_package, $dep_name, $dep_src)])

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -36,7 +36,7 @@ const that = ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVar
 #[test]
 fn zero_arity_imported() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two }"#),
+        ("other", r#"pub type One { Two }"#),
         r#"import other
 pub fn main() {
   other.Two
@@ -58,7 +58,7 @@ pub fn main() {
 #[test]
 fn zero_arity_imported_unqualified() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two }"#),
+        ("other", r#"pub type One { Two }"#),
         r#"import other.{Two}
 pub fn main() {
   Two
@@ -80,7 +80,7 @@ pub fn main() {
 #[test]
 fn zero_arity_imported_unqualified_aliased() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two }"#),
+        ("other", r#"pub type One { Two }"#),
         r#"import other.{Two as Three}
 pub fn main() {
   Three
@@ -102,7 +102,7 @@ pub fn main() {
 #[test]
 fn const_zero_arity_imported() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two }"#),
+        ("other", r#"pub type One { Two }"#),
         r#"import other
 const x = other.Two
 "#,
@@ -112,7 +112,7 @@ const x = other.Two
 #[test]
 fn const_zero_arity_imported_unqualified() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two }"#),
+        ("other", r#"pub type One { Two }"#),
         r#"import other.{Two}
 const a = Two
 "#,
@@ -328,7 +328,7 @@ fn go(x) {
 #[test]
 fn imported_no_label() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two(Int) }"#),
+        ("other", r#"pub type One { Two(Int) }"#),
         r#"import other
 pub fn main() {
   other.Two(1)
@@ -339,11 +339,7 @@ pub fn main() {
 #[test]
 fn imported_ignoring_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other
 pub fn main() {
   other.Two(1)
@@ -354,11 +350,7 @@ pub fn main() {
 #[test]
 fn imported_using_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other
 pub fn main() {
   other.Two(field: 1)
@@ -369,11 +361,7 @@ pub fn main() {
 #[test]
 fn imported_multiple_fields() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(a: Int, b: Int, c: Int) }"#),
         r#"import other
 pub fn main() {
   other.Two(b: 2, c: 3, a: 1)
@@ -384,7 +372,7 @@ pub fn main() {
 #[test]
 fn unqualified_imported_no_label() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two(Int) }"#),
+        ("other", r#"pub type One { Two(Int) }"#),
         r#"import other.{Two}
 pub fn main() {
   Two(1)
@@ -406,11 +394,7 @@ pub fn main() {
 #[test]
 fn unqualified_imported_ignoring_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other.{Two}
 pub fn main() {
   Two(1)
@@ -421,11 +405,7 @@ pub fn main() {
 #[test]
 fn unqualified_imported_using_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other.{Two}
 pub fn main() {
   Two(field: 1)
@@ -436,11 +416,7 @@ pub fn main() {
 #[test]
 fn unqualified_imported_multiple_fields() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(a: Int, b: Int, c: Int) }"#),
         r#"import other.{Two}
 pub fn main() {
   Two(b: 2, c: 3, a: 1)
@@ -451,11 +427,7 @@ pub fn main() {
 #[test]
 fn constructor_as_value() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(a: Int, b: Int, c: Int) }"#),
         r#"import other
 pub fn main() {
   other.Two
@@ -466,11 +438,7 @@ pub fn main() {
 #[test]
 fn unqualified_constructor_as_value() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(a: Int, b: Int, c: Int) }"#),
         r#"import other.{Two}
 pub fn main() {
   Two
@@ -481,7 +449,7 @@ pub fn main() {
 #[test]
 fn const_imported_no_label() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two(Int) }"#),
+        ("other", r#"pub type One { Two(Int) }"#),
         r#"import other
 pub const main = other.Two(1)
 "#,
@@ -491,11 +459,7 @@ pub const main = other.Two(1)
 #[test]
 fn const_imported_ignoring_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other
 pub const main = other.Two(1)
 "#,
@@ -505,11 +469,7 @@ pub const main = other.Two(1)
 #[test]
 fn const_imported_using_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other
 pub const main = other.Two(field: 1)
 "#,
@@ -519,11 +479,7 @@ pub const main = other.Two(field: 1)
 #[test]
 fn const_imported_multiple_fields() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(a: Int, b: Int, c: Int) }"#),
         r#"import other
 pub const main = other.Two(b: 2, c: 3, a: 1)
 "#,
@@ -533,7 +489,7 @@ pub const main = other.Two(b: 2, c: 3, a: 1)
 #[test]
 fn const_unqualified_imported_no_label() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { Two(Int) }"#),
+        ("other", r#"pub type One { Two(Int) }"#),
         r#"import other.{Two}
 pub const main = Two(1)
 "#,
@@ -543,11 +499,7 @@ pub const main = Two(1)
 #[test]
 fn const_unqualified_imported_ignoring_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other.{Two}
 pub const main = Two(1)
 "#,
@@ -557,11 +509,7 @@ pub const main = Two(1)
 #[test]
 fn const_unqualified_imported_using_label() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(field: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(field: Int) }"#),
         r#"import other.{Two}
 pub const main = Two(field: 1)
 "#,
@@ -571,11 +519,7 @@ pub const main = Two(field: 1)
 #[test]
 fn const_unqualified_imported_multiple_fields() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(a: Int, b: Int, c: Int) }"#),
         r#"import other.{Two}
 pub const main = Two(b: 2, c: 3, a: 1)
 "#,
@@ -585,11 +529,7 @@ pub const main = Two(b: 2, c: 3, a: 1)
 #[test]
 fn imported_pattern() {
     assert_js!(
-        (
-            CURRENT_PACKAGE,
-            "other",
-            r#"pub type One { Two(a: Int, b: Int, c: Int) }"#
-        ),
+        ("other", r#"pub type One { Two(a: Int, b: Int, c: Int) }"#),
         r#"import other.{Two}
 
 pub fn main(x) {
@@ -616,7 +556,7 @@ fn keyword_label_name() {
 #[test]
 fn qualified() {
     assert_js!(
-        (CURRENT_PACKAGE, "other", r#"pub type One { One }"#),
+        ("other", r#"pub type One { One }"#),
         r#"import other
 
 pub fn main() {

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -1,7 +1,5 @@
 use crate::{assert_js, assert_ts_def};
 
-use super::CURRENT_PACKAGE;
-
 #[test]
 fn exported_functions() {
     assert_js!(
@@ -212,7 +210,7 @@ fn reserved_word_fn() {
 #[test]
 fn reserved_word_imported() {
     assert_js!(
-        (CURRENT_PACKAGE, "for", "pub fn class() { 1 }"),
+        ("for", "pub fn class() { 1 }"),
         r#"import for.{class}
 
 pub fn export() {
@@ -225,7 +223,7 @@ pub fn export() {
 #[test]
 fn reserved_word_imported_alias() {
     assert_js!(
-        (CURRENT_PACKAGE, "for", "pub fn class() { 1 }"),
+        ("for", "pub fn class() { 1 }"),
         r#"import for.{class as while} as function
 
 pub fn export() {
@@ -370,7 +368,7 @@ pub fn version(n) {
 #[test]
 fn pipe_shadow_import() {
     assert_js!(
-        (CURRENT_PACKAGE, "wibble", "pub fn println(x: String) {  }"),
+        ("wibble", "pub fn println(x: String) {  }"),
         r#"
         import wibble.{println}
         pub fn main() {

--- a/compiler-core/src/javascript/tests/modules.rs
+++ b/compiler-core/src/javascript/tests/modules.rs
@@ -1,5 +1,5 @@
+use crate::assert_js;
 use crate::javascript::tests::CURRENT_PACKAGE;
-use crate::{assert_js, assert_js_with_multiple_imports};
 
 #[test]
 fn empty_module() {
@@ -10,7 +10,7 @@ fn empty_module() {
 #[test]
 fn unqualified_fn_call() {
     assert_js!(
-        (CURRENT_PACKAGE, "rocket_ship", r#"pub fn launch() { 1 }"#),
+        ("rocket_ship", r#"pub fn launch() { 1 }"#),
         r#"import rocket_ship.{launch}
 pub fn go() { launch() }
 "#,
@@ -20,7 +20,7 @@ pub fn go() { launch() }
 #[test]
 fn aliased_unqualified_fn_call() {
     assert_js!(
-        (CURRENT_PACKAGE, "rocket_ship", r#"pub fn launch() { 1 }"#),
+        ("rocket_ship", r#"pub fn launch() { 1 }"#),
         r#"import rocket_ship.{launch as boom_time}
 pub fn go() { boom_time() }
 "#,
@@ -46,7 +46,7 @@ pub fn go() { a() + bb() }
 #[test]
 fn constant() {
     assert_js!(
-        (CURRENT_PACKAGE, "rocket_ship", r#"pub const x = 1"#),
+        ("rocket_ship", r#"pub const x = 1"#),
         r#"
 import rocket_ship
 pub fn go() { rocket_ship.x }
@@ -57,7 +57,7 @@ pub fn go() { rocket_ship.x }
 #[test]
 fn alias_aliased_constant() {
     assert_js!(
-        (CURRENT_PACKAGE, "rocket_ship", r#"pub const x = 1"#),
+        ("rocket_ship", r#"pub const x = 1"#),
         r#"
 import rocket_ship.{ x as y }
 const z = y
@@ -68,7 +68,7 @@ const z = y
 #[test]
 fn renamed_module() {
     assert_js!(
-        (CURRENT_PACKAGE, "x", r#"pub const v = 1"#),
+        ("x", r#"pub const v = 1"#),
         r#"
 import x as y
 const z = y.v
@@ -94,7 +94,7 @@ pub fn go() { launcher.x }
 #[test]
 fn alias_constant() {
     assert_js!(
-        (CURRENT_PACKAGE, "rocket_ship", r#"pub const x = 1"#),
+        ("rocket_ship", r#"pub const x = 1"#),
         r#"
 import rocket_ship as boop
 pub fn go() { boop.x }
@@ -105,7 +105,7 @@ pub fn go() { boop.x }
 #[test]
 fn alias_fn_call() {
     assert_js!(
-        (CURRENT_PACKAGE, "rocket_ship", r#"pub fn go() { 1 }"#),
+        ("rocket_ship", r#"pub fn go() { 1 }"#),
         r#"
 import rocket_ship as boop
 pub fn go() { boop.go() }
@@ -116,7 +116,7 @@ pub fn go() { boop.go() }
 #[test]
 fn nested_fn_call() {
     assert_js!(
-        (CURRENT_PACKAGE, "one/two", r#"pub fn go() { 1 }"#),
+        ("one/two", r#"pub fn go() { 1 }"#),
         r#"import one/two
 pub fn go() { two.go() }"#,
     );
@@ -125,7 +125,7 @@ pub fn go() { two.go() }"#,
 #[test]
 fn nested_nested_fn_call() {
     assert_js!(
-        (CURRENT_PACKAGE, "one/two/three", r#"pub fn go() { 1 }"#),
+        ("one/two/three", r#"pub fn go() { 1 }"#),
         r#"import one/two/three
 pub fn go() { three.go() }"#,
     );
@@ -144,7 +144,7 @@ pub fn go() { one.go() }
 #[test]
 fn nested_same_package() {
     assert_js!(
-        (CURRENT_PACKAGE, "one/two/three", r#"pub fn go() { 1 }"#),
+        ("one/two/three", r#"pub fn go() { 1 }"#),
         r#"import one/two/three
 pub fn go() { three.go() }
 "#,
@@ -153,9 +153,9 @@ pub fn go() { three.go() }
 
 #[test]
 fn discarded_duplicate_import() {
-    assert_js_with_multiple_imports!(
+    assert_js!(
         ("esa/rocket_ship", r#"pub fn go() { 1 }"#),
-        ("nasa/rocket_ship", r#"pub fn go() { 1 }"#);
+        ("nasa/rocket_ship", r#"pub fn go() { 1 }"#),
         r#"
 import esa/rocket_ship
 import nasa/rocket_ship as _nasa_rocket
@@ -166,9 +166,9 @@ pub fn go() { rocket_ship.go() }
 
 #[test]
 fn discarded_duplicate_import_with_unqualified() {
-    assert_js_with_multiple_imports!(
+    assert_js!(
         ("esa/rocket_ship", r#"pub fn go() { 1 }"#),
-        ("nasa/rocket_ship", r#"pub fn go() { 1 }"#);
+        ("nasa/rocket_ship", r#"pub fn go() { 1 }"#),
         r#"
 import esa/rocket_ship
 import nasa/rocket_ship.{go} as _nasa_rocket
@@ -202,7 +202,7 @@ pub fn main() {
 #[test]
 fn constant_module_access_with_keyword() {
     assert_js!(
-        (CURRENT_PACKAGE, "rocket_ship", r#"pub const class = 1"#),
+        ("rocket_ship", r#"pub const class = 1"#),
         r#"
 import rocket_ship
 pub const variable = rocket_ship.class

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_ignoring_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_ignoring_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub const main = other.Two(1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other
 pub const main = other.Two(1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_multiple_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_multiple_fields.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub const main = other.Two(b: 2, c: 3, a: 1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(a: Int, b: Int, c: Int) }
+
+-- main.gleam
 import other
 pub const main = other.Two(b: 2, c: 3, a: 1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_no_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_no_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub const main = other.Two(1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(Int) }
+
+-- main.gleam
 import other
 pub const main = other.Two(1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_using_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_imported_using_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub const main = other.Two(field: 1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other
 pub const main = other.Two(field: 1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_ignoring_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_ignoring_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub const main = Two(1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other.{Two}
 pub const main = Two(1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_multiple_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_multiple_fields.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub const main = Two(b: 2, c: 3, a: 1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(a: Int, b: Int, c: Int) }
+
+-- main.gleam
 import other.{Two}
 pub const main = Two(b: 2, c: 3, a: 1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_no_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_no_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub const main = Two(1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(Int) }
+
+-- main.gleam
 import other.{Two}
 pub const main = Two(1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_using_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_unqualified_imported_using_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub const main = Two(field: 1)\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other.{Two}
 pub const main = Two(field: 1)
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\nconst x = other.Two\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two }
+
+-- main.gleam
 import other
 const x = other.Two
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported_unqualified.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported_unqualified.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\nconst a = Two\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two }
+
+-- main.gleam
 import other.{Two}
 const a = Two
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__constructor_as_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__constructor_as_value.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub fn main() {\n  other.Two\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(a: Int, b: Int, c: Int) }
+
+-- main.gleam
 import other
 pub fn main() {
   other.Two

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_ignoring_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_ignoring_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub fn main() {\n  other.Two(1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other
 pub fn main() {
   other.Two(1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_multiple_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_multiple_fields.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub fn main() {\n  other.Two(b: 2, c: 3, a: 1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(a: Int, b: Int, c: Int) }
+
+-- main.gleam
 import other
 pub fn main() {
   other.Two(b: 2, c: 3, a: 1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_no_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_no_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub fn main() {\n  other.Two(1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(Int) }
+
+-- main.gleam
 import other
 pub fn main() {
   other.Two(1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_pattern.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\n\npub fn main(x) {\n  case x {\n    Two(a: 1, ..) -> 1\n    other.Two(b: 2, c: c, ..) -> c\n    _ -> 3\n  }\n}\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(a: Int, b: Int, c: Int) }
+
+-- main.gleam
 import other.{Two}
 
 pub fn main(x) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_using_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_using_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub fn main() {\n  other.Two(field: 1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other
 pub fn main() {
   other.Two(field: 1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__qualified.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__qualified.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\n\npub fn main() {\n  other.One\n}\n"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { One }
+
+-- main.gleam
 import other
 
 pub fn main() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_constructor_as_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_constructor_as_value.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub fn main() {\n  Two\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(a: Int, b: Int, c: Int) }
+
+-- main.gleam
 import other.{Two}
 pub fn main() {
   Two

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_ignoring_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_ignoring_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub fn main() {\n  Two(1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other.{Two}
 pub fn main() {
   Two(1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_multiple_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_multiple_fields.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub fn main() {\n  Two(b: 2, c: 3, a: 1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(a: Int, b: Int, c: Int) }
+
+-- main.gleam
 import other.{Two}
 pub fn main() {
   Two(b: 2, c: 3, a: 1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_no_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub fn main() {\n  Two(1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(Int) }
+
+-- main.gleam
 import other.{Two}
 pub fn main() {
   Two(1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_using_label.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unqualified_imported_using_label.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub fn main() {\n  Two(field: 1)\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two(field: Int) }
+
+-- main.gleam
 import other.{Two}
 pub fn main() {
   Two(field: 1)

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other\npub fn main() {\n  other.Two\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two }
+
+-- main.gleam
 import other
 pub fn main() {
   other.Two

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two}\npub fn main() {\n  Two\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two }
+
+-- main.gleam
 import other.{Two}
 pub fn main() {
   Two

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/custom_types.rs
 expression: "import other.{Two as Three}\npub fn main() {\n  Three\n}"
 ---
 ----- SOURCE CODE
+-- other.gleam
+pub type One { Two }
+
+-- main.gleam
 import other.{Two as Three}
 pub fn main() {
   Three

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__pipe_shadow_import.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__pipe_shadow_import.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/functions.rs
 expression: "\n        import wibble.{println}\n        pub fn main() {\n          let println =\n            \"oh dear\"\n            |> println\n          println\n        }"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub fn println(x: String) {  }
+
+-- main.gleam
 
         import wibble.{println}
         pub fn main() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__reserved_word_imported.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__reserved_word_imported.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/functions.rs
 expression: "import for.{class}\n\npub fn export() {\n  class()\n}\n"
 ---
 ----- SOURCE CODE
+-- for.gleam
+pub fn class() { 1 }
+
+-- main.gleam
 import for.{class}
 
 pub fn export() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__reserved_word_imported_alias.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__reserved_word_imported_alias.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/functions.rs
 expression: "import for.{class as while} as function\n\npub fn export() {\n  let delete = function.class\n  while()\n}\n"
 ---
 ----- SOURCE CODE
+-- for.gleam
+pub fn class() { 1 }
+
+-- main.gleam
 import for.{class as while} as function
 
 pub fn export() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_aliased_constant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_aliased_constant.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport rocket_ship.{ x as y }\nconst z = y\n"
 ---
 ----- SOURCE CODE
+-- rocket_ship.gleam
+pub const x = 1
+
+-- main.gleam
 
 import rocket_ship.{ x as y }
 const z = y

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_constant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_constant.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport rocket_ship as boop\npub fn go() { boop.x }\n"
 ---
 ----- SOURCE CODE
+-- rocket_ship.gleam
+pub const x = 1
+
+-- main.gleam
 
 import rocket_ship as boop
 pub fn go() { boop.x }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_fn_call.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__alias_fn_call.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport rocket_ship as boop\npub fn go() { boop.go() }\n"
 ---
 ----- SOURCE CODE
+-- rocket_ship.gleam
+pub fn go() { 1 }
+
+-- main.gleam
 
 import rocket_ship as boop
 pub fn go() { boop.go() }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__aliased_unqualified_fn_call.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__aliased_unqualified_fn_call.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "import rocket_ship.{launch as boom_time}\npub fn go() { boom_time() }\n"
 ---
 ----- SOURCE CODE
+-- rocket_ship.gleam
+pub fn launch() { 1 }
+
+-- main.gleam
 import rocket_ship.{launch as boom_time}
 pub fn go() { boom_time() }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__constant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__constant.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport rocket_ship\npub fn go() { rocket_ship.x }\n"
 ---
 ----- SOURCE CODE
+-- rocket_ship.gleam
+pub const x = 1
+
+-- main.gleam
 
 import rocket_ship
 pub fn go() { rocket_ship.x }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__constant_module_access_with_keyword.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__constant_module_access_with_keyword.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport rocket_ship\npub const variable = rocket_ship.class\n"
 ---
 ----- SOURCE CODE
+-- rocket_ship.gleam
+pub const class = 1
+
+-- main.gleam
 
 import rocket_ship
 pub const variable = rocket_ship.class

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_fn_call.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_fn_call.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "import one/two\npub fn go() { two.go() }"
 ---
 ----- SOURCE CODE
+-- one/two.gleam
+pub fn go() { 1 }
+
+-- main.gleam
 import one/two
 pub fn go() { two.go() }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_nested_fn_call.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_nested_fn_call.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "import one/two/three\npub fn go() { three.go() }"
 ---
 ----- SOURCE CODE
+-- one/two/three.gleam
+pub fn go() { 1 }
+
+-- main.gleam
 import one/two/three
 pub fn go() { three.go() }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_same_package.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__nested_same_package.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "import one/two/three\npub fn go() { three.go() }\n"
 ---
 ----- SOURCE CODE
+-- one/two/three.gleam
+pub fn go() { 1 }
+
+-- main.gleam
 import one/two/three
 pub fn go() { three.go() }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__renamed_module.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__renamed_module.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "\nimport x as y\nconst z = y.v\n"
 ---
 ----- SOURCE CODE
+-- x.gleam
+pub const v = 1
+
+-- main.gleam
 
 import x as y
 const z = y.v

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__unqualified_fn_call.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__modules__unqualified_fn_call.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/javascript/tests/modules.rs
 expression: "import rocket_ship.{launch}\npub fn go() { launch() }\n"
 ---
 ----- SOURCE CODE
+-- rocket_ship.gleam
+pub fn launch() { 1 }
+
+-- main.gleam
 import rocket_ship.{launch}
 pub fn go() { launch() }
 

--- a/compiler-core/src/language_server/tests/reference.rs
+++ b/compiler-core/src/language_server/tests/reference.rs
@@ -93,7 +93,7 @@ macro_rules! assert_references {
         let project = $project;
         let src = project.src;
         let position = $position.find_position(src);
-        let result = dbg!(find_references(&project, position)).expect("References not found");
+        let result = find_references(&project, position).expect("References not found");
 
         let mut output = String::new();
         for (name, src) in project.root_package_modules.iter() {

--- a/compiler-core/src/type_/tests/accessors.rs
+++ b/compiler-core/src/type_/tests/accessors.rs
@@ -1,8 +1,8 @@
-use crate::assert_infer_with_module;
+use crate::assert_module_infer;
 
 #[test]
 fn bug_3629() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("imported", "pub type Wibble"),
         r#"
 import imported

--- a/compiler-core/src/type_/tests/custom_types.rs
+++ b/compiler-core/src/type_/tests/custom_types.rs
@@ -1,4 +1,4 @@
-use crate::{assert_module_error, assert_module_infer, assert_warning, assert_with_module_error};
+use crate::{assert_module_error, assert_module_infer, assert_warning};
 
 // https://github.com/gleam-lang/gleam/issues/2215
 #[test]
@@ -115,7 +115,7 @@ type Three(a, a) {
 #[test]
 fn conflict_with_import() {
     // We cannot declare a type with the same name as an imported type
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type A { B }"),
         "import wibble.{type A} type A { C }",
     );

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -1,6 +1,5 @@
 use crate::{
     assert_error, assert_internal_module_error, assert_module_error, assert_module_syntax_error,
-    assert_with_module_error,
 };
 
 #[test]
@@ -1772,7 +1771,7 @@ fn negate_string() {
 
 #[test]
 fn ambiguous_type_error() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Thing { Thing }"),
         "import wibble pub type Thing { Thing }
         pub fn main() {
@@ -1783,7 +1782,7 @@ fn ambiguous_type_error() {
 
 #[test]
 fn ambiguous_import_error_no_unqualified() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble/sub", "pub fn wobble() { 1 }"),
         ("wibble2/sub", "pub fn wobble() { 1 }"),
         "
@@ -1798,7 +1797,7 @@ fn ambiguous_import_error_no_unqualified() {
 
 #[test]
 fn ambiguous_import_error_with_unqualified() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble/sub", "pub fn wobble() { 1 }"),
         ("wibble2/sub", "pub fn wobble() { 1 }"),
         "
@@ -1813,7 +1812,7 @@ fn ambiguous_import_error_with_unqualified() {
 
 #[test]
 fn same_imports_multiple_times() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "gleam/wibble",
             "
@@ -1831,7 +1830,7 @@ fn same_imports_multiple_times() {
 
 #[test]
 fn same_imports_multiple_times_1() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "one",
             "
@@ -1853,7 +1852,7 @@ fn same_imports_multiple_times_1() {
 
 #[test]
 fn same_imports_multiple_times_2() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "one",
             "
@@ -1875,7 +1874,7 @@ fn same_imports_multiple_times_2() {
 
 #[test]
 fn same_imports_multiple_times_3() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "one",
             "
@@ -1897,7 +1896,7 @@ fn same_imports_multiple_times_3() {
 
 #[test]
 fn same_imports_multiple_times_4() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "one",
             "
@@ -1919,7 +1918,7 @@ fn same_imports_multiple_times_4() {
 
 #[test]
 fn same_imports_multiple_times_5() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "one",
             "
@@ -1941,7 +1940,7 @@ fn same_imports_multiple_times_5() {
 
 #[test]
 fn same_imports_multiple_times_6() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "one",
             "
@@ -1963,7 +1962,7 @@ fn same_imports_multiple_times_6() {
 
 #[test]
 fn same_imports_multiple_times_7() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "one",
             "
@@ -2039,7 +2038,7 @@ pub fn main(user: User) {
 
 #[test]
 fn unknown_imported_module_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one/two", ""),
         "
 import one/two
@@ -2053,7 +2052,7 @@ pub fn main(_x: two.Thing) {
 
 #[test]
 fn value_imported_as_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "gleam/wibble",
             "pub type Wibble {
@@ -2066,7 +2065,7 @@ fn value_imported_as_type() {
 
 #[test]
 fn type_imported_as_value() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "gleam/wibble",
             "pub type Wibble {
@@ -2225,7 +2224,7 @@ pub fn main() {
 
 #[test]
 fn unknown_module_suggest_import() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("utils", "pub fn helpful() {}"),
         "
 pub fn main() {
@@ -2237,7 +2236,7 @@ pub fn main() {
 
 #[test]
 fn unknown_module_suggest_typo_for_imported_module() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub fn wobble() {}"),
         "
 import wibble
@@ -2250,7 +2249,7 @@ pub fn main() {
 
 #[test]
 fn unknown_module_suggest_typo_for_unimported_module() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble/wobble", "pub fn wubble() {}"),
         "
 pub fn main() {
@@ -2262,7 +2261,7 @@ pub fn main() {
 
 #[test]
 fn qualified_type_mismatched_type_error() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Wobble"),
         "
 import wibble
@@ -2273,7 +2272,7 @@ const my_wobble: wibble.Wobble = Nil
 
 #[test]
 fn qualified_type_similar_type_name() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Int"),
         "
 import wibble
@@ -2284,7 +2283,7 @@ const value: wibble.Int = 20
 
 #[test]
 fn qualified_type_not_a_function() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Function { Function(fn() -> Nil) }"),
         "
 import wibble.{type Function as FuncWrapper}
@@ -2313,7 +2312,7 @@ pub fn main(not_a_record: gleam.Int) {
 
 #[test]
 fn qualified_type_invalid_operands() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("maths", "pub type Vector { Vector(x: Float, y: Float) }"),
         "
 import maths as math
@@ -2326,7 +2325,7 @@ pub fn add_two_vectors(a: math.Vector, b: math.Vector) {
 
 #[test]
 fn qualified_type_invalid_pipe_argument() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "mod",
             "pub type Wibble pub fn takes_wibble(value: Wibble) { value }"
@@ -2358,7 +2357,7 @@ const list_of_bools = [True, False, gleam.False]
 
 #[test]
 fn qualified_type_not_a_tuple() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("mod", "pub type Pair(a, b) { Pair(a, b) }"),
         "
 import mod.{type Pair as Duo}
@@ -2371,7 +2370,7 @@ pub fn first(pair: Duo(a, b)) {
 
 #[test]
 fn qualified_type_not_fn_in_use() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("some_mod", "pub type Function(param1, param2, return)"),
         "
 import some_mod as sm
@@ -2384,7 +2383,7 @@ pub fn main(func: sm.Function(Int, String, Float)) {
 
 #[test]
 fn qualified_type_use_fn_without_callback() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "some_mod",
             "pub type NotACallback pub fn do_a_thing(a: Int, _b: NotACallback) { a }"
@@ -2414,7 +2413,7 @@ fn add_1(to x) { x + 1 }
 
 #[test]
 fn unknown_field_that_appears_in_an_imported_variant_has_note() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "some_mod",
             "pub type Wibble {
@@ -2535,7 +2534,7 @@ pub fn b_to_a(value: MyRecord) {
 
 #[test]
 fn record_update_wrong_variant_imported_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "wibble",
             "

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1,6 +1,4 @@
-use crate::{
-    assert_error, assert_module_error, assert_no_warnings, assert_warning, assert_with_module_error,
-};
+use crate::{assert_error, assert_module_error, assert_no_warnings, assert_warning};
 
 #[test]
 fn whatever() {
@@ -991,7 +989,7 @@ pub fn main(wibble) {
 
 #[test]
 fn case_error_prints_module_names() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Wibble { Wibble Wobble }"),
         "
 import wibble
@@ -1007,7 +1005,7 @@ pub fn main(wobble_thing) {
 
 #[test]
 fn case_error_prints_module_alias() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Wibble { Wibble Wobble }"),
         "
 import wibble as wobble
@@ -1022,7 +1020,7 @@ pub fn main(wibble) {
 
 #[test]
 fn case_error_prints_unqualified_value() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Wibble { Wibble Wobble }"),
         "
 import wibble.{Wibble, Wobble}
@@ -1037,7 +1035,7 @@ pub fn main(wibble) {
 
 #[test]
 fn case_error_prints_aliased_unqualified_value() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Wibble { Wibble Wobble }"),
         "
 import wibble.{Wibble, Wobble as Wubble}
@@ -1080,7 +1078,7 @@ pub fn main(res: Result(Int, Nil)) {
 
 #[test]
 fn case_error_prints_module_when_shadowed() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("mod", "pub type Wibble { Wibble Wobble }"),
         "
 import mod.{Wibble}
@@ -1097,7 +1095,7 @@ pub fn main() {
 
 #[test]
 fn case_error_prints_module_when_aliased_and_shadowed() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("mod", "pub type Wibble { Wibble Wobble }"),
         "
 import mod.{Wibble as Wobble}
@@ -1114,7 +1112,7 @@ pub fn main() {
 
 #[test]
 fn case_error_prints_unqualifed_when_aliased() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("mod", "pub type Wibble { Wibble Wobble }"),
         "
 import mod.{Wibble as Wobble}

--- a/compiler-core/src/type_/tests/externals.rs
+++ b/compiler-core/src/type_/tests/externals.rs
@@ -1,6 +1,5 @@
 use crate::{
-    assert_infer_with_module, assert_js_module_error, assert_js_module_infer, assert_module_error,
-    assert_module_infer, assert_with_module_error,
+    assert_js_module_error, assert_js_module_infer, assert_module_error, assert_module_infer,
 };
 
 // https://github.com/gleam-lang/gleam/issues/2324
@@ -160,7 +159,7 @@ fn erlang_only() -> Int
 
 #[test]
 fn imported_javascript_only_function() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "module",
             r#"@external(javascript, "one", "two")
@@ -175,7 +174,7 @@ pub fn main() {
 
 #[test]
 fn javascript_only_constant() {
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "module",
             r#"@external(javascript, "one", "two")
@@ -213,7 +212,7 @@ pub fn main() -> Int
 fn unsupported_target_for_unused_import() {
     // If we import a function which doesn't support the current target,
     // even if we don't use it, the compiler should error
-    assert_with_module_error!(
+    assert_module_error!(
         (
             "mod",
             r#"@external(javascript, "wibble", "wobble") pub fn wobble()"#
@@ -224,7 +223,7 @@ fn unsupported_target_for_unused_import() {
 
 #[test]
 fn supported_target_for_imported_value() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         (
             "mod",
             r#"@external(erlang, "wibble", "wobble") pub fn wobble() -> Int"#

--- a/compiler-core/src/type_/tests/guards.rs
+++ b/compiler-core/src/type_/tests/guards.rs
@@ -1,4 +1,4 @@
-use crate::{assert_infer_with_module, assert_module_error, assert_module_infer};
+use crate::{assert_module_error, assert_module_infer};
 
 #[test]
 fn nested_record_access() {
@@ -48,7 +48,7 @@ pub fn a(a: String) {
 
 #[test]
 fn qualified_record() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("wibble", "pub type Wibble { Wibble Wobble }"),
         "
 import wibble
@@ -66,7 +66,7 @@ pub fn main(wibble: wibble.Wibble) {
 
 #[test]
 fn qualified_record_with_arguments() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         (
             "wibble",
             "pub type Wibble { Wibble(Int) Wobble(Int, Float) }"

--- a/compiler-core/src/type_/tests/imports.rs
+++ b/compiler-core/src/type_/tests/imports.rs
@@ -1,9 +1,9 @@
-use crate::{assert_infer_with_module, assert_module_error, assert_with_module_error};
+use crate::{assert_module_error, assert_module_infer};
 
 // https://github.com/gleam-lang/gleam/issues/1760
 #[test]
 fn import_value_with_same_name_as_imported_module() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("other", "pub const other = 1"),
         "
 import other.{other}
@@ -15,7 +15,7 @@ pub const a = other
 
 #[test]
 fn imported_constant_record() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("one/two", "pub type Thing { Thing(Int) }"),
         "
 import one/two
@@ -28,7 +28,7 @@ pub const a = two.Thing(1)
 
 #[test]
 fn using_private_constructor() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type Two { Two }"),
         "import one
 
@@ -40,7 +40,7 @@ pub fn main() {
 
 #[test]
 fn using_private_constructor_pattern() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type Two { Two }"),
         "import one
 
@@ -52,7 +52,7 @@ pub fn main(x) {
 
 #[test]
 fn using_opaque_constructor() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "pub opaque type Two { Two }"),
         "import one
 
@@ -64,7 +64,7 @@ pub fn main() {
 
 #[test]
 fn using_private_function() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "fn two() { 2 }"),
         "import one
 
@@ -76,7 +76,7 @@ pub fn main() {
 
 #[test]
 fn using_private_type_alias() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type X = Int"),
         "import one
 
@@ -88,7 +88,7 @@ pub fn main() {
 
 #[test]
 fn using_private_unqualified_type_alias() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type X = Int"),
         "import one.{X}
 
@@ -100,7 +100,7 @@ pub fn main() {
 
 #[test]
 fn using_private_external_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type X"),
         "import one
 
@@ -112,7 +112,7 @@ pub fn main() {
 
 #[test]
 fn using_private_unqualified_external_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type X"),
         "import one.{X}
 
@@ -124,7 +124,7 @@ pub fn main() {
 
 #[test]
 fn using_private_custom_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type X { Y }"),
         "import one
 
@@ -136,7 +136,7 @@ pub fn main() {
 
 #[test]
 fn using_private_unqualified_custom_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type X { Y }"),
         "import one.{X}
 
@@ -148,7 +148,7 @@ pub fn main() {
 
 #[test]
 fn unqualified_using_private_constructor() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type Two { Two }"),
         "import one.{Two}
 
@@ -160,7 +160,7 @@ pub fn main() {
 
 #[test]
 fn unqualified_using_private_constructor_pattern() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "type Two { Two }"),
         "import one.{Two}
 
@@ -172,7 +172,7 @@ pub fn main(x) {
 
 #[test]
 fn unqualified_using_opaque_constructor() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "pub opaque type Two { Two }"),
         "import one.{Two}
 
@@ -184,7 +184,7 @@ pub fn main() {
 
 #[test]
 fn unqualified_using_private_function() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "fn two() { 2 }"),
         "import one.{two}
 
@@ -196,7 +196,7 @@ pub fn main() {
 
 #[test]
 fn import_type() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("one", "pub type One = Int"),
         "import one.{type One}
 
@@ -210,7 +210,7 @@ pub fn main() -> One {
 
 #[test]
 fn import_type_duplicate() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "pub type One = Int"),
         "import one.{One, type One}
 
@@ -223,7 +223,7 @@ pub fn main() -> One {
 
 #[test]
 fn import_type_duplicate_with_as() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "pub type One = Int"),
         "import one.{type One as MyOne, type One as MyOne}
 
@@ -234,7 +234,7 @@ pub type X = One
 
 #[test]
 fn import_type_duplicate_with_as_multiline() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one", "pub type One = Int"),
         "import one.{
           type One as MyOne,
@@ -249,7 +249,7 @@ pub type X = One
 // https://github.com/gleam-lang/gleam/issues/2379
 #[test]
 fn deprecated_type_import_conflict() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("one", "pub type X { X }"),
         "import one.{X, type X}",
         vec![]
@@ -258,7 +258,7 @@ fn deprecated_type_import_conflict() {
 
 #[test]
 fn aliased_unqualified_type_and_value() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("one", "pub type X { X }"),
         "import one.{X as XX, type X as XX}",
         vec![]
@@ -267,7 +267,7 @@ fn aliased_unqualified_type_and_value() {
 
 #[test]
 fn deprecated_type_import_conflict_two_modules() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("one", "pub type X { X }"),
         ("two", "pub type X { X }"),
         "
@@ -280,7 +280,7 @@ fn deprecated_type_import_conflict_two_modules() {
 
 #[test]
 fn imported_constructor_instead_of_type() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("module", "pub type Wibble { Wibble }"),
         "import module.{Wibble}
 
@@ -315,7 +315,7 @@ pub fn main() -> Integer {
 
 #[test]
 fn module_alias_used_as_a_name() {
-    assert_with_module_error!(
+    assert_module_error!(
         ("one/two", ""),
         "
 import one/two

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_warnings_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_warnings_test.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: import gleam/wibble
 ---
 ----- SOURCE CODE
+-- gleam/wibble.gleam
+pub fn wobble() { 1 }
+
+-- main.gleam
 import gleam/wibble
 
 ----- WARNING

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_with_alias_warnings_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_with_alias_warnings_test.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: import gleam/wibble as wobble
 ---
 ----- SOURCE CODE
+-- gleam/wibble.gleam
+pub fn wobble() { 1 }
+
+-- main.gleam
 import gleam/wibble as wobble
 
 ----- WARNING

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\nimport wibble\n\npub fn main() {\n  wibble.a\n  1\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub const a = 1
+
+-- main.gleam
 
 import wibble
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\nimport wibble\n\npub fn main() {\n  wibble.Wibble\n  1\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble(Int) }
+
+-- main.gleam
 
 import wibble
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor_call.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\nimport wibble\n\npub fn main() {\n  wibble.Wibble(1)\n  1\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble(Int) }
+
+-- main.gleam
 
 import wibble
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\nimport wibble\n\npub fn main() {\n  wibble.println\n  1\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub fn println(a) { Nil }
+
+-- main.gleam
 
 import wibble
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_wuth_alias_warning_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_wuth_alias_warning_test.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: import gleam/wibble as wobble
 ---
 ----- SOURCE CODE
+-- gleam/wibble.gleam
+pub const one = 1
+
+-- main.gleam
 import gleam/wibble as wobble
 
 ----- WARNING

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
@@ -3,6 +3,10 @@ source: compiler-core/src/type_/tests/warnings.rs
 expression: "\nimport wibble\n\npub fn wobble(a) { a }\n\npub fn main() {\n  1 |> wobble |> wibble.Wibble\n  1\n}\n"
 ---
 ----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble(Int) }
+
+-- main.gleam
 
 import wibble
 

--- a/compiler-core/src/type_/tests/type_alias.rs
+++ b/compiler-core/src/type_/tests/type_alias.rs
@@ -1,6 +1,4 @@
-use crate::{
-    assert_infer_with_module, assert_module_error, assert_module_infer, assert_with_module_error,
-};
+use crate::{assert_module_error, assert_module_infer};
 
 #[test]
 fn alias_dep() {
@@ -64,7 +62,7 @@ type A = #(A, A)
 
 #[test]
 fn alias_different_module() {
-    assert_infer_with_module!(
+    assert_module_infer!(
         ("other", "pub type Blah = Bool"),
         r#"
             import other
@@ -143,7 +141,7 @@ fn example(a: X) {
 #[test]
 fn conflict_with_import() {
     // We cannot declare a type with the same name as an imported type
-    assert_with_module_error!(
+    assert_module_error!(
         ("wibble", "pub type Wobble = String"),
         "import wibble.{type Wobble} type Wobble = Int",
     );

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     assert_js_no_warnings, assert_js_warning, assert_no_warnings, assert_warning,
-    assert_warnings_with_gleam_version, assert_warnings_with_imports,
+    assert_warnings_with_gleam_version,
 };
 
 #[test]
@@ -984,8 +984,8 @@ fn unused_module_wuth_alias_warning_test() {
 
 #[test]
 fn unused_alias_warning_test() {
-    assert_warnings_with_imports!(
-        ("gleam/wibble", "pub const one = 1");
+    assert_warning!(
+        ("gleam/wibble", "pub const one = 1"),
         r#"
             import gleam/wibble.{one} as wobble
             const one = one
@@ -1011,9 +1011,9 @@ fn discarded_module_no_warnings_test() {
 
 #[test]
 fn unused_alias_for_duplicate_module_no_warning_for_alias_test() {
-    assert_warnings_with_imports!(
+    assert_warning!(
         ("a/wibble", "pub const one = 1"),
-        ("b/wibble", "pub const two = 2");
+        ("b/wibble", "pub const two = 2"),
         r#"
             import a/wibble
             import b/wibble as wobble


### PR DESCRIPTION
I noticed that a the various test macros were somewhat inconsistent. Some allowed you to specify a second module, some had a `assert_*_with_module` variant.
I this PR, I merged all the `assert_*_with_module` macros into their regular versions. I've also updated the snapshot format of a few of them to make them consistent with the rest of the snapshots.