### PR TITLE
Fix renaming of types in variant constructor definitions

### DIFF
--- a/compiler-core/src/language_server/reference.rs
+++ b/compiler-core/src/language_server/reference.rs
@@ -213,23 +213,24 @@ pub fn reference_for_ast_node(
         }),
         Located::Annotation { ast, type_ } => match type_.named_type_name() {
             Some((module, name)) => {
-                let target_kind = match ast {
+                let (target_kind, location) = match ast {
                     ast::TypeAst::Constructor(constructor) => {
-                        if constructor.module.is_some() {
+                        let kind = if constructor.module.is_some() {
                             RenameTarget::Qualified
                         } else {
                             RenameTarget::Unqualified
-                        }
+                        };
+                        (kind, constructor.name_location)
                     }
                     ast::TypeAst::Fn(_)
                     | ast::TypeAst::Var(_)
                     | ast::TypeAst::Tuple(_)
-                    | ast::TypeAst::Hole(_) => RenameTarget::Unqualified,
+                    | ast::TypeAst::Hole(_) => (RenameTarget::Unqualified, ast.location()),
                 };
                 Some(Referenced::ModuleType {
                     module,
                     name,
-                    location: ast.location(),
+                    location,
                     target_kind,
                 })
             }

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -1275,3 +1275,59 @@ pub fn main() -> wibble.Wibble { todo }
         find_position_of("Wibble")
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4372
+#[test]
+fn rename_type_referenced_in_variant_constructor_argument() {
+    assert_rename!(
+        (
+            "mod",
+            "
+import app
+
+pub type Wobble {
+  Wobble(w: app.Wibble)
+}
+"
+        ),
+        "
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() {
+  let wibble = Wibble
+}
+",
+        "SomeType",
+        find_position_of("Wibble")
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/4372
+#[test]
+fn rename_type_from_variant_constructor_argument() {
+    assert_rename!(
+        (
+            "mod",
+            "
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() {
+  let wibble = Wibble
+}
+"
+        ),
+        "
+import mod
+
+pub type Wobble {
+  Wobble(w: mod.Wibble)
+}
+",
+        "SomeType",
+        find_position_of("Wibble")
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_from_qualified_reference.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_from_qualified_reference.snap
@@ -15,7 +15,7 @@ fn wibble(w: Wibble) -> Wibble { todo }
 import mod
 
 pub fn main(w: mod.Wibble) -> mod.Wibble { todo }
-               ↑▔▔▔▔▔▔▔▔▔                        
+                   ↑▔▔▔▔▔                        
 
 
 ----- AFTER RENAME

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_from_variant_constructor_argument.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_from_variant_constructor_argument.snap
@@ -1,0 +1,45 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport mod\n\npub type Wobble {\n  Wobble(w: mod.Wibble)\n}\n"
+---
+----- BEFORE RENAME
+-- mod.gleam
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() {
+  let wibble = Wibble
+}
+
+
+-- app.gleam
+
+import mod
+
+pub type Wobble {
+  Wobble(w: mod.Wibble)
+                ↑▔▔▔▔▔ 
+}
+
+
+----- AFTER RENAME
+-- mod.gleam
+
+pub type SomeType {
+  Wibble
+}
+
+pub fn main() {
+  let wibble = Wibble
+}
+
+
+-- app.gleam
+
+import mod
+
+pub type Wobble {
+  Wobble(w: mod.SomeType)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_referenced_in_variant_constructor_argument.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_type_referenced_in_variant_constructor_argument.snap
@@ -1,0 +1,45 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn main() {\n  let wibble = Wibble\n}\n"
+---
+----- BEFORE RENAME
+-- mod.gleam
+
+import app
+
+pub type Wobble {
+  Wobble(w: app.Wibble)
+}
+
+
+-- app.gleam
+
+pub type Wibble {
+         ↑▔▔▔▔▔  
+  Wibble
+}
+
+pub fn main() {
+  let wibble = Wibble
+}
+
+
+----- AFTER RENAME
+-- mod.gleam
+
+import app
+
+pub type Wobble {
+  Wobble(w: app.SomeType)
+}
+
+
+-- app.gleam
+
+pub type SomeType {
+  Wibble
+}
+
+pub fn main() {
+  let wibble = Wibble
+}


### PR DESCRIPTION
Fixes #4372 
The issue occurred because in the `custom_type_accessors` function, we traverse the `TypeAst` twice after we've already done so in `register_values_from_custom_type`. This caused 3 references to be registered for any types in the arguments, rather than just 1.
To fix this, I've changed it so that we use the type information we already have instead of rebuilding it continuously from the AST.