### PR TITLE
Fix bug with code generation of case clauses

### DIFF
--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -294,7 +294,7 @@ fn deeply_nested_string_prefix_assignment() {
         r#"
 type Wibble {
   Wibble(Wobble)
-}            
+}
 type Wobble {
   Wobble(wabble: Wabble)
 }
@@ -311,4 +311,28 @@ pub fn main() {
 }
 "#
     )
+}
+
+// https://github.com/gleam-lang/gleam/issues/4383
+#[test]
+fn record_update_in_pipeline_in_case_clause() {
+    assert_js!(
+        "
+type Wibble {
+  Wibble(wibble: Int, wobble: Int)
+}
+
+fn identity(x) {
+  x
+}
+
+fn go(x) {
+  case x {
+    Wibble(1, _) -> Wibble(..x, wibble: 4) |> identity
+    Wibble(_, 3) -> Wibble(..x, wobble: 10) |> identity
+    _ -> panic
+  }
+}
+"
+    );
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__deeply_nested_string_prefix_assignment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__deeply_nested_string_prefix_assignment.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/javascript/tests/case.rs
-expression: "\ntype Wibble {\n  Wibble(Wobble)\n}            \ntype Wobble {\n  Wobble(wabble: Wabble)\n}\ntype Wabble {\n  Wabble(tuple: #(Int, String))\n}\n\npub fn main() {\n  let tmp = Wibble(Wobble(Wabble(#(42, \"wibble\"))))\n  case tmp {\n    Wibble(Wobble(Wabble(#(_int, \"w\" as wibble <> rest)))) -> wibble <> rest\n    _ -> panic\n  }\n}\n"
+expression: "\ntype Wibble {\n  Wibble(Wobble)\n}\ntype Wobble {\n  Wobble(wabble: Wabble)\n}\ntype Wabble {\n  Wabble(tuple: #(Int, String))\n}\n\npub fn main() {\n  let tmp = Wibble(Wobble(Wabble(#(42, \"wibble\"))))\n  case tmp {\n    Wibble(Wobble(Wabble(#(_int, \"w\" as wibble <> rest)))) -> wibble <> rest\n    _ -> panic\n  }\n}\n"
 ---
 ----- SOURCE CODE
 
 type Wibble {
   Wibble(Wobble)
-}            
+}
 type Wobble {
   Wobble(wabble: Wabble)
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__record_update_in_pipeline_in_case_clause.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__record_update_in_pipeline_in_case_clause.snap
@@ -1,0 +1,62 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\ntype Wibble {\n  Wibble(wibble: Int, wobble: Int)\n}\n\nfn identity(x) {\n  x\n}\n\nfn go(x) {\n  case x {\n    Wibble(1, _) -> Wibble(..x, wibble: 4) |> identity\n    Wibble(_, 3) -> Wibble(..x, wobble: 10) |> identity\n    _ -> panic\n  }\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble(wibble: Int, wobble: Int)
+}
+
+fn identity(x) {
+  x
+}
+
+fn go(x) {
+  case x {
+    Wibble(1, _) -> Wibble(..x, wibble: 4) |> identity
+    Wibble(_, 3) -> Wibble(..x, wobble: 10) |> identity
+    _ -> panic
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType, makeError } from "../gleam.mjs";
+
+class Wibble extends $CustomType {
+  constructor(wibble, wobble) {
+    super();
+    this.wibble = wibble;
+    this.wobble = wobble;
+  }
+}
+
+function identity(x) {
+  return x;
+}
+
+function go(x) {
+  if (x instanceof Wibble && x.wibble === 1) {
+    let _block;
+    let _record = x;
+    _block = new Wibble(4, _record.wobble);
+    let _pipe = _block;
+    return identity(_pipe);
+  } else if (x instanceof Wibble && x.wobble === 3) {
+    let _block;
+    let _record = x;
+    _block = new Wibble(_record.wibble, 10);
+    let _pipe = _block;
+    return identity(_pipe);
+  } else {
+    throw makeError(
+      "panic",
+      "my/mod",
+      14,
+      "go",
+      "`panic` expression evaluated.",
+      {}
+    )
+  }
+}


### PR DESCRIPTION
Fixes #4383 
I just forgot to take `statement_level` if the case clause guard wasn't a block.