### PR TITLE
Fix various JavaScript code generation bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,10 @@
   when it could use the cache from previous compilations.
   ([Louis Pilfold](https://github.com/lpil))
 
+- Fixed a bug where `let assert` would not assert that the given value matched
+  the pattern if it was the only expression inside a block.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.9.1 - 2025-03-10
 
 ### Formatter

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -957,7 +957,7 @@ impl<'module, 'a> Generator<'module, 'a> {
     ) -> Output<'a> {
         let message = match message {
             Some(m) => {
-                self.not_in_tail_position(Some(Ordering::Loose), |this| this.expression(m))?
+                self.not_in_tail_position(Some(Ordering::Strict), |this| this.expression(m))?
             }
             None => string("Pattern match failed, no pattern matched the value."),
         };

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -323,3 +323,24 @@ pub fn main() {
 "
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/4395
+#[test]
+fn let_assert_message_no_lifted() {
+    assert_js!(
+        r#"
+fn side_effects(x) {
+  // Some side effects
+  x
+}
+
+pub fn main() {
+  let assert Error(Nil) = side_effects(Ok(10))
+    as {
+    let message = side_effects("some message")
+    message
+  }
+}
+"#
+    )
+}

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -291,3 +291,35 @@ pub fn main() {
 "
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/4394
+#[test]
+fn assignment_last_in_block() {
+    assert_js!(
+        "
+pub fn main() {
+  let a = {
+    let b = 1
+    let c = b + 1
+  }
+  a
+}
+"
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/4394
+#[test]
+fn pattern_assignment_last_in_block() {
+    assert_js!(
+        "
+pub fn main() {
+  let a = {
+    let b = #(1, 2)
+    let #(x, y) = b
+  }
+  a
+}
+"
+    )
+}

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -277,3 +277,17 @@ pub fn main() {
 "
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/4393
+#[test]
+fn let_assert_only_statement_in_block() {
+    assert_js!(
+        "
+pub fn main() {
+  {
+    let assert Ok(1) = Error(Nil)
+  }
+}
+"
+    )
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__assignment_last_in_block.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__assignment_last_in_block.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\npub fn main() {\n  let a = {\n    let b = 1\n    let c = b + 1\n  }\n  a\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let a = {
+    let b = 1
+    let c = b + 1
+  }
+  a
+}
+
+
+----- COMPILED JAVASCRIPT
+export function main() {
+  let _block;
+  {
+    let b = 1;
+    let c = b + 1;
+    _block = c;
+  }
+  let a = _block;
+  return a;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_message_no_lifted.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_message_no_lifted.snap
@@ -1,0 +1,44 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\nfn side_effects(x) {\n  // Some side effects\n  x\n}\n\npub fn main() {\n  let assert Error(Nil) = side_effects(Ok(10))\n    as {\n    let message = side_effects(\"some message\")\n    message\n  }\n}\n"
+---
+----- SOURCE CODE
+
+fn side_effects(x) {
+  // Some side effects
+  x
+}
+
+pub fn main() {
+  let assert Error(Nil) = side_effects(Ok(10))
+    as {
+    let message = side_effects("some message")
+    message
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Ok, makeError } from "../gleam.mjs";
+
+function side_effects(x) {
+  return x;
+}
+
+export function main() {
+  let $ = side_effects(new Ok(10));
+  if ($.isOk() || $[0]) {
+    throw makeError(
+      "let_assert",
+      "my/mod",
+      8,
+      "main",
+      (() => {
+        let message = side_effects("some message");
+        return message;
+      })(),
+      { value: $ }
+    )
+  }
+  return $;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_only_statement_in_block.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_only_statement_in_block.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\npub fn main() {\n  {\n    let assert Ok(1) = Error(Nil)\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  {
+    let assert Ok(1) = Error(Nil)
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Error, makeError } from "../gleam.mjs";
+
+export function main() {
+  {
+    let $ = new Error(undefined);
+    if (!$.isOk() || $[0] !== 1) {
+      throw makeError(
+        "let_assert",
+        "my/mod",
+        4,
+        "main",
+        "Pattern match failed, no pattern matched the value.",
+        { value: $ }
+      )
+    }
+    return $;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__pattern_assignment_last_in_block.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__pattern_assignment_last_in_block.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\npub fn main() {\n  let a = {\n    let b = #(1, 2)\n    let #(x, y) = b\n  }\n  a\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let a = {
+    let b = #(1, 2)
+    let #(x, y) = b
+  }
+  a
+}
+
+
+----- COMPILED JAVASCRIPT
+export function main() {
+  let _block;
+  {
+    let b = [1, 2];
+    let x = b[0];
+    let y = b[1];
+    _block = b;
+  }
+  let a = _block;
+  return a;
+}


### PR DESCRIPTION
This PR fixes #4393, fixes #4394 and fixes #4395
I thought I'd put these all in one PR, as they are relatively small, relatively simple changes to the same part of the codebase. Let me know if I should split this into 3 PRs.
Only the first one is reported in the changelog as the latter two were introduced in this version when I modified code generation of blocks.