### PR TITLE
LS: Trigger full rebuild if build directory has gone missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,11 @@
   variants called `Object` or `Deno` defined in the module.
   ([Louis Pilfold](https://github.com/lpil))
 
+- Fixed a bug where the language server would stop working if the build
+  directory was deleted e.g. as a result of `gleam clean`.
+  ([Sakari Bergen](https://github.com/sbergen))
+
+
 ## v1.9.1 - 2025-03-10
 
 ### Formatter

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -6,6 +6,7 @@ mod document_symbols;
 mod hover;
 mod reference;
 mod rename;
+mod router;
 mod signature_help;
 
 use std::{

--- a/compiler-core/src/language_server/tests/router.rs
+++ b/compiler-core/src/language_server/tests/router.rs
@@ -1,0 +1,121 @@
+use std::time::SystemTime;
+
+use crate::{
+    Error,
+    io::FileSystemWriter,
+    language_server::{files::FileSystemProxy, tests::Action},
+    paths::ProjectPaths,
+};
+
+use super::LanguageServerTestIO;
+
+type Router = crate::language_server::router::Router<LanguageServerTestIO, LanguageServerTestIO>;
+
+#[test]
+fn recompile_after_no_changes_does_not_redownload_dependencies() {
+    let paths = ProjectPaths::new("/app".into());
+    let (io, mut router) = set_up_minimal_router(&paths);
+
+    assert_eq!(
+        compile(&mut router, &paths),
+        Ok(()),
+        "Pre-condition: Initial compile should succeed"
+    );
+
+    {
+        let mut actions = io.actions.lock().unwrap();
+        assert!(
+            actions.contains(&Action::DownloadDependencies),
+            "Expectation: Initial compile should download dependencies"
+        );
+        actions.clear();
+    }
+
+    assert_eq!(
+        compile(&mut router, &paths),
+        Ok(()),
+        "Recompile should succeed"
+    );
+
+    {
+        let actions = io.actions.lock().unwrap();
+        assert!(
+            !actions.contains(&Action::DownloadDependencies),
+            "Recompile should not re-download dependencies"
+        );
+    }
+}
+
+#[test]
+fn deleting_build_dir_redownloads_dependencies() {
+    let paths = ProjectPaths::new("/app".into());
+    let (io, mut router) = set_up_minimal_router(&paths);
+
+    _ = compile(&mut router, &paths);
+    io.actions.lock().unwrap().clear();
+
+    io.delete_directory(&paths.build_directory()).unwrap();
+    assert_eq!(
+        compile(&mut router, &paths),
+        Ok(()),
+        "Compile after deleting build directory should succeed"
+    );
+
+    {
+        let actions = io.actions.lock().unwrap();
+        assert!(
+            actions.contains(&Action::DownloadDependencies),
+            "Compile after deleting build directory should re-download dependencies"
+        );
+    }
+}
+
+#[test]
+fn changing_config_redownloads_dependencies() {
+    let paths = ProjectPaths::new("/app".into());
+    let (io, mut router) = set_up_minimal_router(&paths);
+
+    _ = compile(&mut router, &paths);
+    io.actions.lock().unwrap().clear();
+
+    let toml = r#"name = "wobble"
+    version = "1.0.0""#;
+    io.write(&paths.root_config(), toml).unwrap();
+    io.io
+        .set_modification_time(&paths.root_config(), SystemTime::now());
+
+    assert_eq!(
+        compile(&mut router, &paths),
+        Ok(()),
+        "Compile after changing gleam.toml should succeed"
+    );
+
+    {
+        let actions = io.actions.lock().unwrap();
+        assert!(
+            actions.contains(&Action::DownloadDependencies),
+            "Compile after changing gleam.toml should re-download dependencies"
+        );
+    }
+}
+
+fn compile(router: &mut Router, paths: &ProjectPaths) -> Result<(), Error> {
+    router
+        .project_for_path(paths.root().into())
+        .unwrap()
+        .unwrap()
+        .engine
+        .compile_please()
+        .result
+}
+
+fn set_up_minimal_router(paths: &ProjectPaths) -> (LanguageServerTestIO, Router) {
+    let io = LanguageServerTestIO::new();
+    let router = Router::new(io.clone(), FileSystemProxy::new(io.clone()));
+
+    let toml = r#"name = "wibble"
+    version = "1.0.0""#;
+
+    io.write(&paths.root_config(), toml).unwrap();
+    (io, router)
+}


### PR DESCRIPTION
Resolves #3954

I found writing tests for this challenging. If anyone has any pointers, I'd be glad to take another go at it 😅 

You can still mess things up by deleting individual files from within the build directory. However, that seemed very difficult to solve, and also affects the compiler (in addition to LS). Since the full directory can be deleted with `gleam clean`, this seems like it's worth covering as a special case.

I also stumbled upon an invalid modification time optimization while doing it.