### PR TITLE
Simplify LS compiler result type

### DIFF
--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -162,9 +162,7 @@ where
 
         let result = outcome
             // Register which modules have changed
-            .map(|modules| self.modules_compiled_since_last_feedback.extend(modules))
-            // Return the error, if present
-            .into_result();
+            .map(|modules| self.modules_compiled_since_last_feedback.extend(modules));
 
         self.error = match &result {
             Ok(_) => None,


### PR DESCRIPTION
While I was working on #4404, I noticed that the `Outcome` returned by `LspProjectCompiler::compile` could be replaced with `Result`, making the code quite a bit simpler. However, since the actual fix didn't end up touching that part of the code, I separated this into another PR.