### PR TITLE
No longer show errors on labelled arguments of non existing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,13 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+
 - Compilation of binary operators is now fault tolerant and won't stop at the
   first type error.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The compiler no longer shows errors for a function's labels if the called
+  function itself doesn't exist.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ### Build tool

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2978,3 +2978,16 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn constructor_that_does_not_exist_does_not_produce_error_for_labelled_args() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  // We only want to error on `Wibble` since it doesn't exist, we don't want
+  // an error on the label at this point!
+  Wibble(label: 1)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2965,3 +2965,16 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn function_that_does_not_exist_does_not_produce_error_for_labelled_args() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  // We only want to error on `wibble` since it doesn't exist, we don't want
+  // an error on the label at this point!
+  wibble(label: 1)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__constructor_that_does_not_exist_does_not_produce_error_for_labelled_args.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__constructor_that_does_not_exist_does_not_produce_error_for_labelled_args.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  // We only want to error on `Wibble` since it doesn't exist, we don't want\n  // an error on the label at this point!\n  Wibble(label: 1)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  // We only want to error on `Wibble` since it doesn't exist, we don't want
+  // an error on the label at this point!
+  Wibble(label: 1)
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:5:3
+  │
+5 │   Wibble(label: 1)
+  │   ^^^^^^
+
+The custom type variant constructor `Wibble` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__function_that_does_not_exist_does_not_produce_error_for_labelled_args.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__function_that_does_not_exist_does_not_produce_error_for_labelled_args.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  // We only want to error on `wibble` since it doesn't exist, we don't want\n  // an error on the label at this point!\n  wibble(label: 1)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  // We only want to error on `wibble` since it doesn't exist, we don't want
+  // an error on the label at this point!
+  wibble(label: 1)
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:5:3
+  │
+5 │   wibble(label: 1)
+  │   ^^^^^^
+
+The name `wibble` is not in scope here.


### PR DESCRIPTION
This PR closes #4422 