### PR TITLE
Trigger "rewrite from `use`" code action only when hovering over the `use` line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,6 +344,10 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The "Rewrite from `use`" code action now only triggers if the cursor is on the
+  first line of the `use` expression to rewrite.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Container images

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -3642,7 +3642,7 @@ fn wibble(f) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("use").select_until(find_position_of("todo")),
+        find_position_of("use").select_until(find_position_of("wibble")),
     );
 }
 
@@ -3702,7 +3702,7 @@ fn wibble(n, m, f) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("todo").to_selection(),
+        find_position_of("a <-").to_selection(),
     );
 }
 
@@ -3722,7 +3722,7 @@ fn wibble(n, m, f) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("todo").nth_occurrence(2).to_selection(),
+        find_position_of("wibble").to_selection(),
     );
 }
 
@@ -3742,7 +3742,26 @@ fn wibble(n, m, f) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("todo").under_last_char().to_selection(),
+        find_position_of("use").nth_occurrence(2).to_selection(),
+    );
+}
+
+#[test]
+fn convert_from_use_only_triggers_on_the_use_line() {
+    let src = r#"
+pub fn main() {
+  use a, b <- wibble(1, 2)
+  todo
+}
+
+fn wibble(n, m, f) {
+    f(1, 2)
+}
+"#;
+    assert_no_code_actions!(
+        CONVERT_FROM_USE,
+        TestProject::for_source(src),
+        find_position_of("todo").to_selection(),
     );
 }
 
@@ -3819,7 +3838,7 @@ fn wibble(one _, two _, three f) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("todo").to_selection(),
+        find_position_of("use").to_selection(),
     );
 }
 
@@ -3838,7 +3857,7 @@ fn wibble(one _, two _, three f) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("todo").to_selection(),
+        find_position_of("use").to_selection(),
     );
 }
 
@@ -3857,7 +3876,7 @@ fn wibble(one _, two f, three _) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("todo").to_selection(),
+        find_position_of("use").to_selection(),
     );
 }
 
@@ -3876,7 +3895,7 @@ fn wibble(one f, two _, three _) {
     assert_code_action!(
         CONVERT_FROM_USE,
         TestProject::for_source(src),
-        find_position_of("todo").to_selection(),
+        find_position_of("use").to_selection(),
     );
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_expression_with_multiple_patterns.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_expression_with_multiple_patterns.snap
@@ -6,9 +6,9 @@ expression: "\npub fn main() {\n  use a, b <- wibble(1, 2)\n  todo\n  todo\n}\n\
 
 pub fn main() {
   use a, b <- wibble(1, 2)
+              ↑           
   todo
   todo
-  ↑   
 }
 
 fn wibble(n, m, f) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_expression_with_no_parens.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_expression_with_no_parens.snap
@@ -6,9 +6,8 @@ expression: "\npub fn main() {\n  use <- wibble\n  todo\n  todo\n}\n\nfn wibble(
 
 pub fn main() {
   use <- wibble
-  ▔▔▔▔▔▔▔▔▔▔▔▔▔
+  ▔▔▔▔▔▔▔↑     
   todo
-▔▔↑   
   todo
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_expression_with_single_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_expression_with_single_pattern.snap
@@ -6,8 +6,8 @@ expression: "\npub fn main() {\n  use a <- wibble(1, 2)\n  todo\n  todo\n}\n\nfn
 
 pub fn main() {
   use a <- wibble(1, 2)
+      ↑                
   todo
-  ↑   
   todo
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels.snap
@@ -6,8 +6,8 @@ expression: "\npub fn main() {\n  use a <- wibble(one: 1, two: 2)\n  todo\n}\n\n
 
 pub fn main() {
   use a <- wibble(one: 1, two: 2)
+  ↑                              
   todo
-  ↑   
 }
 
 fn wibble(one _, two _, three f) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels_2.snap
@@ -6,8 +6,8 @@ expression: "\npub fn main() {\n  use a <- wibble(1, two: 2)\n  todo\n}\n\nfn wi
 
 pub fn main() {
   use a <- wibble(1, two: 2)
+  ↑                         
   todo
-  ↑   
 }
 
 fn wibble(one _, two _, three f) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels_3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels_3.snap
@@ -6,8 +6,8 @@ expression: "\npub fn main() {\n  use a <- wibble(1, three: 3)\n  todo\n}\n\nfn 
 
 pub fn main() {
   use a <- wibble(1, three: 3)
+  ↑                           
   todo
-  ↑   
 }
 
 fn wibble(one _, two f, three _) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels_4.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_from_use_with_labels_4.snap
@@ -6,8 +6,8 @@ expression: "\npub fn main() {\n  use a <- wibble(two: 2, three: 3)\n  todo\n}\n
 
 pub fn main() {
   use a <- wibble(two: 2, three: 3)
+  ↑                                
   todo
-  ↑   
 }
 
 fn wibble(one f, two _, three _) {

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_nested_use_expressions_picks_inner_under_cursor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__desugar_nested_use_expressions_picks_inner_under_cursor.snap
@@ -7,8 +7,8 @@ expression: "\npub fn main() {\n  use a, b <- wibble(1, 2)\n  use a, b <- wibble
 pub fn main() {
   use a, b <- wibble(1, 2)
   use a, b <- wibble(a, b)
+  ↑                       
   todo
-     ↑
 }
 
 fn wibble(n, m, f) {


### PR DESCRIPTION
Before the action would be suggested if the cursor is anywhere in the use block. However, it would end up being annoying most of the times suggesting this code action when triggered on seemingly unrelated pieces of code. With this change the action will only trigger if the cursor is placed in the first line of a use expression: the one containing the `use`