### PR TITLE
Use correct location when inlining field access variable

### DIFF
--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -90,6 +90,7 @@ pub enum TypedExpr {
 
     RecordAccess {
         location: SrcSpan,
+        field_start: u32,
         type_: Arc<Type>,
         label: EcoString,
         index: u64,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -213,12 +213,13 @@ pub trait Visit<'ast> {
     fn visit_typed_expr_record_access(
         &mut self,
         location: &'ast SrcSpan,
+        field_start: &'ast u32,
         type_: &'ast Arc<Type>,
         label: &'ast EcoString,
         index: &'ast u64,
         record: &'ast TypedExpr,
     ) {
-        visit_typed_expr_record_access(self, location, type_, label, index, record);
+        visit_typed_expr_record_access(self, location, field_start, type_, label, index, record);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -770,11 +771,12 @@ where
         } => v.visit_typed_expr_case(location, type_, subjects, clauses),
         TypedExpr::RecordAccess {
             location,
+            field_start,
             type_,
             label,
             index,
             record,
-        } => v.visit_typed_expr_record_access(location, type_, label, index, record),
+        } => v.visit_typed_expr_record_access(location, field_start, type_, label, index, record),
         TypedExpr::ModuleSelect {
             location,
             field_start,
@@ -1001,6 +1003,7 @@ pub fn visit_typed_expr_case<'a, V>(
 pub fn visit_typed_expr_record_access<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
+    _field_start: &'a u32,
     _type_: &'a Arc<Type>,
     _label: &'a EcoString,
     _index: &'a u64,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -6100,15 +6100,8 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInBlock<'ast> {
         match *assignment.to_owned().value {
             // To avoid wrapping the same expression in multiple, nested blocks.
             TypedExpr::Block { .. } => {}
-            TypedExpr::RecordAccess {
-                record, location, ..
-            } => {
-                self.selected_expression = Some(SrcSpan {
-                    start: record.location().start,
-                    end: location.end,
-                });
-            }
-            TypedExpr::Int { .. }
+            TypedExpr::RecordAccess { .. }
+            | TypedExpr::Int { .. }
             | TypedExpr::Float { .. }
             | TypedExpr::String { .. }
             | TypedExpr::Pipeline { .. }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -7179,6 +7179,26 @@ pub fn main() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/4430
+#[test]
+fn inline_variable_with_record_field() {
+    assert_code_action!(
+        INLINE_VARIABLE,
+        "
+type Couple {
+  Couple(l: Int, r: Int)
+}
+
+pub fn main() {
+  let c1 = Couple(l: 1, r: 1)
+  let c2 = c1.l
+  echo c2
+}
+",
+        find_position_of("c2").nth_occurrence(2).to_selection()
+    );
+}
+
 #[test]
 fn wrap_case_clause_in_block() {
     assert_code_action!(
@@ -7239,7 +7259,7 @@ fn wrap_case_clause_with_multiple_patterns_in_block() {
   Water
   Fire
 }
-        
+
   pub fn f(pokemon_type: PokemonType) {
     case pokemon_type {
       Water | Air -> soak()
@@ -7259,7 +7279,7 @@ fn wrap_case_clause_inside_assignment_in_block() {
   Water
   Fire
 }
-        
+
   pub fn f(pokemon_type: PokemonType) {
     let damage = case pokemon_type {
       Water -> soak()

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__inline_variable_with_record_field.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__inline_variable_with_record_field.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\ntype Couple {\n  Couple(l: Int, r: Int)\n}\n\npub fn main() {\n  let c1 = Couple(l: 1, r: 1)\n  let c2 = c1.l\n  echo c2\n}\n"
+---
+----- BEFORE ACTION
+
+type Couple {
+  Couple(l: Int, r: Int)
+}
+
+pub fn main() {
+  let c1 = Couple(l: 1, r: 1)
+  let c2 = c1.l
+  echo c2
+       ↑ 
+}
+
+
+----- AFTER ACTION
+
+type Couple {
+  Couple(l: Int, r: Int)
+}
+
+pub fn main() {
+  let c1 = Couple(l: 1, r: 1)
+  echo c1.l
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_case_clause_inside_assignment_in_block.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_case_clause_inside_assignment_in_block.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "pub type PokemonType {\n  Air\n  Water\n  Fire\n}\n        \n  pub fn f(pokemon_type: PokemonType) {\n    let damage = case pokemon_type {\n      Water -> soak()\n      Fire -> burn()\n    }\n\n    \"Pokemon did \" <> damage\n  }"
+expression: "pub type PokemonType {\n  Air\n  Water\n  Fire\n}\n\n  pub fn f(pokemon_type: PokemonType) {\n    let damage = case pokemon_type {\n      Water -> soak()\n      Fire -> burn()\n    }\n\n    \"Pokemon did \" <> damage\n  }"
 ---
 ----- BEFORE ACTION
 pub type PokemonType {
@@ -8,7 +8,7 @@ pub type PokemonType {
   Water
   Fire
 }
-        
+
   pub fn f(pokemon_type: PokemonType) {
     let damage = case pokemon_type {
       Water -> soak()
@@ -26,7 +26,7 @@ pub type PokemonType {
   Water
   Fire
 }
-        
+
   pub fn f(pokemon_type: PokemonType) {
     let damage = case pokemon_type {
       Water -> soak()

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_case_clause_with_multiple_patterns_in_block.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_case_clause_with_multiple_patterns_in_block.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "pub type PokemonType {\n  Air\n  Water\n  Fire\n}\n        \n  pub fn f(pokemon_type: PokemonType) {\n    case pokemon_type {\n      Water | Air -> soak()\n      Fire -> burn()\n    }\n  }"
+expression: "pub type PokemonType {\n  Air\n  Water\n  Fire\n}\n\n  pub fn f(pokemon_type: PokemonType) {\n    case pokemon_type {\n      Water | Air -> soak()\n      Fire -> burn()\n    }\n  }"
 ---
 ----- BEFORE ACTION
 pub type PokemonType {
@@ -8,7 +8,7 @@ pub type PokemonType {
   Water
   Fire
 }
-        
+
   pub fn f(pokemon_type: PokemonType) {
     case pokemon_type {
       Water | Air -> soak()
@@ -24,7 +24,7 @@ pub type PokemonType {
   Water
   Fire
 }
-        
+
   pub fn f(pokemon_type: PokemonType) {
     case pokemon_type {
       Water | Air -> {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1066,6 +1066,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             Ok(record) => self.infer_known_record_expression_access(
                 record,
                 label.clone(),
+                location,
                 label_location,
                 container_location.start,
                 usage,
@@ -2536,13 +2537,19 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         record: TypedExpr,
         label: EcoString,
         location: SrcSpan,
+        label_location: SrcSpan,
         field_start: u32,
         usage: FieldAccessUsage,
     ) -> Result<TypedExpr, Error> {
         let record = Box::new(record);
         let record_type = record.type_();
-        let (index, label, type_) =
-            self.infer_known_record_access(record_type, record.location(), usage, location, label)?;
+        let (index, label, type_) = self.infer_known_record_access(
+            record_type,
+            record.location(),
+            usage,
+            label_location,
+            label,
+        )?;
         Ok(TypedExpr::RecordAccess {
             record,
             label,
@@ -2819,6 +2826,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 let record_access = self.infer_known_record_expression_access(
                     record.clone(),
                     label.clone(),
+                    record_location,
                     record_location,
                     record_location.start,
                     FieldAccessUsage::RecordUpdate,

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
@@ -17,7 +17,7 @@ pub fn main() {
 
 ----- WARNING
 warning: Unused value
-  ┌─ /src/warning/wrn.gleam:8:9
+  ┌─ /src/warning/wrn.gleam:8:3
   │
 8 │   thing.value
-  │         ^^^^^ This value is never used
+  │   ^^^^^^^^^^^ This value is never used


### PR DESCRIPTION
This PR closes #4430
The field access location now spans the entire thing and is consistent with the way we've updated the module select location a while ago.