### PR TITLE
Fix running of `running_modules` tests on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -480,7 +480,7 @@ jobs:
         working-directory: ./test/hextarball
 
       - name: Test running modules
-        run: make test
+        run: make test-all
         working-directory: ./test/running_modules
 
       - name: test/multi_namespace

--- a/test/running_modules/gleam.toml
+++ b/test/running_modules/gleam.toml
@@ -3,11 +3,8 @@ version = "0.1.0"
 description = "A Gleam project"
 
 [dependencies]
-gleam_stdlib = "~> 0.27"
-gleeunit = "~> 0.10"
-# Project used to test if javascript target is detected.
-# https://hex.pm/packages/gleam_module_javascript_test
-gleam_module_javascript_test = "~> 0.2.0"
+gleam_stdlib = ">= 0.58.0 and < 2.0.0"
+gleeunit = ">= 1.0.0 and < 2.0.0"
 
 [javascript.deno]
 allow_read = true

--- a/test/running_modules/manifest.toml
+++ b/test/running_modules/manifest.toml
@@ -2,12 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_module_javascript_test", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_module_javascript_test", source = "hex", outer_checksum = "EB67B6423078E8A37FCB172EC5342BAA1CF45A235F3A9C890532E7487E606E91" },
-  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
-  { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
+  { name = "gleam_stdlib", version = "0.58.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "091F2D2C4A3A4E2047986C47E2C2C9D728A4E068ABB31FDA17B0D347E6248467" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
-gleam_module_javascript_test = { version = "~> 0.2.0" }
-gleam_stdlib = { version = "~> 0.27" }
-gleeunit = { version = "~> 0.10" }
+gleam_stdlib = { version = ">= 0.58.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/test/running_modules/run_tests.sh
+++ b/test/running_modules/run_tests.sh
@@ -61,10 +61,3 @@ should_fail run --module module/no_main_function
 
 # Main function with wrong arity
 should_fail run --module module/wrong_arity
-
-# try running gleam_module_javascript_test, which will crash if target is erlang
-should_succeed run --module gleam_module_javascript_test
-
-# verify that javascript target doesn't crash and erlang target does crash
-should_succeed run --module gleam_module_javascript_test --target=javascript
-should_fail run --module gleam_module_javascript_test --target=erlang


### PR DESCRIPTION
I noticed while working on [this PR](https://github.com/gleam-lang/gleam/pull/4429) that the `test/running_modules` tests weren't actually running properly. (The `make` rule is `test-all`, not `test`)
I also noticed that this test was using old dependencies which no longer compile on the latest Gleam version, so I've updated them.