### PR TITLE
Use local Hex key to revoke local Hex API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@
 - Deprecate `HEXPM_USER` and `HEXPM_PASS` in favour of `HEXPM_API_KEY`.
   ([Samuel Cristobal](https://github.com/scristobal))
 
+- Improved Hex API key removal CLI process.
+  ([Samuel Cristobal](https://github.com/scristobal))
+
 ### Language server
 
 - The language server now allows renaming of functions, constants,


### PR DESCRIPTION
resolves #4319 

After a bit of though, I realized we can use the existing key to revoke itself. Provided the Hex API allows such a thing.

As it turns out, using the existing key to revoke itself works just fine, but requires asking the user for the local password. Hence the command flow needs to change a bit. Here is the result:

<a href="https://asciinema.org/a/f9P3EuBbMvwfZfK32yggKWNXn" target="_blank"><img src="https://asciinema.org/a/f9P3EuBbMvwfZfK32yggKWNXn.svg" /></a>

In any case, if the key couldn't be revoked, the user is hinted to finish the process manually, instead of failing, like in #4319.

Please do let me know if you think this approach is a good fit.

Thanks!