### PR TITLE
Improve error message for some binary operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@
   and patterns.
   ([Richard Viney](https://github.com/richard-viney))
 
-- Improve the error messages for unknown and missing target names
-  in target attributes.
+- Improve the error messages for unknown and missing target names in target
+  attributes.
   ([Alexander Keleschovsky](https://github.com/AlecGhost))
 
 - Fixed a bug where a temporarily moved or removed file does not get recompiled,
@@ -90,9 +90,54 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-
 - Compilation of binary operators is now fault tolerant and won't stop at the
   first type error.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The compiler now provides a better error message when using the wrong operator
+  to try and join two strings together. For example:
+
+  ```txt
+  error: Type mismatch
+    ┌─ /src/wibble.gleam:2:13
+    │
+  2 │   "Hello, " + "Lucy"
+    │             ^ Use <> instead
+
+  The + operator can only be used on Ints.
+  To join two strings together you can use the <> operator.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The compiler now provides a better error message when using an Int operator on
+  Float values, suggesting the correct replacement. For example:
+
+  ```txt
+  error: Type mismatch
+    ┌─ /Users/giacomocavalieri/Desktop/prova/src/prova.gleam:2:7
+    │
+  2 │   1.0 + 2.0
+    │       ^ Use +. instead
+
+  The + operator can only be used on Ints.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The compiler now provides a better error message when using a Float operator
+  on Int values, suggesting the correct replacement. For example:
+
+  ```txt
+  error: Type mismatch
+    ┌─ /Users/giacomocavalieri/Desktop/prova/src/prova.gleam:2:5
+    │
+  2 │   1 >. 2
+    │     ^^ Use > instead
+
+  The >. operator can only be used on Floats.
+  ```
+
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 - The compiler no longer shows errors for a function's labels if the called
@@ -261,6 +306,67 @@
   ```gleam
   pub fn main() {
     1 + 2
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The language server now offers a code action to replace a Float operator used
+  on Int values with the correct operator. For example:
+
+  ```gleam
+  pub fn main() {
+    11 +. 1
+  //^^^^^^^ When hovering anywhere over here
+  }
+  ```
+
+  Triggering the code action would fix the compilation error by using the
+  correct Int operator:
+
+  ```gleam
+  pub fn main() {
+    11 + 1
+  }
+  ```
+
+  This also works the other way around:
+
+  ```gleam
+  pub fn main() {
+    1.1 + 10.0
+  //^^^^^^^^^^ If hovering anywhere over here
+  }
+  ```
+
+  Triggering the code action would replace the wrong operator with the correct
+  equivalent Float operator:
+
+  ```gleam
+  pub fn main() {
+    1.1 +. 10.0
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- If there's a compilation error because two strings are being joined with the
+  wrong `+` operator (instead of using `<>`), the language server now offers a
+  code action to fix the error automatically. For example:
+
+  ```gleam
+  pub fn main() {
+    "Hello, " + "Jak"
+  //^^^^^^^^^^^^^^^^^ When hovering anywhere over here
+  }
+  ```
+
+  Triggering the code action would fix the compilation error by using the
+  correct `<>` operator instead of `+`:
+
+  ```gleam
+  pub fn main() {
+    "Hello, " <> "Jak"
   }
   ```
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1249,6 +1249,90 @@ impl BinOp {
     pub fn can_be_grouped_with(&self, other: &BinOp) -> bool {
         self.operator_kind() == other.operator_kind()
     }
+
+    pub(crate) fn is_float_operator(&self) -> bool {
+        match self {
+            BinOp::LtFloat
+            | BinOp::LtEqFloat
+            | BinOp::GtEqFloat
+            | BinOp::GtFloat
+            | BinOp::AddFloat
+            | BinOp::SubFloat
+            | BinOp::MultFloat
+            | BinOp::DivFloat => true,
+
+            BinOp::And
+            | BinOp::Or
+            | BinOp::Eq
+            | BinOp::NotEq
+            | BinOp::LtInt
+            | BinOp::LtEqInt
+            | BinOp::GtEqInt
+            | BinOp::GtInt
+            | BinOp::AddInt
+            | BinOp::SubInt
+            | BinOp::MultInt
+            | BinOp::DivInt
+            | BinOp::RemainderInt
+            | BinOp::Concatenate => false,
+        }
+    }
+
+    pub(crate) fn is_int_operator(&self) -> bool {
+        match self {
+            BinOp::LtInt
+            | BinOp::LtEqInt
+            | BinOp::GtEqInt
+            | BinOp::GtInt
+            | BinOp::AddInt
+            | BinOp::SubInt
+            | BinOp::MultInt
+            | BinOp::DivInt
+            | BinOp::RemainderInt => true,
+
+            BinOp::And
+            | BinOp::Or
+            | BinOp::Eq
+            | BinOp::NotEq
+            | BinOp::LtFloat
+            | BinOp::LtEqFloat
+            | BinOp::GtEqFloat
+            | BinOp::GtFloat
+            | BinOp::AddFloat
+            | BinOp::SubFloat
+            | BinOp::MultFloat
+            | BinOp::DivFloat
+            | BinOp::Concatenate => false,
+        }
+    }
+
+    pub fn float_equivalent(&self) -> Option<BinOp> {
+        match self {
+            BinOp::LtInt => Some(BinOp::LtFloat),
+            BinOp::LtEqInt => Some(BinOp::LtEqFloat),
+            BinOp::GtEqInt => Some(BinOp::GtEqFloat),
+            BinOp::GtInt => Some(BinOp::GtFloat),
+            BinOp::AddInt => Some(BinOp::AddFloat),
+            BinOp::SubInt => Some(BinOp::SubFloat),
+            BinOp::MultInt => Some(BinOp::MultFloat),
+            BinOp::DivInt => Some(BinOp::DivFloat),
+            _ => None,
+        }
+    }
+
+    pub fn int_equivalent(&self) -> Option<BinOp> {
+        match self {
+            BinOp::LtFloat => Some(BinOp::LtInt),
+            BinOp::LtEqFloat => Some(BinOp::LtEqInt),
+            BinOp::GtEqFloat => Some(BinOp::GtEqInt),
+            BinOp::GtFloat => Some(BinOp::GtInt),
+            BinOp::AddFloat => Some(BinOp::AddInt),
+            BinOp::SubFloat => Some(BinOp::SubInt),
+            BinOp::MultFloat => Some(BinOp::MultInt),
+            BinOp::DivFloat => Some(BinOp::DivInt),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -77,6 +77,7 @@ pub enum TypedExpr {
         location: SrcSpan,
         type_: Arc<Type>,
         name: BinOp,
+        name_location: SrcSpan,
         left: Box<Self>,
         right: Box<Self>,
     },

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -58,6 +58,7 @@ pub enum UntypedExpr {
     BinOp {
         location: SrcSpan,
         name: BinOp,
+        name_location: SrcSpan,
         left: Box<Self>,
         right: Box<Self>,
     },

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -194,10 +194,11 @@ pub trait Visit<'ast> {
         location: &'ast SrcSpan,
         type_: &'ast Arc<Type>,
         name: &'ast BinOp,
+        name_location: &'ast SrcSpan,
         left: &'ast TypedExpr,
         right: &'ast TypedExpr,
     ) {
-        visit_typed_expr_bin_op(self, location, type_, name, left, right);
+        visit_typed_expr_bin_op(self, location, type_, name, name_location, left, right);
     }
 
     fn visit_typed_expr_case(
@@ -760,9 +761,10 @@ where
             location,
             type_,
             name,
+            name_location,
             left,
             right,
-        } => v.visit_typed_expr_bin_op(location, type_, name, left, right),
+        } => v.visit_typed_expr_bin_op(location, type_, name, name_location, left, right),
         TypedExpr::Case {
             location,
             type_,
@@ -973,6 +975,7 @@ pub fn visit_typed_expr_bin_op<'a, V>(
     _location: &'a SrcSpan,
     _type_: &'a Arc<Type>,
     _name: &'a BinOp,
+    _name_location: &'a SrcSpan,
     left: &'a TypedExpr,
     right: &'a TypedExpr,
 ) where

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -291,9 +291,10 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             UntypedExpr::BinOp {
                 location,
                 name,
+                name_location,
                 left,
                 right,
-            } => self.fold_bin_op(location, name, left, right),
+            } => self.fold_bin_op(location, name, name_location, left, right),
 
             UntypedExpr::PipeLine { expressions } => self.fold_pipe_line(expressions),
 
@@ -454,6 +455,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
             UntypedExpr::BinOp {
                 location,
                 name,
+                name_location,
                 left,
                 right,
             } => {
@@ -462,6 +464,7 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
                 UntypedExpr::BinOp {
                     location,
                     name,
+                    name_location,
                     left,
                     right,
                 }
@@ -751,12 +754,14 @@ pub trait UntypedExprFolder: TypeAstFolder + UntypedConstantFolder + PatternFold
         &mut self,
         location: SrcSpan,
         name: BinOp,
+        name_location: SrcSpan,
         left: Box<UntypedExpr>,
         right: Box<UntypedExpr>,
     ) -> UntypedExpr {
         UntypedExpr::BinOp {
             location,
             name,
+            name_location,
             left,
             right,
         }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3540,6 +3540,64 @@ Consider removing the deprecation attribute on the variant.");
                         extra_labels: vec![],
                     }),
                 },
+
+                TypeError::StringConcatenationWithAddInt { location } => Diagnostic {
+                    title: "Type mismatch".to_string(),
+                    text: wrap("The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    String\n"),
+                    hint: None,
+                    level: Level::Error,
+                    location: Some(Location {
+                        label: Label {
+                            text: Some("Use the `<>` operator to concatenate two strings".into()),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
+
+                TypeError::IntOperatorOnFloats { location, operator } => Diagnostic {
+                    title: "Type mismatch".to_string(),
+                    text: wrap_format!("The {} operator can only be used on Ints.", operator.name()),
+                    hint: None,
+                    level: Level::Error,
+                    location: Some(Location {
+                        label: Label {
+                            text: operator.float_equivalent().map(|operator|
+                                format!("Use `{}` instead", operator.name())
+                            ),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
+
+                TypeError::FloatOperatorOnInts { location, operator } => Diagnostic {
+                    title: "Type mismatch".to_string(),
+                    text: wrap_format!("The {} operator can only be used on Floats.", operator.name()),
+                    hint: None,
+                    level: Level::Error,
+                    location: Some(Location {
+                        label: Label {
+                            text: operator.int_equivalent().map(|operator|
+                                format!("Use `{}` instead", operator.name())
+                            ),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
             }
         }).collect_vec(),
 
@@ -4120,10 +4178,7 @@ fn hint_numeric_message(alt: &str, type_: &str) -> String {
 }
 
 fn hint_string_message() -> String {
-    wrap(
-        "Strings can be joined using the `append` or `concat` \
-functions from the `gleam/string` module.",
-    )
+    wrap("Strings can be joined using the `<>` operator.")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3543,18 +3543,12 @@ Consider removing the deprecation attribute on the variant.");
 
                 TypeError::StringConcatenationWithAddInt { location } => Diagnostic {
                     title: "Type mismatch".to_string(),
-                    text: wrap("The + operator expects arguments of this type:
-
-    Int
-
-But this argument has this type:
-
-    String\n"),
+                    text: wrap("The + operator can only be used on Ints."),
                     hint: None,
                     level: Level::Error,
                     location: Some(Location {
                         label: Label {
-                            text: Some("Use the `<>` operator to concatenate two strings".into()),
+                            text: Some("Use <> instead".into()),
                             span: *location,
                         },
                         path: path.clone(),
@@ -3571,7 +3565,7 @@ But this argument has this type:
                     location: Some(Location {
                         label: Label {
                             text: operator.float_equivalent().map(|operator|
-                                format!("Use `{}` instead", operator.name())
+                                format!("Use {} instead", operator.name())
                             ),
                             span: *location,
                         },
@@ -3589,7 +3583,7 @@ But this argument has this type:
                     location: Some(Location {
                         label: Label {
                             text: operator.int_equivalent().map(|operator|
-                                format!("Use `{}` instead", operator.name())
+                                format!("Use {} instead", operator.name())
                             ),
                             span: *location,
                         },

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3543,7 +3543,8 @@ Consider removing the deprecation attribute on the variant.");
 
                 TypeError::StringConcatenationWithAddInt { location } => Diagnostic {
                     title: "Type mismatch".to_string(),
-                    text: wrap("The + operator can only be used on Ints."),
+                    text: wrap("The + operator can only be used on Ints.
+To join two strings together you can use the <> operator."),
                     hint: None,
                     level: Level::Error,
                     location: Some(Location {

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -36,8 +36,8 @@ use super::{
     code_action::{
         AddAnnotations, CodeActionBuilder, ConvertFromUse, ConvertToFunctionCall, ConvertToPipe,
         ConvertToUse, ExpandFunctionCapture, ExtractConstant, ExtractVariable,
-        FillInMissingLabelledArgs, FillUnusedFields, GenerateDynamicDecoder, GenerateFunction,
-        GenerateJsonEncoder, InlineVariable, InterpolateString, LetAssertToCase,
+        FillInMissingLabelledArgs, FillUnusedFields, FixBinaryOperation, GenerateDynamicDecoder,
+        GenerateFunction, GenerateJsonEncoder, InlineVariable, InterpolateString, LetAssertToCase,
         PatternMatchOnValue, RedundantTupleInCaseSubject, RemoveEchos, UseLabelShorthandSyntax,
         WrapInBlock, code_action_add_missing_patterns,
         code_action_convert_qualified_constructor_to_unqualified,
@@ -380,6 +380,7 @@ where
                 &this.error,
                 &mut actions,
             );
+            actions.extend(FixBinaryOperation::new(module, &lines, &params).code_actions());
             actions.extend(LetAssertToCase::new(module, &lines, &params).code_actions());
             actions
                 .extend(RedundantTupleInCaseSubject::new(module, &lines, &params).code_actions());

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -7517,3 +7517,107 @@ pub fn main() {
         find_position_of("print").nth_occurrence(2).to_selection()
     );
 }
+
+#[test]
+fn fix_float_operator_on_ints() {
+    let name = "Use `>=`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  1 >=. 2
+}
+"#,
+        find_position_of("1").to_selection()
+    );
+}
+
+#[test]
+fn fix_float_operator_on_ints_2() {
+    let name = "Use `-`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  1 -. 2
+}
+"#,
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
+fn fix_float_operator_on_ints_3() {
+    let name = "Use `*`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  1 *. wobble()
+}
+
+fn wobble() { 3 }
+"#,
+        find_position_of("*.").to_selection()
+    );
+}
+
+#[test]
+fn fix_int_operator_on_floats() {
+    let name = "Use `>=.`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  1.0 >= 2.3
+}
+"#,
+        find_position_of("1").to_selection()
+    );
+}
+
+#[test]
+fn fix_int_operator_on_floats_2() {
+    let name = "Use `-.`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  1.12 - 2.0
+}
+"#,
+        find_position_of("1").select_until(find_position_of("2.0"))
+    );
+}
+
+#[test]
+fn fix_int_operator_on_floats_3() {
+    let name = "Use `*.`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  1.3 * wobble()
+}
+
+fn wobble() { 3.2 }
+"#,
+        find_position_of("*").to_selection()
+    );
+}
+
+#[test]
+fn fix_plus_operator_on_strings() {
+    let name = "Use `<>`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  "hello, " + name()
+}
+
+fn name() { "Jak" }
+"#,
+        find_position_of("hello").select_until(find_position_of("name()"))
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_float_operator_on_ints.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_float_operator_on_ints.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1 >=. 2\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1 >=. 2
+  ↑      
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1 >= 2
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_float_operator_on_ints_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_float_operator_on_ints_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1 -. 2\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1 -. 2
+  ▔▔▔▔▔↑
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1 - 2
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_float_operator_on_ints_3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_float_operator_on_ints_3.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1 *. wobble()\n}\n\nfn wobble() { 3 }\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1 *. wobble()
+    ↑          
+}
+
+fn wobble() { 3 }
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1 * wobble()
+}
+
+fn wobble() { 3 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_int_operator_on_floats.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_int_operator_on_floats.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1.0 >= 2.3\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1.0 >= 2.3
+  ↑         
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1.0 >=. 2.3
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_int_operator_on_floats_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_int_operator_on_floats_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1.12 - 2.0\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1.12 - 2.0
+  ▔▔▔▔▔▔▔↑  
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1.12 -. 2.0
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_int_operator_on_floats_3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_int_operator_on_floats_3.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  1.3 * wobble()\n}\n\nfn wobble() { 3.2 }\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1.3 * wobble()
+      ↑         
+}
+
+fn wobble() { 3.2 }
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1.3 *. wobble()
+}
+
+fn wobble() { 3.2 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_plus_operator_on_strings.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_plus_operator_on_strings.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  \"hello, \" + name()\n}\n\nfn name() { \"Jak\" }\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  "hello, " + name()
+   ▔▔▔▔▔▔▔▔▔▔▔↑     
+}
+
+fn name() { "Jak" }
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  "hello, " <> name()
+}
+
+fn name() { "Jak" }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3978,7 +3978,11 @@ fn do_reduce_clause_guard(op: Spanned, estack: &mut Vec<UntypedClauseGuard>) {
     }
 }
 
-fn expr_op_reduction((_, token, _): Spanned, l: UntypedExpr, r: UntypedExpr) -> UntypedExpr {
+fn expr_op_reduction(
+    (token_start, token, token_end): Spanned,
+    l: UntypedExpr,
+    r: UntypedExpr,
+) -> UntypedExpr {
     if token == Token::Pipe {
         let expressions = match l {
             UntypedExpr::PipeLine { mut expressions } => {
@@ -3998,6 +4002,10 @@ fn expr_op_reduction((_, token, _): Spanned, l: UntypedExpr, r: UntypedExpr) -> 
                     end: r.location().end,
                 },
                 name: bin_op,
+                name_location: SrcSpan {
+                    start: token_start,
+                    end: token_end,
+                },
                 left: Box::new(l),
                 right: Box::new(r),
             },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__echo_has_lower_precedence_than_binop.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__echo_has_lower_precedence_than_binop.snap
@@ -16,6 +16,10 @@ expression: echo 1 + 1
                         end: 10,
                     },
                     name: AddInt,
+                    name_location: SrcSpan {
+                        start: 7,
+                        end: 8,
+                    },
                     left: Int {
                         location: SrcSpan {
                             start: 5,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__echo_with_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__echo_with_block.snap
@@ -23,6 +23,10 @@ expression: "echo { 1 + 1 }"
                                     end: 12,
                                 },
                                 name: AddInt,
+                                name_location: SrcSpan {
+                                    start: 9,
+                                    end: 10,
+                                },
                                 left: Int {
                                     location: SrcSpan {
                                         start: 7,

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -599,6 +599,35 @@ pub enum Error {
     EchoWithNoFollowingExpression {
         location: SrcSpan,
     },
+    /// When someone tries concatenating two string values using the `+` operator.
+    ///
+    /// ```gleam
+    /// "aaa" + "bbb"
+    /// //    ^ We wont to suggest using `<>` instead!
+    /// ```
+    StringConcatenationWithAddInt {
+        location: SrcSpan,
+    },
+    /// When someone tries using an int operator on two floats.
+    ///
+    /// ```gleam
+    /// 1 +. 3
+    /// //^ We wont to suggest using `+` instead!
+    /// ```
+    FloatOperatorOnInts {
+        operator: BinOp,
+        location: SrcSpan,
+    },
+    /// When someone tries using an int operator on two floats.
+    ///
+    /// ```gleam
+    /// 1.2 + 1.0
+    /// //  ^ We wont to suggest using `+.` instead!
+    /// ```
+    IntOperatorOnFloats {
+        operator: BinOp,
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1072,7 +1101,10 @@ impl Error {
             | Error::AllVariantsDeprecated { location }
             | Error::EchoWithNoFollowingExpression { location }
             | Error::DeprecatedVariantOnDeprecatedType { location }
-            | Error::ErlangFloatUnsafe { location } => location.start,
+            | Error::ErlangFloatUnsafe { location }
+            | Error::FloatOperatorOnInts { location, .. }
+            | Error::IntOperatorOnFloats { location, .. }
+            | Error::StringConcatenationWithAddInt { location } => location.start,
 
             Error::UnknownLabels { unknown, .. } => {
                 unknown.iter().map(|(_, s)| s.start).min().unwrap_or(0)

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1422,6 +1422,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 return TypedExpr::BinOp {
                     location,
                     name,
+                    name_location,
                     type_: bool(),
                     left: Box::new(left),
                     right: Box::new(right),
@@ -1495,6 +1496,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         TypedExpr::BinOp {
             location,
             name,
+            name_location,
             type_: output_type,
             left: Box::new(left),
             right: Box::new(right),

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2991,3 +2991,28 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn float_operator_on_ints() {
+    assert_error!("1 +. 2");
+}
+
+#[test]
+fn float_operator_on_ints_2() {
+    assert_error!("1 <. 2");
+}
+
+#[test]
+fn int_operator_on_floats() {
+    assert_error!("1.1 + 2.0");
+}
+
+#[test]
+fn int_operator_on_floats_2() {
+    assert_error!("1.1 > 2.0");
+}
+
+#[test]
+fn add_on_strings() {
+    assert_error!(r#""Hello, " + "Jak""#);
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__add_on_strings.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__add_on_strings.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\"Hello, \" + \"Jak\""
+---
+----- SOURCE CODE
+"Hello, " + "Jak"
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:1:11
+  │
+1 │ "Hello, " + "Jak"
+  │           ^ Use <> instead
+
+The + operator can only be used on Ints.
+To join two strings together you can use the <> operator.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: 1 +. 2
+---
+----- SOURCE CODE
+1 +. 2
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:1:3
+  │
+1 │ 1 +. 2
+  │   ^^ Use + instead
+
+The +. operator can only be used on Floats.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints_2.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: 1 <. 2
+---
+----- SOURCE CODE
+1 <. 2
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:1:3
+  │
+1 │ 1 <. 2
+  │   ^^ Use < instead
+
+The <. operator can only be used on Floats.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: 1.1 + 2.0
+---
+----- SOURCE CODE
+1.1 + 2.0
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:1:5
+  │
+1 │ 1.1 + 2.0
+  │     ^ Use +. instead
+
+The + operator can only be used on Ints.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats_2.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: 1.1 > 2.0
+---
+----- SOURCE CODE
+1.1 > 2.0
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:1:5
+  │
+1 │ 1.1 > 2.0
+  │     ^ Use >. instead
+
+The > operator can only be used on Ints.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__bad_body_function_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__bad_body_function_fault_tolerance.snap
@@ -44,16 +44,9 @@ error: Type mismatch
   ┌─ /src/one/two.gleam:4:6
   │
 4 │   "" + ""
-  │      ^ Use the `<>` operator to concatenate two strings
+  │      ^ Use <> instead
 
-The + operator expects arguments of this type:
-
-    Int
-
-But this argument has this type:
-
-    String
-
+The + operator can only be used on Ints.
 
 error: Type mismatch
    ┌─ /src/one/two.gleam:16:7

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__bad_body_function_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__bad_body_function_fault_tolerance.snap
@@ -47,6 +47,7 @@ error: Type mismatch
   │      ^ Use <> instead
 
 The + operator can only be used on Ints.
+To join two strings together you can use the <> operator.
 
 error: Type mismatch
    ┌─ /src/one/two.gleam:16:7

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__bad_body_function_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__bad_body_function_fault_tolerance.snap
@@ -27,23 +27,6 @@ error: Type mismatch
   ┌─ /src/one/two.gleam:4:3
   │
 4 │   "" + ""
-  │   ^^
-
-The + operator expects arguments of this type:
-
-    Int
-
-But this argument has this type:
-
-    String
-
-Hint: Strings can be joined using the `append` or `concat` functions from the
-`gleam/string` module.
-
-error: Type mismatch
-  ┌─ /src/one/two.gleam:4:3
-  │
-4 │   "" + ""
   │   ^^^^^^^
 
 The type of this returned value doesn't match the return type
@@ -58,10 +41,10 @@ Found type:
     Int
 
 error: Type mismatch
-  ┌─ /src/one/two.gleam:4:8
+  ┌─ /src/one/two.gleam:4:6
   │
 4 │   "" + ""
-  │        ^^
+  │      ^ Use the `<>` operator to concatenate two strings
 
 The + operator expects arguments of this type:
 
@@ -71,8 +54,6 @@ But this argument has this type:
 
     String
 
-Hint: Strings can be joined using the `append` or `concat` functions from the
-`gleam/string` module.
 
 error: Type mismatch
    ┌─ /src/one/two.gleam:16:7

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
@@ -22,7 +22,7 @@ error: Type mismatch
   ┌─ /src/one/two.gleam:6:11
   │
 6 │       1.0 + 1.0
-  │           ^ Use `+.` instead
+  │           ^ Use +. instead
 
 The + operator can only be used on Ints.
 
@@ -30,6 +30,6 @@ error: Type mismatch
   ┌─ /src/one/two.gleam:9:11
   │
 9 │       1.0 + 1.0
-  │           ^ Use `+.` instead
+  │           ^ Use +. instead
 
 The + operator can only be used on Ints.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
@@ -19,68 +19,17 @@ pub fn main() {
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:6:7
+  ┌─ /src/one/two.gleam:6:11
   │
 6 │       1.0 + 1.0
-  │       ^^^
+  │           ^ Use `+.` instead
 
-The + operator expects arguments of this type:
-
-    Int
-
-But this argument has this type:
-
-    Float
-
-Hint: the +. operator can be used with Floats
-
+The + operator can only be used on Ints.
 
 error: Type mismatch
-  ┌─ /src/one/two.gleam:6:13
-  │
-6 │       1.0 + 1.0
-  │             ^^^
-
-The + operator expects arguments of this type:
-
-    Int
-
-But this argument has this type:
-
-    Float
-
-Hint: the +. operator can be used with Floats
-
-
-error: Type mismatch
-  ┌─ /src/one/two.gleam:9:7
+  ┌─ /src/one/two.gleam:9:11
   │
 9 │       1.0 + 1.0
-  │       ^^^
+  │           ^ Use `+.` instead
 
-The + operator expects arguments of this type:
-
-    Int
-
-But this argument has this type:
-
-    Float
-
-Hint: the +. operator can be used with Floats
-
-
-error: Type mismatch
-  ┌─ /src/one/two.gleam:9:13
-  │
-9 │       1.0 + 1.0
-  │             ^^^
-
-The + operator expects arguments of this type:
-
-    Int
-
-But this argument has this type:
-
-    Float
-
-Hint: the +. operator can be used with Floats
+The + operator can only be used on Ints.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_annotation_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_annotation_fault_tolerance.snap
@@ -54,5 +54,4 @@ But this argument has this type:
 
     String
 
-Hint: Strings can be joined using the `append` or `concat` functions from the
-`gleam/string` module.
+Hint: Strings can be joined using the `<>` operator.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_two_args_type_to_fn_wrong_types.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__provide_two_args_type_to_fn_wrong_types.snap
@@ -26,5 +26,4 @@ But this argument has this type:
 
     String
 
-Hint: Strings can be joined using the `append` or `concat` functions from the
-`gleam/string` module.
+Hint: Strings can be joined using the `<>` operator.


### PR DESCRIPTION
This PR closes #4431, closes #4434 and closes #4435

So now it has better errors if:
- using an int operator on floats
- using a float operator on ints
- using + on strings

And each of this errors also has a code action to automatically fix it!