### PR TITLE
Only show completions for prelude items when not in a module qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,10 @@
   code when the piped argument was a binary operation.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where prelude types and values would be suggested in autocomplete
+  when part of a module select.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.9.1 - 2025-03-10
 
 ### Formatter

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -402,22 +402,10 @@ where
 
         let (insert_range, module_select) = surrounding_completion;
 
-        // Prelude types
-        for type_ in PreludeType::iter() {
-            let label: String = type_.name().into();
-            let sort_text = Some(sort_text(CompletionKind::Prelude, &label));
-            completions.push(CompletionItem {
-                label,
-                detail: Some("Type".into()),
-                kind: Some(CompletionItemKind::CLASS),
-                sort_text,
-                ..Default::default()
-            });
-        }
-
-        // Module types
+        // Module and prelude types
         // Do not complete direct module types if the user has already started typing a module select.
-        // e.x. when the user has typed mymodule.| we know local module types are no longer relevant
+        // e.x. when the user has typed mymodule.| we know local module types and prelude types are no
+        // longer relevant.
         if module_select.is_none() {
             for (name, type_) in &self.module.ast.type_info.types {
                 completions.push(type_completion(
@@ -428,6 +416,18 @@ where
                     TypeCompletionForm::Default,
                     CompletionKind::LocallyDefined,
                 ));
+            }
+
+            for type_ in PreludeType::iter() {
+                let label: String = type_.name().into();
+                let sort_text = Some(sort_text(CompletionKind::Prelude, &label));
+                completions.push(CompletionItem {
+                    label,
+                    detail: Some("Type".into()),
+                    kind: Some(CompletionItemKind::CLASS),
+                    sort_text,
+                    ..Default::default()
+                });
             }
         }
 
@@ -549,44 +549,10 @@ where
 
         let (insert_range, module_select) = surrounding_completion;
 
-        let mut push_prelude_completion = |label: &str, kind| {
-            let label = label.to_string();
-            let sort_text = Some(sort_text(CompletionKind::Prelude, &label));
-            completions.push(CompletionItem {
-                label,
-                detail: Some(PRELUDE_MODULE_NAME.into()),
-                kind: Some(kind),
-                sort_text,
-                ..Default::default()
-            });
-        };
-
-        // Prelude values
-        for type_ in PreludeType::iter() {
-            match type_ {
-                PreludeType::Bool => {
-                    push_prelude_completion("True", CompletionItemKind::ENUM_MEMBER);
-                    push_prelude_completion("False", CompletionItemKind::ENUM_MEMBER);
-                }
-                PreludeType::Nil => {
-                    push_prelude_completion("Nil", CompletionItemKind::ENUM_MEMBER);
-                }
-                PreludeType::Result => {
-                    push_prelude_completion("Ok", CompletionItemKind::CONSTRUCTOR);
-                    push_prelude_completion("Error", CompletionItemKind::CONSTRUCTOR);
-                }
-                PreludeType::BitArray
-                | PreludeType::Float
-                | PreludeType::Int
-                | PreludeType::List
-                | PreludeType::String
-                | PreludeType::UtfCodepoint => {}
-            }
-        }
-
-        // Module values
+        // Module and prelude values
         // Do not complete direct module values if the user has already started typing a module select.
-        // e.x. when the user has typed mymodule.| we know local module values are no longer relevant
+        // e.x. when the user has typed mymodule.| we know local module and prelude values are no longer
+        // relevant.
         if module_select.is_none() {
             let cursor = self
                 .src_line_numbers
@@ -615,6 +581,40 @@ where
                     insert_range,
                     CompletionKind::LocallyDefined,
                 ));
+            }
+
+            let mut push_prelude_completion = |label: &str, kind| {
+                let label = label.to_string();
+                let sort_text = Some(sort_text(CompletionKind::Prelude, &label));
+                completions.push(CompletionItem {
+                    label,
+                    detail: Some(PRELUDE_MODULE_NAME.into()),
+                    kind: Some(kind),
+                    sort_text,
+                    ..Default::default()
+                });
+            };
+
+            for type_ in PreludeType::iter() {
+                match type_ {
+                    PreludeType::Bool => {
+                        push_prelude_completion("True", CompletionItemKind::ENUM_MEMBER);
+                        push_prelude_completion("False", CompletionItemKind::ENUM_MEMBER);
+                    }
+                    PreludeType::Nil => {
+                        push_prelude_completion("Nil", CompletionItemKind::ENUM_MEMBER);
+                    }
+                    PreludeType::Result => {
+                        push_prelude_completion("Ok", CompletionItemKind::CONSTRUCTOR);
+                        push_prelude_completion("Error", CompletionItemKind::CONSTRUCTOR);
+                    }
+                    PreludeType::BitArray
+                    | PreludeType::Float
+                    | PreludeType::Int
+                    | PreludeType::List
+                    | PreludeType::String
+                    | PreludeType::UtfCodepoint => {}
+                }
             }
         }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_private_record_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_private_record_access.snap
@@ -14,26 +14,6 @@ fn fun() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_True
 wibble
   kind:   Field
   detail: Int

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access.snap
@@ -14,26 +14,6 @@ fn fun() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_True
 wibble
   kind:   Field
   detail: Int

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access_known_variant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access_known_variant.snap
@@ -16,26 +16,6 @@ fn fun(some_wibble: Wibble) {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_True
 a
   kind:   Field
   detail: Int

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access_unknown_variant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__completions_for_record_access_unknown_variant.snap
@@ -13,26 +13,6 @@ fn fun(some_wibble: Wibble) {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   4_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   4_True
 a
   kind:   Field
   detail: Int

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_after_dot.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_after_dot.snap
@@ -12,42 +12,6 @@ pub fn wibble(
 
 
 ----- Completion content -----
-BitArray
-  kind:   Class
-  detail: Type
-  sort:   4_BitArray
-Bool
-  kind:   Class
-  detail: Type
-  sort:   4_Bool
-Float
-  kind:   Class
-  detail: Type
-  sort:   4_Float
-Int
-  kind:   Class
-  detail: Type
-  sort:   4_Int
-List
-  kind:   Class
-  detail: Type
-  sort:   4_List
-Nil
-  kind:   Class
-  detail: Type
-  sort:   4_Nil
-Result
-  kind:   Class
-  detail: Type
-  sort:   4_Result
-String
-  kind:   Class
-  detail: Type
-  sort:   4_String
-UtfCodepoint
-  kind:   Class
-  detail: Type
-  sort:   4_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_after_dot_other_matching_modules.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_after_dot_other_matching_modules.snap
@@ -13,42 +13,6 @@ pub fn wibble(
 
 
 ----- Completion content -----
-BitArray
-  kind:   Class
-  detail: Type
-  sort:   4_BitArray
-Bool
-  kind:   Class
-  detail: Type
-  sort:   4_Bool
-Float
-  kind:   Class
-  detail: Type
-  sort:   4_Float
-Int
-  kind:   Class
-  detail: Type
-  sort:   4_Int
-List
-  kind:   Class
-  detail: Type
-  sort:   4_List
-Nil
-  kind:   Class
-  detail: Type
-  sort:   4_Nil
-Result
-  kind:   Class
-  detail: Type
-  sort:   4_Result
-String
-  kind:   Class
-  detail: Type
-  sort:   4_String
-UtfCodepoint
-  kind:   Class
-  detail: Type
-  sort:   4_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_after_dot_other_modules.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_after_dot_other_modules.snap
@@ -12,42 +12,6 @@ pub fn wibble(
 
 
 ----- Completion content -----
-BitArray
-  kind:   Class
-  detail: Type
-  sort:   4_BitArray
-Bool
-  kind:   Class
-  detail: Type
-  sort:   4_Bool
-Float
-  kind:   Class
-  detail: Type
-  sort:   4_Float
-Int
-  kind:   Class
-  detail: Type
-  sort:   4_Int
-List
-  kind:   Class
-  detail: Type
-  sort:   4_List
-Nil
-  kind:   Class
-  detail: Type
-  sort:   4_Nil
-Result
-  kind:   Class
-  detail: Type
-  sort:   4_Result
-String
-  kind:   Class
-  detail: Type
-  sort:   4_String
-UtfCodepoint
-  kind:   Class
-  detail: Type
-  sort:   4_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_mid_phrase_other_modules.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__imported_type_cursor_mid_phrase_other_modules.snap
@@ -12,42 +12,6 @@ pub fn wibble(
 
 
 ----- Completion content -----
-BitArray
-  kind:   Class
-  detail: Type
-  sort:   4_BitArray
-Bool
-  kind:   Class
-  detail: Type
-  sort:   4_Bool
-Float
-  kind:   Class
-  detail: Type
-  sort:   4_Float
-Int
-  kind:   Class
-  detail: Type
-  sort:   4_Int
-List
-  kind:   Class
-  detail: Type
-  sort:   4_List
-Nil
-  kind:   Class
-  detail: Type
-  sort:   4_Nil
-Result
-  kind:   Class
-  detail: Type
-  sort:   4_Result
-String
-  kind:   Class
-  detail: Type
-  sort:   4_String
-UtfCodepoint
-  kind:   Class
-  detail: Type
-  sort:   4_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type


### PR DESCRIPTION
I noticed that when the LSP provides autocomplete for types and values after a module select, e.g.
```gleam
pub fn main() {
  let x = option.|
}
```
It was including completions for prelude values, like `Ok`, which would not be valid after `option.`
This PR fixes that behaviour