### PR TITLE
Fix bug with checking of top-level modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -487,6 +487,10 @@ jobs:
         run: ./test.sh
         working-directory: ./test/multi_namespace
 
+      - name: Test multi namespace bug
+        run: ./test.sh
+        working-directory: ./test/multi_namespace_not_top_level
+
       - name: Test FFI in subdirectories
         run: make
         working-directory: ./test/subdir_ffi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,10 @@
   when part of a module select.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where the check for multiple top-level modules when publishing
+  would incorrectly print a warning.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.9.1 - 2025-03-10
 
 ### Formatter

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -157,7 +157,14 @@ fn check_for_multiple_top_level_modules(package: &Package, i_am_sure: bool) -> R
     let mut top_level_module_names = package
         .modules
         .iter()
-        .filter_map(|module| module.name.split('/').next())
+        .filter_map(|module| {
+            // Top-level modules are those that don't contain any path separators
+            if module.name.contains('/') {
+                None
+            } else {
+                Some(module.name.clone())
+            }
+        })
         .collect::<Vec<_>>();
 
     // Remove duplicates

--- a/test/multi_namespace_not_top_level/.gitignore
+++ b/test/multi_namespace_not_top_level/.gitignore
@@ -1,0 +1,4 @@
+*.beam
+*.ez
+build
+manifest.toml

--- a/test/multi_namespace_not_top_level/gleam.toml
+++ b/test/multi_namespace_not_top_level/gleam.toml
@@ -1,0 +1,4 @@
+name = "multi_namespace"
+version = "1.0.0"
+description = "Test project for multi namespace"
+licences = ["Apache-2.0"]

--- a/test/multi_namespace_not_top_level/src/module1/sub.gleam
+++ b/test/multi_namespace_not_top_level/src/module1/sub.gleam
@@ -1,0 +1,3 @@
+pub fn main() {
+  "Hello from multi_namespace!"
+}

--- a/test/multi_namespace_not_top_level/src/module2/sub.gleam
+++ b/test/multi_namespace_not_top_level/src/module2/sub.gleam
@@ -1,0 +1,3 @@
+pub fn main() {
+  "Hello from second!"
+}

--- a/test/multi_namespace_not_top_level/test.sh
+++ b/test/multi_namespace_not_top_level/test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# https://github.com/gleam-lang/gleam/pull/4445
+
+set -eu
+
+GLEAM_COMMAND=${GLEAM_COMMAND:-"cargo run --quiet --"}
+
+g() {
+	echo "Running: $GLEAM_COMMAND $@"
+	$GLEAM_COMMAND "$@"
+}
+
+echo Resetting the build directory to get to a known state
+rm -fr build
+
+echo Running publish should not print the warning
+output=$(yes "n" | g publish)
+if echo "$output" | grep -q "Your package defines multiple top-level modules"; then
+    echo "Expected warning to be printed"
+    exit 1
+fi
+
+echo
+echo Success! 💖
+echo


### PR DESCRIPTION
It has been pointed out that there is a bug in the code for checking multiple top-level modules when publishing.
This PR fixes the bug, so that only top-level modules are checked for, and not top-level directories.