### PR TITLE
Store username in credentials file and improve key revocation error message

### DIFF
--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -99,7 +99,7 @@ pub(crate) fn authenticate() -> Result<()> {
     let previous = auth.read_stored_api_key()?;
 
     if previous.is_some() {
-        let question = "You already have a local Hex API token. Would you like to replace it
+        let question = "You already have a local Hex API key. Would you like to replace it
 with a new one?";
         if !cli::confirm(question)? {
             return Ok(());
@@ -109,13 +109,33 @@ with a new one?";
     let new_key = auth.create_and_store_api_key()?;
 
     if let Some(previous) = previous {
+        if previous.username != new_key.username {
+            if let Some(previous_username) = previous.username {
+                println!(
+                    "
+Your previous Hex API key was created with username `{}` which is different from the username
+used to create the new Hex API key. You have to delete the key `{}` manually at https://hex.pm",
+                    previous_username, previous.name
+                );
+                return Ok(());
+            }
+        }
+
         println!("Deleting previous key `{}` from Hex", previous.name);
-        runtime.block_on(hex::remove_api_key(
-            &previous.name,
-            &config,
-            &new_key.unencrypted,
-            &http,
-        ))?;
+        if runtime
+            .block_on(hex::remove_api_key(
+                &previous.name,
+                &config,
+                &new_key.unencrypted,
+                &http,
+            ))
+            .is_err()
+        {
+            println!(
+                "There was an error deleting key `{}` from Hex. You have to delete the key manually at https://hex.pm",
+                previous.name
+            );
+        };
     }
     Ok(())
 }

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -1,8 +1,10 @@
 use crate::{cli, fs::ConsoleWarningEmitter, http::HttpClient};
+use camino::Utf8Path;
 use gleam_core::{
     Error, Result, Warning, encryption, hex, paths::global_hexpm_credentials_path,
     warning::WarningEmitter,
 };
+use serde::{Deserialize, Serialize};
 use std::{rc::Rc, time::SystemTime};
 
 pub const USER_PROMPT: &str = "https://hex.pm username";
@@ -12,15 +14,17 @@ pub const LOCAL_PASS_PROMPT: &str = "Local password";
 pub const PASS_ENV_NAME: &str = "HEXPM_PASS";
 pub const API_ENV_NAME: &str = "HEXPM_API_KEY";
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedApiKey {
     pub name: String,
     pub encrypted: String,
+    pub username: Option<String>,
 }
 
 #[derive(Debug)]
 pub struct UnencryptedApiKey {
     pub unencrypted: String,
+    pub username: Option<String>,
 }
 
 pub struct HexAuthentication<'runtime> {
@@ -74,11 +78,18 @@ encrypt your Hex API key.
                 detail: e.to_string(),
             })?;
 
-        crate::fs::write(&path, &format!("{name}\n{encrypted}"))?;
+        let encrypted = EncryptedApiKey {
+            name,
+            encrypted,
+            username: Some(username.clone()),
+        };
+
+        encrypted.save(&path)?;
         println!("Encrypted Hex API key written to {path}");
 
         Ok(UnencryptedApiKey {
             unencrypted: api_key,
+            username: Some(username),
         })
     }
 
@@ -117,7 +128,12 @@ encrypt your Hex API key.
     }
 
     fn read_and_decrypt_stored_api_key(&mut self) -> Result<Option<UnencryptedApiKey>> {
-        let Some(EncryptedApiKey { encrypted, .. }) = self.read_stored_api_key()? else {
+        let Some(EncryptedApiKey {
+            encrypted,
+            username,
+            ..
+        }) = self.read_stored_api_key()?
+        else {
             return Ok(None);
         };
 
@@ -127,7 +143,10 @@ encrypt your Hex API key.
                 detail: e.to_string(),
             })?;
 
-        Ok(Some(UnencryptedApiKey { unencrypted }))
+        Ok(Some(UnencryptedApiKey {
+            unencrypted,
+            username,
+        }))
     }
 
     pub fn read_stored_api_key(&self) -> Result<Option<EncryptedApiKey>> {
@@ -135,18 +154,32 @@ encrypt your Hex API key.
         if !path.exists() {
             return Ok(None);
         }
-        let text = crate::fs::read(&path)?;
-        let mut chunks = text.splitn(2, '\n');
-        let Some(name) = chunks.next() else {
-            return Ok(None);
-        };
-        let Some(encrypted) = chunks.next() else {
-            return Ok(None);
-        };
-        Ok(Some(EncryptedApiKey {
-            name: name.to_string(),
-            encrypted: encrypted.to_string(),
-        }))
+
+        let encrypted_key = EncryptedApiKey::load(&path);
+
+        if let Ok(encrypted_key) = encrypted_key {
+            Ok(Some(encrypted_key))
+        } else {
+            // fallback from old format
+            let text = crate::fs::read(&path)?;
+            let mut chunks = text.splitn(2, '\n');
+            let Some(name) = chunks.next() else {
+                return Ok(None);
+            };
+            let Some(encrypted) = chunks.next() else {
+                return Ok(None);
+            };
+
+            let key = EncryptedApiKey {
+                name: name.to_string(),
+                encrypted: encrypted.to_string(),
+                username: None,
+            };
+
+            key.save(&path)?;
+
+            Ok(Some(key))
+        }
     }
 }
 
@@ -155,6 +188,25 @@ impl Drop for HexAuthentication<'_> {
         while let Some(warning) = self.warnings.pop() {
             self.warning_emitter.emit(warning);
         }
+    }
+}
+
+impl EncryptedApiKey {
+    pub fn save(&self, path: &Utf8Path) -> Result<()> {
+        let text = toml::to_string(self).map_err(|_| Error::InvalidCredentialsFile {
+            path: path.to_string(),
+        })?;
+        crate::fs::write(path, &text)?;
+        Ok(())
+    }
+
+    pub fn load(path: &Utf8Path) -> Result<Self> {
+        let text = crate::fs::read(path)?;
+        let key = toml::from_str(&text).map_err(|_| Error::InvalidCredentialsFile {
+            path: path.to_string(),
+        })?;
+
+        Ok(key)
     }
 }
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -321,6 +321,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
 
     #[error("Failed to decrypt local Hex API key")]
     FailedToDecryptLocalHexApiKey { detail: String },
+
+    #[error("Invalid Credentials file")]
+    InvalidCredentialsFile { path: String },
 }
 
 /// This is to make clippy happy and not make the error variant too big by
@@ -1484,6 +1487,18 @@ The error from the encryption library was:
                     hint: None,
                     level: Level::Error,
                     location: None,
+                }]
+            }
+
+            Error::InvalidCredentialsFile {path}=> {
+                let text = wrap_format!("Your credentials file at {path} is in the wrong format. Try deleting the file and authenticate again.");
+
+                vec![Diagnostic {
+                    title: "Invalid credentials file".into(),
+                    text,
+                    level: Level::Error,
+                    location: None,
+                    hint: None
                 }]
             }
 


### PR DESCRIPTION
resolves #4319 

Only try to revoke token if new and previous usernames match, otherwise hint the user to delete the token manually.

Summary of changes: 
- Store `username` in credentials file.
- Change credentials file format to TOML.
- Fallback to old format when TOML deserialization fails.

before:
```
% gleam hex authenticate

You already have a local Hex API token. Would you like to replace it
with a new one? [y/n]: y
https://hex.pm username: B
https://hex.pm password (will not be printed as you type): 

Please enter a new unique password. This will be used to locally
encrypt your Hex API key.

Local password (will not be printed as you type):
Encrypted Hex API key written to .../gleam/hex/hexpm/credentials
Deleting previous key `...` from Hex
error: Hex API failure

There was a problem when using the Hex API.

This was error from the Hex client library:

    an unexpected response was sent by Hex: 404 Not Found: {"message":"Page not found","status":404}
```

after: 
```
% gleam hex authenticate

You already have a local Hex API key. Would you like to replace it
with a new one? [y/n]: y
https://hex.pm username: B
https://hex.pm password (will not be printed as you type):

Please enter a new unique password. This will be used to locally
encrypt your Hex API key.

Local password (will not be printed as you type):
Encrypted Hex API key written to /Users/samu/Library/Caches/gleam/hex/hexpm/credentials

Your previous Hex API key was created with username `A` which is different from the username
used to create the new Hex API key. You have to delete the key `Mac-1743837627` manually at https://hex.pm
```



