### PR TITLE
Added `hex deauthenticate` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@
 - Deprecate `HEXPM_USER` and `HEXPM_PASS` in favour of `HEXPM_API_KEY`.
   ([Samuel Cristobal](https://github.com/scristobal))
 
+- Added `gleam hex deauthenticate` command.
+  ([Samuel Cristobal](https://github.com/scristobal))
+
 ### Language server
 
 - The language server now allows renaming of functions, constants,

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -119,3 +119,28 @@ with a new one?";
     }
     Ok(())
 }
+
+pub(crate) fn deauthenticate() -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
+    let config = hexpm::Config::new();
+    let mut auth = HexAuthentication::new(&runtime, config.clone());
+
+    let previous = auth.read_stored_api_key()?;
+
+    if previous.is_none() {
+        println!("You must authenticate first");
+        return Ok(());
+    }
+
+    let question = "This will delelete and revoke your existing Hex API key. The operation can not be undone. Do you want to proceed?";
+
+    if !cli::confirm(question)? {
+        return Ok(());
+    };
+
+    if let Some(name) = auth.remove_stored_api_key()? {
+        println!("The Hex API key `{name}` was been removed succesfully.")
+    }
+
+    Ok(())
+}

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -437,6 +437,9 @@ enum Hex {
 
     /// Authenticate with Hex
     Authenticate,
+
+    /// Deauthenticate from Hex
+    Deauthenticate,
 }
 
 #[derive(Subcommand, Debug)]
@@ -557,6 +560,8 @@ fn parse_and_run_command() -> Result<(), Error> {
         }
 
         Command::Hex(Hex::Authenticate) => hex::authenticate(),
+
+        Command::Hex(Hex::Deauthenticate) => hex::deauthenticate(),
 
         Command::New(options) => new::create(options, COMPILER_VERSION),
 


### PR DESCRIPTION
When the user runs `gleam hex deauthenticate` the credential file will be deleted and the key revoked. 

This is recycled code from https://github.com/gleam-lang/gleam/pull/4441 after trying to resolve #4319 