### PR TITLE
Display const values on hover action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,9 @@
   first line of the `use` expression to rewrite.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Hovering const values now displays their values.
+  ([David Mo](https://github.com/unknown))
+
 ### Formatter
 
 ### Container images

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -453,7 +453,7 @@ impl<'comments> Formatter<'comments> {
         }
     }
 
-    fn const_expr<'a, A, B>(&mut self, value: &'a Constant<A, B>) -> Document<'a> {
+    pub fn const_expr<'a, A, B>(&mut self, value: &'a Constant<A, B>) -> Document<'a> {
         let comments = self.pop_comments(value.location().start);
         let document = match value {
             Constant::Int { value, .. } => self.int(value),

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1589,3 +1589,11 @@ import wibble
         find_position_of("wibble")
     );
 }
+
+#[test]
+fn hover_module_constant_invalid_expression() {
+    let code = "
+const value = undefined_var
+";
+    assert_hover!(TestProject::for_source(code), find_position_of("value"));
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type.snap
@@ -10,6 +10,6 @@ const value = wobble.Wobble
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwobble.Wibble\n```\n",
+        "```gleam\nconst value: wobble.Wibble = wobble.Wobble\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased.snap
@@ -11,6 +11,6 @@ const value = wobble.Wobble
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nLocal\n```\n",
+        "```gleam\nconst value: Local = wobble.Wobble\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_aliased_module.snap
@@ -10,6 +10,6 @@ const value = wubble.Wobble
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nwubble.Wibble\n```\n",
+        "```gleam\nconst value: wubble.Wibble = wubble.Wobble\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified.snap
@@ -10,6 +10,6 @@ const value = wobble.Wobble
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nWibble\n```\n",
+        "```gleam\nconst value: Wibble = wobble.Wobble\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified_aliased.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_contextual_type_unqualified_aliased.snap
@@ -10,6 +10,6 @@ const value = wobble.Wobble
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nWobble\n```\n",
+        "```gleam\nconst value: Wobble = wobble.Wobble\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_imported_constants.snap
@@ -12,6 +12,6 @@ fn main() {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
+        "```gleam\nconst my_const: Int = 42\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
@@ -13,6 +13,6 @@ fn main() {
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nInt\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
+        "```gleam\nconst my_const: Int = 42\n```\n\nView on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant.snap
@@ -11,6 +11,6 @@ const one = 1
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nInt\n```\n Exciting documentation\n Maybe even multiple lines",
+        "```gleam\nconst one: Int = 1\n```\n Exciting documentation\n Maybe even multiple lines",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant_invalid_expression.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_module_constant_invalid_expression.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst value = undefined_var\n"
+---
+const value = undefined_var
+▔▔▔▔▔▔↑▔▔▔▔                
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nconst value: a\n```\n",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_prelude_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_prelude_type.snap
@@ -9,6 +9,6 @@ const number = 100
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nInt\n```\n",
+        "```gleam\nconst number: Int = 100\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_aliased_imported_generic_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_aliased_imported_generic_type.snap
@@ -11,6 +11,6 @@ const none: Maybe(Int) = option.None
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nMaybe(Int)\n```\n",
+        "```gleam\nconst none: Maybe(Int) = option.None\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_imported_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_imported_alias.snap
@@ -10,6 +10,6 @@ const thing: Aliased = 10
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\nAliased\n```\n",
+        "```gleam\nconst thing: Aliased = 10\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_alias.snap
@@ -10,6 +10,6 @@ const ok = Ok(10)
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\ngleam.Result(Int, a)\n```\n",
+        "```gleam\nconst ok: gleam.Result(Int, a) = Ok(10)\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_imported_alias.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_print_qualified_prelude_type_when_shadowed_by_imported_alias.snap
@@ -10,6 +10,6 @@ const value = True
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\ngleam.Bool\n```\n",
+        "```gleam\nconst value: gleam.Bool = True\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type.snap
@@ -10,6 +10,6 @@ const number = 100
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\ngleam.Int\n```\n",
+        "```gleam\nconst number: gleam.Int = 100\n```\n",
     ),
 )

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_shadowed_prelude_type_imported.snap
@@ -10,6 +10,6 @@ const number = 100
 ----- Hover content -----
 Scalar(
     String(
-        "```gleam\ngleam.Int\n```\n",
+        "```gleam\nconst number: gleam.Int = 100\n```\n",
     ),
 )


### PR DESCRIPTION
Closes https://github.com/gleam-lang/gleam/issues/4280. Displays the expressions of consts when they are hovered.

```gleam
// consts.gleam
pub const pi = 3.1415
```

```gleam
// main.gleam
import consts

pub fn main() {
  consts.pi
}
```

For example, hovering `pi` in `consts.gleam` and `consts.pi` in `main.gleam` renders `const pi: Float = 3.1415`.

I think we can make further improvements in the future to other hover actions to be more consistent with this new behavior such as making hovering `a` in `let a = 42` render `let a: Int`.