### PR TITLE
Improve error message for wrong operator on Ints/Floats

### DIFF
--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints.snap
@@ -13,3 +13,4 @@ error: Type mismatch
   │   ^^ Use + instead
 
 The +. operator can only be used on Floats.
+To sum two Ints you can use the + operator.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__float_operator_on_ints_2.snap
@@ -13,3 +13,4 @@ error: Type mismatch
   │   ^^ Use < instead
 
 The <. operator can only be used on Floats.
+To compare two Ints you can use the < operator.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats.snap
@@ -13,3 +13,4 @@ error: Type mismatch
   │     ^ Use +. instead
 
 The + operator can only be used on Ints.
+To sum two Floats you can use the +. operator.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__int_operator_on_floats_2.snap
@@ -13,3 +13,4 @@ error: Type mismatch
   │     ^ Use >. instead
 
 The > operator can only be used on Ints.
+To compare two Floats you can use the >. operator.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__case_clause_then_fault_tolerance.snap
@@ -25,6 +25,7 @@ error: Type mismatch
   │           ^ Use +. instead
 
 The + operator can only be used on Ints.
+To sum two Floats you can use the +. operator.
 
 error: Type mismatch
   ┌─ /src/one/two.gleam:9:11
@@ -33,3 +34,4 @@ error: Type mismatch
   │           ^ Use +. instead
 
 The + operator can only be used on Ints.
+To sum two Floats you can use the +. operator.


### PR DESCRIPTION
The error message now explains what operator can be used instead!