### PR TITLE
Implement autocomplete, hover and goto-definition for constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,11 @@
     }
   }
   ```
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+- The language server now provides hover, autocomplete and goto definition
+  for constant definitions.
+  ([Surya Rose](https://github.com/GearsDatapacks))
 
 ### Formatter
 

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -42,6 +42,7 @@ pub enum Constant<T, RecordTag> {
         tag: RecordTag,
         type_: T,
         field_map: Option<FieldMap>,
+        record_constructor: Option<Box<ValueConstructor>>,
     },
 
     BitArray {
@@ -115,6 +116,29 @@ impl TypedConstant {
                 .or_else(|| right.find_node(byte_index))
                 .unwrap_or(Located::Constant(self)),
         })
+    }
+
+    pub fn definition_location(&self) -> Option<DefinitionLocation> {
+        match self {
+            Constant::Int { .. }
+            | Constant::Float { .. }
+            | Constant::String { .. }
+            | Constant::Tuple { .. }
+            | Constant::List { .. }
+            | Constant::BitArray { .. }
+            | Constant::StringConcatenation { .. }
+            | Constant::Invalid { .. } => None,
+            Constant::Record {
+                record_constructor: value_constructor,
+                ..
+            }
+            | Constant::Var {
+                constructor: value_constructor,
+                ..
+            } => value_constructor
+                .as_ref()
+                .map(|constructor| constructor.definition_location()),
+        }
     }
 }
 

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -925,6 +925,7 @@ pub trait UntypedConstantFolder {
                 tag: (),
                 type_: (),
                 field_map: _,
+                record_constructor: _,
             } => self.fold_constant_record(location, module, name, args),
 
             Constant::BitArray { location, segments } => {
@@ -1008,6 +1009,7 @@ pub trait UntypedConstantFolder {
             tag: (),
             type_: (),
             field_map: None,
+            record_constructor: None,
         }
     }
 
@@ -1088,6 +1090,7 @@ pub trait UntypedConstantFolder {
                 tag,
                 type_,
                 field_map,
+                record_constructor,
             } => {
                 let args = args
                     .into_iter()
@@ -1104,6 +1107,7 @@ pub trait UntypedConstantFolder {
                     tag,
                     type_,
                     field_map,
+                    record_constructor,
                 }
             }
 

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -17,8 +17,9 @@ pub use self::project_compiler::{Built, Options, ProjectCompiler};
 pub use self::telemetry::{NullTelemetry, Telemetry};
 
 use crate::ast::{
-    self, CallArg, CustomType, DefinitionLocation, TypeAst, TypedArg, TypedDefinition, TypedExpr,
-    TypedFunction, TypedPattern, TypedRecordConstructor, TypedStatement,
+    self, CallArg, CustomType, DefinitionLocation, TypeAst, TypedArg, TypedConstant,
+    TypedDefinition, TypedExpr, TypedFunction, TypedPattern, TypedRecordConstructor,
+    TypedStatement,
 };
 use crate::type_::Type;
 use crate::{
@@ -357,6 +358,7 @@ pub enum Located<'a> {
         name: &'a EcoString,
         layer: ast::Layer,
     },
+    Constant(&'a TypedConstant),
 }
 
 impl<'a> Located<'a> {
@@ -419,6 +421,7 @@ impl<'a> Located<'a> {
                 module: Some((*name).clone()),
                 span: SrcSpan::new(0, 0),
             }),
+            Self::Constant(constant) => None,
         }
     }
 
@@ -429,6 +432,7 @@ impl<'a> Located<'a> {
             Located::Expression(typed_expr) => Some(typed_expr.type_()),
             Located::Arg(arg) => Some(arg.type_.clone()),
             Located::Label(_, type_) | Located::Annotation { type_, .. } => Some(type_.clone()),
+            Located::Constant(constant) => Some(constant.type_()),
 
             Located::PatternSpread { .. } => None,
             Located::ModuleStatement(definition) => None,

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -421,7 +421,7 @@ impl<'a> Located<'a> {
                 module: Some((*name).clone()),
                 span: SrcSpan::new(0, 0),
             }),
-            Self::Constant(constant) => None,
+            Self::Constant(constant) => constant.definition_location(),
         }
     }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -266,12 +266,10 @@ where
                 .module_line_numbers
                 .byte_index(params.position.line, params.position.character);
 
-            dbg!("here1");
             // If in comment context, do not provide completions
             if module.extra.is_within_comment(byte_index) {
                 return Ok(None);
             }
-            dbg!("here2");
 
             // Check current filercontents if the user is writing an import
             // and handle separately from the rest of the completion flow
@@ -280,15 +278,11 @@ where
                 return value;
             }
 
-            dbg!("here3");
-            dbg!(&module.ast);
-            dbg!(byte_index);
             let Some(found) = module.find_node(byte_index) else {
                 return Ok(None);
             };
-            dbg!("here4");
 
-            let completions = match dbg!(found) {
+            let completions = match found {
                 Located::PatternSpread { .. } => None,
                 Located::Pattern(_pattern) => None,
                 // Do not show completions when typing inside a string.

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -1973,3 +1973,68 @@ pub fn main(something: Bool) {
         Position::new(2, 9)
     );
 }
+
+#[test]
+fn constant() {
+    let code = "
+const hello = 10
+const world = he
+";
+
+    assert_completion!(TestProject::for_source(code), Position::new(2, 16));
+}
+
+#[test]
+fn constant_with_many_options() {
+    let code = "
+import wibble.{Wobble}
+
+type Wibble {
+  Wibble
+}
+
+const pi = 3.14159
+
+fn some_function() {
+  todo
+}
+
+const my_constant = a
+";
+
+    assert_completion!(
+        TestProject::for_source(code).add_hex_module("wibble", "pub type Wibble { Wobble Wubble }"),
+        Position::new(13, 21)
+    );
+}
+
+#[test]
+fn constant_with_module_select() {
+    let code = "
+import wibble
+
+type Wibble {
+  Wibble
+}
+
+const pi = 3.14159
+
+fn some_function() {
+  todo
+}
+
+const my_constant = wibble.W
+";
+
+    assert_completion!(
+        TestProject::for_source(code).add_hex_module(
+            "wibble",
+            "
+pub type Wibble { Wobble Wubble }
+pub const some_constant = 1
+pub fn some_function() { todo }
+"
+        ),
+        Position::new(13, 28)
+    );
+}

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -807,3 +807,57 @@ pub fn main() {
         find_position_of("wibble.").under_char('i')
     );
 }
+
+#[test]
+fn goto_definition_constant() {
+    assert_goto!(
+        "
+const value = 25
+
+const my_constant = value
+",
+        find_position_of("= value").under_char('a')
+    );
+}
+
+#[test]
+fn goto_definition_constant_record() {
+    assert_goto!(
+        "
+type Wibble {
+  Wibble(Int)
+}
+
+const wibble = Wibble(10)
+",
+        find_position_of("Wibble(10)").under_char('l')
+    );
+}
+
+#[test]
+fn goto_definition_imported_constant() {
+    let src = "
+import wibble
+
+const my_constant = wibble.value
+";
+
+    assert_goto!(
+        TestProject::for_source(src).add_hex_module("wibble", "pub const value = 10"),
+        find_position_of("= wibble").under_char('w')
+    );
+}
+
+#[test]
+fn goto_definition_constant_imported_record() {
+    let src = "
+import wibble
+
+const my_constant = wibble.Wibble(10)
+";
+
+    assert_goto!(
+        TestProject::for_source(src).add_hex_module("wibble", "pub type Wibble { Wibble(Int) }"),
+        find_position_of("= wibble").under_char('w')
+    );
+}

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1589,3 +1589,164 @@ import wibble
         find_position_of("wibble")
     );
 }
+
+#[test]
+fn hover_for_constant_int() {
+    assert_hover!(
+        "
+const ten = 10
+",
+        find_position_of("10")
+    );
+}
+
+#[test]
+fn hover_for_constant_float() {
+    assert_hover!(
+        "
+const pi = 3.14
+",
+        find_position_of("3.14")
+    );
+}
+#[test]
+fn hover_for_constant_string() {
+    assert_hover!(
+        r#"
+const message = "Hello!"
+"#,
+        find_position_of("!")
+    );
+}
+
+#[test]
+fn hover_for_constant_other_constant() {
+    assert_hover!(
+        "
+const constant1 = 10
+const constant2 = constant1
+",
+        find_position_of("= constant1").under_char('s')
+    );
+}
+
+#[test]
+fn hover_for_constant_record() {
+    assert_hover!(
+        "
+type Wibble {
+  Wibble(Int)
+}
+
+const w = Wibble(10)
+",
+        find_position_of("Wibble(10)").under_char('i')
+    );
+}
+
+#[test]
+fn hover_for_constant_tuple() {
+    assert_hover!(
+        "
+const tuple = #(1, 3.5, False)
+",
+        find_position_of("#(")
+    );
+}
+
+#[test]
+fn hover_for_constant_tuple_element() {
+    assert_hover!(
+        "
+const tuple = #(1, 3.5, False)
+",
+        find_position_of("False")
+    );
+}
+
+#[test]
+fn hover_for_constant_list() {
+    assert_hover!(
+        "
+const numbers = [2, 4, 6, 8]
+",
+        find_position_of("[")
+    );
+}
+
+#[test]
+fn hover_for_constant_list_element() {
+    assert_hover!(
+        "
+const numbers = [2, 4, 6, 8]
+",
+        find_position_of("4")
+    );
+}
+
+#[test]
+fn hover_for_constant_string_concatenation() {
+    assert_hover!(
+        r#"
+const name = "Bob"
+const message = "Hello " <> name
+"#,
+        find_position_of("<>")
+    );
+}
+
+#[test]
+fn hover_for_constant_string_concatenation_side() {
+    assert_hover!(
+        r#"
+const name = "Bob"
+const message = "Hello " <> name
+"#,
+        find_position_of("<> name").under_char('n')
+    );
+}
+
+#[test]
+fn hover_for_constant_bit_array() {
+    assert_hover!(
+        "
+const bits = <<1:2, 3:4>>
+",
+        find_position_of(",")
+    );
+}
+
+#[test]
+fn hover_for_constant_bit_array_segment() {
+    assert_hover!(
+        "
+const bits = <<1:2, 3:4>>
+",
+        find_position_of("1")
+    );
+}
+
+#[test]
+fn hover_for_constant_bit_array_segment_option() {
+    assert_hover!(
+        "
+const bits = <<1:size(2), 3:4>>
+",
+        find_position_of("2")
+    );
+}
+
+#[test]
+fn hover_for_nested_constant() {
+    assert_hover!(
+        "
+type Wibble {
+  Wibble
+  Wobble(BitArray)
+}
+
+const value = #(1, 2, [Wibble, Wobble(<<1, 2, 3>>), Wibble])
+",
+        find_position_of("3")
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__constant.snap
@@ -1,0 +1,43 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\nconst hello = 10\nconst world = he\n"
+---
+const hello = 10
+const world = he|
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+hello
+  kind:   Constant
+  detail: Int
+  sort:   2_hello
+  desc:   app
+  edits:
+    [2:14-2:14]: "hello"
+world
+  kind:   Constant
+  detail: a
+  sort:   2_world
+  desc:   app
+  edits:
+    [2:14-2:14]: "world"

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__constant_with_many_options.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__constant_with_many_options.snap
@@ -1,0 +1,89 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\nimport wibble.{Wobble}\n\ntype Wibble {\n  Wibble\n}\n\nconst pi = 3.14159\n\nfn some_function() {\n  todo\n}\n\nconst my_constant = a\n"
+---
+import wibble.{Wobble}
+
+type Wibble {
+  Wibble
+}
+
+const pi = 3.14159
+
+fn some_function() {
+  todo
+}
+
+const my_constant = a|
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+Wibble
+  kind:   EnumMember
+  detail: Wibble
+  sort:   2_Wibble
+  desc:   app
+  edits:
+    [13:20-13:20]: "Wibble"
+Wobble
+  kind:   EnumMember
+  detail: Wibble
+  sort:   3_Wobble
+  desc:   app
+  edits:
+    [13:20-13:20]: "Wobble"
+my_constant
+  kind:   Constant
+  detail: a
+  sort:   2_my_constant
+  desc:   app
+  edits:
+    [13:20-13:20]: "my_constant"
+pi
+  kind:   Constant
+  detail: Float
+  sort:   2_pi
+  desc:   app
+  edits:
+    [13:20-13:20]: "pi"
+some_function
+  kind:   Function
+  detail: fn() -> a
+  sort:   2_some_function
+  desc:   app
+  edits:
+    [13:20-13:20]: "some_function"
+wibble.Wobble
+  kind:   EnumMember
+  detail: Wibble
+  sort:   3_wibble.Wobble
+  desc:   app
+  edits:
+    [13:20-13:20]: "wibble.Wobble"
+wibble.Wubble
+  kind:   EnumMember
+  detail: Wibble
+  sort:   3_wibble.Wubble
+  desc:   app
+  edits:
+    [13:20-13:20]: "wibble.Wubble"

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__constant_with_module_select.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__constant_with_module_select.snap
@@ -1,0 +1,48 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\nimport wibble\n\ntype Wibble {\n  Wibble\n}\n\nconst pi = 3.14159\n\nfn some_function() {\n  todo\n}\n\nconst my_constant = wibble.W\n"
+---
+import wibble
+
+type Wibble {
+  Wibble
+}
+
+const pi = 3.14159
+
+fn some_function() {
+  todo
+}
+
+const my_constant = wibble.W|
+
+
+----- Completion content -----
+wibble.Wobble
+  kind:   EnumMember
+  detail: Wibble
+  sort:   3_wibble.Wobble
+  desc:   app
+  edits:
+    [13:20-13:20]: "wibble.Wobble"
+wibble.Wubble
+  kind:   EnumMember
+  detail: Wibble
+  sort:   3_wibble.Wubble
+  desc:   app
+  edits:
+    [13:20-13:20]: "wibble.Wubble"
+wibble.some_constant
+  kind:   Constant
+  detail: Int
+  sort:   3_wibble.some_constant
+  desc:   app
+  edits:
+    [13:20-13:20]: "wibble.some_constant"
+wibble.some_function
+  kind:   Function
+  detail: fn() -> a
+  sort:   3_wibble.some_function
+  desc:   app
+  edits:
+    [13:20-13:20]: "wibble.some_function"

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_constant.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+const value = 25
+
+const my_constant = value
+                     ↑   
+
+----- Jumped to `src/app.gleam`
+
+const value = 25
+↑▔▔▔▔▔▔▔▔▔▔     
+
+const my_constant = value

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_constant_imported_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_constant_imported_record.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+import wibble
+
+const my_constant = wibble.Wibble(10)
+                    ↑                
+
+----- Jumped to `build/packages/hex/src/wibble.gleam`
+pub type Wibble { Wibble(Int) }
+                  ↑▔▔▔▔▔▔▔▔▔▔

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_constant_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_constant_record.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+type Wibble {
+  Wibble(Int)
+}
+
+const wibble = Wibble(10)
+                   ↑     
+
+----- Jumped to `src/app.gleam`
+
+type Wibble {
+  Wibble(Int)
+  ↑▔▔▔▔▔▔▔▔▔▔
+}
+
+const wibble = Wibble(10)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_imported_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_imported_constant.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+import wibble
+
+const my_constant = wibble.value
+                    ↑           
+
+----- Jumped to `build/packages/hex/src/wibble.gleam`
+pub const value = 10
+↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_bit_array.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_bit_array.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst bits = <<1:2, 3:4>>\n"
+---
+const bits = <<1:2, 3:4>>
+                 ▔↑      
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_bit_array_segment.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_bit_array_segment.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst bits = <<1:2, 3:4>>\n"
+---
+const bits = <<1:2, 3:4>>
+               ↑         
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_bit_array_segment_option.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_bit_array_segment_option.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst bits = <<1:size(2), 3:4>>\n"
+---
+const bits = <<1:size(2), 3:4>>
+                      ↑        
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_float.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_float.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst pi = 3.14\n"
+---
+const pi = 3.14
+           ↑▔▔▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nFloat\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_int.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_int.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst ten = 10\n"
+---
+const ten = 10
+            ↑▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_list.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_list.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst numbers = [2, 4, 6, 8]\n"
+---
+const numbers = [2, 4, 6, 8]
+                ↑▔▔▔▔▔▔▔▔▔▔▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nList(Int)\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_list_element.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_list_element.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst numbers = [2, 4, 6, 8]\n"
+---
+const numbers = [2, 4, 6, 8]
+                    ↑       
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_other_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_other_constant.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst constant1 = 10\nconst constant2 = constant1\n"
+---
+const constant1 = 10
+const constant2 = constant1
+                  ▔▔▔↑▔▔▔▔▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_record.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_record.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype Wibble {\n  Wibble(Int)\n}\n\nconst w = Wibble(10)\n"
+---
+type Wibble {
+  Wibble(Int)
+}
+
+const w = Wibble(10)
+          ▔↑▔▔▔▔▔▔▔▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nWibble\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_string.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_string.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst message = \"Hello!\"\n"
+---
+const message = "Hello!"
+                ▔▔▔▔▔▔↑▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_string_concatenation.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_string_concatenation.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst name = \"Bob\"\nconst message = \"Hello \" <> name\n"
+---
+const name = "Bob"
+const message = "Hello " <> name
+                ▔▔▔▔▔▔▔▔▔↑▔▔▔▔▔▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_string_concatenation_side.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_string_concatenation_side.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst name = \"Bob\"\nconst message = \"Hello \" <> name\n"
+---
+const name = "Bob"
+const message = "Hello " <> name
+                            ↑▔▔▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nString\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_tuple.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst tuple = #(1, 3.5, False)\n"
+---
+const tuple = #(1, 3.5, False)
+              ↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\n#(Int, Float, Bool)\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_tuple_element.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_constant_tuple_element.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\nconst tuple = #(1, 3.5, False)\n"
+---
+const tuple = #(1, 3.5, False)
+                        ↑▔▔▔▔ 
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nBool\n```",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_nested_constant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_for_nested_constant.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\ntype Wibble {\n  Wibble\n  Wobble(BitArray)\n}\n\nconst value = #(1, 2, [Wibble, Wobble(<<1, 2, 3>>), Wibble])\n"
+---
+type Wibble {
+  Wibble
+  Wobble(BitArray)
+}
+
+const value = #(1, 2, [Wibble, Wobble(<<1, 2, 3>>), Wibble])
+                                              ↑             
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nInt\n```",
+    ),
+)

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -431,6 +431,7 @@ impl ModuleDecoder {
             tag,
             type_,
             field_map: None,
+            record_constructor: None,
         })
     }
 

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -1125,6 +1125,7 @@ fn constant_record() {
         tag: "thetag".into(),
         type_: type_::int(),
         field_map: None,
+        record_constructor: None,
     });
 
     assert_eq!(roundtrip(&module), module);

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3098,6 +3098,7 @@ where
                     tag: (),
                     type_: (),
                     field_map: None,
+                    record_constructor: None,
                 }))
             }
             _ => Ok(Some(Constant::Record {
@@ -3108,6 +3109,7 @@ where
                 tag: (),
                 type_: (),
                 field_map: None,
+                record_constructor: None,
             })),
         }
     }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -3347,9 +3347,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     location,
                     name,
                     args: vec![],
-                    type_: constructor.type_,
+                    type_: constructor.type_.clone(),
                     tag,
                     field_map,
+                    record_constructor: Some(Box::new(constructor)),
                 })
             }
 
@@ -3418,7 +3419,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     }
 
                     None => TypedExpr::Var {
-                        constructor,
+                        constructor: constructor.clone(),
                         location,
                         name: name.clone(),
                     },
@@ -3480,6 +3481,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     type_: return_type,
                     tag,
                     field_map,
+                    record_constructor: Some(Box::new(constructor)),
                 })
             }
 


### PR DESCRIPTION
Fixes #3631 
I thought that while I was at it I may as well also add hover and goto-definition functionality.