### PR TITLE
Add warning for truncated int segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,28 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler now raises a warning when it can tell that an integer segment
+  with a literal value is going to be truncated. For example, if you wrote this:
+
+  ```gleam
+  <<258>>
+  ```
+
+  The compiler will now warn you:
+
+  ```txt
+  warning: Truncated bit array segment
+    ┌─ /src/main.gleam:4:5
+    │
+  4 │   <<258>>
+    │     ^^^ You can safely replace this with 2
+
+  This segment is 1 byte long, but 258 doesn't fit in that many bytes. It
+  would be truncated by taking its its first byte, resulting in the value 2.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The compiler will now include labels in the error message when a `case`
   expression is inexhaustive. For example, this code:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -45,7 +45,7 @@ unicode-segmentation = "1.12.0"
 # Bijective (bi-directional) hashmap
 bimap = "0.6.3"
 # Parsing of arbitrary width int values
-num-bigint = "0.4.6"
+num-bigint = { version = "0.4.6", features = ["serde"] }
 num-traits = "0.2.19"
 # Encryption
 age = { version = "0.11", features = ["armor"] }

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -2410,7 +2410,7 @@ where
                 (-(BigInt::one() << (segment_bits - 1)))
                     ..((BigInt::one() << (segment_bits - 1)) - 1)
             }
-            Sign::Plus => BigInt::ZERO..((BigInt::one() << segment_bits) - 1),
+            Sign::Plus => BigInt::ZERO..(BigInt::one() << segment_bits),
         };
 
         if !safe_range.contains(&literal_value) {

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -178,13 +178,12 @@ impl<A, B> HasLocation for Constant<A, B> {
     }
 }
 
-impl<A, B> crate::bit_array::GetLiteralValue for Constant<A, B> {
-    fn as_int_literal(&self) -> Option<i64> {
-        if let Constant::Int { value, .. } = self {
-            if let Ok(val) = value.parse::<i64>() {
-                return Some(val);
-            }
+impl<A, B> bit_array::GetLiteralValue for Constant<A, B> {
+    fn as_int_literal(&self) -> Option<BigInt> {
+        if let Constant::Int { int_value, .. } = self {
+            Some(int_value.clone())
+        } else {
+            None
         }
-        None
     }
 }

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -1011,13 +1011,12 @@ impl HasType for TypedExpr {
     }
 }
 
-impl crate::bit_array::GetLiteralValue for TypedExpr {
-    fn as_int_literal(&self) -> Option<i64> {
-        if let TypedExpr::Int { value: val, .. } = self {
-            if let Ok(val) = val.parse::<i64>() {
-                return Some(val);
-            }
+impl bit_array::GetLiteralValue for TypedExpr {
+    fn as_int_literal(&self) -> Option<BigInt> {
+        if let TypedExpr::Int { int_value, .. } = self {
+            Some(int_value.clone())
+        } else {
+            None
         }
-        None
     }
 }

--- a/compiler-core/src/bit_array.rs
+++ b/compiler-core/src/bit_array.rs
@@ -1,6 +1,7 @@
 use ecow::EcoString;
+use num_bigint::BigInt;
 
-use crate::ast::{BitArrayOption, SrcSpan};
+use crate::ast::{self, BitArrayOption, SrcSpan};
 use crate::type_::Type;
 use std::sync::Arc;
 
@@ -265,9 +266,7 @@ where
         if let Some(abox) = size.value() {
             match abox.as_int_literal() {
                 None => (),
-                Some(16) => (),
-                Some(32) => (),
-                Some(64) => (),
+                Some(value) if value == 16.into() || value == 32.into() || value == 64.into() => (),
                 _ => return err(ErrorType::FloatWithSize, size.location()),
             }
         }
@@ -277,21 +276,16 @@ where
 }
 
 pub trait GetLiteralValue {
-    fn as_int_literal(&self) -> Option<i64>;
+    fn as_int_literal(&self) -> Option<BigInt>;
 }
 
-impl GetLiteralValue for crate::ast::TypedPattern {
-    fn as_int_literal(&self) -> Option<i64> {
-        match self {
-            crate::ast::Pattern::Int { value, .. } => {
-                if let Ok(val) = value.parse::<i64>() {
-                    return Some(val);
-                }
-            }
-            crate::ast::Pattern::VarUsage { .. } => return None,
-            _ => (),
+impl GetLiteralValue for ast::TypedPattern {
+    fn as_int_literal(&self) -> Option<BigInt> {
+        if let ast::Pattern::Int { int_value, .. } = self {
+            Some(int_value.clone())
+        } else {
+            None
         }
-        None
     }
 }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -38,11 +38,11 @@ use super::{
     code_action::{
         AddAnnotations, CodeActionBuilder, ConvertFromUse, ConvertToFunctionCall, ConvertToPipe,
         ConvertToUse, ExpandFunctionCapture, ExtractConstant, ExtractVariable,
-        FillInMissingLabelledArgs, FillUnusedFields, FixBinaryOperation, GenerateDynamicDecoder,
-        GenerateFunction, GenerateJsonEncoder, InlineVariable, InterpolateString, LetAssertToCase,
-        PatternMatchOnValue, RedundantTupleInCaseSubject, RemoveEchos, UseLabelShorthandSyntax,
-        WrapInBlock, code_action_add_missing_patterns,
-        code_action_convert_qualified_constructor_to_unqualified,
+        FillInMissingLabelledArgs, FillUnusedFields, FixBinaryOperation,
+        FixTruncatedBitArraySegment, GenerateDynamicDecoder, GenerateFunction, GenerateJsonEncoder,
+        InlineVariable, InterpolateString, LetAssertToCase, PatternMatchOnValue,
+        RedundantTupleInCaseSubject, RemoveEchos, UseLabelShorthandSyntax, WrapInBlock,
+        code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified,
         code_action_convert_unqualified_constructor_to_qualified, code_action_import_module,
         code_action_inexhaustive_let_to_case,
     },
@@ -409,6 +409,8 @@ where
                 &mut actions,
             );
             actions.extend(FixBinaryOperation::new(module, &lines, &params).code_actions());
+            actions
+                .extend(FixTruncatedBitArraySegment::new(module, &lines, &params).code_actions());
             actions.extend(LetAssertToCase::new(module, &lines, &params).code_actions());
             actions
                 .extend(RedundantTupleInCaseSubject::new(module, &lines, &params).code_actions());

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -120,6 +120,32 @@ macro_rules! assert_no_code_actions {
 }
 
 #[test]
+fn fix_truncated_segment_1() {
+    let name = "Replace with `1`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  <<1, 257, 259:size(1)>>
+}"#,
+        find_position_of("257").to_selection()
+    );
+}
+
+#[test]
+fn fix_truncated_segment_2() {
+    let name = "Replace with `0`";
+    assert_code_action!(
+        name,
+        r#"
+pub fn main() {
+  <<1, 1024:size(10)>>
+}"#,
+        find_position_of("size").to_selection()
+    );
+}
+
+#[test]
 fn fill_unused_fields_with_ignored_labelled_fields() {
     assert_code_action!(
         FILL_UNUSED_FIELDS,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_truncated_segment_1.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_truncated_segment_1.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  <<1, 257, 259:size(1)>>\n}"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  <<1, 257, 259:size(1)>>
+       ↑                 
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  <<1, 1, 259:size(1)>>
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_truncated_segment_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__fix_truncated_segment_2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  <<1, 1024:size(10)>>\n}"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  <<1, 1024:size(10)>>
+            ↑         
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  <<1, 0:size(10)>>
+}

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -3,7 +3,7 @@ use super::{
     expression::{ArgumentKind, CallKind},
 };
 use crate::{
-    ast::{BinOp, Layer, SrcSpan, TodoKind},
+    ast::{BinOp, BitArraySegmentTruncation, Layer, SrcSpan, TodoKind},
     build::Target,
     type_::Type,
 };
@@ -968,6 +968,14 @@ pub enum Warning {
     AssertLiteralValue {
         location: SrcSpan,
     },
+
+    /// When a segment has a constant value that is bigger than its size and we
+    /// know for certain is going to be truncated.
+    ///
+    BitArraySegmentTruncatedValue {
+        truncation: BitArraySegmentTruncation,
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Eq, Copy, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -1189,7 +1197,8 @@ impl Warning {
             | Warning::RedundantPipeFunctionCapture { location, .. }
             | Warning::FeatureRequiresHigherGleamVersion { location, .. }
             | Warning::JavaScriptIntUnsafe { location, .. }
-            | Warning::AssertLiteralValue { location, .. } => *location,
+            | Warning::AssertLiteralValue { location, .. }
+            | Warning::BitArraySegmentTruncatedValue { location, .. } => *location,
         }
     }
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_negative_truncated_segment.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_negative_truncated_segment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 3114
 expression: "\npub fn main() {\n  // -5 in 2's complement is 1111...111011\n  // so if we truncate it to its first 3 bits we\n  // get 011, which is positive 3!\n  <<-5:size(3)>>\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_negative_truncated_segment.snap.new
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_negative_truncated_segment.snap.new
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+assertion_line: 3114
+expression: "\npub fn main() {\n  // -5 in 2's complement is 1111...111011\n  // so if we truncate it to its first 3 bits we\n  // get 011, which is positive 3!\n  <<-5:size(3)>>\n}\n"
+snapshot_kind: text
+---
+----- SOURCE CODE
+
+pub fn main() {
+  // -5 in 2's complement is 1111...111011
+  // so if we truncate it to its first 3 bits we
+  // get 011, which is positive 3!
+  <<-5:size(3)>>
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:6:5
+  │
+6 │   <<-5:size(3)>>
+  │     ^^ You can safely replace this with 3
+
+This segment is 3 bits long, but -5 doesn't fit in that many bits. It would
+be truncated by taking its its first 3 bits, resulting in the value 3.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_negative_truncated_segment_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_negative_truncated_segment_2.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  <<-200:size(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  <<-200:size(8)>>
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │   <<-200:size(8)>>
+  │     ^^^^ You can safely replace this with 56
+
+This segment is 1 byte long, but -200 doesn't fit in that many bytes. It
+would be truncated by taking its its first byte, resulting in the value 56.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_truncated_segment.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_truncated_segment.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  <<12:size(1)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  <<12:size(1)>>
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │   <<12:size(1)>>
+  │     ^^ You can safely replace this with 0
+
+This segment is 1 bit long, but 12 doesn't fit in that many bits. It would
+be truncated by taking its its first bit, resulting in the value 0.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_truncated_segment_in_bytes.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_truncated_segment_in_bytes.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  <<258:size(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  <<258:size(8)>>
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │   <<258:size(8)>>
+  │     ^^^ You can safely replace this with 2
+
+This segment is 1 byte long, but 258 doesn't fit in that many bytes. It
+would be truncated by taking its its first byte, resulting in the value 2.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_truncated_segment_in_bytes_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_truncated_segment_in_bytes_2.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  <<65_537:size(2)-unit(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  <<65_537:size(2)-unit(8)>>
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:3:5
+  │
+3 │   <<65_537:size(2)-unit(8)>>
+  │     ^^^^^^ You can safely replace this with 1
+
+This segment is 2 bytes long, but 65537 doesn't fit in that many bytes. It
+would be truncated by taking its its first 2 bytes, resulting in the value
+1.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -3065,3 +3065,36 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn bit_array_truncated_segment() {
+    assert_warning!(
+        "
+pub fn main() {
+  <<12:size(1)>>
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_truncated_segment_in_bytes() {
+    assert_warning!(
+        "
+pub fn main() {
+  <<258:size(8)>>
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_truncated_segment_in_bytes_2() {
+    assert_warning!(
+        "
+pub fn main() {
+  <<65_537:size(2)-unit(8)>>
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -3098,3 +3098,61 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn bit_array_truncated_segment_in_range() {
+    assert_no_warnings!(
+        "
+pub fn main() {
+  <<255>>
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_truncated_segment_in_range_2() {
+    assert_no_warnings!(
+        "
+pub fn main() {
+  <<0>>
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_negative_truncated_segment() {
+    assert_warning!(
+        "
+pub fn main() {
+  // -5 in 2's complement is 1111...111011
+  // so if we truncate it to its first 3 bits we
+  // get 011, which is positive 3!
+  <<-5:size(3)>>
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_negative_truncated_segment_2() {
+    assert_warning!(
+        "
+pub fn main() {
+  <<-200:size(8)>>
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_negative_truncated_segment_in_range() {
+    assert_no_warnings!(
+        "
+pub fn main() {
+  <<-128>>
+}
+"
+    );
+}

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -15,8 +15,6 @@ use crate::{
 use camino::Utf8PathBuf;
 use debug_ignore::DebugIgnore;
 use ecow::EcoString;
-use num_bigint::BigInt;
-use num_traits::One;
 use std::{
     io::Write,
     sync::{Arc, atomic::Ordering},
@@ -1212,10 +1210,10 @@ information.",
                             value_location,
                         },
                 } => {
-                    let (unit, segment_size, taken) = if segment_bits % 8 == BigInt::ZERO {
+                    let (unit, segment_size, taken) = if segment_bits % 8 == 0 {
                         let bytes = segment_bits / 8;
-                        let segment_size = pluralise(format!("{bytes} byte"), &bytes);
-                        let taken = if bytes == BigInt::one() {
+                        let segment_size = pluralise(format!("{bytes} byte"), bytes);
+                        let taken = if bytes == 1 {
                             "its first byte".into()
                         } else {
                             format!("its first {bytes} bytes")
@@ -1223,8 +1221,8 @@ information.",
 
                         ("bytes", segment_size, taken)
                     } else {
-                        let segment_size = pluralise(format!("{segment_bits} bit"), segment_bits);
-                        let taken = if segment_bits == &BigInt::one() {
+                        let segment_size = pluralise(format!("{segment_bits} bit"), *segment_bits);
+                        let taken = if *segment_bits == 1 {
                             "its first bit".into()
                         } else {
                             format!("its first {segment_bits} bits")
@@ -1309,8 +1307,8 @@ can already tell whether it will be true or false.",
     }
 }
 
-fn pluralise(string: String, quantity: &BigInt) -> String {
-    if quantity == &BigInt::one() {
+fn pluralise(string: String, quantity: i64) -> String {
+    if quantity == 1 {
         string
     } else {
         format!("{string}s")


### PR DESCRIPTION
This PR closes #791 by adding a warning when the compiler can tell that a segment with a positive literal int is going to be truncated, suggesting what value to use instead.

And there's also a code action to automatically fix it!