### PR TITLE
LS: hover info for custom types

### DIFF
--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -4,6 +4,7 @@ use crate::{
     ast::{
         self, CustomType, Definition, DefinitionLocation, ModuleConstant, PatternUnusedArguments,
         SrcSpan, TypedArg, TypedExpr, TypedFunction, TypedModule, TypedPattern,
+        TypedRecordConstructor,
     },
     build::{Located, Module, UnqualifiedImport, type_constructor_from_modules},
     config::PackageConfig,
@@ -822,6 +823,9 @@ where
                 Located::ModuleStatement(Definition::Function(fun)) => {
                     Some(hover_for_function_head(fun, lines, module))
                 }
+                Located::ModuleStatement(Definition::CustomType(type_)) => {
+                    Some(hover_for_custom_type(type_, lines))
+                }
                 Located::ModuleStatement(Definition::ModuleConstant(constant)) => {
                     Some(hover_for_module_constant(constant, lines, module))
                 }
@@ -837,7 +841,9 @@ where
                     ))
                 }
                 Located::ModuleStatement(_) => None,
-                Located::VariantConstructorDefinition(_) => None,
+                Located::VariantConstructorDefinition(constructor) => {
+                    Some(hover_for_constructor(constructor, lines, module))
+                }
                 Located::UnqualifiedImport(UnqualifiedImport {
                     name,
                     module: module_name,
@@ -1239,6 +1245,52 @@ fn hover_for_module_constant(
     Hover {
         contents: HoverContents::Scalar(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(constant.location, &line_numbers)),
+    }
+}
+
+fn hover_for_custom_type(type_: &CustomType<Arc<Type>>, line_numbers: LineNumbers) -> Hover {
+    let name = &type_.name;
+    let empty_str = EcoString::from("");
+    let documentation = type_
+        .documentation
+        .as_ref()
+        .map(|(_, doc)| doc)
+        .unwrap_or(&empty_str);
+    let contents = format!("```gleam\n{name}\n```\n{documentation}");
+    Hover {
+        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        range: Some(src_span_to_lsp_range(type_.full_location(), &line_numbers)),
+    }
+}
+
+fn hover_for_constructor(
+    constructor: &TypedRecordConstructor,
+    line_numbers: LineNumbers,
+    module: &Module,
+) -> Hover {
+    let name = &constructor.name;
+    let mut arguments = Vec::with_capacity(constructor.arguments.len());
+    let mut printer = Printer::new(&module.ast.names);
+
+    for argument in &constructor.arguments {
+        let Some((_, label)) = argument.label.as_ref() else {
+            continue;
+        };
+        let type_ = printer.print_type(&argument.type_);
+        arguments.push(format!("{label}: {type_}"));
+    }
+
+    let arguments = arguments.join(", ");
+    let empty_str = EcoString::from("");
+    let documentation = constructor
+        .documentation
+        .as_ref()
+        .map(|(_, doc)| doc)
+        .unwrap_or(&empty_str);
+    let contents = format!("```gleam\n{name}({arguments})\n```\n{documentation}");
+    Hover {
+        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        range: Some(src_span_to_lsp_range(constructor.location, &line_numbers)),
     }
 }
 

--- a/compiler-core/src/language_server/tests/hover.rs
+++ b/compiler-core/src/language_server/tests/hover.rs
@@ -1589,3 +1589,33 @@ import wibble
         find_position_of("wibble")
     );
 }
+
+#[test]
+fn hover_custom_type() {
+    assert_hover!(
+        "
+/// Exciting documentation
+/// Maybe even multiple lines
+type Wibble {
+    /// Some more exciting documentation
+    Wibble(arg: String)
+}
+",
+        find_position_of("Wibble")
+    );
+}
+
+#[test]
+fn hover_type_constructor() {
+    assert_hover!(
+        "
+/// Exciting documentation
+/// Maybe even multiple lines
+type Wibble {
+    /// Some more exciting documentation
+    Wibble(arg: String)
+}
+",
+        find_position_of("Wibble").nth_occurrence(2)
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_custom_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_custom_type.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\ntype Wibble {\n    /// Some more exciting documentation\n    Wibble(arg: String)\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+type Wibble {
+▔▔▔▔▔↑▔▔▔▔▔▔▔
+    /// Some more exciting documentation
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    Wibble(arg: String)
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+}
+▔
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nWibble\n```\n Exciting documentation\n Maybe even multiple lines",
+    ),
+)

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_constructor.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__hover__hover_type_constructor.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/hover.rs
+expression: "\n/// Exciting documentation\n/// Maybe even multiple lines\ntype Wibble {\n    /// Some more exciting documentation\n    Wibble(arg: String)\n}\n"
+---
+/// Exciting documentation
+/// Maybe even multiple lines
+type Wibble {
+    /// Some more exciting documentation
+    Wibble(arg: String)
+    ↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+}
+
+
+----- Hover content -----
+Scalar(
+    String(
+        "```gleam\nWibble(arg: String)\n```\n Some more exciting documentation",
+    ),
+)


### PR DESCRIPTION
Adds hover info for custom types and closes https://github.com/gleam-lang/gleam/issues/4451. I marked this PR as a draft, because the behavior I implemented differs slightly from the original proposed behavior I proposed. See https://github.com/gleam-lang/gleam/issues/4451#issuecomment-2783984769 for more context.

This PR changes the language server display type info like the following:
```gleam
//// wibble.gleam

type Wibble {
  // ^ Wibble

  Wibble(Int)
  // ^ Wibble(Int)

  Wobble(String)
  // ^ Wobble(String)
}
```