### PR TITLE
Ignore .DS_Store in new Gleam Projects

### DIFF
--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -117,6 +117,9 @@ gleam test  # Run the tests
 *.ez
 /build
 erl_crash.dump
+
+# macOS-specific files
+.DS_Store
 "
                 .into(),
             ),

--- a/compiler-cli/src/new/snapshots/gleam_cli__new__tests__new_with_default_template@.gitignore.snap
+++ b/compiler-cli/src/new/snapshots/gleam_cli__new__tests__new_with_default_template@.gitignore.snap
@@ -6,3 +6,6 @@ expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf())
 *.ez
 /build
 erl_crash.dump
+
+# macOS-specific files
+.DS_Store

--- a/compiler-cli/src/new/snapshots/gleam_cli__new__tests__new_with_javascript_template@.gitignore.snap
+++ b/compiler-cli/src/new/snapshots/gleam_cli__new__tests__new_with_javascript_template@.gitignore.snap
@@ -6,3 +6,6 @@ expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf())
 *.ez
 /build
 erl_crash.dump
+
+# macOS-specific files
+.DS_Store


### PR DESCRIPTION
Hi!

I noticed in a lot of my gleam projects, that .DS_Store files pop up sometimes and I have to manually add it to the .gitignore every time. As far as I know it is best practice to not include that file, so I thought I add it to the template for a `gleam new` project.

Happy to discuss, if this makes sense 🙂