### PR TITLE
Fix issue with slow response to TERM signal within docker containers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@
   module, for running development entrypoints.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Updated the `erlang-shipment-entrypoint.sh` to add an exec statement so the
+  erlang process replaces the shell's process and can receive signals when
+  deployed in a docker container.
+  ([Christopher De Vries](https://github.com/devries))
+
 ### Language server
 
 - The code action to add missing labels to function now also works in patterns:

--- a/compiler-cli/templates/erlang-shipment-entrypoint.sh
+++ b/compiler-cli/templates/erlang-shipment-entrypoint.sh
@@ -6,7 +6,7 @@ BASE=$(dirname "$0")
 COMMAND="${1-default}"
 
 run() {
-  erl \
+  exec erl \
     -pa "$BASE"/*/ebin \
     -eval "$PACKAGE@@main:run($PACKAGE)" \
     -noshell \


### PR DESCRIPTION
One deployment pattern for gleam programs running on the BEAM is to split the build into two parts. The first runs in the gleam container and exports an erlang shipment with `gleam export erlang-shipment` while the second container can the an erlang container that uses the `entrypoint.sh` script as its ENTRYPOINT.

I noticed an issue where gleam containers are not terminating quickly when they receive the TERM signal. This is because the TERM signal is being received by the unix shell which terminates, but the erlang program continues to run until it is killed by the docker daemon. By adding the `exec` prior to the `erl` statement in the script, the erlang program takes over the entrypoint process and will receive any signals sent to the docker container directly. This should improve the responsiveness of gleam containers built in this way to signals within the docker ecosystem.