### PR TITLE
Bump pubgrub.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -687,7 +687,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -927,7 +927,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ dependencies = [
  "strum",
  "tar",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "toml",
  "tracing",
  "unicode-segmentation",
@@ -1240,6 +1240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,9 +1259,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hexpm"
-version = "3.3.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4ea53d065cbbcc44f7a5f1814ae2c526d934c5344b97caf2953125aea28e79"
+checksum = "4f62182f03cb6894803f78f69dd22720bb9ed5ee6f7e5a64034c67a043e72f81"
 dependencies = [
  "base16",
  "bytes",
@@ -1270,7 +1276,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "x509-parser",
 ]
@@ -1428,7 +1434,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.69",
  "unic-langid",
 ]
 
@@ -1448,7 +1454,7 @@ dependencies = [
  "log",
  "parking_lot",
  "rust-embed",
- "thiserror",
+ "thiserror 1.0.69",
  "unic-langid",
  "walkdir",
 ]
@@ -1688,12 +1694,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2208,6 +2214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef08705fa1589a1a59aa924ad77d14722cb0cd97b67dd5004ed5f4a4873fce8d"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,12 +2318,16 @@ dependencies = [
 
 [[package]]
 name = "pubgrub"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd14552ad5f5d743a323c10d576f26822a044355d6601f377d813ece46f38fd"
+checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
 dependencies = [
- "rustc-hash 1.1.0",
- "thiserror",
+ "indexmap",
+ "log",
+ "priority-queue",
+ "rustc-hash 2.0.0",
+ "thiserror 2.0.12",
+ "version-ranges",
 ]
 
 [[package]]
@@ -2339,7 +2360,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 1.1.0",
  "rustls",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -2356,7 +2377,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tracing",
 ]
@@ -2492,7 +2513,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3171,7 +3192,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3179,6 +3209,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3288,20 +3329,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -3557,6 +3605,15 @@ name = "vec1"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8d079415ceb2be83fc355adbadafe401307d5c309c7e6ade6638e6f9f42f42d"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "version_check"
@@ -3999,9 +4056,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]
@@ -4052,7 +4109,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ toml = "0"
 # Enum trait impl macros
 strum = { version = "0", features = ["derive"] }
 # Hex package manager client
-hexpm = "3.3"
+hexpm = "4"
 # Creation of tar file archives
 tar = "0"
 # gzip compression
@@ -61,4 +61,4 @@ pretty_assertions = "1"
 insta = { version = "1", features = ["glob"] }
 # A transitive dependency needed to compile into wasm32-unknown-unknown
 # See https://docs.rs/getrandom/latest/getrandom/index.html#webassembly-support
-getrandom = { version = "0", features = ["js"] }
+getrandom = { version = "0.2", features = ["js"] }

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -36,7 +36,7 @@ same-file = "1"
 # Open generated docs in browser
 opener = "0"
 # Pubgrub dependency resolution algorithm
-pubgrub = "0"
+pubgrub = "0.3"
 
 camino = { workspace = true, features = ["serde1"] }
 async-trait.workspace = true

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -320,60 +320,36 @@ fn parse_gleam_add_specifier_non_numeric_version() {
 #[test]
 fn parse_gleam_add_specifier_default() {
     let provided = "some_package";
-    let expected = ">= 0.0.0";
+    let expected = Requirement::hex(">= 0.0.0").unwrap();
     let (package, version) = parse_gleam_add_specifier(provided).unwrap();
-    match &version {
-        Requirement::Hex { version: v } => {
-            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {v}");
-        }
-        _ => assert!(false, "failed hexpm version parse: {provided}"),
-    }
-    assert_eq!(version, Requirement::hex(expected));
+    assert_eq!(version, expected);
     assert_eq!("some_package", package);
 }
 
 #[test]
 fn parse_gleam_add_specifier_major_only() {
     let provided = "wobble@1";
-    let expected = ">= 1.0.0 and < 2.0.0";
+    let expected = Requirement::hex(">= 1.0.0 and < 2.0.0").unwrap();
     let (package, version) = parse_gleam_add_specifier(provided).unwrap();
-    match &version {
-        Requirement::Hex { version: v } => {
-            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {v}");
-        }
-        _ => assert!(false, "failed hexpm version parse: {provided}"),
-    }
-    assert_eq!(version, Requirement::hex(expected));
+    assert_eq!(version, expected);
     assert_eq!("wobble", package);
 }
 
 #[test]
 fn parse_gleam_add_specifier_major_and_minor() {
     let provided = "wibble@1.2";
-    let expected = ">= 1.2.0 and < 2.0.0";
+    let expected = Requirement::hex(">= 1.2.0 and < 2.0.0").unwrap();
     let (package, version) = parse_gleam_add_specifier(provided).unwrap();
-    match &version {
-        Requirement::Hex { version: v } => {
-            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {v}");
-        }
-        _ => assert!(false, "failed hexpm version parse: {provided}"),
-    }
-    assert_eq!(version, Requirement::hex(expected));
+    assert_eq!(version, expected);
     assert_eq!("wibble", package);
 }
 
 #[test]
 fn parse_gleam_add_specifier_major_minor_and_patch() {
     let provided = "bobble@1.2.3";
-    let expected = "1.2.3";
+    let expected = Requirement::hex("1.2.3").unwrap();
     let (package, version) = parse_gleam_add_specifier(provided).unwrap();
-    match &version {
-        Requirement::Hex { version: v } => {
-            assert!(v.to_pubgrub().is_ok(), "failed pubgrub parse: {v}");
-        }
-        _ => assert!(false, "failed hexpm version parse: {provided}"),
-    }
-    assert_eq!(version, Requirement::hex(expected));
+    assert_eq!(version, expected);
     assert_eq!("bobble", package);
 }
 
@@ -533,7 +509,10 @@ fn provide_existing_package() {
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
-    assert_eq!(result, Ok(hexpm::version::Range::new("== 0.1.0".into())));
+    assert_eq!(
+        result,
+        Ok(hexpm::version::Range::new("== 0.1.0".into()).unwrap())
+    );
 
     let result = provide_local_package(
         "hello_world".into(),
@@ -543,7 +522,10 @@ fn provide_existing_package() {
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
-    assert_eq!(result, Ok(hexpm::version::Range::new("== 0.1.0".into())));
+    assert_eq!(
+        result,
+        Ok(hexpm::version::Range::new("== 0.1.0".into()).unwrap())
+    );
 }
 
 #[test]
@@ -558,7 +540,10 @@ fn provide_conflicting_package() {
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
-    assert_eq!(result, Ok(hexpm::version::Range::new("== 0.1.0".into())));
+    assert_eq!(
+        result,
+        Ok(hexpm::version::Range::new("== 0.1.0".into()).unwrap())
+    );
 
     let result = provide_package(
         "hello_world".into(),
@@ -592,7 +577,10 @@ fn provided_is_absolute() {
         &mut provided,
         &mut vec!["root".into(), "subpackage".into()],
     );
-    assert_eq!(result, Ok(hexpm::version::Range::new("== 0.1.0".into())));
+    assert_eq!(
+        result,
+        Ok(hexpm::version::Range::new("== 0.1.0".into()).unwrap())
+    );
     let package = provided.get("hello_world").unwrap().clone();
     match package.source {
         ProvidedPackageSource::Local { path } => {
@@ -634,11 +622,11 @@ fn provided_local_to_hex() {
         requirements: [
             (
                 "req_1".into(),
-                hexpm::version::Range::new("~> 1.0.0".into()),
+                hexpm::version::Range::new("~> 1.0.0".into()).unwrap(),
             ),
             (
                 "req_2".into(),
-                hexpm::version::Range::new("== 1.0.0".into()),
+                hexpm::version::Range::new("== 1.0.0".into()).unwrap(),
             ),
         ]
         .into(),
@@ -656,7 +644,7 @@ fn provided_local_to_hex() {
                 (
                     "req_1".into(),
                     hexpm::Dependency {
-                        requirement: hexpm::version::Range::new("~> 1.0.0".into()),
+                        requirement: hexpm::version::Range::new("~> 1.0.0".into()).unwrap(),
                         optional: false,
                         app: None,
                         repository: None,
@@ -665,7 +653,7 @@ fn provided_local_to_hex() {
                 (
                     "req_2".into(),
                     hexpm::Dependency {
-                        requirement: hexpm::version::Range::new("== 1.0.0".into()),
+                        requirement: hexpm::version::Range::new("== 1.0.0".into()).unwrap(),
                         optional: false,
                         app: None,
                         repository: None,
@@ -693,11 +681,11 @@ fn provided_git_to_hex() {
         requirements: [
             (
                 "req_1".into(),
-                hexpm::version::Range::new("~> 1.0.0".into()),
+                hexpm::version::Range::new("~> 1.0.0".into()).unwrap(),
             ),
             (
                 "req_2".into(),
-                hexpm::version::Range::new("== 1.0.0".into()),
+                hexpm::version::Range::new("== 1.0.0".into()).unwrap(),
             ),
         ]
         .into(),
@@ -715,7 +703,7 @@ fn provided_git_to_hex() {
                 (
                     "req_1".into(),
                     hexpm::Dependency {
-                        requirement: hexpm::version::Range::new("~> 1.0.0".into()),
+                        requirement: hexpm::version::Range::new("~> 1.0.0".into()).unwrap(),
                         optional: false,
                         app: None,
                         repository: None,
@@ -724,7 +712,7 @@ fn provided_git_to_hex() {
                 (
                     "req_2".into(),
                     hexpm::Dependency {
-                        requirement: hexpm::version::Range::new("== 1.0.0".into()),
+                        requirement: hexpm::version::Range::new("== 1.0.0".into()).unwrap(),
                         optional: false,
                         app: None,
                         repository: None,
@@ -751,11 +739,11 @@ fn provided_local_to_manifest() {
         requirements: [
             (
                 "req_1".into(),
-                hexpm::version::Range::new("~> 1.0.0".into()),
+                hexpm::version::Range::new("~> 1.0.0".into()).unwrap(),
             ),
             (
                 "req_2".into(),
-                hexpm::version::Range::new("== 1.0.0".into()),
+                hexpm::version::Range::new("== 1.0.0".into()).unwrap(),
             ),
         ]
         .into(),
@@ -789,11 +777,11 @@ fn provided_git_to_manifest() {
         requirements: [
             (
                 "req_1".into(),
-                hexpm::version::Range::new("~> 1.0.0".into()),
+                hexpm::version::Range::new("~> 1.0.0".into()).unwrap(),
             ),
             (
                 "req_2".into(),
-                hexpm::version::Range::new("== 1.0.0".into()),
+                hexpm::version::Range::new("== 1.0.0".into()).unwrap(),
             ),
         ]
         .into(),
@@ -875,7 +863,7 @@ fn create_testable_unlock_manifest(
             (
                 name,
                 Requirement::Hex {
-                    version: hexpm::version::Range::new(range.into()),
+                    version: hexpm::version::Range::new(range.into()).unwrap(),
                 },
             )
         })
@@ -1219,14 +1207,14 @@ fn package_config(
 #[test]
 fn test_remove_do_nothing() {
     let config = package_config(
-        HashMap::from([("a".into(), Requirement::hex("~>1"))]),
-        HashMap::from([("b".into(), Requirement::hex("~>2"))]),
+        HashMap::from([("a".into(), Requirement::hex("~>1.0").unwrap())]),
+        HashMap::from([("b".into(), Requirement::hex("~>2.0").unwrap())]),
     );
 
     let mut manifest = Manifest {
         requirements: HashMap::from([
-            ("a".into(), Requirement::hex("~>1")),
-            ("b".into(), Requirement::hex("~>2")),
+            ("a".into(), Requirement::hex("~>1.0").unwrap()),
+            ("b".into(), Requirement::hex("~>2.0").unwrap()),
         ]),
         packages: vec![
             manifest_package("a", "1.0.0", vec![]),
@@ -1247,7 +1235,7 @@ fn test_remove_simple() {
     let config = package_config(HashMap::new(), HashMap::new());
 
     let mut manifest = Manifest {
-        requirements: HashMap::from([("a".into(), Requirement::hex("~>1"))]),
+        requirements: HashMap::from([("a".into(), Requirement::hex("~>1.0").unwrap())]),
         packages: vec![manifest_package("a", "1.0.0", vec![])],
     };
 
@@ -1262,7 +1250,7 @@ fn test_remove_package_with_transitive_dependencies() {
     let config = package_config(HashMap::new(), HashMap::new());
 
     let mut manifest = Manifest {
-        requirements: HashMap::from([("a".into(), Requirement::hex("~>1"))]),
+        requirements: HashMap::from([("a".into(), Requirement::hex("~>1.0").unwrap())]),
         packages: vec![
             manifest_package("a", "1.0.0", vec!["b".into()]),
             manifest_package("b", "1.2.3", vec!["c".into()]),
@@ -1279,14 +1267,14 @@ fn test_remove_package_with_transitive_dependencies() {
 #[test]
 fn test_remove_package_with_shared_transitive_dependencies() {
     let config = package_config(
-        HashMap::from([("a".into(), Requirement::hex("~>1"))]),
+        HashMap::from([("a".into(), Requirement::hex("~>1.0").unwrap())]),
         HashMap::new(),
     );
 
     let mut manifest = Manifest {
         requirements: HashMap::from([
-            ("a".into(), Requirement::hex("~>1")),
-            ("b".into(), Requirement::hex("~>1")),
+            ("a".into(), Requirement::hex("~>1.0").unwrap()),
+            ("b".into(), Requirement::hex("~>1.0").unwrap()),
         ]),
         packages: vec![
             manifest_package("a", "1.0.0", vec!["c".into()]),
@@ -1311,14 +1299,14 @@ fn test_remove_package_with_shared_transitive_dependencies() {
 #[test]
 fn test_remove_package_that_is_also_a_transitive_dependency() {
     let config = package_config(
-        HashMap::from([("a".into(), Requirement::hex("~>1"))]),
+        HashMap::from([("a".into(), Requirement::hex("~>1.0").unwrap())]),
         HashMap::new(),
     );
 
     let mut manifest = Manifest {
         requirements: HashMap::from([
-            ("a".into(), Requirement::hex("~>1")),
-            ("b".into(), Requirement::hex("~>1")),
+            ("a".into(), Requirement::hex("~>1.0").unwrap()),
+            ("b".into(), Requirement::hex("~>1.0").unwrap()),
         ]),
         packages: vec![
             manifest_package("a", "1.0.0", vec!["b".into(), "c".into()]),

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -335,8 +335,7 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
             // inferred lower bound could be lower.
             let minimum_required_version =
                 std::cmp::max(minimum_required_version, Version::new(1, 0, 0));
-            let inferred_version_range =
-                pubgrub::range::Range::higher_than(minimum_required_version);
+            let inferred_version_range = pubgrub::Range::higher_than(minimum_required_version);
             config.gleam_version = Some(GleamVersion::from_pubgrub(inferred_version_range));
         }
         // Otherwise we need to check that the annotated version range is
@@ -699,8 +698,8 @@ fn release_metadata_as_erlang() {
     let version = "1.2.3".try_into().unwrap();
     let homepage = "https://gleam.run".parse().unwrap();
     let github = "https://github.com/lpil/myapp".parse().unwrap();
-    let req1 = Range::new("~> 1.2.3 or >= 5.0.0".into());
-    let req2 = Range::new("~> 1.2".into());
+    let req1 = Range::new("~> 1.2.3 or >= 5.0.0".into()).unwrap();
+    let req2 = Range::new("~> 1.2".into()).unwrap();
     let meta = ReleaseMetadata {
         name: "myapp",
         version: &version,

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -31,7 +31,7 @@ globset = { version = "0", features = ["serde1"] }
 # Checksums
 xxhash-rust = { version = "0", features = ["xxh3"] }
 # Pubgrub dependency resolution algorithm
-pubgrub = "0"
+pubgrub = "0.3"
 # Used for converting absolute path to relative path
 pathdiff = { version = "0", features = ["camino"] }
 # Memory arena using ids rather than references

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -214,7 +214,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 .package_config
                 .gleam_version
                 .clone()
-                .map(|version| version.as_pubgrub()),
+                .map(|version| version.into()),
             current_module: self.module_name.clone(),
             target: self.target,
             importable_modules: self.importable_modules,

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -24,7 +24,7 @@ use crate::{
 use ecow::EcoString;
 use hexpm::version::Version;
 use itertools::Itertools;
-use pubgrub::range::Range;
+use pubgrub::Range;
 use std::{
     cmp,
     collections::{HashMap, HashSet},

--- a/compiler-core/src/config/stale_package_remover.rs
+++ b/compiler-core/src/config/stale_package_remover.rs
@@ -95,7 +95,7 @@ mod tests {
         let requirements = HashMap::from_iter([(
             "required_package".into(),
             Requirement::Hex {
-                version: Range::new("1.0.0".into()),
+                version: Range::new("1.0.0".into()).unwrap(),
             },
         )]);
         let manifest = Manifest {

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -1,5 +1,5 @@
 use hexpm::version::Version;
-use pubgrub::range::Range;
+use pubgrub::Range;
 
 use crate::{
     assert_js, assert_js_no_warnings_with_gleam_version, assert_js_warnings_with_gleam_version,

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -311,7 +311,7 @@ fn add_package_from_manifest<B>(
         package.name.clone(),
         match package.source {
             ManifestPackageSource::Hex { .. } => Requirement::Hex {
-                version: Range::new("1.0.0".into()),
+                version: Range::new("1.0.0".into()).unwrap(),
             },
             ManifestPackageSource::Local { ref path } => Requirement::Path { path: path.into() },
             ManifestPackageSource::Git {
@@ -336,7 +336,7 @@ fn add_dev_package_from_manifest<B>(
         package.name.clone(),
         match package.source {
             ManifestPackageSource::Hex { .. } => Requirement::Hex {
-                version: Range::new("1.0.0".into()),
+                version: Range::new("1.0.0".into()).unwrap(),
             },
             ManifestPackageSource::Local { ref path } => Requirement::Path { path: path.into() },
             ManifestPackageSource::Git {

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -232,8 +232,8 @@ mod tests {
     fn manifest_toml_format() {
         let manifest = Manifest {
             requirements: [
-                ("zzz".into(), Requirement::hex("> 0.0.0")),
-                ("aaa".into(), Requirement::hex("> 0.0.0")),
+                ("zzz".into(), Requirement::hex("> 0.0.0").unwrap()),
+                ("aaa".into(), Requirement::hex("> 0.0.0").unwrap()),
                 (
                     "awsome_local2".into(),
                     Requirement::git("https://github.com/gleam-lang/gleam.git", "bd9fe02f"),
@@ -242,8 +242,8 @@ mod tests {
                     "awsome_local1".into(),
                     Requirement::path("../path/to/package"),
                 ),
-                ("gleam_stdlib".into(), Requirement::hex("~> 0.17")),
-                ("gleeunit".into(), Requirement::hex("~> 0.1")),
+                ("gleam_stdlib".into(), Requirement::hex("~> 0.17").unwrap()),
+                ("gleeunit".into(), Requirement::hex("~> 0.1").unwrap()),
             ]
             .into(),
             packages: vec![
@@ -342,8 +342,8 @@ zzz = { version = "> 0.0.0" }
     fn manifest_toml_format_with_unc() {
         let manifest = Manifest {
             requirements: [
-                ("zzz".into(), Requirement::hex("> 0.0.0")),
-                ("aaa".into(), Requirement::hex("> 0.0.0")),
+                ("zzz".into(), Requirement::hex("> 0.0.0").unwrap()),
+                ("aaa".into(), Requirement::hex("> 0.0.0").unwrap()),
                 (
                     "awsome_local2".into(),
                     Requirement::git("https://github.com/gleam-lang/gleam.git", "main"),
@@ -352,8 +352,8 @@ zzz = { version = "> 0.0.0" }
                     "awsome_local1".into(),
                     Requirement::path("../path/to/package"),
                 ),
-                ("gleam_stdlib".into(), Requirement::hex("~> 0.17")),
-                ("gleeunit".into(), Requirement::hex("~> 0.1")),
+                ("gleam_stdlib".into(), Requirement::hex("~> 0.17").unwrap()),
+                ("gleeunit".into(), Requirement::hex("~> 0.1").unwrap()),
             ]
             .into(),
             packages: vec![

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -1,4 +1,4 @@
-use pubgrub::range::Range;
+use pubgrub::Range;
 
 use crate::{
     analyse::TargetSupport,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -18,7 +18,7 @@ use crate::{
     parse::PatternPosition,
     reference::ReferenceKind,
 };
-use hexpm::version::Version;
+use hexpm::version::{LowestVersion, Version};
 use im::hashmap;
 use itertools::Itertools;
 use num_bigint::BigInt;

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -1,4 +1,4 @@
-use hexpm::version::Version;
+use hexpm::version::{LowestVersion, Version};
 use im::hashmap;
 use itertools::Itertools;
 use num_bigint::BigInt;

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use ecow::EcoString;
 use itertools::Itertools;
-use pubgrub::range::Range;
+use pubgrub::Range;
 use std::rc::Rc;
 use vec1::Vec1;
 


### PR DESCRIPTION
This PR requires https://github.com/gleam-lang/hexpm-rust/pull/43. Create a symlink named hexpm in the root of the project linking to my `hexpm-rust` branch to look at my changes. `Cargo.toml` needs to be cleaned before a merge.

Most changes are one of these three types of changes:
1. Accommodating the `hexpm-rust` change that parses `hexpm::version::Range`.
2. Changing imports to coincide with the 0.3 structure of pubgurb.
3. Changes to the dependency resolution due to changes to the `pubgrub::DependencyProvider` trait.

Out of those, I believe nr. 3 warrants the most explanation (2. is explained in the `hexpm-rust` pull  request -- let me know if anything is unclear). The major changes include `choose_package_version` of `pubgrub::DependencyProvider` being split into the functions `choose_version` and `prioritize`, and the trait requiring the the associated type `Err: Error + 'static`. The changes to the `choose_package_version`, might be the hardest one to get correct, but all tests are passing so I _think_ we are good. The change to the associated `Err` type required a new error type and caused this to propagate a bit. I don't know if this is the best way to do it, but it does the job :D

Again: Let me know if anything is unclear or if you want me to write a more detailed changelog.