### PR TITLE
Make analysis of lists, tuples, negation operators, `panic`, `echo` and `todo` fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@
       Person(name:, age:)
   ```
 
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+- The analysis of lists, tuples, negation operators, `panic`, `echo` and `todo`
+  is now fault tolerant, meaning that the compiler will not stop reporting
+  errors as soon as it finds one.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The build tool now supports placing modules in a directory called `dev`,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -330,7 +330,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             UntypedExpr::Tuple {
                 location, elements, ..
-            } => self.infer_tuple(elements, location),
+            } => Ok(self.infer_tuple(elements, location)),
 
             UntypedExpr::Float {
                 location, value, ..
@@ -933,21 +933,17 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         }
     }
 
-    fn infer_tuple(
-        &mut self,
-        elements: Vec<UntypedExpr>,
-        location: SrcSpan,
-    ) -> Result<TypedExpr, Error> {
-        let elements: Vec<_> = elements
+    fn infer_tuple(&mut self, elements: Vec<UntypedExpr>, location: SrcSpan) -> TypedExpr {
+        let elements = elements
             .into_iter()
-            .map(|element| self.infer(element))
-            .try_collect()?;
-        let type_ = tuple(elements.iter().map(HasType::type_).collect());
-        Ok(TypedExpr::Tuple {
+            .map(|element| self.infer_no_error(element))
+            .collect_vec();
+        let type_ = tuple(elements.iter().map(HasType::type_).collect_vec());
+        TypedExpr::Tuple {
             location,
             elements,
             type_,
-        })
+        }
     }
 
     fn infer_var(

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3016,3 +3016,25 @@ fn int_operator_on_floats_2() {
 fn add_on_strings() {
     assert_error!(r#""Hello, " + "Jak""#);
 }
+
+#[test]
+fn fault_tolerant_list() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  [1, "a", 1.0, "a" + 1]
+}
+"#
+    );
+}
+
+#[test]
+fn fault_tolerant_list_tail() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  [1, "a", ..["a", "b"]]
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3060,3 +3060,14 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn fault_tolerant_tuple() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  #(1, 1 + "a", not_in_scope)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3038,3 +3038,25 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn fault_tolerant_negate_bool() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  !!{ True || a }
+}
+"#
+    );
+}
+
+#[test]
+fn fault_tolerant_negate_int() {
+    assert_module_error!(
+        r#"
+pub fn main() {
+  --{ 1 + a }
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_list.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_list.snap
@@ -1,0 +1,61 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  [1, \"a\", 1.0, \"a\" + 1]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  [1, "a", 1.0, "a" + 1]
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:7
+  │
+3 │   [1, "a", 1.0, "a" + 1]
+  │       ^^^
+
+All elements of a list must be the same type, but this one doesn't
+match the one before it.
+
+Expected type:
+
+    Int
+
+Found type:
+
+    String
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:12
+  │
+3 │   [1, "a", 1.0, "a" + 1]
+  │            ^^^
+
+All elements of a list must be the same type, but this one doesn't
+match the one before it.
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Float
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:17
+  │
+3 │   [1, "a", 1.0, "a" + 1]
+  │                 ^^^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    String
+
+Hint: Strings can be joined using the `<>` operator.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_list_tail.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_list_tail.snap
@@ -1,0 +1,45 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  [1, \"a\", ..[\"a\", \"b\"]]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  [1, "a", ..["a", "b"]]
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:7
+  │
+3 │   [1, "a", ..["a", "b"]]
+  │       ^^^
+
+All elements of a list must be the same type, but this one doesn't
+match the one before it.
+
+Expected type:
+
+    Int
+
+Found type:
+
+    String
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:14
+  │
+3 │   [1, "a", ..["a", "b"]]
+  │              ^^^^^^^^^^
+
+All elements in a list must have the same type, but the elements of
+this list don't match the type of the elements being prepended to it.
+
+Expected type:
+
+    List(Int)
+
+Found type:
+
+    List(String)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_negate_bool.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_negate_bool.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  !!{ True || a }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  !!{ True || a }
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:15
+  │
+3 │   !!{ True || a }
+  │               ^
+
+The name `a` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_negate_int.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_negate_int.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  --{ 1 + a }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  --{ 1 + a }
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:11
+  │
+3 │   --{ 1 + a }
+  │           ^
+
+The name `a` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_tuple.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__fault_tolerant_tuple.snap
@@ -1,0 +1,35 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main() {\n  #(1, 1 + \"a\", not_in_scope)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  #(1, 1 + "a", not_in_scope)
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:12
+  │
+3 │   #(1, 1 + "a", not_in_scope)
+  │            ^^^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    String
+
+Hint: Strings can be joined using the `<>` operator.
+
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:17
+  │
+3 │   #(1, 1 + "a", not_in_scope)
+  │                 ^^^^^^^^^^^^
+
+The name `not_in_scope` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__negative_out_of_range_erlang_float_in_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__negative_out_of_range_erlang_float_in_pattern.snap
@@ -14,6 +14,14 @@ error: Unknown variable
 
 The name `x` is not in scope here.
 
+error: Unknown variable
+  ┌─ /src/one/two.gleam:1:32
+  │
+1 │ let assert [-1.8e308, b] = [x, y]
+  │                                ^
+
+The name `y` is not in scope here.
+
 error: Float is outside Erlang's floating point range
   ┌─ /src/one/two.gleam:1:13
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__out_of_range_erlang_float_in_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__out_of_range_erlang_float_in_pattern.snap
@@ -14,6 +14,14 @@ error: Unknown variable
 
 The name `x` is not in scope here.
 
+error: Unknown variable
+  ┌─ /src/one/two.gleam:1:31
+  │
+1 │ let assert [1.8e308, b] = [x, y]
+  │                               ^
+
+The name `y` is not in scope here.
+
 error: Float is outside Erlang's floating point range
   ┌─ /src/one/two.gleam:1:13
   │

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_destructure.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_destructure.snap
@@ -17,3 +17,11 @@ error: Unknown variable
   │     ^
 
 The name `name` is not in scope here.
+
+error: Unknown variable
+  ┌─ src/two.gleam:8:11
+  │
+8 │   #(name, score)
+  │           ^
+
+The name `score` is not in scope here.


### PR DESCRIPTION
This PR closes #4482 and also improves fault tolerance for tuples, negation operators (`-` and `!`), `panic`, `echo` and `todo`