### PR TITLE
Improve generate function code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,11 +156,37 @@
     }
   }
   ```
+
   ([Surya Rose](https://github.com/GearsDatapacks))
 
 - The language server now provides hover, autocomplete and goto definition
   for constant definitions.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+- The "generate function" code action can now choose better names based on the
+  labels and variables used. For example if I write the following code:
+
+  ```gleam
+  pub fn main() -> List(Int) {
+    let list = [1, 2, 3]
+    let number = 1
+    remove(each: number, in: list)
+  //^^^^ This function doesn't exist yet!
+  }
+  ```
+
+  And ask the language server to generate the missing function, the generated
+  code will now look like this:
+
+  ```gleam
+  fn remove(each number: Int, in list: List(Int)) -> List(Int) {
+    todo
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ### Formatter
 
@@ -177,3 +203,7 @@
 - Fixed a bug where an underscore after a zero in a number would compile to
   invalid syntax on the JavaScript target.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the "generate function" code action could generate invalid
+  code when the same variable was passed as an argument twice.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -6361,6 +6361,49 @@ pub fn main() {
 }
 
 #[test]
+fn generate_function_labels_and_arguments_can_share_the_same_name() {
+    assert_code_action!(
+        GENERATE_FUNCTION,
+        "
+pub fn main() {
+  let wibble = 10
+  wubble(wibble, wibble: 14)
+}
+",
+        find_position_of("wubble").to_selection()
+    );
+}
+
+#[test]
+fn generate_function_arguments_with_same_name_get_renamed() {
+    assert_code_action!(
+        GENERATE_FUNCTION,
+        "
+pub fn main() {
+  let wibble = 10
+  wubble(wibble, wibble)
+}
+",
+        find_position_of("wubble").to_selection()
+    );
+}
+
+#[test]
+fn generate_function_arguments_with_labels_and_variables_uses_different_names() {
+    assert_code_action!(
+        GENERATE_FUNCTION,
+        "
+pub fn main() {
+  let list = [2, 4, 5]
+  let value = 1
+  find(each: value, in: list)
+}
+",
+        find_position_of("find").to_selection()
+    );
+}
+
+#[test]
 fn pattern_match_on_argument_generates_unique_names_even_with_labels() {
     assert_code_action!(
         PATTERN_MATCH_ON_ARGUMENT,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_arguments_with_labels_and_variables_uses_different_names.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_arguments_with_labels_and_variables_uses_different_names.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let list = [2, 4, 5]\n  let value = 1\n  find(each: value, in: list)\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let list = [2, 4, 5]
+  let value = 1
+  find(each: value, in: list)
+  ↑                          
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let list = [2, 4, 5]
+  let value = 1
+  find(each: value, in: list)
+}
+
+fn find(each value: Int, in list: List(Int)) -> a {
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_arguments_with_same_name_get_renamed.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_arguments_with_same_name_get_renamed.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  wubble(wibble, wibble)\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let wibble = 10
+  wubble(wibble, wibble)
+  ↑                     
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let wibble = 10
+  wubble(wibble, wibble)
+}
+
+fn wubble(wibble: Int, wibble_2: Int) -> a {
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_labels_and_arguments_can_share_the_same_name.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_labels_and_arguments_can_share_the_same_name.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  wubble(wibble, wibble: 14)\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let wibble = 10
+  wubble(wibble, wibble: 14)
+  ↑                         
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let wibble = 10
+  wubble(wibble, wibble: 14)
+}
+
+fn wubble(wibble: Int, wibble wibble_2: Int) -> a {
+  todo
+}


### PR DESCRIPTION
This PR improves the generate function code action in a couple of ways:
- There was a bug where it would generate invalid code if the call had a variable used twice (e.g. `wibble(one, one)`)
- Now if someone uses a label and a variable, those two distinct names are used instead of duplicating the label name. For example, if you have this piece of code:
  ```gleam
  let number = 1
  let list = [1, 2, 3, 1]
  remove(each: number, in: list)
  ```
  The generated `remove` function would now look like this:
  ```diff
  +fn remove(each number: Int, in list: List(Int)) -> List(Int) {
  -fn remove(each each: Int, in in: List(Int)) -> List(Int) {
    todo
  }
  ```