### PR TITLE
Improve the error message for type constructors used with the wrong number of type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,31 @@
   errors as soon as it finds one.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The error message for types used with the wrong number of arguments has been
+  improved. For example, this piece of code:
+
+  ```gleam
+  type Wibble(a)
+
+  type Wobble {
+    Wobble(Wibble)
+  }
+  ```
+
+  Produces the following error:
+
+  ```txt
+    error: Incorrect arity
+    ┌─ /src/one/two.gleam:5:10
+    │
+  5 │   Wobble(Wibble)
+    │          ^^^^^^ Expected 1 type argument, got 0
+
+  `Wibble` requires 1 type argument but none where provided.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The build tool now supports placing modules in a directory called `dev`,
@@ -156,6 +181,7 @@
     }
   }
   ```
+
   ([Surya Rose](https://github.com/GearsDatapacks))
 
 - The language server now provides hover, autocomplete and goto definition

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2163,16 +2163,20 @@ But function expects:
                 TypeError::IncorrectTypeArity {
                     location,
                     expected,
-                    given,
-                    ..
+                    given: given_number,
+                    name,
                 } => {
-                    let text = wrap("Functions and constructors have to be \
-called with their expected number of arguments.");
                     let expected = match expected {
-                        0 => "no arguments".into(),
-                        1 => "1 argument".into(),
-                        _ => format!("{expected} arguments"),
+                        0 => "no type arguments".into(),
+                        1 => "1 type argument".into(),
+                        _ => format!("{expected} type arguments"),
                     };
+                    let given = match given_number {
+                        0 => "none",
+                        _ => &format!("{given_number}")
+                    };
+                    let text = wrap_format!("`{name}` requires {expected} \
+but {given} where provided.");
                     Diagnostic {
                         title: "Incorrect arity".into(),
                         text,
@@ -2180,7 +2184,7 @@ called with their expected number of arguments.");
                         level: Level::Error,
                         location: Some(Location {
                             label: Label {
-                                text: Some(format!("Expected {expected}, got {given}")),
+                                text: Some(format!("Expected {expected}, got {given_number}")),
                                 span: *location,
                             },
                             path: path.clone(),

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3071,3 +3071,16 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn error_for_missing_type_parameters() {
+    assert_module_error!(
+        r#"
+type Wibble(a)
+
+type Wobble {
+  Wobble(Wibble)
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__error_for_missing_type_parameters.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__error_for_missing_type_parameters.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\ntype Wibble(a)\n\ntype Wobble {\n  Wobble(Wibble)\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble(a)
+
+type Wobble {
+  Wobble(Wibble)
+}
+
+
+----- ERROR
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:5:10
+  │
+5 │   Wobble(Wibble)
+  │          ^^^^^^ Expected 1 type argument, got 0
+
+`Wibble` requires 1 type argument but none where provided.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_arity_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_arity_error.snap
@@ -10,7 +10,6 @@ error: Incorrect arity
   ┌─ /src/one/two.gleam:1:10
   │
 1 │ fn go(x: List(a, b)) -> Int { 1 }
-  │          ^^^^^^^^^^ Expected 1 argument, got 2
+  │          ^^^^^^^^^^ Expected 1 type argument, got 2
 
-Functions and constructors have to be called with their expected number of
-arguments.
+`List` requires 1 type argument but 2 where provided.


### PR DESCRIPTION
This PR closes #4464 