### PR TITLE
Improve deprecated environment variable warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@
   when deployed.
   ([Christopher De Vries](https://github.com/devries))
 
+- The build tool now provides additional information when printing warnings for
+  deprecated environment variables.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Language server
 
 - The code action to add missing labels to function now also works in patterns:

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -1,7 +1,8 @@
 use crate::{cli, fs::ConsoleWarningEmitter, http::HttpClient};
 use gleam_core::{
-    Error, Result, Warning, encryption, hex, paths::global_hexpm_credentials_path,
-    warning::WarningEmitter,
+    Error, Result, Warning, encryption, hex,
+    paths::global_hexpm_credentials_path,
+    warning::{DeprecatedEnvironmentVariable, WarningEmitter},
 };
 use std::{rc::Rc, time::SystemTime};
 
@@ -162,10 +163,7 @@ fn ask_local_password(warnings: &mut Vec<Warning>) -> std::result::Result<String
     std::env::var(PASS_ENV_NAME)
         .inspect(|_| {
             warnings.push(Warning::DeprecatedEnvironmentVariable {
-                name: PASS_ENV_NAME.into(),
-                message: Some(format!(
-                    "Use the `{API_ENV_NAME}` environment variable instead."
-                )),
+                variable: DeprecatedEnvironmentVariable::HexpmPass,
             })
         })
         .or_else(|_| cli::ask_password(LOCAL_PASS_PROMPT))
@@ -175,10 +173,7 @@ fn ask_password(warnings: &mut Vec<Warning>) -> std::result::Result<String, Erro
     std::env::var(PASS_ENV_NAME)
         .inspect(|_| {
             warnings.push(Warning::DeprecatedEnvironmentVariable {
-                name: PASS_ENV_NAME.into(),
-                message: Some(format!(
-                    "Use the `{API_ENV_NAME}` environment variable instead."
-                )),
+                variable: DeprecatedEnvironmentVariable::HexpmPass,
             })
         })
         .or_else(|_| cli::ask_password(PASS_PROMPT))
@@ -188,10 +183,7 @@ fn ask_username(warnings: &mut Vec<Warning>) -> std::result::Result<String, Erro
     std::env::var(USER_ENV_NAME)
         .inspect(|_| {
             warnings.push(Warning::DeprecatedEnvironmentVariable {
-                name: USER_ENV_NAME.into(),
-                message: Some(format!(
-                    "Use the `{API_ENV_NAME}` environment variable instead."
-                )),
+                variable: DeprecatedEnvironmentVariable::HexpmUser,
             })
         })
         .or_else(|_| cli::ask(USER_PROMPT))

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -163,6 +163,9 @@ fn ask_local_password(warnings: &mut Vec<Warning>) -> std::result::Result<String
         .inspect(|_| {
             warnings.push(Warning::DeprecatedEnvironmentVariable {
                 name: PASS_ENV_NAME.into(),
+                message: Some(format!(
+                    "Use the `{API_ENV_NAME}` environment variable instead."
+                )),
             })
         })
         .or_else(|_| cli::ask_password(LOCAL_PASS_PROMPT))
@@ -173,6 +176,9 @@ fn ask_password(warnings: &mut Vec<Warning>) -> std::result::Result<String, Erro
         .inspect(|_| {
             warnings.push(Warning::DeprecatedEnvironmentVariable {
                 name: PASS_ENV_NAME.into(),
+                message: Some(format!(
+                    "Use the `{API_ENV_NAME}` environment variable instead."
+                )),
             })
         })
         .or_else(|_| cli::ask_password(PASS_PROMPT))
@@ -183,6 +189,9 @@ fn ask_username(warnings: &mut Vec<Warning>) -> std::result::Result<String, Erro
         .inspect(|_| {
             warnings.push(Warning::DeprecatedEnvironmentVariable {
                 name: USER_ENV_NAME.into(),
+                message: Some(format!(
+                    "Use the `{API_ENV_NAME}` environment variable instead."
+                )),
             })
         })
         .or_else(|_| cli::ask(USER_PROMPT))

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -164,9 +164,34 @@ pub enum Warning {
     },
 
     DeprecatedEnvironmentVariable {
-        name: String,
-        message: Option<String>,
+        variable: DeprecatedEnvironmentVariable,
     },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Copy)]
+pub enum DeprecatedEnvironmentVariable {
+    HexpmUser,
+    HexpmPass,
+}
+
+impl DeprecatedEnvironmentVariable {
+    fn name(&self) -> &'static str {
+        match self {
+            DeprecatedEnvironmentVariable::HexpmUser => "HEXPM_USER",
+            DeprecatedEnvironmentVariable::HexpmPass => "HEXPM_PASS",
+        }
+    }
+
+    fn message(&self) -> &'static str {
+        match self {
+            DeprecatedEnvironmentVariable::HexpmUser => {
+                "Use the `{API_ENV_NAME}` environment variable instead."
+            }
+            DeprecatedEnvironmentVariable::HexpmPass => {
+                "Use the `{API_ENV_NAME}` environment variable instead."
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Copy)]
@@ -1175,14 +1200,14 @@ information.",
                 },
             },
 
-            Warning::DeprecatedEnvironmentVariable { name, message } => {
-                let text = if let Some(message) = message {
-                    wrap(&format!(
-                        "The environment variable `{name}` is deprecated.\n\n{message}"
-                    ))
-                } else {
-                    wrap(&format!("The environment variable `{name}` is deprecated."))
-                };
+            Warning::DeprecatedEnvironmentVariable { variable } => {
+                let name = variable.name();
+                let message = variable.message();
+
+                let text = wrap(&format!(
+                    "The environment variable `{name}` is deprecated.\n\n{message}"
+                ));
+
                 Diagnostic {
                     title: "Use of deprecated environment variable".into(),
                     text,

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -165,6 +165,7 @@ pub enum Warning {
 
     DeprecatedEnvironmentVariable {
         name: String,
+        message: Option<String>,
     },
 }
 
@@ -1174,13 +1175,22 @@ information.",
                 },
             },
 
-            Warning::DeprecatedEnvironmentVariable { name } => Diagnostic {
-                title: "Use of deprecated environment variable".into(),
-                text: wrap(&format!("The environment variable `{name}` is deprecated.")),
-                hint: None,
-                level: diagnostic::Level::Warning,
-                location: None,
-            },
+            Warning::DeprecatedEnvironmentVariable { name, message } => {
+                let text = if let Some(message) = message {
+                    wrap(&format!(
+                        "The environment variable `{name}` is deprecated.\n\n{message}"
+                    ))
+                } else {
+                    wrap(&format!("The environment variable `{name}` is deprecated."))
+                };
+                Diagnostic {
+                    title: "Use of deprecated environment variable".into(),
+                    text,
+                    hint: None,
+                    level: diagnostic::Level::Warning,
+                    location: None,
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I noticed that although the `HEXPM_USER` and `HEXPM_PASS` variables are now deprecated as of Gleam 1.10, no information is provided in the warning message about what to use instead of them. This PR improves that.

Before:
```
warning: Use of deprecated environment variable

The environment variable `HEXPM_PASS` is deprecated.
```
After:
```
warning: Use of deprecated environment variable

The environment variable `HEXPM_PASS` is deprecated.

Use the `HEXPM_API_KEY` environment variable instead.
```