### PR TITLE
Implement proper label completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,8 +163,6 @@
   for constant definitions.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-  ([Surya Rose](https://github.com/GearsDatapacks))
-
 - The "generate function" code action can now choose better names based on the
   labels and variables used. For example if I write the following code:
 
@@ -187,6 +185,24 @@
   ```
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The language server now provides autocomplete suggestions for labels after
+  part of the label has already been typed. For example, in this code:
+
+  ```gleam
+  pub type Person {
+    Person(name: String, number: Int)
+  }
+
+  pub fn main() {
+    Person(n|)
+  }
+  ```
+
+  The language server will provide `name:` and `number:` as autocomplete
+  suggestions.
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
 
 ### Formatter
 

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1416,7 +1416,10 @@ impl CallArg<TypedExpr> {
             //
             _ => match self.value.find_node(byte_index) {
                 Some(Located::Expression { expression, .. })
-                    if expression.location() == self.value.location() && self.label.is_none() =>
+                // This is only possibly a label if we are at the end of the expression
+                // (so not in the middle like `[abc|]`) and if this argument doesn't
+                // already have a label.
+                    if byte_index == self.value.location().end && self.label.is_none() =>
                 {
                     Some(Located::Expression {
                         expression,

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -748,6 +748,15 @@ fn find_node_call() {
         type_: type_::int(),
     };
 
+    let TypedExpr::Call {
+        fun: called_function,
+        args: function_arguments,
+        ..
+    } = expr
+    else {
+        panic!("Expression was not a function call");
+    };
+
     assert_eq!(
         expr.find_node(11),
         Some(Located::Expression {
@@ -766,7 +775,10 @@ fn find_node_call() {
         expr.find_node(16),
         Some(Located::Expression {
             expression: &arg1,
-            position: ExpressionPosition::Expression
+            position: ExpressionPosition::ArgumentOrLabel {
+                called_function,
+                function_arguments
+            }
         })
     );
     assert_eq!(
@@ -787,7 +799,10 @@ fn find_node_call() {
         expr.find_node(19),
         Some(Located::Expression {
             expression: &arg2,
-            position: ExpressionPosition::Expression
+            position: ExpressionPosition::ArgumentOrLabel {
+                called_function,
+                function_arguments
+            }
         })
     );
     assert_eq!(

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use camino::Utf8PathBuf;
 
 use crate::analyse::TargetSupport;
-use crate::build::Target;
+use crate::build::{ExpressionPosition, Target};
 use crate::config::PackageConfig;
 use crate::line_numbers::LineNumbers;
 use crate::type_::error::VariableOrigin;
@@ -163,9 +163,27 @@ fn find_node_todo() {
     let statement = compile_expression(r#" todo "#);
     let expr = get_bare_expression(&statement);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(4), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(5), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(1),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(4),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(5),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
     assert_eq!(expr.find_node(6), None);
 }
 
@@ -174,9 +192,27 @@ fn find_node_todo_with_string() {
     let statement = compile_expression(r#" todo as "ok" "#);
     let expr = get_bare_expression(&statement);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(12), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(13), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(1),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(12),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(13),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
     assert_eq!(expr.find_node(14), None);
 }
 
@@ -185,9 +221,27 @@ fn find_node_string() {
     let statement = compile_expression(r#" "ok" "#);
     let expr = get_bare_expression(&statement);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(4), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(5), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(1),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(4),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(5),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
     assert_eq!(expr.find_node(6), None);
 }
 
@@ -196,9 +250,27 @@ fn find_node_float() {
     let statement = compile_expression(r#" 1.02 "#);
     let expr = get_bare_expression(&statement);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(4), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(5), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(1),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(4),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(5),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
     assert_eq!(expr.find_node(6), None);
 }
 
@@ -207,9 +279,27 @@ fn find_node_int() {
     let statement = compile_expression(r#" 1302 "#);
     let expr = get_bare_expression(&statement);
     assert_eq!(expr.find_node(0), None);
-    assert_eq!(expr.find_node(1), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(4), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(5), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(1),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(4),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(5),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
     assert_eq!(expr.find_node(6), None);
 }
 
@@ -242,10 +332,34 @@ wibble}"#,
         name: "wibble".into(),
     };
 
-    assert_eq!(expr.find_node(15), Some(Located::Expression(&int1)));
-    assert_eq!(expr.find_node(16), Some(Located::Expression(&var)));
-    assert_eq!(expr.find_node(21), Some(Located::Expression(&var)));
-    assert_eq!(expr.find_node(22), Some(Located::Expression(&var)));
+    assert_eq!(
+        expr.find_node(15),
+        Some(Located::Expression {
+            expression: &int1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(16),
+        Some(Located::Expression {
+            expression: &var,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(21),
+        Some(Located::Expression {
+            expression: &var,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(22),
+        Some(Located::Expression {
+            expression: &var,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -285,16 +399,76 @@ fn find_node_list() {
         int_value: 3.into(),
     };
 
-    assert_eq!(list.find_node(0), Some(Located::Expression(list)));
-    assert_eq!(list.find_node(1), Some(Located::Expression(&int1)));
-    assert_eq!(list.find_node(2), Some(Located::Expression(&int1)));
-    assert_eq!(list.find_node(3), Some(Located::Expression(list)));
-    assert_eq!(list.find_node(4), Some(Located::Expression(&int2)));
-    assert_eq!(list.find_node(5), Some(Located::Expression(&int2)));
-    assert_eq!(list.find_node(6), Some(Located::Expression(list)));
-    assert_eq!(list.find_node(7), Some(Located::Expression(&int3)));
-    assert_eq!(list.find_node(8), Some(Located::Expression(&int3)));
-    assert_eq!(list.find_node(9), Some(Located::Expression(list)));
+    assert_eq!(
+        list.find_node(0),
+        Some(Located::Expression {
+            expression: list,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(1),
+        Some(Located::Expression {
+            expression: &int1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(2),
+        Some(Located::Expression {
+            expression: &int1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(3),
+        Some(Located::Expression {
+            expression: list,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(4),
+        Some(Located::Expression {
+            expression: &int2,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(5),
+        Some(Located::Expression {
+            expression: &int2,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(6),
+        Some(Located::Expression {
+            expression: list,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(7),
+        Some(Located::Expression {
+            expression: &int3,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(8),
+        Some(Located::Expression {
+            expression: &int3,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        list.find_node(9),
+        Some(Located::Expression {
+            expression: list,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -321,17 +495,83 @@ fn find_node_tuple() {
         int_value: 3.into(),
     };
 
-    assert_eq!(tuple.find_node(0), Some(Located::Expression(tuple)));
-    assert_eq!(tuple.find_node(1), Some(Located::Expression(tuple)));
-    assert_eq!(tuple.find_node(2), Some(Located::Expression(&int1)));
-    assert_eq!(tuple.find_node(3), Some(Located::Expression(&int1)));
-    assert_eq!(tuple.find_node(4), Some(Located::Expression(tuple)));
-    assert_eq!(tuple.find_node(5), Some(Located::Expression(&int2)));
-    assert_eq!(tuple.find_node(6), Some(Located::Expression(&int2)));
-    assert_eq!(tuple.find_node(7), Some(Located::Expression(tuple)));
-    assert_eq!(tuple.find_node(8), Some(Located::Expression(&int3)));
-    assert_eq!(tuple.find_node(9), Some(Located::Expression(&int3)));
-    assert_eq!(tuple.find_node(10), Some(Located::Expression(tuple)));
+    assert_eq!(
+        tuple.find_node(0),
+        Some(Located::Expression {
+            expression: tuple,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(1),
+        Some(Located::Expression {
+            expression: tuple,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(2),
+        Some(Located::Expression {
+            expression: &int1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(3),
+        Some(Located::Expression {
+            expression: &int1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(4),
+        Some(Located::Expression {
+            expression: tuple,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(5),
+        Some(Located::Expression {
+            expression: &int2,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(6),
+        Some(Located::Expression {
+            expression: &int2,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(7),
+        Some(Located::Expression {
+            expression: tuple,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(8),
+        Some(Located::Expression {
+            expression: &int3,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(9),
+        Some(Located::Expression {
+            expression: &int3,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        tuple.find_node(10),
+        Some(Located::Expression {
+            expression: tuple,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -358,9 +598,27 @@ fn find_node_tuple_index() {
         type_: type_::int(),
     };
 
-    assert_eq!(expr.find_node(2), Some(Located::Expression(&int)));
-    assert_eq!(expr.find_node(5), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(6), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(2),
+        Some(Located::Expression {
+            expression: &int,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(5),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(6),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -392,8 +650,20 @@ fn find_node_module_select() {
             layer: super::Layer::Value
         })
     );
-    assert_eq!(expr.find_node(2), Some(Located::Expression(&expr)));
-    assert_eq!(expr.find_node(3), Some(Located::Expression(&expr)));
+    assert_eq!(
+        expr.find_node(2),
+        Some(Located::Expression {
+            expression: &expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(3),
+        Some(Located::Expression {
+            expression: &expr,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -408,12 +678,48 @@ fn find_node_fn() {
         type_: type_::int(),
     };
 
-    assert_eq!(expr.find_node(0), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(6), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(7), Some(Located::Expression(&int)));
-    assert_eq!(expr.find_node(8), Some(Located::Expression(&int)));
-    assert_eq!(expr.find_node(9), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(10), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(0),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(6),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(7),
+        Some(Located::Expression {
+            expression: &int,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(8),
+        Some(Located::Expression {
+            expression: &int,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(9),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(10),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -442,13 +748,55 @@ fn find_node_call() {
         type_: type_::int(),
     };
 
-    assert_eq!(expr.find_node(11), Some(Located::Expression(&return_)));
-    assert_eq!(expr.find_node(15), Some(Located::Expression(&arg1)));
-    assert_eq!(expr.find_node(16), Some(Located::Expression(&arg1)));
-    assert_eq!(expr.find_node(17), Some(Located::Expression(expr)));
-    assert_eq!(expr.find_node(18), Some(Located::Expression(&arg2)));
-    assert_eq!(expr.find_node(19), Some(Located::Expression(&arg2)));
-    assert_eq!(expr.find_node(20), Some(Located::Expression(expr)));
+    assert_eq!(
+        expr.find_node(11),
+        Some(Located::Expression {
+            expression: &return_,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(15),
+        Some(Located::Expression {
+            expression: &arg1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(16),
+        Some(Located::Expression {
+            expression: &arg1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(17),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(18),
+        Some(Located::Expression {
+            expression: &arg2,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(19),
+        Some(Located::Expression {
+            expression: &arg2,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        expr.find_node(20),
+        Some(Located::Expression {
+            expression: expr,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -469,12 +817,48 @@ fn find_node_record_access() {
         type_: type_::int(),
     };
 
-    assert_eq!(access.find_node(4), Some(Located::Expression(&string)));
-    assert_eq!(access.find_node(9), Some(Located::Expression(&string)));
-    assert_eq!(access.find_node(12), Some(Located::Expression(&int)));
-    assert_eq!(access.find_node(15), Some(Located::Expression(access)));
-    assert_eq!(access.find_node(18), Some(Located::Expression(access)));
-    assert_eq!(access.find_node(19), Some(Located::Expression(access)));
+    assert_eq!(
+        access.find_node(4),
+        Some(Located::Expression {
+            expression: &string,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        access.find_node(9),
+        Some(Located::Expression {
+            expression: &string,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        access.find_node(12),
+        Some(Located::Expression {
+            expression: &int,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        access.find_node(15),
+        Some(Located::Expression {
+            expression: access,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        access.find_node(18),
+        Some(Located::Expression {
+            expression: access,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        access.find_node(19),
+        Some(Located::Expression {
+            expression: access,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -489,11 +873,41 @@ fn find_node_record_update() {
         type_: type_::int(),
     };
 
-    assert_eq!(update.find_node(0), Some(Located::Expression(update)));
-    assert_eq!(update.find_node(3), Some(Located::Expression(update)));
-    assert_eq!(update.find_node(27), Some(Located::Expression(&int)));
-    assert_eq!(update.find_node(28), Some(Located::Expression(&int)));
-    assert_eq!(update.find_node(29), Some(Located::Expression(update)));
+    assert_eq!(
+        update.find_node(0),
+        Some(Located::Expression {
+            expression: update,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        update.find_node(3),
+        Some(Located::Expression {
+            expression: update,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        update.find_node(27),
+        Some(Located::Expression {
+            expression: &int,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        update.find_node(28),
+        Some(Located::Expression {
+            expression: &int,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        update.find_node(29),
+        Some(Located::Expression {
+            expression: update,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]
@@ -528,12 +942,48 @@ case 1, 2 {
         type_: type_::int(),
     };
 
-    assert_eq!(case.find_node(1), Some(Located::Expression(case)));
-    assert_eq!(case.find_node(6), Some(Located::Expression(&int1)));
-    assert_eq!(case.find_node(9), Some(Located::Expression(&int2)));
-    assert_eq!(case.find_node(23), Some(Located::Expression(&int3)));
-    assert_eq!(case.find_node(25), Some(Located::Expression(case)));
-    assert_eq!(case.find_node(26), Some(Located::Expression(case)));
+    assert_eq!(
+        case.find_node(1),
+        Some(Located::Expression {
+            expression: case,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        case.find_node(6),
+        Some(Located::Expression {
+            expression: &int1,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        case.find_node(9),
+        Some(Located::Expression {
+            expression: &int2,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        case.find_node(23),
+        Some(Located::Expression {
+            expression: &int3,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        case.find_node(25),
+        Some(Located::Expression {
+            expression: case,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        case.find_node(26),
+        Some(Located::Expression {
+            expression: case,
+            position: ExpressionPosition::Expression
+        })
+    );
     assert_eq!(case.find_node(27), None);
 }
 
@@ -562,12 +1012,48 @@ fn find_node_bool() {
         name: "True".into(),
     };
 
-    assert_eq!(negate.find_node(0), Some(Located::Expression(negate)));
-    assert_eq!(negate.find_node(1), Some(Located::Expression(&bool)));
-    assert_eq!(negate.find_node(2), Some(Located::Expression(&bool)));
-    assert_eq!(negate.find_node(3), Some(Located::Expression(&bool)));
-    assert_eq!(negate.find_node(4), Some(Located::Expression(&bool)));
-    assert_eq!(negate.find_node(5), Some(Located::Expression(&bool)));
+    assert_eq!(
+        negate.find_node(0),
+        Some(Located::Expression {
+            expression: negate,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        negate.find_node(1),
+        Some(Located::Expression {
+            expression: &bool,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        negate.find_node(2),
+        Some(Located::Expression {
+            expression: &bool,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        negate.find_node(3),
+        Some(Located::Expression {
+            expression: &bool,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        negate.find_node(4),
+        Some(Located::Expression {
+            expression: &bool,
+            position: ExpressionPosition::Expression
+        })
+    );
+    assert_eq!(
+        negate.find_node(5),
+        Some(Located::Expression {
+            expression: &bool,
+            position: ExpressionPosition::Expression
+        })
+    );
 }
 
 #[test]

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1025,9 +1025,12 @@ pub fn code_action_add_missing_patterns(
             return;
         }
 
-        let Some(Located::Expression(TypedExpr::Case {
-            clauses, subjects, ..
-        })) = module.find_node(location.start)
+        let Some(Located::Expression {
+            expression: TypedExpr::Case {
+                clauses, subjects, ..
+            },
+            ..
+        }) = module.find_node(location.start)
         else {
             continue;
         };

--- a/compiler-core/src/language_server/reference.rs
+++ b/compiler-core/src/language_server/reference.rs
@@ -46,19 +46,23 @@ pub fn reference_for_ast_node(
     current_module: &EcoString,
 ) -> Option<Referenced> {
     match found {
-        Located::Expression(TypedExpr::Var {
-            constructor:
-                ValueConstructor {
-                    variant:
-                        ValueConstructorVariant::LocalVariable {
-                            location: definition_location,
-                            origin,
+        Located::Expression {
+            expression:
+                TypedExpr::Var {
+                    constructor:
+                        ValueConstructor {
+                            variant:
+                                ValueConstructorVariant::LocalVariable {
+                                    location: definition_location,
+                                    origin,
+                                },
+                            ..
                         },
+                    location,
                     ..
                 },
-            location,
             ..
-        }) => Some(Referenced::LocalVariable {
+        } => Some(Referenced::LocalVariable {
             definition_location: *definition_location,
             location: *location,
             origin: Some(origin.clone()),
@@ -104,18 +108,22 @@ pub fn reference_for_ast_node(
             }),
             ArgNames::Discard { .. } | ArgNames::LabelledDiscard { .. } => None,
         },
-        Located::Expression(TypedExpr::Var {
-            constructor:
-                ValueConstructor {
-                    variant:
-                        ValueConstructorVariant::ModuleConstant { module, .. }
-                        | ValueConstructorVariant::ModuleFn { module, .. },
+        Located::Expression {
+            expression:
+                TypedExpr::Var {
+                    constructor:
+                        ValueConstructor {
+                            variant:
+                                ValueConstructorVariant::ModuleConstant { module, .. }
+                                | ValueConstructorVariant::ModuleFn { module, .. },
+                            ..
+                        },
+                    name,
+                    location,
                     ..
                 },
-            name,
-            location,
             ..
-        }) => Some(Referenced::ModuleValue {
+        } => Some(Referenced::ModuleValue {
             module: module.clone(),
             name: name.clone(),
             location: *location,
@@ -123,14 +131,19 @@ pub fn reference_for_ast_node(
             target_kind: RenameTarget::Unqualified,
         }),
 
-        Located::Expression(TypedExpr::ModuleSelect {
-            module_name,
-            label,
-            constructor: ModuleValueConstructor::Fn { .. } | ModuleValueConstructor::Constant { .. },
-            location,
-            field_start,
+        Located::Expression {
+            expression:
+                TypedExpr::ModuleSelect {
+                    module_name,
+                    label,
+                    constructor:
+                        ModuleValueConstructor::Fn { .. } | ModuleValueConstructor::Constant { .. },
+                    location,
+                    field_start,
+                    ..
+                },
             ..
-        }) => Some(Referenced::ModuleValue {
+        } => Some(Referenced::ModuleValue {
             module: module_name.clone(),
             name: label.clone(),
 
@@ -155,29 +168,37 @@ pub fn reference_for_ast_node(
             name_kind: Named::Function,
             target_kind: RenameTarget::Definition,
         }),
-        Located::Expression(TypedExpr::Var {
-            constructor:
-                ValueConstructor {
-                    variant: ValueConstructorVariant::Record { module, name, .. },
+        Located::Expression {
+            expression:
+                TypedExpr::Var {
+                    constructor:
+                        ValueConstructor {
+                            variant: ValueConstructorVariant::Record { module, name, .. },
+                            ..
+                        },
+                    location,
                     ..
                 },
-            location,
             ..
-        }) => Some(Referenced::ModuleValue {
+        } => Some(Referenced::ModuleValue {
             module: module.clone(),
             name: name.clone(),
             location: *location,
             name_kind: Named::CustomTypeVariant,
             target_kind: RenameTarget::Unqualified,
         }),
-        Located::Expression(TypedExpr::ModuleSelect {
-            module_name,
-            label,
-            constructor: ModuleValueConstructor::Record { .. },
-            location,
-            field_start,
+        Located::Expression {
+            expression:
+                TypedExpr::ModuleSelect {
+                    module_name,
+                    label,
+                    constructor: ModuleValueConstructor::Record { .. },
+                    location,
+                    field_start,
+                    ..
+                },
             ..
-        }) => Some(Referenced::ModuleValue {
+        } => Some(Referenced::ModuleValue {
             module: module_name.clone(),
             name: label.clone(),
             location: SrcSpan::new(*field_start, location.end),

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -2115,3 +2115,19 @@ pub fn main() {
         Position::new(4, 21)
     );
 }
+
+#[test]
+fn no_label_completions_in_nested_expression() {
+    // Since we are completing inside a list, labels are no longer available
+    let code = "
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble([w])
+}
+";
+
+    assert_completion!(TestProject::for_source(code), Position::new(6, 11));
+}

--- a/compiler-core/src/language_server/tests/completion.rs
+++ b/compiler-core/src/language_server/tests/completion.rs
@@ -2038,3 +2038,80 @@ pub fn some_function() { todo }
         Position::new(13, 28)
     );
 }
+
+#[test]
+fn labelled_arguments() {
+    let code = "
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble(w)
+}
+";
+
+    assert_completion!(TestProject::for_source(code), Position::new(6, 10));
+}
+
+#[test]
+fn labelled_arguments_with_existing_label() {
+    // This should only suggest the `wobble:` label
+    let code = "
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble(wibble: 10, w)
+}
+";
+
+    assert_completion!(TestProject::for_source(code), Position::new(6, 22));
+}
+
+#[test]
+fn labelled_arguments_after_label() {
+    // This should not suggest any labels, as `wibble: wibble:` is not valid syntax.
+    let code = "
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble(wibble: w)
+}
+";
+
+    assert_completion!(TestProject::for_source(code), Position::new(6, 18));
+}
+
+#[test]
+fn labelled_arguments_function_call() {
+    let code = "
+pub fn divide(x: Int, by y: Int) { x / y }
+
+pub fn main() {
+  divide(10, b)
+}
+";
+
+    assert_completion!(TestProject::for_source(code), Position::new(4, 14));
+}
+
+#[test]
+fn labelled_arguments_from_different_module() {
+    let code = "
+import wibble
+
+pub fn main() {
+  wibble.divide(10, b)
+}
+";
+
+    assert_completion!(
+        TestProject::for_source(code)
+            .add_hex_module("wibble", "pub fn divide(x: Int, by y: Int) { x / y }"),
+        Position::new(4, 21)
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments.snap
@@ -1,0 +1,56 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Float)\n}\n\npub fn main() {\n  Wibble(w)\n}\n"
+---
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble(w|)
+}
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+Wibble
+  kind:   Constructor
+  detail: fn(Int, Float) -> Wibble
+  sort:   2_Wibble
+  desc:   app
+  edits:
+    [6:9-6:9]: "Wibble"
+main
+  kind:   Function
+  detail: fn() -> Wibble
+  sort:   2_main
+  desc:   app
+  edits:
+    [6:9-6:9]: "main"
+wibble:
+  kind:   Field
+  detail: Int
+  sort:   0_wibble:
+wobble:
+  kind:   Field
+  detail: Float
+  sort:   0_wobble:

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_after_label.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_after_label.snap
@@ -1,0 +1,48 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Float)\n}\n\npub fn main() {\n  Wibble(wibble: w)\n}\n"
+---
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble(wibble: w|)
+}
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+Wibble
+  kind:   Constructor
+  detail: fn(Int, Float) -> Wibble
+  sort:   2_Wibble
+  desc:   app
+  edits:
+    [6:17-6:17]: "Wibble"
+main
+  kind:   Function
+  detail: fn() -> Wibble
+  sort:   2_main
+  desc:   app
+  edits:
+    [6:17-6:17]: "main"

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_from_different_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_from_different_module.snap
@@ -1,0 +1,50 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\nimport wibble\n\npub fn main() {\n  wibble.divide(10, b)\n}\n"
+---
+import wibble
+
+pub fn main() {
+  wibble.divide(10, b|)
+}
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+by:
+  kind:   Field
+  detail: Int
+  sort:   0_by:
+main
+  kind:   Function
+  detail: fn() -> Int
+  sort:   2_main
+  desc:   app
+  edits:
+    [4:20-4:20]: "main"
+wibble.divide
+  kind:   Function
+  detail: fn(Int, Int) -> Int
+  sort:   3_wibble.divide
+  desc:   app
+  edits:
+    [4:20-4:20]: "wibble.divide"

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_function_call.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_function_call.snap
@@ -1,0 +1,50 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\npub fn divide(x: Int, by y: Int) { x / y }\n\npub fn main() {\n  divide(10, b)\n}\n"
+---
+pub fn divide(x: Int, by y: Int) { x / y }
+
+pub fn main() {
+  divide(10, b|)
+}
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+by:
+  kind:   Field
+  detail: Int
+  sort:   0_by:
+divide
+  kind:   Function
+  detail: fn(Int, Int) -> Int
+  sort:   2_divide
+  desc:   app
+  edits:
+    [4:13-4:13]: "divide"
+main
+  kind:   Function
+  detail: fn() -> Int
+  sort:   2_main
+  desc:   app
+  edits:
+    [4:13-4:13]: "main"

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_with_existing_label.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__labelled_arguments_with_existing_label.snap
@@ -1,0 +1,52 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Float)\n}\n\npub fn main() {\n  Wibble(wibble: 10, w)\n}\n"
+---
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble(wibble: 10, w|)
+}
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+Wibble
+  kind:   Constructor
+  detail: fn(Int, Float) -> Wibble
+  sort:   2_Wibble
+  desc:   app
+  edits:
+    [6:21-6:21]: "Wibble"
+main
+  kind:   Function
+  detail: fn() -> Wibble
+  sort:   2_main
+  desc:   app
+  edits:
+    [6:21-6:21]: "main"
+wobble:
+  kind:   Field
+  detail: Float
+  sort:   0_wobble:

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__no_label_completions_in_nested_expression.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__completion__no_label_completions_in_nested_expression.snap
@@ -1,0 +1,48 @@
+---
+source: compiler-core/src/language_server/tests/completion.rs
+expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Float)\n}\n\npub fn main() {\n  Wibble([w])\n}\n"
+---
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Float)
+}
+
+pub fn main() {
+  Wibble([w|])
+}
+
+
+----- Completion content -----
+Error
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Error
+False
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_False
+Nil
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_Nil
+Ok
+  kind:   Constructor
+  detail: gleam
+  sort:   4_Ok
+True
+  kind:   EnumMember
+  detail: gleam
+  sort:   4_True
+Wibble
+  kind:   Constructor
+  detail: fn(Int, Float) -> Wibble
+  sort:   2_Wibble
+  desc:   app
+  edits:
+    [6:10-6:10]: "Wibble"
+main
+  kind:   Function
+  detail: fn() -> Wibble
+  sort:   2_main
+  desc:   app
+  edits:
+    [6:10-6:10]: "main"


### PR DESCRIPTION
Closes #3961 
As discussed in the above issue, there was already label completion functionality in the language server, but it only worked if no part of the label was yet typed, e.g. `Wibble(|)`.
This PR adds support for label completions when part of the label has already been typed, e.g. `Wibble(wib|)`.