### PR TITLE
Fix caching bug with git dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,3 +227,7 @@
 - Fixed a bug where replacing a Hex dependency with a Git dependency of the
   same name would cause the build tool to fail.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where updating the remote URL of a Git dependency would fail to
+  update the remote in the local dependency, causing a caching issue.
+  ([Surya Rose](https://github.com/GearsDatapacks))


### PR DESCRIPTION
Fixes #4492 
I've also added a comment explaining why the current method is used, and how we might want to optimise it in the future. This should hopefully make it more clear what is happening in this function.