### PR TITLE
Some refactoring to expression inference

### DIFF
--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4010,7 +4010,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             // Used to track if any argument names are used more than once
             let mut argument_names = HashSet::with_capacity(args.len());
 
-            for (arg, t) in args.iter().zip(args.iter().map(|arg| arg.type_.clone())) {
+            for arg in args.iter() {
                 match &arg.names {
                     ArgNames::Named { name, location }
                     | ArgNames::NamedLabelled {
@@ -4032,7 +4032,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             name.clone(),
                             *location,
                             VariableOrigin::Variable(name.clone()),
-                            t,
+                            arg.type_.clone(),
                         );
 
                         if !body.first().is_placeholder() {


### PR DESCRIPTION
While working on the fault tolerance of lists and tuples I noticed a couple of functions that could not fail but returned a result anyway. I've changed those and made sure some more functions that can't fail will not return an error!
With this we're very close to making all the `infer_` functions fault tolerant, now there's only one or two left that are a bit more tricky