### PR TITLE
Warn for individual unreachable patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,3 +289,8 @@
 
 - Fix slightly wrong error message for missing main function in test module.
   ([Samuel Cristobal](https://github.com/scristobal))
+
+- Fixed a bug where the compiler would not properly warn for unreachable
+  patterns in a `case` expression when the clause matched on multiple
+  alternative patterns.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -824,9 +824,9 @@ pub enum Warning {
         layer: Layer,
     },
 
-    UnreachableCaseClause {
+    UnreachableCasePattern {
         location: SrcSpan,
-        reason: UnreachableCaseClauseReason,
+        reason: UnreachablePatternReason,
     },
 
     /// This happens when someone tries to write a case expression where one of
@@ -1043,7 +1043,7 @@ pub enum TodoOrPanic {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum UnreachableCaseClauseReason {
+pub enum UnreachablePatternReason {
     /// The clause is unreachable because a previous pattern
     /// matches the same case.
     DuplicatePattern,
@@ -1177,7 +1177,7 @@ impl Warning {
             | Warning::InefficientEmptyListCheck { location, .. }
             | Warning::TransitiveDependencyImported { location, .. }
             | Warning::DeprecatedItem { location, .. }
-            | Warning::UnreachableCaseClause { location, .. }
+            | Warning::UnreachableCasePattern { location, .. }
             | Warning::CaseMatchOnLiteralCollection { location, .. }
             | Warning::CaseMatchOnLiteralValue { location, .. }
             | Warning::OpaqueExternalType { location, .. }

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1658,3 +1658,36 @@ fn different_catch_all_bytes_are_not_redundant() {
 }"#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2616
+#[test]
+fn duplicated_alternative_patterns() {
+    assert_warning!(
+        "
+pub fn main() {
+  let x = 1
+  case x {
+    2 | 2 -> 2
+    _ -> panic
+  }
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/2616
+#[test]
+fn duplicated_pattern_in_alternative() {
+    assert_warning!(
+        "
+pub fn main() {
+  let x = 1
+  case x {
+    2 -> x
+    1 | 2 -> x - 4
+    _ -> panic
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1691,3 +1691,56 @@ pub fn main() {
 "
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/2616
+#[test]
+fn duplicated_pattern_with_multiple_alternatives() {
+    assert_warning!(
+        "
+pub fn main() {
+  let x = 1
+  case x {
+    1 -> 1
+    3 -> 3
+    5 -> 5
+    1 | 2 | 3 | 4 | 5 -> x - 1
+    _ -> panic
+  }
+}
+"
+    );
+}
+
+#[test]
+fn unreachable_multi_pattern() {
+    assert_warning!(
+        "
+pub fn main() {
+  let x = 1
+  let y = 2
+  case x, y {
+    1, 2 -> True
+    1, 2 -> False
+    _, _ -> panic
+  }
+}
+"
+    );
+}
+
+#[test]
+fn unreachable_alternative_multi_pattern() {
+    assert_warning!(
+        "
+pub fn main() {
+  let x = 1
+  let y = 2
+  case x, y {
+    1, 2 -> True
+    3, 4 | 1, 2 -> False
+    _, _ -> panic
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_bits_catches_everything.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_bits_catches_everything.snap
@@ -13,24 +13,24 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     <<1>> -> 2
-  │     ^^^^^^^^^^
+  │     ^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.
 
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:6:5
   │
 6 │     _ -> 2
-  │     ^^^^^^
+  │     ^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_overlapping_patterns_are_redundant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_overlapping_patterns_are_redundant.snap
@@ -13,13 +13,13 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     <<1, b:size(8)-unit(2)>> -> b
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_overlapping_redundant_patterns_with_variable_size.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_overlapping_redundant_patterns_with_variable_size.snap
@@ -14,13 +14,13 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:6:5
   │
 6 │     <<_:size(len), b:size(8)-unit(2)>> -> b
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_overlapping_redundant_patterns_with_variable_size_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__bit_array_overlapping_redundant_patterns_with_variable_size_2.snap
@@ -13,13 +13,13 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     <<len, _:size(len)-unit(2), 1:size(len)>> -> 2
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__duplicated_alternative_patterns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__duplicated_alternative_patterns.snap
@@ -1,24 +1,24 @@
 ---
 source: compiler-core/src/type_/tests/exhaustiveness.rs
-expression: "\npub fn main(x) {\n  case x {\n    True -> 1\n    False -> 2\n    True -> 3\n  }\n}\n"
+expression: "\npub fn main() {\n  let x = 1\n  case x {\n    2 | 2 -> 2\n    _ -> panic\n  }\n}\n"
 ---
 ----- SOURCE CODE
 
-pub fn main(x) {
+pub fn main() {
+  let x = 1
   case x {
-    True -> 1
-    False -> 2
-    True -> 3
+    2 | 2 -> 2
+    _ -> panic
   }
 }
 
 
 ----- WARNING
 warning: Unreachable pattern
-  ┌─ /src/warning/wrn.gleam:6:5
+  ┌─ /src/warning/wrn.gleam:5:9
   │
-6 │     True -> 3
-  │     ^^^^
+5 │     2 | 2 -> 2
+  │         ^
 
 This pattern cannot be reached as a previous pattern matches the same
 values.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__duplicated_pattern_in_alternative.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__duplicated_pattern_in_alternative.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\npub fn main() {\n  let x = 1\n  case x {\n    2 -> x\n    1 | 2 -> x - 4\n    _ -> panic\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let x = 1
+  case x {
+    2 -> x
+    1 | 2 -> x - 4
+    _ -> panic
+  }
+}
+
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:6:9
+  │
+6 │     1 | 2 -> x - 4
+  │         ^
+
+This pattern cannot be reached as a previous pattern matches the same
+values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__duplicated_pattern_with_multiple_alternatives.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__duplicated_pattern_with_multiple_alternatives.snap
@@ -1,0 +1,51 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\npub fn main() {\n  let x = 1\n  case x {\n    1 -> 1\n    3 -> 3\n    5 -> 5\n    1 | 2 | 3 | 4 | 5 -> x - 1\n    _ -> panic\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let x = 1
+  case x {
+    1 -> 1
+    3 -> 3
+    5 -> 5
+    1 | 2 | 3 | 4 | 5 -> x - 1
+    _ -> panic
+  }
+}
+
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:8:5
+  │
+8 │     1 | 2 | 3 | 4 | 5 -> x - 1
+  │     ^
+
+This pattern cannot be reached as a previous pattern matches the same
+values.
+
+Hint: It can be safely removed.
+
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:8:13
+  │
+8 │     1 | 2 | 3 | 4 | 5 -> x - 1
+  │             ^
+
+This pattern cannot be reached as a previous pattern matches the same
+values.
+
+Hint: It can be safely removed.
+
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:8:21
+  │
+8 │     1 | 2 | 3 | 4 | 5 -> x - 1
+  │                     ^
+
+This pattern cannot be reached as a previous pattern matches the same
+values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns.snap
@@ -14,24 +14,24 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     "wibble" <> rest -> rest
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.
 
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:6:5
   │
 6 │     "wibblest" <> rest -> rest
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__multiple_unreachable_prefix_patterns_1.snap
@@ -14,13 +14,13 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:6:5
   │
 6 │     "wibblest" <> rest -> rest
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__other_variant_unreachable_when_inferred.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__other_variant_unreachable_when_inferred.snap
@@ -19,13 +19,13 @@ pub fn main() {
 
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
    ┌─ /src/warning/wrn.gleam:10:5
    │
 10 │     Wibble -> panic
-   │     ^^^^^^^^^^^^^^^
+   │     ^^^^^^
 
-This case clause cannot be reached as it matches on a variant of a type
-which is never present.
+This pattern cannot be reached as it matches on a variant of a type which
+is never present.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__other_variant_unreachable_when_inferred2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__other_variant_unreachable_when_inferred2.snap
@@ -20,13 +20,24 @@ pub fn main() {
 
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
    ┌─ /src/warning/wrn.gleam:11:5
    │
 11 │     Wibble | Wubble -> panic
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^
+   │     ^^^^^^
 
-This case clause cannot be reached as it matches on a variant of a type
-which is never present.
+This pattern cannot be reached as it matches on a variant of a type which
+is never present.
+
+Hint: It can be safely removed.
+
+warning: Unreachable pattern
+   ┌─ /src/warning/wrn.gleam:11:14
+   │
+11 │     Wibble | Wubble -> panic
+   │              ^^^^^^
+
+This pattern cannot be reached as it matches on a variant of a type which
+is never present.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_1.snap
@@ -13,13 +13,13 @@ pub fn main(x) {
 
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     _ -> 2
-  │     ^^^^^^
+  │     ^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_3.snap
@@ -18,35 +18,35 @@ _ -> "glooper"
 
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:8:1
   │
 8 │ 2 -> ""
-  │ ^^^^^^^
+  │ ^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.
 
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:9:1
   │
 9 │ 3 -> "glen"
-  │ ^^^^^^^^^^^
+  │ ^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.
 
-warning: Unreachable case clause
+warning: Unreachable pattern
    ┌─ /src/warning/wrn.gleam:10:1
    │
 10 │ 4 -> "glew"
-   │ ^^^^^^^^^^^
+   │ ^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_4.snap
@@ -14,13 +14,13 @@ _ -> 3
 
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:6:1
   │
 6 │ "geeper!" -> 5
-  │ ^^^^^^^^^^^^^^
+  │ ^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_5.snap
@@ -15,13 +15,13 @@ _ -> 3
 
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:6:1
   │
 6 │ "P" -> 19
-  │ ^^^^^^^^^
+  │ ^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__same_catch_all_bytes_are_redundant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__same_catch_all_bytes_are_redundant.snap
@@ -13,13 +13,13 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     <<a:bytes>> -> a
-  │     ^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_alternative_multi_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_alternative_multi_pattern.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\npub fn main() {\n  let x = 1\n  let y = 2\n  case x, y {\n    1, 2 -> True\n    3, 4 | 1, 2 -> False\n    _, _ -> panic\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let x = 1
+  let y = 2
+  case x, y {
+    1, 2 -> True
+    3, 4 | 1, 2 -> False
+    _, _ -> panic
+  }
+}
+
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:7:12
+  │
+7 │     3, 4 | 1, 2 -> False
+  │            ^^^^
+
+This pattern cannot be reached as a previous pattern matches the same
+values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_multi_pattern.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_multi_pattern.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\npub fn main() {\n  let x = 1\n  let y = 2\n  case x, y {\n    1, 2 -> True\n    1, 2 -> False\n    _, _ -> panic\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let x = 1
+  let y = 2
+  case x, y {
+    1, 2 -> True
+    1, 2 -> False
+    _, _ -> panic
+  }
+}
+
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:7:5
+  │
+7 │     1, 2 -> False
+  │     ^^^^
+
+This pattern cannot be reached as a previous pattern matches the same
+values.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_prefix_pattern_after_prefix.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_prefix_pattern_after_prefix.snap
@@ -13,13 +13,13 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     "wibble" <> rest -> rest
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^
+  │     ^^^^^^^^^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_string_pattern_after_prefix.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__unreachable_string_pattern_after_prefix.snap
@@ -13,13 +13,13 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Unreachable case clause
+warning: Unreachable pattern
   ┌─ /src/warning/wrn.gleam:5:5
   │
 5 │     "wibble" -> "a"
-  │     ^^^^^^^^^^^^^^^
+  │     ^^^^^^^^
 
-This case clause cannot be reached as a previous clause matches the same
+This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -7,7 +7,7 @@ use crate::{
         self,
         error::{
             FeatureKind, LiteralCollectionKind, PanicPosition, TodoOrPanic,
-            UnreachableCaseClauseReason,
+            UnreachablePatternReason,
         },
         pretty::Printer,
     },
@@ -804,19 +804,19 @@ Run this command to add it to your dependencies:
                     }
                 }
 
-                type_::Warning::UnreachableCaseClause { location, reason } => {
+                type_::Warning::UnreachableCasePattern { location, reason } => {
                     let text: String = match reason {
-                        UnreachableCaseClauseReason::DuplicatePattern => wrap(
-                            "This case clause cannot be reached as a previous clause matches \
-the same values.\n",
+                        UnreachablePatternReason::DuplicatePattern => wrap(
+                            "This pattern cannot be reached as a previous \
+pattern matches the same values.\n",
                         ),
-                        UnreachableCaseClauseReason::ImpossibleVariant => wrap(
-                            "This case clause cannot be reached as it matches \
-on a variant of a type which is never present.\n",
+                        UnreachablePatternReason::ImpossibleVariant => wrap(
+                            "This pattern cannot be reached as it matches on \
+a variant of a type which is never present.\n",
                         ),
                     };
                     Diagnostic {
-                        title: "Unreachable case clause".into(),
+                        title: "Unreachable pattern".into(),
                         text,
                         hint: Some("It can be safely removed.".into()),
                         level: diagnostic::Level::Warning,


### PR DESCRIPTION
Fixes #2616 
This PR changes the unreachable pattern system to warn for individual patterns, rather than the whole unreachable clause. This allows us to properly warn for unreachable patterns in an alternative pattern.