### PR TITLE
Windows ARM64 Builds

### DIFF
--- a/.github/actions/build-release/action.yml
+++ b/.github/actions/build-release/action.yml
@@ -75,7 +75,7 @@ runs:
           BINARY_PATH="${BINARY_PATH}.exe"
         fi
 
-        if ! file -b "$BINARY_PATH" | grep -q "${{ inputs.expected-binary-architecture }}"; then
+        if ! file -b "$BINARY_PATH" | grep -iq "${{ inputs.expected-binary-architecture }}"; then
           echo "error: Architecture mismatch"
           echo "Expected architecture: '${{ inputs.expected-binary-architecture }}'"
           echo "Found binary type: '$(file -b "$BINARY_PATH")'"
@@ -117,7 +117,7 @@ runs:
       shell: bash
       run: |
         case "$TARGET" in
-          x86_64-pc-windows-msvc)
+          *windows*)
             7z x "$ARCHIVE"
             ./gleam.exe --version
             ;;

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -66,6 +66,7 @@ jobs:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
         toolchain: [ stable ]
         include:
           - os: ubuntu-latest
@@ -88,6 +89,10 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             expected-binary-architecture: x86-64
+            cargo-tool: cargo
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            expected-binary-architecture: arm64
             cargo-tool: cargo
           - os: ubuntu-latest
             target: wasm32-unknown-unknown

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
         toolchain: [ stable ]
         include:
           - os: ubuntu-latest
@@ -48,6 +49,10 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             expected-binary-architecture: x86-64
+            cargo-tool: cargo
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            expected-binary-architecture: arm64
             cargo-tool: cargo
           - os: ubuntu-latest
             target: wasm32-unknown-unknown


### PR DESCRIPTION
Relatively simple to add since GitHub supports new ARM64 Windows Runners.

## Example

* Nightly CI: https://github.com/maennchen/gleam/actions/runs/14651507224
* Nightly Release: https://github.com/maennchen/gleam/releases/tag/nightly
* Release CI: https://github.com/maennchen/gleam/actions/runs/14651501051/job/41118152000
* Version Release: https://github.com/maennchen/gleam/releases/tag/vWinARM64