### PR TITLE
Improve generated code for `let assert` on the Erlang target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,10 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The compiler will now generate more efficient code for `let assert` on the
+  Erlang target.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - The build tool now supports placing modules in a directory called `dev`,
@@ -343,3 +347,8 @@
 - Fixed a bug where the language server would generate invalid code for the
   "fill in missing labels" code action.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where referencing an earlier segment of the bit array in a bit
+  array pattern in a `let assert` assignment would generate invalid code on the
+  Erlang target.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -2235,6 +2235,28 @@ impl TypedPattern {
             labelled,
         })
     }
+
+    /// Whether the pattern always matches. For example, a tuple or simple
+    /// variable assignment always match and can never fail.
+    #[must_use]
+    pub fn always_matches(&self) -> bool {
+        match self {
+            Pattern::Variable { .. } | Pattern::Discard { .. } => true,
+            Pattern::Assign { pattern, .. } => pattern.always_matches(),
+            Pattern::Tuple { elements, .. } => {
+                elements.iter().all(|element| element.always_matches())
+            }
+            Pattern::Int { .. }
+            | Pattern::Float { .. }
+            | Pattern::String { .. }
+            | Pattern::VarUsage { .. }
+            | Pattern::List { .. }
+            | Pattern::Constructor { .. }
+            | Pattern::BitArray { .. }
+            | Pattern::StringPrefix { .. }
+            | Pattern::Invalid { .. } => false,
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1189,7 +1189,6 @@ fn let_assert<'a>(
             docvec![
                 break_("{", "{"),
                 join(variables, break_(",", ", ")).nest(INDENT),
-                break_(",", ""),
                 "}"
             ]
             .group()
@@ -1206,7 +1205,6 @@ fn let_assert<'a>(
             docvec![
                 break_("{", "{"),
                 join(variables, break_(",", ", ")).nest(INDENT),
-                break_(",", ""),
                 "} = "
             ]
             .group()

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -93,7 +93,10 @@ fn print<'a>(
             ..
         } => {
             let right = match right_side_assignment {
-                AssignName::Variable(right) => env.next_local_var_name(right),
+                AssignName::Variable(right) => {
+                    vars.push(right);
+                    env.next_local_var_name(right)
+                }
                 AssignName::Discard(_) => "_".to_doc(),
             };
 
@@ -110,6 +113,7 @@ fn print<'a>(
                     //   to variables within the pattern, we first match the expected prefix length in
                     //   bytes, then use a guard clause to verify the content.
                     //
+                    vars.push(left_name);
                     let name = env.next_local_var_name(left_name);
                     guards.push(docvec![name.clone(), " =:= ", string(left_side_string)]);
                     docvec![

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__discard_in_assert.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__discard_in_assert.snap
@@ -17,8 +17,8 @@ pub fn x(y) {
 -file("project/test/my/mod.gleam", 1).
 -spec x({ok, any()} | {error, any()}) -> integer().
 x(Y) ->
-    {ok, _} = case Y of
-        {ok, _} -> Y;
+    case Y of
+        {ok, _} -> nil;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/let_assert.rs
+++ b/compiler-core/src/erlang/tests/let_assert.rs
@@ -69,13 +69,157 @@ pub fn expect(value, message) {
     );
 }
 
-// TODO: patterns that are just vars don't render a case expression
-// #[test]
-// fn just_pattern() {
-//     assert_erl!(
-//         r#"pub fn go() {
-//   let assert x = Ok(1)
-//   x
-// }"#
-//     );
-// }
+#[test]
+fn just_variable() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert x = Ok(1)
+  x
+}"#
+    );
+}
+
+#[test]
+fn tuple_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert #(a, b, c) = #(1, 2, 3)
+  a + b + c
+}"#
+    );
+}
+
+#[test]
+fn int_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert 1 = 2
+}"#
+    );
+}
+
+#[test]
+fn float_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert 1.5 = 5.1
+}"#
+    );
+}
+
+#[test]
+fn string_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert "Hello!" = "Hel" <> "lo!"
+}"#
+    );
+}
+
+#[test]
+fn assignment_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert 123 as x = 123
+  x
+}"#
+    );
+}
+
+#[test]
+fn discard_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert _ = 123
+}"#
+    );
+}
+
+#[test]
+fn list_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert [1, x, 3] = [1, 2, 3]
+  x
+}"#
+    );
+}
+
+#[test]
+fn list_pattern_with_multiple_variables() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert [a, b, c] = [1, 2, 3]
+  a + b + c
+}"#
+    );
+}
+
+#[test]
+fn constructor_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert Ok(x) = Error(Nil)
+  x
+}"#
+    );
+}
+
+#[test]
+fn constructor_pattern_with_multiple_variables() {
+    assert_erl!(
+        r#"
+pub type Wibble {
+  Wibble(Int, Float)
+}
+
+pub fn go() {
+  let assert Wibble(x, 2.0 as y) = Wibble(1, 2.0)
+  x
+}"#
+    );
+}
+
+#[test]
+fn bit_array_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert <<a:2, b:3, c:3>> = <<123>>
+  a + b + c
+}"#
+    );
+}
+
+#[test]
+fn string_prefix_pattern() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert "Hello " <> name = "Hello John"
+  name
+}"#
+    );
+}
+
+#[test]
+fn string_prefix_pattern_with_prefix_binding() {
+    assert_erl!(
+        r#"pub fn go() {
+  let assert "Hello " as greeting <> name = "Hello John"
+  #(greeting, name)
+}"#
+    );
+}
+
+#[test]
+fn let_assert_at_end_of_block() {
+    assert_erl!(
+        r#"
+pub fn go() {
+  let result = Ok(10)
+  let x = {
+    let assert Ok(_) = result
+  }
+  x
+}"#
+    );
+}

--- a/compiler-core/src/erlang/tests/let_assert.rs
+++ b/compiler-core/src/erlang/tests/let_assert.rs
@@ -223,3 +223,16 @@ pub fn go() {
 }"#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4145
+#[test]
+fn reference_earlier_segment() {
+    assert_erl!(
+        "
+pub fn main() {
+  let assert <<length, bytes:size(length)-unit(8)>> = <<3, 1, 2, 3>>
+  bytes
+}
+"
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array.snap
@@ -26,9 +26,8 @@ main() ->
     A = 1,
     Simple = <<1, A>>,
     Complex = <<4/integer-big, 5.0/little-float, 6/native-integer>>,
-    _assert_subject = <<1>>,
-    <<7:2, 8:3, B:4/binary>> = case _assert_subject of
-        <<7:2, 8:3, _:4/binary>> -> _assert_subject;
+    B = case <<1>> of
+        <<7:2, 8:3, B:4/binary>> -> B;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
@@ -37,9 +36,8 @@ main() ->
                         function => <<"main"/utf8>>,
                         line => 5})
     end,
-    _assert_subject@1 = <<1>>,
-    <<C:8/unit:1, D:2/binary-unit:2>> = case _assert_subject@1 of
-        <<_:8/unit:1, _:2/binary-unit:2>> -> _assert_subject@1;
+    {C, D} = case <<1>> of
+        <<C:8/unit:1, D:2/binary-unit:2>> -> {C, D};
         _assert_fail@1 ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array.snap
@@ -26,7 +26,7 @@ main() ->
     A = 1,
     Simple = <<1, A>>,
     Complex = <<4/integer-big, 5.0/little-float, 6/native-integer>>,
-    B = case <<1>> of
+    B@1 = case <<1>> of
         <<7:2, 8:3, B:4/binary>> -> B;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -36,7 +36,7 @@ main() ->
                         function => <<"main"/utf8>>,
                         line => 5})
     end,
-    {C, D} = case <<1>> of
+    {C@1, D@1} = case <<1>> of
         <<C:8/unit:1, D:2/binary-unit:2>> -> {C, D};
         _assert_fail@1 ->
             erlang:error(#{gleam_error => let_assert,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array2.snap
@@ -20,7 +20,7 @@ pub fn main() {
 -spec main() -> integer().
 main() ->
     A = 1,
-    B = case <<1, A>> of
+    B@1 = case <<1, A>> of
         <<B, 1>> -> B;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -30,4 +30,4 @@ main() ->
                         function => <<"main"/utf8>>,
                         line => 3})
     end,
-    B.
+    B@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array2.snap
@@ -20,9 +20,8 @@ pub fn main() {
 -spec main() -> integer().
 main() ->
     A = 1,
-    _assert_subject = <<1, A>>,
-    <<B, 1>> = case _assert_subject of
-        <<_, 1>> -> _assert_subject;
+    B = case <<1, A>> of
+        <<B, 1>> -> B;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array3.snap
@@ -20,8 +20,8 @@ pub fn main() {
 -spec main() -> integer().
 main() ->
     A = <<"test"/utf8>>,
-    <<B/utf8, "st"/utf8>> = case A of
-        <<_/utf8, "st"/utf8>> -> A;
+    B = case A of
+        <<B/utf8, "st"/utf8>> -> B;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array3.snap
@@ -20,7 +20,7 @@ pub fn main() {
 -spec main() -> integer().
 main() ->
     A = <<"test"/utf8>>,
-    B = case A of
+    B@1 = case A of
         <<B/utf8, "st"/utf8>> -> B;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -30,4 +30,4 @@ main() ->
                         function => <<"main"/utf8>>,
                         line => 3})
     end,
-    B.
+    B@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_declare_and_use_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_declare_and_use_var.snap
@@ -17,7 +17,7 @@ pub fn go(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec go(bitstring()) -> bitstring().
 go(X) ->
-    {Name_size, Name} = case X of
+    {Name_size@1, Name@1} = case X of
         <<Name_size:8, Name:Name_size/binary>> -> {Name_size, Name};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -27,4 +27,4 @@ go(X) ->
                         function => <<"go"/utf8>>,
                         line => 2})
     end,
-    Name.
+    Name@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_declare_and_use_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_declare_and_use_var.snap
@@ -17,8 +17,8 @@ pub fn go(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec go(bitstring()) -> bitstring().
 go(X) ->
-    <<Name_size@1:8, Name:Name_size@1/binary>> = case X of
-        <<_:8, _:Name_size/binary>> -> X;
+    {Name_size, Name} = case X of
+        <<Name_size:8, Name:Name_size/binary>> -> {Name_size, Name};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_float.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_float.snap
@@ -23,8 +23,8 @@ main() ->
         5.0:32/float,
         6.0:64/float-little,
         1.0:(lists:max([(B), 0]))/float>>,
-    <<1.0:16/float, 5.0:32/float, 6.0:64/float-little, 1.0:B/float>> = case Floats of
-        <<1.0:16/float, 5.0:32/float, 6.0:64/float-little, 1.0:B/float>> -> Floats;
+    case Floats of
+        <<1.0:16/float, 5.0:32/float, 6.0:64/float-little, 1.0:B/float>> -> nil;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_float.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_float.snap
@@ -24,7 +24,7 @@ main() ->
         6.0:64/float-little,
         1.0:(lists:max([(B), 0]))/float>>,
     case Floats of
-        <<1.0:16/float, 5.0:32/float, 6.0:64/float-little, 1.0:B/float>> -> nil;
+        <<1.0:16/float, 5.0:32/float, 6.0:64/float-little, 1.0:B/float>> -> Floats;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
@@ -17,9 +17,8 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 2).
 -spec main() -> bitstring().
 main() ->
-    _assert_subject = <<>>,
-    <<_/utf8, Rest/bitstring>> = case _assert_subject of
-        <<_/utf8, _/bitstring>> -> _assert_subject;
+    Rest = case <<>> of
+        <<_/utf8, Rest/bitstring>> -> Rest;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
@@ -17,7 +17,7 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 2).
 -spec main() -> bitstring().
 main() ->
-    Rest = case <<>> of
+    Rest@1 = case <<>> of
         <<_/utf8, Rest/bitstring>> -> Rest;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
@@ -17,8 +17,9 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 2).
 -spec main() -> bitstring().
 main() ->
-    Rest@1 = case <<>> of
-        <<_/utf8, Rest/bitstring>> -> Rest;
+    _assert_subject = <<>>,
+    case _assert_subject of
+        <<_/utf8, Rest/bitstring>> -> _assert_subject;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__assignment_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__assignment_pattern.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert 123 as x = 123\n  x\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert 123 as x = 123
+  x
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> integer().
+go() ->
+    X@1 = case 123 of
+        123 = X -> X;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end,
+    X@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_pattern.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert <<a:2, b:3, c:3>> = <<123>>\n  a + b + c\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert <<a:2, b:3, c:3>> = <<123>>
+  a + b + c
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> integer().
+go() ->
+    {A@1, B@1, C@1} = case <<123>> of
+        <<A:2, B:3, C:3>> -> {A, B, C};
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end,
+    (A@1 + B@1) + C@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert Ok(x) = Error(Nil)\n  x\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert Ok(x) = Error(Nil)
+  x
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> any().
+go() ->
+    X@1 = case {error, nil} of
+        {ok, X} -> X;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end,
+    X@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern_with_multiple_variables.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern_with_multiple_variables.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "\npub type Wibble {\n  Wibble(Int, Float)\n}\n\npub fn go() {\n  let assert Wibble(x, 2.0 as y) = Wibble(1, 2.0)\n  x\n}"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(Int, Float)
+}
+
+pub fn go() {
+  let assert Wibble(x, 2.0 as y) = Wibble(1, 2.0)
+  x
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+-export_type([wibble/0]).
+
+-type wibble() :: {wibble, integer(), float()}.
+
+-file("project/test/my/mod.gleam", 6).
+-spec go() -> integer().
+go() ->
+    {X@1, Y@1} = case {wibble, 1, 2.0} of
+        {wibble, X, 2.0 = Y} -> {X, Y};
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 7})
+    end,
+    X@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__discard_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__discard_pattern.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert _ = 123\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert _ = 123
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> integer().
+go() ->
+    _ = 123.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__float_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__float_pattern.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert 1.5 = 5.1\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert 1.5 = 5.1
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> float().
+go() ->
+    case 5.1 of
+        1.5 -> nil;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__float_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__float_pattern.snap
@@ -16,8 +16,9 @@ pub fn go() {
 -file("project/test/my/mod.gleam", 1).
 -spec go() -> float().
 go() ->
-    case 5.1 of
-        1.5 -> nil;
+    _assert_subject = 5.1,
+    case _assert_subject of
+        1.5 -> _assert_subject;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__int_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__int_pattern.snap
@@ -16,8 +16,9 @@ pub fn go() {
 -file("project/test/my/mod.gleam", 1).
 -spec go() -> integer().
 go() ->
-    case 2 of
-        1 -> nil;
+    _assert_subject = 2,
+    case _assert_subject of
+        1 -> _assert_subject;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__int_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__int_pattern.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert 1 = 2\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert 1 = 2
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> integer().
+go() ->
+    case 2 of
+        1 -> nil;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__just_variable.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__just_variable.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert x = Ok(1)\n  x\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert x = Ok(1)
+  x
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> {ok, integer()} | {error, any()}.
+go() ->
+    X = {ok, 1},
+    X.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_at_end_of_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_at_end_of_block.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "\npub fn go() {\n  let result = Ok(10)\n  let x = {\n    let assert Ok(_) = result\n  }\n  x\n}"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  let result = Ok(10)
+  let x = {
+    let assert Ok(_) = result
+  }
+  x
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec go() -> {ok, integer()} | {error, any()}.
+go() ->
+    Result = {ok, 10},
+    X = begin
+        case Result of
+            {ok, _} -> Result;
+            _assert_fail ->
+                erlang:error(#{gleam_error => let_assert,
+                            message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                            value => _assert_fail,
+                            module => <<"my/mod"/utf8>>,
+                            function => <<"go"/utf8>>,
+                            line => 5})
+        end
+    end,
+    X.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert [1, x, 3] = [1, 2, 3]\n  x\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert [1, x, 3] = [1, 2, 3]
+  x
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> integer().
+go() ->
+    X@1 = case [1, 2, 3] of
+        [1, X, 3] -> X;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end,
+    X@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern_with_multiple_variables.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern_with_multiple_variables.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert [a, b, c] = [1, 2, 3]\n  a + b + c\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert [a, b, c] = [1, 2, 3]
+  a + b + c
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> integer().
+go() ->
+    {A@1, B@1, C@1} = case [1, 2, 3] of
+        [A, B, C] -> {A, B, C};
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end,
+    (A@1 + B@1) + C@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__message.snap
@@ -19,8 +19,8 @@ pub fn unwrap_or_panic(value) {
 -file("project/test/my/mod.gleam", 2).
 -spec unwrap_or_panic({ok, K} | {error, any()}) -> K.
 unwrap_or_panic(Value) ->
-    {ok, Inner} = case Value of
-        {ok, _} -> Value;
+    Inner = case Value of
+        {ok, Inner} -> Inner;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Oops, there was an error"/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__message.snap
@@ -19,7 +19,7 @@ pub fn unwrap_or_panic(value) {
 -file("project/test/my/mod.gleam", 2).
 -spec unwrap_or_panic({ok, K} | {error, any()}) -> K.
 unwrap_or_panic(Value) ->
-    Inner = case Value of
+    Inner@1 = case Value of
         {ok, Inner} -> Inner;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -29,4 +29,4 @@ unwrap_or_panic(Value) ->
                         function => <<"unwrap_or_panic"/utf8>>,
                         line => 3})
     end,
-    Inner.
+    Inner@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__more_than_one_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__more_than_one_var.snap
@@ -17,7 +17,7 @@ pub fn go(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec go(list(integer())) -> list(integer()).
 go(X) ->
-    {A, B, C} = case X of
+    {A@1, B@1, C@1} = case X of
         [1, A, B, C] -> {A, B, C};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -27,4 +27,4 @@ go(X) ->
                         function => <<"go"/utf8>>,
                         line => 2})
     end,
-    [A, B, C].
+    [A@1, B@1, C@1].

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__more_than_one_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__more_than_one_var.snap
@@ -17,8 +17,8 @@ pub fn go(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec go(list(integer())) -> list(integer()).
 go(X) ->
-    [1, A, B, C] = case X of
-        [1, _, _, _] -> X;
+    {A, B, C} = case X of
+        [1, A, B, C] -> {A, B, C};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__one_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__one_var.snap
@@ -17,7 +17,7 @@ pub fn go() {
 -file("project/test/my/mod.gleam", 1).
 -spec go() -> integer().
 go() ->
-    Y = case {ok, 1} of
+    Y@1 = case {ok, 1} of
         {ok, Y} -> Y;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -27,4 +27,4 @@ go() ->
                         function => <<"go"/utf8>>,
                         line => 2})
     end,
-    Y.
+    Y@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__one_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__one_var.snap
@@ -17,9 +17,8 @@ pub fn go() {
 -file("project/test/my/mod.gleam", 1).
 -spec go() -> integer().
 go() ->
-    _assert_subject = {ok, 1},
-    {ok, Y} = case _assert_subject of
-        {ok, _} -> _assert_subject;
+    Y = case {ok, 1} of
+        {ok, Y} -> Y;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__pattern_let.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__pattern_let.snap
@@ -17,8 +17,8 @@ pub fn go(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec go(list(integer())) -> list(integer()).
 go(X) ->
-    [1 = A, B, C] = case X of
-        [1, _, _] -> X;
+    {A, B, C} = case X of
+        [1 = A, B, C] -> {A, B, C};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__pattern_let.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__pattern_let.snap
@@ -17,7 +17,7 @@ pub fn go(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec go(list(integer())) -> list(integer()).
 go(X) ->
-    {A, B, C} = case X of
+    {A@1, B@1, C@1} = case X of
         [1 = A, B, C] -> {A, B, C};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -27,4 +27,4 @@ go(X) ->
                         function => <<"go"/utf8>>,
                         line => 2})
     end,
-    [A, B, C].
+    [A@1, B@1, C@1].

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__reference_earlier_segment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__reference_earlier_segment.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "\npub fn main() {\n  let assert <<length, bytes:size(length)-unit(8)>> = <<3, 1, 2, 3>>\n  bytes\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let assert <<length, bytes:size(length)-unit(8)>> = <<3, 1, 2, 3>>
+  bytes
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec main() -> integer().
+main() ->
+    {Length@1, Bytes@1} = case <<3, 1, 2, 3>> of
+        <<Length, Bytes:Length/unit:8>> -> {Length, Bytes};
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"main"/utf8>>,
+                        line => 3})
+    end,
+    Bytes@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_pattern.snap
@@ -16,8 +16,9 @@ pub fn go() {
 -file("project/test/my/mod.gleam", 1).
 -spec go() -> binary().
 go() ->
-    case <<"Hel"/utf8, "lo!"/utf8>> of
-        <<"Hello!"/utf8>> -> nil;
+    _assert_subject = <<"Hel"/utf8, "lo!"/utf8>>,
+    case _assert_subject of
+        <<"Hello!"/utf8>> -> _assert_subject;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_pattern.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert \"Hello!\" = \"Hel\" <> \"lo!\"\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert "Hello!" = "Hel" <> "lo!"
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> binary().
+go() ->
+    case <<"Hel"/utf8, "lo!"/utf8>> of
+        <<"Hello!"/utf8>> -> nil;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert \"Hello \" <> name = \"Hello John\"\n  name\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert "Hello " <> name = "Hello John"
+  name
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> binary().
+go() ->
+    Name@1 = case <<"Hello John"/utf8>> of
+        <<"Hello "/utf8, Name/binary>> -> Name;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end,
+    Name@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern_with_prefix_binding.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern_with_prefix_binding.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert \"Hello \" as greeting <> name = \"Hello John\"\n  #(greeting, name)\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert "Hello " as greeting <> name = "Hello John"
+  #(greeting, name)
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> {binary(), binary()}.
+go() ->
+    {Name@1, Greeting@1} = case <<"Hello John"/utf8>> of
+        <<Greeting:6/binary, Name/binary>> when Greeting =:= <<"Hello "/utf8>> -> {
+        Name,
+            Greeting};
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        value => _assert_fail,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"go"/utf8>>,
+                        line => 2})
+    end,
+    {Greeting@1, Name@1}.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__tuple_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__tuple_pattern.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "pub fn go() {\n  let assert #(a, b, c) = #(1, 2, 3)\n  a + b + c\n}"
+---
+----- SOURCE CODE
+pub fn go() {
+  let assert #(a, b, c) = #(1, 2, 3)
+  a + b + c
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+
+-export([go/0]).
+
+-file("project/test/my/mod.gleam", 1).
+-spec go() -> integer().
+go() ->
+    {A, B, C} = {1, 2, 3},
+    (A + B) + C.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_message.snap
@@ -19,8 +19,8 @@ pub fn expect(value, message) {
 -file("project/test/my/mod.gleam", 2).
 -spec expect({ok, L} | {error, any()}, binary()) -> L.
 expect(Value, Message) ->
-    {ok, Inner} = case Value of
-        {ok, _} -> Value;
+    Inner = case Value of
+        {ok, Inner} -> Inner;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => Message,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_message.snap
@@ -19,7 +19,7 @@ pub fn expect(value, message) {
 -file("project/test/my/mod.gleam", 2).
 -spec expect({ok, L} | {error, any()}, binary()) -> L.
 expect(Value, Message) ->
-    Inner = case Value of
+    Inner@1 = case Value of
         {ok, Inner} -> Inner;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -29,4 +29,4 @@ expect(Value, Message) ->
                         function => <<"expect"/utf8>>,
                         line => 3})
     end,
-    Inner.
+    Inner@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_rewrites.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_rewrites.snap
@@ -18,7 +18,7 @@ pub fn go() {
 -file("project/test/my/mod.gleam", 1).
 -spec go() -> integer().
 go() ->
-    Y = case {ok, 1} of
+    Y@1 = case {ok, 1} of
         {ok, Y} -> Y;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -28,8 +28,8 @@ go() ->
                         function => <<"go"/utf8>>,
                         line => 2})
     end,
-    Y@1 = case {ok, 1} of
-        {ok, Y@1} -> Y@1;
+    Y@3 = case {ok, 1} of
+        {ok, Y@2} -> Y@2;
         _assert_fail@1 ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
@@ -38,4 +38,4 @@ go() ->
                         function => <<"go"/utf8>>,
                         line => 3})
     end,
-    Y@1.
+    Y@3.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_rewrites.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_rewrites.snap
@@ -18,9 +18,8 @@ pub fn go() {
 -file("project/test/my/mod.gleam", 1).
 -spec go() -> integer().
 go() ->
-    _assert_subject = {ok, 1},
-    {ok, Y} = case _assert_subject of
-        {ok, _} -> _assert_subject;
+    Y = case {ok, 1} of
+        {ok, Y} -> Y;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
@@ -29,9 +28,8 @@ go() ->
                         function => <<"go"/utf8>>,
                         line => 2})
     end,
-    _assert_subject@1 = {ok, 1},
-    {ok, Y@1} = case _assert_subject@1 of
-        {ok, _} -> _assert_subject@1;
+    Y@1 = case {ok, 1} of
+        {ok, Y@1} -> Y@1;
         _assert_fail@1 ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores2.snap
@@ -20,9 +20,8 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 2).
 -spec main() -> integer().
 main() ->
-    _assert_subject = 1,
-    100000 = case _assert_subject of
-        100000 -> _assert_subject;
+    case 1 of
+        100000 -> nil;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
@@ -31,9 +30,8 @@ main() ->
                         function => <<"main"/utf8>>,
                         line => 3})
     end,
-    _assert_subject@1 = 1.0,
-    100000.00101 = case _assert_subject@1 of
-        100000.00101 -> _assert_subject@1;
+    case 1.0 of
+        100000.00101 -> nil;
         _assert_fail@1 ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_assertion.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_assertion.snap
@@ -17,9 +17,8 @@ pub fn a(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec a(any()) -> binary().
 a(X) ->
-    _assert_subject = <<"wibble"/utf8>>,
-    <<A@1:1/binary, Rest/binary>> = case _assert_subject of
-        <<A:1/binary, _/binary>> when A =:= <<"a"/utf8>> -> _assert_subject;
+    {Rest, A} = case <<"wibble"/utf8>> of
+        <<A:1/binary, Rest/binary>> when A =:= <<"a"/utf8>> -> {Rest, A};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
@@ -28,4 +27,4 @@ a(X) ->
                         function => <<"a"/utf8>>,
                         line => 2})
     end,
-    A@1.
+    A.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_assertion.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_assertion.snap
@@ -17,7 +17,7 @@ pub fn a(x) {
 -file("project/test/my/mod.gleam", 1).
 -spec a(any()) -> binary().
 a(X) ->
-    {Rest, A} = case <<"wibble"/utf8>> of
+    {Rest@1, A@1} = case <<"wibble"/utf8>> of
         <<A:1/binary, Rest/binary>> when A =:= <<"a"/utf8>> -> {Rest, A};
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -27,4 +27,4 @@ a(X) ->
                         function => <<"a"/utf8>>,
                         line => 2})
     end,
-    A.
+    A@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix.snap
@@ -19,7 +19,7 @@ pub fn main(x) {
 -file("project/test/my/mod.gleam", 2).
 -spec main(binary()) -> binary().
 main(X) ->
-    Rest = case X of
+    Rest@1 = case X of
         <<"m-"/utf8, Rest/binary>> -> Rest;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
@@ -29,4 +29,4 @@ main(X) ->
                         function => <<"main"/utf8>>,
                         line => 3})
     end,
-    Rest.
+    Rest@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix.snap
@@ -19,8 +19,8 @@ pub fn main(x) {
 -file("project/test/my/mod.gleam", 2).
 -spec main(binary()) -> binary().
 main(X) ->
-    <<"m-"/utf8, Rest/binary>> = case X of
-        <<"m-"/utf8, _/binary>> -> X;
+    Rest = case X of
+        <<"m-"/utf8, Rest/binary>> -> Rest;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix_discar.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix_discar.snap
@@ -18,8 +18,8 @@ pub fn main(x) {
 -file("project/test/my/mod.gleam", 2).
 -spec main(binary()) -> binary().
 main(X) ->
-    <<"m-"/utf8, _/binary>> = case X of
-        <<"m-"/utf8, _/binary>> -> X;
+    case X of
+        <<"m-"/utf8, _/binary>> -> nil;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix_discar.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix_discar.snap
@@ -19,7 +19,7 @@ pub fn main(x) {
 -spec main(binary()) -> binary().
 main(X) ->
     case X of
-        <<"m-"/utf8, _/binary>> -> nil;
+        <<"m-"/utf8, _/binary>> -> X;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_inferred_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_inferred_count_once.snap
@@ -37,9 +37,8 @@ wobble() ->
 -file("project/test/my/mod.gleam", 2).
 -spec wibble() -> {ok, any()} | {error, wobble(any())}.
 wibble() ->
-    _assert_subject = wobble(),
-    {ok, _} = case _assert_subject of
-        {ok, _} -> _assert_subject;
+    case wobble() of
+        {ok, _} -> nil;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_inferred_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_inferred_count_once.snap
@@ -37,8 +37,9 @@ wobble() ->
 -file("project/test/my/mod.gleam", 2).
 -spec wibble() -> {ok, any()} | {error, wobble(any())}.
 wibble() ->
-    case wobble() of
-        {ok, _} -> nil;
+    _assert_subject = wobble(),
+    case _assert_subject of
+        {ok, _} -> _assert_subject;
         _assert_fail ->
             erlang:error(#{gleam_error => let_assert,
                         message => <<"Pattern match failed, no pattern matched the value."/utf8>>,


### PR DESCRIPTION
Closes #4497 and fixes #4145 
This PR improves the generated code for `let assert` in a couple of ways:
- Instead of pattern matching on the value twice, we match once, extract the variables, then return a tuple from the `case` expression.
- If a pattern always matches (e.g. a plain variable or tuple pattern) we omit the check entirely and just assign like a simple `let` assignment.
This simplification fixes the other bug by default, as we no longer ignore variables in the first pattern match.