### PR TITLE
Fix "convert to use" code action when used on function calls with labelled out-of-order arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,3 +369,8 @@
 - Fixed a bug where a using the pipe operator in the `size` option of a bit array
   segment would generate invalid code on the Erlang target.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the language server would generate invalid code for the
+  "convert to use" code action, when used on a function call with labelled
+  arguments.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -2701,6 +2701,16 @@ fn turn_expression_into_use(expr: &TypedExpr) -> Option<CallLocations> {
         return None;
     };
 
+    // The function arguments in the ast are reordered using function's field map.
+    // This means that in the `args` array they might not appear in the same order
+    // in which they are written by the user. Since the rest of the code relies
+    // on their order in the written code we first have to sort them by their
+    // source position.
+    let args = args
+        .iter()
+        .sorted_by_key(|arg| arg.location.start)
+        .collect_vec();
+
     let CallArg {
         value: last_arg,
         implicit: None,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -4241,6 +4241,24 @@ pub fn main() {
 }
 
 #[test]
+// https://github.com/gleam-lang/gleam/issues/4498
+fn turn_call_into_use_with_out_of_order_arguments() {
+    assert_code_action!(
+        CONVERT_TO_USE,
+        r#"
+pub fn main() {
+  fold(0, over: [], with: fn (a, b) { todo })
+}
+
+fn fold(over list: List(a), from acc: acc, with fun: fn(acc, a) -> acc) -> acc {
+  todo
+}
+"#,
+        find_position_of("fold").to_selection(),
+    );
+}
+
+#[test]
 fn inexhaustive_let_result_to_case() {
     assert_code_action!(
         CONVERT_TO_CASE,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__turn_call_into_use_with_out_of_order_arguments.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__turn_call_into_use_with_out_of_order_arguments.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  fold(0, over: [], with: fn (a, b) { todo })\n}\n\nfn fold(over list: List(a), from acc: acc, with fun: fn(acc, a) -> acc) -> acc {\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  fold(0, over: [], with: fn (a, b) { todo })
+  ↑                                          
+}
+
+fn fold(over list: List(a), from acc: acc, with fun: fn(acc, a) -> acc) -> acc {
+  todo
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  use a, b <- fold(0, over: [])
+  todo
+}
+
+fn fold(over list: List(a), from acc: acc, with fun: fn(acc, a) -> acc) -> acc {
+  todo
+}


### PR DESCRIPTION
If a function was called with arguments that ended up being out of order because of labels, the "convert to use" code action would end up removing more arguments than it actually should. This PR fixes this bug, closes #4498 