### PR TITLE
Fix typo in warning for pure unused value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,7 +164,7 @@
 
   This expression computes a value without any side effects, but then the
   value isn't used at all. You might way to assign it to a variable, or
-  delete the expression entirely if it not needed.
+  delete the expression entirely if it's not needed.
   ```
 
   ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constructing_anonymous_function_is_pure.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constructing_anonymous_function_is_pure.snap
@@ -23,4 +23,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_erlang_if_external_on_js.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_erlang_if_external_on_js.snap
@@ -22,4 +22,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_js_if_external_on_erlang.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_js_if_external_on_erlang.snap
@@ -22,4 +22,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_raises_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_raises_warning.snap
@@ -21,4 +21,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_with_many_steps_raises_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_with_many_steps_raises_warning.snap
@@ -21,4 +21,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_standard_library_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_standard_library_function.snap
@@ -33,4 +33,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_binary_operation_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_binary_operation_raises_a_warning.snap
@@ -19,4 +19,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expression.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expression.snap
@@ -19,4 +19,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expressions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expressions.snap
@@ -25,7 +25,7 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.
 
 warning: Unused literal
   ┌─ /src/warning/wrn.gleam:4:5

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_bool_negation_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_bool_negation_raises_a_warning.snap
@@ -19,4 +19,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_case_expression.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_case_expression.snap
@@ -26,4 +26,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_fn_function_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_fn_function_call.snap
@@ -19,4 +19,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_function_literal_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_function_literal_raises_a_warning.snap
@@ -19,4 +19,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
@@ -25,4 +25,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
@@ -25,4 +25,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor_call.snap
@@ -25,4 +25,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
@@ -25,4 +25,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_pure_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_pure_fn.snap
@@ -22,4 +22,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning.snap
@@ -22,4 +22,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
@@ -27,4 +27,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function.snap
@@ -21,4 +21,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function_that_calls_other_pure_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function_that_calls_other_pure_function.snap
@@ -23,4 +23,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
@@ -24,4 +24,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_update_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_update_raises_a_warning.snap
@@ -24,4 +24,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_tuple_index_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_tuple_index_raises_a_warning.snap
@@ -19,4 +19,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_variable_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_variable_raises_a_warning.snap
@@ -20,4 +20,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
@@ -26,4 +26,4 @@ warning: Unused value
 
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might way to assign it to a variable, or
-delete the expression entirely if it not needed.
+delete the expression entirely if it's not needed.

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -909,7 +909,7 @@ can already tell which branch is going to match with this value.",
                     text: wrap(
                         "This expression computes a value without any side \
 effects, but then the value isn't used at all. You might way to assign it to a \
-variable, or delete the expression entirely if it not needed.",
+variable, or delete the expression entirely if it's not needed.",
                     ),
                     hint: None,
                     level: diagnostic::Level::Warning,


### PR DESCRIPTION
This PR fixes a small typo I noticed in the error message for pure unused values.