### PR TITLE
Improve documentation printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,11 +204,12 @@
   deprecated environment variables.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- When generating documentation, the build tool now prints correct type variable
-  names for function signatures. For example, this code:
+- When generating documentation, the build tool now prints type variable using
+  the same names as were used in the code for function signatures. For example,
+  this code:
 
   ```gleam
-  pub fn to_list(list: List(#(key, value))) -> Dict(key, value) {
+  pub fn to_list(entries: List(#(key, value))) -> Dict(key, value) {
     ...
   }
   ```
@@ -216,13 +217,13 @@
   Previously would have been printed as:
 
   ```gleam
-  pub fn to_list(list: List(#(a, b))) -> Dict(a, b)
+  pub fn to_list(entries: List(#(a, b))) -> Dict(a, b)
   ```
 
   But now is rendered as the following:
 
   ```gleam
-  pub fn to_list(list: List(#(key, value))) -> Dict(key, value)
+  pub fn to_list(entries: List(#(key, value))) -> Dict(key, value)
   ```
 
   ([Surya Rose](https://github.com/GearsDatapacks))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,59 @@
   deprecated environment variables.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- When generating documentation, the build tool now prints correct type variable
+  names for function signatures. For example, this code:
+
+  ```gleam
+  pub fn to_list(list: List(#(key, value))) -> Dict(key, value) {
+    ...
+  }
+  ```
+
+  Previously would have been printed as:
+
+  ```gleam
+  pub fn to_list(list: List(#(a, b))) -> Dict(a, b)
+  ```
+
+  But now is rendered as the following:
+
+  ```gleam
+  pub fn to_list(list: List(#(key, value))) -> Dict(key, value)
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+- When generating documentation, types from other modules are now rendered with
+  their module qualifiers. Hovering over them shows the full path to their module.
+  For example, this code:
+
+  ```gleam
+  import gleam/dynamic/decode
+
+  pub fn something_decoder() -> decode.Decoder(Something) {
+    ...
+  }
+  ```
+
+  Will now generate the following documentation:
+
+  ```gleam
+  pub fn something_decoder() -> decode.Decoder(Something)
+  ```
+
+  And hovering over the `decode.Decoder` text will show the following:
+
+  ```txt
+  gleam/dynamic/decode.{type Decoder}
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+- When generating documentation, types in rendered documentation code will now
+  link to their corresponding documentation pages.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Language server
 
 - The code action to add missing labels to function now also works in patterns:

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -146,13 +146,15 @@ pub(crate) fn build_documentation(
     pages.extend(config.documentation.pages.iter().cloned());
     let mut outputs = gleam_core::docs::generate_html(
         paths,
-        config,
-        dependencies,
-        compiled.modules.as_slice(),
-        &pages,
+        gleam_core::docs::DocumentationConfig {
+            package_config: config,
+            dependencies,
+            analysed: compiled.modules.as_slice(),
+            docs_pages: &pages,
+            rendering_timestamp: SystemTime::now(),
+            context: is_hex_publish,
+        },
         ProjectIO::new(),
-        SystemTime::now(),
-        is_hex_publish,
     );
 
     outputs.push(gleam_core::docs::generate_json_package_interface(

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -1,4 +1,7 @@
-use std::time::{Instant, SystemTime};
+use std::{
+    collections::HashMap,
+    time::{Instant, SystemTime},
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use ecow::EcoString;
@@ -9,10 +12,11 @@ use gleam_core::{
     analyse::TargetSupport,
     build::{Codegen, Compile, Mode, Options, Package, Target},
     config::{DocsPage, PackageConfig},
-    docs::DocContext,
+    docs::{Dependency, DependencyKind, DocContext},
     error::Error,
     hex,
     io::HttpClient as _,
+    manifest::ManifestPackageSource,
     paths::ProjectPaths,
     type_,
 };
@@ -49,6 +53,26 @@ pub fn build(paths: &ProjectPaths, options: BuildOptions) -> Result<()> {
     crate::fs::delete_directory(&paths.build_directory_for_target(Mode::Prod, config.target))?;
 
     let out = paths.build_documentation_directory(&config.name);
+
+    let manifest = crate::build::download_dependencies(paths, cli::Reporter::new())?;
+    let dependencies = manifest
+        .packages
+        .iter()
+        .map(|package| {
+            (
+                package.name.clone(),
+                Dependency {
+                    version: package.version.clone(),
+                    kind: match &package.source {
+                        ManifestPackageSource::Hex { .. } => DependencyKind::Hex,
+                        ManifestPackageSource::Git { .. } => DependencyKind::Git,
+                        ManifestPackageSource::Local { .. } => DependencyKind::Path,
+                    },
+                },
+            )
+        })
+        .collect();
+
     let mut built = crate::build::main(
         paths,
         Options {
@@ -60,11 +84,12 @@ pub fn build(paths: &ProjectPaths, options: BuildOptions) -> Result<()> {
             root_target_support: TargetSupport::Enforced,
             no_print_progress: false,
         },
-        crate::build::download_dependencies(paths, cli::Reporter::new())?,
+        manifest,
     )?;
     let outputs = build_documentation(
         paths,
         &config,
+        dependencies,
         &mut built.root_package,
         DocContext::Build,
         &built.module_interfaces,
@@ -106,6 +131,7 @@ fn open_docs(path: &Utf8Path) -> Result<()> {
 pub(crate) fn build_documentation(
     paths: &ProjectPaths,
     config: &PackageConfig,
+    dependencies: HashMap<EcoString, Dependency>,
     compiled: &mut Package,
     is_hex_publish: DocContext,
     cached_modules: &im::HashMap<EcoString, type_::ModuleInterface>,
@@ -121,6 +147,7 @@ pub(crate) fn build_documentation(
     let mut outputs = gleam_core::docs::generate_html(
         paths,
         config,
+        dependencies,
         compiled.modules.as_slice(),
         &pages,
         ProjectIO::new(),
@@ -147,6 +174,25 @@ pub fn publish(paths: &ProjectPaths) -> Result<()> {
     // Reset the build directory so we know the state of the project
     crate::fs::delete_directory(&paths.build_directory_for_target(Mode::Prod, config.target))?;
 
+    let manifest = crate::build::download_dependencies(paths, cli::Reporter::new())?;
+    let dependencies = manifest
+        .packages
+        .iter()
+        .map(|package| {
+            (
+                package.name.clone(),
+                Dependency {
+                    version: package.version.clone(),
+                    kind: match &package.source {
+                        ManifestPackageSource::Hex { .. } => DependencyKind::Hex,
+                        ManifestPackageSource::Git { .. } => DependencyKind::Git,
+                        ManifestPackageSource::Local { .. } => DependencyKind::Path,
+                    },
+                },
+            )
+        })
+        .collect();
+
     let mut built = crate::build::main(
         paths,
         Options {
@@ -158,11 +204,12 @@ pub fn publish(paths: &ProjectPaths) -> Result<()> {
             target: None,
             no_print_progress: false,
         },
-        crate::build::download_dependencies(paths, cli::Reporter::new())?,
+        manifest,
     )?;
     let outputs = build_documentation(
         paths,
         &config,
+        dependencies,
         &mut built.root_package,
         DocContext::HexPublish,
         &built.module_interfaces,

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -814,6 +814,7 @@ impl<T> CustomType<T> {
 }
 
 pub type UntypedTypeAlias = TypeAlias<()>;
+pub type TypedTypeAlias = TypeAlias<Arc<Type>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A new name for an existing type

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -814,7 +814,6 @@ impl<T> CustomType<T> {
 }
 
 pub type UntypedTypeAlias = TypeAlias<()>;
-pub type TypedTypeAlias = TypeAlias<Arc<Type>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A new name for an existing type

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -3,9 +3,10 @@ mod source_links;
 #[cfg(test)]
 mod tests;
 
-use std::time::SystemTime;
+use std::{collections::HashMap, time::SystemTime};
 
 use camino::Utf8PathBuf;
+use hexpm::version::Version;
 use printer::Printer;
 
 use crate::{
@@ -36,9 +37,25 @@ pub struct PackageInformation {
     package_config: PackageConfig,
 }
 
+/// Like `ManifestPackage`, but lighter and cheaper to clone as it is all that
+/// we need for printing documentation.
+#[derive(Debug, Clone)]
+pub struct Dependency {
+    pub version: Version,
+    pub kind: DependencyKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DependencyKind {
+    Hex,
+    Path,
+    Git,
+}
+
 pub fn generate_html<IO: FileSystemReader>(
     paths: &ProjectPaths,
     config: &PackageConfig,
+    dependencies: HashMap<EcoString, Dependency>,
     analysed: &[Module],
     docs_pages: &[DocsPage],
     fs: IO,
@@ -174,6 +191,7 @@ pub fn generate_html<IO: FileSystemReader>(
             module.ast.type_info.package.clone(),
             module.name.clone(),
             &module.ast.names,
+            &dependencies,
         );
 
         let types: Vec<TypeDefinition<'_>> = module

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -52,16 +52,30 @@ pub enum DependencyKind {
     Git,
 }
 
+#[derive(Debug)]
+pub struct DocumentationConfig<'a> {
+    pub package_config: &'a PackageConfig,
+    pub dependencies: HashMap<EcoString, Dependency>,
+    pub analysed: &'a [Module],
+    pub docs_pages: &'a [DocsPage],
+    pub rendering_timestamp: SystemTime,
+    pub context: DocContext,
+}
+
 pub fn generate_html<IO: FileSystemReader>(
     paths: &ProjectPaths,
-    config: &PackageConfig,
-    dependencies: HashMap<EcoString, Dependency>,
-    analysed: &[Module],
-    docs_pages: &[DocsPage],
+    config: DocumentationConfig<'_>,
     fs: IO,
-    rendering_timestamp: SystemTime,
-    is_hex_publish: DocContext,
 ) -> Vec<OutputFile> {
+    let DocumentationConfig {
+        package_config: config,
+        dependencies,
+        analysed,
+        docs_pages,
+        rendering_timestamp,
+        context: is_hex_publish,
+    } = config;
+
     let modules = analysed
         .iter()
         .filter(|module| module.origin.is_src())

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -531,7 +531,7 @@ fn text_documentation(doc: &Option<(u32, EcoString)>) -> String {
         .unwrap_or_else(|| "".into());
 
     // TODO: parse markdown properly and extract the text nodes
-    escape_html_content(raw_text.replace("```gleam", "").replace("```", ""))
+    raw_text.replace("```gleam", "").replace("```", "")
 }
 
 fn markdown_documentation(doc: &Option<(u32, EcoString)>) -> String {

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -229,14 +229,13 @@ impl Printer<'_> {
             )
         };
 
-        let keywords = if opaque { "opaque type " } else { "type " };
+        let keywords = if opaque {
+            "pub opaque type "
+        } else {
+            "pub type "
+        };
 
-        let type_head = docvec![
-            self.keyword("pub "),
-            self.keyword(keywords),
-            self.title(name),
-            arguments
-        ];
+        let type_head = docvec![self.keyword(keywords), self.title(name), arguments];
 
         if constructors.is_empty() || opaque {
             return type_head;

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -292,8 +292,8 @@ impl Printer<'_> {
             self.keyword("pub type "),
             self.title(name),
             parameters,
-            break_(" =", " = "),
-            self.type_(type_).nest(INDENT)
+            " =",
+            line().append(self.type_(type_)).nest(INDENT)
         ]
     }
 

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -127,7 +127,6 @@ impl Printer<'_> {
                 source_url: source_links.url(*location),
                 opaque: *opaque,
             }),
-
             Definition::TypeAlias(TypeAlias {
                 publicity: Publicity::Public,
                 location,
@@ -150,8 +149,11 @@ impl Printer<'_> {
                 },
                 opaque: false,
             }),
-
-            _ => None,
+            Definition::TypeAlias(_)
+            | Definition::CustomType(_)
+            | Definition::Function(_)
+            | Definition::Import(_)
+            | Definition::ModuleConstant(_) => None,
         }
     }
 
@@ -208,7 +210,11 @@ impl Printer<'_> {
                 },
             }),
 
-            _ => None,
+            Definition::TypeAlias(_)
+            | Definition::CustomType(_)
+            | Definition::Function(_)
+            | Definition::Import(_)
+            | Definition::ModuleConstant(_) => None,
         }
     }
 
@@ -436,7 +442,7 @@ impl Printer<'_> {
 
         loop {
             n = rest % alphabet_length;
-            rest /= alphabet_length;
+            rest = rest / alphabet_length;
             chars.push((n as u8 + char_offset) as char);
 
             if rest == 0 {

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -58,7 +58,7 @@ pub struct Printer<'a> {
 }
 
 impl Printer<'_> {
-    pub fn new<'a>(package: EcoString, module: EcoString, names: &'a Names) -> Printer<'a> {
+    pub fn new(package: EcoString, module: EcoString, names: &Names) -> Printer<'_> {
         Printer {
             options: PrintOptions::all(),
             names,
@@ -430,7 +430,7 @@ impl Printer<'_> {
     // Copied from the `next_letter` method of the `type_::printer`.
     fn next_letter(&mut self) -> EcoString {
         let alphabet_length = 26;
-        let char_offset = 'a' as u8;
+        let char_offset = b'a';
         let mut chars = vec![];
         let mut n;
         let mut rest = self.next_type_variable_id;

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -1,0 +1,358 @@
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Deref,
+};
+
+use ecow::EcoString;
+use itertools::Itertools;
+
+use crate::{
+    ast::{
+        ArgNames, Definition, Function, Publicity, RecordConstructorArg, TypedArg, TypedCustomType,
+        TypedDefinition, TypedFunction, TypedModuleConstant, TypedRecordConstructor,
+        TypedTypeAlias,
+    },
+    docvec,
+    pretty::{Document, Documentable, break_, join, line},
+    type_::{Deprecation, Type, TypeVar, printer::Names},
+};
+
+use super::{
+    DocsValues, TypeConstructor, TypeConstructorArg, TypeDefinition, markdown_documentation,
+    source_links::SourceLinker, text_documentation,
+};
+
+pub struct Printer<'a> {
+    names: &'a Names,
+    printed_type_variables: HashMap<u64, EcoString>,
+    printed_type_variable_names: HashSet<EcoString>,
+    uid: u64,
+}
+
+impl Printer<'_> {
+    pub fn new<'a>(names: &'a Names) -> Printer<'a> {
+        Printer {
+            names,
+            printed_type_variables: HashMap::new(),
+            printed_type_variable_names: HashSet::new(),
+            uid: 0,
+        }
+    }
+
+    pub fn type_definition<'a>(
+        &mut self,
+        source_links: &SourceLinker,
+        statement: &'a TypedDefinition,
+    ) -> Option<TypeDefinition<'a>> {
+        match statement {
+            Definition::CustomType(ct) if ct.publicity.is_public() => Some(TypeDefinition {
+                name: &ct.name,
+                definition: print(self.custom_type(ct)),
+                documentation: markdown_documentation(&ct.documentation),
+                text_documentation: text_documentation(&ct.documentation),
+                deprecation_message: match &ct.deprecation {
+                    Deprecation::NotDeprecated => "".to_string(),
+                    Deprecation::Deprecated { message } => message.to_string(),
+                },
+                constructors: ct
+                    .constructors
+                    .iter()
+                    .map(|constructor| TypeConstructor {
+                        definition: print(self.record_constructor(constructor)),
+                        documentation: markdown_documentation(&constructor.documentation),
+                        text_documentation: text_documentation(&constructor.documentation),
+                        arguments: constructor
+                            .arguments
+                            .iter()
+                            .filter_map(|arg| arg.label.as_ref().map(|(_, label)| (arg, label)))
+                            .map(|(argument, label)| TypeConstructorArg {
+                                name: label.trim_end().to_string(),
+                                doc: markdown_documentation(&argument.doc),
+                            })
+                            .filter(|arg| !arg.doc.is_empty())
+                            .collect(),
+                    })
+                    .collect(),
+                source_url: source_links.url(ct.location),
+                opaque: ct.opaque,
+            }),
+
+            Definition::TypeAlias(alias) if alias.publicity.is_public() => Some(TypeDefinition {
+                name: alias.alias.as_str(),
+                definition: print(self.type_alias(alias).group()),
+                documentation: markdown_documentation(&alias.documentation),
+                text_documentation: text_documentation(&alias.documentation),
+                constructors: vec![],
+                source_url: source_links.url(alias.location),
+                deprecation_message: match &alias.deprecation {
+                    Deprecation::NotDeprecated => "".to_string(),
+                    Deprecation::Deprecated { message } => message.to_string(),
+                },
+                opaque: false,
+            }),
+
+            _ => None,
+        }
+    }
+
+    pub fn value<'a>(
+        &mut self,
+        source_links: &SourceLinker,
+        statement: &'a TypedDefinition,
+    ) -> Option<DocsValues<'a>> {
+        match statement {
+            Definition::Function(
+                function @ Function {
+                    publicity: Publicity::Public,
+                    name,
+                    documentation: doc,
+
+                    location,
+                    deprecation,
+                    ..
+                },
+            ) => {
+                let (_, name) = name
+                    .as_ref()
+                    .expect("Function in a definition must be named");
+
+                Some(DocsValues {
+                    name,
+                    definition: print(self.function_signature(function)),
+                    documentation: markdown_documentation(doc),
+                    text_documentation: text_documentation(doc),
+                    source_url: source_links.url(*location),
+                    deprecation_message: match deprecation {
+                        Deprecation::NotDeprecated => "".to_string(),
+                        Deprecation::Deprecated { message } => message.to_string(),
+                    },
+                })
+            }
+
+            Definition::ModuleConstant(constant) if constant.publicity.is_public() => {
+                Some(DocsValues {
+                    name: constant.name.as_str(),
+                    definition: print(self.constant(constant)),
+                    documentation: markdown_documentation(&constant.documentation),
+                    text_documentation: text_documentation(&constant.documentation),
+                    source_url: source_links.url(constant.location),
+                    deprecation_message: match &constant.deprecation {
+                        Deprecation::NotDeprecated => "".to_string(),
+                        Deprecation::Deprecated { message } => message.to_string(),
+                    },
+                })
+            }
+
+            _ => None,
+        }
+    }
+
+    fn custom_type<'a>(&mut self, custom_type: &'a TypedCustomType) -> Document<'a> {
+        let doc = "pub "
+            .to_doc()
+            .append(if custom_type.opaque {
+                "opaque type "
+            } else {
+                "type "
+            })
+            .append(if custom_type.parameters.is_empty() {
+                custom_type.name.clone().to_doc()
+            } else {
+                let arguments = custom_type.parameters.iter().map(|(_, e)| e.to_doc());
+
+                custom_type
+                    .name
+                    .as_str()
+                    .to_doc()
+                    .append(Self::wrap_arguments(arguments))
+                    .group()
+            });
+
+        if custom_type.constructors.is_empty() {
+            return doc;
+        }
+        let doc = doc.append(" {");
+
+        let inner = custom_type
+            .constructors
+            .iter()
+            .map(|constructor| {
+                line()
+                    .append(self.record_constructor(constructor))
+                    .nest(INDENT)
+            })
+            .collect_vec();
+
+        doc.append(inner).append(line()).append("}")
+    }
+
+    pub fn record_constructor<'a>(
+        &mut self,
+        constructor: &'a TypedRecordConstructor,
+    ) -> Document<'a> {
+        if constructor.arguments.is_empty() {
+            return constructor.name.as_str().to_doc();
+        }
+
+        let arguments = constructor.arguments.iter().map(
+            |RecordConstructorArg { label, type_, .. }| match label {
+                Some((_, label)) => label.to_doc().append(": ").append(self.type_(type_)),
+                None => self.type_(type_),
+            },
+        );
+
+        constructor
+            .name
+            .as_str()
+            .to_doc()
+            .append(Self::wrap_arguments(arguments))
+    }
+
+    fn type_alias<'a>(&mut self, alias: &'a TypedTypeAlias) -> Document<'a> {
+        "pub type "
+            .to_doc()
+            .append(alias.alias.as_str())
+            .append(" = ")
+            .append(self.type_(&alias.type_))
+    }
+
+    fn constant<'a>(&mut self, constant: &'a TypedModuleConstant) -> Document<'a> {
+        "pub const "
+            .to_doc()
+            .append(constant.name.as_str())
+            .append(": ")
+            .append(self.type_(&constant.type_))
+    }
+
+    fn function_signature<'a>(&mut self, function: &'a TypedFunction) -> Document<'a> {
+        let arguments = function.arguments.iter().map(|argument| {
+            let name = self.argument_name(argument);
+            docvec![name, ": ", self.type_(&argument.type_)].group()
+        });
+
+        "pub fn "
+            .to_doc()
+            .append(
+                function
+                    .name
+                    .as_ref()
+                    .expect("Module functions must have names")
+                    .1
+                    .as_str(),
+            )
+            .append(Self::wrap_arguments(arguments))
+            .append(" -> ")
+            .append(self.type_(&function.return_type))
+            .group()
+    }
+
+    fn argument_name<'a>(&self, arg: &'a TypedArg) -> Document<'a> {
+        match &arg.names {
+            ArgNames::Named { name, .. } => name.to_doc(),
+            ArgNames::NamedLabelled { label, name, .. } => docvec![label, " ", name],
+            // We remove the underscore from discarded function arguments since we don't want to
+            // expose this kind of detail: https://github.com/gleam-lang/gleam/issues/2561
+            ArgNames::Discard { name, .. } => match name.strip_prefix('_').unwrap_or(name) {
+                "" => "arg".to_doc(),
+                name => name.to_doc(),
+            },
+            ArgNames::LabelledDiscard { label, name, .. } => {
+                docvec![label, " ", name.strip_prefix('_').unwrap_or(name).to_doc()]
+            }
+        }
+    }
+
+    fn wrap_arguments<'a>(arguments: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
+        break_("(", "(")
+            .append(join(arguments, break_(",", ", ")))
+            .nest_if_broken(INDENT)
+            .append(break_(",", ""))
+            .append(")")
+    }
+
+    fn type_arguments<'a>(arguments: impl IntoIterator<Item = Document<'a>>) -> Document<'a> {
+        break_("", "")
+            .append(join(arguments, break_(",", ", ")))
+            .nest_if_broken(INDENT)
+            .append(break_(",", ""))
+            .group()
+            .surround("(", ")")
+    }
+
+    fn type_(&mut self, type_: &Type) -> Document<'static> {
+        match type_ {
+            Type::Named { name, args, .. } => {
+                if args.is_empty() {
+                    name.clone().to_doc()
+                } else {
+                    name.clone().to_doc().append(Self::type_arguments(
+                        args.iter().map(|argument| self.type_(argument)),
+                    ))
+                }
+            }
+            Type::Fn { args, return_ } => docvec![
+                "fn",
+                Self::type_arguments(args.iter().map(|argument| self.type_(argument))),
+                " -> ",
+                self.type_(return_)
+            ],
+            Type::Tuple { elements } => docvec![
+                "#",
+                Self::type_arguments(elements.iter().map(|element| self.type_(element))),
+            ],
+            Type::Var { type_ } => match type_.as_ref().borrow().deref() {
+                TypeVar::Link { type_ } => self.type_(type_),
+
+                TypeVar::Unbound { id } | TypeVar::Generic { id } => self.type_variable(*id),
+            },
+        }
+    }
+
+    fn type_variable(&mut self, id: u64) -> Document<'static> {
+        if let Some(name) = self.names.get_type_variable(id) {
+            return name.clone().to_doc();
+        }
+
+        if let Some(name) = self.printed_type_variables.get(&id) {
+            return name.clone().to_doc();
+        }
+
+        loop {
+            let name = self.next_letter();
+            if !self.printed_type_variable_names.contains(&name) {
+                _ = self.printed_type_variable_names.insert(name.clone());
+                _ = self.printed_type_variables.insert(id, name.clone());
+                return name.to_doc();
+            }
+        }
+    }
+
+    fn next_letter(&mut self) -> EcoString {
+        let alphabet_length = 26;
+        let char_offset = 97;
+        let mut chars = vec![];
+        let mut n;
+        let mut rest = self.uid;
+
+        loop {
+            n = rest % alphabet_length;
+            rest /= alphabet_length;
+            chars.push((n as u8 + char_offset) as char);
+
+            if rest == 0 {
+                break;
+            }
+            rest -= 1
+        }
+
+        self.uid += 1;
+        chars.into_iter().rev().collect()
+    }
+}
+
+const MAX_COLUMNS: isize = 65;
+const INDENT: isize = 2;
+
+fn print(doc: Document<'_>) -> String {
+    doc.to_pretty_string(MAX_COLUMNS)
+}

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
@@ -311,6 +311,9 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 
@@ -595,7 +598,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -675,6 +678,9 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 
@@ -959,7 +965,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -1039,6 +1045,9 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
@@ -598,7 +598,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -965,7 +965,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn discard(discarded: a) -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">discard</span>(<span class="hljs-variable">discarded</span>: <span class="hljs-variable">a</span>) -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>
@@ -343,6 +343,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">discard</span>(<span class="hljs-variable">discarded</span>: <span class="hljs-variable">a</span>) -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">discard</span>(<span class="hljs-variable">discarded</span>: <span class="hljs-variable">a</span>) -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
@@ -272,8 +272,8 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam">pub type Wibble {
-  Wobble(wabble: Int)
+      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Wibble</span> {
+  <span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)
 }</code></pre>
       
       <h3>
@@ -284,7 +284,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">Wobble(wabble: Int)</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam hljs-ignore"><span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -335,7 +335,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn main() -&gt; a</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">main</span>() -> <span class="hljs-variable">a</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>
@@ -414,6 +414,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
@@ -272,7 +272,7 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub type </span><span class="hljs-title">Wibble</span> {
+      <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub type </span><span class="hljs-title">Wibble</span> {
   <span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)
 }</code></pre>
       
@@ -284,7 +284,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam hljs-ignore"><span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)</code></pre>
+            <pre class="constructor-name"><code class="hljs hljs-ignore"><span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -335,7 +335,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">main</span>() -> <span class="hljs-variable">a</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">main</span>() -> <span class="hljs-variable">a</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
@@ -272,7 +272,7 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Wibble</span> {
+      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub type </span><span class="hljs-title">Wibble</span> {
   <span class="hljs-title">Wobble</span>(<span class="hljs-variable">wabble</span>: <span class="hljs-title">Int</span>)
 }</code></pre>
       

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables.snap
@@ -2,6 +2,14 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub fn wibble(_a, _b, _c, _d) {
+  todo
+}
+
+
 ---- VALUES
 
 --- wibble

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- wibble
+<pre><code>pub fn wibble(a: a, b: b, c: c, d: d) -> e</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_do_not_take_into_account_other_definitions.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_do_not_take_into_account_other_definitions.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- identity
+<pre><code>pub fn identity(x: a) -> a</code></pre>
+
+--- wibble
+<pre><code>pub fn wibble(a: a, b: b, c: c) -> d</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_do_not_take_into_account_other_definitions.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_do_not_take_into_account_other_definitions.snap
@@ -2,6 +2,16 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub fn wibble(_a: a, _b: b, _c: c) -> d {
+  todo
+}
+
+pub fn identity(x) { x }
+
+
 ---- VALUES
 
 --- identity

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_mixed_with_existing_variables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_mixed_with_existing_variables.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- wibble
+<pre><code>pub fn wibble(a: b, b: a, c: c, d: d) -> e</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_mixed_with_existing_variables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_mixed_with_existing_variables.snap
@@ -2,6 +2,14 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub fn wibble(_a: b, _b: a, _c, _d) {
+  todo
+}
+
+
 ---- VALUES
 
 --- wibble

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_with_existing_variables_coming_afterwards.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_with_existing_variables_coming_afterwards.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- wibble
+<pre><code>pub fn wibble(a: c, b: d, c: b, d: a) -> e</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_with_existing_variables_coming_afterwards.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__generated_type_variables_with_existing_variables_coming_afterwards.snap
@@ -2,6 +2,14 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub fn wibble(_a, _b, _c: b, _d: a) {
+  todo
+}
+
+
 ---- VALUES
 
 --- wibble

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -344,6 +344,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_constant_definition.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_constant_definition.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- x
+<pre><code><span class="hljs-keyword">pub const </span><span class="hljs-title">x</span>: <span class="hljs-title">Int</span></code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_constant_definition.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_constant_definition.snap
@@ -2,6 +2,12 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub const x = 22
+
+
 ---- VALUES
 
 --- x

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_custom_type.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_custom_type.snap
@@ -5,7 +5,7 @@ expression: output
 ---- TYPES
 
 --- Wibble
-<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>) {
+<pre><code><span class="hljs-keyword">pub type </span><span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>) {
   <span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">i</span>: <span class="hljs-title">Int</span>)
   <span class="hljs-title">Wobble</span>(<span class="hljs-variable">b</span>: <span class="hljs-variable">b</span>, <span class="hljs-variable">c</span>: <span class="hljs-title">String</span>)
 }</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_custom_type.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_custom_type.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- TYPES
+
+--- Wibble
+<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>) {
+  <span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">i</span>: <span class="hljs-title">Int</span>)
+  <span class="hljs-title">Wobble</span>(<span class="hljs-variable">b</span>: <span class="hljs-variable">b</span>, <span class="hljs-variable">c</span>: <span class="hljs-title">String</span>)
+}</code></pre>
+
+-- CONSTRUCTORS
+
+<pre><code><span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">i</span>: <span class="hljs-title">Int</span>)</code></pre>
+
+<pre><code><span class="hljs-title">Wobble</span>(<span class="hljs-variable">b</span>: <span class="hljs-variable">b</span>, <span class="hljs-variable">c</span>: <span class="hljs-title">String</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_custom_type.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_custom_type.snap
@@ -2,6 +2,15 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub type Wibble(a, b) {
+  Wibble(a, i: Int)
+  Wobble(b: b, c: String)
+}
+
+
 ---- TYPES
 
 --- Wibble

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_function_definition.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_function_definition.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- wibble
+<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">wibble</span>(
+  <span class="hljs-variable">list</span>: <span class="hljs-title">List</span>(<span class="hljs-title">Int</span>),
+  <span class="hljs-variable">generic</span>: <span class="hljs-variable">a</span>,
+  <span class="hljs-variable">function</span>: <span class="hljs-keyword">fn</span>(<span class="hljs-variable">a</span>) -> <span class="hljs-variable">b</span>,
+) -> #(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_function_definition.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_function_definition.snap
@@ -2,6 +2,12 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub fn wibble(list: List(Int), generic: a, function: fn(a) -> b) -> #(a, b) { todo }
+
+
 ---- VALUES
 
 --- wibble

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_opaque_custom_type.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_opaque_custom_type.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- TYPES
+
+--- Wibble
+<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">opaque type </span><span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_opaque_custom_type.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_opaque_custom_type.snap
@@ -2,6 +2,15 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub opaque type Wibble(a, b) {
+  Wibble(a, i: Int)
+  Wobble(b: b, c: String)
+}
+
+
 ---- TYPES
 
 --- Wibble

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_opaque_custom_type.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_opaque_custom_type.snap
@@ -5,4 +5,4 @@ expression: output
 ---- TYPES
 
 --- Wibble
-<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">opaque type </span><span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>
+<pre><code><span class="hljs-keyword">pub opaque type </span><span class="hljs-title">Wibble</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_type_alias.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_type_alias.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- TYPES
+
+--- Option
+<pre><code><span class="hljs-keyword">pub type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">a</span>) = <span class="hljs-title">Result</span>(<span class="hljs-variable">a</span>, <span class="hljs-title">Nil</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_type_alias.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_type_alias.snap
@@ -2,6 +2,12 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub type Option(a) = Result(a, Nil)
+
+
 ---- TYPES
 
 --- Option

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_type_alias.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__highlight_type_alias.snap
@@ -5,4 +5,5 @@ expression: output
 ---- TYPES
 
 --- Option
-<pre><code><span class="hljs-keyword">pub type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">a</span>) = <span class="hljs-title">Result</span>(<span class="hljs-variable">a</span>, <span class="hljs-title">Nil</span>)</code></pre>
+<pre><code><span class="hljs-keyword">pub type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">a</span>) =
+  <span class="hljs-title">Result</span>(<span class="hljs-variable">a</span>, <span class="hljs-title">Nil</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__ignored_argument_is_called_arg.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__ignored_argument_is_called_arg.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>(<span class="hljs-variable">arg</span>: <span class="hljs-variable">a</span>) -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>(<span class="hljs-variable">arg</span>: <span class="hljs-variable">a</span>) -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__ignored_argument_is_called_arg.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__ignored_argument_is_called_arg.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one(arg: a) -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>(<span class="hljs-variable">arg</span>: <span class="hljs-variable">a</span>) -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"></div>
   </div>
@@ -343,6 +343,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
@@ -313,6 +313,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
@@ -5,4 +5,4 @@ expression: output
 ---- VALUES
 
 --- make_dict
-<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">make_dict</span>() -> <a href="https://hexdocs.pm/thepackage/gleam/dict.html#Dict" title="gleam/dict.{type Dict}"><span class="hljs-variable">dict</span>.<span class="hljs-title">Dict</span></a>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>
+<pre><code>pub fn make_dict() -> <a href="https://hexdocs.pm/thepackage/gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- make_dict
+<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">make_dict</span>() -> <a href="https://hexdocs.pm/thepackage/gleam/dict.html#Dict" title="gleam/dict.{type Dict}"><span class="hljs-variable">dict</span>.<span class="hljs-title">Dict</span></a>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
@@ -16,4 +16,4 @@ pub fn make_dict() -> dict.Dict(a, b) { todo }
 ---- VALUES
 
 --- make_dict
-<pre><code>pub fn make_dict() -> <a href="https://hexdocs.pm/thepackage/gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>
+<pre><code>pub fn make_dict() -> <a href="gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module.snap
@@ -2,6 +2,17 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- gleam/dict.gleam
+pub type Dict(a, b)
+
+-- main.gleam
+
+import gleam/dict
+
+pub fn make_dict() -> dict.Dict(a, b) { todo }
+
+
 ---- VALUES
 
 --- make_dict

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module_from_nested_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module_from_nested_module.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- gleam/dict.gleam
+pub type Dict(a, b)
+
+-- gleam/dynamic/decode.gleam
+
+import gleam/dict
+
+pub fn decode_dict() -> dict.Dict(a, b) { todo }
+
+
+---- VALUES
+
+--- decode_dict
+<pre><code>pub fn decode_dict() -> <a href="../dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module_from_nested_module_with_shared_path.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_module_from_nested_module_with_shared_path.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- gleam/dynamic.gleam
+pub type Dynamic
+
+-- gleam/dynamic/decode.gleam
+
+import gleam/dynamic
+
+pub type Dynamic = dynamic.Dynamic
+
+
+---- TYPES
+
+--- Dynamic
+<pre><code>pub type Dynamic =
+  <a href="../dynamic.html#Dynamic" title="gleam/dynamic.{type Dynamic}">dynamic.Dynamic</a></code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- make_dict
+<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">make_dict</span>() -> <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#Dict" title="gleam/dict.{type Dict}"><span class="hljs-variable">dict</span>.<span class="hljs-title">Dict</span></a>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
@@ -5,4 +5,4 @@ expression: output
 ---- VALUES
 
 --- make_dict
-<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">make_dict</span>() -> <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#Dict" title="gleam/dict.{type Dict}"><span class="hljs-variable">dict</span>.<span class="hljs-title">Dict</span></a>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>
+<pre><code>pub fn make_dict() -> <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
@@ -2,6 +2,17 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- gleam/dict.gleam
+pub type Dict(a, b)
+
+-- main.gleam
+
+import gleam/dict
+
+pub fn make_dict() -> dict.Dict(a, b) { todo }
+
+
 ---- VALUES
 
 --- make_dict

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_same_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_same_module.snap
@@ -5,9 +5,9 @@ expression: output
 ---- TYPES
 
 --- Dict
-<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Dict</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>
+<pre><code>pub type Dict(a, b)</code></pre>
 
 ---- VALUES
 
 --- new
-<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">new</span>() -> <a href="#Dict"><span class="hljs-title">Dict</span></a>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>
+<pre><code>pub fn new() -> <a href="#Dict">Dict</a>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_same_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_same_module.snap
@@ -2,6 +2,14 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub type Dict(a, b)
+
+pub fn new() -> Dict(a, b) { todo }
+
+
 ---- TYPES
 
 --- Dict

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_same_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_same_module.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- TYPES
+
+--- Dict
+<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Dict</span>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>
+
+---- VALUES
+
+--- new
+<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">new</span>() -> <a href="#Dict"><span class="hljs-title">Dict</span></a>(<span class="hljs-variable">a</span>, <span class="hljs-variable">b</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -272,9 +272,9 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam">pub type Option(t) {
-  Some(t)
-  None
+      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">t</span>) {
+  <span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)
+  <span class="hljs-title">None</span>
 }</code></pre>
       
       <h3>
@@ -285,7 +285,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">Some(t)</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam hljs-ignore"><span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -298,7 +298,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">None</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam hljs-ignore"><span class="hljs-title">None</span></code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -333,10 +333,10 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn lazy_or(
-  first: Option(a),
-  second: fn() -&gt; Option(a),
-) -&gt; Option(a)</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">lazy_or</span>(
+  <span class="hljs-variable">first</span>: <a href="#Option"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>),
+  <span class="hljs-variable">second</span>: <span class="hljs-keyword">fn</span>() -> <a href="#Option"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>),
+) -> <a href="#Option"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>)</code></pre>
     
     <div class="rendered-markdown"><p>Returns the first value if it is <code>Some</code>, otherwise evaluates the given
 function for a fallback value.</p>
@@ -417,6 +417,9 @@ function for a fallback value.</p>
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -272,7 +272,7 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">t</span>) {
+      <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">t</span>) {
   <span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)
   <span class="hljs-title">None</span>
 }</code></pre>
@@ -285,7 +285,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam hljs-ignore"><span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)</code></pre>
+            <pre class="constructor-name"><code class="hljs hljs-ignore"><span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -298,7 +298,7 @@ expression: "compile(config, modules)"
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam hljs-ignore"><span class="hljs-title">None</span></code></pre>
+            <pre class="constructor-name"><code class="hljs hljs-ignore"><span class="hljs-title">None</span></code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -333,7 +333,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">lazy_or</span>(
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">lazy_or</span>(
   <span class="hljs-variable">first</span>: <a href="#Option"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>),
   <span class="hljs-variable">second</span>: <span class="hljs-keyword">fn</span>() -> <a href="#Option"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>),
 ) -> <a href="#Option"><span class="hljs-title">Option</span></a>(<span class="hljs-variable">a</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -272,7 +272,7 @@ expression: "compile(config, modules)"
     
     <div class="custom-type-constructors">
       <div class="rendered-markdown"></div>
-      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">t</span>) {
+      <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub type </span><span class="hljs-title">Option</span>(<span class="hljs-variable">t</span>) {
   <span class="hljs-title">Some</span>(<span class="hljs-variable">t</span>)
   <span class="hljs-title">None</span>
 }</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">indentation_test</span>() -> <span class="hljs-variable">a</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">indentation_test</span>() -> <span class="hljs-variable">a</span></code></pre>
     
     <div class="rendered-markdown"><p>Here’s an example code snippet:</p>
 <pre><code>wibble

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn indentation_test() -&gt; a</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">indentation_test</span>() -> <span class="hljs-variable">a</span></code></pre>
     
     <div class="rendered-markdown"><p>Here’s an example code snippet:</p>
 <pre><code>wibble
@@ -347,6 +347,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
@@ -317,6 +317,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
@@ -311,6 +311,9 @@ expression: "compile_with_markdown_pages(config, vec![], pages,\nCompileWithMark
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_hex_publish.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_hex_publish.snap
@@ -584,7 +584,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -944,7 +944,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_hex_publish.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_hex_publish.snap
@@ -304,6 +304,9 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 
@@ -581,7 +584,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -661,6 +664,9 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 
@@ -938,7 +944,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><p>Here is some documentation</p>
 </div>
@@ -1018,6 +1024,9 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_link_to_type_in_git_dependency.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_link_to_type_in_git_dependency.snap
@@ -16,4 +16,4 @@ pub fn make_dict() -> dict.Dict(a, b) { todo }
 ---- VALUES
 
 --- make_dict
-<pre><code>pub fn make_dict() -> <a href="https://hexdocs.pm/gleam_stdlib/1.0.0/gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>
+<pre><code>pub fn make_dict() -> <span title="gleam/dict.{type Dict}">dict.Dict</span>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_link_to_type_in_path_dependency.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_link_to_type_in_path_dependency.snap
@@ -16,4 +16,4 @@ pub fn make_dict() -> dict.Dict(a, b) { todo }
 ---- VALUES
 
 --- make_dict
-<pre><code>pub fn make_dict() -> <a href="https://hexdocs.pm/gleam_stdlib/1.0.0/gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>
+<pre><code>pub fn make_dict() -> <span title="gleam/dict.{type Dict}">dict.Dict</span>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_links_to_prelude_types.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_links_to_prelude_types.snap
@@ -5,4 +5,4 @@ expression: output
 ---- VALUES
 
 --- int_to_string
-<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">int_to_string</span>(<span class="hljs-variable">i</span>: <span class="hljs-title">Int</span>) -> <span class="hljs-title">String</span></code></pre>
+<pre><code>pub fn int_to_string(i: Int) -> String</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_links_to_prelude_types.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_links_to_prelude_types.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- int_to_string
+<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">int_to_string</span>(<span class="hljs-variable">i</span>: <span class="hljs-title">Int</span>) -> <span class="hljs-title">String</span></code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_links_to_prelude_types.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__no_links_to_prelude_types.snap
@@ -2,6 +2,12 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub fn int_to_string(i: Int) -> String { todo }
+
+
 ---- VALUES
 
 --- int_to_string

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_qualified_names_from_other_modules.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_qualified_names_from_other_modules.snap
@@ -2,6 +2,27 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- gleam/option.gleam
+
+pub type Option(t) {
+  Some(t)
+  None
+}
+
+
+-- main.gleam
+
+import gleam/option.{type Option, Some, None}
+
+pub fn from_option(o: Option(t), e: e) -> Result(t, e) {
+  case o {
+    Some(t) -> Ok(t)
+    None -> Error(e)
+  }
+}
+
+
 ---- VALUES
 
 --- from_option

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_qualified_names_from_other_modules.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_qualified_names_from_other_modules.snap
@@ -5,4 +5,4 @@ expression: output
 ---- VALUES
 
 --- from_option
-<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">from_option</span>(<span class="hljs-variable">o</span>: <a href="https://hexdocs.pm/thepackage/gleam/option.html#Option" title="gleam/option.{type Option}"><span class="hljs-variable">option</span>.<span class="hljs-title">Option</span></a>(<span class="hljs-variable">t</span>), <span class="hljs-variable">e</span>: <span class="hljs-variable">e</span>) -> <span class="hljs-title">Result</span>(<span class="hljs-variable">t</span>, <span class="hljs-variable">e</span>)</code></pre>
+<pre><code>pub fn from_option(o: option.Option(t), e: e) -> Result(t, e)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_qualified_names_from_other_modules.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_qualified_names_from_other_modules.snap
@@ -1,0 +1,8 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- VALUES
+
+--- from_option
+<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">from_option</span>(<span class="hljs-variable">o</span>: <a href="https://hexdocs.pm/thepackage/gleam/option.html#Option" title="gleam/option.{type Option}"><span class="hljs-variable">option</span>.<span class="hljs-title">Option</span></a>(<span class="hljs-variable">t</span>), <span class="hljs-variable">e</span>: <span class="hljs-variable">e</span>) -> <span class="hljs-title">Result</span>(<span class="hljs-variable">t</span>, <span class="hljs-variable">e</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_type_variables_in_function_signatures.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_type_variables_in_function_signatures.snap
@@ -5,13 +5,13 @@ expression: output
 ---- TYPES
 
 --- Dict
-<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Dict</span>(<span class="hljs-variable">key</span>, <span class="hljs-variable">value</span>)</code></pre>
+<pre><code>pub type Dict(key, value)</code></pre>
 
 ---- VALUES
 
 --- insert
-<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">insert</span>(
-  <span class="hljs-variable">dict</span>: <a href="#Dict"><span class="hljs-title">Dict</span></a>(<span class="hljs-variable">key</span>, <span class="hljs-variable">value</span>),
-  <span class="hljs-variable">key</span>: <span class="hljs-variable">key</span>,
-  <span class="hljs-variable">value</span>: <span class="hljs-variable">value</span>,
-) -> <a href="#Dict"><span class="hljs-title">Dict</span></a>(<span class="hljs-variable">key</span>, <span class="hljs-variable">value</span>)</code></pre>
+<pre><code>pub fn insert(
+  dict: Dict(key, value),
+  key: key,
+  value: value,
+) -> Dict(key, value)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_type_variables_in_function_signatures.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_type_variables_in_function_signatures.snap
@@ -2,6 +2,16 @@
 source: compiler-core/src/docs/tests.rs
 expression: output
 ---
+---- SOURCE CODE
+-- main.gleam
+
+pub type Dict(key, value)
+
+pub fn insert(dict: Dict(key, value), key: key, value: value) -> Dict(key, value) {
+  dict
+}
+
+
 ---- TYPES
 
 --- Dict

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_type_variables_in_function_signatures.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__print_type_variables_in_function_signatures.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- TYPES
+
+--- Dict
+<pre><code><span class="hljs-keyword">pub </span><span class="hljs-keyword">type </span><span class="hljs-title">Dict</span>(<span class="hljs-variable">key</span>, <span class="hljs-variable">value</span>)</code></pre>
+
+---- VALUES
+
+--- insert
+<pre><code><span class="hljs-keyword">pub fn </span><span class="hljs-title">insert</span>(
+  <span class="hljs-variable">dict</span>: <a href="#Dict"><span class="hljs-title">Dict</span></a>(<span class="hljs-variable">key</span>, <span class="hljs-variable">value</span>),
+  <span class="hljs-variable">key</span>: <span class="hljs-variable">key</span>,
+  <span class="hljs-variable">value</span>: <span class="hljs-variable">value</span>,
+) -> <a href="#Dict"><span class="hljs-title">Dict</span></a>(<span class="hljs-variable">key</span>, <span class="hljs-variable">value</span>)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam">pub fn one() -&gt; Int</code></pre>
+    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><table><thead><tr><th>heading 1</th><th>heading 2</th></tr></thead><tbody>
 <tr><td>row 1 cell 1</td><td>row 1 cell 2</td></tr>
@@ -347,6 +347,9 @@ expression: "compile(config, modules)"
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
@@ -264,7 +264,7 @@ expression: "compile(config, modules)"
       
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
+    <pre><code class="hljs hljs-ignore"><span class="hljs-keyword">pub fn </span><span class="hljs-title">one</span>() -> <span class="hljs-title">Int</span></code></pre>
     
     <div class="rendered-markdown"><table><thead><tr><th>heading 1</th><th>heading 2</th></tr></thead><tbody>
 <tr><td>row 1 cell 1</td><td>row 1 cell 2</td></tr>

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -137,7 +137,7 @@ fn compile_documentation(
     modules: Vec<(&str, &str, &str)>,
     options: PrintOptions,
 ) -> EcoString {
-    let module = type_::tests::compile_module("main", main_module, None, modules)
+    let module = type_::tests::compile_module("main", main_module, None, modules.clone())
         .expect("Module should compile successfully");
 
     let mut config = PackageConfig::default();
@@ -181,8 +181,15 @@ fn compile_documentation(
 
     let mut output = EcoString::new();
 
+    output.push_str("---- SOURCE CODE\n");
+    for (_package, name, src) in modules {
+        output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+    }
+    output.push_str("-- main.gleam\n");
+    output.push_str(main_module);
+
     if !types.is_empty() {
-        output.push_str("---- TYPES");
+        output.push_str("\n\n---- TYPES");
     }
     for type_ in types {
         output.push_str("\n\n--- ");

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -707,6 +707,57 @@ const NONE: PrintOptions = PrintOptions {
     print_links: false,
 };
 
+#[test]
+fn highlight_function_definition() {
+    assert_documentation!(
+        "
+pub fn wibble(list: List(Int), generic: a, function: fn(a) -> b) -> #(a, b) { todo }
+"
+    );
+}
+
+#[test]
+fn highlight_constant_definition() {
+    assert_documentation!(
+        "
+pub const x = 22
+"
+    );
+}
+
+#[test]
+fn highlight_type_alias() {
+    assert_documentation!(
+        "
+pub type Option(a) = Result(a, Nil)
+"
+    );
+}
+
+#[test]
+fn highlight_custom_type() {
+    assert_documentation!(
+        "
+pub type Wibble(a, b) {
+  Wibble(a, i: Int)
+  Wobble(b: b, c: String)
+}
+"
+    );
+}
+
+#[test]
+fn highlight_opaque_custom_type() {
+    assert_documentation!(
+        "
+pub opaque type Wibble(a, b) {
+  Wibble(a, i: Int)
+  Wobble(b: b, c: String)
+}
+"
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/2629
 #[test]
 fn print_type_variables_in_function_signatures() {

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -799,3 +799,53 @@ pub fn int_to_string(i: Int) -> String { todo }
         ONLY_LINKS
     );
 }
+
+#[test]
+fn generated_type_variables() {
+    assert_documentation!(
+        "
+pub fn wibble(_a, _b, _c, _d) {
+  todo
+}
+",
+        NONE
+    );
+}
+
+#[test]
+fn generated_type_variables_mixed_with_existing_variables() {
+    assert_documentation!(
+        "
+pub fn wibble(_a: b, _b: a, _c, _d) {
+  todo
+}
+",
+        NONE
+    );
+}
+
+#[test]
+fn generated_type_variables_with_existing_variables_coming_afterwards() {
+    assert_documentation!(
+        "
+pub fn wibble(_a, _b, _c: b, _d: a) {
+  todo
+}
+",
+        NONE
+    );
+}
+
+#[test]
+fn generated_type_variables_do_not_take_into_account_other_definitions() {
+    assert_documentation!(
+        "
+pub fn wibble(_a: a, _b: b, _c: c) -> d {
+  todo
+}
+
+pub fn identity(x) { x }
+",
+        NONE
+    );
+}

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use super::{
-    Dependency, DependencyKind, SearchData, SearchItem, SearchItemType, SearchProgrammingLanguage,
+    Dependency, DependencyKind, DocumentationConfig, SearchData, SearchItem, SearchItemType,
+    SearchProgrammingLanguage,
     printer::{PrintOptions, Printer},
     source_links::SourceLinker,
 };
@@ -99,17 +100,19 @@ fn compile_with_markdown_pages(
 
     super::generate_html(
         &paths,
-        &config,
-        HashMap::new(),
-        &modules,
-        &docs_pages,
-        pages_fs,
-        SystemTime::UNIX_EPOCH,
-        if let Some(doc_context) = opts.hex_publish {
-            doc_context
-        } else {
-            DocContext::HexPublish
+        DocumentationConfig {
+            package_config: &config,
+            dependencies: HashMap::new(),
+            analysed: &modules,
+            docs_pages: &docs_pages,
+            rendering_timestamp: SystemTime::UNIX_EPOCH,
+            context: if let Some(doc_context) = opts.hex_publish {
+                doc_context
+            } else {
+                DocContext::HexPublish
+            },
         },
+        pages_fs,
     )
     .into_iter()
     .filter(|file| file.path.extension() == Some("html"))

--- a/compiler-core/src/pretty/tests.rs
+++ b/compiler-core/src/pretty/tests.rs
@@ -109,6 +109,18 @@ fn fits_test() {
     assert!(fits(2, 0, vector![(0, Unbroken, &doc)]));
     assert!(!fits(1, 0, vector![(0, Broken, &doc)]));
     assert!(!fits(1, 0, vector![(0, Unbroken, &doc)]));
+
+    let doc = ZeroWidthString {
+        string: "this is a very long string that doesn't count towards line width".into(),
+    };
+    assert!(fits(10, 0, vector![(0, Unbroken, &doc)]));
+    assert!(fits(10, 9, vector![(0, Unbroken, &doc)]));
+    let string_doc = "hello!".to_doc();
+    assert!(fits(
+        10,
+        0,
+        vector![(0, Unbroken, &string_doc), (0, Unbroken, &doc)]
+    ));
 }
 
 #[test]
@@ -156,6 +168,24 @@ fn format_test() {
         kind: BreakKind::Flex,
     }));
     assert_eq!("unbroken".to_string(), doc.to_pretty_string(100));
+
+    let doc = Vec(vec![
+        Break {
+            broken: "broken",
+            unbroken: "unbroken",
+            kind: BreakKind::Strict,
+        },
+        zero_width_string("<This will not cause a line break>".into()),
+        Break {
+            broken: "broken",
+            unbroken: "unbroken",
+            kind: BreakKind::Strict,
+        },
+    ]);
+    assert_eq!(
+        "unbroken<This will not cause a line break>unbroken",
+        doc.to_pretty_string(20)
+    );
 }
 
 #[test]
@@ -308,6 +338,7 @@ fn empty_documents() {
     assert!("".to_doc().append("".to_doc()).is_empty());
     assert!(!"wibble".to_doc().append("".to_doc()).is_empty());
     assert!(!"".to_doc().append("wibble".to_doc()).is_empty());
+    assert!(!zero_width_string("wibble".into()).is_empty());
 }
 
 #[test]

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -248,6 +248,10 @@ impl Names {
     pub fn is_imported(&self, module: &str) -> bool {
         self.imported_modules.contains_key(module)
     }
+
+    pub fn get_type_variable(&self, id: u64) -> Option<&EcoString> {
+        self.type_variables.get(&id)
+    }
 }
 
 #[derive(Debug)]

--- a/compiler-core/templates/documentation_layout.html
+++ b/compiler-core/templates/documentation_layout.html
@@ -300,6 +300,9 @@
           elem.classList.add("gleam");
         }
       });
+      hljs.configure({
+        cssSelector: 'pre code:not(.hljs-ignore)'
+      })
       hljs.highlightAll();
     </script>
 

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -55,7 +55,7 @@
     {% endif %}
     <div class="custom-type-constructors">
       <div class="rendered-markdown">{{ typ.documentation|safe }}</div>
-      <pre><code class="hljs gleam hljs-ignore">{{ typ.definition|safe }}</code></pre>
+      <pre><code class="hljs hljs-ignore">{{ typ.definition|safe }}</code></pre>
       {% if !typ.constructors.is_empty() %}
       <h3>
         Constructors
@@ -65,7 +65,7 @@
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam hljs-ignore">{{ constructor.definition|safe }}</code></pre>
+            <pre class="constructor-name"><code class="hljs hljs-ignore">{{ constructor.definition|safe }}</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -119,7 +119,7 @@
       {% endif %}
     </div>
 
-    <pre><code class="hljs gleam hljs-ignore">{{ value.definition|safe }}</code></pre>
+    <pre><code class="hljs hljs-ignore">{{ value.definition|safe }}</code></pre>
     {% if !value.deprecation_message.is_empty() %}
     <p>
       <b>Deprecated:</b> {{ value.deprecation_message }}

--- a/compiler-core/templates/documentation_module.html
+++ b/compiler-core/templates/documentation_module.html
@@ -55,7 +55,7 @@
     {% endif %}
     <div class="custom-type-constructors">
       <div class="rendered-markdown">{{ typ.documentation|safe }}</div>
-      <pre><code class="hljs gleam">{{ typ.definition }}</code></pre>
+      <pre><code class="hljs gleam hljs-ignore">{{ typ.definition|safe }}</code></pre>
       {% if !typ.constructors.is_empty() %}
       <h3>
         Constructors
@@ -65,7 +65,7 @@
         <li class="constructor-item">
           <div class="constructor-row">
             <svg class="icon icon-star"><use xlink:href="#icon-star"></use></svg>
-            <pre class="constructor-name"><code class="hljs gleam">{{ constructor.definition }}</code></pre>
+            <pre class="constructor-name"><code class="hljs gleam hljs-ignore">{{ constructor.definition|safe }}</code></pre>
           </div>
 
           <div class="constructor-item-docs">
@@ -119,7 +119,7 @@
       {% endif %}
     </div>
 
-    <pre><code class="hljs gleam">{{ value.definition }}</code></pre>
+    <pre><code class="hljs gleam hljs-ignore">{{ value.definition|safe }}</code></pre>
     {% if !value.deprecation_message.is_empty() %}
     <p>
       <b>Deprecated:</b> {{ value.deprecation_message }}


### PR DESCRIPTION
This PR closes #2629, closes #828 and closes #3461
This PR is a continuation of #3471, thanks @yoshi-monster for doing the initial work!
What I've done in this PR:
- Extracted the logic for printing the definitions of types and values from the formatter, and made a `docs::printer::Printer` struct.
- This struct now prints highlighting HTML tags, because as Yoshi discovered, highlight.js doesn't support links.
- To support that, I've added a `ZeroWidthString` variant to the `Document` enum in the pretty printing module
- While I was doing this, I thought it made sense to rework the type printing for these, so we now have proper type-variable printing and module qualifiers.
- Since the snapshots were very large (~400 lines each), I've made a new function to pretty-print the generated documentation, including a way to turn off all the HTML highlighting so we can properly see the generated code.