### PR TITLE
Only print the user-friendly LSP message when stdin is a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,3 +407,7 @@
 - Fixed a bug where LSP ranges would be incorrect when a file contained characters
   that were represented wit more than one byte in UTF-8.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Only print the user-friendly LSP message when stdin is a terminal to avoid
+  emitting redundant logs.
+  ([Ariel Parker](https://github.com/arielherself))

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -23,6 +23,9 @@ Many editors will automatically start the language server for you
 when you open a Gleam project. If yours does not you may need to
 look up how to configure your editor to use a language server.
 
+If you are seeing this in the logs of your editor you can safely
+ignore this message.
+
 If you have run `gleam lsp` yourself in your terminal then exit
 this program by pressing ctrl+c.
 "

--- a/compiler-cli/src/lsp.rs
+++ b/compiler-cli/src/lsp.rs
@@ -12,8 +12,9 @@ use gleam_core::{
 pub fn main() -> Result<()> {
     tracing::info!("language_server_starting");
 
-    eprintln!(
-        "Hello human!
+    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        eprintln!(
+            "Hello human!
 
 This command is intended to be run by language server clients such
 as a text editor rather than being run directly in the console.
@@ -22,13 +23,11 @@ Many editors will automatically start the language server for you
 when you open a Gleam project. If yours does not you may need to
 look up how to configure your editor to use a language server.
 
-If you are seeing this in the logs of your editor you can safely
-ignore this message.
-
 If you have run `gleam lsp` yourself in your terminal then exit
 this program by pressing ctrl+c.
 "
-    );
+        );
+    }
 
     // Create the transport. Includes the stdio (stdin and stdout) versions but this could
     // also be implemented to use sockets or HTTP.


### PR DESCRIPTION
This PR adds a check using `std::io::IsTerminal` to avoid emitting redundant logs on proper LSP starts, so that it matches the common practice of this kind of tools.