### PR TITLE
Fix LSP ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,3 +403,7 @@
 - Fixed a bug where some code actions would produce invalid code when a file
   contained characters that were represented with more than one byte in UTF-8.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where LSP ranges would be incorrect when a file contained characters
+  that were represented wit more than one byte in UTF-8.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -14368,11 +14368,19 @@ pub mod line_numbers {
     pub fn get_length(self) -> u32 {
       self.reader.get_data_field::<u32>(0)
     }
+    #[inline]
+    pub fn get_mapping(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::character::Owned>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_mapping(&self) -> bool {
+      !self.reader.get_pointer_field(1).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -14446,6 +14454,22 @@ pub mod line_numbers {
     pub fn set_length(&mut self, value: u32)  {
       self.builder.set_data_field::<u32>(0, value);
     }
+    #[inline]
+    pub fn get_mapping(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::character::Owned>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_mapping(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::character::Owned>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(1), value, false)
+    }
+    #[inline]
+    pub fn init_mapping(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::character::Owned> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), size)
+    }
+    #[inline]
+    pub fn has_mapping(&self) -> bool {
+      !self.builder.is_pointer_field_null(1)
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -14457,17 +14481,17 @@ pub mod line_numbers {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 53] = [
+    pub static ENCODED_NODE: [::capnp::Word; 72] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(101, 33, 49, 62, 78, 11, 246, 235),
       ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
-      ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 202, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(29, 0, 0, 0, 119, 0, 0, 0),
+      ::capnp::word(29, 0, 0, 0, 175, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -14475,21 +14499,28 @@ pub mod line_numbers {
       ::capnp::word(101, 78, 117, 109, 98, 101, 114, 115),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(41, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(69, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(68, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(96, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(65, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(93, 0, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(60, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(72, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(88, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(100, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(97, 0, 0, 0, 66, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(120, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(108, 105, 110, 101, 83, 116, 97, 114),
       ::capnp::word(116, 115, 0, 0, 0, 0, 0, 0),
       ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
@@ -14511,11 +14542,24 @@ pub mod line_numbers {
       ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(109, 97, 112, 112, 105, 110, 103, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(130, 77, 162, 53, 234, 228, 146, 132),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
         0 => <::capnp::primitive_list::Owned<u32> as ::capnp::introspect::Introspect>::introspect(),
         1 => <u32 as ::capnp::introspect::Introspect>::introspect(),
+        2 => <::capnp::struct_list::Owned<crate::schema_capnp::character::Owned> as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -14528,9 +14572,262 @@ pub mod line_numbers {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[1,0];
+    pub static MEMBERS_BY_NAME : &[u16] = &[1,0,2];
     pub const TYPE_ID: u64 = 0xebf6_0b4e_3e31_2165;
+  }
+}
+
+pub mod character {
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  impl <> ::core::marker::Copy for Reader<'_,>  {}
+  impl <> ::core::clone::Clone for Reader<'_,>  {
+    fn clone(&self) -> Self { *self }
+  }
+
+  impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+    fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+      Self { reader,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+    fn from(reader: Reader<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <> ::core::fmt::Debug for Reader<'_,>  {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+      core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(reader.get_struct(default)?.into())
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <> Reader<'_,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Self { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn get_byte_index(self) -> u64 {
+      self.reader.get_data_field::<u64>(0)
+    }
+    #[inline]
+    pub fn get_length_utf8(self) -> u8 {
+      self.reader.get_data_field::<u8>(8)
+    }
+    #[inline]
+    pub fn get_length_utf16(self) -> u8 {
+      self.reader.get_data_field::<u8>(9)
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 0 };
+  }
+  impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+    fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+      Self { builder,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+    fn from(builder: Builder<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+      builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+    }
+  }
+
+  impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      self.builder.into_reader().into()
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { builder: self.builder.reborrow() }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      self.builder.as_reader().into()
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.as_reader().total_size()
+    }
+    #[inline]
+    pub fn get_byte_index(self) -> u64 {
+      self.builder.get_data_field::<u64>(0)
+    }
+    #[inline]
+    pub fn set_byte_index(&mut self, value: u64)  {
+      self.builder.set_data_field::<u64>(0, value);
+    }
+    #[inline]
+    pub fn get_length_utf8(self) -> u8 {
+      self.builder.get_data_field::<u8>(8)
+    }
+    #[inline]
+    pub fn set_length_utf8(&mut self, value: u8)  {
+      self.builder.set_data_field::<u8>(8, value);
+    }
+    #[inline]
+    pub fn get_length_utf16(self) -> u8 {
+      self.builder.get_data_field::<u8>(9)
+    }
+    #[inline]
+    pub fn set_length_utf16(&mut self, value: u8)  {
+      self.builder.set_data_field::<u8>(9, value);
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+      Self { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+  }
+  mod _private {
+    pub static ENCODED_NODE: [::capnp::Word; 65] = [
+      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      ::capnp::word(130, 77, 162, 53, 234, 228, 146, 132),
+      ::capnp::word(13, 0, 0, 0, 1, 0, 2, 0),
+      ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
+      ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(21, 0, 0, 0, 186, 0, 0, 0),
+      ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(25, 0, 0, 0, 175, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
+      ::capnp::word(97, 112, 110, 112, 58, 67, 104, 97),
+      ::capnp::word(114, 97, 99, 116, 101, 114, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(69, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(1, 0, 0, 0, 8, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(77, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(76, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(88, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 9, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(85, 0, 0, 0, 98, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(84, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(96, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(98, 121, 116, 101, 73, 110, 100, 101),
+      ::capnp::word(120, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(108, 101, 110, 103, 116, 104, 85, 116),
+      ::capnp::word(102, 56, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(6, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(6, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(108, 101, 110, 103, 116, 104, 85, 116),
+      ::capnp::word(102, 49, 54, 0, 0, 0, 0, 0),
+      ::capnp::word(6, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(6, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+    ];
+    pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+      match index {
+        0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
+        1 => <u8 as ::capnp::introspect::Introspect>::introspect(),
+        2 => <u8 as ::capnp::introspect::Introspect>::introspect(),
+        _ => panic!("invalid field index {}", index),
+      }
+    }
+    pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+      panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+    }
+    pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+      encoded_node: &ENCODED_NODE,
+      nonunion_members: NONUNION_MEMBERS,
+      members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+      members_by_name: MEMBERS_BY_NAME,
+    };
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
+    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
+    pub static MEMBERS_BY_NAME : &[u16] = &[0,2,1];
+    pub const TYPE_ID: u64 = 0x8492_e4ea_35a2_4d82;
   }
 }

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -341,4 +341,11 @@ struct BitArraySegmentOption {
 struct LineNumbers {
   lineStarts @0 :List(UInt32);
   length @1 :UInt32;
+  mapping @2 :List(Character);
+}
+
+struct Character {
+  byteIndex @0 :UInt64;
+  lengthUtf8 @1 :UInt8;
+  lengthUtf16 @2 :UInt8;
 }

--- a/compiler-core/src/language_server.rs
+++ b/compiler-core/src/language_server.rs
@@ -52,9 +52,8 @@ pub fn src_span_to_lsp_range(location: SrcSpan, line_numbers: &LineNumbers) -> R
 }
 
 pub fn lsp_range_to_src_span(range: Range, line_numbers: &LineNumbers) -> SrcSpan {
-    let Range { start, end } = range;
-    let start = line_numbers.byte_index(start.line + 1, start.character + 1);
-    let end = line_numbers.byte_index(end.line + 1, end.character + 1);
+    let start = line_numbers.byte_index(range.start);
+    let end = line_numbers.byte_index(range.end);
     SrcSpan { start, end }
 }
 

--- a/compiler-core/src/language_server.rs
+++ b/compiler-core/src/language_server.rs
@@ -53,8 +53,8 @@ pub fn src_span_to_lsp_range(location: SrcSpan, line_numbers: &LineNumbers) -> R
 
 pub fn lsp_range_to_src_span(range: Range, line_numbers: &LineNumbers) -> SrcSpan {
     let Range { start, end } = range;
-    let start = line_numbers.byte_index(start.line, start.character);
-    let end = line_numbers.byte_index(end.line, end.character);
+    let start = line_numbers.byte_index(start.line + 1, start.character + 1);
+    let end = line_numbers.byte_index(end.line + 1, end.character + 1);
     SrcSpan { start, end }
 }
 

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -130,10 +130,7 @@ where
         &'a self,
         valid_phrase_char: &impl Fn(char) -> bool,
     ) -> (Range, String) {
-        let cursor = self.src_line_numbers.byte_index(
-            self.cursor_position.line + 1,
-            self.cursor_position.character + 1,
-        );
+        let cursor = self.src_line_numbers.byte_index(*self.cursor_position);
 
         // Get part of phrase prior to cursor
         let before = self
@@ -194,12 +191,14 @@ where
     /// If the line includes a dot then it provides unqualified import completions.
     /// Otherwise it provides direct module import completions.
     pub fn import_completions(&'a self) -> Option<Result<Option<Vec<CompletionItem>>>> {
-        let start_of_line = self
-            .src_line_numbers
-            .byte_index(self.cursor_position.line + 1, 1);
-        let end_of_line = self
-            .src_line_numbers
-            .byte_index(self.cursor_position.line + 2, 1);
+        let start_of_line = self.src_line_numbers.byte_index(Position {
+            line: self.cursor_position.line,
+            character: 0,
+        });
+        let end_of_line = self.src_line_numbers.byte_index(Position {
+            line: self.cursor_position.line + 1,
+            character: 0,
+        });
 
         // Drop all lines except the line the cursor is on
         let src = self.src.get(start_of_line as usize..end_of_line as usize)?;
@@ -562,10 +561,7 @@ where
         // e.x. when the user has typed mymodule.| we know local module and prelude values are no longer
         // relevant.
         if module_select.is_none() {
-            let cursor = self.src_line_numbers.byte_index(
-                self.cursor_position.line + 1,
-                self.cursor_position.character + 1,
-            );
+            let cursor = self.src_line_numbers.byte_index(*self.cursor_position);
 
             // Find the function that the cursor is in and push completions for
             // its arguments and local variables.

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -130,9 +130,10 @@ where
         &'a self,
         valid_phrase_char: &impl Fn(char) -> bool,
     ) -> (Range, String) {
-        let cursor = self
-            .src_line_numbers
-            .byte_index(self.cursor_position.line, self.cursor_position.character);
+        let cursor = self.src_line_numbers.byte_index(
+            self.cursor_position.line + 1,
+            self.cursor_position.character + 1,
+        );
 
         // Get part of phrase prior to cursor
         let before = self
@@ -195,10 +196,10 @@ where
     pub fn import_completions(&'a self) -> Option<Result<Option<Vec<CompletionItem>>>> {
         let start_of_line = self
             .src_line_numbers
-            .byte_index(self.cursor_position.line, 0);
+            .byte_index(self.cursor_position.line + 1, 1);
         let end_of_line = self
             .src_line_numbers
-            .byte_index(self.cursor_position.line + 1, 0);
+            .byte_index(self.cursor_position.line + 2, 1);
 
         // Drop all lines except the line the cursor is on
         let src = self.src.get(start_of_line as usize..end_of_line as usize)?;
@@ -561,9 +562,10 @@ where
         // e.x. when the user has typed mymodule.| we know local module and prelude values are no longer
         // relevant.
         if module_select.is_none() {
-            let cursor = self
-                .src_line_numbers
-                .byte_index(self.cursor_position.line, self.cursor_position.character);
+            let cursor = self.src_line_numbers.byte_index(
+                self.cursor_position.line + 1,
+                self.cursor_position.character + 1,
+            );
 
             // Find the function that the cursor is in and push completions for
             // its arguments and local variables.

--- a/compiler-core/src/language_server/edits.rs
+++ b/compiler-core/src/language_server/edits.rs
@@ -46,8 +46,7 @@ pub fn add_newlines_after_import(
     line_numbers: &LineNumbers,
     src: &str,
 ) -> Newlines {
-    let import_start_cursor =
-        line_numbers.byte_index(import_location.line + 1, import_location.character + 1);
+    let import_start_cursor = line_numbers.byte_index(import_location);
     let is_new_line = src
         .chars()
         .nth(import_start_cursor as usize)

--- a/compiler-core/src/language_server/edits.rs
+++ b/compiler-core/src/language_server/edits.rs
@@ -47,7 +47,7 @@ pub fn add_newlines_after_import(
     src: &str,
 ) -> Newlines {
     let import_start_cursor =
-        line_numbers.byte_index(import_location.line, import_location.character);
+        line_numbers.byte_index(import_location.line + 1, import_location.character + 1);
     let is_new_line = src
         .chars()
         .nth(import_start_cursor as usize)

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -266,7 +266,7 @@ where
             let completer = Completer::new(&src, &params, &this.compiler, module);
             let byte_index = completer
                 .module_line_numbers
-                .byte_index(params.position.line, params.position.character);
+                .byte_index(params.position.line + 1, params.position.character + 1);
 
             // If in comment context, do not provide completions
             if module.extra.is_within_comment(byte_index) {
@@ -629,7 +629,8 @@ where
                 )))
             };
 
-            let byte_index = lines.byte_index(params.position.line, params.position.character);
+            let byte_index =
+                lines.byte_index(params.position.line + 1, params.position.character + 1);
 
             Ok(match reference_for_ast_node(found, &current_module.name) {
                 Some(Referenced::LocalVariable {
@@ -762,7 +763,8 @@ where
                 return Ok(None);
             };
 
-            let byte_index = lines.byte_index(position.position.line, position.position.character);
+            let byte_index =
+                lines.byte_index(position.position.line + 1, position.position.character + 1);
 
             Ok(match reference_for_ast_node(found, &module.name) {
                 Some(Referenced::LocalVariable {
@@ -996,7 +998,8 @@ Unused labelled fields:
         module: &'a Module,
     ) -> Option<(LineNumbers, Located<'a>)> {
         let line_numbers = LineNumbers::new(&module.code);
-        let byte_index = line_numbers.byte_index(params.position.line, params.position.character);
+        let byte_index =
+            line_numbers.byte_index(params.position.line + 1, params.position.character + 1);
         let node = module.find_node(byte_index);
         let node = node?;
         Some((line_numbers, node))

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -264,9 +264,7 @@ where
             };
 
             let completer = Completer::new(&src, &params, &this.compiler, module);
-            let byte_index = completer
-                .module_line_numbers
-                .byte_index(params.position.line + 1, params.position.character + 1);
+            let byte_index = completer.module_line_numbers.byte_index(params.position);
 
             // If in comment context, do not provide completions
             if module.extra.is_within_comment(byte_index) {
@@ -629,8 +627,7 @@ where
                 )))
             };
 
-            let byte_index =
-                lines.byte_index(params.position.line + 1, params.position.character + 1);
+            let byte_index = lines.byte_index(params.position);
 
             Ok(match reference_for_ast_node(found, &current_module.name) {
                 Some(Referenced::LocalVariable {
@@ -763,8 +760,7 @@ where
                 return Ok(None);
             };
 
-            let byte_index =
-                lines.byte_index(position.position.line + 1, position.position.character + 1);
+            let byte_index = lines.byte_index(position.position);
 
             Ok(match reference_for_ast_node(found, &module.name) {
                 Some(Referenced::LocalVariable {
@@ -998,8 +994,7 @@ Unused labelled fields:
         module: &'a Module,
     ) -> Option<(LineNumbers, Located<'a>)> {
         let line_numbers = LineNumbers::new(&module.code);
-        let byte_index =
-            line_numbers.byte_index(params.position.line + 1, params.position.character + 1);
+        let byte_index = line_numbers.byte_index(params.position);
         let node = module.find_node(byte_index);
         let node = node?;
         Some((line_numbers, node))

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -831,11 +831,13 @@ pub fn apply_code_edit(src: &str, mut change: Vec<lsp_types::TextEdit>) -> Strin
 
     change.sort_by_key(|edit| (edit.range.start.line, edit.range.start.character));
     for edit in change {
-        let start = line_numbers.byte_index(edit.range.start.line, edit.range.start.character)
+        let start = line_numbers
+            .byte_index(edit.range.start.line + 1, edit.range.start.character + 1)
             as i32
             - offset;
-        let end =
-            line_numbers.byte_index(edit.range.end.line, edit.range.end.character) as i32 - offset;
+        let end = line_numbers.byte_index(edit.range.end.line + 1, edit.range.end.character + 1)
+            as i32
+            - offset;
         let range = (start as usize)..(end as usize);
         offset += end - start;
         offset -= edit.new_text.len() as i32;

--- a/compiler-core/src/language_server/tests.rs
+++ b/compiler-core/src/language_server/tests.rs
@@ -831,13 +831,8 @@ pub fn apply_code_edit(src: &str, mut change: Vec<lsp_types::TextEdit>) -> Strin
 
     change.sort_by_key(|edit| (edit.range.start.line, edit.range.start.character));
     for edit in change {
-        let start = line_numbers
-            .byte_index(edit.range.start.line + 1, edit.range.start.character + 1)
-            as i32
-            - offset;
-        let end = line_numbers.byte_index(edit.range.end.line + 1, edit.range.end.character + 1)
-            as i32
-            - offset;
+        let start = line_numbers.byte_index(edit.range.start) as i32 - offset;
+        let end = line_numbers.byte_index(edit.range.end) as i32 - offset;
         let range = (start as usize)..(end as usize);
         offset += end - start;
         offset -= edit.new_text.len() as i32;

--- a/compiler-core/src/line_numbers.rs
+++ b/compiler-core/src/line_numbers.rs
@@ -1,7 +1,16 @@
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct LineNumbers {
     pub line_starts: Vec<u32>,
     pub length: u32,
+    pub mapping: HashMap<usize, Character>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct Character {
+    pub length_utf8: u8,
+    pub length_utf16: u8,
 }
 
 impl LineNumbers {
@@ -11,7 +20,27 @@ impl LineNumbers {
             line_starts: std::iter::once(0)
                 .chain(src.match_indices('\n').map(|(i, _)| i as u32 + 1))
                 .collect(),
+            mapping: Self::mapping(src),
         }
+    }
+
+    fn mapping(src: &str) -> HashMap<usize, Character> {
+        let mut map = HashMap::new();
+
+        for (i, char) in src.char_indices() {
+            let length = char.len_utf8();
+            if length != 1 {
+                _ = map.insert(
+                    i,
+                    Character {
+                        length_utf8: length as u8,
+                        length_utf16: char.len_utf16() as u8,
+                    },
+                );
+            }
+        }
+
+        map
     }
 
     /// Get the line number for a byte index
@@ -22,8 +51,7 @@ impl LineNumbers {
             + 1
     }
 
-    // TODO: handle unicode characters that may be more than 1 byte in width
-    pub fn line_and_column_number(&self, byte_index: u32) -> LineColumn {
+    pub fn line_and_column_number_utf8(&self, byte_index: u32) -> LineColumn {
         let line = self.line_number(byte_index);
         let column = byte_index
             - self
@@ -35,19 +63,64 @@ impl LineNumbers {
         LineColumn { line, column }
     }
 
-    // TODO: handle unicode characters that may be more than 1 byte in width
+    pub fn line_and_column_number(&self, byte_index: u32) -> LineColumn {
+        let mut line_and_column = self.line_and_column_number_utf8(byte_index);
+
+        let mut u8_offset = 0;
+        let mut u16_offset = 0;
+        let target = line_and_column.column - 1;
+
+        loop {
+            if u8_offset >= target {
+                break;
+            }
+
+            if let Some(length) = self.mapping.get(&(u8_offset as usize)) {
+                u8_offset += length.length_utf8 as u32;
+                u16_offset += length.length_utf16 as u32;
+            } else {
+                u16_offset += 1;
+                u8_offset += 1;
+            }
+        }
+
+        line_and_column.column = u16_offset + 1;
+
+        line_and_column
+    }
+
     /// 0 indexed line and character to byte index
     pub fn byte_index(&self, line: u32, character: u32) -> u32 {
-        match self.line_starts.get((line) as usize) {
-            Some(line_index) => *line_index + character,
-            None => self.length,
+        let line_start = match self.line_starts.get(line as usize) {
+            Some(&line_start) => line_start,
+            None => return self.length,
+        };
+
+        let mut u8_offset = 0;
+        let mut u16_offset = 0;
+        let target = character;
+
+        loop {
+            if u16_offset >= target {
+                break;
+            }
+
+            if let Some(length) = self.mapping.get(&(u8_offset as usize)) {
+                u8_offset += length.length_utf8 as u32;
+                u16_offset += length.length_utf16 as u32;
+            } else {
+                u16_offset += 1;
+                u8_offset += 1;
+            }
         }
+
+        line_start + u8_offset
     }
 }
 
 #[test]
 fn byte_index() {
-    let src = &r#"import gleam/io
+    let src = r#"import gleam/io
 
 pub fn main() {
   io.println("Hello, world!")
@@ -61,7 +134,7 @@ pub fn main() {
     assert_eq!(line_numbers.byte_index(2, 1), 18);
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LineColumn {
     pub line: u32,
     pub column: u32,

--- a/compiler-core/src/line_numbers.rs
+++ b/compiler-core/src/line_numbers.rs
@@ -1,15 +1,38 @@
 use std::collections::HashMap;
 
+/// A struct which contains information about line numbers of a source file,
+/// and can convert between byte offsets that are used in the compiler and
+/// line-column pairs used in LSP.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct LineNumbers {
+    /// The byte offsets of the start of each line of the source file
     pub line_starts: Vec<u32>,
+    /// The total length of the source file
     pub length: u32,
+    /// A mapping of byte offsets to character length information. This is used
+    /// when converting between byte indices and line-column numbers, because
+    /// LSP uses UTF-16, while Rust encodes strings as UTF-8.
+    ///
+    /// This only contains characters which are more than one byte in UTF-8,
+    /// because one byte UTF-8 characters are one UTF-16 segment also, so no
+    /// translation is needed.
+    ///
+    /// We could store the whole source file here instead, however that would
+    /// be quite wasteful. Most Gleam programs use only ASCII characters, meaning
+    /// UTF-8 offsets are the same as UTF-16 ones. With this representation, we
+    /// only need to store a few characters.
+    ///
+    /// In most programs this will be empty because they will only be using
+    /// ASCII characters.
     pub mapping: HashMap<usize, Character>,
 }
 
+/// Information about how a character is encoded in UTF-8 and UTF-16.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct Character {
+    /// The number of bytes needed to encode this in UTF-8.
     pub length_utf8: u8,
+    /// The number of 16-bit segments needed to encode this in UTF-16.
     pub length_utf16: u8,
 }
 
@@ -43,7 +66,7 @@ impl LineNumbers {
         map
     }
 
-    /// Get the line number for a byte index
+    /// Returns the 1-indexed line number of a given byte index
     pub fn line_number(&self, byte_index: u32) -> u32 {
         self.line_starts
             .binary_search(&byte_index)
@@ -51,6 +74,8 @@ impl LineNumbers {
             + 1
     }
 
+    /// Returns the 1-indexed line and column number of a given byte index,
+    /// using a UTF-16 character offset.
     pub fn line_and_column_number(&self, byte_index: u32) -> LineColumn {
         let line = self.line_number(byte_index);
         let line_start = self
@@ -82,9 +107,10 @@ impl LineNumbers {
         }
     }
 
-    /// 0 indexed line and character to byte index
+    /// Returns the byte index of the corresponding 1-indexed line and column
+    /// numbers, translating from a UTF-16 character index to a UTF-8 byte index.
     pub fn byte_index(&self, line: u32, character: u32) -> u32 {
-        let line_start = match self.line_starts.get(line as usize) {
+        let line_start = match self.line_starts.get(line as usize - 1) {
             Some(&line_start) => line_start,
             None => return self.length,
         };
@@ -93,7 +119,7 @@ impl LineNumbers {
         let mut u16_offset = 0;
 
         loop {
-            if u16_offset >= character {
+            if u16_offset >= character - 1 {
                 break;
             }
 
@@ -120,10 +146,10 @@ pub fn main() {
 "#;
     let line_numbers = LineNumbers::new(src);
 
-    assert_eq!(line_numbers.byte_index(0, 0), 0);
-    assert_eq!(line_numbers.byte_index(0, 4), 4);
+    assert_eq!(line_numbers.byte_index(1, 1), 0);
+    assert_eq!(line_numbers.byte_index(1, 5), 4);
     assert_eq!(line_numbers.byte_index(100, 1), src.len() as u32);
-    assert_eq!(line_numbers.byte_index(2, 1), 18);
+    assert_eq!(line_numbers.byte_index(3, 2), 18);
 }
 
 // https://github.com/gleam-lang/gleam/issues/3628
@@ -139,10 +165,10 @@ pub fn main() {
 "#;
     let line_numbers = LineNumbers::new(src);
 
-    assert_eq!(line_numbers.byte_index(1, 6), 30);
-    assert_eq!(line_numbers.byte_index(5, 2), 52);
-    assert_eq!(line_numbers.byte_index(5, 17), 75);
-    assert_eq!(line_numbers.byte_index(6, 1), 91);
+    assert_eq!(line_numbers.byte_index(2, 7), 30);
+    assert_eq!(line_numbers.byte_index(6, 3), 52);
+    assert_eq!(line_numbers.byte_index(6, 18), 75);
+    assert_eq!(line_numbers.byte_index(7, 2), 91);
 }
 
 // https://github.com/gleam-lang/gleam/issues/3628

--- a/compiler-core/src/line_numbers.rs
+++ b/compiler-core/src/line_numbers.rs
@@ -64,14 +64,18 @@ impl LineNumbers {
     }
 
     pub fn line_and_column_number(&self, byte_index: u32) -> LineColumn {
-        let mut line_and_column = self.line_and_column_number_utf8(byte_index);
+        let line = self.line_number(byte_index);
+        let line_start = self
+            .line_starts
+            .get(line as usize - 1)
+            .copied()
+            .unwrap_or_default();
 
-        let mut u8_offset = 0;
+        let mut u8_offset = line_start;
         let mut u16_offset = 0;
-        let target = line_and_column.column - 1;
 
         loop {
-            if u8_offset >= target {
+            if u8_offset >= byte_index {
                 break;
             }
 
@@ -84,9 +88,10 @@ impl LineNumbers {
             }
         }
 
-        line_and_column.column = u16_offset + 1;
-
-        line_and_column
+        LineColumn {
+            line,
+            column: u16_offset + 1,
+        }
     }
 
     /// 0 indexed line and character to byte index
@@ -96,12 +101,11 @@ impl LineNumbers {
             None => return self.length,
         };
 
-        let mut u8_offset = 0;
+        let mut u8_offset = line_start;
         let mut u16_offset = 0;
-        let target = character;
 
         loop {
-            if u16_offset >= target {
+            if u16_offset >= character {
                 break;
             }
 
@@ -114,7 +118,7 @@ impl LineNumbers {
             }
         }
 
-        line_start + u8_offset
+        u8_offset
     }
 }
 

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -62,10 +62,20 @@ impl<'a> ModuleEncoder<'a> {
     fn set_line_numbers(&mut self, module: &mut module::Builder<'_>) {
         let mut line_numbers = module.reborrow().init_line_numbers();
         line_numbers.set_length(self.data.line_numbers.length);
-        let mut line_starts =
-            line_numbers.init_line_starts(self.data.line_numbers.line_starts.len() as u32);
+
+        let mut line_starts = line_numbers
+            .reborrow()
+            .init_line_starts(self.data.line_numbers.line_starts.len() as u32);
         for (i, l) in self.data.line_numbers.line_starts.iter().enumerate() {
             line_starts.reborrow().set(i as u32, *l);
+        }
+
+        let mut mapping = line_numbers.init_mapping(self.data.line_numbers.mapping.len() as u32);
+        for (i, (byte_index, character)) in self.data.line_numbers.mapping.iter().enumerate() {
+            let mut builder = mapping.reborrow().get(i as u32);
+            builder.set_byte_index(*byte_index as u64);
+            builder.set_length_utf8(character.length_utf8);
+            builder.set_length_utf16(character.length_utf16);
         }
     }
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
@@ -6,7 +6,7 @@ expression: "./cases/alias_unqualified_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<77 byte binary>
+<85 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -27,7 +27,7 @@ id(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<88 byte binary>
+<96 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_app_generation"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<49 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_bug_752"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<57 byte binary>
+<65 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -23,7 +23,7 @@ expression: "./cases/erlang_bug_752"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<84 byte binary>
+<92 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_empty"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<49 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.erl
 -module(empty).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_escape_names"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<61 byte binary>
+<69 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +24,7 @@ expression: "./cases/erlang_escape_names"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<136 byte binary>
+<144 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<88 byte binary>
+<96 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -25,7 +25,7 @@ unbox(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<57 byte binary>
+<65 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_import_shadowing_prelude"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<61 byte binary>
+<69 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -23,7 +23,7 @@ expression: "./cases/erlang_import_shadowing_prelude"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<88 byte binary>
+<96 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_nested"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<57 byte binary>
+<65 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_nested_qualified_constant"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<57 byte binary>
+<65 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
@@ -23,7 +23,7 @@ expression: "./cases/erlang_nested_qualified_constant"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<100 byte binary>
+<108 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
@@ -6,7 +6,7 @@ expression: "./cases/hello_joe"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.cache_meta
-<57 byte binary>
+<65 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.erl
 -module(hello_joe).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -6,7 +6,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<57 byte binary>
+<65 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -23,7 +23,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<120 byte binary>
+<128 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<89 byte binary>
+<97 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -27,7 +27,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<324 byte binary>
+<332 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_external_fns"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<69 byte binary>
+<77 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -29,7 +29,7 @@ escaped_thing() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<479 byte binary>
+<487 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.cache_meta
-<89 byte binary>
+<97 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.erl
 -module(one@one).
@@ -27,7 +27,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<491 byte binary>
+<499 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -6,7 +6,7 @@ expression: "./cases/javascript_d_ts"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello.cache_meta
-<73 byte binary>
+<81 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
 export * from "../prelude.mjs";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
@@ -6,7 +6,7 @@ expression: "./cases/javascript_empty"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<49 byte binary>
+<57 byte binary>
 
 //// /out/lib/the_package/empty.mjs
 export {}

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -6,13 +6,13 @@ expression: "./cases/javascript_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<57 byte binary>
+<65 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<80 byte binary>
+<88 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
 export * from "../prelude.mjs";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__not_overwriting_erlang_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__not_overwriting_erlang_module.snap
@@ -6,7 +6,7 @@ expression: "./cases/not_overwriting_erlang_module"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/app@code.cache_meta
-<65 byte binary>
+<73 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/app@code.erl
 -module(app@code).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
@@ -6,7 +6,7 @@ expression: "./cases/variable_or_module"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<118 byte binary>
+<126 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).
@@ -29,7 +29,7 @@ record_field(Power) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.cache_meta
-<77 byte binary>
+<85 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.erl
 -module(power).


### PR DESCRIPTION
Fixes #3628 and fixes #4543 
This PR changes the `LineNumbers` struct so that it takes into account multi-byte characters and converts between UTF-8 byte indices, which is what Rust uses, and UTF-16 line/character indices, which is what LSP uses.
I thought a lot about the best way to approach this, and eventually found the solution which is used in this PR. My reasoning is explained in the doc comment.
Let me know if you think I should use a different method to convert between them.