### PR TITLE
Remove all kind of unused imported items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,6 +422,28 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server can now also remove unused imported values and types:
+
+  ```gleam
+  import a_module.{type Unused, unused, used}
+
+  pub fn main() {
+    used
+  }
+  ```
+
+  Triggering the code action will remove all unused types and values:
+
+  ```gleam
+  import a_module.{used}
+
+  pub fn main() {
+    used
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 - Improved the formatting of `echo` when followed by long binary expressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,11 @@
   segments.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- When an import with unqualified types and values is unused the compiler will
+  now raise a single warning for the entire import rather than warning for each
+  individual item.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The build tool now supports placing modules in a directory called `dev`,
@@ -422,7 +427,7 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- The language server can now also remove unused imported values and types:
+- The language server can now remove unused imported values and types:
 
   ```gleam
   import a_module.{type Unused, unused, used}

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -938,7 +938,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             .collect();
         let typed_parameters = environment
             .get_type_constructor(&None, &name)
-            .expect("Could not find preregistered type constructor ")
+            .expect("Could not find preregistered type constructor")
             .parameters
             .clone();
 

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -70,7 +70,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         }
 
         // Insert unqualified imports into scope
-        let module_name = module_info.name.clone();
+        let module_name = &module_info.name;
         for type_ in &import.unqualified_types {
             self.register_unqualified_type(type_, module_name.clone(), module_info);
         }

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -136,7 +136,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
     fn register_unqualified_value(
         &mut self,
         import: &UnqualifiedImport,
-        module_full_name: EcoString,
+        module_name: EcoString,
         module: &ModuleInterface,
     ) {
         let import_name = &import.name;
@@ -189,7 +189,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 self.environment.references.register_value(
                     used_name.clone(),
                     EntityKind::ImportedConstructor {
-                        module: module_full_name,
+                        module: module_name,
                     },
                     location,
                     Publicity::Private,
@@ -208,7 +208,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 self.environment.references.register_value(
                     used_name.clone(),
                     EntityKind::ImportedValue {
-                        module: module_full_name,
+                        module: module_name,
                     },
                     location,
                     Publicity::Private,

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -70,19 +70,19 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         }
 
         // Insert unqualified imports into scope
-        let module_full_name = module_info.name.clone();
+        let module_name = module_info.name.clone();
         for type_ in &import.unqualified_types {
-            self.register_unqualified_type(type_, module_full_name.clone(), module_info);
+            self.register_unqualified_type(type_, module_name.clone(), module_info);
         }
         for value in &import.unqualified_values {
-            self.register_unqualified_value(value, module_full_name.clone(), module_info);
+            self.register_unqualified_value(value, module_name.clone(), module_info);
         }
     }
 
     fn register_unqualified_type(
         &mut self,
         import: &UnqualifiedImport,
-        module_full_name: EcoString,
+        module_name: EcoString,
         module: &ModuleInterface,
     ) {
         let imported_name = import.as_name.as_ref().unwrap_or(&import.name);
@@ -111,7 +111,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         self.environment.references.register_type(
             imported_name.clone(),
             EntityKind::ImportedType {
-                module: module_full_name,
+                module: module_name,
             },
             import.location,
             Publicity::Private,

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1908,7 +1908,18 @@ impl TypedClauseGuard {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Default, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    Clone,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct SrcSpan {
     pub start: u32,
     pub end: u32,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -7112,7 +7112,7 @@ impl<'a> RemoveUnusedImports<'a> {
                 // When an entire module is unused we can delete its entire location
                 // in the source code.
                 UnusedImport::Module(location) | UnusedImport::ModuleAlias(location) => {
-                    if self.edits.line_numbers.spans_entire_line(&location) {
+                    if self.edits.line_numbers.spans_entire_line(location) {
                         // If the unused module spans over the entire line then
                         // we also take care of removing the following newline
                         // characther!
@@ -7130,7 +7130,7 @@ impl<'a> RemoveUnusedImports<'a> {
                 // comma that we also need to remove!
                 UnusedImport::ValueOrType(location) => {
                     let imported = self.imported_values(*location);
-                    let unused_index = imported.binary_search(&location);
+                    let unused_index = imported.binary_search(location);
                     let is_last = unused_index.is_ok_and(|index| index == imported.len() - 1);
                     let next_value = unused_index
                         .ok()

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -862,6 +862,32 @@ pub type Used
 }
 
 #[test]
+fn test_remove_entire_unused_import() {
+    let src = "
+// test
+import result.{unused, unused_again}
+
+pub fn main() {
+  todo
+}
+";
+    assert_code_action!(
+        REMOVE_UNUSED_IMPORTS,
+        TestProject::for_source(src).add_hex_module(
+            "result",
+            "
+pub const used = 1
+pub const unused = 2
+pub const unused_again = 3
+pub type Unused
+pub type Used
+"
+        ),
+        find_position_of("// test").select_until(find_position_of("pub")),
+    );
+}
+
+#[test]
 fn test_remove_redundant_tuple_in_case_subject_simple() {
     assert_code_action!(
         REMOVE_REDUNDANT_TUPLES,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -812,9 +812,7 @@ fn test_remove_multiple_unused_values() {
 import result.{type Unused, used, unused, unused_again, type Used, used_again}
 
 pub fn main(x: Used) {
-  used
-  used_again
-  todo
+  #(used, used_again)
 }
 ";
     assert_code_action!(
@@ -842,7 +840,6 @@ import result.{type Unused, used, unused, type Used, unused_again}
 
 pub fn main(x: Used) {
   used
-  todo
 }
 ";
     assert_code_action!(

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_aliased_unused_value.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_aliased_unused_value.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\n// test\nimport result.{is_ok as ok}\nimport option\n\npub fn main() {\n  result.is_ok\n}\n"
+---
+----- BEFORE ACTION
+
+// test
+▔▔▔▔▔▔▔
+import result.{is_ok as ok}
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+import option
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main() {
+↑              
+  result.is_ok
+}
+
+
+----- AFTER ACTION
+
+// test
+import result.{}
+
+pub fn main() {
+  result.is_ok
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_entire_unused_import.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_entire_unused_import.snap
@@ -18,7 +18,6 @@ pub fn main() {
 ----- AFTER ACTION
 
 // test
-import result.{}
 
 pub fn main() {
   todo

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_entire_unused_import.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_entire_unused_import.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\n// test\nimport result.{unused, unused_again}\n\npub fn main() {\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+// test
+▔▔▔▔▔▔▔
+import result.{unused, unused_again}
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main() {
+↑              
+  todo
+}
+
+
+----- AFTER ACTION
+
+// test
+import result.{}
+
+pub fn main() {
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\n// test\nimport result.{type Unused, used, unused, unused_again, type Used, used_again}\n\npub fn main(x: Used) {\n  used\n  used_again\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+// test
+▔▔▔▔▔▔▔
+import result.{type Unused, used, unused, unused_again, type Used, used_again}
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main(x: Used) {
+↑                     
+  used
+  used_again
+  todo
+}
+
+
+----- AFTER ACTION
+
+// test
+import result.{used, type Used, used_again}
+
+pub fn main(x: Used) {
+  used
+  used_again
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\n// test\nimport result.{type Unused, used, unused, unused_again, type Used, used_again}\n\npub fn main(x: Used) {\n  used\n  used_again\n  todo\n}\n"
+expression: "\n// test\nimport result.{type Unused, used, unused, unused_again, type Used, used_again}\n\npub fn main(x: Used) {\n  #(used, used_again)\n}\n"
 ---
 ----- BEFORE ACTION
 
@@ -11,9 +11,7 @@ import result.{type Unused, used, unused, unused_again, type Used, used_again}
 
 pub fn main(x: Used) {
 ↑                     
-  used
-  used_again
-  todo
+  #(used, used_again)
 }
 
 
@@ -23,7 +21,5 @@ pub fn main(x: Used) {
 import result.{used, type Used, used_again}
 
 pub fn main(x: Used) {
-  used
-  used_again
-  todo
+  #(used, used_again)
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values_2.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/action.rs
-expression: "\n// test\nimport result.{type Unused, used, unused, type Used, unused_again}\n\npub fn main(x: Used) {\n  used\n  todo\n}\n"
+expression: "\n// test\nimport result.{type Unused, used, unused, type Used, unused_again}\n\npub fn main(x: Used) {\n  used\n}\n"
 ---
 ----- BEFORE ACTION
 
@@ -12,7 +12,6 @@ import result.{type Unused, used, unused, type Used, unused_again}
 pub fn main(x: Used) {
 ↑                     
   used
-  todo
 }
 
 
@@ -23,5 +22,4 @@ import result.{used, type Used}
 
 pub fn main(x: Used) {
   used
-  todo
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_multiple_unused_values_2.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\n// test\nimport result.{type Unused, used, unused, type Used, unused_again}\n\npub fn main(x: Used) {\n  used\n  todo\n}\n"
+---
+----- BEFORE ACTION
+
+// test
+▔▔▔▔▔▔▔
+import result.{type Unused, used, unused, type Used, unused_again}
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main(x: Used) {
+↑                     
+  used
+  todo
+}
+
+
+----- AFTER ACTION
+
+// test
+import result.{used, type Used}
+
+pub fn main(x: Used) {
+  used
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_value.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_unused_value.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\n// test\nimport result.{is_ok}\nimport option\n\npub fn main() {\n  result.is_ok\n}\n"
+---
+----- BEFORE ACTION
+
+// test
+▔▔▔▔▔▔▔
+import result.{is_ok}
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+import option
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+pub fn main() {
+↑              
+  result.is_ok
+}
+
+
+----- AFTER ACTION
+
+// test
+import result.{}
+
+pub fn main() {
+  result.is_ok
+}

--- a/compiler-core/src/line_numbers.rs
+++ b/compiler-core/src/line_numbers.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-
+use crate::ast::SrcSpan;
 use lsp_types::Position;
+use std::collections::HashMap;
 
 /// A struct which contains information about line numbers of a source file,
 /// and can convert between byte offsets that are used in the compiler and
@@ -135,6 +135,14 @@ impl LineNumbers {
         }
 
         u8_offset
+    }
+
+    /// Checks if the given span spans an entire line (excluding the newline
+    /// character itself).
+    pub fn spans_entire_line(&self, span: &SrcSpan) -> bool {
+        self.line_starts.iter().any(|&line_start| {
+            line_start == span.start && self.line_starts.contains(&(span.end + 1))
+        })
     }
 }
 

--- a/compiler-core/src/reference.rs
+++ b/compiler-core/src/reference.rs
@@ -95,7 +95,7 @@ pub struct ReferenceTracker {
     pub type_references: ReferenceMap,
 
     /// This map is used to access the nodes of modules that were not
-    /// aliased, given their full name.
+    /// aliased, given their name.
     /// We need this to keep track of references made to imports by unqualified
     /// values/types: when an unqualified item is used we want to add an edge
     /// pointing to the import it comes from, so that if the item is used the
@@ -287,7 +287,7 @@ impl ReferenceTracker {
         // unused!
         self.current_node = self.create_node(used_name.clone(), EntityLayer::Module);
         // Also we want to register the fact that if this alias is used then the
-        // import is used: so we add a reference from the alias to the full import
+        // import is used: so we add a reference from the alias to the import
         // we've just added.
         self.register_module_reference(module_name.clone());
 

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -678,8 +678,8 @@ impl Environment<'_> {
                     imported: false,
                     location,
                 },
-                EntityKind::ImportedModule { full_name } => {
-                    let _ = unused_modules.insert(full_name.clone());
+                EntityKind::ImportedModule { module_name } => {
+                    let _ = unused_modules.insert(module_name.clone());
                     Warning::UnusedImportedModule { name, location }
                 }
                 EntityKind::ImportedType { module } => {

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -372,10 +372,10 @@ impl Environment<'_> {
     ///
     pub fn get_type_constructor(
         &mut self,
-        module_alias: &Option<(EcoString, SrcSpan)>,
+        module: &Option<(EcoString, SrcSpan)>,
         name: &EcoString,
     ) -> Result<&TypeConstructor, UnknownTypeConstructorError> {
-        match module_alias {
+        match module {
             None => self
                 .module_types
                 .get(name)

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1173,7 +1173,7 @@ impl Warning {
         }
     }
 
-    fn location(&self) -> SrcSpan {
+    pub(crate) fn location(&self) -> SrcSpan {
         match self {
             Warning::Todo { location, .. }
             | Warning::ImplicitlyDiscardedResult { location, .. }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2727,7 +2727,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         // This is the name of the module coming before the `.`: for example
         // in `result.try` it's `result`.
-        selected_module: &EcoString,
+        module_alias: &EcoString,
         label: EcoString,
         module_location: &SrcSpan,
         select_location: SrcSpan,
@@ -2738,13 +2738,13 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             let (_, module) = self
                 .environment
                 .imported_modules
-                .get(selected_module)
+                .get(module_alias)
                 .ok_or_else(|| Error::UnknownModule {
-                    name: selected_module.clone(),
+                    name: module_alias.clone(),
                     location: *module_location,
                     suggestions: self
                         .environment
-                        .suggest_modules(selected_module, Imported::Value(label.clone())),
+                        .suggest_modules(module_alias, Imported::Value(label.clone())),
                 })?;
 
             let constructor =
@@ -2770,7 +2770,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             self.environment
                 .references
-                .register_module_reference(selected_module.clone());
+                .register_module_reference(module_alias.clone());
 
             (module.name.clone(), constructor.clone())
         };
@@ -2798,7 +2798,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             label,
             type_: Arc::clone(&type_),
             module_name,
-            module_alias: selected_module.clone(),
+            module_alias: module_alias.clone(),
             constructor,
         })
     }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_type_only_referenced_by_unused_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_type_only_referenced_by_unused_function.snap
@@ -18,11 +18,11 @@ fn unused() -> Wibble {
 
 
 ----- WARNING
-warning: Unused imported type
-  ┌─ /src/warning/wrn.gleam:2:16
+warning: Unused imported module
+  ┌─ /src/warning/wrn.gleam:2:1
   │
 2 │ import wibble.{type Wibble}
-  │                ^^^^^^^^^^^ This imported type is never used
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_value_only_referenced_by_unused_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_value_only_referenced_by_unused_function.snap
@@ -20,11 +20,11 @@ fn unused() {
 
 
 ----- WARNING
-warning: Unused imported item
-  ┌─ /src/warning/wrn.gleam:2:16
+warning: Unused imported module
+  ┌─ /src/warning/wrn.gleam:2:1
   │
 2 │ import wibble.{Wibble}
-  │                ^^^^^^ This imported constructor is never used
+  │ ^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__shadowed_imported_value_marked_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__shadowed_imported_value_marked_unused.snap
@@ -16,10 +16,10 @@ pub const wibble = 2
 
 
 ----- WARNING
-warning: Unused imported value
-  ┌─ /src/warning/wrn.gleam:2:16
+warning: Unused imported module
+  ┌─ /src/warning/wrn.gleam:2:1
   │
 2 │ import wibble.{wibble}
-  │                ^^^^^^ This imported value is never used
+  │ ^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_with_alias_and_unqualified_name_warnings_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_imported_module_with_alias_and_unqualified_name_warnings_test.snap
@@ -10,20 +10,10 @@ pub fn two() { 1 }
 import gleam/one.{two} as three
 
 ----- WARNING
-warning: Unused imported value
-  ┌─ /src/warning/wrn.gleam:1:19
+warning: Unused imported module
+  ┌─ /src/warning/wrn.gleam:1:1
   │
 1 │ import gleam/one.{two} as three
-  │                   ^^^ This imported value is never used
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
 
 Hint: You can safely remove it.
-
-warning: Unused imported module alias
-  ┌─ /src/warning/wrn.gleam:1:24
-  │
-1 │ import gleam/one.{two} as three
-  │                        ^^^^^^^^ This alias is never used
-
-Hint: You can safely remove it.
-
-    import gleam/one as _


### PR DESCRIPTION
This PR closes #3257 and closes #4510

With this PR:
- The language server can now remove individual unused values and types
- When all unqualified values and types in an import are unused, the entire import is now marked as unused...
- ...And it will be removed accordingly by the language server

For example:
```gleam
import wibble.{unused, Unused, type UnusedAgain}

pub fn main() { 1 }
```
This will now a single warning for the entire unused module and removing it with the language server will just remove the entire line altogether.