### PR TITLE
Allow specifying a tag prefix for documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,13 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The `repository` section in `gleam.toml` now allows specifying the
+  `tag_prefix` property, which overrides the default `v`.
+  This makes it possible to have multiple packages with different versions in
+  the same repository (together with `path`), without breaking links to source
+  code in documentation.
+  ([Sakari Bergen](https://github.com/sbergen))
+
 ### Language server
 
 - It is now possible to use the "Pattern match on variable" code action on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,7 +325,7 @@
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 - The `repository` section in `gleam.toml` now allows specifying the
-  `tag_prefix` property, which overrides the default `v`.
+  `tag_prefix` property, which is prepended to the default tag.
   This makes it possible to have multiple packages with different versions in
   the same repository (together with `path`), without breaking links to source
   code in documentation.

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use gleam_core::{
     Error,
     build::Runtime,
-    config::{DenoConfig, DenoFlag, Docs, ErlangConfig, JavaScriptConfig, Repository},
+    config::{DenoConfig, DenoFlag, Docs, ErlangConfig, JavaScriptConfig},
     manifest::{Base16Checksum, Manifest, ManifestPackage, ManifestPackageSource},
     requirement::Requirement,
 };
@@ -1176,7 +1176,7 @@ fn package_config(
         documentation: Docs { pages: vec![] },
         dependencies,
         dev_dependencies,
-        repository: Repository::None,
+        repository: None,
         links: vec![],
         erlang: ErlangConfig {
             application_start_module: None,

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -109,16 +109,16 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
     // Prompt the user to make a git tag if they have not.
     let has_repo = config.repository.url().is_some();
     let git = PathBuf::from(".git");
-    let version = format!("v{}", &config.version);
-    let git_tag = git.join("refs").join("tags").join(&version);
+    let tag_name = config.repository.tag_for_version(&config.version);
+    let git_tag = git.join("refs").join("tags").join(&tag_name);
     if has_repo && git.exists() && !git_tag.exists() {
         println!(
             "
 Please push a git tag for this release so source code links in the
 HTML documentation will work:
 
-    git tag {version}
-    git push origin {version}
+    git tag {tag_name}
+    git push origin {tag_name}
 "
         )
     }

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -769,27 +769,32 @@ pub enum Repository {
         user: String,
         repo: String,
         path: Option<String>,
+        tag_prefix: Option<String>,
     },
     GitLab {
         user: String,
         repo: String,
         path: Option<String>,
+        tag_prefix: Option<String>,
     },
     BitBucket {
         user: String,
         repo: String,
         path: Option<String>,
+        tag_prefix: Option<String>,
     },
     Codeberg {
         user: String,
         repo: String,
         path: Option<String>,
+        tag_prefix: Option<String>,
     },
     #[serde(alias = "forgejo")]
     Gitea {
         user: String,
         repo: String,
         path: Option<String>,
+        tag_prefix: Option<String>,
         #[serde(
             serialize_with = "uri_serde::serialize",
             deserialize_with = "uri_serde_default_https::deserialize"
@@ -800,6 +805,7 @@ pub enum Repository {
         user: String,
         repo: String,
         path: Option<String>,
+        tag_prefix: Option<String>,
     },
     Custom {
         url: String,
@@ -847,6 +853,24 @@ impl Repository {
             | Repository::Gitea { path, .. } => path.as_ref(),
 
             Repository::Custom { .. } | Repository::None => None,
+        }
+    }
+
+    pub fn tag_for_version(&self, version: &Version) -> String {
+        let prefix = match self {
+            Repository::GitHub { tag_prefix, .. }
+            | Repository::GitLab { tag_prefix, .. }
+            | Repository::BitBucket { tag_prefix, .. }
+            | Repository::Codeberg { tag_prefix, .. }
+            | Repository::SourceHut { tag_prefix, .. }
+            | Repository::Gitea { tag_prefix, .. } => tag_prefix.as_ref(),
+
+            Repository::Custom { .. } | Repository::None => None,
+        };
+
+        match prefix {
+            Some(prefix) => format!("{prefix}v{version}"),
+            None => format!("v{version}"),
         }
     }
 }

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -869,7 +869,7 @@ impl Repository {
         };
 
         match prefix {
-            Some(prefix) => format!("{prefix}v{version}"),
+            Some(prefix) => format!("{prefix}{version}"),
             None => format!("v{version}"),
         }
     }

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -101,10 +101,14 @@ pub fn generate_html<IO: FileSystemReader>(
         path: doc_link.href.to_string(),
     });
 
-    let repo_link = config.repository.url().map(|path| Link {
-        name: "Repository".into(),
-        path,
-    });
+    let repo_link = config
+        .repository
+        .as_ref()
+        .map(|r| r.url())
+        .map(|path| Link {
+            name: "Repository".into(),
+            path,
+        });
 
     let host = if is_hex_publish == DocContext::HexPublish {
         "https://hexdocs.pm"

--- a/compiler-core/src/docs/source_links.rs
+++ b/compiler-core/src/docs/source_links.rs
@@ -32,40 +32,29 @@ impl SourceLinker {
         }
         .unwrap_or_default();
 
+        let tag = project_config
+            .repository
+            .tag_for_version(&project_config.version);
+
         let url_pattern = match &project_config.repository {
             Repository::GitHub { user, repo, .. } => Some((
-                format!(
-                    "https://github.com/{}/{}/blob/v{}/{}#L",
-                    user, repo, project_config.version, path_in_repo
-                ),
+                format!("https://github.com/{user}/{repo}/blob/{tag}/{path_in_repo}#L"),
                 "-L".into(),
             )),
             Repository::GitLab { user, repo, .. } => Some((
-                format!(
-                    "https://gitlab.com/{}/{}/-/blob/v{}/{}#L",
-                    user, repo, project_config.version, path_in_repo
-                ),
+                format!("https://gitlab.com/{user}/{repo}/-/blob/{tag}/{path_in_repo}#L"),
                 "-".into(),
             )),
             Repository::BitBucket { user, repo, .. } => Some((
-                format!(
-                    "https://bitbucket.com/{}/{}/src/v{}/{}#lines-",
-                    user, repo, project_config.version, path_in_repo
-                ),
+                format!("https://bitbucket.com/{user}/{repo}/src/{tag}/{path_in_repo}#lines-"),
                 ":".into(),
             )),
             Repository::Codeberg { user, repo, .. } => Some((
-                format!(
-                    "https://codeberg.org/{}/{}/src/tag/v{}/{}#L",
-                    user, repo, project_config.version, path_in_repo
-                ),
+                format!("https://codeberg.org/{user}/{repo}/src/tag/{tag}/{path_in_repo}#L"),
                 "-".into(),
             )),
             Repository::SourceHut { user, repo, .. } => Some((
-                format!(
-                    "https://git.sr.ht/~{}/{}/tree/v{}/item/{}#L",
-                    user, repo, project_config.version, path_in_repo
-                ),
+                format!("https://git.sr.ht/~{user}/{repo}/tree/{tag}/item/{path_in_repo}#L"),
                 "-".into(),
             )),
             Repository::Gitea {
@@ -74,10 +63,7 @@ impl SourceLinker {
                 let string_host = host.to_string();
                 let cleaned_host = string_host.trim_end_matches('/');
                 Some((
-                    format!(
-                        "{cleaned_host}/{user}/{repo}/src/tag/v{}/{}#L",
-                        project_config.version, path_in_repo
-                    ),
+                    format!("{cleaned_host}/{user}/{repo}/src/tag/{tag}/{path_in_repo}#L",),
                     "-".into(),
                 ))
             }

--- a/compiler-core/src/docs/source_links.rs
+++ b/compiler-core/src/docs/source_links.rs
@@ -26,49 +26,59 @@ impl SourceLinker {
             .expect("path is not in root")
             .with_extension("gleam");
 
-        let path_in_repo = match project_config.repository.path() {
+        let path_in_repo = match project_config
+            .repository
+            .as_ref()
+            .map(|r| r.path())
+            .unwrap_or_default()
+        {
             Some(repo_path) => to_url_path(&Utf8PathBuf::from(repo_path).join(path)),
             _ => to_url_path(&path),
         }
         .unwrap_or_default();
 
-        let tag = project_config
-            .repository
-            .tag_for_version(&project_config.version);
+        let tag = project_config.tag_for_version(&project_config.version);
 
-        let url_pattern = match &project_config.repository {
-            Repository::GitHub { user, repo, .. } => Some((
-                format!("https://github.com/{user}/{repo}/blob/{tag}/{path_in_repo}#L"),
-                "-L".into(),
-            )),
-            Repository::GitLab { user, repo, .. } => Some((
-                format!("https://gitlab.com/{user}/{repo}/-/blob/{tag}/{path_in_repo}#L"),
-                "-".into(),
-            )),
-            Repository::BitBucket { user, repo, .. } => Some((
-                format!("https://bitbucket.com/{user}/{repo}/src/{tag}/{path_in_repo}#lines-"),
-                ":".into(),
-            )),
-            Repository::Codeberg { user, repo, .. } => Some((
-                format!("https://codeberg.org/{user}/{repo}/src/tag/{tag}/{path_in_repo}#L"),
-                "-".into(),
-            )),
-            Repository::SourceHut { user, repo, .. } => Some((
-                format!("https://git.sr.ht/~{user}/{repo}/tree/{tag}/item/{path_in_repo}#L"),
-                "-".into(),
-            )),
-            Repository::Gitea {
-                user, repo, host, ..
-            } => {
-                let string_host = host.to_string();
-                let cleaned_host = string_host.trim_end_matches('/');
-                Some((
-                    format!("{cleaned_host}/{user}/{repo}/src/tag/{tag}/{path_in_repo}#L",),
+        let url_pattern = project_config
+            .repository
+            .as_ref()
+            .map(|r| match r {
+                Repository::GitHub { user, repo, .. } => Some((
+                    format!("https://github.com/{user}/{repo}/blob/{tag}/{path_in_repo}#L"),
+                    "-L".into(),
+                )),
+                Repository::GitLab { user, repo, .. } => Some((
+                    format!("https://gitlab.com/{user}/{repo}/-/blob/{tag}/{path_in_repo}#L"),
                     "-".into(),
-                ))
-            }
-            Repository::Custom { .. } | Repository::None => None,
-        };
+                )),
+                Repository::BitBucket { user, repo, .. } => Some((
+                    format!("https://bitbucket.com/{user}/{repo}/src/{tag}/{path_in_repo}#lines-"),
+                    ":".into(),
+                )),
+                Repository::Codeberg { user, repo, .. } => Some((
+                    format!("https://codeberg.org/{user}/{repo}/src/tag/{tag}/{path_in_repo}#L"),
+                    "-".into(),
+                )),
+                Repository::SourceHut { user, repo, .. } => Some((
+                    format!("https://git.sr.ht/~{user}/{repo}/tree/{tag}/item/{path_in_repo}#L"),
+                    "-".into(),
+                )),
+                Repository::Gitea {
+                    user, repo, host, ..
+                }
+                | Repository::Forgejo {
+                    user, repo, host, ..
+                } => {
+                    let string_host = host.to_string();
+                    let cleaned_host = string_host.trim_end_matches('/');
+                    Some((
+                        format!("{cleaned_host}/{user}/{repo}/src/tag/{tag}/{path_in_repo}#L",),
+                        "-".into(),
+                    ))
+                }
+                Repository::Custom { .. } => None,
+            })
+            .unwrap_or_default();
 
         SourceLinker {
             line_numbers: LineNumbers::new(&module.code),

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -618,12 +618,12 @@ pub type Wibble = Int
 fn source_link_for_github_repository() {
     let mut config = PackageConfig::default();
     config.name = EcoString::from("test_project_name");
-    config.repository = Repository::GitHub {
+    config.repository = Some(Repository::GitHub {
         user: "wibble".to_string(),
         repo: "wobble".to_string(),
         path: None,
         tag_prefix: None,
-    };
+    });
 
     let modules = vec![("app.gleam", "pub type Wibble = Int")];
     assert!(
@@ -636,12 +636,12 @@ fn source_link_for_github_repository() {
 fn source_link_for_github_repository_with_path_and_tag_prefix() {
     let mut config = PackageConfig::default();
     config.name = EcoString::from("test_project_name");
-    config.repository = Repository::GitHub {
+    config.repository = Some(Repository::GitHub {
         user: "wibble".to_string(),
         repo: "wobble".to_string(),
         path: Some("path/to/package".to_string()),
-        tag_prefix: Some("subdir-v".into()),
-    };
+        tag_prefix: Some("subdir-".into()),
+    });
 
     let modules = vec![("app.gleam", "pub type Wibble = Int")];
     assert!(compile(config, modules).contains(
@@ -1168,17 +1168,15 @@ pub type Wibble {
 
 #[test]
 fn gitea_repository_url_has_no_double_slash() {
-    let repo = Repository::Gitea {
+    let repo = Repository::Forgejo {
         host: "https://code.example.org/".parse::<Uri>().unwrap(),
         user: "person".into(),
         repo: "forgejo_bug".into(),
         path: None,
+        tag_prefix: None,
     };
 
-    assert_eq!(
-        repo.url().unwrap(),
-        "https://code.example.org/person/forgejo_bug"
-    );
+    assert_eq!(repo.url(), "https://code.example.org/person/forgejo_bug");
 }
 
 #[test]

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -622,6 +622,7 @@ fn source_link_for_github_repository() {
         user: "wibble".to_string(),
         repo: "wobble".to_string(),
         path: None,
+        tag_prefix: None,
     };
 
     let modules = vec![("app.gleam", "pub type Wibble = Int")];
@@ -632,21 +633,20 @@ fn source_link_for_github_repository() {
 }
 
 #[test]
-fn source_link_for_github_repository_with_path() {
+fn source_link_for_github_repository_with_path_and_tag_prefix() {
     let mut config = PackageConfig::default();
     config.name = EcoString::from("test_project_name");
     config.repository = Repository::GitHub {
         user: "wibble".to_string(),
         repo: "wobble".to_string(),
         path: Some("path/to/package".to_string()),
+        tag_prefix: Some("subdir-".into()),
     };
 
     let modules = vec![("app.gleam", "pub type Wibble = Int")];
-    assert!(
-        compile(config, modules).contains(
-            "https://github.com/wibble/wobble/blob/v0.1.0/path/to/package/src/app.gleam#L1"
-        )
-    );
+    assert!(compile(config, modules).contains(
+        "https://github.com/wibble/wobble/blob/subdir-v0.1.0/path/to/package/src/app.gleam#L1"
+    ));
 }
 
 #[test]

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -640,7 +640,7 @@ fn source_link_for_github_repository_with_path_and_tag_prefix() {
         user: "wibble".to_string(),
         repo: "wobble".to_string(),
         path: Some("path/to/package".to_string()),
-        tag_prefix: Some("subdir-".into()),
+        tag_prefix: Some("subdir-v".into()),
     };
 
     let modules = vec![("app.gleam", "pub type Wibble = Int")];

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -8,7 +8,7 @@ use hexpm::version::Identifier;
 use crate::{
     analyse::TargetSupport,
     build::{Module, Origin, Package, Target},
-    config::{Docs, ErlangConfig, GleamVersion, JavaScriptConfig, PackageConfig, Repository},
+    config::{Docs, ErlangConfig, GleamVersion, JavaScriptConfig, PackageConfig},
     line_numbers::LineNumbers,
     type_::PRELUDE_MODULE_NAME,
     uid::UniqueIdGenerator,
@@ -162,7 +162,7 @@ fn package_from_module(module: Module) -> Package {
             documentation: Docs { pages: vec![] },
             dependencies: std::collections::HashMap::new(),
             dev_dependencies: std::collections::HashMap::new(),
-            repository: Repository::default(),
+            repository: None,
             links: vec![],
             erlang: ErlangConfig::default(),
             javascript: JavaScriptConfig::default(),

--- a/compiler-core/src/snapshots/gleam_core__config__barebones_package_config_to_json.snap
+++ b/compiler-core/src/snapshots/gleam_core__config__barebones_package_config_to_json.snap
@@ -1,6 +1,8 @@
 ---
 source: compiler-core/src/config.rs
+assertion_line: 1116
 expression: output
+snapshot_kind: text
 ---
 --- GLEAM.TOML
 
@@ -21,9 +23,7 @@ version = "1.0.0"
   },
   "dependencies": {},
   "dev-dependencies": {},
-  "repository": {
-    "type": "none"
-  },
+  "repository": null,
   "links": [],
   "erlang": {
     "application_start_module": null,

--- a/compiler-core/src/snapshots/gleam_core__config__package_config_to_json.snap
+++ b/compiler-core/src/snapshots/gleam_core__config__package_config_to_json.snap
@@ -77,7 +77,8 @@ allow_read = ["./database.sqlite"]
     "type": "github",
     "user": "example",
     "repo": "my_dep",
-    "path": null
+    "path": null,
+    "tag_prefix": null
   },
   "links": [
     {

--- a/compiler-core/src/snapshots/gleam_core__config__package_config_to_json.snap
+++ b/compiler-core/src/snapshots/gleam_core__config__package_config_to_json.snap
@@ -1,6 +1,8 @@
 ---
 source: compiler-core/src/config.rs
+assertion_line: 1106
 expression: output
+snapshot_kind: text
 ---
 --- GLEAM.TOML
 
@@ -78,7 +80,7 @@ allow_read = ["./database.sqlite"]
     "user": "example",
     "repo": "my_dep",
     "path": null,
-    "tag_prefix": null
+    "tag-prefix": null
   },
   "links": [
     {

--- a/compiler-core/src/snapshots/gleam_core__docs__barebones_package_config_to_json.snap
+++ b/compiler-core/src/snapshots/gleam_core__docs__barebones_package_config_to_json.snap
@@ -1,6 +1,8 @@
 ---
 source: compiler-core/src/docs.rs
+assertion_line: 785
 expression: output
+snapshot_kind: text
 ---
 --- GLEAM.TOML
 
@@ -22,9 +24,7 @@ version = "1.0.0"
     },
     "dependencies": {},
     "dev-dependencies": {},
-    "repository": {
-      "type": "none"
-    },
+    "repository": null,
     "links": [],
     "erlang": {
       "application_start_module": null,

--- a/compiler-core/src/snapshots/gleam_core__docs__package_config_to_json.snap
+++ b/compiler-core/src/snapshots/gleam_core__docs__package_config_to_json.snap
@@ -1,6 +1,8 @@
 ---
 source: compiler-core/src/docs.rs
+assertion_line: 765
 expression: output
+snapshot_kind: text
 ---
 --- GLEAM.TOML
 
@@ -79,7 +81,7 @@ allow_read = ["./database.sqlite"]
       "user": "example",
       "repo": "my_dep",
       "path": null,
-      "tag_prefix": null
+      "tag-prefix": null
     },
     "links": [
       {

--- a/compiler-core/src/snapshots/gleam_core__docs__package_config_to_json.snap
+++ b/compiler-core/src/snapshots/gleam_core__docs__package_config_to_json.snap
@@ -78,7 +78,8 @@ allow_read = ["./database.sqlite"]
       "type": "github",
       "user": "example",
       "repo": "my_dep",
-      "path": null
+      "path": null,
+      "tag_prefix": null
     },
     "links": [
       {


### PR DESCRIPTION
Resolves #3858

I originally left the `v` in there, but looking at it, thought it would be nice to be able to override that also (see second commit). Now I'm not sure if we should make the tag prefix non-`Optional`, and use "v" as the default. Happy to tweak it some more if we want to change it.