### PR TITLE
Add Elixir to required tools for compiler tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Code changes to Gleam are welcomed via the process below.
 ## Local development
 
 To run the compiler tests. This will require a recent stable version of Rust,
-Erlang, NodeJS, Deno, and Bun to be installed.
+Erlang, Elixir, NodeJS, Deno, and Bun to be installed.
 
 If you are using the Nix package manager, there's a [gleam-nix flake](https://github.com/vic/gleam-nix)
 you can use for running any Gleam version or quickly obtaining a development environment for Gleam.


### PR DESCRIPTION
This PR updates the CONTRIBUTING.md file to include Elixir as a required tool for running compiler tests. This improves clarity for contributors setting up their environments.

Closes #4558 