### PR TITLE
Add Generate Variant action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,11 @@
   continue to occur if a function references invalid type in its signature.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The compiler is now fault tolerant when analysing patterns for custom types,
+  meaning it won't stop at the first error it encounters (for example if a
+  constructor is wrong).
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The build tool now supports placing modules in a directory called `dev`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,34 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The language server now provides a code action to automatically generate a new
+  variant from incorrect code:
+
+  ```gleam
+  pub type Msg {
+    ServerSentResponse(Json)
+  }
+
+  pub fn view() -> Element(Msg) {
+    div([], [
+      button([on_click(UserPressedButton)], [text("Press me!")])
+  //                   ^^^^^^^^^^^^^^^^^ This doesn't exist yet!
+    ])
+  }
+  ```
+
+  Triggering the code action on the `UserPressedButton` will add it to the `Msg`
+  type:
+
+  ```gleam
+  pub type Msg {
+    ServerSentResponse(Json)
+    UserPressedButton
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Installation

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -542,6 +542,10 @@ pub trait Visit<'ast> {
         );
     }
 
+    fn visit_typed_pattern_invalid(&mut self, location: &'ast SrcSpan, type_: &'ast Arc<Type>) {
+        visit_typed_pattern_invalid(self, location, type_);
+    }
+
     fn visit_type_ast(&mut self, node: &'ast TypeAst) {
         visit_type_ast(self, node);
     }
@@ -1720,6 +1724,12 @@ pub fn visit_typed_pattern_string_prefix<'a, V>(
     _left_side_string: &'a EcoString,
     _right_side_assignment: &'a AssignName,
 ) where
+    V: Visit<'a> + ?Sized,
+{
+}
+
+pub fn visit_typed_pattern_invalid<'a, V>(_v: &mut V, _location: &'a SrcSpan, _type_: &'a Arc<Type>)
+where
     V: Visit<'a> + ?Sized,
 {
 }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -1544,7 +1544,7 @@ where
             left_side_string,
             right_side_assignment,
         ),
-        Pattern::Invalid { location, type_ } => v.visit_typed_expr_invalid(location, type_),
+        Pattern::Invalid { location, type_ } => v.visit_typed_pattern_invalid(location, type_),
     }
 }
 

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -104,7 +104,7 @@ pub struct ProjectCompiler<IO> {
     pub(crate) config: PackageConfig,
     pub(crate) packages: HashMap<String, ManifestPackage>,
     importable_modules: im::HashMap<EcoString, type_::ModuleInterface>,
-    defined_modules: im::HashMap<EcoString, Utf8PathBuf>,
+    pub(crate) defined_modules: im::HashMap<EcoString, Utf8PathBuf>,
     stale_modules: StaleTracker,
     /// The set of modules that have had partial compilation done since the last
     /// successful compilation.

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5233,7 +5233,7 @@ impl<'a> Arguments<'a> {
     }
 }
 
-impl<'a> Argument<'a> {
+impl Argument<'_> {
     fn label(&self) -> Option<EcoString> {
         match self {
             Argument::Expression(call_arg) => call_arg.label.clone(),
@@ -5280,7 +5280,7 @@ where
             name,
             arguments_types,
             given_arguments,
-            &module_name,
+            module_name,
             *end_position,
             *type_braces,
         ) else {
@@ -5329,7 +5329,7 @@ where
             .join(", ");
 
         let variant = if arguments.is_empty() {
-            format!("{variant_name}")
+            variant_name.to_string()
         } else {
             format!("{variant_name}({arguments})")
         };
@@ -5343,7 +5343,7 @@ where
             // If we're editing the current module we can use the line numbers that
             // were already computed before-hand without wasting any time to add the
             // new edit.
-            let mut edits = TextEdits::new(&self.line_numbers);
+            let mut edits = TextEdits::new(self.line_numbers);
             edits.insert(insert_at, new_text);
             Some((self.params.text_document.uri.clone(), edits.edits))
         } else {

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5140,14 +5140,21 @@ impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
     }
 }
 
-/// Builder for the TODO
-/// TODO:
-/// - [X] Pop up when putting stuff in another module
-/// - [X] Variant with no fields is not caught up as it is not a function
-/// - [X] Generate from patterns as well!
-/// - [X] Generate for module select as well!
-/// - [ ] Qualify it or not!
-/// - [X] Never generate the same variant twice! If the variant is already there it should propose to qualify it!
+/// Builder for the "generate variant" code action. This will generate a variant
+/// for a type if it can tell the type it should come from. It will work with
+/// non-existing variants both used as expressions
+///
+/// ```gleam
+/// let a = IDoNotExist(1)
+/// //      ^^^^^^^^^^^ It would generate this variant here
+/// ```
+///
+/// And as patterns:
+///
+/// ```gleam
+/// let assert IDoNotExist(1) = todo
+///            ^^^^^^^^^^^ It would generate this variant here
+/// ```
 ///
 pub struct GenerateVariant<'a, IO> {
     module: &'a Module,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5001,7 +5001,11 @@ pub struct GenerateFunction<'a> {
 
 struct FunctionToGenerate<'a> {
     name: &'a str,
-    arguments: Vec<(Option<EcoString>, Arc<Type>)>,
+    arguments_types: Vec<Arc<Type>>,
+    /// The arguments actually supplied as input to the function, if any.
+    /// A function to generate might as well be just a name passed as an argument
+    /// `list.map([1, 2, 3], to_generate)` so it's not guaranteed to actually
+    /// have any actual arguments!
     given_arguments: Option<&'a [TypedCallArg]>,
     return_type: Arc<Type>,
     previous_function_end: Option<u32>,
@@ -5027,7 +5031,7 @@ impl<'a> GenerateFunction<'a> {
 
         let Some(FunctionToGenerate {
             name,
-            arguments,
+            arguments_types,
             given_arguments,
             previous_function_end: Some(insert_at),
             return_type,
@@ -5041,7 +5045,7 @@ impl<'a> GenerateFunction<'a> {
         let mut label_names = NameGenerator::new();
         let mut argument_names = NameGenerator::new();
         let mut printer = Printer::new(&self.module.ast.names);
-        let args = arguments
+        let arguments = arguments_types
             .iter()
             .enumerate()
             .map(|(index, (arg_label, arg_type))| {
@@ -5071,7 +5075,7 @@ impl<'a> GenerateFunction<'a> {
 
         self.edits.insert(
             insert_at,
-            format!("\n\nfn {name}({args}) -> {return_type} {{\n  todo\n}}"),
+            format!("\n\nfn {name}({arguments}) -> {return_type} {{\n  todo\n}}"),
         );
 
         let mut action = Vec::with_capacity(1);
@@ -5087,30 +5091,25 @@ impl<'a> GenerateFunction<'a> {
         &mut self,
         function_name_location: SrcSpan,
         function_type: &Arc<Type>,
-        labels: HashMap<usize, EcoString>,
         given_arguments: Option<&'a [TypedCallArg]>,
     ) {
         let name_range = function_name_location.start as usize..function_name_location.end as usize;
-        let candidate_name = self.module.code.get(name_range);
-        match (candidate_name, function_type.fn_types()) {
-            (None, _) | (_, None) => (),
-            (Some(name), _) if !is_valid_lowercase_name(name) => (),
-            (Some(name), Some((arguments_types, return_type))) => {
-                let arguments = arguments_types
-                    .iter()
-                    .enumerate()
-                    .map(|(i, arg)| (labels.get(&i).cloned(), arg.clone()))
-                    .collect_vec();
+        let name = self.module.code.get(name_range).expect("valid code range");
+        if !is_valid_lowercase_name(name) {
+            return;
+        };
 
-                self.function_to_generate = Some(FunctionToGenerate {
-                    name,
-                    arguments,
-                    given_arguments,
-                    return_type,
-                    previous_function_end: self.last_visited_function_end,
-                })
-            }
-        }
+        let Some((arguments_types, return_type)) = function_type.fn_types() else {
+            return;
+        };
+
+        self.function_to_generate = Some(FunctionToGenerate {
+            name,
+            arguments_types,
+            given_arguments,
+            return_type,
+            previous_function_end: self.last_visited_function_end,
+        })
     }
 }
 
@@ -5123,7 +5122,7 @@ impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
     fn visit_typed_expr_invalid(&mut self, location: &'ast SrcSpan, type_: &'ast Arc<Type>) {
         let invalid_range = self.edits.src_span_to_lsp_range(*location);
         if within(self.params.range, invalid_range) {
-            self.try_save_function_to_generate(*location, type_, HashMap::new(), None);
+            self.try_save_function_to_generate(*location, type_, None);
         }
 
         ast::visit::visit_typed_expr_invalid(self, location, type_);
@@ -5142,18 +5141,7 @@ impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
 
         if within(self.params.range, fun_range) && fun.is_invalid() {
             if labels_are_correct(args) {
-                let labels = args
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, arg)| arg.label.as_ref().map(|label| (i, label.clone())))
-                    .collect();
-
-                self.try_save_function_to_generate(
-                    fun.location(),
-                    &fun.type_(),
-                    labels,
-                    Some(args),
-                );
+                self.try_save_function_to_generate(fun.location(), &fun.type_(), Some(args));
             }
         } else {
             ast::visit::visit_typed_expr_call(self, location, type_, fun, args);
@@ -5209,6 +5197,42 @@ impl NameGenerator {
                 let _ = self.used_names.insert(candidate_name.clone());
                 return candidate_name;
             }
+        }
+    }
+
+    /// Returns the argument's label (if it should have any) and the name it
+    /// comes up with for the argument.
+    ///
+    pub fn generate_name_from_call_arg(
+        &mut self,
+        call_arg: &CallArg<TypedExpr>,
+    ) -> (Option<EcoString>, EcoString) {
+        if let Some(label) = &call_arg.label {
+            // If the called argument has an explicit label we use it as both the
+            // argument's name and label.
+            let label = self.rename_to_avoid_shadowing(label.clone());
+            (Some(label.clone()), label)
+        } else {
+            // Otherwise we try and pick the best name generating it from the
+            // expression itself. The argument won't have a label.
+            (None, self.generate_name_from_expression(&call_arg.value))
+        }
+    }
+
+    pub fn generate_name_from_expression(&mut self, value: &TypedExpr) -> EcoString {
+        match value {
+            // If the argument is a record, we can't use it as an argument name.
+            // Similarly, we don't want to base the variable name off a
+            // compiler-generated variable like `_pipe`.
+            TypedExpr::Var {
+                name, constructor, ..
+            } if !constructor.variant.is_record()
+                && !constructor.variant.is_generated_variable() =>
+            {
+                self.add_used_name(name.clone());
+                name.clone()
+            }
+            _ => self.generate_name_from_type(&value.type_()),
         }
     }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -40,7 +40,7 @@ use super::{
         ConvertToUse, ExpandFunctionCapture, ExtractConstant, ExtractVariable,
         FillInMissingLabelledArgs, FillUnusedFields, FixBinaryOperation,
         FixTruncatedBitArraySegment, GenerateDynamicDecoder, GenerateFunction, GenerateJsonEncoder,
-        InlineVariable, InterpolateString, LetAssertToCase, PatternMatchOnValue,
+        GenerateVariant, InlineVariable, InterpolateString, LetAssertToCase, PatternMatchOnValue,
         RedundantTupleInCaseSubject, RemoveEchos, UseLabelShorthandSyntax, WrapInBlock,
         code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified,
         code_action_convert_unqualified_constructor_to_qualified, code_action_import_module,
@@ -422,6 +422,9 @@ where
             actions.extend(ExtractVariable::new(module, &lines, &params).code_actions());
             actions.extend(ExtractConstant::new(module, &lines, &params).code_actions());
             actions.extend(GenerateFunction::new(module, &lines, &params).code_actions());
+            actions.extend(
+                GenerateVariant::new(module, &this.compiler, &lines, &params).code_actions(),
+            );
             actions.extend(ConvertToPipe::new(module, &lines, &params).code_actions());
             actions.extend(ConvertToFunctionCall::new(module, &lines, &params).code_actions());
             actions.extend(

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -83,6 +83,7 @@ const INTERPOLATE_STRING: &str = "Interpolate string";
 const FILL_UNUSED_FIELDS: &str = "Fill unused fields";
 const REMOVE_ALL_ECHOS_FROM_THIS_MODULE: &str = "Remove all `echo`s from this module";
 const WRAP_IN_BLOCK: &str = "Wrap in block";
+const GENERATE_VARIANT: &str = "Generate variant";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -142,6 +143,114 @@ pub fn main() {
   <<1, 1024:size(10)>>
 }"#,
         find_position_of("size").to_selection()
+    );
+}
+
+#[test]
+fn generate_variant_with_fields_in_same_module() {
+    assert_code_action!(
+        GENERATE_VARIANT,
+        r#"
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() -> Wibble {
+  Wobble(1)
+}"#,
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_variant_with_no_fields_in_same_module() {
+    assert_code_action!(
+        GENERATE_VARIANT,
+        r#"
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() -> Wibble {
+  Wobble
+}"#,
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_variant_with_labels_in_same_module() {
+    assert_code_action!(
+        GENERATE_VARIANT,
+        r#"
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() -> Wibble {
+  Wobble("hello", label: 1)
+}"#,
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_variant_from_pattern_with_fields() {
+    assert_code_action!(
+        GENERATE_VARIANT,
+        r#"
+pub type Wibble {
+  Wibble
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble(1) = new()
+}
+
+"#,
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_variant_from_pattern_with_labelled_fields() {
+    assert_code_action!(
+        GENERATE_VARIANT,
+        r#"
+pub type Wibble {
+  Wibble
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble("hello", label: 1) = new()
+}
+
+"#,
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_variant_from_pattern_with_no_fields() {
+    assert_code_action!(
+        GENERATE_VARIANT,
+        r#"
+pub type Wibble {
+  Wibble
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble = new()
+}
+
+"#,
+        find_position_of("Wobble").to_selection()
     );
 }
 

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_qualified_variant_in_other_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_qualified_variant_in_other_module.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport other\n\npub fn main() -> other.Wibble {\n  let assert other.Wobble = new()\n}\n\npub fn new() -> other.Wibble { todo }\n"
+---
+----- BEFORE ACTION
+
+import other
+
+pub fn main() -> other.Wibble {
+  let assert other.Wobble = new()
+                   ↑             
+}
+
+pub fn new() -> other.Wibble { todo }
+
+
+----- AFTER ACTION
+// --- Edits applied to module 'other'
+pub type Wibble {
+  Wobble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_unqualified_variant_in_other_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_unqualified_variant_in_other_module.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport other\n\npub fn main() -> other.Wibble {\n  let assert Wobble = new()\n}\n\npub fn new() -> other.Wibble { todo }\n"
+---
+----- BEFORE ACTION
+
+import other
+
+pub fn main() -> other.Wibble {
+  let assert Wobble = new()
+             ↑             
+}
+
+pub fn new() -> other.Wibble { todo }
+
+
+----- AFTER ACTION
+// --- Edits applied to module 'other'
+pub type Wibble {
+  Wobble
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn main() -> Wibble {\n  Wobble(1)\n}"
+---
+----- BEFORE ACTION
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() -> Wibble {
+  Wobble(1)
+  ↑        
+}
+
+
+----- AFTER ACTION
+
+pub type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub fn main() -> Wibble {
+  Wobble(1)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_from_pattern_with_fields.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_from_pattern_with_fields.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn new() { Wibble }\n\npub fn main() -> Wibble {\n  let assert Wobble(1) = new()\n}\n\n"
+---
+----- BEFORE ACTION
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble(1) = new()
+             ↑                
+}
+
+
+
+----- AFTER ACTION
+
+pub type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble(1) = new()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_from_pattern_with_labelled_fields.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_from_pattern_with_labelled_fields.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn new() { Wibble }\n\npub fn main() -> Wibble {\n  let assert Wobble(\"hello\", label: 1) = new()\n}\n\n"
+---
+----- BEFORE ACTION
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble("hello", label: 1) = new()
+             ↑                                
+}
+
+
+
+----- AFTER ACTION
+
+pub type Wibble {
+  Wibble
+  Wobble(String, label: Int)
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble("hello", label: 1) = new()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_from_pattern_with_no_fields.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_from_pattern_with_no_fields.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn new() { Wibble }\n\npub fn main() -> Wibble {\n  let assert Wobble = new()\n}\n\n"
+---
+----- BEFORE ACTION
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble = new()
+             ↑             
+}
+
+
+
+----- AFTER ACTION
+
+pub type Wibble {
+  Wibble
+  Wobble
+}
+
+pub fn new() { Wibble }
+
+pub fn main() -> Wibble {
+  let assert Wobble = new()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_with_fields_in_same_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_with_fields_in_same_module.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn main() -> Wibble {\n  Wobble(1)\n}"
+---
+----- BEFORE ACTION
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() -> Wibble {
+  Wobble(1)
+  ↑        
+}
+
+
+----- AFTER ACTION
+
+pub type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub fn main() -> Wibble {
+  Wobble(1)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_with_labels_in_same_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_with_labels_in_same_module.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn main() -> Wibble {\n  Wobble(\"hello\", label: 1)\n}"
+---
+----- BEFORE ACTION
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() -> Wibble {
+  Wobble("hello", label: 1)
+  ↑                        
+}
+
+
+----- AFTER ACTION
+
+pub type Wibble {
+  Wibble
+  Wobble(String, label: Int)
+}
+
+pub fn main() -> Wibble {
+  Wobble("hello", label: 1)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_with_no_fields_in_same_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_variant_with_no_fields_in_same_module.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Wibble {\n  Wibble\n}\n\npub fn main() -> Wibble {\n  Wobble\n}"
+---
+----- BEFORE ACTION
+
+pub type Wibble {
+  Wibble
+}
+
+pub fn main() -> Wibble {
+  Wobble
+  ↑     
+}
+
+
+----- AFTER ACTION
+
+pub type Wibble {
+  Wibble
+  Wobble
+}
+
+pub fn main() -> Wibble {
+  Wobble
+}

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1327,6 +1327,7 @@ pub struct TypeConstructor {
     pub deprecation: Deprecation,
     pub documentation: Option<EcoString>,
 }
+
 impl TypeConstructor {
     pub(crate) fn with_location(mut self, location: SrcSpan) -> Self {
         self.origin = location;

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -166,13 +166,6 @@ impl Type {
         }
     }
 
-    pub fn is_type_variable(&self) -> bool {
-        match self {
-            Self::Var { type_ } => type_.borrow().is_variable(),
-            _ => false,
-        }
-    }
-
     pub fn return_type(&self) -> Option<Arc<Self>> {
         match self {
             Self::Fn { return_, .. } => Some(return_.clone()),
@@ -1185,7 +1178,7 @@ impl TypeVar {
     pub fn is_variable(&self) -> bool {
         match self {
             Self::Unbound { .. } | Self::Generic { .. } => true,
-            Self::Link { type_ } => type_.is_type_variable(),
+            Self::Link { type_ } => type_.is_variable(),
         }
     }
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_pattern_fault_tolerance2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__multiple_bad_statement_assignment_with_pattern_fault_tolerance2.snap
@@ -35,11 +35,3 @@ Expected type:
 Found type:
 
     Result(Int, a)
-
-error: Unknown variable
-  ┌─ /src/one/two.gleam:7:11
-  │
-7 │   let c = a + b
-  │           ^ Did you mean `b`?
-
-The name `a` is not in scope here.

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_destructure.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__opaque_type_destructure.snap
@@ -9,19 +9,3 @@ error: Unknown module value
   │       ^
 
 The module `one` does not have a `User` value.
-
-error: Unknown variable
-  ┌─ src/two.gleam:8:5
-  │
-8 │   #(name, score)
-  │     ^
-
-The name `name` is not in scope here.
-
-error: Unknown variable
-  ┌─ src/two.gleam:8:11
-  │
-8 │   #(name, score)
-  │           ^
-
-The name `score` is not in scope here.


### PR DESCRIPTION
This PR adds the "Generate variant" code action to automatically add a variant to a type starting from incorrect code. This works correctly with types defined in the same module, or other modules. The code action can be triggered on expressions:

```gleam
pub type Msg {
  ServerSentResponse(Json)
}

pub fn view() -> Element(Msg) {
  div([], [
    button([on_click(UserPressedButton)], [])
  //                 ^^^^^^^ [Generate variant]
  ])
}

// Generates:
pub type Msg {
  ServerSentResponse(Json)
  UserPressedButton
}
```

and on patterns:

```gleam
pub type Pet {
  Dog(name: String)
}

pub fn greet(pet: Pet) {
  case pet {
    Dog(name:) -> name <> " good boy"
    Cat(name:) -> "psps " <> name
//  ^^^^^ [Generate variant]
  }
}

// Will generate
pub type Pet {
  Dog(name: String)
  Cat(name: String)
}
```

In order to make this work for patterns I've improved on fault tolerance, meaning that now when a variant pattern is incorrect (it doesn't correspond to any constructor in scope), the compiler doesn't just give up but still tries to infer all the argument patterns