### PR TITLE
Adding --verbose flag to check commit hash

### DIFF
--- a/compiler-cli/build.rs
+++ b/compiler-cli/build.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+
+fn main() {
+    // Try to get the current Git commit hash (short format) for use in --version --verbose
+    let commit_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok() // if the command fails to launch
+        .filter(|output| output.status.success()) // if the command fails (e.g. not a git repo)
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", commit_hash);
+}


### PR DESCRIPTION
This PR adds a `--verbose` flag to the `gleam --version` command. When used, it will include the current git commit hash in the output.

### Usage

```sh
$ gleam --version
1.0.0

$ gleam --version --verbose
1.0.0 (commit abc1234)
```

Closes #4544 