### PR TITLE
Remove some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "strsim",
  "strum",
  "tar",
  "termcolor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,6 @@ dependencies = [
  "flate2",
  "futures",
  "globset",
- "heck",
  "hexpm",
  "http",
  "id-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,6 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber 0.2.25",
- "walkdir",
 ]
 
 [[package]]
@@ -3113,7 +3112,6 @@ dependencies = [
  "regex",
  "test-helpers-rs",
  "toml",
- "walkdir",
 ]
 
 [[package]]
@@ -3128,7 +3126,6 @@ dependencies = [
  "regex",
  "test-helpers-rs",
  "toml",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,6 @@ version = "1.10.0"
 dependencies = [
  "async-trait",
  "base16",
- "bytes",
  "camino",
  "clap",
  "ctrlc",
@@ -1149,7 +1148,6 @@ dependencies = [
  "base16",
  "bimap",
  "bincode",
- "bytes",
  "camino",
  "capnp",
  "capnpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ hexpm = "3.3"
 tar = "0"
 # gzip compression
 flate2 = "1"
-# Byte array data type
-bytes = "1"
 # Logging
 tracing = "0"
 # Macro to work around Rust's traits not working with async. Sigh.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 # toml config file parsing
 toml = "0"
-walkdir = "2"
 # Enum trait impl macros
 strum = { version = "0", features = ["derive"] }
 # Hex package manager client

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -60,7 +60,6 @@ tar.workspace = true
 termcolor.workspace = true
 toml.workspace = true
 tracing.workspace = true
-walkdir.workspace = true
 
 [dev-dependencies]
 # Creation of temporary directories

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -41,7 +41,6 @@ pubgrub = "0"
 camino = { workspace = true, features = ["serde1"] }
 async-trait.workspace = true
 base16.workspace = true
-bytes.workspace = true
 debug-ignore.workspace = true
 ecow.workspace = true
 flate2.workspace = true

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -49,7 +49,6 @@ radix_trie = "0.2.1"
 
 async-trait.workspace = true
 base16.workspace = true
-bytes.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 debug-ignore.workspace = true
 ecow = { workspace = true, features = ["serde"] }

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -10,8 +10,6 @@ license-file = "LICENCE"
 codespan-reporting = "0"
 # Graph data structures
 petgraph = "0"
-# Levenshtein string distance for typo suggestions
-strsim = "0"
 # Cap'n Proto binary format runtime
 capnp = "0"
 # Template rendering

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -8,8 +8,6 @@ license-file = "LICENCE"
 [dependencies]
 # Error message and warning formatting
 codespan-reporting = "0"
-# String case conversion
-heck = "0"
 # Graph data structures
 petgraph = "0"
 # Levenshtein string distance for typo suggestions

--- a/compiler-core/src/analyse/name.rs
+++ b/compiler-core/src/analyse/name.rs
@@ -5,11 +5,11 @@ use regex::Regex;
 
 use crate::{
     ast::{ArgNames, SrcSpan},
+    strings::{to_snake_case, to_upper_camel_case},
     type_::Problems,
 };
 
 use super::{Error, Named};
-use heck::{ToSnakeCase, ToUpperCamelCase};
 
 static VALID_NAME_PATTERN: OnceLock<Regex> = OnceLock::new();
 
@@ -62,16 +62,14 @@ pub fn check_name_case(location: SrcSpan, name: &EcoString, kind: Named) -> Resu
 
 pub fn correct_name_case(name: &EcoString, kind: Named) -> EcoString {
     match kind {
-        Named::Type | Named::TypeAlias | Named::CustomTypeVariant => {
-            name.to_upper_camel_case().into()
-        }
+        Named::Type | Named::TypeAlias | Named::CustomTypeVariant => to_upper_camel_case(name),
         Named::Variable
         | Named::TypeVariable
         | Named::Argument
         | Named::Label
         | Named::Constant
-        | Named::Function => name.to_snake_case().into(),
-        Named::Discard => eco_format!("_{}", name.to_snake_case()),
+        | Named::Function => to_snake_case(name),
+        Named::Discard => eco_format!("_{}", to_snake_case(name)),
     }
 }
 

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -118,7 +118,7 @@ impl<'a> ErlangApp<'a> {
             .chain(native_modules)
             .unique()
             .sorted()
-            .map(|m| escape_atom_string(m.clone().into()))
+            .map(escape_atom_string)
             .join(",\n               ");
 
         // TODO: When precompiling for production (i.e. as a precompiled hex

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -159,10 +159,10 @@ fn tag_tuple_pattern<'a>(
     guards: &mut Vec<Document<'a>>,
 ) -> Document<'a> {
     if args.is_empty() {
-        atom_string(name.to_snake_case())
+        atom_string(to_snake_case(name))
     } else {
         tuple(
-            [atom_string(name.to_snake_case())]
+            [atom_string(to_snake_case(name))]
                 .into_iter()
                 .chain(args.iter().map(|p| print(&p.value, vars, env, guards))),
         )

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::build::{Origin, Outcome, Runtime, Target};
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
+use crate::strings::{to_snake_case, to_upper_camel_case, uppercase_first_letter};
 use crate::type_::collapse_links;
 use crate::type_::error::{
     InvalidImportKind, MissingAnnotation, ModuleValueUsageContext, Named, UnknownField,
@@ -11,7 +12,6 @@ use crate::type_::{FieldAccessUsage, error::PatternMatchKind};
 use crate::{ast::BinOp, parse::error::ParseErrorType, type_::Type};
 use crate::{bit_array, diagnostic::Level, javascript, type_::UnifyErrorSituation};
 use ecow::EcoString;
-use heck::{ToSnakeCase, ToTitleCase, ToUpperCamelCase};
 use hexpm::version::ResolutionError;
 use itertools::Itertools;
 use pubgrub::package::Package;
@@ -3519,7 +3519,7 @@ See: https://tour.gleam.run/advanced-features/use/");
                         Named::CustomTypeVariant => wrap_format!("Hint: {} names start with an uppercase \
 letter and contain only lowercase letters, numbers, \
 and uppercase letters.
-Try: {}", kind_str.to_title_case(), name.to_upper_camel_case()),
+Try: {}", uppercase_first_letter(kind_str), to_upper_camel_case(name)),
                         Named::Variable |
                         Named::TypeVariable |
                         Named::Argument |
@@ -3527,10 +3527,10 @@ Try: {}", kind_str.to_title_case(), name.to_upper_camel_case()),
                         Named::Constant  |
                         Named::Function => wrap_format!("Hint: {} names start with a lowercase letter \
 and contain a-z, 0-9, or _.
-Try: {}", kind_str.to_title_case(), name.to_snake_case()),
+Try: {}", uppercase_first_letter(kind_str), to_snake_case(name)),
                         Named::Discard => wrap_format!("Hint: {} names start with _ and contain \
 a-z, 0-9, or _.
-Try: _{}", kind_str.to_title_case(), name.to_snake_case()),
+Try: _{}", uppercase_first_letter(kind_str), to_snake_case(name)),
                     };
 
                     Diagnostic {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::build::{Origin, Outcome, Runtime, Target};
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
-use crate::strings::{to_snake_case, to_upper_camel_case, uppercase_first_letter};
+use crate::strings::{to_snake_case, to_upper_camel_case};
 use crate::type_::collapse_links;
 use crate::type_::error::{
     InvalidImportKind, MissingAnnotation, ModuleValueUsageContext, Named, UnknownField,
@@ -3512,14 +3512,14 @@ See: https://tour.gleam.run/advanced-features/use/");
 
                 TypeError::BadName { location, name, kind } => {
                     let kind_str = kind.as_str();
-                    let label = format!("This is not a valid {kind_str} name");
+                    let label = format!("This is not a valid {} name", kind_str.to_lowercase());
                     let text = match kind {
                         Named::Type |
                         Named::TypeAlias |
                         Named::CustomTypeVariant => wrap_format!("Hint: {} names start with an uppercase \
 letter and contain only lowercase letters, numbers, \
 and uppercase letters.
-Try: {}", uppercase_first_letter(kind_str), to_upper_camel_case(name)),
+Try: {}", kind_str, to_upper_camel_case(name)),
                         Named::Variable |
                         Named::TypeVariable |
                         Named::Argument |
@@ -3527,14 +3527,14 @@ Try: {}", uppercase_first_letter(kind_str), to_upper_camel_case(name)),
                         Named::Constant  |
                         Named::Function => wrap_format!("Hint: {} names start with a lowercase letter \
 and contain a-z, 0-9, or _.
-Try: {}", uppercase_first_letter(kind_str), to_snake_case(name)),
+Try: {}", kind_str, to_snake_case(name)),
                         Named::Discard => wrap_format!("Hint: {} names start with _ and contain \
 a-z, 0-9, or _.
-Try: _{}", uppercase_first_letter(kind_str), to_snake_case(name)),
+Try: _{}", kind_str, to_snake_case(name)),
                     };
 
                     Diagnostic {
-                        title: format!("Invalid {kind_str} name"),
+                        title: format!("Invalid {} name", kind_str.to_lowercase()),
                         text,
                         hint: None,
                         level: Level::Error,

--- a/compiler-core/src/strings.rs
+++ b/compiler-core/src/strings.rs
@@ -110,15 +110,3 @@ pub fn to_upper_camel_case(string: &str) -> EcoString {
 
     pascal_case
 }
-
-pub fn uppercase_first_letter(string: &str) -> EcoString {
-    let mut uppercased = EcoString::with_capacity(string.len());
-    let mut chars = string.chars();
-    if let Some(first) = chars.next() {
-        uppercased.push(first.to_ascii_uppercase());
-    }
-    for char in chars {
-        uppercased.push(char);
-    }
-    uppercased
-}

--- a/compiler-core/src/strings.rs
+++ b/compiler-core/src/strings.rs
@@ -64,3 +64,61 @@ pub fn convert_string_escape_chars(str: &EcoString) -> EcoString {
     }
     filtered_str
 }
+
+pub fn to_snake_case(string: &str) -> EcoString {
+    let mut snake_case = EcoString::with_capacity(string.len());
+    let mut is_word_boundary = true;
+
+    for char in string.chars() {
+        match char {
+            '_' | ' ' => {
+                is_word_boundary = true;
+                continue;
+            }
+            _ if char.is_uppercase() => {
+                is_word_boundary = true;
+            }
+            _ => {}
+        }
+
+        if is_word_boundary {
+            // We don't want to push an underscore at the start of the string,
+            // even if it starts with a capital letter or other delimiter.
+            if !snake_case.is_empty() {
+                snake_case.push('_');
+            }
+            is_word_boundary = false;
+        }
+        snake_case.push(char.to_ascii_lowercase());
+    }
+
+    snake_case
+}
+
+pub fn to_upper_camel_case(string: &str) -> EcoString {
+    let mut pascal_case = EcoString::with_capacity(string.len());
+    let mut chars = string.chars();
+
+    while let Some(char) = chars.next() {
+        if char == '_' {
+            let Some(next) = chars.next() else { break };
+            pascal_case.push(next.to_ascii_uppercase());
+        } else {
+            pascal_case.push(char);
+        }
+    }
+
+    pascal_case
+}
+
+pub fn uppercase_first_letter(string: &str) -> EcoString {
+    let mut uppercased = EcoString::with_capacity(string.len());
+    let mut chars = string.chars();
+    if let Some(first) = chars.next() {
+        uppercased.push(first.to_ascii_uppercase());
+    }
+    for char in chars {
+        uppercased.push(char);
+    }
+    uppercased
+}

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -690,16 +690,16 @@ pub enum Named {
 impl Named {
     pub fn as_str(self) -> &'static str {
         match self {
-            Named::Type => "type",
-            Named::TypeAlias => "type alias",
-            Named::TypeVariable => "type variable",
-            Named::CustomTypeVariant => "type variant",
-            Named::Variable => "variable",
-            Named::Argument => "argument",
-            Named::Label => "label",
-            Named::Constant => "constant",
-            Named::Function => "function",
-            Named::Discard => "discard",
+            Named::Type => "Type",
+            Named::TypeAlias => "Type alias",
+            Named::TypeVariable => "Type variable",
+            Named::CustomTypeVariant => "Type variant",
+            Named::Variable => "Variable",
+            Named::Argument => "Argument",
+            Named::Label => "Label",
+            Named::Constant => "Constant",
+            Named::Function => "Function",
+            Named::Discard => "Discard",
         }
     }
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_constructor_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_constructor_name.snap
@@ -12,6 +12,6 @@ error: Invalid type variant name
 1 │ type MyType { Int_Value(Int) }
   │               ^^^^^^^^^ This is not a valid type variant name
 
-Hint: Type Variant names start with an uppercase letter and contain only
+Hint: Type variant names start with an uppercase letter and contain only
 lowercase letters, numbers, and uppercase letters.
 Try: IntValue

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_type_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_function_type_parameter_name.snap
@@ -12,6 +12,6 @@ error: Invalid type variable name
 1 │ fn identity(value: someType) { value }
   │                    ^^^^^^^^ This is not a valid type variable name
 
-Hint: Type Variable names start with a lowercase letter and contain a-z,
+Hint: Type variable names start with a lowercase letter and contain a-z,
 0-9, or _.
 Try: some_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_name.snap
@@ -12,6 +12,6 @@ error: Invalid type alias name
 1 │ type Fancy_Bool = Bool
   │      ^^^^^^^^^^ This is not a valid type alias name
 
-Hint: Type Alias names start with an uppercase letter and contain only
+Hint: Type alias names start with an uppercase letter and contain only
 lowercase letters, numbers, and uppercase letters.
 Try: FancyBool

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_alias_parameter_name.snap
@@ -12,6 +12,6 @@ error: Invalid type variable name
 1 │ type GleamOption(okType) = Result(okType, Nil)
   │                  ^^^^^^ This is not a valid type variable name
 
-Hint: Type Variable names start with a lowercase letter and contain a-z,
+Hint: Type variable names start with a lowercase letter and contain a-z,
 0-9, or _.
 Try: ok_type

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_parameter_name.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_type_parameter_name.snap
@@ -12,6 +12,6 @@ error: Invalid type variable name
 1 │ type Wrapper(innerType) {}
   │              ^^^^^^^^^ This is not a valid type variable name
 
-Hint: Type Variable names start with a lowercase letter and contain a-z,
+Hint: Type variable names start with a lowercase letter and contain a-z,
 0-9, or _.
 Try: inner_type

--- a/test-helpers-rs/Cargo.toml
+++ b/test-helpers-rs/Cargo.toml
@@ -6,10 +6,11 @@ license = "Apache-2.0"
 
 [dependencies]
 gleam-core = { path = "../compiler-core" }
+walkdir = "2"
+
 toml.workspace = true
 im.workspace = true
 itertools.workspace = true
-walkdir.workspace = true
 regex.workspace = true
 camino.workspace = true
 

--- a/test-package-compiler/Cargo.toml
+++ b/test-package-compiler/Cargo.toml
@@ -11,7 +11,6 @@ test-helpers-rs = { path = "../test-helpers-rs" }
 toml.workspace = true
 im.workspace = true
 itertools.workspace = true
-walkdir.workspace = true
 regex.workspace = true
 camino.workspace = true
 

--- a/test-project-compiler/Cargo.toml
+++ b/test-project-compiler/Cargo.toml
@@ -11,7 +11,6 @@ test-helpers-rs = { path = "../test-helpers-rs" }
 toml.workspace = true
 im.workspace = true
 itertools.workspace = true
-walkdir.workspace = true
 regex.workspace = true
 camino.workspace = true
 


### PR DESCRIPTION
Louis mentioned recently that if possible we would be removing dependencies from the compiler, so this PR does that:
- Removed `heck` dependency and reimplemented the two methods that were used. The reimplemented versions are simplified but all we need for the compiler.
- Removed `strsim` dependency as it seems to no longer be used anywhere
- Removed `bytes` dependency as it seemed to no longer be used anywhere
- Moved `walkdir` dependency from the root workspace to the `test-helpers-rs` project, as that is the only place it is used. This removes it from the production build and only requires it in a test build.