### PR TITLE
Make function parameters fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,10 @@
 - The compiler will not generate needless code for unused pattern variables.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Function parameters are now fault tolerant, meaning that type-checking can
+  continue to occur if a function references invalid type in its signature.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - The build tool now supports placing modules in a directory called `dev`,

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__function_parameter_errors_do_not_stop_inference.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__function_parameter_errors_do_not_stop_inference.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "\npub fn wibble(x: NonExistent) {\n  1 + False\n}\n"
+---
+----- SOURCE CODE
+
+pub fn wibble(x: NonExistent) {
+  1 + False
+}
+
+
+----- ERROR
+error: Unknown type
+  ┌─ /src/one/two.gleam:2:18
+  │
+2 │ pub fn wibble(x: NonExistent) {
+  │                  ^^^^^^^^^^^
+
+The type `NonExistent` is not defined or imported in this module.
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:7
+  │
+3 │   1 + False
+  │       ^^^^^
+
+The + operator expects arguments of this type:
+
+    Int
+
+But this argument has this type:
+
+    Bool

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -3107,3 +3107,14 @@ pub type Bad {
 "
     );
 }
+
+#[test]
+fn function_parameter_errors_do_not_stop_inference() {
+    assert_module_error!(
+        "
+pub fn wibble(x: NonExistent) {
+  1 + False
+}
+"
+    );
+}


### PR DESCRIPTION
This PR seems to fix #4092.
This PR makes function parameters fault tolerant, meaning that if an error occurs (e.g. an invalid type is referenced), type inference can continue. As far as I can tell, this is what was causing the linked issue.
As detailed in the above issue, it's not easy to reproduce, especially using automated tests. I'm not sure if there's a good way to test it. For now I've added a test in `type_::tests` to test this fault tolerance.