### PR TITLE
Display original function definition generic names on function signature helper when arguments are unbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,23 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The function signature helper now displays original function definition
+  generic names when arguments are unbound. For example, in this code:
+
+  ```gleam
+  pub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }
+
+  pub fn main() {
+      wibble( )
+          // ↑ triggering signature help here, will produce:
+          //      wibble(something, fn() -> something, anything)
+          // instead of
+          //      wibble(a, fn() -> a, b) -> Nil
+  }
+  ```
+
+  ([Samuel Cristobal](https://github.com/scristobal))
+
 ### Formatter
 
 ### Installation

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -76,6 +76,22 @@ impl TypedModule {
             .iter()
             .find_map(|definition| definition.find_statement(byte_index))
     }
+
+    pub fn find_funtion_definition(&self, name: &str) -> Option<&Function<Arc<Type>, TypedExpr>> {
+        self.definitions
+            .iter()
+            .find_map(|definition| match definition {
+                Definition::Function(funtion) => {
+                    if let Some(function_name) = funtion.name.as_ref() {
+                        if function_name.1 == name {
+                            return Some(funtion);
+                        }
+                    }
+                    None
+                }
+                _ => None,
+            })
+    }
 }
 
 /// The `@target(erlang)` and `@target(javascript)` attributes can be used to

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -989,15 +989,21 @@ Unused labelled fields:
         &mut self,
         params: lsp_types::SignatureHelpParams,
     ) -> Response<Option<SignatureHelp>> {
-        self.respond(
-            |this| match this.node_at_position(&params.text_document_position_params) {
+        self.respond(|this| {
+            let document_uri = &params.text_document_position_params.text_document.uri;
+
+            let Some(module) = this.module_for_uri(document_uri) else {
+                return Ok(None);
+            };
+
+            match this.node_at_position(&params.text_document_position_params) {
                 Some((_lines, Located::Expression { expression, .. })) => {
-                    Ok(signature_help::for_expression(expression))
+                    Ok(signature_help::for_expression(expression, module))
                 }
                 Some((_lines, _located)) => Ok(None),
                 None => Ok(None),
-            },
-        )
+            }
+        })
     }
 
     fn module_node_at_position(

--- a/compiler-core/src/language_server/tests/signature_help.rs
+++ b/compiler-core/src/language_server/tests/signature_help.rs
@@ -410,6 +410,35 @@ pub fn main() {
 }
 
 #[test]
+pub fn help_for_use_function_call_uses_generic_names_when_missing_all_arguments() {
+    assert_signature_help!(
+        r#"
+pub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }
+
+pub fn main() {
+    wibble( )
+}
+"#,
+        find_position_of("wibble( ").under_last_char()
+    );
+}
+
+#[test]
+pub fn help_for_use_function_call_uses_concrete_types_when_possible_or_generic_names_when_unbound()
+{
+    assert_signature_help!(
+        r#"
+pub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }
+
+pub fn main() {
+    wibble(1, )
+}
+"#,
+        find_position_of("wibble(1, )").under_last_char()
+    );
+}
+
+#[test]
 pub fn help_for_use_function_shows_next_unlabelled_argument() {
     assert_signature_help!(
         r#"

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_for_use_function_call_uses_concrete_types_when_possible_or_generic_names_when_unbound.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_for_use_function_call_uses_concrete_types_when_possible_or_generic_names_when_unbound.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/signature_help.rs
+expression: "\npub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }\n\npub fn main() {\n    wibble(1, )\n}\n"
+---
+pub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }
+
+pub fn main() {
+    wibble(1, )
+              ↑
+}
+
+
+----- Signature help -----
+wibble(Int, fn() -> Int, anything) -> Nil
+            ▔▔▔▔▔▔▔▔▔▔▔
+
+No documentation

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_for_use_function_call_uses_generic_names_when_missing_all_arguments.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_for_use_function_call_uses_generic_names_when_missing_all_arguments.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/signature_help.rs
+expression: "\npub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }\n\npub fn main() {\n    wibble( )\n}\n"
+---
+pub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }
+
+pub fn main() {
+    wibble( )
+           ↑ 
+}
+
+
+----- Signature help -----
+wibble(something, fn() -> something, anything) -> Nil
+       ▔▔▔▔▔▔▔▔▔
+
+No documentation


### PR DESCRIPTION
While working on #4570, I noticed that generics were not displayed with the original names, so I also changed that. Hope the feature is interesting. 

- The function signature helper now displays original function definition
  generic names when arguments are unbound. For example, in this code:

  ```gleam
  pub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }

  pub fn main() {
      wibble( )
          // ↑ triggering signature help here, will produce:
          //      wibble(something, fn() -> something, anything)
          // instead of
          //      wibble(a, fn() -> a, b) -> Nil
  }
  ```

[link to snapshot](https://github.com/scristobal/gleam/blob/issue-4570/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_for_use_function_call_uses_generic_names_when_missing_all_arguments.snap)


It also works in scenarios where not all parameters are unbounded.

```gleam
pub fn wibble(x: something, y: fn() -> something, z: anything) { Nil }

pub fn main() {
    wibble(1, )
          // ↑ triggering signature help here, will produce:
          //     wibble(Int, fn() -> Int, anything) -> Nil
          // instead of
          //     wibble(Int, fn() -> Int, a) -> Nil
}
```

[link to snapshot](https://github.com/scristobal/gleam/blob/issue-4570/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__signature_help__help_for_use_function_call_uses_concrete_types_when_possible_or_generic_names_when_unbound.snap)