### PR TITLE
Error for conflicting Gleam and Erlang files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,10 @@
   deprecated environment variables.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The build tool will now emit an error when compiling a package if the package
+  has a Gleam and Erlang file which would collide.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Language server
 
 - The code action to add missing labels to function now also works in patterns:

--- a/compiler-core/src/build/native_file_copier/tests.rs
+++ b/compiler-core/src/build/native_file_copier/tests.rs
@@ -1,6 +1,6 @@
 use super::NativeFileCopier;
 use crate::{
-    build::native_file_copier::CopiedNativeFiles,
+    build::{native_file_copier::CopiedNativeFiles, package_compiler::PackageKind},
     io::{FileSystemWriter, memory::InMemoryFileSystem},
 };
 use std::{
@@ -26,7 +26,7 @@ fn javascript_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/src/wibble.js"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -45,7 +45,7 @@ fn javascript_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/test/wibble.js"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -64,7 +64,7 @@ fn javascript_files_are_copied_from_dev() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/dev/wibble.js"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -83,7 +83,7 @@ fn mjavascript_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/src/wibble.mjs"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -102,7 +102,7 @@ fn mjavascript_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/test/wibble.mjs"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -121,7 +121,7 @@ fn mjavascript_files_are_copied_from_dev() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/dev/wibble.mjs"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -140,7 +140,7 @@ fn typescript_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/src/wibble.ts"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -159,7 +159,7 @@ fn typescript_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/test/wibble.ts"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -178,7 +178,7 @@ fn typescript_files_are_copied_from_dev() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/dev/wibble.ts"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -201,7 +201,7 @@ fn all_javascript_files_are_copied_from_src_subfolders() {
         .unwrap();
     fs.write(&Utf8Path::new("/src/def/wobble.ts"), "3").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -229,7 +229,7 @@ fn all_javascript_files_are_copied_from_test_subfolders() {
     fs.write(&Utf8Path::new("/test/def/wobble.ts"), "3")
         .unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -256,7 +256,7 @@ fn all_javascript_files_are_copied_from_dev_subfolders() {
         .unwrap();
     fs.write(&Utf8Path::new("/dev/def/wobble.ts"), "3").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -279,7 +279,7 @@ fn erlang_header_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/src/wibble.hrl"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -298,7 +298,7 @@ fn erlang_header_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/test/wibble.hrl"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -317,7 +317,7 @@ fn erlang_header_files_are_copied_from_dev() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/dev/wibble.hrl"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -336,7 +336,7 @@ fn erlang_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/src/wibble.erl"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -355,7 +355,7 @@ fn erlang_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/test/wibble.erl"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -374,7 +374,7 @@ fn erlang_files_are_copied_from_dev() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/dev/wibble.erl"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -393,7 +393,7 @@ fn elixir_files_are_copied_from_src() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/src/wibble.ex"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
@@ -412,7 +412,7 @@ fn elixir_files_are_copied_from_test() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/test/wibble.ex"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
@@ -431,7 +431,7 @@ fn elixir_files_are_copied_from_dev() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/dev/wibble.ex"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
@@ -454,7 +454,7 @@ fn all_erlang_files_are_copied_from_src_subfolders() {
         .unwrap();
     fs.write(&Utf8Path::new("/src/def/wobble.ex"), "3").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
@@ -494,7 +494,7 @@ fn all_erlang_files_are_copied_from_test_subfolders() {
     fs.write(&Utf8Path::new("/test/def/wobble.ex"), "3")
         .unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
@@ -533,7 +533,7 @@ fn all_erlang_files_are_copied_from_dev_subfolders() {
         .unwrap();
     fs.write(&Utf8Path::new("/dev/def/wobble.ex"), "3").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(copied.any_elixir);
@@ -568,7 +568,7 @@ fn other_files_are_ignored() {
     let fs = InMemoryFileSystem::new();
     fs.write(&Utf8Path::new("/src/wibble.cpp"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -589,7 +589,7 @@ fn files_do_not_get_copied_if_there_already_is_a_new_version() {
     fs.set_modification_time(&out, UNIX_EPOCH + Duration::from_secs(1));
     fs.set_modification_time(&src, UNIX_EPOCH);
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -613,7 +613,7 @@ fn files_get_copied_if_the_previously_copied_version_is_older() {
     fs.set_modification_time(&out, UNIX_EPOCH);
     fs.set_modification_time(&src, UNIX_EPOCH + Duration::from_secs(1));
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     let copied = copier.run().unwrap();
 
     assert!(!copied.any_elixir);
@@ -633,7 +633,7 @@ fn duplicate_native_files_result_in_an_error() {
     fs.write(&Utf8Path::new("/src/wibble.mjs"), "1").unwrap();
     fs.write(&Utf8Path::new("/test/wibble.mjs"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     assert!(copier.run().is_err());
 }
 
@@ -645,7 +645,7 @@ fn conflicting_erlang_modules_in_src_result_in_an_error() {
     fs.write(&Utf8Path::new("/src/e/f/wibble.erl"), "1")
         .unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     assert!(copier.run().is_err());
 }
 
@@ -657,7 +657,7 @@ fn conflicting_erlang_modules_in_src_and_test_result_in_an_error() {
     fs.write(&Utf8Path::new("/test/e/f/wibble.erl"), "1")
         .unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     assert!(copier.run().is_err());
 }
 
@@ -669,7 +669,7 @@ fn conflicting_erlang_modules_in_src_and_dev_result_in_an_error() {
     fs.write(&Utf8Path::new("/dev/e/f/wibble.erl"), "1")
         .unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     assert!(copier.run().is_err());
 }
 
@@ -681,7 +681,7 @@ fn conflicting_erlang_modules_in_dev_and_test_result_in_an_error() {
     fs.write(&Utf8Path::new("/test/e/f/wibble.erl"), "1")
         .unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     assert!(copier.run().is_err());
 }
 
@@ -691,7 +691,7 @@ fn conflicting_gleam_and_javascript_modules_result_in_an_error() {
     fs.write(&Utf8Path::new("/src/wibble.gleam"), "1").unwrap();
     fs.write(&Utf8Path::new("/src/wibble.mjs"), "1").unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
     assert!(copier.run().is_err());
 }
 
@@ -703,6 +703,49 @@ fn differently_nested_gleam_and_javascript_modules_with_same_name_are_ok() {
     fs.write(&Utf8Path::new("/src/d/e/wibble.mjs"), "1")
         .unwrap();
 
-    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
+    assert!(copier.run().is_ok());
+}
+
+#[test]
+fn conflicting_gleam_and_erlang_modules_result_in_an_error() {
+    let fs = InMemoryFileSystem::new();
+    fs.write(&Utf8Path::new("/src/wibble.gleam"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.erl"), "1").unwrap();
+
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
+    assert!(copier.run().is_err());
+}
+
+#[test]
+fn conflicting_nested_gleam_and_erlang_modules_result_in_an_error() {
+    let fs = InMemoryFileSystem::new();
+    fs.write(&Utf8Path::new("/src/wibble/wobble.gleam"), "1")
+        .unwrap();
+    fs.write(&Utf8Path::new("/src/wibble@wobble.erl"), "1")
+        .unwrap();
+
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
+    assert!(copier.run().is_err());
+}
+
+#[test]
+fn conflicting_nested_gleam_file_does_not_conflict_with_root_erlang_file() {
+    let fs = InMemoryFileSystem::new();
+    fs.write(&Utf8Path::new("/src/wibble/wobble.gleam"), "1")
+        .unwrap();
+    fs.write(&Utf8Path::new("/src/wobble.erl"), "1").unwrap();
+
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Root);
+    assert!(copier.run().is_ok());
+}
+
+#[test]
+fn conflicting_gleam_and_erlang_modules_produce_no_error_in_dependency() {
+    let fs = InMemoryFileSystem::new();
+    fs.write(&Utf8Path::new("/src/wibble.gleam"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.erl"), "1").unwrap();
+
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out(), PackageKind::Dependency);
     assert!(copier.run().is_ok());
 }

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -94,7 +94,7 @@ fn run_loader(fs: InMemoryFileSystem, root: &Utf8Path, artefact: &Utf8Path) -> L
         stale_modules: &mut StaleTracker::default(),
         already_defined_modules: &mut defined,
         incomplete_modules: &mut HashSet::new(),
-        cached_warnings: CachedWarnings::Ignore,
+        package_kind: PackageKind::Dependency,
     };
     let loaded = loader.run().unwrap();
 

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -38,7 +38,7 @@ use std::{
 use super::{
     Codegen, Compile, ErlangAppCodegenConfiguration, Outcome,
     elixir_libraries::ElixirLibraries,
-    package_compiler::{CachedWarnings, Compiled},
+    package_compiler::{Compiled, PackageKind},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -613,10 +613,10 @@ where
             // unaccessible so long as they are not used by the root package.
             TargetSupport::NotEnforced
         };
-        compiler.cached_warnings = if is_root {
-            CachedWarnings::Use
+        compiler.package_kind = if is_root {
+            PackageKind::Root
         } else {
-            CachedWarnings::Ignore
+            PackageKind::Dependency
         };
 
         // Compile project to Erlang or JavaScript source code


### PR DESCRIPTION
Closes #2738
Errors for conflicting Gleam and JavaScript modules have already been implemented, so this does the same for Erlang and Gleam.