### PR TITLE
feat(Makefile): add fmt, fmt-check and lint targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,18 @@ test: ## Run the compiler unit tests
 	cd test/running_modules && make test
 	cd test/subdir_ffi && make
 
+.PHONY: fmt
+fmt: ## Run rustfmt to format all Rust code
+	cargo fmt
+
+.PHONY: fmt-check
+fmt-check: ## Check that all Rust code is properly formatted
+	cargo fmt -- --check
+
+.PHONY: lint
+lint: ## Run Clippy and treat all warnings as errors
+	cargo clippy -- -D warnings
+
 .PHONY: language-test
 language-test: ## Run the language integration tests for all targets
 	cd test/language && make


### PR DESCRIPTION
- `make fmt`        → runs `cargo fmt` to auto-format all Rust code
- `make fmt-check`  → runs `cargo fmt -- --check` to verify formatting
- `make lint`       → runs `cargo clippy -- -D warnings` to treat all warnings as errors

These targets can be used in CI to avoid raw usage of clippy or rustfmt

Closes #4579 