### PR TITLE
Fixing typo in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@
     │   ^^^^^^^^^ This value is never used
 
   This expression computes a value without any side effects, but then the
-  value isn't used at all. You might way to assign it to a variable, or
+  value isn't used at all. You might want to assign it to a variable, or
   delete the expression entirely if it's not needed.
   ```
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constructing_anonymous_function_is_pure.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constructing_anonymous_function_is_pure.snap
@@ -22,5 +22,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_erlang_if_external_on_js.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_erlang_if_external_on_js.snap
@@ -21,5 +21,5 @@ warning: Unused value
   │   ^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_js_if_external_on_erlang.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__function_is_pure_on_js_if_external_on_erlang.snap
@@ -21,5 +21,5 @@ warning: Unused value
   │   ^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_raises_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_raises_warning.snap
@@ -20,5 +20,5 @@ warning: Unused value
   │   ^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_with_many_steps_raises_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_pipeline_with_many_steps_raises_warning.snap
@@ -20,5 +20,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_standard_library_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__pure_standard_library_function.snap
@@ -32,5 +32,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_binary_operation_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_binary_operation_raises_a_warning.snap
@@ -18,5 +18,5 @@ warning: Unused value
   │                           ^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expression.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expression.snap
@@ -18,5 +18,5 @@ warning: Unused value
   │   ^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expressions.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_block_wrapping_pure_expressions.snap
@@ -24,7 +24,7 @@ warning: Unused value
   │ ╰───^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.
 
 warning: Unused literal

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_bool_negation_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_bool_negation_raises_a_warning.snap
@@ -18,5 +18,5 @@ warning: Unused value
   │   ^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_case_expression.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_case_expression.snap
@@ -25,5 +25,5 @@ warning: Unused value
   │ ╰─────^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_fn_function_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_fn_function_call.snap
@@ -18,5 +18,5 @@ warning: Unused value
   │     ^^^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_function_literal_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_function_literal_raises_a_warning.snap
@@ -18,5 +18,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_const.snap
@@ -24,5 +24,5 @@ warning: Unused value
   │   ^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor.snap
@@ -24,5 +24,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor_call.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_constructor_call.snap
@@ -24,5 +24,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_module_select_function.snap
@@ -24,5 +24,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_pure_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_pure_fn.snap
@@ -21,5 +21,5 @@ warning: Unused value
   │ ╰──────────────────────^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning.snap
@@ -21,5 +21,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pipeline_ending_with_variant_raises_a_warning_2.snap
@@ -26,5 +26,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function.snap
@@ -20,5 +20,5 @@ warning: Unused value
   │   ^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function_that_calls_other_pure_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_pure_function_that_calls_other_pure_function.snap
@@ -22,5 +22,5 @@ warning: Unused value
   │   ^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_access_raises_a_warning.snap
@@ -23,5 +23,5 @@ warning: Unused value
   │   ^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_update_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_record_update_raises_a_warning.snap
@@ -23,5 +23,5 @@ warning: Unused value
   │   ^^^^^^^^^^^^^^^^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_tuple_index_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_tuple_index_raises_a_warning.snap
@@ -18,5 +18,5 @@ warning: Unused value
   │   ^^^^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_variable_raises_a_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_variable_raises_a_warning.snap
@@ -19,5 +19,5 @@ warning: Unused value
   │   ^^^^^^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
@@ -25,5 +25,5 @@ warning: Unused value
   │ ╰─────^ This value is never used
 
 This expression computes a value without any side effects, but then the
-value isn't used at all. You might way to assign it to a variable, or
+value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -908,7 +908,7 @@ can already tell which branch is going to match with this value.",
                     title: "Unused value".into(),
                     text: wrap(
                         "This expression computes a value without any side \
-effects, but then the value isn't used at all. You might way to assign it to a \
+effects, but then the value isn't used at all. You might want to assign it to a \
 variable, or delete the expression entirely if it's not needed.",
                     ),
                     hint: None,


### PR DESCRIPTION
I just saw a typo when reading the changelogs, `You might way` -> `You might want`.

I had to modify the snapshot tests as well, which was done with grep and sed, hopefully this is the correct way to fix them.