### PR TITLE
Improve formatting of `echo` and `assert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,9 @@
 
 ### Formatter
 
+- Improved the formatting of `echo` when followed by long binary expressions.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Installation
 
 - Windows ARM64 pre-built binaries are now provided.

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2464,11 +2464,13 @@ impl<'comments> Formatter<'comments> {
                 .append("as ".to_doc().append(self.expr(message).group()))
         });
 
-        let document = "assert "
-            .to_doc()
-            .append(self.expr(&assert.value))
-            .append(message);
+        let expression = if assert.value.is_binop() || assert.value.is_pipeline() {
+            self.expr(&assert.value).nest(INDENT)
+        } else {
+            self.expr(&assert.value)
+        };
 
+        let document = docvec!["assert ", expression, message];
         commented(document, comments)
     }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2753,28 +2753,29 @@ impl<'comments> Formatter<'comments> {
             return "echo".to_doc();
         };
 
-        match expression.as_ref() {
-            // When a pipeline gets broken on multiple lines we don't want it to
-            // be on the same line as echo, or it would look confusing; instead
-            // it's nested onto a new line:
-            //
-            // ```gleam
-            // echo first
-            //   |> wobble
-            //   |> wibble
-            // ```
-            //
-            // So it's easier to see echo is printing the whole thing. Otherwise,
-            // it would look like echo is printing just the first item:
-            //
-            // ```gleam
-            // echo first
-            // |> wobble
-            // |> wibble
-            // ```
-            //
-            UntypedExpr::PipeLine { .. } => docvec!["echo ", self.expr(expression).nest(INDENT)],
-            _ => docvec!["echo ", self.expr(expression)],
+        // When a binary expression gets broken on multiple lines we don't want
+        // it to be on the same line as echo, or it would look confusing;
+        // instead it's nested onto a new line:
+        //
+        // ```gleam
+        // echo first
+        //   |> wobble
+        //   |> wibble
+        // ```
+        //
+        // So it's easier to see echo is printing the whole thing. Otherwise,
+        // it would look like echo is printing just the first item:
+        //
+        // ```gleam
+        // echo first
+        // |> wobble
+        // |> wibble
+        // ```
+        //
+        if expression.is_binop() || expression.is_pipeline() {
+            docvec!["echo ", self.expr(expression).nest(INDENT)]
+        } else {
+            docvec!["echo ", self.expr(expression)]
         }
     }
 }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6610,3 +6610,19 @@ fn echo_with_long_binary_expression() {
     );
 }
 
+#[test]
+fn assert_with_long_binary_expression() {
+    assert_format!(
+        r#"pub fn main() {
+  assert wibble_wobble_wibble_wobble_wibble_wobble_wibble
+    >= wibble_wobble_wibble_wobble_wibble_wobble_wibble
+
+  assert wibble_wobble_wibble_wobble_wibble_wobble_wibble
+    + wibble_wobble_wibble_wobble_wibble_wobble_wibble
+
+  assert wibble_wobble_wibble_wobble_wibble_wobble_wibble
+    == wibble_wobble_wibble_wobble_wibble_wobble_wibble
+}
+"#
+    );
+}

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6592,3 +6592,21 @@ fn assert_with_long_expression_and_long_message() {
 "#
     );
 }
+
+#[test]
+fn echo_with_long_binary_expression() {
+    assert_format!(
+        r#"pub fn main() {
+  echo wibble_wobble_wibble_wobble_wibble_wobble_wibble
+    >= wibble_wobble_wibble_wobble_wibble_wobble_wibble
+
+  echo wibble_wobble_wibble_wobble_wibble_wobble_wibble
+    + wibble_wobble_wibble_wobble_wibble_wobble_wibble
+
+  echo wibble_wobble_wibble_wobble_wibble_wobble_wibble
+    == wibble_wobble_wibble_wobble_wibble_wobble_wibble
+}
+"#
+    );
+}
+


### PR DESCRIPTION
With this PR I've improved formatting of binary expressions used on the right of an echo/assert. Previously they wouldn't be indented properly!
I've only updated the changelog for `echo` as `assert` hasn't been released yet