### PR TITLE
Make sure build tool does not try and run module whose main function is private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -636,3 +636,7 @@
 - Fixed a bug where the compiler would crash if duplicate variables were defined
   in alternative patterns.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the build tool would try and run a module whose main
+  function is private.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -945,7 +945,7 @@ to `{}/{module}.gleam`.", origin.folder_name()
             Error::MainFunctionIsPrivate { module } => vec![
                 Diagnostic {
                     title: "Module does not have a public main function".into(),
-                    text: format!(
+                    text: wrap_format!(
                         "`{module}` has a main function, but it is private, so it cannot be run."
                     ),
                     level: Level::Error,
@@ -967,7 +967,7 @@ target, so it cannot be run."
 
             Error::MainFunctionHasWrongArity { module, arity } => vec![Diagnostic {
                 title: "Main function has wrong arity".into(),
-                text: format!(
+                text: wrap_format!(
                     "`{module}:main` should have an arity of 0 to be run but its arity is {arity}."
                 ),
                 level: Level::Error,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -950,7 +950,7 @@ to `{}/{module}.gleam`.", origin.folder_name()
                     ),
                     level: Level::Error,
                     location: None,
-                    hint: Some(format!("Make the `main` function in the `{module}` module public."))
+                    hint: Some(wrap_format!("Make the `main` function in the `{module}` module public."))
                 }
             ],
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -179,6 +179,9 @@ pub enum Error {
     #[error("{module} does not have a main function")]
     ModuleDoesNotHaveMainFunction { module: EcoString, origin: Origin },
 
+    #[error("{module} does not have a public main function")]
+    MainFunctionIsPrivate { module: EcoString },
+
     #[error("{module}'s main function has the wrong arity so it can not be run")]
     MainFunctionHasWrongArity { module: EcoString, arity: usize },
 
@@ -938,6 +941,18 @@ forward slash and must not end with a slash."
 to `{}/{module}.gleam`.", origin.folder_name()
                 )),
             }],
+
+            Error::MainFunctionIsPrivate { module } => vec![
+                Diagnostic {
+                    title: "Module does not have a public main function".into(),
+                    text: format!(
+                        "`{module}` has a main function, but it is private, so it cannot be run."
+                    ),
+                    level: Level::Error,
+                    location: None,
+                    hint: Some(format!("Make the `main` function in the `{module}` module public."))
+                }
+            ],
 
             Error::MainFunctionDoesNotSupportTarget { module, target } => vec![Diagnostic {
                 title: "Target not supported".into(),

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1683,5 +1683,13 @@ fn assert_suitable_main_function(
         });
     }
 
+    // The function must be public, or trying to run it would result in a
+    // runtime crash
+    if !value.publicity.is_importable() {
+        return Err(crate::Error::MainFunctionIsPrivate {
+            module: module_name.clone(),
+        });
+    }
+
     Ok(())
 }


### PR DESCRIPTION
This PR fixes #4592 

The build tool would not check that the main function defined by a module is not private so `gleam run` would result in a runtime crash, instead of a build error