### PR TITLE
Fix #4565

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@
 - Fixed a bug where a bit array segment matching on a floating point number
   would match with `NaN` or `Infinity` on the JavaScript target.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the language server would not show the "Unqualify type"
+  code action for record declarations.
+  ([cysabi](https://github.com/cysabi))

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -704,10 +704,15 @@ where
 {
 }
 
-pub fn visit_typed_custom_type<'a, V>(_v: &mut V, _custom_type: &'a TypedCustomType)
+pub fn visit_typed_custom_type<'a, V>(v: &mut V, custom_type: &'a TypedCustomType)
 where
     V: Visit<'a> + ?Sized,
 {
+    for record in &custom_type.constructors {
+        for argument in &record.arguments {
+            v.visit_type_ast(&argument.ast);
+        }
+    }
 }
 
 pub fn visit_typed_expr<'a, V>(v: &mut V, node: &'a TypedExpr)

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -2917,6 +2917,22 @@ pub fn main() {
 }
 
 #[test]
+fn test_qualified_to_unqualified_import_custom_type_record_declaration() {
+    let src = r#"
+import wobble
+
+pub type Wibble {
+  Wibble(wibble: wobble.Wobble)
+}
+"#;
+    assert_code_action!(
+        "Unqualify wobble.Wobble",
+        TestProject::for_source(src).add_hex_module("wobble", "pub type Wobble { Wibble }"),
+        find_position_of(".").select_until(find_position_of("Wobble"))
+    );
+}
+
+#[test]
 fn test_qualified_to_unqualified_import_basic_type_without_argument() {
     let src = r#"
 import wobble

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__qualified_to_unqualified_import_custom_type_record_declaration.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__qualified_to_unqualified_import_custom_type_record_declaration.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport wobble\n\npub type Wibble {\n  Wibble(wibble: wobble.Wobble)\n}\n"
+---
+----- BEFORE ACTION
+
+import wobble
+
+pub type Wibble {
+  Wibble(wibble: wobble.Wobble)
+                       ▔↑      
+}
+
+
+----- AFTER ACTION
+
+import wobble.{type Wobble}
+
+pub type Wibble {
+  Wibble(wibble: Wobble)
+}


### PR DESCRIPTION
- Unsure if the test should be renamed
- Unsure if the implementation belongs in `visit.rs` (where it is now) or as an override in `QualifiedToUnqualifiedImportFirstPass`