### PR TITLE
Fix project generation test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,7 +275,7 @@ jobs:
 
           # Test adding of deps
           gleam add exception    # No specifier
-          gleam add gleam_http@3 # Version specifier
+          gleam add gleam_http@4 # Version specifier
           gleam test
 
           # Test documentation generation


### PR DESCRIPTION
Since the latest version of the standard library, `gleam_http` no longer works. This PR updates the integration test to use `gleam_http` v4.