### PR TITLE
Update to Rust 1.87

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1064,7 +1064,7 @@ impl<A, B, C, E> Definition<A, B, C, E> {
             | Definition::TypeAlias(TypeAlias { documentation, .. })
             | Definition::CustomType(CustomType { documentation, .. })
             | Definition::ModuleConstant(ModuleConstant { documentation, .. }) => {
-                let _ = std::mem::replace(documentation, Some(new_doc));
+                let _ = documentation.replace(new_doc);
             }
         }
     }
@@ -2342,7 +2342,7 @@ pub enum AssignmentKind<Expression> {
         /// let asset Ok(a) = something() as "This will never fail"
         /// //                                ^ Message
         /// ```
-        message: Option<Box<Expression>>,
+        message: Option<Expression>,
     },
 }
 
@@ -2878,7 +2878,7 @@ pub enum Statement<TypeT, ExpressionT> {
     /// A bare expression that is not assigned to any variable.
     Expression(ExpressionT),
     /// Assigning an expression to variables using a pattern.
-    Assignment(Assignment<TypeT, ExpressionT>),
+    Assignment(Box<Assignment<TypeT, ExpressionT>>),
     /// A `use` expression.
     Use(Use<TypeT, ExpressionT>),
     /// A bool assertion.
@@ -3133,7 +3133,7 @@ impl TypedStatement {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Assignment<TypeT, ExpressionT> {
     pub location: SrcSpan,
-    pub value: Box<ExpressionT>,
+    pub value: ExpressionT,
     pub pattern: Pattern<TypeT>,
     pub kind: AssignmentKind<ExpressionT>,
     pub compiled_case: CompiledCase,

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -164,7 +164,7 @@ pub enum TypedExpr {
     RecordUpdate {
         location: SrcSpan,
         type_: Arc<Type>,
-        record: TypedAssignment,
+        record: Box<TypedAssignment>,
         constructor: Box<Self>,
         args: Vec<CallArg<Self>>,
     },

--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -154,7 +154,7 @@ where
         Error::Parse {
             path: path.clone(),
             src: code.clone(),
-            error,
+            error: Box::new(error),
         }
     })?;
     let mut ast = parsed.module;

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -560,7 +560,7 @@ fn analyse(
 
             Outcome::PartialFailure(ast, errors) => {
                 let error = Error::Type {
-                    names: ast.names.clone(),
+                    names: Box::new(ast.names.clone()),
                     path: path.clone(),
                     src: code.clone(),
                     errors,

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2246,7 +2246,7 @@ fn assignment<'a>(
             &assignment.value,
             &assignment.pattern,
             env,
-            message.as_deref(),
+            message.as_ref(),
             position,
         ),
     }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -64,7 +64,7 @@ pub enum Error {
     Parse {
         path: Utf8PathBuf,
         src: EcoString,
-        error: crate::parse::error::ParseError,
+        error: Box<crate::parse::error::ParseError>,
     },
 
     #[error("type checking failed")]
@@ -72,7 +72,7 @@ pub enum Error {
         path: Utf8PathBuf,
         src: EcoString,
         errors: Vec1<crate::type_::Error>,
-        names: Names,
+        names: Box<Names>,
     },
 
     #[error("unknown import {import}")]

--- a/compiler-core/src/fix.rs
+++ b/compiler-core/src/fix.rs
@@ -12,7 +12,7 @@ pub fn parse_fix_and_format(src: &EcoString, path: &Utf8Path) -> Result<String> 
         .map_err(|error| Error::Parse {
             path: path.to_path_buf(),
             src: src.clone(),
-            error,
+            error: Box::new(error),
         })?;
     let intermediate = Intermediate::from_extra(&parsed.extra, src);
     let module = parsed.module;

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -30,7 +30,7 @@ pub fn pretty(writer: &mut impl Utf8Writer, src: &EcoString, path: &Utf8Path) ->
         .map_err(|error| Error::Parse {
             path: path.to_path_buf(),
             src: src.clone(),
-            error,
+            error: Box::new(error),
         })?;
     let intermediate = Intermediate::from_extra(&parsed.extra, src);
     Formatter::with_comments(&intermediate)

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -772,7 +772,7 @@ impl<'module, 'a> Generator<'module, 'a> {
 
                 Statement::Assignment(assignment) => match &assignment.kind {
                     AssignmentKind::Let | AssignmentKind::Generated => {
-                        return self.child_expression(assignment.value.as_ref());
+                        return self.child_expression(&assignment.value);
                     }
                     // We can't just return the right-hand side of a `let assert`
                     // assignment; we still need to check that the pattern matches.

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -504,14 +504,20 @@ pub fn code_action_inexhaustive_let_to_case(
             return;
         }
 
-        let Some(Located::Statement(TypedStatement::Assignment(TypedAssignment {
+        let Some(Located::Statement(TypedStatement::Assignment(assignment))) =
+            module.find_node(location.start)
+        else {
+            continue;
+        };
+
+        let TypedAssignment {
             value,
             pattern,
             kind: AssignmentKind::Let,
             location,
             compiled_case: _,
             annotation: _,
-        }))) = module.find_node(location.start)
+        } = assignment.as_ref()
         else {
             continue;
         };
@@ -6814,7 +6820,7 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInBlock<'ast> {
         ) {
             return;
         }
-        match assignment.value.as_ref() {
+        match &assignment.value {
             // To avoid wrapping the same expression in multiple, nested blocks.
             TypedExpr::Block { .. } => {}
             TypedExpr::RecordAccess { .. }

--- a/compiler-core/src/language_server/feedback.rs
+++ b/compiler-core/src/language_server/feedback.rs
@@ -276,10 +276,10 @@ mod tests {
         let error = Error::Parse {
             path: file3.clone(),
             src: "blah".into(),
-            error: ParseError {
+            error: Box::new(ParseError {
                 error: ParseErrorType::ConcatPatternVariableLeftHandSide,
                 location: SrcSpan::new(1, 4),
-            },
+            }),
         };
 
         let feedback = book_keeper.build_with_error(
@@ -336,10 +336,10 @@ mod tests {
         let error = Error::Parse {
             path: file1.clone(),
             src: "blah".into(),
-            error: ParseError {
+            error: Box::new(ParseError {
                 error: ParseErrorType::ConcatPatternVariableLeftHandSide,
                 location: SrcSpan::new(1, 4),
-            },
+            }),
         };
 
         let feedback =
@@ -377,10 +377,10 @@ mod tests {
         let error = |file: &camino::Utf8Path| Error::Parse {
             path: file.to_path_buf(),
             src: "blah".into(),
-            error: ParseError {
+            error: Box::new(ParseError {
                 error: ParseErrorType::ConcatPatternVariableLeftHandSide,
                 location: SrcSpan::new(1, 4),
-            },
+            }),
         };
 
         let feedback =
@@ -420,10 +420,10 @@ mod tests {
         let error = Error::Parse {
             path: file1.clone(),
             src: "blah".into(),
-            error: ParseError {
+            error: Box::new(ParseError {
                 error: ParseErrorType::ConcatPatternVariableLeftHandSide,
                 location: SrcSpan::new(1, 4),
-            },
+            }),
         };
 
         let feedback =

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1055,19 +1055,19 @@ where
                     let message_expression =
                         self.expect_expression_unit(ExpressionUnitContext::Other)?;
                     end = message_expression.location().end;
-                    *message = Some(Box::new(message_expression));
+                    *message = Some(message_expression);
                 }
             }
         }
 
-        Ok(Statement::Assignment(Assignment {
+        Ok(Statement::Assignment(Box::new(Assignment {
             location: SrcSpan { start, end },
-            value: Box::new(value),
+            value,
             compiled_case: CompiledCase::failure(),
             pattern,
             annotation,
             kind,
-        }))
+        })))
     }
 
     // An assert statement, with `Assert` already consumed
@@ -3442,7 +3442,7 @@ functions are declared separately from types.";
                         }
                     };
                     let field_type = match self.parse_type_annotation(&Token::Colon) {
-                        Ok(Some(annotation)) => Some(annotation),
+                        Ok(Some(annotation)) => Some(Box::new(annotation)),
                         _ => None,
                     };
                     parse_error(

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -403,7 +403,7 @@ pub enum ParseErrorType {
         public: bool,
         opaque: bool,
         field: EcoString,
-        field_type: Option<TypeAst>,
+        field_type: Option<Box<TypeAst>>,
     },
     CallInClauseGuard, // case x { _ if f() -> 1 }
     IfExpression,

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -57,7 +57,7 @@ pub fn expect_module_error(src: &str) -> String {
     let error = crate::error::Error::Parse {
         src: src.into(),
         path: Utf8PathBuf::from("/src/parse/error.gleam"),
-        error: result,
+        error: Box::new(result),
     };
     error.pretty_string()
 }
@@ -67,7 +67,7 @@ pub fn expect_error(src: &str) -> String {
     let error = crate::error::Error::Parse {
         src: src.into(),
         path: Utf8PathBuf::from("/src/parse/error.gleam"),
-        error: result,
+        error: Box::new(result),
     };
     error.pretty_string()
 }

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -146,7 +146,7 @@ macro_rules! assert_error {
         let (error, names) = $crate::type_::tests::compile_statement_sequence($src)
             .expect_err("should infer an error");
         let error = $crate::error::Error::Type {
-            names,
+            names: Box::new(names),
             src: $src.into(),
             path: camino::Utf8PathBuf::from("/src/one/two.gleam"),
             errors: error,
@@ -547,7 +547,7 @@ pub fn module_error_with_target(
     )
     .expect_err("should infer an error");
     let error = Error::Type {
-        names,
+        names: Box::new(names),
         src: src.into(),
         path: Utf8PathBuf::from("/src/one/two.gleam"),
         errors: Vec1::try_from_vec(error).expect("should have at least one error"),
@@ -575,7 +575,7 @@ pub fn internal_module_error_with_target(
     )
     .expect_err("should infer an error");
     let error = Error::Type {
-        names,
+        names: Box::new(names),
         src: src.into(),
         path: Utf8PathBuf::from("/src/one/two.gleam"),
         errors: Vec1::try_from_vec(error).expect("should have at least one error"),
@@ -590,7 +590,7 @@ pub fn syntax_error(src: &str) -> String {
     let error = Error::Parse {
         src: src.into(),
         path: Utf8PathBuf::from("/src/one/two.gleam"),
-        error,
+        error: Box::new(error),
     };
     error.pretty_string()
 }


### PR DESCRIPTION
This PR updates the codebase to Rust 1.87 by fixing clippy warnings on the latest version.
Most of these warnings concerned the sizes of various types, and so I've done the most basic solution which is to `Box` the big stuff.
There might be a better solution to some of these cases, so please have a look.