### PR TITLE
Made compiler show a hint to import unqualified types/values

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -937,7 +937,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             )
             .collect();
         let typed_parameters = environment
-            .get_type_constructor(&None, &name)
+            .get_type_constructor(&None, &name, Some(parameters.len()))
             .expect("Could not find preregistered type constructor")
             .parameters
             .clone();
@@ -1601,7 +1601,7 @@ fn analyse_type_alias(t: UntypedTypeAlias, environment: &mut Environment<'_>) ->
     // analysis aims to be fault tolerant to get the best possible feedback for
     // the programmer in the language server, so the analyser gets here even
     // though there was previously errors.
-    let type_ = match environment.get_type_constructor(&None, &alias) {
+    let type_ = match environment.get_type_constructor(&None, &alias, Some(args.len())) {
         Ok(constructor) => constructor.type_.clone(),
         Err(_) => environment.new_generic_var(),
     };

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -815,7 +815,7 @@ impl Variable {
                 ..
             } => {
                 let constructors = ConstructorSpecialiser::specialise_constructors(
-                    env.get_constructors_for_type(module, name)
+                    env.get_constructors_for_type(module, name, Some(args.len()))
                         .expect("Custom type variants must exist"),
                     args.as_slice(),
                 );

--- a/compiler-core/src/exhaustiveness/missing_patterns.rs
+++ b/compiler-core/src/exhaustiveness/missing_patterns.rs
@@ -181,7 +181,7 @@ impl<'a, 'env> MissingPatternsGenerator<'a, 'env> {
 
                 let name = self
                     .environment
-                    .get_constructors_for_type(&module, &name)
+                    .get_constructors_for_type(&module, &name, Some(fields.len()))
                     .expect("Custom type constructor must have custom type kind")
                     .variants
                     .get(*index)

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -2,7 +2,7 @@ use pubgrub::range::Range;
 
 use crate::{
     analyse::TargetSupport,
-    ast::{PIPE_VARIABLE, Publicity},
+    ast::{Layer, Publicity, PIPE_VARIABLE},
     build::Target,
     error::edit_distance,
     reference::{EntityKind, ReferenceTracker},
@@ -374,6 +374,7 @@ impl Environment<'_> {
         &mut self,
         module: &Option<(EcoString, SrcSpan)>,
         name: &EcoString,
+        arity: Option<usize>,
     ) -> Result<&TypeConstructor, UnknownTypeConstructorError> {
         match module {
             None => self
@@ -382,6 +383,7 @@ impl Environment<'_> {
                 .ok_or_else(|| UnknownTypeConstructorError::Type {
                     name: name.clone(),
                     hint: self.unknown_type_hint(name),
+                    suggestions: self.suggest_unqualified_modules(name, Layer::Type, arity)
                 }),
 
             Some((module_name, _)) => {
@@ -419,6 +421,7 @@ impl Environment<'_> {
         &self,
         module: &EcoString,
         name: &EcoString,
+        arity: Option<usize>,
     ) -> Result<&TypeVariantConstructors, UnknownTypeConstructorError> {
         let module = if module.is_empty() || *module == self.current_module {
             None
@@ -430,6 +433,7 @@ impl Environment<'_> {
                 UnknownTypeConstructorError::Type {
                     name: name.clone(),
                     hint: self.unknown_type_hint(name),
+                    suggestions: self.suggest_unqualified_modules(name, Layer::Type, arity)
                 }
             }),
 
@@ -458,6 +462,7 @@ impl Environment<'_> {
         &mut self,
         module: Option<&EcoString>,
         name: &EcoString,
+        arity: Option<usize>,
     ) -> Result<&ValueConstructor, UnknownValueConstructorError> {
         match module {
             None => self.scope.get(name).ok_or_else(|| {
@@ -466,6 +471,7 @@ impl Environment<'_> {
                     name: name.clone(),
                     variables: self.local_value_names(),
                     type_with_name_in_scope,
+                    suggestions: self.suggest_unqualified_modules(name, Layer::Value, arity)
                 }
             }),
 
@@ -495,8 +501,9 @@ impl Environment<'_> {
         &self,
         module: &EcoString,
         name: &EcoString,
+        arity: Option<usize>,
     ) -> Vec<&EcoString> {
-        self.get_constructors_for_type(module, name)
+        self.get_constructors_for_type(module, name, arity)
             .iter()
             .flat_map(|c| &c.variants)
             .filter_map(|variant| {
@@ -748,6 +755,137 @@ impl Environment<'_> {
             .filter(|&t| PIPE_VARIABLE != t)
             .cloned()
             .collect()
+    }
+
+        /// Suggest modules to import or use unqualified
+    pub fn suggest_unqualified_modules(
+        &self,
+        name: &EcoString,
+        layer: Layer,
+        arity: Option<usize>,
+    ) -> Vec<ModuleSuggestion> {
+        // Don't suggest unqualified imports for values which aren't record constructors.
+        if layer.is_value() && name.chars().next().is_none_or(|c| c.is_lowercase()) {
+            return vec![];
+        }
+
+        let suggestions = match layer {
+            Layer::Type => self.suggest_modules_for_type(name, arity),
+            Layer::Value => self.suggest_modules_for_value(name, arity),
+        };
+
+        // Sort options based on if its already imported and on lexicographical order.
+        suggestions.into_iter().sorted().collect()
+    }
+
+    fn suggest_modules_for_type(
+        &self,
+        name: &EcoString,
+        arity: Option<usize>,
+    ) -> Vec<ModuleSuggestion> {
+        let mut imported_modules = HashSet::new();
+
+        let mut suggestions = self
+            .imported_modules
+            .iter()
+            .filter_map(|(_, (_, module_info))| {
+                let Some(type_) = module_info.get_public_type(name) else {
+                    return None;
+                };
+                // If we couldn't find the arity of the type, consider all modules.
+                let Some(arity) = arity else {
+                    // Should be impossible to exist already
+                    let _ = imported_modules.insert(module_info.name.clone());
+                    return Some(ModuleSuggestion::Imported(module_info.name.clone()));
+                };
+                // Make sure the arities match.
+                if type_.parameters.len() == arity {
+                    // Should be impossible to exist already
+                    let _ = imported_modules.insert(module_info.name.clone());
+                    Some(ModuleSuggestion::Imported(module_info.name.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+
+        suggestions.extend(self.importable_modules.iter().filter_map(
+            |(importable, module_info)| {
+                if imported_modules.contains(importable) {
+                    return None;
+                }
+                let Some(type_) = module_info.get_public_type(name) else {
+                    return None;
+                };
+                // If we couldn't find the arity of the type, consider all modules.
+                let Some(arity) = arity else {
+                    return Some(ModuleSuggestion::Importable(importable.clone()));
+                };
+                // Make sure the arities match.
+                if type_.parameters.len() == arity {
+                    Some(ModuleSuggestion::Importable(importable.clone()))
+                } else {
+                    None
+                }
+            },
+        ));
+
+        suggestions
+    }
+
+    fn suggest_modules_for_value(
+        &self,
+        name: &EcoString,
+        arity: Option<usize>,
+    ) -> Vec<ModuleSuggestion> {
+        let mut imported_modules = HashSet::new();
+
+        let mut suggestions = self
+            .imported_modules
+            .iter()
+            .filter_map(|(_, (_, module_info))| {
+                let Some(value) = module_info.get_public_value(name) else {
+                    return None;
+                };
+                // If we couldn't find the arity of the value, consider all modules.
+                if arity == None {
+                    // Should be impossible to exist already
+                    let _ = imported_modules.insert(module_info.name.clone());
+                    return Some(ModuleSuggestion::Imported(module_info.name.clone()));
+                }
+                // Make sure the arities match.
+                if value.type_.fn_arity() == arity {
+                    // Should be impossible to exist already
+                    let _ = imported_modules.insert(module_info.name.clone());
+                    Some(ModuleSuggestion::Imported(module_info.name.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+
+        suggestions.extend(self.importable_modules.iter().filter_map(
+            |(importable, module_info)| {
+                if imported_modules.contains(importable) {
+                    return None;
+                }
+                let Some(value) = module_info.get_public_value(name) else {
+                    return None;
+                };
+                // If we couldn't find the arity of the value, consider all modules.
+                if arity == None {
+                    return Some(ModuleSuggestion::Importable(module_info.name.clone()));
+                }
+                // Make sure the arities match.
+                if value.type_.fn_arity() == arity {
+                    Some(ModuleSuggestion::Importable(module_info.name.clone()))
+                } else {
+                    None
+                }
+            },
+        ));
+
+        suggestions
     }
 
     /// Suggest modules to import or use, for an unknown module

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -119,7 +119,7 @@ pub enum ModuleSuggestion {
 }
 
 impl ModuleSuggestion {
-    pub fn suggestion(&self, module: &str) -> String {
+    pub fn suggest_import(&self, module: &str) -> String {
         match self {
             ModuleSuggestion::Importable(name) => {
                 // Add a little extra information if the names don't match
@@ -131,6 +131,23 @@ impl ModuleSuggestion {
                 }
             }
             ModuleSuggestion::Imported(name) => format!("Did you mean `{name}`?"),
+        }
+    }
+
+    pub fn suggest_unqualified_import(&self, name: &str, layer: Layer) -> String {
+        match self {
+            ModuleSuggestion::Importable(module) => match layer {
+                Layer::Type => {
+                    format!("Did you mean to import the `{name}` type from the `{module}` module?")
+                }
+                Layer::Value => {
+                    format!("Did you mean to import the `{name}` value from the `{module}` module?")
+                }
+            },
+
+            ModuleSuggestion::Imported(module) => {
+                format!("Did you mean to update the import of `{module}`?")
+            }
         }
     }
 
@@ -168,12 +185,14 @@ pub enum Error {
         name: EcoString,
         variables: Vec<EcoString>,
         type_with_name_in_scope: bool,
+        suggestions: Vec<ModuleSuggestion>,
     },
 
     UnknownType {
         location: SrcSpan,
         name: EcoString,
         hint: UnknownTypeHint,
+        suggestions: Vec<ModuleSuggestion>,
     },
 
     UnknownModule {
@@ -1225,6 +1244,7 @@ pub enum UnknownValueConstructorError {
         name: EcoString,
         variables: Vec<EcoString>,
         type_with_name_in_scope: bool,
+        suggestions: Vec<ModuleSuggestion>,
     },
 
     Module {
@@ -1250,11 +1270,13 @@ pub fn convert_get_value_constructor_error(
             name,
             variables,
             type_with_name_in_scope,
+            suggestions
         } => Error::UnknownVariable {
             location,
             name,
             variables,
             type_with_name_in_scope,
+            suggestions
         },
 
         UnknownValueConstructorError::Module { name, suggestions } => Error::UnknownModule {
@@ -1308,6 +1330,7 @@ pub enum UnknownTypeConstructorError {
     Type {
         name: EcoString,
         hint: UnknownTypeHint,
+        suggestions: Vec<ModuleSuggestion>,
     },
 
     Module {
@@ -1329,10 +1352,11 @@ pub fn convert_get_type_constructor_error(
     module_location: Option<SrcSpan>,
 ) -> Error {
     match e {
-        UnknownTypeConstructorError::Type { name, hint } => Error::UnknownType {
+        UnknownTypeConstructorError::Type { name, hint, suggestions } => Error::UnknownType {
             location: *location,
             name,
             hint,
+            suggestions
         },
 
         UnknownTypeConstructorError::Module { name, suggestions } => Error::UnknownModule {

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -133,7 +133,7 @@ impl Hydrator {
                     deprecation,
                     ..
                 } = environment
-                    .get_type_constructor(module, name)
+                    .get_type_constructor(module, name, Some(args.len()))
                     .map_err(|e| {
                         convert_get_type_constructor_error(
                             e,
@@ -273,6 +273,11 @@ impl Hydrator {
                             name: name.clone(),
                             location: *location,
                             hint,
+                            suggestions: environment.suggest_unqualified_modules(
+                                name,
+                                Layer::Type,
+                                None,
+                            ),
                         })
                     }
                 }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -621,6 +621,11 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                     .module_types
                                     .keys()
                                     .any(|type_| type_ == &name),
+                                suggestions: self.environment.suggest_unqualified_modules(
+                                    &name,
+                                    Layer::Value,
+                                    None,
+                                ),
                             });
                             return Pattern::Invalid { location, type_ };
                         }
@@ -863,7 +868,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
 
                 let constructor = self
                     .environment
-                    .get_value_constructor(module.as_ref().map(|(module, _)| module), &name);
+                    .get_value_constructor(module.as_ref().map(|(module, _)| module), &name, Some(pattern_args.len()));
 
                 let constructor = match constructor {
                     Ok(constructor) => constructor,

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3125,3 +3125,80 @@ fn bit_array_using_pattern_variables_from_other_bit_array() {
 fn non_utf8_string_assignment() {
     assert_error!(r#"let assert <<"Hello" as message:utf16>> = <<>>"#);
 }
+
+#[test]
+fn suggest_unqualified_import_for_type_without_existing_import() {
+    assert_module_error!(
+        (
+            "gleam/wibble",
+            "
+            pub type Wobble { Wobble }
+            "
+        ),
+        "
+        pub fn go(wob: Wobble) { 1 }
+        "
+    );
+}
+
+#[test]
+fn suggest_unqualified_import_for_type_with_existing_import() {
+    assert_module_error!(
+        (
+            "gleam/wibble",
+            "
+            pub type Wobble { Wobble }
+            "
+        ),
+        "
+        import gleam/wibble
+        pub fn go(wob: Wobble) { 1 }
+        "
+    );
+}
+
+#[test]
+fn suggest_unqualified_import_for_constructor_without_existing_import() {
+    assert_module_error!(
+        (
+            "gleam/wibble",
+            "
+            pub type Wobble { Wobble }
+            "
+        ),
+        "
+        pub fn go() { Wobble }
+        "
+    );
+}
+
+#[test]
+fn suggest_unqualified_import_for_constructor_with_existing_import() {
+    assert_module_error!(
+        (
+            "gleam/wibble",
+            "
+            pub type Wobble { Wobble }
+            "
+        ),
+        "
+        import gleam/wibble
+        pub fn go() { Wobble }
+        "
+    );
+}
+
+#[test]
+fn dont_suggest_unqualified_import_for_value() {
+    assert_module_error!(
+        (
+            "gleam/wibble",
+            "
+            pub fn wobble() { 1 }
+            "
+        ),
+        "
+        pub fn go() { wobble() }
+        "
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__dont_suggest_unqualified_import_for_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__dont_suggest_unqualified_import_for_value.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n        pub fn go() { wobble() }\n        "
+---
+----- SOURCE CODE
+-- gleam/wibble.gleam
+
+            pub fn wobble() { 1 }
+            
+
+-- main.gleam
+
+        pub fn go() { wobble() }
+        
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:2:23
+  │
+2 │         pub fn go() { wobble() }
+  │                       ^^^^^^
+
+The name `wobble` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_constructor_with_existing_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_constructor_with_existing_import.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n        import gleam/wibble\n        pub fn go() { Wobble }\n        "
+---
+----- SOURCE CODE
+-- gleam/wibble.gleam
+
+            pub type Wobble { Wobble }
+            
+
+-- main.gleam
+
+        import gleam/wibble
+        pub fn go() { Wobble }
+        
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:23
+  │
+3 │         pub fn go() { Wobble }
+  │                       ^^^^^^
+
+The custom type variant constructor `Wobble` is not in scope here.
+Hint: Did you mean to update the import of `gleam/wibble`?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_constructor_without_existing_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_constructor_without_existing_import.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n        pub fn go() { Wobble }\n        "
+---
+----- SOURCE CODE
+-- gleam/wibble.gleam
+
+            pub type Wobble { Wobble }
+            
+
+-- main.gleam
+
+        pub fn go() { Wobble }
+        
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:2:23
+  │
+2 │         pub fn go() { Wobble }
+  │                       ^^^^^^
+
+The custom type variant constructor `Wobble` is not in scope here.
+Hint: Did you mean to import the `Wobble` value from the `gleam/wibble` module?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_type_with_existing_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_type_with_existing_import.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n        import gleam/wibble\n        pub fn go(wob: Wobble) { 1 }\n        "
+---
+----- SOURCE CODE
+-- gleam/wibble.gleam
+
+            pub type Wobble { Wobble }
+            
+
+-- main.gleam
+
+        import gleam/wibble
+        pub fn go(wob: Wobble) { 1 }
+        
+
+----- ERROR
+error: Unknown type
+  ┌─ /src/one/two.gleam:3:24
+  │
+3 │         pub fn go(wob: Wobble) { 1 }
+  │                        ^^^^^^
+
+The type `Wobble` is not defined or imported in this module.
+Hint: Did you mean to update the import of `gleam/wibble`?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_type_without_existing_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__suggest_unqualified_import_for_type_without_existing_import.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n        pub fn go(wob: Wobble) { 1 }\n        "
+---
+----- SOURCE CODE
+-- gleam/wibble.gleam
+
+            pub type Wobble { Wobble }
+            
+
+-- main.gleam
+
+        pub fn go(wob: Wobble) { 1 }
+        
+
+----- ERROR
+error: Unknown type
+  ┌─ /src/one/two.gleam:2:24
+  │
+2 │         pub fn go(wob: Wobble) { 1 }
+  │                        ^^^^^^
+
+The type `Wobble` is not defined or imported in this module.
+Hint: Did you mean to import the `Wobble` type from the `gleam/wibble` module?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__imported_constructor_instead_of_type.snap.new
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__imported_constructor_instead_of_type.snap.new
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/imports.rs
+assertion_line: 283
+expression: "import module.{Wibble}\n\npub fn main(x: Wibble) {\n  todo\n}"
+snapshot_kind: text
+---
+----- SOURCE CODE
+-- module.gleam
+pub type Wibble { Wibble }
+
+-- main.gleam
+import module.{Wibble}
+
+pub fn main(x: Wibble) {
+  todo
+}
+
+----- ERROR
+error: Unknown type
+  ┌─ /src/one/two.gleam:3:16
+  │
+3 │ pub fn main(x: Wibble) {
+  │                ^^^^^^
+
+The type `Wibble` is not defined or imported in this module.
+There is a value in scope with the name `Wibble`, but no type in scope with
+that name.
+Hint: Did you mean to update the import of `module`?


### PR DESCRIPTION
Continues #4304 and closes #4297.

The hint also considers the type/value's arity, and decides which module to hint is by preferring imported modules over importable ones, and sorting by name length. Also, I'd say the current ideas can be adapted to the `environment::suggest_modules` function so that it, too, considers arity.