### PR TITLE
Remove entire echo statement when followed by a literal expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+### Language server
+
+- When using the "remove `echo`" code action, the language server will also
+  remove any literal expression being printed by `echo` statements. For example
+
+  ```gleam
+  pub fn main() {
+    echo "Before"
+    do_complex_stuff()
+    echo "After"
+    do_something_else()
+  }
+  ```
+
+  Will become:
+
+  ```gleam
+  pub fn main() {
+    do_complex_stuff()
+    do_something_else()
+  }
+  ```
+
+  Making it easier to get rid of debug printing messages once they're no longer
+  needed.
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug fixes
 
 - Fixed a bug where type constructors with many fields would not be formatted
@@ -454,32 +482,6 @@
     used
   }
   ```
-
-  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
-
-- When using the "remove `echo`" code action, the language server will also
-  remove any literal expression being printed by `echo` statements. For example
-
-  ```gleam
-  pub fn main() {
-    echo "Before"
-    do_complex_stuff()
-    echo "After"
-    do_something_else()
-  }
-  ```
-
-  Will become:
-
-  ```gleam
-  pub fn main() {
-    do_complex_stuff()
-    do_something_else()
-  }
-  ```
-
-  Making it easier to get rid of debug printing messages once they're no longer
-  needed.
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,32 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- When using the "remove `echo`" code action, the language server will also
+  remove any literal expression being printed by `echo` statements. For example
+
+  ```gleam
+  pub fn main() {
+    echo "Before"
+    do_complex_stuff()
+    echo "After"
+    do_something_else()
+  }
+  ```
+
+  Will become:
+
+  ```gleam
+  pub fn main() {
+    do_complex_stuff()
+    do_something_else()
+  }
+  ```
+
+  Making it easier to get rid of debug printing messages once they're no longer
+  needed.
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 - Improved the formatting of `echo` when followed by long binary expressions.

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -605,6 +605,111 @@ fn remove_echo_removes_all_echos_1() {
 }
 
 #[test]
+fn remove_echo_removes_entire_echo_statement_used_with_literals() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        "pub fn main() {
+  echo 1
+  Nil
+}",
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
+fn remove_echo_removes_entire_echo_statement_used_with_a_var() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        "pub fn main() {
+  let a = 1
+  echo a
+  Nil
+}",
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
+fn remove_echo_removes_multiple_entire_echo_statement_used_with_literals() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        r#"pub fn main() {
+  echo 1
+  echo "wibble"
+  Nil
+}"#,
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
+fn remove_echo_removes_multiple_entire_echo_statement_used_with_literals_but_stops_at_comments() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        r#"pub fn main() {
+  echo 1
+
+  // Oh no I hope I'm not deleted by the code action!!
+  Nil
+}"#,
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
+fn remove_echo_removes_entire_echo_statement_used_with_literals_in_a_fn() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        "pub fn main() {
+  fn() {
+    echo 1
+    Nil
+  }
+}",
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
+fn remove_echo_removes_multiple_entire_echo_statement_used_with_literals_in_a_fn() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        r#"pub fn main() {
+  fn() {
+    echo 1
+    echo "wibble"
+    Nil
+  }
+}"#,
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
+fn remove_echo_removes_does_not_remove_entire_echo_statement_if_its_the_return() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        "pub fn main() {
+  echo 1
+}",
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
+fn remove_echo_removes_does_not_remove_entire_echo_statement_if_its_the_return_of_a_fn() {
+    assert_code_action!(
+        REMOVE_ALL_ECHOS_FROM_THIS_MODULE,
+        r#"pub fn main() {
+  fn() {
+    echo 1
+  }
+}"#,
+        find_position_of("echo").to_selection()
+    );
+}
+
+#[test]
 fn split_string() {
     assert_code_action!(
         INTERPOLATE_STRING,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_does_not_remove_entire_echo_statement_if_its_the_return.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_does_not_remove_entire_echo_statement_if_its_the_return.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  echo 1\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  echo 1
+  ↑     
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  1
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_does_not_remove_entire_echo_statement_if_its_the_return_of_a_fn.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_does_not_remove_entire_echo_statement_if_its_the_return_of_a_fn.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  fn() {\n    echo 1\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  fn() {
+    echo 1
+    ↑     
+  }
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  fn() {
+    1
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_entire_echo_statement_used_with_a_var.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_entire_echo_statement_used_with_a_var.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  let a = 1\n  echo a\n  Nil\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  let a = 1
+  echo a
+  ↑     
+  Nil
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  let a = 1
+  Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_entire_echo_statement_used_with_literals.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_entire_echo_statement_used_with_literals.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  echo 1\n  Nil\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  echo 1
+  ↑     
+  Nil
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_entire_echo_statement_used_with_literals_in_a_fn.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_entire_echo_statement_used_with_literals_in_a_fn.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  fn() {\n    echo 1\n    Nil\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  fn() {
+    echo 1
+    ↑     
+    Nil
+  }
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  fn() {
+    Nil
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_multiple_entire_echo_statement_used_with_literals.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_multiple_entire_echo_statement_used_with_literals.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  echo 1\n  echo \"wibble\"\n  Nil\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  echo 1
+  ↑     
+  echo "wibble"
+  Nil
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_multiple_entire_echo_statement_used_with_literals_but_stops_at_comments.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_multiple_entire_echo_statement_used_with_literals_but_stops_at_comments.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  echo 1\n\n  // Oh no I hope I'm not deleted by the code action!!\n  Nil\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  echo 1
+  ↑     
+
+  // Oh no I hope I'm not deleted by the code action!!
+  Nil
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  // Oh no I hope I'm not deleted by the code action!!
+  Nil
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_multiple_entire_echo_statement_used_with_literals_in_a_fn.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__remove_echo_removes_multiple_entire_echo_statement_used_with_literals_in_a_fn.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n  fn() {\n    echo 1\n    echo \"wibble\"\n    Nil\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn main() {
+  fn() {
+    echo 1
+    ↑     
+    echo "wibble"
+    Nil
+  }
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+  fn() {
+    Nil
+  }
+}

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -36,6 +36,10 @@ impl ModuleExtra {
     }
 
     pub(crate) fn has_comment_between(&self, start: u32, end: u32) -> bool {
+        self.first_comment_between(start, end).is_some()
+    }
+
+    pub(crate) fn first_comment_between(&self, start: u32, end: u32) -> Option<SrcSpan> {
         self.comments
             .binary_search_by(|comment| {
                 if comment.end < start {
@@ -46,7 +50,8 @@ impl ModuleExtra {
                     Ordering::Equal
                 }
             })
-            .is_ok()
+            .map(|index| self.comments.get(index).unwrap().clone())
+            .ok()
     }
 }
 


### PR DESCRIPTION
When using the `remove echos from this module` code action, instead of just removing `echo`, the LS is a bit smarter and if it's safe to do so (that is echo is used as a standalone statement, it's not the last one in a function, and is printing a literal value) it's also going to remove the literal value it was printing.