### PR TITLE
RC - Fix generated documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fixed a bug where type constructors with many fields would not be formatted
+  properly in the generated documentation.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.11.0-rc1 - 2025-05-15
 
 ### Compiler

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -286,7 +286,7 @@ impl Printer<'_> {
 
         let arguments = Self::wrap_arguments(arguments);
 
-        docvec![self.title(&constructor.name), arguments]
+        docvec![self.title(&constructor.name), arguments].group()
     }
 
     fn type_alias<'a>(

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__constructor_with_long_types_and_many_fields.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__constructor_with_long_types_and_many_fields.snap
@@ -1,0 +1,51 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- option.gleam
+pub type Option(a)
+
+-- main.gleam
+
+import option
+
+pub type Uri {
+    Uri(
+        scheme: option.Option(String),
+        userinfo: option.Option(String),
+        host: option.Option(String),
+        port: option.Option(Int),
+        path: String,
+        query: option.Option(String),
+        fragment: option.Option(String)
+    )
+}
+
+
+---- TYPES
+
+--- Uri
+<pre><code>pub type Uri {
+  Uri(
+    scheme: option.Option(String),
+    userinfo: option.Option(String),
+    host: option.Option(String),
+    port: option.Option(Int),
+    path: String,
+    query: option.Option(String),
+    fragment: option.Option(String),
+  )
+}</code></pre>
+
+-- CONSTRUCTORS
+
+<pre><code>Uri(
+  scheme: option.Option(String),
+  userinfo: option.Option(String),
+  host: option.Option(String),
+  port: option.Option(Int),
+  path: String,
+  query: option.Option(String),
+  fragment: option.Option(String),
+)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__constructor_with_long_types_and_many_fields_that_need_splitting.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__constructor_with_long_types_and_many_fields_that_need_splitting.snap
@@ -1,0 +1,47 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- option.gleam
+pub type Option(a)
+
+-- main.gleam
+
+import option
+
+pub type TypeWithAVeryLoooooooooooooooooooongName
+
+pub type Wibble {
+    Wibble(
+        wibble: #(TypeWithAVeryLoooooooooooooooooooongName, TypeWithAVeryLoooooooooooooooooooongName),
+        wobble: option.Option(String),
+    )
+}
+
+
+---- TYPES
+
+--- TypeWithAVeryLoooooooooooooooooooongName
+<pre><code>pub type TypeWithAVeryLoooooooooooooooooooongName</code></pre>
+
+--- Wibble
+<pre><code>pub type Wibble {
+  Wibble(
+    wibble: #(
+      TypeWithAVeryLoooooooooooooooooooongName,
+      TypeWithAVeryLoooooooooooooooooooongName,
+    ),
+    wobble: option.Option(String),
+  )
+}</code></pre>
+
+-- CONSTRUCTORS
+
+<pre><code>Wibble(
+  wibble: #(
+    TypeWithAVeryLoooooooooooooooooooongName,
+    TypeWithAVeryLoooooooooooooooooooongName,
+  ),
+  wobble: option.Option(String),
+)</code></pre>

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -1119,3 +1119,46 @@ pub type External =
         ONLY_LINKS
     );
 }
+
+#[test]
+fn constructor_with_long_types_and_many_fields() {
+    assert_documentation!(
+        ("option", "pub type Option(a)"),
+        "
+import option
+
+pub type Uri {
+    Uri(
+        scheme: option.Option(String),
+        userinfo: option.Option(String),
+        host: option.Option(String),
+        port: option.Option(Int),
+        path: String,
+        query: option.Option(String),
+        fragment: option.Option(String)
+    )
+}
+",
+        NONE
+    );
+}
+
+#[test]
+fn constructor_with_long_types_and_many_fields_that_need_splitting() {
+    assert_documentation!(
+        ("option", "pub type Option(a)"),
+        "
+import option
+
+pub type TypeWithAVeryLoooooooooooooooooooongName
+
+pub type Wibble {
+    Wibble(
+        wibble: #(TypeWithAVeryLoooooooooooooooooooongName, TypeWithAVeryLoooooooooooooooooooongName),
+        wobble: option.Option(String),
+    )
+}
+",
+        NONE
+    );
+}


### PR DESCRIPTION
In the RC type constructors are not properly formatted in the generated docs. This PR fixes it.

Before:
![image](https://github.com/user-attachments/assets/7b1eeaca-0b23-4c64-a694-827989d1fd96)

After:
![Screenshot 2025-05-18 alle 12 37 28](https://github.com/user-attachments/assets/1d52ffd5-30b5-4bf6-ad11-4c2d356e366a)
