### PR TITLE
Add jsdoc comments to generated javascript code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Build tool
+
+- Generated JavaScript functions, constants, and custom type constructors now
+  include any doc comment as a JSDoc comment, making it easier to use the
+  generated code and browse its documentation from JavaScript.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+## v1.11.0-rc1 - 2025-05-15
+
 ### Compiler
 
 - Generated JavaScript functions, constants, and custom type constructors now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Compiler
 
-- The generated JavaScript functions now include any doc comment as a JSDoc
-  comment, making it easier to use the generated code and browse its
+- Generated JavaScript functions and constants now include any doc comment as a
+  JSDoc comment, making it easier to use the generated code and browse its
   documentation from JavaScript.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Compiler
 
+- The generated JavaScript functions now include any doc comment as a JSDoc
+  comment, making it easier to use the generated code and browse its
+  documentation from JavaScript.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The code generated for a `case` expression on the JavaScript target is now
   reduced in size in many cases.
   ([Surya Rose](https://github.com/GearsDatapacks))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Compiler
 
-- Generated JavaScript functions and constants now include any doc comment as a
-  JSDoc comment, making it easier to use the generated code and browse its
-  documentation from JavaScript.
+- Generated JavaScript functions, constants, and custom type constructors now
+  include any doc comment as a JSDoc comment, making it easier to use the
+  generated code and browse its documentation from JavaScript.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 - The code generated for a `case` expression on the JavaScript target is now

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -377,6 +377,12 @@ impl<'a> Generator<'a> {
                 .to_doc()
         }
 
+        let doc = if let Some((_, documentation)) = &constructor.documentation {
+            jsdoc_comment(&documentation, publicity).append(line())
+        } else {
+            nil()
+        };
+
         let head = if publicity.is_private() || opaque {
             "class "
         } else {
@@ -417,7 +423,7 @@ impl<'a> Generator<'a> {
         ]
         .nest(INDENT);
 
-        docvec![head, class_body, line(), "}"]
+        docvec![doc, head, class_body, line(), "}"]
     }
 
     fn collect_definitions(&mut self) -> Vec<Output<'a>> {

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -378,7 +378,7 @@ impl<'a> Generator<'a> {
         }
 
         let doc = if let Some((_, documentation)) = &constructor.documentation {
-            jsdoc_comment(&documentation, publicity).append(line())
+            jsdoc_comment(documentation, publicity).append(line())
         } else {
             nil()
         };

--- a/compiler-core/src/javascript/tests/consts.rs
+++ b/compiler-core/src/javascript/tests/consts.rs
@@ -126,3 +126,13 @@ fn literal_nil_does_not_get_constant_annotation() {
 fn constructor_function_in_constant() {
     assert_js!("pub const a = Ok");
 }
+
+#[test]
+fn constants_get_their_own_jsdoc_comment() {
+    assert_js!(
+        "
+/// 11 is clearly the best number!
+pub const jaks_favourite_number = 11
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -672,3 +672,18 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn constructors_get_their_own_jsdoc() {
+    assert_js!(
+        r#"
+pub type Wibble {
+  /// Wibbling!!
+  Wibble(field: Int)
+
+  /// Wobbling!!
+  Wobble(field: Int)
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -585,15 +585,3 @@ pub fn main() { 1 }
 "
     );
 }
-
-#[test]
-fn private_function_gets_ignored_jsdoc() {
-    assert_js!(
-        "
-/// Hello! This is the documentation of the `main`
-/// function, which is private!
-///
-fn main() { 1 }
-"
-    );
-}

--- a/compiler-core/src/javascript/tests/functions.rs
+++ b/compiler-core/src/javascript/tests/functions.rs
@@ -560,3 +560,40 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn public_function_gets_jsdoc() {
+    assert_js!(
+        "
+/// Hello! This is the documentation of the `main`
+/// function.
+///
+pub fn main() { 1 }
+"
+    );
+}
+
+#[test]
+fn internal_function_gets_ignored_jsdoc() {
+    assert_js!(
+        "
+/// Hello! This is the documentation of the `main`
+/// function, which is internal!
+///
+@internal
+pub fn main() { 1 }
+"
+    );
+}
+
+#[test]
+fn private_function_gets_ignored_jsdoc() {
+    assert_js!(
+        "
+/// Hello! This is the documentation of the `main`
+/// function, which is private!
+///
+fn main() { 1 }
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constants_get_their_own_jsdoc_comment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constants_get_their_own_jsdoc_comment.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/javascript/tests/consts.rs
+expression: "\n/// 11 is clearly the best number!\npub const jaks_favourite_number = 11\n"
+---
+----- SOURCE CODE
+
+/// 11 is clearly the best number!
+pub const jaks_favourite_number = 11
+
+
+----- COMPILED JAVASCRIPT
+/**
+ * 11 is clearly the best number!
+ */
+export const jaks_favourite_number = 11;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__constructors_get_their_own_jsdoc.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__constructors_get_their_own_jsdoc.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Wibble {\n  /// Wibbling!!\n  Wibble(field: Int)\n\n  /// Wobbling!!\n  Wobble(field: Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  /// Wibbling!!
+  Wibble(field: Int)
+
+  /// Wobbling!!
+  Wobble(field: Int)
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+/**
+ * Wibbling!!
+ */
+export class Wibble extends $CustomType {
+  constructor(field) {
+    super();
+    this.field = field;
+  }
+}
+
+/**
+ * Wobbling!!
+ */
+export class Wobble extends $CustomType {
+  constructor(field) {
+    super();
+    this.field = field;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__internal_function_gets_ignored_jsdoc.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__internal_function_gets_ignored_jsdoc.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\n/// Hello! This is the documentation of the `main`\n/// function, which is internal!\n///\n@internal\npub fn main() { 1 }\n"
+---
+----- SOURCE CODE
+
+/// Hello! This is the documentation of the `main`
+/// function, which is internal!
+///
+@internal
+pub fn main() { 1 }
+
+
+----- COMPILED JAVASCRIPT
+/**
+ * Hello! This is the documentation of the `main`
+ * function, which is internal!
+ * 
+ * @ignore
+ */
+export function main() {
+  return 1;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__private_function_gets_ignored_jsdoc.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__private_function_gets_ignored_jsdoc.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\n/// Hello! This is the documentation of the `main`\n/// function, which is private!\n///\nfn main() { 1 }\n"
+---
+----- SOURCE CODE
+
+/// Hello! This is the documentation of the `main`
+/// function, which is private!
+///
+fn main() { 1 }
+
+
+----- COMPILED JAVASCRIPT
+/**
+ * Hello! This is the documentation of the `main`
+ * function, which is private!
+ * 
+ * @ignore
+ */
+function main() {
+  return 1;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__private_function_gets_ignored_jsdoc.snap.new
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__private_function_gets_ignored_jsdoc.snap.new
@@ -1,6 +1,8 @@
 ---
 source: compiler-core/src/javascript/tests/functions.rs
+assertion_line: 591
 expression: "\n/// Hello! This is the documentation of the `main`\n/// function, which is private!\n///\nfn main() { 1 }\n"
+snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -11,12 +13,4 @@ fn main() { 1 }
 
 
 ----- COMPILED JAVASCRIPT
-/**
- * Hello! This is the documentation of the `main`
- * function, which is private!
- * 
- * @ignore
- */
-function main() {
-  return 1;
-}
+export {}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__public_function_gets_jsdoc.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__public_function_gets_jsdoc.snap
@@ -14,7 +14,6 @@ pub fn main() { 1 }
 /**
  * Hello! This is the documentation of the `main`
  * function.
-
  */
 export function main() {
   return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__public_function_gets_jsdoc.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__public_function_gets_jsdoc.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/javascript/tests/functions.rs
+expression: "\n/// Hello! This is the documentation of the `main`\n/// function.\n///\npub fn main() { 1 }\n"
+---
+----- SOURCE CODE
+
+/// Hello! This is the documentation of the `main`
+/// function.
+///
+pub fn main() { 1 }
+
+
+----- COMPILED JAVASCRIPT
+/**
+ * Hello! This is the documentation of the `main`
+ * function.
+
+ */
+export function main() {
+  return 1;
+}


### PR DESCRIPTION
This PR fixes #4597 by adding jsdoc comments to generated functions, constants and constructors