### PR TITLE
Make `static_vcruntime` dependency windows-specific

### DIFF
--- a/gleam-bin/Cargo.toml
+++ b/gleam-bin/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "LICENCE"
 [dependencies]
 gleam-cli = { path = "../compiler-cli" }
 
-[build-dependencies]
+[target.'cfg(windows)'.build-dependencies]
 # For statically linking the VCRuntime on Windows when
 # using the MSVC toolchain
 static_vcruntime = "2"

--- a/gleam-bin/build.rs
+++ b/gleam-bin/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    #[cfg(windows)]
     static_vcruntime::metabuild();
 }


### PR DESCRIPTION
The `static_vcruntime` package is only for windows, so this PR makes it a conditional dependency, meaning it is not even downloaded when building on non-windows targets.