### PR TITLE
Allow zero-length bit array segments on JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
   JavaScript target.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where a zero-length segment of a bit array would never match
+  in a case expression on the JavaScript target.
+  ([Sakari Bergen](https://github.com/sbergen))
+
 ## v1.11.0-rc1 - 2025-05-15
 
 ### Compiler

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -1061,11 +1061,11 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                     }
                 }
 
-                BitArrayTest::VariableIsPositive { variable } => {
+                BitArrayTest::VariableIsNotNegative { variable } => {
                     if negation.is_negated() {
-                        docvec![self.local_var(variable.name()), " <= 0"]
+                        docvec![self.local_var(variable.name()), " < 0"]
                     } else {
-                        docvec![self.local_var(variable.name()), " > 0"]
+                        docvec![self.local_var(variable.name()), " >= 0"]
                     }
                 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_dynamic_size_float_pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_dynamic_size_float_pattern_with_unit.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 function go(x) {
   let size = 3;
-  if (size > 0) {
+  if (size >= 0) {
     if (x.bitSize === size * 2) {
       if (bitArraySliceToFloat(x, 0, size * 2, true) === 1.3) {
         return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_dynamic_size_pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_dynamic_size_pattern_with_unit.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToInt } from "../gleam.mjs";
 
 function go(x) {
   let size = 3;
-  if (size > 0) {
+  if (size >= 0) {
     if (x.bitSize === size * 2) {
       if (bitArraySliceToInt(x, 0, size * 2, true, false) === 1) {
         return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_bits_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_bits_size.snap
@@ -18,7 +18,7 @@ import { bitArraySlice } from "../gleam.mjs";
 
 function go(x) {
   let n = 16;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize === n) {
       let a = bitArraySlice(x, 0, n);
       return a;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_bytes_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_bytes_size.snap
@@ -18,7 +18,7 @@ import { bitArraySlice } from "../gleam.mjs";
 
 function go(x) {
   let n = 3;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize === n * 8) {
       let a = bitArraySlice(x, 0, n * 8);
       return a;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToInt } from "../gleam.mjs";
 
 function go(x) {
   let n = 16;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize === n) {
       let a = bitArraySliceToInt(x, 0, n, true, false);
       return a;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size_literal_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size_literal_value.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToInt } from "../gleam.mjs";
 
 function go(x) {
   let n = 8;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize >= n) {
       if (x.bitSize === 8 + n) {
         if (bitArraySliceToInt(x, n, n + 8, true, false) === 21) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size_shadowed_variable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size_shadowed_variable.snap
@@ -20,7 +20,7 @@ import { bitArraySliceToInt } from "../gleam.mjs";
 function go(x) {
   let n = 16;
   let n$1 = 5;
-  if (n$1 > 0) {
+  if (n$1 >= 0) {
     if (x.bitSize === n$1) {
       let a = bitArraySliceToInt(x, 0, n$1, true, false);
       return a;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size_with_other_segments.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_dynamic_size_with_other_segments.snap
@@ -21,9 +21,9 @@ function go(x) {
   let n = 16;
   let m = 32;
   if (x.bitSize >= 8) {
-    if (n > 0) {
+    if (n >= 0) {
       if (x.bitSize >= 8 + n) {
-        if (m > 0) {
+        if (m >= 0) {
           if (x.bitSize >= 8 + m + n) {
             let first = x.byteAt(0);
             let a = bitArraySliceToInt(x, 8, 8 + n, true, false);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_literal_unaligned_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_literal_unaligned_float.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 function go(x) {
   let n = 1;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize >= n) {
       if (x.bitSize >= 64 + n) {
         if (bitArraySliceToFloat(x, n, n + 64, true) === 1.1) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_with_remaining_bytes_after_variable_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_with_remaining_bytes_after_variable_size.snap
@@ -16,7 +16,7 @@ fn go(x) {
 ----- COMPILED JAVASCRIPT
 function go(x) {
   let n = 1;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize >= n) {
       if (x.bitSize >= 8 + n) {
         if ((x.bitSize - (8 + n)) % 8 === 0) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_with_remaining_bytes_after_variable_size_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_with_remaining_bytes_after_variable_size_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToInt } from "../gleam.mjs";
 
 function go(x) {
   let n = 1;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize >= n) {
       let m = bitArraySliceToInt(x, 0, n, true, false);
       if (x.bitSize >= m + n) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
@@ -18,7 +18,7 @@ const FILEPATH = "src/module.gleam";
 function go(x) {
   let size = 3;
   if (
-    size <= 0 ||
+    size < 0 ||
     x.bitSize !== size * 2 ||
     bitArraySliceToInt(x, 0, size * 2, true, false) !== 1
   ) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bits_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bits_size.snap
@@ -17,7 +17,7 @@ const FILEPATH = "src/module.gleam";
 
 function go(x) {
   let n = 16;
-  if (n <= 0 || x.bitSize !== n) {
+  if (n < 0 || x.bitSize !== n) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bytes_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bytes_size.snap
@@ -17,7 +17,7 @@ const FILEPATH = "src/module.gleam";
 
 function go(x) {
   let n = 3;
-  if (n <= 0 || x.bitSize !== n * 8) {
+  if (n < 0 || x.bitSize !== n * 8) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size.snap
@@ -17,7 +17,7 @@ const FILEPATH = "src/module.gleam";
 
 function go(x) {
   let n = 16;
-  if (n <= 0 || x.bitSize !== n) {
+  if (n < 0 || x.bitSize !== n) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_literal_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_literal_value.snap
@@ -18,7 +18,7 @@ const FILEPATH = "src/module.gleam";
 function go(x) {
   let n = 8;
   if (
-    n <= 0 ||
+    n < 0 ||
     x.bitSize !== 8 + n ||
     bitArraySliceToInt(x, n, n + 8, true, false) !== 21
   ) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_shadowed_variable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_shadowed_variable.snap
@@ -19,7 +19,7 @@ const FILEPATH = "src/module.gleam";
 function go(x) {
   let n = 16;
   let n$1 = 5;
-  if (n$1 <= 0 || x.bitSize !== n$1) {
+  if (n$1 < 0 || x.bitSize !== n$1) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_with_other_segments.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_with_other_segments.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 966
 expression: "\nfn go(x) {\n  let n = 16\n  let m = 32\n  let assert <<first:size(8), a:size(n), b:size(m), rest:bits>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,7 @@ const FILEPATH = "src/module.gleam";
 function go(x) {
   let n = 16;
   let m = 32;
-  if (x.bitSize < 8 + m + n || n <= 0 || m <= 0) {
+  if (x.bitSize < 8 + m + n || n < 0 || m < 0) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_unaligned_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_unaligned_float.snap
@@ -18,7 +18,7 @@ const FILEPATH = "src/module.gleam";
 function go(x) {
   let n = 1;
   if (
-    n <= 0 ||
+    n < 0 ||
     x.bitSize < 64 + n ||
     bitArraySliceToFloat(x, n, n + 64, true) !== 1.1
   ) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size_pattern.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToInt } from "../gleam.mjs";
 
 function go(x) {
   let n = -10;
-  if (n > 0) {
+  if (n >= 0) {
     if (x.bitSize === n) {
       let int = bitArraySliceToInt(x, 0, n, true, false);
       return int;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size_pattern_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__negative_size_pattern_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToInt } from "../gleam.mjs";
 function go(x) {
   if (x.bitSize >= 8) {
     let n = bitArraySliceToInt(x, 0, 8, true, true);
-    if (n > 0) {
+    if (n >= 0) {
       if (x.bitSize === 8 + n) {
         let n$1 = n;
         let int = bitArraySliceToInt(x, 8, 8 + n$1, true, false);


### PR DESCRIPTION
We were checking for a positive number, when we should be checking for non-negative instead.

Resolves #4635