### PR TITLE
Fix `assert` warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   function is private.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would sometime warn that an assertion was
+  unnecessary because it only asserted literal values, when that was not the case.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.11.0-rc2 - 2025-05-29
 
 ### Compiler

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -664,12 +664,15 @@ impl TypedExpr {
 
     pub fn is_literal(&self) -> bool {
         match self {
-            Self::Int { .. }
-            | Self::List { .. }
-            | Self::Float { .. }
-            | Self::Tuple { .. }
-            | Self::String { .. }
-            | Self::BitArray { .. } => true,
+            Self::Int { .. } | Self::Float { .. } | Self::String { .. } => true,
+
+            Self::List { elements, .. } | Self::Tuple { elements, .. } => {
+                elements.iter().all(|value| value.is_literal())
+            }
+
+            Self::BitArray { segments, .. } => {
+                segments.iter().all(|segment| segment.value.is_literal())
+            }
 
             // Calls are literals if they are records and all the arguemnts are also literals.
             Self::Call { fun, args, .. } => {
@@ -693,23 +696,13 @@ impl TypedExpr {
 
     pub fn is_known_value(&self) -> bool {
         match self {
-            Self::Int { .. } | Self::Float { .. } | Self::String { .. } => true,
-
-            Self::List { elements, .. } | Self::Tuple { elements, .. } => {
-                elements.iter().all(|value| value.is_known_value())
-            }
-
-            Self::BitArray { segments, .. } => segments
-                .iter()
-                .all(|segment| segment.value.is_known_value()),
             TypedExpr::BinOp { left, right, .. } => left.is_known_value() && right.is_known_value(),
+
             TypedExpr::NegateBool { value, .. } | TypedExpr::NegateInt { value, .. } => {
                 value.is_known_value()
             }
-            TypedExpr::Call { fun, args, .. } if fun.is_record_builder() => {
-                args.iter().all(|argument| argument.value.is_known_value())
-            }
-            expr => expr.is_record_builder(),
+
+            _ => self.is_literal(),
         }
     }
 

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -3646,3 +3646,57 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn no_assert_warning_for_bit_array_with_variable() {
+    assert_no_warnings!(
+        r#"
+@external(erlang, "gleam@function", "identity")
+fn codepoint(value: Int) -> UtfCodepoint
+
+pub fn main() {
+  let codepoint = codepoint(32)
+  assert <<codepoint:utf8_codepoint>> == <<" ">>
+}
+"#
+    );
+}
+
+#[test]
+fn no_assert_warning_for_tuple_with_variable() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+  let x = 3
+  assert #(1, 2, x) == #(1, 2, 3)
+}
+"#
+    );
+}
+
+#[test]
+fn no_assert_warning_for_list_with_variable() {
+    assert_no_warnings!(
+        r#"
+pub fn main() {
+  let x = 3
+  assert [1, 2, x] == [1, 2, 3]
+}
+"#
+    );
+}
+#[test]
+fn no_assert_warning_for_constructor_with_variable() {
+    assert_no_warnings!(
+        r#"
+type Box(t) {
+  Box(t)
+}
+
+pub fn main() {
+  let x = 42
+  assert Box(x) == Box(42)
+}
+"#
+    );
+}


### PR DESCRIPTION
I noticed that the compiler was incorrectly warning for asserting the comparison of literal values, when the literal values contained variables. For example:
```gleam
assert <some_variable:utf8_codepoint> == <<"X">>
```
This PR fixes that.