### PR TITLE
Fix bugs with "Inline variable" code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
   for record fields in custom type definitions.
   ([cysabi](https://github.com/cysabi))
 
+- Fixed a bug where the "Inline variable" code action would be offered for
+  function parameters and other invalid cases.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the "Inline variable" code action would not be applied
+  correctly to variables using label shorthand syntax.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.11.1 - 2025-06-05
 
 ### Compiler

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -6,7 +6,7 @@ use crate::analyse::TargetSupport;
 use crate::build::{ExpressionPosition, Origin, Target};
 use crate::config::PackageConfig;
 use crate::line_numbers::LineNumbers;
-use crate::type_::error::VariableOrigin;
+use crate::type_::error::{VariableDeclarationKind, VariableOrigin};
 use crate::type_::expression::{FunctionDefinition, Purity};
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME, Problems};
 use crate::warning::WarningEmitter;
@@ -327,7 +327,10 @@ wibble}"#,
             publicity: Publicity::Private,
             variant: ValueConstructorVariant::LocalVariable {
                 location: SrcSpan { start: 5, end: 11 },
-                origin: VariableOrigin::Variable("wibble".into()),
+                origin: VariableOrigin::Variable {
+                    name: "wibble".into(),
+                    kind: VariableDeclarationKind::LetPattern,
+                },
             },
             type_: type_::int(),
         },

--- a/compiler-core/src/ast/tests.rs
+++ b/compiler-core/src/ast/tests.rs
@@ -6,7 +6,7 @@ use crate::analyse::TargetSupport;
 use crate::build::{ExpressionPosition, Origin, Target};
 use crate::config::PackageConfig;
 use crate::line_numbers::LineNumbers;
-use crate::type_::error::{VariableDeclarationKind, VariableOrigin};
+use crate::type_::error::{VariableDeclaration, VariableOrigin, VariableSyntax};
 use crate::type_::expression::{FunctionDefinition, Purity};
 use crate::type_::{Deprecation, PRELUDE_MODULE_NAME, Problems};
 use crate::warning::WarningEmitter;
@@ -327,9 +327,9 @@ wibble}"#,
             publicity: Publicity::Private,
             variant: ValueConstructorVariant::LocalVariable {
                 location: SrcSpan { start: 5, end: 11 },
-                origin: VariableOrigin::Variable {
-                    name: "wibble".into(),
-                    kind: VariableDeclarationKind::LetPattern,
+                origin: VariableOrigin {
+                    syntax: VariableSyntax::Variable("wibble".into()),
+                    declaration: VariableDeclaration::LetPattern,
                 },
             },
             type_: type_::int(),

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -19,7 +19,7 @@ use crate::{
     strings::to_snake_case,
     type_::{
         self, FieldMap, ModuleValueConstructor, Type, TypeVar, TypedCallArg, ValueConstructor,
-        error::{ModuleSuggestion, VariableDeclarationKind, VariableOrigin},
+        error::{ModuleSuggestion, VariableDeclaration, VariableOrigin},
         printer::{Names, Printer},
     },
 };
@@ -5968,19 +5968,14 @@ impl<'ast> ast::visit::Visit<'ast> for InlineVariable<'ast> {
             return;
         };
 
-        // We can only inline it if it comes from a regular variable pattern,
-        // not a complex pattern or generated assignment. We can also only inline
-        // variables assigned by `let` statements, as it doesn't make sense to do
-        // so with any other kind of variable.
-        match origin {
-            VariableOrigin::Variable {
-                kind: VariableDeclarationKind::LetPattern,
-                ..
-            } => {}
-            VariableOrigin::Variable { .. }
-            | VariableOrigin::LabelShorthand(_)
-            | VariableOrigin::AssignmentPattern
-            | VariableOrigin::Generated => return,
+        // We can only inline variables assigned by `let` statements, as it
+        //doesn't make sense to do so with any other kind of variable.
+        match origin.declaration {
+            VariableDeclaration::LetPattern => {}
+            VariableDeclaration::UsePattern
+            | VariableDeclaration::ClausePattern
+            | VariableDeclaration::FunctionParameter
+            | VariableDeclaration::Generated => return,
         }
 
         self.maybe_inline(*location);
@@ -5993,16 +5988,14 @@ impl<'ast> ast::visit::Visit<'ast> for InlineVariable<'ast> {
         _type: &'ast Arc<Type>,
         origin: &'ast VariableOrigin,
     ) {
-        // We can only inline it if it is a regular variable pattern
-        match origin {
-            VariableOrigin::Variable {
-                kind: VariableDeclarationKind::LetPattern,
-                ..
-            } => {}
-            VariableOrigin::Variable { .. }
-            | VariableOrigin::LabelShorthand(_)
-            | VariableOrigin::AssignmentPattern
-            | VariableOrigin::Generated => return,
+        // We can only inline variables assigned by `let` statements, as it
+        //doesn't make sense to do so with any other kind of variable.
+        match origin.declaration {
+            VariableDeclaration::LetPattern => {}
+            VariableDeclaration::UsePattern
+            | VariableDeclaration::ClausePattern
+            | VariableDeclaration::FunctionParameter
+            | VariableDeclaration::Generated => return,
         }
 
         let range = self.edits.src_span_to_lsp_range(*location);

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -35,7 +35,7 @@ use super::{
     edits::{add_newlines_after_import, get_import_edit, position_of_first_definition_if_import},
     engine::{overlaps, within},
     files::FileSystemProxy,
-    reference::find_variable_references,
+    reference::{VariableReferenceKind, find_variable_references},
     src_span_to_lsp_range, url_from_path,
 };
 
@@ -5883,11 +5883,10 @@ impl<'a> InlineVariable<'a> {
     }
 
     fn maybe_inline(&mut self, location: SrcSpan) {
-        let variable_location =
-            match find_variable_references(&self.module.ast, location).as_slice() {
-                [only_reference] => only_reference.location,
-                _ => return,
-            };
+        let reference = match find_variable_references(&self.module.ast, location).as_slice() {
+            [only_reference] => *only_reference,
+            _ => return,
+        };
 
         let Some(ast::Statement::Assignment(assignment)) =
             self.module.ast.find_statement(location.start)
@@ -5919,7 +5918,15 @@ impl<'a> InlineVariable<'a> {
             .get(value_location.start as usize..value_location.end as usize)
             .expect("Span is valid");
 
-        self.edits.replace(variable_location, value.into());
+        match reference.kind {
+            VariableReferenceKind::Variable => {
+                self.edits.replace(reference.location, value.into());
+            }
+            VariableReferenceKind::LabelShorthand => {
+                self.edits
+                    .insert(reference.location.end, format!(" {value}"));
+            }
+        }
 
         let mut location = assignment.location;
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -19,7 +19,7 @@ use crate::{
     type_::{
         self, Deprecation, ModuleInterface, Type, TypeConstructor, ValueConstructor,
         ValueConstructorVariant,
-        error::{Named, VariableOrigin},
+        error::{Named, VariableSyntax},
         printer::Printer,
     },
 };
@@ -637,12 +637,12 @@ where
             Ok(match reference_for_ast_node(found, &current_module.name) {
                 Some(Referenced::LocalVariable {
                     location, origin, ..
-                }) if location.contains(byte_index) => match origin {
-                    Some(VariableOrigin::Generated) => None,
+                }) if location.contains(byte_index) => match origin.map(|origin| origin.syntax) {
+                    Some(VariableSyntax::Generated) => None,
                     Some(
-                        VariableOrigin::Variable { .. }
-                        | VariableOrigin::AssignmentPattern
-                        | VariableOrigin::LabelShorthand(_),
+                        VariableSyntax::Variable { .. }
+                        | VariableSyntax::AssignmentPattern
+                        | VariableSyntax::LabelShorthand(_),
                     )
                     | None => success_response(location),
                 },
@@ -695,13 +695,13 @@ where
                     definition_location,
                     ..
                 }) => {
-                    let rename_kind = match origin {
-                        Some(VariableOrigin::Generated) => return Ok(None),
-                        Some(VariableOrigin::LabelShorthand(_)) => {
+                    let rename_kind = match origin.map(|origin| origin.syntax) {
+                        Some(VariableSyntax::Generated) => return Ok(None),
+                        Some(VariableSyntax::LabelShorthand(_)) => {
                             VariableReferenceKind::LabelShorthand
                         }
                         Some(
-                            VariableOrigin::AssignmentPattern | VariableOrigin::Variable { .. },
+                            VariableSyntax::AssignmentPattern | VariableSyntax::Variable { .. },
                         )
                         | None => VariableReferenceKind::Variable,
                     };
@@ -774,12 +774,12 @@ where
                     origin,
                     definition_location,
                     location,
-                }) if location.contains(byte_index) => match origin {
-                    Some(VariableOrigin::Generated) => None,
+                }) if location.contains(byte_index) => match origin.map(|origin| origin.syntax) {
+                    Some(VariableSyntax::Generated) => None,
                     Some(
-                        VariableOrigin::LabelShorthand(_)
-                        | VariableOrigin::AssignmentPattern
-                        | VariableOrigin::Variable { .. },
+                        VariableSyntax::LabelShorthand(_)
+                        | VariableSyntax::AssignmentPattern
+                        | VariableSyntax::Variable { .. },
                     )
                     | None => {
                         let variable_references =

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -640,7 +640,7 @@ where
                 }) if location.contains(byte_index) => match origin {
                     Some(VariableOrigin::Generated) => None,
                     Some(
-                        VariableOrigin::Variable(_)
+                        VariableOrigin::Variable { .. }
                         | VariableOrigin::AssignmentPattern
                         | VariableOrigin::LabelShorthand(_),
                     )
@@ -700,7 +700,9 @@ where
                         Some(VariableOrigin::LabelShorthand(_)) => {
                             VariableReferenceKind::LabelShorthand
                         }
-                        Some(VariableOrigin::AssignmentPattern | VariableOrigin::Variable(_))
+                        Some(
+                            VariableOrigin::AssignmentPattern | VariableOrigin::Variable { .. },
+                        )
                         | None => VariableReferenceKind::Variable,
                     };
                     rename_local_variable(module, &lines, &params, definition_location, rename_kind)
@@ -777,7 +779,7 @@ where
                     Some(
                         VariableOrigin::LabelShorthand(_)
                         | VariableOrigin::AssignmentPattern
-                        | VariableOrigin::Variable(_),
+                        | VariableOrigin::Variable { .. },
                     )
                     | None => {
                         let variable_references =

--- a/compiler-core/src/language_server/reference.rs
+++ b/compiler-core/src/language_server/reference.rs
@@ -329,11 +329,13 @@ fn find_references_in_module(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct VariableReference {
     pub location: SrcSpan,
     pub kind: VariableReferenceKind,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum VariableReferenceKind {
     Variable,
     LabelShorthand,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -8681,3 +8681,60 @@ pub fn main() {
         find_position_of("sum = ").to_selection()
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4660
+#[test]
+fn no_inline_variable_action_for_parameter() {
+    assert_no_code_actions!(
+        INLINE_VARIABLE,
+        "
+pub fn main() {
+  let x = fn(something) {
+    something
+  }
+
+  x
+}
+",
+        find_position_of("something")
+            .nth_occurrence(2)
+            .to_selection()
+    );
+}
+
+#[test]
+fn no_inline_variable_action_for_use_pattern() {
+    assert_no_code_actions!(
+        INLINE_VARIABLE,
+        "
+pub fn main() {
+  let x = {
+    use something <- todo
+    something
+  }
+
+  x
+}
+",
+        find_position_of("something").to_selection()
+    );
+}
+
+#[test]
+fn no_inline_variable_action_for_case_pattern() {
+    assert_no_code_actions!(
+        INLINE_VARIABLE,
+        "
+pub fn main() {
+  let x = case todo {
+    something -> something
+  }
+
+  x
+}
+",
+        find_position_of("something")
+            .nth_occurrence(2)
+            .to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -8661,3 +8661,23 @@ pub fn main() {
         find_position_of("add").to_selection()
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4660#issuecomment-2932371619
+#[test]
+fn inline_variable_label_shorthand() {
+    assert_code_action!(
+        INLINE_VARIABLE,
+        "
+pub type Example {
+  Example(sum: Int, nil: Nil)
+}
+
+pub fn main() {
+  let sum = 1 + 1
+
+  Example(Nil, sum:)
+}
+",
+        find_position_of("sum = ").to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__inline_variable_label_shorthand.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__inline_variable_label_shorthand.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type Example {\n  Example(sum: Int, nil: Nil)\n}\n\npub fn main() {\n  let sum = 1 + 1\n\n  Example(Nil, sum:)\n}\n"
+---
+----- BEFORE ACTION
+
+pub type Example {
+  Example(sum: Int, nil: Nil)
+}
+
+pub fn main() {
+  let sum = 1 + 1
+      ↑          
+
+  Example(Nil, sum:)
+}
+
+
+----- AFTER ACTION
+
+pub type Example {
+  Example(sum: Int, nil: Nil)
+}
+
+pub fn main() {
+  Example(Nil, sum: 1 + 1)
+}

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__arithmetic_in_guards.snap
@@ -42,9 +42,12 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                                 },
                                 name: "x",
                                 type_: (),
-                                origin: Variable(
-                                    "x",
-                                ),
+                                origin: VariableOrigin {
+                                    syntax: Variable(
+                                        "x",
+                                    ),
+                                    declaration: ClausePattern,
+                                },
                             },
                             Variable {
                                 location: SrcSpan {
@@ -53,9 +56,12 @@ expression: "\ncase 2, 3 {\n    x, y if x + y == 1 -> True\n}"
                                 },
                                 name: "y",
                                 type_: (),
-                                origin: Variable(
-                                    "y",
-                                ),
+                                origin: VariableOrigin {
+                                    syntax: Variable(
+                                        "y",
+                                    ),
+                                    declaration: ClausePattern,
+                                },
                             },
                         ],
                         alternative_patterns: [],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples.snap
@@ -56,9 +56,12 @@ expression: "\nlet tup = #(#(#(#(4))))\n{{{tup.0}.0}.0}.0\n"
                 },
                 name: "tup",
                 type_: (),
-                origin: Variable(
-                    "tup",
-                ),
+                origin: VariableOrigin {
+                    syntax: Variable(
+                        "tup",
+                    ),
+                    declaration: LetPattern,
+                },
             },
             kind: Let,
             compiled_case: CompiledCase {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deeply_nested_tuples_no_block.snap
@@ -56,9 +56,12 @@ expression: "\nlet tup = #(#(#(#(4))))\ntup.0.0.0.0\n"
                 },
                 name: "tup",
                 type_: (),
-                origin: Variable(
-                    "tup",
-                ),
+                origin: VariableOrigin {
+                    syntax: Variable(
+                        "tup",
+                    ),
+                    declaration: LetPattern,
+                },
             },
             kind: Let,
             compiled_case: CompiledCase {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__inner_single_quote_parses.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__inner_single_quote_parses.snap
@@ -23,9 +23,12 @@ expression: "\nlet a = \"inner 'quotes'\"\n"
                 },
                 name: "a",
                 type_: (),
-                origin: Variable(
-                    "a",
-                ),
+                origin: VariableOrigin {
+                    syntax: Variable(
+                        "a",
+                    ),
+                    declaration: LetPattern,
+                },
             },
             kind: Let,
             compiled_case: CompiledCase {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples.snap
@@ -48,9 +48,12 @@ expression: "\nlet tup = #(#(5, 6))\n{tup.0}.1\n"
                 },
                 name: "tup",
                 type_: (),
-                origin: Variable(
-                    "tup",
-                ),
+                origin: VariableOrigin {
+                    syntax: Variable(
+                        "tup",
+                    ),
+                    declaration: LetPattern,
+                },
             },
             kind: Let,
             compiled_case: CompiledCase {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__nested_tuples_no_block.snap
@@ -48,9 +48,12 @@ expression: "\nlet tup = #(#(5, 6))\ntup.0.1\n"
                 },
                 name: "tup",
                 type_: (),
-                origin: Variable(
-                    "tup",
-                ),
+                origin: VariableOrigin {
+                    syntax: Variable(
+                        "tup",
+                    ),
+                    declaration: LetPattern,
+                },
             },
             kind: Let,
             compiled_case: CompiledCase {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 440
 expression: "let assert [x] = [2]"
-snapshot_kind: text
 ---
 [
     Assignment(
@@ -41,9 +39,12 @@ snapshot_kind: text
                         },
                         name: "x",
                         type_: (),
-                        origin: Variable(
-                            "x",
-                        ),
+                        origin: VariableOrigin {
+                            syntax: Variable(
+                                "x",
+                            ),
+                            declaration: LetPattern,
+                        },
                     },
                 ],
                 tail: None,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/parse/tests.rs
-assertion_line: 445
 expression: "let assert [x]: List(Int) = [2]"
-snapshot_kind: text
 ---
 [
     Assignment(
@@ -41,9 +39,12 @@ snapshot_kind: text
                         },
                         name: "x",
                         type_: (),
-                        origin: Variable(
-                            "x",
-                        ),
+                        origin: VariableOrigin {
+                            syntax: Variable(
+                                "x",
+                            ),
+                            declaration: LetPattern,
+                        },
                     },
                 ],
                 tail: None,

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -789,11 +789,9 @@ impl ValueConstructorVariant {
     #[must_use]
     pub fn is_generated_variable(&self) -> bool {
         match self {
-            ValueConstructorVariant::LocalVariable {
-                origin: VariableOrigin::Generated,
-                ..
-            } => true,
-            ValueConstructorVariant::LocalVariable { .. } => false,
+            ValueConstructorVariant::LocalVariable { origin, .. } => {
+                matches!(origin.syntax, VariableSyntax::Generated)
+            }
             ValueConstructorVariant::ModuleConstant { .. }
             | ValueConstructorVariant::LocalConstant { .. }
             | ValueConstructorVariant::ModuleFn { .. }

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -712,7 +712,10 @@ impl Named {
 /// The origin of a variable. Used to determine how it can be ignored when unused.
 pub enum VariableOrigin {
     /// A variable that can be ignored by prefixing with an underscore, `_name`
-    Variable(EcoString),
+    Variable {
+        name: EcoString,
+        kind: VariableDeclarationKind,
+    },
     /// A variable from label shorthand syntax, which can be ignored with an underscore: `label: _`
     LabelShorthand(EcoString),
     /// A variable from an assignment pattern, which can be ignored by removing `as name`,
@@ -721,10 +724,19 @@ pub enum VariableOrigin {
     Generated,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum VariableDeclarationKind {
+    LetPattern,
+    UsePattern,
+    ClausePattern,
+    FunctionParameter,
+    Implicit,
+}
+
 impl VariableOrigin {
     pub fn how_to_ignore(&self) -> Option<String> {
         match self {
-            VariableOrigin::Variable(name) => {
+            VariableOrigin::Variable { name, .. } => {
                 Some(format!("You can ignore it with an underscore: `_{name}`."))
             }
             VariableOrigin::LabelShorthand(label) => Some(format!(

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -709,13 +709,17 @@ impl Named {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-/// The origin of a variable. Used to determine how it can be ignored when unused.
-pub enum VariableOrigin {
+pub struct VariableOrigin {
+    pub syntax: VariableSyntax,
+    pub declaration: VariableDeclaration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// The syntax used to define a variable. Used to determine how it can be ignored
+/// when unused.
+pub enum VariableSyntax {
     /// A variable that can be ignored by prefixing with an underscore, `_name`
-    Variable {
-        name: EcoString,
-        kind: VariableDeclarationKind,
-    },
+    Variable(EcoString),
     /// A variable from label shorthand syntax, which can be ignored with an underscore: `label: _`
     LabelShorthand(EcoString),
     /// A variable from an assignment pattern, which can be ignored by removing `as name`,
@@ -725,25 +729,33 @@ pub enum VariableOrigin {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum VariableDeclarationKind {
+/// The source of a variable, such as a `let` assignment, or function parameter.
+pub enum VariableDeclaration {
     LetPattern,
     UsePattern,
     ClausePattern,
     FunctionParameter,
-    Implicit,
+    Generated,
 }
 
 impl VariableOrigin {
     pub fn how_to_ignore(&self) -> Option<String> {
-        match self {
-            VariableOrigin::Variable { name, .. } => {
+        match &self.syntax {
+            VariableSyntax::Variable(name) => {
                 Some(format!("You can ignore it with an underscore: `_{name}`."))
             }
-            VariableOrigin::LabelShorthand(label) => Some(format!(
+            VariableSyntax::LabelShorthand(label) => Some(format!(
                 "You can ignore it with an underscore: `{label}: _`."
             )),
-            VariableOrigin::AssignmentPattern => Some("You can safely remove it.".to_string()),
-            VariableOrigin::Generated => None,
+            VariableSyntax::AssignmentPattern => Some("You can safely remove it.".to_string()),
+            VariableSyntax::Generated => None,
+        }
+    }
+
+    pub fn generated() -> Self {
+        Self {
+            syntax: VariableSyntax::Generated,
+            declaration: VariableDeclaration::Generated,
         }
     }
 }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     build::Target,
     exhaustiveness::{self, CompileCaseResult, CompiledCase, Reachability},
+    parse::PatternPosition,
     reference::ReferenceKind,
 };
 use hexpm::version::Version;
@@ -1760,6 +1761,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             &self.current_function_definition,
             &self.hydrator,
             self.problems,
+            PatternPosition::LetAssignment,
         );
 
         let pattern = pattern_typer.infer_single_pattern(pattern, &value);
@@ -2111,6 +2113,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             &self.current_function_definition,
             &self.hydrator,
             self.problems,
+            PatternPosition::CaseClause,
         );
 
         let typed_pattern = pattern_typer.infer_multi_pattern(pattern, subjects, location);
@@ -2977,7 +2980,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location: record_location,
                 name: RECORD_UPDATE_VARIABLE.into(),
                 type_: record_type.clone(),
-                origin: VariableOrigin::Generated,
+                origin: VariableOrigin::generated(),
             },
             annotation: None,
             compiled_case: CompiledCase::failure(),
@@ -2993,7 +2996,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 type_: record_type,
                 variant: ValueConstructorVariant::LocalVariable {
                     location: record_location,
-                    origin: VariableOrigin::Generated,
+                    origin: VariableOrigin::generated(),
                 },
             },
             name: RECORD_UPDATE_VARIABLE.into(),
@@ -4266,13 +4269,15 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             });
                         }
 
-                        let origin = if name == CAPTURE_VARIABLE {
-                            VariableOrigin::Generated
+                        let syntax = if name == CAPTURE_VARIABLE {
+                            VariableSyntax::Generated
                         } else {
-                            VariableOrigin::Variable {
-                                name: name.clone(),
-                                kind: VariableDeclarationKind::FunctionParameter,
-                            }
+                            VariableSyntax::Variable(name.clone())
+                        };
+
+                        let origin = VariableOrigin {
+                            syntax,
+                            declaration: VariableDeclaration::FunctionParameter,
                         };
 
                         // Insert a variable for the argument into the environment

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4269,7 +4269,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         let origin = if name == CAPTURE_VARIABLE {
                             VariableOrigin::Generated
                         } else {
-                            VariableOrigin::Variable(name.clone())
+                            VariableOrigin::Variable {
+                                name: name.clone(),
+                                kind: VariableDeclarationKind::FunctionParameter,
+                            }
                         };
 
                         // Insert a variable for the argument into the environment

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -12,6 +12,7 @@ use crate::{
     ast::{
         AssignName, BitArrayOption, ImplicitCallArgOrigin, Layer, UntypedPatternBitArraySegment,
     },
+    parse::PatternPosition,
     reference::ReferenceKind,
     type_::expression::FunctionDefinition,
 };
@@ -45,6 +46,9 @@ pub struct PatternTyper<'a, 'b> {
     /// keeps track of whether it is in scope, so that we can correctly detect
     /// valid/invalid uses.
     variables: HashMap<EcoString, LocalVariable>,
+
+    /// What kind of pattern we are typing
+    position: PatternPosition,
 }
 
 #[derive(Debug)]
@@ -96,6 +100,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
         current_function: &'a FunctionDefinition,
         hydrator: &'a Hydrator,
         problems: &'a mut Problems,
+        position: PatternPosition,
     ) -> Self {
         Self {
             environment,
@@ -109,6 +114,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             problems,
             error_encountered: false,
             variables: HashMap::new(),
+            position,
         }
     }
 
@@ -209,14 +215,20 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 let _ = self
                     .inferred_variant_variables
                     .insert(name.clone(), variant_index);
+
+                let origin = match &variable.variant {
+                    ValueConstructorVariant::LocalVariable { origin, .. } => origin.clone(),
+                    ValueConstructorVariant::ModuleConstant { .. }
+                    | ValueConstructorVariant::LocalConstant { .. }
+                    | ValueConstructorVariant::ModuleFn { .. }
+                    | ValueConstructorVariant::Record { .. } => VariableOrigin::generated(),
+                };
+
                 // This variable is only inferred in this branch of the case expression
                 self.environment.insert_local_variable(
                     name.clone(),
                     variable.definition_location().span,
-                    VariableOrigin::Variable {
-                        name,
-                        kind: VariableDeclarationKind::Implicit,
-                    },
+                    origin,
                     type_,
                 );
             }
@@ -663,7 +675,10 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         left,
                         string(),
                         *left_location,
-                        VariableOrigin::AssignmentPattern,
+                        VariableOrigin {
+                            syntax: VariableSyntax::AssignmentPattern,
+                            declaration: self.position.to_declaration(),
+                        },
                     );
                 }
 
@@ -674,9 +689,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             right,
                             string(),
                             right_location,
-                            VariableOrigin::Variable {
-                                name: right.clone(),
-                                kind: VariableDeclarationKind::ClausePattern,
+                            VariableOrigin {
+                                syntax: VariableSyntax::Variable(right.clone()),
+                                declaration: self.position.to_declaration(),
                             },
                         );
                     }
@@ -707,7 +722,10 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     &name,
                     pattern.type_().clone(),
                     location,
-                    VariableOrigin::AssignmentPattern,
+                    VariableOrigin {
+                        syntax: VariableSyntax::AssignmentPattern,
+                        declaration: self.position.to_declaration(),
+                    },
                 );
                 Pattern::Assign {
                     name,

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -213,7 +213,10 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 self.environment.insert_local_variable(
                     name.clone(),
                     variable.definition_location().span,
-                    VariableOrigin::Variable(name),
+                    VariableOrigin::Variable {
+                        name,
+                        kind: VariableDeclarationKind::Implicit,
+                    },
                     type_,
                 );
             }
@@ -671,7 +674,10 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             right,
                             string(),
                             right_location,
-                            VariableOrigin::Variable(right.clone()),
+                            VariableOrigin::Variable {
+                                name: right.clone(),
+                                kind: VariableDeclarationKind::ClausePattern,
+                            },
                         );
                     }
                     AssignName::Discard(_) => {

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -252,7 +252,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             name: PIPE_VARIABLE.into(),
             constructor: ValueConstructor::local_variable(
                 self.argument_location,
-                VariableOrigin::Generated,
+                VariableOrigin::generated(),
                 self.argument_type.clone(),
             ),
         }
@@ -443,7 +443,7 @@ fn new_pipeline_assignment(
     expr_typer.environment.insert_local_variable(
         PIPE_VARIABLE.into(),
         location,
-        VariableOrigin::Generated,
+        VariableOrigin::generated(),
         expression.type_(),
     );
     TypedPipelineAssignment {


### PR DESCRIPTION
This PR fixes #4660.
I've had to rework `VariableOrigin` as I needed some more information to determine when inlining a variable was valid.