### PR TITLE
Add more control over list formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,9 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- The formatter now allows more control over how lists made up of simple
-  constants are formatted. If a list is split with multiple elements on the same
-  line, removing the trailing comma will make sure the formatter keeps each item
-  on its own line:
+- The formatter now allows more control over how lists are formatted.
+  If a list is split with multiple elements on the same line, removing the
+  trailing comma will make sure the formatter keeps each item on its own line:
 
   ```gleam
   pub fn my_favourite_pokemon() -> List(String) {
@@ -79,7 +78,7 @@
 
 - The formatter no longer removes empty lines between list items. In case an
   empty line is added between list items they will all be split on multiple
-  lines.
+  lines. For example:
 
   ```gleam
   pub fn main() {
@@ -103,6 +102,8 @@
     ]
   }
   ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ### Compiler
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,33 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The formatter no longer removes empty lines between list items. In case an
+  empty line is added between list items they will all be split on multiple
+  lines.
+
+  ```gleam
+  pub fn main() {
+    [
+      "natu", "xatu",
+
+      "chimeco"
+    ]
+  }
+  ```
+
+  Is formatted as:
+
+  ```gleam
+  pub fn main() {
+    [
+      "natu",
+      "xatu",
+
+      "chimeco",
+    ]
+  }
+  ```
+
 ### Compiler
 
 ### Build tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,81 @@
 
 ## Unreleased
 
+### Formatter
+
+- The formatter now allows more control over how lists are split. By adding a
+  trailing comma at the end of a list that can fit on a single line, the list
+  will be split on multiple lines:
+
+  ```gleam
+  pub fn my_favourite_pokemon() -> List(String) {
+    ["natu", "chimecho", "milotic",]
+  }
+  ```
+
+  Will be formatted as:
+
+  ```gleam
+  pub fn my_favourite_pokemon() -> List(String) {
+    [
+      "natu",
+      "chimecho",
+      "milotic",
+    ]
+  }
+  ```
+
+  By removing the trailing comma, the formatter will try and fit the list on a
+  single line again:
+
+  ```gleam
+  pub fn my_favourite_pokemon() -> List(String) {
+    [
+      "natu",
+      "chimecho",
+      "milotic"
+    ]
+  }
+  ```
+
+  Will be formatted back to a single line:
+
+  ```gleam
+  pub fn my_favourite_pokemon() -> List(String) {
+    ["natu", "chimecho", "milotic"]
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The formatter now allows more control over how lists made up of simple
+  constants are formatted. If a list is split with multiple elements on the same
+  line, removing the trailing comma will make sure the formatter keeps each item
+  on its own line:
+
+  ```gleam
+  pub fn my_favourite_pokemon() -> List(String) {
+    [
+      "This list was formatted", "keeping multiple elements on the same line",
+      "notice how the formatting changes by removing the trailing comma ->"
+    ]
+  }
+  ```
+
+  Is formatted as:
+
+  ```gleam
+  pub fn my_favourite_pokemon() -> List(String) {
+    [
+      "This list was formatted",
+      "keeping multiple elements on the same line",
+      "notice how the formatting changes by removing the trailing comma ->",
+    ]
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Compiler
 
 ### Build tool

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -200,11 +200,21 @@ impl<A, B> Constant<A, B> {
         }
     }
 
-    pub fn is_simple(&self) -> bool {
-        matches!(
-            self,
-            Self::Int { .. } | Self::Float { .. } | Self::String { .. }
-        )
+    #[must_use]
+    pub fn can_have_multiple_per_line(&self) -> bool {
+        match self {
+            Constant::Int { .. }
+            | Constant::Float { .. }
+            | Constant::String { .. }
+            | Constant::Var { .. } => true,
+
+            Constant::Tuple { .. }
+            | Constant::List { .. }
+            | Constant::Record { .. }
+            | Constant::BitArray { .. }
+            | Constant::StringConcatenation { .. }
+            | Constant::Invalid { .. } => false,
+        }
     }
 }
 

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -202,11 +202,35 @@ impl UntypedExpr {
         }
     }
 
-    pub fn is_simple_constant(&self) -> bool {
-        matches!(
-            self,
-            Self::String { .. } | Self::Int { .. } | Self::Float { .. }
-        )
+    pub fn can_have_multiple_per_line(&self) -> bool {
+        match self {
+            UntypedExpr::Int { .. }
+            | UntypedExpr::Float { .. }
+            | UntypedExpr::String { .. }
+            | UntypedExpr::Var { .. } => true,
+
+            UntypedExpr::NegateBool { value, .. }
+            | UntypedExpr::NegateInt { value, .. }
+            | UntypedExpr::FieldAccess {
+                container: value, ..
+            } => value.can_have_multiple_per_line(),
+
+            UntypedExpr::Block { .. }
+            | UntypedExpr::Fn { .. }
+            | UntypedExpr::List { .. }
+            | UntypedExpr::Call { .. }
+            | UntypedExpr::BinOp { .. }
+            | UntypedExpr::PipeLine { .. }
+            | UntypedExpr::Case { .. }
+            | UntypedExpr::Tuple { .. }
+            | UntypedExpr::TupleIndex { .. }
+            | UntypedExpr::Todo { .. }
+            | UntypedExpr::Panic { .. }
+            | UntypedExpr::Echo { .. }
+            | UntypedExpr::BitArray { .. }
+            | UntypedExpr::RecordUpdate { .. }
+            | UntypedExpr::Placeholder { .. } => false,
+        }
     }
 
     pub fn is_tuple(&self) -> bool {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -44,6 +44,7 @@ pub(crate) struct Intermediate<'a> {
     module_comments: Vec<Comment<'a>>,
     empty_lines: &'a [u32],
     new_lines: &'a [u32],
+    trailing_commas: &'a [u32],
 }
 
 impl<'a> Intermediate<'a> {
@@ -66,6 +67,7 @@ impl<'a> Intermediate<'a> {
                 .map(|span| Comment::from((span, src)))
                 .collect(),
             new_lines: &extra.new_lines,
+            trailing_commas: &extra.trailing_commas,
         }
     }
 }
@@ -102,6 +104,7 @@ pub struct Formatter<'a> {
     module_comments: &'a [Comment<'a>],
     empty_lines: &'a [u32],
     new_lines: &'a [u32],
+    trailing_commas: &'a [u32],
 }
 
 impl<'comments> Formatter<'comments> {
@@ -116,6 +119,7 @@ impl<'comments> Formatter<'comments> {
             module_comments: &extra.module_comments,
             empty_lines: extra.empty_lines,
             new_lines: extra.new_lines,
+            trailing_commas: extra.trailing_commas,
         }
     }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1500,7 +1500,7 @@ impl<'comments> Formatter<'comments> {
     /// Returns true if there's a trailing comma between `start` and `end`.
     ///
     fn has_trailing_comma(&self, start: u32, end: u32) -> bool {
-        dbg!(self.trailing_commas)
+        self.trailing_commas
             .binary_search_by(|comma| {
                 if *comma < start {
                     Ordering::Less
@@ -2882,6 +2882,7 @@ impl<'a> Documentable<'a> for &'a BinOp {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 enum ListItemsPacking {
     /// Try and fit everything on a single line; if the items don't fit, break
     /// the list putting each item into its own line.
@@ -2925,6 +2926,7 @@ enum ListItemsPacking {
     ///   3,
     /// ]
     /// ```
+    ///
     BreakOnePerLine,
 }
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -5992,9 +5992,11 @@ fn const_concat_long_including_list() {
         r#"const x = "some long string 1"
   <> "some long string 2"
   <> [
-    "here is a list", "with several elements",
+    "here is a list",
+    "with several elements",
     "in order to make it be too long to fit on one line",
-    "so we can see how it breaks", "onto multiple lines",
+    "so we can see how it breaks",
+    "onto multiple lines",
   ]
   <> "and a last string"
 "#,

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -12,6 +12,7 @@ mod external_types;
 mod function;
 mod guards;
 mod imports;
+mod lists;
 mod pipeline;
 mod record_update;
 mod tuple;

--- a/compiler-core/src/format/tests/lists.rs
+++ b/compiler-core/src/format/tests/lists.rs
@@ -1,0 +1,275 @@
+use crate::{assert_format, assert_format_rewrite};
+
+#[test]
+fn list_with_trailing_comma_is_broken() {
+    assert_format_rewrite!(
+        "pub fn main() { [ 1, 2, a, ] }",
+        r#"pub fn main() {
+  [
+    1,
+    2,
+    a,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn constant_list_with_trailing_comma_is_broken() {
+    assert_format_rewrite!(
+        "const list = [ 1, 2, a, ]",
+        r#"const list = [
+  1,
+  2,
+  a,
+]
+"#
+    );
+}
+
+#[test]
+fn list_with_trailing_comma_is_kept_broken() {
+    assert_format!(
+        r#"pub fn main() {
+  [
+    1,
+    2,
+    a,
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn constant_list_with_trailing_comma_is_kept_broken() {
+    assert_format!(
+        r#"const list = [
+  1,
+  2,
+  a,
+]
+"#
+    );
+}
+
+#[test]
+fn list_with_no_trailing_comma_is_packed_on_a_single_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  [
+    1,
+    2,
+    a
+  ]
+}
+"#,
+        r#"pub fn main() {
+  [1, 2, a]
+}
+"#
+    );
+}
+
+#[test]
+fn constant_list_with_no_trailing_comma_is_packed_on_a_single_line() {
+    assert_format_rewrite!(
+        r#"const list = [
+  1,
+  2,
+  a
+]"#,
+        "const list = [1, 2, a]\n"
+    );
+}
+
+#[test]
+fn list_with_no_comma_is_packed_on_a_single_line_or_split_one_item_per_line() {
+    assert_format_rewrite!(
+        "pub fn main() {
+  [
+    1,
+    a,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312,
+    b,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312
+  ]
+}
+",
+        "pub fn main() {
+  [
+    1,
+    a,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312,
+    b,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312,
+    12_312_312_312_312_312_312_312,
+  ]
+}
+"
+    );
+}
+
+#[test]
+fn constant_list_with_no_comma_is_packed_on_a_single_line_or_split_one_item_per_line() {
+    assert_format_rewrite!(
+        "const list = [
+  1,
+  a,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312,
+  b,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312
+]
+",
+        "const list = [
+  1,
+  a,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312,
+  b,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312,
+  12_312_312_312_312_312_312_312,
+]
+"
+    );
+}
+
+#[test]
+fn simple_list_with_no_comma_is_packed_on_a_single_line_or_split_one_item_per_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  [
+    "hello",
+    "wibble wobble",
+    "these are all simple strings",
+    "but the list won't be packed",
+    "the formatter will keep",
+    "one item",
+    "per line",
+    "since there's no trailing comma here ->"
+  ]
+}
+"#,
+        r#"pub fn main() {
+  [
+    "hello",
+    "wibble wobble",
+    "these are all simple strings",
+    "but the list won't be packed",
+    "the formatter will keep",
+    "one item",
+    "per line",
+    "since there's no trailing comma here ->",
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn simple_list_with_trailing_comma_and_multiple_items_per_line_is_packed() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  [
+    "hello",
+    "wibble wobble",
+    "these are all simple strings",
+    "and the list will be packed since the following strings are",
+    "on the same", "line", "and there's a trailing comma ->",
+  ]
+}
+"#,
+        r#"pub fn main() {
+  [
+    "hello", "wibble wobble", "these are all simple strings",
+    "and the list will be packed since the following strings are", "on the same",
+    "line", "and there's a trailing comma ->",
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn simple_constant_list_with_trailing_comma_and_multiple_items_per_line_is_packed() {
+    assert_format_rewrite!(
+        r#"pub const list = [
+  "hello",
+  "wibble wobble",
+  "these are all simple strings",
+  "and the list will be packed since the following strings are",
+  "on the same", "line", "and there's a trailing comma ->",
+]
+"#,
+        r#"pub const list = [
+  "hello", "wibble wobble", "these are all simple strings",
+  "and the list will be packed since the following strings are", "on the same",
+  "line", "and there's a trailing comma ->",
+]
+"#
+    );
+}
+
+#[test]
+fn simple_packed_list_with_trailing_comma_is_kept_with_multiple_items_per_line() {
+    assert_format!(
+        r#"pub fn main() {
+  [
+    "hello", "wibble wobble", "these are all simple strings",
+    "and the list will be kept packed since it ends with a trailing comma",
+    "right here! ->",
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn simple_single_line_list_with_trailing_comma_is_split_one_item_per_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  ["these are all simple strings", "but the list won't be packed", "since it ends with a trailing comma ->",]
+}
+"#,
+        r#"pub fn main() {
+  [
+    "these are all simple strings",
+    "but the list won't be packed",
+    "since it ends with a trailing comma ->",
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn simple_single_line_list_with_no_trailing_comma_is_split_one_item_per_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  ["these are all simple strings", "but the list won't be packed", "even if it doesn't end with a trailing comma!"]
+}
+"#,
+        r#"pub fn main() {
+  [
+    "these are all simple strings",
+    "but the list won't be packed",
+    "even if it doesn't end with a trailing comma!",
+  ]
+}
+"#
+    );
+}

--- a/compiler-core/src/format/tests/lists.rs
+++ b/compiler-core/src/format/tests/lists.rs
@@ -273,3 +273,93 @@ fn simple_single_line_list_with_no_trailing_comma_is_split_one_item_per_line() {
 "#
     );
 }
+
+#[test]
+fn empty_lines_in_list_are_not_ignored() {
+    assert_format_rewrite!(
+        "pub fn main() {
+  [1, 2,
+
+  3
+  ]
+}
+",
+        "pub fn main() {
+  [
+    1,
+    2,
+
+    3,
+  ]
+}
+"
+    );
+}
+
+#[test]
+fn empty_lines_in_const_list_are_not_ignored() {
+    assert_format_rewrite!(
+        "const list =
+  [1, 2,
+
+  3
+  ]
+",
+        "const list = [
+  1,
+  2,
+
+  3,
+]
+"
+    );
+}
+
+#[test]
+fn lists_with_empty_lines_are_always_broken() {
+    assert_format_rewrite!(
+        "pub fn main() {
+  [
+    1,
+    2,
+
+    3, 4, 5
+  ]
+}
+",
+        "pub fn main() {
+  [
+    1,
+    2,
+
+    3,
+    4,
+    5,
+  ]
+}
+"
+    );
+}
+
+#[test]
+fn const_lists_with_empty_lines_are_always_broken() {
+    assert_format_rewrite!(
+        "const list =
+  [
+    1,
+    2,
+
+    3, 4, 5
+  ]
+",
+        "const list = [
+  1,
+  2,
+
+  3,
+  4,
+  5,
+]
+"
+    );
+}

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3594,16 +3594,17 @@ functions are declared separately from types.";
         sep: Option<&Token>,
     ) -> Result<(Vec<A>, bool), ParseError> {
         let mut results = vec![];
-        let mut ends_with_sep = false;
+        let mut final_separator = None;
         while let Some(result) = parser(self)? {
             results.push(result);
             if let Some(sep) = sep {
-                if self.maybe_one(sep).is_none() {
-                    ends_with_sep = false;
-                    break;
+                if let Some(separator) = self.maybe_one(sep) {
+                    final_separator = Some(separator);
                 } else {
-                    ends_with_sep = true;
+                    final_separator = None;
+                    break;
                 }
+
                 // Helpful error if extra separator
                 if let Some((start, end)) = self.maybe_one(sep) {
                     return parse_error(ParseErrorType::ExtraSeparator, SrcSpan { start, end });
@@ -3611,7 +3612,13 @@ functions are declared separately from types.";
             }
         }
 
-        Ok((results, ends_with_sep))
+        // If the sequence ends with a trailing comma we want to keep track of
+        // its position.
+        if let (Some(Token::Comma), Some((_, end))) = (sep, final_separator) {
+            self.extra.trailing_commas.push(end)
+        };
+
+        Ok((results, final_separator.is_some()))
     }
 
     // If next token is a Name, consume it and return relevant info, otherwise, return none

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -11,6 +11,7 @@ pub struct ModuleExtra {
     pub comments: Vec<SrcSpan>,
     pub empty_lines: Vec<u32>,
     pub new_lines: Vec<u32>,
+    pub trailing_commas: Vec<u32>,
 }
 
 impl ModuleExtra {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -112,5 +112,6 @@ Parsed {
             20,
             51,
         ],
+        trailing_commas: [],
     },
 }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
@@ -84,5 +84,6 @@ Parsed {
             59,
             61,
         ],
+        trailing_commas: [],
     },
 }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -77,5 +77,6 @@ Parsed {
         comments: [],
         empty_lines: [],
         new_lines: [],
+        trailing_commas: [],
     },
 }

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -187,5 +187,6 @@ Parsed {
             73,
             75,
         ],
+        trailing_commas: [],
     },
 }


### PR DESCRIPTION
This PR closes #4628:
- by adding a trailing comma to a list the formatter will be forced to break it with one item per line
- by removing a trailing comma from a list the formatter will try to fit it on a single line, if it can't it will break it one item per line
- by putting multiple elements on the same line (if the list is only made up of simple constants), the formatter will try and fit as many elements as possible on a single line

So now the formatter will never pack a list of constants **unless explicitly told so**