### PR TITLE
Improve definitions naming

### DIFF
--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -8,7 +8,7 @@ use crate::{
     GLEAM_CORE_PACKAGE_NAME,
     ast::{
         self, Arg, BitArrayOption, CustomType, Definition, DefinitionLocation, Function,
-        GroupedStatements, Import, ModuleConstant, Publicity, RecordConstructor,
+        GroupedDefinitions, Import, ModuleConstant, Publicity, RecordConstructor,
         RecordConstructorArg, SrcSpan, Statement, TypeAlias, TypeAst, TypeAstConstructor,
         TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar, TypedDefinition, TypedExpr,
         TypedFunction, TypedModule, UntypedArg, UntypedCustomType, UntypedFunction, UntypedImport,
@@ -223,71 +223,80 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         }
         .build();
 
-        let statements = GroupedStatements::new(module.into_iter_statements(self.target));
-        let statements_count = statements.len();
+        let definitions = GroupedDefinitions::new(module.into_iter_definitions(self.target));
+        let definitions_count = definitions.len();
 
         // Register any modules, types, and values being imported
         // We process imports first so that anything imported can be referenced
         // anywhere in the module.
-        let mut env = Importer::run(self.origin, env, &statements.imports, &mut self.problems);
+        let mut env = Importer::run(self.origin, env, &definitions.imports, &mut self.problems);
 
         // Register types so they can be used in constructors and functions
         // earlier in the module.
-        for t in &statements.custom_types {
-            if let Err(error) = self.register_types_from_custom_type(t, &mut env) {
+        for type_ in &definitions.custom_types {
+            if let Err(error) = self.register_types_from_custom_type(type_, &mut env) {
                 return self.all_errors(error);
             }
         }
 
-        let sorted_aliases = match sorted_type_aliases(&statements.type_aliases) {
-            Ok(it) => it,
+        let sorted_aliases = match sorted_type_aliases(&definitions.type_aliases) {
+            Ok(sorted_aliases) => sorted_aliases,
             Err(error) => return self.all_errors(error),
         };
-        for t in sorted_aliases {
-            self.register_type_alias(t, &mut env);
+        for type_alias in sorted_aliases {
+            self.register_type_alias(type_alias, &mut env);
         }
 
-        for f in &statements.functions {
-            self.register_value_from_function(f, &mut env);
+        for function in &definitions.functions {
+            self.register_value_from_function(function, &mut env);
         }
 
         // Infer the types of each statement in the module
-        let mut typed_statements = Vec::with_capacity(statements_count);
-        for i in statements.imports {
-            optionally_push(&mut typed_statements, self.analyse_import(i, &env));
+        let mut typed_definitions = Vec::with_capacity(definitions_count);
+        for import in definitions.imports {
+            optionally_push(&mut typed_definitions, self.analyse_import(import, &env));
         }
-        for t in statements.custom_types {
-            optionally_push(&mut typed_statements, self.analyse_custom_type(t, &mut env));
+        for type_ in definitions.custom_types {
+            optionally_push(
+                &mut typed_definitions,
+                self.analyse_custom_type(type_, &mut env),
+            );
         }
-        for t in statements.type_aliases {
-            typed_statements.push(analyse_type_alias(t, &mut env));
+        for type_alias in definitions.type_aliases {
+            typed_definitions.push(analyse_type_alias(type_alias, &mut env));
         }
 
-        // Sort functions and constants into dependency order for inference. Definitions that do
-        // not depend on other definitions are inferred first, then ones that depend
-        // on those, etc.
+        // Sort functions and constants into dependency order for inference.
+        // Definitions that do not depend on other definitions are inferred
+        // first, then ones that depend on those, etc.
         let definition_groups =
-            match into_dependency_order(statements.functions, statements.constants) {
-                Ok(it) => it,
+            match into_dependency_order(definitions.functions, definitions.constants) {
+                Ok(definition_groups) => definition_groups,
                 Err(error) => return self.all_errors(error),
             };
         let mut working_group = vec![];
 
         for group in definition_groups {
-            // A group may have multiple functions that depend on each other through
-            // mutual recursion.
+            // A group may have multiple functions that depend on each other
+            // through mutual recursion.
 
             for definition in group {
-                let def = match definition {
-                    CallGraphNode::Function(f) => self.infer_function(f, &mut env),
-                    CallGraphNode::ModuleConstant(c) => self.infer_module_constant(c, &mut env),
+                let definition = match definition {
+                    CallGraphNode::Function(function) => self.infer_function(function, &mut env),
+                    CallGraphNode::ModuleConstant(constant) => {
+                        self.infer_module_constant(constant, &mut env)
+                    }
                 };
-                working_group.push(def);
+                working_group.push(definition);
             }
 
             // Now that the entire group has been inferred, generalise their types.
             for inferred in working_group.drain(..) {
-                typed_statements.push(generalise_statement(inferred, &self.module_name, &mut env));
+                typed_definitions.push(generalise_definition(
+                    inferred,
+                    &self.module_name,
+                    &mut env,
+                ));
             }
         }
 
@@ -335,7 +344,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         let module = ast::Module {
             documentation: documentation.clone(),
             name: self.module_name.clone(),
-            definitions: typed_statements,
+            definitions: typed_definitions,
             names: type_names,
             unused_definition_positions,
             type_info: ModuleInterface {
@@ -1667,19 +1676,19 @@ where
     }
 }
 
-fn generalise_statement(
-    s: TypedDefinition,
+fn generalise_definition(
+    definition: TypedDefinition,
     module_name: &EcoString,
     environment: &mut Environment<'_>,
 ) -> TypedDefinition {
-    match s {
+    match definition {
         Definition::Function(function) => generalise_function(function, environment, module_name),
         Definition::ModuleConstant(constant) => {
             generalise_module_constant(constant, environment, module_name)
         }
-        statement @ (Definition::TypeAlias(TypeAlias { .. })
+        definition @ (Definition::TypeAlias(TypeAlias { .. })
         | Definition::CustomType(CustomType { .. })
-        | Definition::Import(Import { .. })) => statement,
+        | Definition::Import(Import { .. })) => definition,
     }
 }
 

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -587,8 +587,8 @@ pub fn visit_typed_module<'a, V>(v: &mut V, module: &'a TypedModule)
 where
     V: Visit<'a> + ?Sized,
 {
-    for def in &module.definitions {
-        v.visit_typed_definition(def);
+    for definition in &module.definitions {
+        v.visit_typed_definition(definition);
     }
 }
 

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -22,51 +22,53 @@ use crate::{
 #[allow(dead_code)]
 pub trait UntypedModuleFolder: TypeAstFolder + UntypedExprFolder {
     /// You probably don't want to override this method.
-    fn fold_module(&mut self, mut m: UntypedModule) -> UntypedModule {
-        m.definitions = m
+    fn fold_module(&mut self, mut module: UntypedModule) -> UntypedModule {
+        module.definitions = module
             .definitions
             .into_iter()
-            .map(|d| {
-                let TargetedDefinition { definition, target } = d;
+            .map(|definition| {
+                let TargetedDefinition { definition, target } = definition;
                 match definition {
-                    Definition::Function(f) => {
-                        let f = self.fold_function_definition(f, target);
-                        let definition = self.walk_function_definition(f);
+                    Definition::Function(function) => {
+                        let function = self.fold_function_definition(function, target);
+                        let definition = self.walk_function_definition(function);
                         TargetedDefinition { definition, target }
                     }
 
-                    Definition::TypeAlias(a) => {
-                        let a = self.fold_type_alias(a, target);
-                        let definition = self.walk_type_alias(a);
+                    Definition::TypeAlias(type_alias) => {
+                        let type_alias = self.fold_type_alias(type_alias, target);
+                        let definition = self.walk_type_alias(type_alias);
                         TargetedDefinition { definition, target }
                     }
 
-                    Definition::CustomType(t) => {
-                        let t = self.fold_custom_type(t, target);
-                        let definition = self.walk_custom_type(t);
+                    Definition::CustomType(custom_type) => {
+                        let custom_type = self.fold_custom_type(custom_type, target);
+                        let definition = self.walk_custom_type(custom_type);
                         TargetedDefinition { definition, target }
                     }
 
-                    Definition::Import(i) => {
-                        let i = self.fold_import(i, target);
-                        let definition = self.walk_import(i);
+                    Definition::Import(import) => {
+                        let import = self.fold_import(import, target);
+                        let definition = self.walk_import(import);
                         TargetedDefinition { definition, target }
                     }
 
-                    Definition::ModuleConstant(c) => {
-                        let c = self.fold_module_constant(c, target);
-                        let definition = self.walk_module_constant(c);
+                    Definition::ModuleConstant(constant) => {
+                        let constant = self.fold_module_constant(constant, target);
+                        let definition = self.walk_module_constant(constant);
                         TargetedDefinition { definition, target }
                     }
                 }
             })
             .collect();
-        m
+        module
     }
 
     /// You probably don't want to override this method.
     fn walk_function_definition(&mut self, mut function: UntypedFunction) -> UntypedDefinition {
-        function.body = function.body.mapped(|s| self.fold_statement(s));
+        function.body = function
+            .body
+            .mapped(|statement| self.fold_statement(statement));
         function.return_annotation = function
             .return_annotation
             .map(|type_| self.fold_type(type_));

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -272,26 +272,26 @@ impl Module {
 
         self.ast.type_info.documentation = self.ast.documentation.clone();
 
-        // Order statements to avoid misassociating doc comments after the
+        // Order definitions to avoid misassociating doc comments after the
         // order has changed during compilation.
-        let mut statements: Vec<_> = self.ast.definitions.iter_mut().collect();
-        statements.sort_by(|a, b| a.location().start.cmp(&b.location().start));
+        let mut definitions: Vec<_> = self.ast.definitions.iter_mut().collect();
+        definitions.sort_by(|a, b| a.location().start.cmp(&b.location().start));
 
         // Doc Comments
         let mut doc_comments = self.extra.doc_comments.iter().peekable();
-        for statement in &mut statements {
+        for definition in &mut definitions {
             let (docs_start, docs): (u32, Vec<&str>) = doc_comments_before(
                 &mut doc_comments,
                 &self.extra,
-                statement.location().start,
+                definition.location().start,
                 &self.code,
             );
             if !docs.is_empty() {
                 let doc = docs.join("\n").into();
-                statement.put_doc((docs_start, doc));
+                definition.put_doc((docs_start, doc));
             }
 
-            if let Definition::CustomType(CustomType { constructors, .. }) = statement {
+            if let Definition::CustomType(CustomType { constructors, .. }) = definition {
                 for constructor in constructors {
                     let (docs_start, docs): (u32, Vec<&str>) = doc_comments_before(
                         &mut doc_comments,

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -212,7 +212,7 @@ pub fn generate_html<IO: FileSystemReader>(
             .ast
             .definitions
             .iter()
-            .filter_map(|statement| printer.type_definition(&source_links, statement))
+            .filter_map(|definition| printer.type_definition(&source_links, definition))
             .sorted()
             .collect();
 
@@ -220,7 +220,7 @@ pub fn generate_html<IO: FileSystemReader>(
             .ast
             .definitions
             .iter()
-            .filter_map(|statement| printer.value(&source_links, statement))
+            .filter_map(|definition| printer.value(&source_links, definition))
             .sorted()
             .collect();
 

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -192,12 +192,12 @@ fn compile_documentation(
         .definitions
         .iter()
         .filter_map(
-            |statement: &crate::ast::Definition<
+            |definition: &crate::ast::Definition<
                 std::sync::Arc<type_::Type>,
                 crate::ast::TypedExpr,
                 EcoString,
                 EcoString,
-            >| printer.type_definition(&source_links, statement),
+            >| printer.type_definition(&source_links, definition),
         )
         .sorted()
         .collect_vec();
@@ -205,7 +205,7 @@ fn compile_documentation(
     let values = module
         .definitions
         .iter()
-        .filter_map(|statement| printer.value(&source_links, statement))
+        .filter_map(|definition| printer.value(&source_links, definition))
         .sorted()
         .collect_vec();
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -119,7 +119,7 @@ impl<'a> Generator<'a> {
             self.module
                 .definitions
                 .iter()
-                .flat_map(|s| self.statement(s)),
+                .flat_map(|definition| self.definition(definition)),
         );
 
         // Two lines between each statement
@@ -298,8 +298,8 @@ impl<'a> Generator<'a> {
         imports.register_module(path, [], [member]);
     }
 
-    pub fn statement(&mut self, statement: &'a TypedDefinition) -> Option<Output<'a>> {
-        match statement {
+    pub fn definition(&mut self, definition: &'a TypedDefinition) -> Option<Output<'a>> {
+        match definition {
             Definition::TypeAlias(TypeAlias { .. }) => None,
 
             // Handled in collect_imports
@@ -423,7 +423,7 @@ impl<'a> Generator<'a> {
         self.module
             .definitions
             .iter()
-            .flat_map(|statement| match statement {
+            .flat_map(|definition| match definition {
                 // If a custom type is unused then we don't need to generate code for it
                 Definition::CustomType(CustomType { location, .. })
                     if self
@@ -452,8 +452,8 @@ impl<'a> Generator<'a> {
     fn collect_imports(&mut self) -> Imports<'a> {
         let mut imports = Imports::new();
 
-        for statement in &self.module.definitions {
-            match statement {
+        for definition in &self.module.definitions {
+            match definition {
                 Definition::Import(Import {
                     module,
                     as_name,
@@ -659,8 +659,8 @@ impl<'a> Generator<'a> {
     }
 
     fn register_module_definitions_in_scope(&mut self) {
-        for statement in self.module.definitions.iter() {
-            match statement {
+        for definition in self.module.definitions.iter() {
+            match definition {
                 Definition::ModuleConstant(ModuleConstant { name, .. }) => {
                     self.register_in_scope(name)
                 }

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -197,7 +197,7 @@ impl<'a> TypeScriptGenerator<'a> {
             .module
             .definitions
             .iter()
-            .flat_map(|s| self.statement(s));
+            .flat_map(|definition| self.definition(definition));
 
         // Two lines between each statement
         let mut statements: Vec<_> =
@@ -364,8 +364,8 @@ impl<'a> TypeScriptGenerator<'a> {
         }
     }
 
-    fn statement(&mut self, statement: &'a TypedDefinition) -> Vec<Output<'a>> {
-        match statement {
+    fn definition(&mut self, definition: &'a TypedDefinition) -> Vec<Output<'a>> {
+        match definition {
             Definition::TypeAlias(TypeAlias {
                 alias,
                 publicity,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1352,8 +1352,8 @@ impl<'a> QualifiedToUnqualifiedImportFirstPass<'a> {
     ) -> Option<&'a Import<EcoString>> {
         let mut matching_import = None;
 
-        for def in &self.module.ast.definitions {
-            if let ast::Definition::Import(import) = def {
+        for definition in &self.module.ast.definitions {
+            if let ast::Definition::Import(import) = definition {
                 let imported = if layer.is_value() {
                     &import.unqualified_values
                 } else {
@@ -1906,7 +1906,7 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
                 .ast
                 .definitions
                 .iter()
-                .find_map(|def| match def {
+                .find_map(|definition| match definition {
                     ast::Definition::Import(import) if import.module == *module_name => import
                         .unqualified_values
                         .iter()
@@ -1928,7 +1928,7 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
                 .ast
                 .definitions
                 .iter()
-                .find_map(|def| match def {
+                .find_map(|definition| match definition {
                     ast::Definition::Import(import) => {
                         if let Some(ty) = import
                             .unqualified_types

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -565,12 +565,22 @@ where
 
             // Find the function that the cursor is in and push completions for
             // its arguments and local variables.
-            if let Some(fun) = self.module.ast.definitions.iter().find_map(|d| match d {
-                Definition::Function(f) if f.full_location().contains(cursor) => Some(f),
-                _ => None,
-            }) {
+            if let Some(function) =
+                self.module
+                    .ast
+                    .definitions
+                    .iter()
+                    .find_map(|definition| match definition {
+                        Definition::Function(function)
+                            if function.full_location().contains(cursor) =>
+                        {
+                            Some(function)
+                        }
+                        _ => None,
+                    })
+            {
                 completions.extend(
-                    LocalCompletion::new(mod_name, insert_range, cursor).fn_completions(fun),
+                    LocalCompletion::new(mod_name, insert_range, cursor).fn_completions(function),
                 );
             }
 

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -1565,12 +1565,17 @@ fn get_hexdocs_link_section(
     ast: &TypedModule,
     hex_deps: &HashSet<EcoString>,
 ) -> Option<String> {
-    let package_name = ast.definitions.iter().find_map(|def| match def {
-        Definition::Import(p) if p.module == module_name && hex_deps.contains(&p.package) => {
-            Some(&p.package)
-        }
-        _ => None,
-    })?;
+    let package_name = ast
+        .definitions
+        .iter()
+        .find_map(|definition| match definition {
+            Definition::Import(import)
+                if import.module == module_name && hex_deps.contains(&import.package) =>
+            {
+                Some(&import.package)
+            }
+            _ => None,
+        })?;
 
     Some(format_hexdocs_link_section(
         package_name,


### PR DESCRIPTION
I noticed that all throughout the compiler module's definitions were referred to as `statements` instead of `definitions` (and their type is indeed `UntypedDefinition` or `TypedDefinition`). This was confusing since the `Statement` type and `statement` name are already widely used to refer to the actual statements that are part of a function's body.
I've changed all the references to module definitions to use `definitions` as a name instead of `statements` so now we use distinct names to refer to module definitions and a function's body statements.

I've also renamed a couple of single letter/abbreviated variable names I found along the way!