### PR TITLE
Improve the look of error labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   JavaScript circular references.
   ([Louis Pilfold](https://github.com/lpil))
 
+- The look of errors and warnings has been improved. Additional labels providing
+  context for the error message are no longer highlighted with the same style as
+  the source of the problem.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - `gleam update`, `gleam deps update`, and `gleam deps download` will now print
@@ -33,7 +38,6 @@
   ```
 
   ([Amjad Mohamed](https://github.com/andho))
-
 
 ### Language server
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__conflict_with_import.snap
@@ -11,10 +11,10 @@ import wibble.{type A} type A { C }
 
 ----- ERROR
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:1:16
+  ┌─ /src/one/two.gleam:1:24
   │
 1 │ import wibble.{type A} type A { C }
-  │                ^^^^^^  ^^^^^^ Redefined here
+  │                ------  ^^^^^^ Redefined here
   │                │        
   │                First defined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_no_unqualified.snap
@@ -20,10 +20,10 @@ pub fn wobble() { 1 }
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import wibble/sub
-  │         ^^^^^^^^^^^^^^^^^ First imported here
+  │         ----------------- First imported here
 3 │         import wibble2/sub
   │         ^^^^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__ambiguous_import_error_with_unqualified.snap
@@ -20,10 +20,10 @@ pub fn wobble() { 1 }
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import wibble/sub
-  │         ^^^^^^^^^^^^^^^^^ First imported here
+  │         ----------------- First imported here
 3 │         import wibble2/sub.{wobble}
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_alias_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_alias_names.snap
@@ -7,10 +7,10 @@ type X = Int type X = Int
 
 ----- ERROR
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:1:14
   │
 1 │ type X = Int type X = Int
-  │ ^^^^^^^^^^^^ ^^^^^^^^^^^^ Redefined here
+  │ ------------ ^^^^^^^^^^^^ Redefined here
   │ │             
   │ First defined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_and_function_names_const_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_and_function_names_const_fn.snap
@@ -8,10 +8,10 @@ fn duplicate() { 2 }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ const duplicate = 1
-  │ ^^^^^^^^^^^^^^^ First defined here
+  │ --------------- First defined here
 2 │ fn duplicate() { 2 }
   │ ^^^^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_const.snap
@@ -8,10 +8,10 @@ const wibble = 2
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ const wibble = 1
-  │ ^^^^^^^^^^^^ First defined here
+  │ ------------ First defined here
 2 │ const wibble = 2
   │ ^^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_extfn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_extfn.snap
@@ -11,10 +11,10 @@ fn wibble() -> Float
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:4:1
   │
 1 │ const wibble = 1
-  │ ^^^^^^^^^^^^ First defined here
+  │ ------------ First defined here
   ·
 4 │ fn wibble() -> Float
   │ ^^^^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_fn.snap
@@ -8,10 +8,10 @@ fn wibble() { 2 }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ const wibble = 1
-  │ ^^^^^^^^^^^^ First defined here
+  │ ------------ First defined here
 2 │ fn wibble() { 2 }
   │ ^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_const_names.snap
@@ -8,10 +8,10 @@ pub const duplicate = 1
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ const duplicate = 1
-  │ ^^^^^^^^^^^^^^^ First defined here
+  │ --------------- First defined here
 2 │ pub const duplicate = 1
   │ ^^^^^^^^^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_constructors.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_constructors.snap
@@ -8,10 +8,10 @@ type Boxy { Box(Int) }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:12
+  ┌─ /src/one/two.gleam:2:13
   │
 1 │ type Box { Box(x: Int) }
-  │            ^^^^^^^^^^^ First defined here
+  │            ----------- First defined here
 2 │ type Boxy { Box(Int) }
   │             ^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_constructors2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_constructors2.snap
@@ -8,10 +8,10 @@ type Box { Box(x: Int) }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:13
+  ┌─ /src/one/two.gleam:2:12
   │
 1 │ type Boxy { Box(Int) }
-  │             ^^^^^^^^ First defined here
+  │             -------- First defined here
 2 │ type Box { Box(x: Int) }
   │            ^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_constructors3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_constructors3.snap
@@ -7,10 +7,10 @@ type Boxy { Box(Int) Box(Float) }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:13
+  ┌─ /src/one/two.gleam:1:22
   │
 1 │ type Boxy { Box(Int) Box(Float) }
-  │             ^^^^^^^^ ^^^^^^^^^^ Redefined here
+  │             -------- ^^^^^^^^^^ Redefined here
   │             │         
   │             First defined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_custom_type_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_custom_type_names.snap
@@ -7,10 +7,10 @@ type DupType { A } type DupType { B }
 
 ----- ERROR
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:1:20
   │
 1 │ type DupType { A } type DupType { B }
-  │ ^^^^^^^^^^^^       ^^^^^^^^^^^^ Redefined here
+  │ ------------       ^^^^^^^^^^^^ Redefined here
   │ │                   
   │ First defined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_const.snap
@@ -11,10 +11,10 @@ const wibble = 2
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:3:1
+  ┌─ /src/one/two.gleam:5:1
   │
 3 │ fn wibble() -> Float
-  │ ^^^^^^^^^^^ First defined here
+  │ ----------- First defined here
 4 │ 
 5 │ const wibble = 2
   │ ^^^^^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_extfn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_extfn.snap
@@ -12,10 +12,10 @@ fn wibble() -> Float
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:3:1
+  ┌─ /src/one/two.gleam:5:1
   │
 3 │ fn wibble() -> Float
-  │ ^^^^^^^^^^^ First defined here
+  │ ----------- First defined here
 4 │ @external(erlang, "module2", "function2")
 5 │ fn wibble() -> Float
   │ ^^^^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_extfn_fn.snap
@@ -11,10 +11,10 @@ fn wibble() { 2 }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:3:1
+  ┌─ /src/one/two.gleam:5:1
   │
 3 │ fn wibble() -> Float
-  │ ^^^^^^^^^^^ First defined here
+  │ ----------- First defined here
 4 │ 
 5 │ fn wibble() { 2 }
   │ ^^^^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_const.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_const.snap
@@ -8,10 +8,10 @@ const wibble = 2
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ fn wibble() { 1 }
-  │ ^^^^^^^^^^^ First defined here
+  │ ----------- First defined here
 2 │ const wibble = 2
   │ ^^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_extfn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_extfn.snap
@@ -11,10 +11,10 @@ fn wibble() -> Float
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:4:1
   │
 1 │ fn wibble() { 1 }
-  │ ^^^^^^^^^^^ First defined here
+  │ ----------- First defined here
   ·
 4 │ fn wibble() -> Float
   │ ^^^^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_fn.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_fn_fn.snap
@@ -8,10 +8,10 @@ fn wibble() { 2 }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ fn wibble() { 1 }
-  │ ^^^^^^^^^^^ First defined here
+  │ ----------- First defined here
 2 │ fn wibble() { 2 }
   │ ^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names.snap
@@ -8,10 +8,10 @@ fn dupe() { 2 }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ fn dupe() { 1 }
-  │ ^^^^^^^^^ First defined here
+  │ --------- First defined here
 2 │ fn dupe() { 2 }
   │ ^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_2.snap
@@ -8,10 +8,10 @@ fn dupe() { 2.0 }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ fn dupe() { 1 }
-  │ ^^^^^^^^^ First defined here
+  │ --------- First defined here
 2 │ fn dupe() { 2.0 }
   │ ^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_3.snap
@@ -8,10 +8,10 @@ fn dupe(x) { x }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:2:1
   │
 1 │ fn dupe() { 1 }
-  │ ^^^^^^^^^ First defined here
+  │ --------- First defined here
 2 │ fn dupe(x) { x }
   │ ^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_4.snap
@@ -10,10 +10,10 @@ fn dupe(x) -> x
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:1:1
+  ┌─ /src/one/two.gleam:3:1
   │
 1 │ fn dupe() { 1 }
-  │ ^^^^^^^^^ First defined here
+  │ --------- First defined here
 2 │ @external(erlang, "a", "b")
 3 │ fn dupe(x) -> x
   │ ^^^^^^^^^^ Redefined here

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__duplicate_function_names_5.snap
@@ -11,10 +11,10 @@ fn dupe() { 1 }
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:3:1
+  ┌─ /src/one/two.gleam:4:1
   │
 3 │ fn dupe(x) -> x
-  │ ^^^^^^^^^^ First defined here
+  │ ---------- First defined here
 4 │ fn dupe() { 1 }
   │ ^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition.snap
@@ -19,10 +19,10 @@ pub fn main() {
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:3:3
+  ┌─ /src/one/two.gleam:4:3
   │
 3 │   Wobble
-  │   ^^^^^^ First defined here
+  │   ------ First defined here
 4 │   Wobble
   │   ^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__no_crash_on_duplicate_definition2.snap
@@ -23,10 +23,10 @@ pub fn main() {
 
 ----- ERROR
 error: Duplicate definition
-  ┌─ /src/one/two.gleam:4:3
+  ┌─ /src/one/two.gleam:5:3
   │
 4 │   Wobble
-  │   ^^^^^^ First defined here
+  │   ------ First defined here
 5 │   Wobble
   │   ^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -18,10 +18,10 @@ expression: "\n        import gleam/wibble.{wobble}\n        import gleam/wibble
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import gleam/wibble.{wobble}
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ First imported here
+  │         ---------------------------- First imported here
 3 │         import gleam/wibble.{zoo}
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_1.snap
@@ -21,10 +21,10 @@ expression: "\n        import one\n        import two as one\n        "
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import one
-  │         ^^^^^^^^^^ First imported here
+  │         ---------- First imported here
 3 │         import two as one
   │         ^^^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_2.snap
@@ -21,10 +21,10 @@ expression: "\n        import one as two\n        import two\n        "
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import one as two
-  │         ^^^^^^^^^^^^^^^^^ First imported here
+  │         ----------------- First imported here
 3 │         import two
   │         ^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_3.snap
@@ -21,10 +21,10 @@ expression: "\n        import one as x\n        import two as x\n        "
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import one as x
-  │         ^^^^^^^^^^^^^^^ First imported here
+  │         --------------- First imported here
 3 │         import two as x
   │         ^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_4.snap
@@ -21,10 +21,10 @@ expression: "\n        import one.{fn1}\n        import two.{fn2} as one\n      
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import one.{fn1}
-  │         ^^^^^^^^^^^^^^^^ First imported here
+  │         ---------------- First imported here
 3 │         import two.{fn2} as one
   │         ^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_5.snap
@@ -21,10 +21,10 @@ expression: "\n        import one.{fn1} as two\n        import two.{fn2}\n      
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import one.{fn1} as two
-  │         ^^^^^^^^^^^^^^^^^^^^^^^ First imported here
+  │         ----------------------- First imported here
 3 │         import two.{fn2}
   │         ^^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_6.snap
@@ -21,10 +21,10 @@ expression: "\n        import one.{fn1} as x\n        import two.{fn2} as x\n   
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:3:9
   │
 2 │         import one.{fn1} as x
-  │         ^^^^^^^^^^^^^^^^^^^^^ First imported here
+  │         --------------------- First imported here
 3 │         import two.{fn2} as x
   │         ^^^^^^^^^^^^^^^^^^^^^ Reimported here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_7.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times_7.snap
@@ -25,12 +25,12 @@ expression: "\n        import one.{\n          fn1\n        } as x\n        impo
 
 ----- ERROR
 error: Duplicate import
-  ┌─ /src/one/two.gleam:2:9
+  ┌─ /src/one/two.gleam:5:9
   │    
 2 │   ╭         import one.{
 3 │   │           fn1
 4 │   │         } as x
-  │   ╰──────────────^ First imported here
+  │   ╰──────────────' First imported here
 5 │ ╭           import two.{
 6 │ │             fn2
 7 │ │           } as x

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as.snap
@@ -14,10 +14,10 @@ pub type X = One
 
 ----- ERROR
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:1:13
+  ┌─ /src/one/two.gleam:1:32
   │
 1 │ import one.{type One as MyOne, type One as MyOne}
-  │             ^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^ Redefined here
+  │             -----------------  ^^^^^^^^^^^^^^^^^ Redefined here
   │             │                   
   │             First defined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as_multiline.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__imports__import_type_duplicate_with_as_multiline.snap
@@ -17,10 +17,10 @@ pub type X = One
 
 ----- ERROR
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:2:11
+  ┌─ /src/one/two.gleam:3:11
   │
 2 │           type One as MyOne,
-  │           ^^^^^^^^^^^^^^^^^ First defined here
+  │           ----------------- First defined here
 3 │           type One as MyOne
   │           ^^^^^^^^^^^^^^^^^ Redefined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__conflict_with_import.snap
@@ -11,10 +11,10 @@ import wibble.{type Wobble} type Wobble = Int
 
 ----- ERROR
 error: Duplicate type definition
-  ┌─ /src/one/two.gleam:1:16
+  ┌─ /src/one/two.gleam:1:29
   │
 1 │ import wibble.{type Wobble} type Wobble = Int
-  │                ^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^ Redefined here
+  │                -----------  ^^^^^^^^^^^^^^^^^ Redefined here
   │                │             
   │                First defined here
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_arity.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_arity.snap
@@ -11,10 +11,10 @@ use <- f
 
 ----- ERROR
 error: Incorrect arity
-  ┌─ /src/one/two.gleam:3:1
+  ┌─ /src/one/two.gleam:3:8
   │
 3 │ use <- f
-  │ ^^^    ^
+  │ ---    ^
   │ │       
   │ Expected 2 arguments, got 0
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_callback_arity.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_callback_arity.snap
@@ -11,10 +11,10 @@ use _ <- x()
 
 ----- ERROR
 error: Incorrect arity
-  ┌─ /src/one/two.gleam:3:5
+  ┌─ /src/one/two.gleam:3:10
   │
 3 │ use _ <- x()
-  │     ^    ^^^
+  │     -    ^^^
   │     │     
   │     Expected no arguments, got 1
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_callback_arity_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_callback_arity_2.snap
@@ -11,10 +11,10 @@ use <- x()
 
 ----- ERROR
 error: Incorrect arity
-  ┌─ /src/one/two.gleam:3:1
+  ┌─ /src/one/two.gleam:3:8
   │
 3 │ use <- x()
-  │ ^^^    ^^^
+  │ ---    ^^^
   │ │       
   │ Expected 1 argument, got 0
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_callback_arity_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___wrong_callback_arity_3.snap
@@ -11,10 +11,10 @@ use _, _ <- x()
 
 ----- ERROR
 error: Incorrect arity
-  ┌─ /src/one/two.gleam:3:5
+  ┌─ /src/one/two.gleam:3:13
   │
 3 │ use _, _ <- x()
-  │     ^^^^    ^^^
+  │     ----    ^^^
   │     │        
   │     Expected 1 argument, got 2
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__import_module_twice.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__import_module_twice.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-assertion_line: 3918
 expression: "import gleam/wibble as a\nimport gleam/wibble as b\n\npub fn main() {\n  a.wobble() + b.wobble()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 -- gleam/wibble.gleam
@@ -19,11 +17,11 @@ pub fn main() {
 
 ----- WARNING
 warning: Duplicate import
-  ┌─ /src/warning/wrn.gleam:1:1
+  ┌─ /src/warning/wrn.gleam:2:1
   │
 1 │ import gleam/wibble as a
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  │ ------------------------ First imported here
 2 │ import gleam/wibble as b
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^ Reimported here
 
 The gleam/wibble module has been imported twice.

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1290,14 +1290,14 @@ can already tell whether it will be true or false.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: None,
-                            span: *first,
+                            text: Some("Reimported here".into()),
+                            span: *second,
                         },
                         extra_labels: vec![ExtraLabel {
                             src_info: None,
                             label: diagnostic::Label {
-                                text: None,
-                                span: *second,
+                                text: Some("First imported here".into()),
+                                span: *first,
                             },
                         }],
                     }),

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle_multi.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_cycle_multi.snap
@@ -11,12 +11,12 @@ error: Import cycle
   ┌─ src/two.gleam:1:1
   │
 1 │ import three
-  │ ^ Imported here
+  │ ------------ Imported here
   │
   ┌─ src/one.gleam:1:1
   │
 1 │ import two
-  │ ^ Imported here
+  │ ---------- Imported here
 
 The import statements for these modules form a cycle:
 


### PR DESCRIPTION
This PR changes the look of secondary labels in error messages and warnings so they are no longer highlighted in red/yellow. This way additional context that is added to errors using extra labels looks a bit nicer.