### PR TITLE
Better error message for unknown variable named as an ignored variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,33 @@
   shadows an imported name in the current module.
   ([Aayush Tripathi](https://github.com/aayush-tripathi))
 
+- The compiler can now tell when an unknown variable might be referring to an
+  ignored variable and provide an helpful error message highlighting it. For
+  example, this piece of code:
+
+  ```gleam
+  pub fn go() {
+    let _x = 1
+    x + 1
+  }
+  ```
+
+  Now results in the following error:
+
+  ```
+  error: Unknown variable
+    ┌─ /src/one/two.gleam:4:3
+    │
+  3 │   let _x = 1
+    │       -- Did you mean to use this ignored variable?
+  4 │   x + 1
+    │   ^
+
+  The name `x` is not in scope here.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - `gleam update`, `gleam deps update`, and `gleam deps download` will now print

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## Unreleased
 
-### Build tool
-
-- Generated JavaScript functions, constants, and custom type constructors now
-  include any doc comment as a JSDoc comment, making it easier to use the
-  generated code and browse its documentation from JavaScript.
-  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
-
-## v1.11.0-rc1 - 2025-05-15
-
 ### Compiler
 
 - Generated JavaScript functions, constants, and custom type constructors now

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -14,7 +14,7 @@ use hexpm::version::Version;
 use num_bigint::BigInt;
 #[cfg(test)]
 use pretty_assertions::assert_eq;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 /// Errors and warnings discovered when compiling a module.
 ///
@@ -167,6 +167,7 @@ pub enum Error {
         location: SrcSpan,
         name: EcoString,
         variables: Vec<EcoString>,
+        ignored_variables: HashMap<EcoString, SrcSpan>,
         type_with_name_in_scope: bool,
     },
 
@@ -1297,6 +1298,7 @@ pub fn convert_get_value_constructor_error(
             location,
             name,
             variables,
+            ignored_variables: HashMap::new(),
             type_with_name_in_scope,
         },
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1008,6 +1008,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             .map(|type_| self.type_from_ast(&type_))
             .unwrap_or_else(|| Ok(self.new_unbound_var()))?;
 
+        match &names {
+            ArgNames::Named { .. } | ArgNames::NamedLabelled { .. } => (),
+            ArgNames::Discard { name, .. } | ArgNames::LabelledDiscard { name, .. } => {
+                let _ = self
+                    .environment
+                    .ignored_names
+                    .insert(name.clone(), location);
+            }
+        }
+
         // If we know the expected type of the argument from its contextual
         // usage then unify the newly constructed type with the expected type.
         // We do this here because then there is more type information for the
@@ -3469,6 +3479,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location: *location,
                 name: name.clone(),
                 variables: self.environment.local_value_names(),
+                ignored_variables: self.environment.ignored_names.clone(),
                 type_with_name_in_scope: self
                     .environment
                     .module_types

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3125,3 +3125,70 @@ fn bit_array_using_pattern_variables_from_other_bit_array() {
 fn non_utf8_string_assignment() {
     assert_error!(r#"let assert <<"Hello" as message:utf16>> = <<>>"#);
 }
+
+#[test]
+fn shadowed_function_argument() {
+    assert_module_error!(
+        "
+pub fn go(_x) {
+  x + 1
+}
+"
+    );
+}
+
+#[test]
+fn shadowed_fn_argument() {
+    assert_module_error!(
+        "
+pub fn go(x) {
+  fn(_y) {
+    y + x
+  }
+}
+"
+    );
+}
+
+#[test]
+fn shadowed_let_variable() {
+    assert_module_error!(
+        "
+pub fn go() {
+  let _x = 1
+  x + 1
+}
+"
+    );
+}
+
+#[test]
+fn shadowed_pattern_variable() {
+    assert_module_error!(
+        "
+pub type Wibble {
+  Wibble(Int)
+}
+
+pub fn go(x) {
+  case x {
+    Wibble(_y) -> y + 1
+  }
+}
+"
+    );
+}
+
+#[test]
+fn do_not_suggest_ignored_variable_outside_of_current_scope() {
+    assert_module_error!(
+        "
+pub fn go() {
+  let _ = {
+    let _y = 1 // <- this shouldn't be highlighted!
+  }
+  y
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_ignored_variable_outside_of_current_scope.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_ignored_variable_outside_of_current_scope.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn go() {\n  let _ = {\n    let _y = 1 // <- this shouldn't be highlighted!\n  }\n  y\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  let _ = {
+    let _y = 1 // <- this shouldn't be highlighted!
+  }
+  y
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:3
+  │
+6 │   y
+  │   ^
+
+The name `y` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_fn_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_fn_argument.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn go(x) {\n  fn(_y) {\n    y + x\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  fn(_y) {
+    y + x
+  }
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:4:5
+  │
+3 │   fn(_y) {
+  │      -- Did you mean to use this ignored variable?
+4 │     y + x
+  │     ^
+
+The name `y` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_function_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_function_argument.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn go(_x) {\n  x + 1\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(_x) {
+  x + 1
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:3:3
+  │
+2 │ pub fn go(_x) {
+  │           -- Did you mean to use this ignored variable?
+3 │   x + 1
+  │   ^
+
+The name `x` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_let_variable.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_let_variable.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn go() {\n  let _x = 1\n  x + 1\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  let _x = 1
+  x + 1
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:4:3
+  │
+3 │   let _x = 1
+  │       -- Did you mean to use this ignored variable?
+4 │   x + 1
+  │   ^
+
+The name `x` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_pattern_variable.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__shadowed_pattern_variable.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble {\n  Wibble(Int)\n}\n\npub fn go(x) {\n  case x {\n    Wibble(_y) -> y + 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(Int)
+}
+
+pub fn go(x) {
+  case x {
+    Wibble(_y) -> y + 1
+  }
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:8:19
+  │
+8 │     Wibble(_y) -> y + 1
+  │            --     ^
+  │            │       
+  │            Did you mean to use this ignored variable?
+
+The name `y` is not in scope here.


### PR DESCRIPTION
When a variable has the same name as an ignored variable the compiler can now show more context in the "unknown variable" error, pointing to the ignored variable.
This PR fixes #4512