### PR TITLE
Fix extracting `use` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,10 @@
   with the wrong number of labels.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would generate invalid code when the
+  "Extract variable" code action was used on a `use` expression.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.11.1 - 2025-06-05
 
 ### Compiler

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3012,21 +3012,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
                 | ExtractVariablePosition::InsideCaseClause
                 | ExtractVariablePosition::CallArg,
             )
-            | None => {
-                match expr {
-                    // We don't extract variables, they're already good.
-                    // And we don't extract module selects by themselves but always
-                    // want to consider those as part of a function call.
-                    TypedExpr::Var { .. } | TypedExpr::ModuleSelect { .. } => (),
-                    _ => {
-                        self.selected_expression = Some((expr_location, expr.type_()));
-
-                        if !matches!(self.position, Some(ExtractVariablePosition::CallArg)) {
-                            self.statement_before_selected_expression = self.latest_statement;
-                        }
-                    }
-                }
-            }
+            | None => {}
         }
 
         match expr {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -8738,3 +8738,20 @@ pub fn main() {
             .to_selection()
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4675
+#[test]
+fn extract_variable_use() {
+    assert_no_code_actions!(
+        EXTRACT_VARIABLE,
+        "
+pub fn main() {
+  #({
+    use <- todo
+    todo
+  })
+}
+  ",
+        find_position_of("use").to_selection()
+    );
+}


### PR DESCRIPTION
This PR fixes #4675 
There was some duplicated logic that worked slightly differently between the two implementations, causing this bug.