### PR TITLE
Only show relevant labels for "incorrect arity" error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,36 @@
   ([Carl Bordum Hansen](https://github.com/carlbordum)) and
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The error message one gets when calling a function with the wrong number of
+  arguments has been improved and now only suggests the relevant missing labels.
+  For example, this piece of code:
+
+  ```gleam
+  pub type Pokemon {
+    Pokemon(id: Int, name: String, moves: List(String))
+  }
+
+  pub fn best_pokemon() {
+    Pokemon(198, name: "murkrow")
+  }
+  ```
+
+  Would result in the following error, suggesting the missing labels:
+
+  ```txt
+  error: Incorrect arity
+    ┌─ /src/main.gleam:6:3
+    │
+  6 │   Pokemon(198, name: "murkrow")
+    │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected 3 arguments, got 2
+
+  This call accepts these additional labelled arguments:
+
+    - moves
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - `gleam update`, `gleam deps update`, and `gleam deps download` will now print
@@ -125,7 +155,7 @@
 
 - Docs generator now strips trailing slashes from Gitea/Forgejo hosts so
   sidebar "Repository" and "View Source" links never include `//`, and
-  single-line “View Source” anchors emit `#Lx` instead of `#Lx-x`.
+  single-line "View Source" anchors emit `#Lx` instead of `#Lx-x`.
   ([Aayush Tripathi](https://github.com/aayush-tripathi))
 
 ### Language server

--- a/compiler-core/src/type_/fields.rs
+++ b/compiler-core/src/type_/fields.rs
@@ -55,7 +55,7 @@ impl FieldMap {
 
         if self.arity as usize != args.len() {
             return Err(Error::IncorrectArity {
-                labels: self.incorrect_arity_labels(args),
+                labels: self.missing_labels(args),
                 location,
                 context,
                 expected: self.arity as usize,
@@ -145,17 +145,6 @@ impl FieldMap {
         }
     }
 
-    pub fn incorrect_arity_labels<A>(&self, args: &[CallArg<A>]) -> Vec<EcoString> {
-        let given: HashSet<_> = args.iter().filter_map(|arg| arg.label.as_ref()).collect();
-
-        self.fields
-            .keys()
-            .filter(|f| !given.contains(f))
-            .cloned()
-            .sorted()
-            .collect()
-    }
-
     /// This returns an array of the labels that are unused given an argument
     /// list.
     /// The unused labels are in the order they are expected to be passed in
@@ -169,7 +158,7 @@ impl FieldMap {
     /// wibble(1, label3: 2) // -> unused labels: [label2]
     /// ```
     ///
-    pub fn missing_labels<A: std::fmt::Debug>(&self, args: &[CallArg<A>]) -> Vec<EcoString> {
+    pub fn missing_labels<A>(&self, args: &[CallArg<A>]) -> Vec<EcoString> {
         // We need to know how many positional arguments are in the function
         // arguments. That's given by the position of the first labelled
         // argument; if the first label argument is third, then we know the

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3208,3 +3208,19 @@ pub fn main() {
 "
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3884
+#[test]
+fn show_only_missing_labels() {
+    assert_module_error!(
+        "
+fn wibble(a a: Int, b b: Float, c c: String) {
+    todo
+}
+
+pub fn wobble() {
+    wibble(1, 2.0)
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_record_wrong_arity.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_record_wrong_arity.snap
@@ -17,5 +17,4 @@ error: Incorrect arity
 
 This call accepts these additional labelled arguments:
 
-  - a
   - b

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__show_only_missing_labels.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__show_only_missing_labels.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nfn wibble(a a: Int, b b: Float, c c: String) {\n    todo\n}\n\npub fn wobble() {\n    wibble(1, 2.0)\n}\n"
+---
+----- SOURCE CODE
+
+fn wibble(a a: Int, b b: Float, c c: String) {
+    todo
+}
+
+pub fn wobble() {
+    wibble(1, 2.0)
+}
+
+
+----- ERROR
+error: Incorrect arity
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     wibble(1, 2.0)
+  │     ^^^^^^^^^^^^^^ Expected 3 arguments, got 2
+
+This call accepts these additional labelled arguments:
+
+  - c

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_label_shorthand_fault_tolerance2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_label_shorthand_fault_tolerance2.snap
@@ -24,7 +24,6 @@ error: Incorrect arity
 This call accepts these additional labelled arguments:
 
   - wabble
-  - wibble
 
 error: Type mismatch
   ┌─ /src/one/two.gleam:8:10

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_labels_fault_tolerance2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__functions__function_call_incorrect_arity_with_labels_fault_tolerance2.snap
@@ -23,7 +23,6 @@ error: Incorrect arity
 This call accepts these additional labelled arguments:
 
   - wabble
-  - wibble
 
 error: Type mismatch
   ┌─ /src/one/two.gleam:7:10


### PR DESCRIPTION
This PR fixes #3884
There was a newer, more accurate function to figure out missing labels; it was as simple as using it instead of that older version 😁
And now the nice thing is it's consistent with the labels suggested by the "add missing labels" code action, win-win!