### PR TITLE
Enable inlining on the Erlang target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,10 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- On the Erlang target each generated module enables inlining from the Erlang
+  compiler.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - `gleam update`, `gleam deps update`, and `gleam deps download` will now print

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -272,7 +272,7 @@ fn module_document<'a>(
 
     let module = docvec![
         header,
-        "-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).",
+        "-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).",
         line(),
         "-define(FILEPATH, \"",
         src_path_relative,

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__allowed_string_escapes.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__allowed_string_escapes.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 531
 expression: "pub fn a() { \"\\n\" \"\\r\" \"\\t\" \"\\\\\" \"\\\"\" \"\\\\^\" }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a() { "\n" "\r" "\t" "\\" "\"" "\\^" }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__binop_parens.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__binop_parens.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 425
 expression: "\npub fn main() {\n    let a = 2 * {3 + 1} / 2\n    let b = 5 + 3 / 3 * 2 - 6 * 4\n    b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__bit_pattern_shadowing.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__bit_pattern_shadowing.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 988
 expression: "\npub fn main() {\n  let code = <<\"hello world\":utf8>>\n  let pre = 1\n  case code {\n    <<pre:bytes-size(pre), _:bytes>> -> pre\n    _ -> panic\n  }\n}        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__block_assignment.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__block_assignment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 469
 expression: "\npub fn main() {\n  let x = {\n    1\n    2\n  }\n  x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 787
 expression: "\npub const module_info = 1\n\npub fn main() {\n    module_info\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_imported.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_imported.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 801
 expression: "\nimport some_module\n\npub fn main() {\n    some_module.module_info\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_imported_qualified.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_imported_qualified.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 822
 expression: "\nimport some_module.{module_info}\n\npub fn main() {\n    module_info\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 843
 expression: "\npub fn function() {\n    1\n}\n\npub const module_info = function\n\npub fn main() {\n    module_info()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([function/0, main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside_imported.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside_imported.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 861
 expression: "\nimport some_module\n\npub fn main() {\n    some_module.module_info()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside_imported_qualified.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside_imported_qualified.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 886
 expression: "\nimport some_module.{module_info}\n\npub fn main() {\n    module_info()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__discard_in_assert.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__discard_in_assert.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 548
 expression: "pub fn x(y) {\n  let assert Ok(_) = y\n  1\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn x(y) {
@@ -12,7 +10,7 @@ pub fn x(y) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__dynamic.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__dynamic.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 644
 expression: pub type Dynamic
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Dynamic
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export_type([dynamic_/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__field_access_function_call.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__field_access_function_call.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 439
 expression: "\npub type FnBox {\n  FnBox(f: fn(Int) -> Int)\n}\n\npub fn main() {\n    let b = FnBox(f: fn(x) { x })\n    b.f(5)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([fn_box/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__field_access_function_call1.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__field_access_function_call1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 455
 expression: "\npub fn main() {\n    let t = #(fn(x) { x })\n\n    t.0(5)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_argument_shadowing.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_argument_shadowing.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 629
 expression: "pub fn main(a) {\n  Box\n}\n\npub type Box {\n  Box(Int)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main(a) {
@@ -16,7 +14,7 @@ pub type Box {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 -export_type([box/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 725
 expression: "\npub fn module_info() {\n    1\n}\n\npub fn main() {\n    module_info()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export(['moduleInfo'/0, main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_imported.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_imported.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 741
 expression: "\nimport some_module\n\npub fn main() {\n    some_module.module_info()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_imported_qualified.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_imported_qualified.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 764
 expression: "\nimport some_module.{module_info}\n\npub fn main() {\n    module_info()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 911
 expression: "\npub fn module_info() {\n    1\n}\n\npub const constant = module_info\n\npub fn main() {\n    constant()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export(['moduleInfo'/0, main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant_imported.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant_imported.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 929
 expression: "\nimport some_module\n\npub fn main() {\n    some_module.constant()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant_imported_qualified.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant_imported_qualified.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 954
 expression: "\nimport some_module.{constant}\n\npub fn main() {\n    constant()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__guard_variable_rewriting.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__guard_variable_rewriting.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 612
 expression: "pub fn main() {\n  case 1.0 {\n    a if a <. 0.0 -> {\n      let a = a\n      a\n    }\n    _ -> 0.0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main() {
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__inline_const_pattern_option.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__inline_const_pattern_option.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 650
 expression: "pub fn main() {\n            let fifteen = 15\n            let x = <<5:size(sixteen)>>\n            case x {\n              <<5:size(sixteen)>> -> <<5:size(sixteen)>>\n              <<6:size(fifteen)>> -> <<5:size(fifteen)>>\n              _ -> <<>>\n            }\n          }\n\n          pub const sixteen = 16"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main() {
@@ -19,7 +17,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 161
 expression: "pub fn go() {\nlet x = #(100000000000000000, #(2000000000, 3000000000000, 40000000000), 50000, 6000000000)\n  x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ let x = #(100000000000000000, #(2000000000, 3000000000000, 40000000000), 50000, 
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test0_1.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test0_1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 171
 expression: "pub fn go() {\n  let y = 1\n  let y = 2\n  y\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -13,7 +11,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test0_2.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test0_2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 183
 expression: "pub fn go() {\n    let fifteen = 0xF\n    let nine = 0o11\n    let ten = 0b1010\n  fifteen\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -14,7 +12,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test0_3.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test0_3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 195
 expression: "pub fn go() {\n  let y = 1\n  let y = 2\n  y\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -13,7 +11,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 206
 expression: "pub fn t() { True }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn t() { True }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([t/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test10.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test10.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 291
 expression: "pub type Null { Null }\npub fn x() { Null }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Null { Null }
@@ -10,7 +8,7 @@ pub fn x() { Null }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 -export_type([null/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test11.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test11.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 307
 expression: "pub type Point { Point(x: Int, y: Int) }\npub fn x() { Point(x: 4, y: 6) Point(y: 1, x: 9) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Point { Point(x: Int, y: Int) }
@@ -10,7 +8,7 @@ pub fn x() { Point(x: 4, y: 6) Point(y: 1, x: 9) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 -export_type([point/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test12.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test12.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 315
 expression: "pub type Point { Point(x: Int, y: Int) }\npub fn x(y) { let Point(a, b) = y a }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Point { Point(x: Int, y: Int) }
@@ -10,7 +8,7 @@ pub fn x(y) { let Point(a, b) = y a }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/1]).
 -export_type([point/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test13.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test13.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 318
 expression: "pub type State{ Start(Int) End(Int) }\n            pub fn build(constructor : fn(Int) -> a) -> a { constructor(1) }\n            pub fn main() { build(End) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type State{ Start(Int) End(Int) }
@@ -11,7 +9,7 @@ pub type State{ Start(Int) End(Int) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([build/1, main/0]).
 -export_type([state/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test16.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test16.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 327
 expression: "fn go(x xx, y yy) { xx }\npub fn x() { go(x: 1, y: 2) go(y: 3, x: 4) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn go(x xx, y yy) { xx }
@@ -10,7 +8,7 @@ pub fn x() { go(x: 1, y: 2) go(y: 3, x: 4) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test17.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test17.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 342
 expression: "\npub type User { User(id: Int, name: String, age: Int) }\npub fn create_user(user_id) { User(age: 22, id: user_id, name: \"\") }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn create_user(user_id) { User(age: 22, id: user_id, name: "") }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([create_user/1]).
 -export_type([user/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test18.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test18.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 346
 expression: "pub fn run() { case 1, 2 { a, b -> a } }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn run() { case 1, 2 { a, b -> a } }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([run/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test19.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test19.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 357
 expression: "pub type X { X(x: Int, y: Float) }\npub fn x() { X(x: 1, y: 2.) X(y: 3., x: 4) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type X { X(x: Int, y: Float) }
@@ -10,7 +8,7 @@ pub fn x() { X(x: 1, y: 2.) X(y: 3., x: 4) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 -export_type([x/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_1.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 211
 expression: "pub type Money { Pound(Int) }\npub fn pound(x) { Pound(x) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Money { Pound(Int) }
@@ -10,7 +8,7 @@ pub fn pound(x) { Pound(x) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([pound/1]).
 -export_type([money/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_2.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_2.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 219
 expression: "pub fn loop() { loop() }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn loop() { loop() }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([loop/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_4.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_4.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 224
 expression: "fn inc(x) { x + 1 }\n                    pub fn go() { 1 |> inc |> inc |> inc }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn inc(x) { x + 1 }
@@ -10,7 +8,7 @@ fn inc(x) { x + 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_5.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_5.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 232
 expression: "fn add(x, y) { x + y }\n                    pub fn go() { 1 |> add(_, 1) |> add(2, _) |> add(_, 3) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn add(x, y) { x + y }
@@ -10,7 +8,7 @@ fn add(x, y) { x + y }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_6.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test1_6.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 240
 expression: "pub fn and(x, y) { x && y }\npub fn or(x, y) { x || y }\npub fn remainder(x, y) { x % y }\npub fn fdiv(x, y) { x /. y }\n            "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn and(x, y) { x && y }
@@ -13,7 +11,7 @@ pub fn fdiv(x, y) { x /. y }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export(['and'/2, 'or'/2, remainder/2, fdiv/2]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test2.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 251
 expression: "pub fn second(list) { case list { [x, y] -> y z -> 1 } }\npub fn tail(list) { case list { [x, ..xs] -> xs z -> list } }\n            "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn second(list) { case list { [x, y] -> y z -> 1 } }
@@ -11,7 +9,7 @@ pub fn tail(list) { case list { [x, ..xs] -> xs z -> list } }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([second/1, tail/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test20.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test20.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 359
 expression: "\npub fn go(a) {\n  let a = a + 1\n  a\n}\n\n                    "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn go(a) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test21.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test21.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 372
 expression: "\npub fn go(a) {\n  let a = 1\n  a\n}\n\n                    "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn go(a) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test22.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test22.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 386
 expression: "\npub fn factory(f, i) {\n  f(i)\n}\n\npub type Box {\n  Box(i: Int)\n}\n\npub fn main() {\n  factory(Box, 0)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([factory/2, main/0]).
 -export_type([box/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test23.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test23.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 406
 expression: "\npub fn main(args) {\n  case args {\n    _ -> {\n      let a = 1\n      a\n    }\n  }\n  let a = 2\n  a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ pub fn main(args) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test3.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 299
 expression: "pub type Point { Point(x: Int, y: Int) }\npub fn y() { fn() { Point }()(4, 6) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Point { Point(x: Int, y: Int) }
@@ -10,7 +8,7 @@ pub fn y() { fn() { Point }()(4, 6) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([y/0]).
 -export_type([point/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test5.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test5.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 260
 expression: "pub fn tail(list) {\n  case list {\n    [x, ..] -> x\n    _ -> 0\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn tail(list) {
@@ -14,7 +12,7 @@ pub fn tail(list) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([tail/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test6.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test6.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 272
 expression: "pub fn x() { let x = 1 let x = x + 1 x }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn x() { let x = 1 let x = x + 1 x }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test8.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test8.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 278
 expression: "pub fn x() { 1. <. 2.3 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn x() { 1. <. 2.3 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test9.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__integration_test9.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 284
 expression: "pub type Pair(x, y) { Pair(x: x, y: y) } pub fn x() { Pair(1, 2) Pair(3., 4.) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Pair(x, y) { Pair(x: x, y: y) } pub fn x() { Pair(1, 2) Pair(3., 4.) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 -export_type([pair/2]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__keyword_constructors.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__keyword_constructors.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 537
 expression: "pub type X { Div }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type X { Div }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export_type([x/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__keyword_constructors1.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__keyword_constructors1.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 543
 expression: "pub type X { Fun(Int) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type X { Fun(Int) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export_type([x/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__negation.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__negation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 572
 expression: "pub fn negate(x) {\n  !x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn negate(x) {
@@ -11,7 +9,7 @@ pub fn negate(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([negate/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__negation_block.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__negation_block.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 581
 expression: "pub fn negate(x) {\n  !{\n    123\n    x\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn negate(x) {
@@ -14,7 +12,7 @@ pub fn negate(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([negate/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__operator_pipe_right_hand_side.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__operator_pipe_right_hand_side.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 559
 expression: "fn id(x) {\n  x\n}\n\npub fn bool_expr(x, y) {\n  y || x |> id\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn id(x) {
@@ -15,7 +13,7 @@ pub fn bool_expr(x, y) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([bool_expr/2]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__positive_zero.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__positive_zero.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 668
 expression: "\npub fn main() {\n  0.0\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__recursive_type.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__recursive_type.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 487
 expression: "\nfn id(x) {\n  x\n}\n\npub fn main() {\n  id(id)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__scientific_notation.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__scientific_notation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 680
 expression: "\npub fn main() {\n  1.0e6\n  1.e6\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr_block.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tail_maybe_expr_block.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 594
 expression: "pub fn a() {\n  let fake_tap = fn(x) { x }\n  let b = [99]\n  [\n    1,\n    2,\n    ..b\n    |> fake_tap\n  ]\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a() {
@@ -19,7 +17,7 @@ pub fn a() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tuple_access_in_guard.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__tuple_access_in_guard.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 502
 expression: "\npub fn main() {\n    let key = 10\n    let x = [#(10, 2), #(1, 2)]\n    case x {\n        [first, ..rest] if first.0 == key -> \"ok\"\n        _ -> \"ko\"\n    }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__type_named_else.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__type_named_else.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 693
 expression: "\npub type Else {\n  Else\n}\n\npub fn main() {\n  Else\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type(['else'/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__type_named_module_info.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__type_named_module_info.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 709
 expression: "\npub type ModuleInfo {\n    ModuleInfo\n}\n\npub fn main() {\n    ModuleInfo\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([module_info/0]).

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__variable_name_underscores_preserved.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__variable_name_underscores_preserved.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 518
 expression: "pub fn a(name_: String) -> String {\n    let name__ = name_\n    let name = name__\n    let one_1 = 1\n    let one1 = one_1\n    name\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a(name_: String) -> String {
@@ -15,7 +13,7 @@ pub fn a(name_: String) -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/1]).
 

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__windows_file_escaping_bug.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__windows_file_escaping_bug.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler-core/src/erlang/tests.rs
-assertion_line: 982
 expression: "pub fn main() { Nil }"
-snapshot_kind: text
 ---
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "C:\\root\\project\\test\\my\\mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 28
 expression: "\npub fn main() {\n  let x = True\n  assert x || False\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operation2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operation2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 40
 expression: "\npub fn eq(a, b) {\n  assert a == b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn eq(a, b) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([eq/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operation3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operation3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 51
 expression: "\npub fn assert_answer(x) {\n  assert x == 42\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn assert_answer(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([assert_answer/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operator_with_side_effects.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operator_with_side_effects.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 107
 expression: "\nfn wibble(a, b) {\n  let result = a + b\n  result == 10\n}\n\npub fn go(x) {\n  assert True && wibble(1, 4)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operator_with_side_effects2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_binary_operator_with_side_effects2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 123
 expression: "\nfn wibble(a, b) {\n  let result = a + b\n  result == 10\n}\n\npub fn go(x) {\n  assert wibble(5, 5) && wibble(4, 6)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_function_call.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_function_call.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 62
 expression: "\nfn bool() {\n  True\n}\n\npub fn main() {\n  assert bool()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_function_call2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_function_call2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 77
 expression: "\nfn and(a, b) {\n  a && b\n}\n\npub fn go(x) {\n  assert and(True, x)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_literal.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_literal.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 17
 expression: "\npub fn main() {\n  assert False\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_nested_function_call.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_nested_function_call.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 92
 expression: "\nfn and(x, y) {\n  x && y\n}\n\npub fn main() {\n  assert and(and(True, False), True)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_variable.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_variable.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 5
 expression: "\npub fn main() {\n  let x = True\n  assert x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_with_block_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_with_block_message.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 150
 expression: "\nfn identity(a) {\n  a\n}\n\npub fn main() {\n  assert identity(True) as {\n    let message = identity(\"This shouldn't fail\")\n    message\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_with_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__assert__assert_with_message.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/assert.rs
-assertion_line: 139
 expression: "\npub fn main() {\n  assert True as \"This shouldn't fail\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 5
 expression: "pub fn main() {\n  let a = 1\n  let simple = <<1, a>>\n  let complex = <<4:int-big, 5.0:little-float, 6:native-int>>\n  let assert <<7:2, 8:size(3), b:bytes-size(4)>> = <<1>>\n  let assert <<c:8-unit(1), d:bytes-size(2)-unit(2)>> = <<1>>\n\n  simple\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main() {
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 32
 expression: "pub fn x() { 2 }\npub fn main() {\n  let a = -1\n  let b = <<a:unit(2)-size(a * 2), a:size(3 + x())-unit(1)>>\n\n  b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn x() { 2 }
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 46
 expression: "pub fn main() {\n  let a = 1\n  let assert <<b, 1>> = <<1, a>>\n  b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main() {
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 58
 expression: "pub fn main() {\n  let a = <<\"test\":utf8>>\n  let assert <<b:utf8_codepoint, \"st\":utf8>> = a\n  b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main() {
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array4.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array4.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 70
 expression: "fn x() { 1 }\npub fn main() {\n  let a = <<x():int>>\n  a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn x() { 1 }
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array5.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array5.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 82
 expression: "const bit_size = 8\npub fn main() {\n  let a = <<10:size(bit_size)>>\n  a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 const bit_size = 8
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_declare_and_use_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_declare_and_use_var.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 124
 expression: "pub fn go(x) {\n  let assert <<name_size:8, name:bytes-size(name_size)>> = x\n  name\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go(x) {
@@ -12,7 +10,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_discard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_discard.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 96
 expression: "\npub fn bit_array_discard(x) -> Bool {\n case x {\n  <<_:utf8, rest:bytes>> -> True\n   _ -> False\n }\n}\n                    "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn bit_array_discard(x) -> Bool {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([bit_array_discard/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_discard1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_discard1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 110
 expression: "\npub fn bit_array_discard(x) -> Bool {\n case x {\n  <<_discardme:utf8, rest:bytes>> -> True\n   _ -> False\n }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn bit_array_discard(x) -> Bool {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([bit_array_discard/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_float.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_float.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 21
 expression: "pub fn main() {\n  let b = 16\n  let floats = <<1.0:16-float, 5.0:float-32, 6.0:float-64-little, 1.0:float-size(b)>>\n  let assert <<1.0:16-float, 5.0:float-32, 6.0:float-64-little, 1.0:float-size(b)>> = floats\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main() {
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_literal_string_constant_is_treated_as_utf8.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_literal_string_constant_is_treated_as_utf8.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 156
 expression: "\nconst a = <<\"hello\", \" \", \"world\">>\npub fn main() { a }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn main() { a }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_literal_string_is_treated_as_utf8.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_literal_string_is_treated_as_utf8.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 166
 expression: "\npub fn main() {\n  <<\"hello\", \" \", \"world\">>\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_literal_string_pattern_is_treated_as_utf8.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__bit_array_literal_string_pattern_is_treated_as_utf8.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 176
 expression: "\npub fn main() {\n  case <<>> {\n    <<\"a\", \"b\", _:bits>> -> 1\n    _ -> 2\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__block_in_pattern_size.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__block_in_pattern_size.snap
@@ -11,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__discard_utf8_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 189
 expression: "\npub fn main() {\n    let assert <<_:utf8, rest:bits>> = <<>>\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__non_byte_aligned_size_calculation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__non_byte_aligned_size_calculation.snap
@@ -14,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__operator_in_pattern_size.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__operator_in_pattern_size.snap
@@ -11,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__operator_in_pattern_size2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__operator_in_pattern_size2.snap
@@ -11,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__operator_in_pattern_size3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__operator_in_pattern_size3.snap
@@ -12,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__pattern_match_utf16_codepoint_little_endian.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__pattern_match_utf16_codepoint_little_endian.snap
@@ -12,7 +12,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__pattern_match_utf32_codepoint_little_endian.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__pattern_match_utf32_codepoint_little_endian.snap
@@ -12,7 +12,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__pipe_size_segment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__pipe_size_segment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 200
 expression: "\npub fn main() {\n  <<0xAE:size(5 |> identity)>>\n}\n\nfn identity(x) {\n  x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ fn identity(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 135
 expression: "\n    pub fn main() {\n        let emoji = \"\\u{1F600}\"\n        let arr = <<emoji:utf8>>\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unicode_bit_array_2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-assertion_line: 146
 expression: "\n    pub fn main() {\n        let arr = <<\"\\u{1F600}\":utf8>>\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__utf16_codepoint_little_endian.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__utf16_codepoint_little_endian.snap
@@ -11,7 +11,7 @@ pub fn go(codepoint) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__utf32_codepoint_little_endian.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__utf32_codepoint_little_endian.snap
@@ -11,7 +11,7 @@ pub fn go(codepoint) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__alternative_pattern_variable_rewriting.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__alternative_pattern_variable_rewriting.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/case.rs
-assertion_line: 6
 expression: "\npub fn myfun(mt) {\n  case mt {\n    1 | _ ->\n      1\n      |> Ok\n  }\n  1\n  |> Ok\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn myfun(mt) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([myfun/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__negative_zero_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__negative_zero_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/case.rs
-assertion_line: 39
 expression: "\npub fn main(x) {\n  case x {\n    -0.0 -> 1\n    _ -> 2\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__not.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__not.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/case.rs
-assertion_line: 53
 expression: "pub fn main(x, y) {\n  case x {\n    _ if !y -> 0\n    _ -> 1\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main(x, y) {
@@ -15,7 +13,7 @@ pub fn main(x, y) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__not_two.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__not_two.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/case.rs
-assertion_line: 66
 expression: "pub fn main(x, y) {\n  case x {\n    _ if !y && !x -> 0\n    _ -> 1\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main(x, y) {
@@ -15,7 +13,7 @@ pub fn main(x, y) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__positive_zero_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__positive_zero_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/case.rs
-assertion_line: 24
 expression: "\npub fn main(x) {\n  case x {\n    0.0 -> 1\n    _ -> 2\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__spread_empty_list.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__spread_empty_list.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/case.rs
-assertion_line: 80
 expression: "\npub fn main() {\n  case [] {\n    [..] -> 1\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__spread_empty_list_assigning.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__spread_empty_list_assigning.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/case.rs
-assertion_line: 94
 expression: "\npub fn main() {\n  case [] {\n    [..rest] -> rest\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__conditional_compilation__included_attribute_syntax.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__conditional_compilation__included_attribute_syntax.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/conditional_compilation.rs
-assertion_line: 14
 expression: "@target(erlang)\n  pub fn main() { 1 }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 @target(erlang)
@@ -11,7 +9,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__const_generalise.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__const_generalise.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 53
 expression: "\nfn identity(a: a) -> a {\na\n}\n\nconst id  = identity\n\npub fn main(){\n  let num  = id(1)\n  let word = id(\"Word\")\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn main(){
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__pub_const_equal_to_private_function.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__pub_const_equal_to_private_function.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 70
 expression: "\n          fn identity(a) {\n            a\n          }\n\n          pub const id = identity\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__pub_const_equal_to_record_with_nested_private_function_field.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__pub_const_equal_to_record_with_nested_private_function_field.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 100
 expression: "\n          fn identity(a) {\n            a\n          }\n\n          pub type Mapper(b) {\n            Mapper(fn(b) -> b)\n          }\n\n          pub type Funcs(b) {\n            Funcs(mapper: Mapper(b))\n          }\n\n          pub const id_mapper = Funcs(Mapper(identity))\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -23,7 +21,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 -export_type([mapper/1, funcs/1]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__pub_const_equal_to_record_with_private_function_field.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__pub_const_equal_to_record_with_private_function_field.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 83
 expression: "\n          fn identity(a) {\n            a\n          }\n\n          pub type Mapper(b) {\n            Mapper(fn(b) -> b)\n          }\n\n          pub const id_mapper = Mapper(identity)\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 -export_type([mapper/1]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__record_constructor.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__record_constructor.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 6
 expression: "\npub type X {\n  X(Int)\n}\n\npub const z = X\n\npub fn main() {\n  z\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([x/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__record_constructor_in_tuple.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__record_constructor_in_tuple.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 23
 expression: "\npub type X {\n  X(Int)\n}\n\npub const z = #(X)\n\npub fn main() {\n  z\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([x/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_private_in_internal.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_private_in_internal.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 168
 expression: "\n              fn identity(a) {\n                a\n              }\n\n              pub type Mapper(b) {\n                Mapper(fn(b) -> b)\n              }\n\n              @internal\n              pub const id_mapper = Mapper(identity)\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 -export_type([mapper/1]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_private_in_list.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_private_in_list.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 186
 expression: "\n          fn identity(a) {\n            a\n          }\n\n          pub const funcs = [identity]\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_private_in_tuple.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_private_in_tuple.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 199
 expression: "\n          fn identity(a) {\n            a\n          }\n\n          pub const funcs = #(identity)\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_qualified_pub_const_equal_to_record_with_private_function_field.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_qualified_pub_const_equal_to_record_with_private_function_field.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 151
 expression: "\n              fn identity(a) {\n                a\n              }\n\n              pub type Mapper(b) {\n                Mapper(fn(b) -> b)\n              }\n\n              pub const id_mapper = Mapper(identity)\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 -export_type([mapper/1]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_unqualified_pub_const_equal_to_private_function.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_unqualified_pub_const_equal_to_private_function.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 121
 expression: "\n              fn identity(a) {\n                a\n              }\n\n              pub const id = identity\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_unqualified_pub_const_equal_to_record_with_private_function_field.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__use_unqualified_pub_const_equal_to_record_with_private_function_field.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/consts.rs
-assertion_line: 134
 expression: "\n              fn identity(a) {\n                a\n              }\n\n              pub type Mapper(b) {\n                Mapper(fn(b) -> b)\n              }\n\n              pub const id_mapper = Mapper(identity)\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1]).
 -export_type([mapper/1]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__custom_types__phantom.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__custom_types__phantom.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests/custom_types.rs
-assertion_line: 5
 expression: "pub type Map(k, v)"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Map(k, v)
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export_type([map_/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_are_escaped_in_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_are_escaped_in_module_comment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 75
 expression: "\n//// \\backslashes!\\\n\npub fn main() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn main() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_in_documentation_are_escaped.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__backslashes_in_documentation_are_escaped.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 34
 expression: "\n/// \\hello\\\npub fn documented() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -11,7 +9,7 @@ pub fn documented() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([documented/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__double_quotes_are_escaped_in_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__double_quotes_are_escaped_in_module_comment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 65
 expression: "\n//// \"quotes!\"\n\npub fn main() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn main() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_documentation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_documentation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 5
 expression: "\n/// Function doc!\npub fn documented() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -11,7 +9,7 @@ pub fn documented() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([documented/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_multiline_documentation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__function_with_multiline_documentation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 14
 expression: "\n/// Function doc!\n/// Hello!!\n///\npub fn documented() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn documented() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([documented/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__internal_function_has_no_documentation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__internal_function_has_no_documentation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 85
 expression: "\n/// hidden!\n@internal\npub fn main() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn main() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__multi_line_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__multi_line_module_comment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 53
 expression: "\n//// Hello! This is a multi-\n//// line module comment.\n////\n\npub fn main() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__quotes_in_documentation_are_escaped.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__quotes_in_documentation_are_escaped.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 25
 expression: "\n/// \"hello\"\npub fn documented() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -11,7 +9,7 @@ pub fn documented() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([documented/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__single_line_module_comment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__documentation__single_line_module_comment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/documentation.rs
-assertion_line: 43
 expression: "\n//// Hello! This is a single line module comment.\n\npub fn main() { 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn main() { 1 }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_in_a_pipeline.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_in_a_pipeline.snap
@@ -15,7 +15,7 @@ pub fn wibble(n) { n }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/1, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_in_a_pipeline_with_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_in_a_pipeline_with_message.snap
@@ -15,7 +15,7 @@ pub fn wibble(n) { n }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/1, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_block.snap
@@ -14,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_case_expression.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_case_expression.snap
@@ -13,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_function_call.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_function_call.snap
@@ -13,7 +13,7 @@ fn wibble(n: Int, m: Int) { n + m }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_function_call_and_a_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_function_call_and_a_message.snap
@@ -14,7 +14,7 @@ fn message() { "Hello!" }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_panic.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_panic.snap
@@ -11,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_simple_expression.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_simple_expression.snap
@@ -11,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_simple_expression_and_a_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_a_simple_expression_and_a_message.snap
@@ -11,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_complex_expression_as_a_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__echo_with_complex_expression_as_a_message.snap
@@ -16,7 +16,7 @@ fn name() { "Giacomo" }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__multiple_echos_in_a_pipeline.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__multiple_echos_in_a_pipeline.snap
@@ -18,7 +18,7 @@ pub fn wibble(n) { n }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/1, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__multiple_echos_inside_expression.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__multiple_echos_inside_expression.snap
@@ -12,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__pipeline_printed_by_echo_is_wrapped_in_begin_end_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__pipeline_printed_by_echo_is_wrapped_in_begin_end_block.snap
@@ -16,7 +16,7 @@ pub fn wibble(n) { n }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/1, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__record_update_printed_by_echo_is_wrapped_in_begin_end_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__echo__record_update_printed_by_echo_is_wrapped_in_begin_end_block.snap
@@ -14,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([wobble/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__attribute_erlang.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__attribute_erlang.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 147
 expression: "\n@external(erlang, \"one\", \"one\")\npub fn one(x: Int) -> Int {\n  todo\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn one(x: Int) -> Int {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([one/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__attribute_javascript.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__attribute_javascript.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 159
 expression: "\n@external(javascript, \"./one.mjs\", \"one\")\npub fn one(x: Int) -> Int {\n  todo\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn one(x: Int) -> Int {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([one/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__both_externals_no_valid_impl.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__both_externals_no_valid_impl.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 346
 expression: "\n@external(javascript, \"one\", \"one\")\npub fn js() -> Nil\n\n@external(erlang, \"one\", \"one\")\npub fn erl() -> Nil\n\npub fn should_not_be_generated() {\n  js()\n  erl()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ pub fn should_not_be_generated() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([erl/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__discarded_arg_in_external_are_passed_correctly.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__discarded_arg_in_external_are_passed_correctly.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 396
 expression: "\n@external(erlang, \"wibble\", \"wobble\")\npub fn woo(_a: a) -> Nil\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn woo(_a: a) -> Nil
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([woo/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__elixir.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__elixir.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 289
 expression: "\npub fn main() {\n  #(do, do())\n}\n\n@external(erlang, \"Elixir.String\", \"main\")\nfn do() -> Int\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ fn do() -> Int
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__erlang_and_javascript.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__erlang_and_javascript.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 171
 expression: "\n@external(erlang, \"one\", \"one\")\n@external(javascript, \"./one.mjs\", \"one\")\npub fn one(x: Int) -> Int {\n  todo\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn one(x: Int) -> Int {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([one/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__inlining_external_functions_from_another_module.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__inlining_external_functions_from_another_module.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 63
 expression: "import atom\npub fn main() {\n  atom.make(\"ok\")\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 import atom
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__integration_test1_3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__integration_test1_3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 5
 expression: "\n@external(erlang, \"Elixir.MyApp\", \"run\")\npub fn run() -> Int\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn run() -> Int
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([run/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__integration_test7.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__integration_test7.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 15
 expression: "\n@external(erlang, \"try\", \"and\")\npub fn receive() -> Int\npub fn catch(x) { receive() }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn catch(x) { receive() }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export(['receive'/0, 'catch'/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__javascript_only.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__javascript_only.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 313
 expression: "\npub fn should_be_generated(x: Int) -> Int {\n  x\n}\n\n@external(javascript, \"one\", \"one\")\npub fn should_not_be_generated(x: Int) -> Int\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn should_not_be_generated(x: Int) -> Int
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([should_be_generated/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__javascript_only_indirect.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__javascript_only_indirect.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 327
 expression: "\npub fn should_be_generated(x: Int) -> Int {\n  x\n}\n\n@external(javascript, \"one\", \"one\")\npub fn should_not_be_generated(x: Int) -> Int\n\npub fn also_should_not_be_generated() {\n  should_not_be_generated(1)\n  |> should_be_generated\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,7 @@ pub fn also_should_not_be_generated() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([should_be_generated/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__multiple_discarded_args_in_external_are_passed_correctly.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__multiple_discarded_args_in_external_are_passed_correctly.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 406
 expression: "\n@external(erlang, \"wibble\", \"wobble\")\npub fn woo(_: a, _: b) -> Nil\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn woo(_: a, _: b) -> Nil
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([woo/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__multiple_discarded_args_in_external_are_passed_correctly_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__multiple_discarded_args_in_external_are_passed_correctly_2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 416
 expression: "\n@external(erlang, \"wibble\", \"wobble\")\npub fn woo(__: a, _two: b) -> Nil\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn woo(__: a, _two: b) -> Nil
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([woo/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__no_body.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__no_body.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 256
 expression: "\n@external(erlang, \"one\", \"one\")\npub fn one(x: Int) -> Int\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn one(x: Int) -> Int
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([one/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__private.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__private.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 275
 expression: "\npub fn main() {\n  do()\n}\n\n@external(erlang, \"library\", \"main\")\nfn do() -> Int\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ fn do() -> Int
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__private_external_function_calls.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__private_external_function_calls.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 27
 expression: "\n@external(erlang, \"m\", \"f\")\nfn go(x x: Int, y y: Int) -> Int\n\npub fn x() { go(x: 1, y: 2) go(y: 3, x: 4) }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn x() { go(x: 1, y: 2) go(y: 3, x: 4) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__private_local_function_references.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__private_local_function_references.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 52
 expression: "\n@external(erlang, \"m\", \"f\")\nfn go(x: Int, y: Int) -> Int\npub fn x() { go }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn x() { go }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__public_elixir.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__public_elixir.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 303
 expression: "\n@external(erlang, \"Elixir.String\", \"main\")\npub fn do() -> Int\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -12,7 +10,7 @@ pub fn do() -> Int
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([do/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__public_local_function_calls.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__public_local_function_calls.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 40
 expression: "\n@external(erlang, \"m\", \"f\")\npub fn go(x x: Int, y y: Int) -> Int\npub fn x() { go(x: 1, y: 2) go(y: 3, x: 4) }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn x() { go(x: 1, y: 2) go(y: 3, x: 4) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/2, x/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__reference_to_imported_elixir_external_fn.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__reference_to_imported_elixir_external_fn.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 105
 expression: "import my_app\npub fn main() {\n  let x = my_app.run\n  id(my_app.run)\n}\nfn id(x) { x }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 import my_app
@@ -15,7 +13,7 @@ fn id(x) { x }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__unqualified_inlining_external_functions_from_another_module.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__unqualified_inlining_external_functions_from_another_module.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 84
 expression: "import atom.{make}\npub fn main() {\n  make(\"ok\")\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 import atom.{make}
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__unqualified_reference_to_imported_elixir_external_fn.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__unqualified_reference_to_imported_elixir_external_fn.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-assertion_line: 126
 expression: "import my_app.{run}\npub fn main() {\n  let x = run\n  id(run)\n}\nfn id(x) { x }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 import my_app.{run}
@@ -15,7 +13,7 @@ fn id(x) { x }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__function_as_value.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__function_as_value.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 5
 expression: "\nfn other() {\n  Nil\n}\n\npub fn main() {\n  other\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__function_called.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__function_called.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 62
 expression: "\npub fn main() {\n  main()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__labelled_argument_ordering.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__labelled_argument_ordering.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 116
 expression: "\ntype A { A }\ntype B { B }\ntype C { C }\ntype D { D }\n\nfn wibble(a a: A, b b: B, c c: C, d d: D) {\n  Nil\n}\n\npub fn main() {\n  wibble(A, C, D, b: B)\n  wibble(A, C, D, b: B)\n  wibble(B, C, D, a: A)\n  wibble(B, C, a: A, d: D)\n  wibble(B, C, d: D, a: A)\n  wibble(B, D, a: A, c: C)\n  wibble(B, D, c: C, a: A)\n  wibble(C, D, b: B, a: A)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -29,7 +27,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([a/0, b/0, c/0, d/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_aliased_imported_function_as_value.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_aliased_imported_function_as_value.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 48
 expression: "\nimport some/other.{wibble as wobble}\n\npub fn main() {\n  wobble\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_aliased_imported_function_called.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_aliased_imported_function_called.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 101
 expression: "\nimport some/other.{wibble as wobble}\n\npub fn main() {\n  wobble()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_imported_function_as_value.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_imported_function_as_value.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 20
 expression: "\nimport some/other\n\npub fn main() {\n  other.wibble\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_imported_function_called.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_imported_function_called.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 73
 expression: "\nimport some/other\n\npub fn main() {\n  other.wibble()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_unqualified_imported_function_as_value.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_unqualified_imported_function_as_value.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 34
 expression: "\nimport some/other.{wibble}\n\npub fn main() {\n  wibble\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_unqualified_imported_function_called.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__nested_unqualified_imported_function_called.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 87
 expression: "\nimport some/other.{wibble}\n\npub fn main() {\n  wibble()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__unused_private_functions.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__functions__unused_private_functions.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/functions.rs
-assertion_line: 143
 expression: "\npub fn main() -> Int {\n  used()\n}\n\nfn used() -> Int {\n  123\n}\n\nfn unused1() -> Int {\n  unused2()\n}\n\nfn unused2() -> Int {\n  used()\n}\n\nfn unused3() -> Int {\n  used()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -29,7 +27,7 @@ fn unused3() -> Int {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 6
 expression: "\npub fn main(args) {\n  case args {\n    x if x == args -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main(args) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards20.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards20.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 162
 expression: "\npub fn main() {\n  let x = 0.123\n  case x {\n    _ if 0.123 <. x -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards21.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards21.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 177
 expression: "\npub fn main(x) {\n  case x {\n    _ if x == [1, 2, 3] -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards22.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards22.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 191
 expression: "\npub fn main() {\n  let x = 0\n  case x {\n    0 -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards23.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards23.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 208
 expression: "\npub fn main() {\n  let x = #(1, 2, 3)\n  case x {\n    _ if x == #(1, 2, 3) -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards24.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards24.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 223
 expression: "\npub fn main() {\n  let x = #(1, 2, 3)\n  case x {\n    _ if x == #(1, 2, 3) -> 1\n    _ if x == #(2, 3, 4) -> 2\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards25.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards25.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 241
 expression: "\npub fn main() {\n  let x = 0\n  case x {\n    _ if x == 0 -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards26.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards26.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 256
 expression: "\npub fn main() {\n  let x = 0\n  case x {\n    _ if 0 < x -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards27.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards27.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 273
 expression: "\npub fn main() {\n  case \"test\" {\n    x if x == \"test\" -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards28.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards28.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 289
 expression: "\n    type Test { Test(x: Int, y: Float) }\n    pub fn main() {\n      let x = Test(1, 3.0)\n      case x {\n        _ if x == Test(1, 1.0) -> 1\n        _ if x == Test(y: 2.0, x: 2) -> 2\n        _ if x != Test(2, 3.0) -> 2\n        _ -> 0\n      }\n    }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([test/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards29.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards29.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 309
 expression: "\npub fn main() {\n  case 0.1, 1.0 {\n    x, y if x <. y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards30.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards30.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 323
 expression: "\npub fn main() {\n  case 0.1, 1.0 {\n    x, y if x <=. y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards31.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards31.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 337
 expression: "\npub fn main(args) {\n  case args {\n    [x] | [x, _] if x -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main(args) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 20
 expression: "\npub fn main(args) {\n  case args {\n    x if {x != x} == {args == args} -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main(args) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_10.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_10.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 147
 expression: "\npub fn main() {\n  let x = 0.123\n  case x {\n    _ if x == 3.14 -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 34
 expression: "\npub fn main(args) {\n  case args {\n    x if x && x || x == x && x -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main(args) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 48
 expression: "\npub fn main() {\n  case 1, 0 {\n    x, y if x > y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_4.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_4.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 62
 expression: "\npub fn main() {\n  case 1, 0 {\n    x, y if x >= y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_5.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_5.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 76
 expression: "\npub fn main() {\n  case 1, 0 {\n    x, y if x < y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_6.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_6.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 90
 expression: "\npub fn main() {\n  case 1, 0 {\n    x, y if x <= y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_7.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_7.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 104
 expression: "\npub fn main() {\n  case 1.0, 0.1 {\n    x, y if x >. y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_8.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_8.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 118
 expression: "\npub fn main() {\n  case 1.0, 0.1 {\n    x, y if x >=. y -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_9.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__clause_guards_9.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 132
 expression: "\npub fn main() {\n  let x = 0.123\n  case x {\n    99.9854 -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__constants_in_guards.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__constants_in_guards.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 351
 expression: "\npub const string_value = \"constant value\"\npub const float_value = 3.14\npub const int_value = 42\npub const tuple_value = #(1, 2.0, \"3\")\npub const list_value = [1, 2, 3]\n\npub fn main(arg) {\n  let _ = list_value\n  case arg {\n    #(w, x, y, z) if w == tuple_value && x == string_value && y >. float_value && z == int_value -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -23,7 +21,7 @@ pub fn main(arg) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__constants_in_guards1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__constants_in_guards1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 372
 expression: "\npub const list = [1, 2, 3]\n\npub fn main(arg) {\n  case arg {\n    _ if arg == list -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main(arg) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__field_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__field_access.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 452
 expression: "\n        pub type Person {\n          Person(username: String, name: String, age: Int)\n        }\n        \n        pub fn main() {\n          let given_name = \"jack\"\n          let raiden = Person(\"raiden\", \"jack\", 31)\n        \n          case given_name {\n            name if name == raiden.name -> \"It's jack\"\n            _ -> \"It's not jack\"\n          }\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -23,7 +21,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_access.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 568
 expression: "\n          import hero\n          pub fn main() {\n            let name = \"Tony Stark\"\n            case name {\n              n if n == hero.ironman.name -> True\n              _ -> False\n            }\n          }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_list_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_list_access.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 522
 expression: "\n          import hero\n          pub fn main() {\n            let names = [\"Tony Stark\", \"Bruce Wayne\"]\n            case names {\n              n if n == hero.heroes -> True\n              _ -> False\n            }\n          }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_nested_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_nested_access.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 594
 expression: "\n          import hero\n          pub fn main() {\n            let name = \"Bruce Wayne\"\n            case name {\n              n if n == hero.batman.secret_identity.name -> True\n              _ -> False\n            }\n          }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_string_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_string_access.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 499
 expression: "\n          import hero\n          pub fn main() {\n            let name = \"Tony Stark\"\n            case name {\n              n if n == hero.ironman -> True\n              _ -> False\n            }\n          }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_tuple_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__module_tuple_access.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 545
 expression: "\n          import hero\n          pub fn main() {\n            let name = \"Tony Stark\"\n            case name {\n              n if n == hero.hero.1 -> True\n              _ -> False\n            }\n          }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__nested_record_access.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__nested_record_access.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 473
 expression: "\npub type A {\n  A(b: B)\n}\n\npub type B {\n  B(c: C)\n}\n\npub type C {\n  C(d: Bool)\n}\n\npub fn a(a: A) {\n  case a {\n    _ if a.b.c.d -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -28,7 +26,7 @@ pub fn a(a: A) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/1]).
 -export_type([a/0, b/0, c/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 388
 expression: "\npub const string_value = \"constant value\"\n\npub fn main(arg) {\n  case arg {\n    _ if arg == string_value -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main(arg) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 404
 expression: "\npub const bits = <<1, \"ok\":utf8, 3, 4:50>>\n\npub fn main(arg) {\n  case arg {\n    _ if arg == bits -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main(arg) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 420
 expression: "\npub const constant = #(1, 2.0)\n\npub fn main(arg) {\n  case arg {\n    _ if arg == constant -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main(arg) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__guards__only_guards3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/guards.rs
-assertion_line: 436
 expression: "\npub const float_value = 3.14\n\npub fn main(arg) {\n  case arg {\n    _ if arg >. float_value -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main(arg) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__assignment_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__assignment_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 121
 expression: "pub fn go() {\n  let assert 123 as x = 123\n  x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_discard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_discard.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 282
 expression: "\npub fn main() {\n  let assert <<_ as number>> = <<10>>\n  number\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_float.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_float.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 256
 expression: "\npub fn main() {\n  let assert <<3.14 as pi:float>> = <<3.14>>\n  pi\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_int.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_int.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 243
 expression: "\npub fn main() {\n  let assert <<1 as a>> = <<1>>\n  a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_string.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_assignment_string.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 269
 expression: "\npub fn main() {\n  let assert <<\"Hello, world!\" as message:utf8>> = <<\"Hello, world!\">>\n  message\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__bit_array_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 185
 expression: "pub fn go() {\n  let assert <<a:2, b:3, c:3>> = <<123>>\n  a + b + c\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 160
 expression: "pub fn go() {\n  let assert Ok(x) = Error(Nil)\n  x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern_with_multiple_variables.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__constructor_pattern_with_multiple_variables.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 170
 expression: "\npub type Wibble {\n  Wibble(Int, Float)\n}\n\npub fn go() {\n  let assert Wibble(x, 2.0 as y) = Wibble(1, 2.0)\n  x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 -export_type([wibble/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__discard_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__discard_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 131
 expression: "pub fn go() {\n  let assert _ = 123\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -11,7 +9,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__float_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__float_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 103
 expression: "pub fn go() {\n  let assert 1.5 = 5.1\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -11,7 +9,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__int_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__int_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 94
 expression: "pub fn go() {\n  let assert 1 = 2\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -11,7 +9,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__just_variable.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__just_variable.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 74
 expression: "pub fn go() {\n  let assert x = Ok(1)\n  x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_at_end_of_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_at_end_of_block.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 215
 expression: "\npub fn go() {\n  let result = Ok(10)\n  let x = {\n    let assert Ok(_) = result\n  }\n  x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 140
 expression: "pub fn go() {\n  let assert [1, x, 3] = [1, 2, 3]\n  x\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern_with_multiple_variables.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__list_pattern_with_multiple_variables.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 150
 expression: "pub fn go() {\n  let assert [a, b, c] = [1, 2, 3]\n  a + b + c\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__message.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 50
 expression: "\npub fn unwrap_or_panic(value) {\n  let assert Ok(inner) = value as \"Oops, there was an error\"\n  inner\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn unwrap_or_panic(value) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([unwrap_or_panic/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__more_than_one_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__more_than_one_var.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 17
 expression: "pub fn go(x) {\n  let assert [1, a, b, c] = x\n  [a, b, c]\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go(x) {
@@ -12,7 +10,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__one_var.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__one_var.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 6
 expression: "pub fn go() {\n  let assert Ok(y) = Ok(1)\n  y\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__pattern_let.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__pattern_let.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 28
 expression: "pub fn go(x) {\n  let assert [1 as a, b, c] = x\n  [a, b, c]\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go(x) {
@@ -12,7 +10,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__reference_earlier_segment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__reference_earlier_segment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 230
 expression: "\npub fn main() {\n  let assert <<length, bytes:size(length)-unit(8)>> = <<3, 1, 2, 3>>\n  bytes\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 112
 expression: "pub fn go() {\n  let assert \"Hello!\" = \"Hel\" <> \"lo!\"\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -11,7 +9,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 195
 expression: "pub fn go() {\n  let assert \"Hello \" <> name = \"Hello John\"\n  name\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern_with_prefix_binding.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__string_prefix_pattern_with_prefix_binding.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 205
 expression: "pub fn go() {\n  let assert \"Hello \" as greeting <> name = \"Hello John\"\n  #(greeting, name)\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__tuple_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__tuple_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 84
 expression: "pub fn go() {\n  let assert #(a, b, c) = #(1, 2, 3)\n  a + b + c\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -12,7 +10,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_message.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_message.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 62
 expression: "\npub fn expect(value, message) {\n  let assert Ok(inner) = value as message\n  inner\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn expect(value, message) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([expect/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_rewrites.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__variable_rewrites.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/let_assert.rs
-assertion_line: 39
 expression: "pub fn go() {\n  let assert Ok(y) = Ok(1)\n  let assert Ok(y) = Ok(1)\n  y\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -13,7 +11,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__int_negation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__int_negation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/numbers.rs
-assertion_line: 59
 expression: "\npub fn main() {\n  let a = 3\n  let b = -a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_scientific_notation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_scientific_notation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/numbers.rs
-assertion_line: 44
 expression: "\nconst i = 100.001e223\nconst j = -100.001e-223\n\npub fn main() {\n  i\n  j\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/numbers.rs
-assertion_line: 5
 expression: "\npub fn main() {\n  100_000\n  100_000.00101\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/numbers.rs
-assertion_line: 17
 expression: "\nconst i = 100_000\nconst f = 100_000.00101\npub fn main() {\n  i\n  f\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__numbers_with_underscores2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/numbers.rs
-assertion_line: 31
 expression: "\npub fn main() {\n  let assert 100_000 = 1\n  let assert 100_000.00101 = 1.\n  1\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__repeated_int_negation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__repeated_int_negation.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/numbers.rs
-assertion_line: 71
 expression: "\npub fn main() {\n  let a = 3\n  let b = --a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__zero_b_in_hex.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__numbers__zero_b_in_hex.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/numbers.rs
-assertion_line: 84
 expression: "\npub fn main() {\n  0xffe0bb\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__panic_as.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__panic_as.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/panic.rs
-assertion_line: 5
 expression: "\npub fn main() {\n  panic as \"wibble\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__panic_as_function.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__panic_as_function.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/panic.rs
-assertion_line: 27
 expression: "\npub fn retstring() {\n  \"wibble\"\n}\npub fn main() {\n  panic as { retstring() <> \"wobble\" }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([retstring/0, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__piped.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__piped.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/panic.rs
-assertion_line: 42
 expression: "\npub fn main() {\n  \"lets\"\n  |> panic\n}\n    "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__piped_chain.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__piped_chain.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/panic.rs
-assertion_line: 54
 expression: "\n     pub fn main() {\n      \"lets\"\n      |> panic as \"pipe\"\n      |> panic as \"other panic\"\n    }\n    "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__plain.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__panic__plain.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/panic.rs
-assertion_line: 16
 expression: "\npub fn main() {\n  panic\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 6
 expression: "\npub fn main() {\n  let duplicate_name = 1\n\n  case 1 {\n    1 | 2 -> {\n      let duplicate_name = duplicate_name + 1\n      duplicate_name\n    }\n    _ -> 0\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 25
 expression: "\npub fn main() {\n  case Ok(1) {\n    Ok(duplicate_name) | Error(duplicate_name) -> duplicate_name\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 38
 expression: "\npub fn main() {\n    let duplicate_name = 1\n\n    case 1 {\n        1 | 2 if duplicate_name == 1 -> duplicate_name\n        _ -> 0\n    }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__alternative_patterns3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 53
 expression: "\npub const constant = Ok(1)\n\npub fn main(arg) {\n  let _ = constant\n  case arg {\n    _ if arg == constant -> 1\n    _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn main(arg) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__pattern_as.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__pattern_as.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 70
 expression: "pub fn a(x) {\n  case x {\n    Ok(1 as y) -> 1\n    _ -> 0\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a(x) {
@@ -14,7 +12,7 @@ pub fn a(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_assertion.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_assertion.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 118
 expression: "pub fn a(x) {\n  let assert \"a\" as a <> rest = \"wibble\"\n  a\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a(x) {
@@ -12,7 +10,7 @@ pub fn a(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_list.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_list.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 106
 expression: "pub fn a(x) {\n  case x {\n    [\"a\" as a <> _, \"b\" as b <> _] -> a <> b\n    _ -> \"\"\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a(x) {
@@ -14,7 +12,7 @@ pub fn a(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_multiple_subjects.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_multiple_subjects.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 82
 expression: "pub fn a(x) {\n  case x, x {\n    _, \"a\" as a <> _  -> a\n    _, _ -> \"a\"\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a(x) {
@@ -14,7 +12,7 @@ pub fn a(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_multiple_subjects_and_guard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__patterns__string_prefix_as_pattern_with_multiple_subjects_and_guard.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/patterns.rs
-assertion_line: 94
 expression: "pub fn a(x) {\n  case x, x {\n    _, \"a\" as a <> rest if rest == \"a\" -> a\n    _, _ -> \"a\"\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn a(x) {
@@ -14,7 +12,7 @@ pub fn a(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__block_expr_into_pipe.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__block_expr_into_pipe.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 26
 expression: "fn id(a) { a }\npub fn main() {\n  {\n    let x = 1\n    x\n  }\n  |> id\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn id(a) { a }
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__call_pipeline_result.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__call_pipeline_result.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 106
 expression: "\npub fn main() {\n  { 1 |> add }(1)\n}\n\npub fn add(x) {\n  fn(y) { x + y }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn add(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([add/1, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__clever_pipe_rewriting.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__clever_pipe_rewriting.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 6
 expression: "\npub fn apply(f: fn(a) -> b, a: a) { a |> f }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -11,7 +9,7 @@ pub fn apply(f: fn(a) -> b, a: a) { a |> f }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([apply/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__clever_pipe_rewriting1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__clever_pipe_rewriting1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 16
 expression: "\npub fn apply(f: fn(a, Int) -> b, a: a) { a |> f(1) }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -11,7 +9,7 @@ pub fn apply(f: fn(a, Int) -> b, a: a) { a |> f(1) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([apply/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_call.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_call.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 122
 expression: "\npub fn main() {\n  123\n  |> two(\n    1 |> two(2),\n    _,\n  )\n}\n\npub fn two(a, b) {\n  a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,7 @@ pub fn two(a, b) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([two/2, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_case_subject.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_case_subject.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 62
 expression: "pub fn x(f) {\n  case 1 |> f {\n    x -> x\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn x(f) {
@@ -13,7 +11,7 @@ pub fn x(f) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_eq.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_eq.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 92
 expression: "fn id(x) {\n  x\n}\n        \npub fn main() {\n    1 == 1 |> id\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 fn id(x) {
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_list.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_list.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 40
 expression: "pub fn x(f) {\n  [\n    1 |> f\n  ]\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn x(f) {
@@ -13,7 +11,7 @@ pub fn x(f) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_record_update.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_record_update.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 74
 expression: "pub type X {\n  X(a: Int, b: Int)\n}\n\nfn id(x) {\n  x\n}\n        \npub fn main(x) {\n  X(..x, a: 1 |> id)\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type X {
@@ -19,7 +17,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 -export_type([x/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_tuple.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__pipes__pipe_in_tuple.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/pipes.rs
-assertion_line: 51
 expression: "pub fn x(f) {\n  #(\n    1 |> f\n  )\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn x(f) {
@@ -13,7 +11,7 @@ pub fn x(f) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([x/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__imported_qualified_constructor_as_fn_name_escape.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__imported_qualified_constructor_as_fn_name_escape.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 359
 expression: "import other_module\n\npub fn main() {\n  other_module.Let\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 import other_module
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__nested_record_update.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__nested_record_update.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 371
 expression: "pub type Wibble {\n  Wibble(a: Int, b: Wobble, c: Int)\n}\n\npub type Wobble {\n  Wobble(a: Int, b: Int)\n}\n\npub fn main() {\n  let base = Wibble(1, Wobble(2, 3), 4)\n  Wibble(..base, b: Wobble(..base.b, b: 5))\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Wibble {
@@ -20,7 +18,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([wibble/0, wobble/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__nested_record_update_with_blocks.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__nested_record_update_with_blocks.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 389
 expression: "pub type A { A(b: B) }\npub type B { B(c: C) }\npub type C { C(val: Int) }\n\npub fn main(a: A) {\n    A(..a, b: {\n        B(..a.b, c: {\n            C(..a.b.c, val: 0)\n        })\n    })\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type A { A(b: B) }
@@ -19,7 +17,7 @@ pub fn main(a: A) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 -export_type([a/0, b/0, c/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__pipe_update_subject.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__pipe_update_subject.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 325
 expression: "pub type Thing {\n  Thing(a: Int, b: Int)\n}\n\npub fn identity(x) { x }\n\npub fn main() {\n  let thing = Thing(1, 2)\n  Thing(..thing |> identity, b: 1000)\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Thing {
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([identity/1, main/0]).
 -export_type([thing/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__private_unused_records.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__private_unused_records.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 406
 expression: "type A { A(inner: Int) }\ntype B { B(String) }\ntype C { C(Int) }\n\npub fn main(x: Int) -> Int {\n  let a = A(x)\n  a.inner\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 type A { A(inner: Int) }
@@ -17,7 +15,7 @@ pub fn main(x: Int) -> Int {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 -export_type([a/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_access_block.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_access_block.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 342
 expression: "pub type Thing {\n  Thing(a: Int, b: Int)\n}\n\npub fn main() {\n  {\n    let thing = Thing(1, 2)\n    thing\n  }.a\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Thing {
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([thing/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 101
 expression: "\npub type Person {\n    Teacher(name: String, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn get_name(person: Person) { person.name }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([get_name/1]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants_parameterised_types.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants_parameterised_types.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 130
 expression: "\npub type Person {\n    Teacher(name: String, age: List(Int), title: String)\n    Student(name: String, age: List(Int))\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn get_age(person: Person) { person.age }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([get_name/1, get_age/1]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants_positions_other_than_first.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_variants_positions_other_than_first.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 115
 expression: "\npub type Person {\n    Teacher(name: String, age: Int, title: String)\n    Student(name: String, age: Int)\n}\npub fn get_name(person: Person) { person.name }\npub fn get_age(person: Person) { person.age }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn get_age(person: Person) { person.age }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([get_name/1, get_age/1]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_with_first_position_different_types.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessor_multiple_with_first_position_different_types.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 145
 expression: "\npub type Person {\n    Teacher(name: Nil, age: Int)\n    Student(name: String, age: Int)\n}\npub fn get_age(person: Person) { person.age }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn get_age(person: Person) { person.age }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([get_age/1]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessors.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_accessors.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 89
 expression: "\npub type Person { Person(name: String, age: Int) }\npub fn get_age(person: Person) { person.age }\npub fn get_name(person: Person) { person.name }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn get_name(person: Person) { person.name }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([get_age/1, get_name/1]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_constants.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_constants.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 315
 expression: "pub type Test { A }\nconst some_test = A\npub fn a() { A }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Test { A }
@@ -11,7 +9,7 @@ pub fn a() { A }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([a/0]).
 -export_type([test/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 158
 expression: "\npub type Triple {\n    Triple(a: Int, b: Int, c: Int)\n}\n\npub fn main() {\n  let triple = Triple(1,2,3)\n  let Triple(the_a, ..) = triple\n  the_a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([triple/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 177
 expression: "\npub type Triple {\n  Triple(a: Int, b: Int, c: Int)\n}\n\npub fn main() {\n  let triple = Triple(1,2,3)\n  let Triple(b: the_b, ..) = triple\n  the_b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([triple/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 195
 expression: "\npub type Triple {\n  Triple(a: Int, b: Int, c: Int)\n}\n\npub fn main() {\n  let triple = Triple(1,2,3)\n  let Triple(the_a, c: the_c, ..) = triple\n  the_c\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([triple/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_spread3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 213
 expression: "\npub type Triple {\n  Triple(a: Int, b: Int, c: Int)\n}\n\npub fn main() {\n  let triple = Triple(1,2,3)\n  case triple {\n    Triple(b: the_b, ..) -> the_b\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([triple/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 232
 expression: "\npub type Person { Person(name: String, age: Int) }\n\npub fn main() {\n    let p = Person(\"Quinn\", 27)\n    let new_p = Person(..p, age: 28)\n    new_p\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 248
 expression: "\npub type Person { Person(name: String, age: Int) }\n\npub fn main() {\n    let p = Person(\"Quinn\", 27)\n    let new_p = Person(..p, age: p.age + 1)\n    new_p\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 264
 expression: "\npub type Person { Person(name: String, age: Int) }\n\npub fn main() {\n    let p = Person(\"Quinn\", 27)\n    let new_p = Person(..p, age: 28, name: \"Riley\")\n    new_p\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 280
 expression: "\npub type Person { Person(name: String, age: Int) }\n\npub fn main() {\n    let new_p = Person(..return_person(), age: 28)\n    new_p\n}\n\nfn return_person() {\n    Person(\"Quinn\", 27)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,7 +18,7 @@ fn return_person() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates4.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__record_updates4.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/records.rs
-assertion_line: 299
 expression: "\npub type Car { Car(make: String, model: String, driver: Person) }\npub type Person { Person(name: String, age: Int) }\n\npub fn main() {\n    let car = Car(make: \"Amphicar\", model: \"Model 770\", driver: Person(name: \"John Doe\", age: 27))\n    let new_p = Person(..car.driver, age: 28)\n    new_p\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 -export_type([car/0, person/0]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__reserved__build_in_erlang_type_escaping.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__reserved__build_in_erlang_type_escaping.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler-core/src/erlang/tests/reserved.rs
-assertion_line: 5
 expression: pub type Map
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type Map
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export_type([map_/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__reserved__escape_erlang_reserved_keywords_in_type_names.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__reserved__escape_erlang_reserved_keywords_in_type_names.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/reserved.rs
-assertion_line: 12
 expression: "pub type After { TestAfter }\npub type And { TestAnd }\npub type Andalso { TestAndAlso }\npub type Band { TestBAnd }\npub type Begin { TestBegin }\npub type Bnot { TestBNot }\npub type Bor { TestBOr }\npub type Bsl { TestBsl }\npub type Bsr { TestBsr }\npub type Bxor { TestBXor }\npub type Case { TestCase }\npub type Catch { TestCatch }\npub type Cond { TestCond }\npub type Div { TestDiv }\npub type End { TestEnd }\npub type Fun { TestFun }\npub type If { TestIf }\npub type Let { TestLet }\npub type Maybe { TestMaybe }\npub type Not { TestNot }\npub type Of { TestOf }\npub type Or { TestOr }\npub type Orelse { TestOrElse }\npub type Query { TestQuery }\npub type Receive { TestReceive }\npub type Rem { TestRem }\npub type Try { TestTry }\npub type When { TestWhen }\npub type Xor { TestXor }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub type After { TestAfter }
@@ -37,7 +35,7 @@ pub type Xor { TestXor }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export_type(['after'/0, 'and'/0, 'andalso'/0, 'band'/0, 'begin'/0, 'bnot'/0, 'bor'/0, 'bsl'/0, 'bsr'/0, 'bxor'/0, 'case'/0, 'catch'/0, 'cond'/0, 'div'/0, 'end'/0, 'fun'/0, 'if'/0, 'let'/0, 'maybe'/0, 'not'/0, 'of'/0, 'or'/0, 'orelse'/0, 'query'/0, 'receive'/0, 'rem'/0, 'try'/0, 'when'/0, 'xor'/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__ascii_as_unicode_escape_sequence.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__ascii_as_unicode_escape_sequence.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 106
 expression: "\npub fn y() -> String {\n  \"\\u{79}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn y() -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([y/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 444
 expression: "\nconst cute = \"cute\"\nconst cute_bee = cute <> \"bee\"\n\npub fn main() {\n  cute_bee\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat_many_strings.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat_many_strings.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 458
 expression: "\nconst big_concat = \"a\" <> \"b\" <> \"c\" <> \"d\" <> \"e\" <> \"f\" <> \"g\" <> \"h\" <> \"i\" <> \"j\" <> \"k\" <> \"l\" <> \"m\" <> \"n\" <> \"o\" <> \"p\" <> \"q\" <> \"r\" <> \"s\" <> \"t\" <> \"u\" <> \"v\" <> \"w\" <> \"x\" <> \"y\" <> \"z\"\n\npub fn main() {\n  big_concat\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat_many_strings_in_list.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat_many_strings_in_list.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 471
 expression: "\nconst big_concat_list = [\"a\" <> \"b\" <> \"c\" <> \"d\" <> \"e\" <> \"f\" <> \"g\" <> \"h\" <> \"i\" <> \"j\" <> \"k\" <> \"l\" <> \"m\" <> \"n\" <> \"o\" <> \"p\" <> \"q\" <> \"r\" <> \"s\" <> \"t\" <> \"u\" <> \"v\" <> \"w\" <> \"x\" <> \"y\" <> \"z\"]\n\npub fn main() {\n  big_concat_list\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat_other_const_concat.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_const_concat_other_const_concat.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 484
 expression: "\nconst cute_bee = \"cute\" <> \"bee\"\nconst cute_cute_bee_buzz = cute_bee <> \"buzz\"\n\npub fn main() {\n  cute_cute_bee_buzz\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 421
 expression: "\npub fn main(x) {\n  let assert \"m-\" <> rest = x\n  rest\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix_discar.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__assert_string_prefix_discar.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 433
 expression: "\npub fn main(x) {\n  let assert \"m-\" <> _ = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 117
 expression: "\npub fn go(x, y) {\n  x <> y\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn go(x, y) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/2]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_3_variables.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_3_variables.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 128
 expression: "\npub fn go(x, y, z) {\n  x <> y <> z\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn go(x, y, z) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/3]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_constant.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 375
 expression: "\nconst a = \"Hello, \"\nconst b = \"Joe!\"\n\npub fn go() {\n  a <> b\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_constant_fn.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_constant_fn.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 389
 expression: "\nconst cs = s\n\nfn s() {\n  \"s\"\n}\n\npub fn go() {\n  cs() <> cs()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_function_call.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_function_call.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 360
 expression: "\nfn x() {\n  \"\"\n}\n\npub fn go() {\n  x() <> x()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__discard_concat_rest_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__discard_concat_rest_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 335
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" <> _ -> Nil\n    _ -> Nil\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__not_unicode_escape_sequence.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__not_unicode_escape_sequence.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 62
 expression: "\npub fn not_unicode_escape_sequence() -> String {\n  \"\\\\u{03a9}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn not_unicode_escape_sequence() -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([not_unicode_escape_sequence/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__not_unicode_escape_sequence2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__not_unicode_escape_sequence2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 73
 expression: "\npub fn not_unicode_escape_sequence() -> String {\n  \"\\\\\\\\u{03a9}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn not_unicode_escape_sequence() -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([not_unicode_escape_sequence/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__pipe_concat.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__pipe_concat.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 406
 expression: "\nfn id(x) {\n  x\n}\n\npub fn main() {\n  { \"\" |> id } <> { \"\" |> id }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__rest_variable_rewriting.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__rest_variable_rewriting.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 320
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" <> x -> x\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_of_number_concat.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_of_number_concat.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 349
 expression: "\npub fn go(x) {\n  x <> \"1\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 139
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" <> name -> name\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 153
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as greeting <> name -> greeting\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_not_unicode_escape_sequence.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_not_unicode_escape_sequence.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 243
 expression: "\npub fn go(x) {\n  let _ = case x {\n    \"\\\\u{9}\" as start <> rest -> \"test\"\n    \"\\\\u{000009}\" as start <> rest -> \"test\"\n    \"\\\\u{21}\" as start <> rest -> \"test\"\n    \"\\\\u{100}\" as start <> rest -> \"test\"\n    \"\\\\u{1000}\" as start <> rest -> \"test\"\n    \"\\\\u{1F600}\" as start <> rest -> \"test\"\n    \"\\\\u{1f600}\" as start <> rest -> \"test\"\n    \"\\\\u{01F600}\" as start <> rest -> \"test\"\n    \"\\\\u{01f600}\" as start <> rest -> \"test\"\n    \"\\\\u{9} \\\\u{000009} \\\\u{21} \\\\u{100} \\\\u{1000} \\\\u{1F600} \\\\u{01F600}\" as start <> rest -> \"test\"\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -25,7 +23,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_escape_sequences.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_escape_sequences.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 183
 expression: "\npub fn go(x) {\n  let _ = case x {\n    \"\\f\" as start <> rest -> \"test\"\n    \"\\n\" as start <> rest -> \"test\"\n    \"\\r\" as start <> rest -> \"test\"\n    \"\\t\" as start <> rest -> \"test\"\n    \"\\\"\" as start <> rest -> \"test\"\n    \"\\\\\" as start <> rest -> \"test\"\n    \"\\f \\n \\r \\t \\\" \\\\\" as start <> rest -> \"control chars with prefix assignment\"\n    \"\\u{9}\" as start <> rest -> \"test\"\n    \"\\u{000009}\" as start <> rest -> \"test\"\n    \"\\u{21}\" as start <> rest -> \"test\"\n    \"\\u{100}\" as start <> rest -> \"test\"\n    \"\\u{1000}\" as start <> rest -> \"test\"\n    \"\\u{1F600}\" as start <> rest -> \"test\"\n    \"\\u{1f600}\" as start <> rest -> \"test\"\n    \"\\u{01F600}\" as start <> rest -> \"test\"\n    \"\\u{01f600}\" as start <> rest -> \"test\"\n    \"\\u{9} \\u{000009} \\u{21} \\u{100} \\u{1000} \\u{1F600} \\u{01F600}\" as start <> rest -> \"test\"\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -32,7 +30,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_guard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_guard.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 167
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as greeting <> name if name == \"Dude\" -> greeting <> \"Mate\"\n    \"Hello, \" as greeting <> name -> greeting\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 290
 expression: "\npub fn go(x) {\n  case x {\n    \"1\" as digit <> _ | \"2\" as digit <> _ -> digit\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_not_unicode_escape_sequence.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_not_unicode_escape_sequence.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 266
 expression: "\npub fn go(x) {\n  let _ = case x {\n    \"\\\\u{9}\" <> rest -> \"test\"\n    \"\\\\u{000009}\" <> rest -> \"test\"\n    \"\\\\u{21}\" <> rest -> \"test\"\n    \"\\\\u{100}\" <> rest -> \"test\"\n    \"\\\\u{1000}\" <> rest -> \"test\"\n    \"\\\\u{1F600}\" <> rest -> \"test\"\n    \"\\\\u{1f600}\" <> rest -> \"test\"\n    \"\\\\u{01F600}\" <> rest -> \"test\"\n    \"\\\\u{01f600}\" <> rest -> \"test\"\n    \"\\\\u{9} \\\\u{000009} \\\\u{21} \\\\u{100} \\\\u{1000} \\\\u{1F600} \\\\u{01F600}\" <> rest -> \"test\"\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -25,7 +23,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_shadowing.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_shadowing.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 304
 expression: "\npub fn go(x) {\n  case x {\n    \"Hello, \" as x <> name -> x\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_with_escape_sequences.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_with_escape_sequences.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 213
 expression: "\npub fn go(x) {\n  let _ = case x {\n    \"\\f\" <> rest -> \"test\"\n    \"\\n\" <> rest -> \"test\"\n    \"\\r\" <> rest -> \"test\"\n    \"\\t\" <> rest -> \"test\"\n    \"\\\"\" <> rest -> \"test\"\n    \"\\\\\" <> rest -> \"test\"\n    \"\\f \\n \\r \\t \\\" \\\\\" <> rest -> \"control chars with prefix assignment\"\n    \"\\u{9}\" <> rest -> \"test\"\n    \"\\u{000009}\" <> rest -> \"test\"\n    \"\\u{21}\" <> rest -> \"test\"\n    \"\\u{100}\" <> rest -> \"test\"\n    \"\\u{1000}\" <> rest -> \"test\"\n    \"\\u{1F600}\" <> rest -> \"test\"\n    \"\\u{1f600}\" <> rest -> \"test\"\n    \"\\u{01F600}\" <> rest -> \"test\"\n    \"\\u{01f600}\" <> rest -> \"test\"\n    \"\\u{9} \\u{000009} \\u{21} \\u{100} \\u{1000} \\u{1F600} \\u{01F600}\" <> rest -> \"test\"\n    _ -> \"Unknown\"\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -32,7 +30,7 @@ pub fn go(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 5
 expression: "\npub fn emoji() -> String {\n  \"\\u{1f600}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn emoji() -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([emoji/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 16
 expression: "\npub fn y_with_dieresis() -> String {\n  \"\\u{0308}y\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn y_with_dieresis() -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([y_with_dieresis/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 84
 expression: "\npub fn y_with_dieresis_with_slash() -> String {\n  \"\\\\\\u{0308}y\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn y_with_dieresis_with_slash() -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([y_with_dieresis_with_slash/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_concat1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_concat1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 27
 expression: "\npub fn main(x) -> String {\n  x <> \"\\u{0308}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main(x) -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_concat2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_concat2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 38
 expression: "\npub fn main(x) -> String {\n  x <> \"\\\\u{0308}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main(x) -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_concat3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_concat3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 49
 expression: "\npub fn main(x) -> String {\n  x <> \"\\\\\\u{0308}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main(x) -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_escape_sequence_6_digits.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__unicode_escape_sequence_6_digits.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/strings.rs
-assertion_line: 95
 expression: "\npub fn unicode_escape_sequence_6_digits() -> String {\n  \"\\u{10abcd}\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn unicode_escape_sequence_6_digits() -> String {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([unicode_escape_sequence_6_digits/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__named.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__named.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/todo.rs
-assertion_line: 27
 expression: "\npub fn main() {\n  todo as \"testing\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__piped.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__piped.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/todo.rs
-assertion_line: 52
 expression: "\n     pub fn main() {\n      \"lets\"\n      |> todo as \"pipe\"\n      |> todo as \"other todo\"\n    }\n    "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__plain.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__plain.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/todo.rs
-assertion_line: 5
 expression: "\npub fn main() {\n  todo\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__todo_as.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__todo_as.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/todo.rs
-assertion_line: 16
 expression: "\npub fn main() {\n  todo as \"wibble\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__todo_as_function.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__todo__todo_as_function.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/todo.rs
-assertion_line: 38
 expression: "\npub fn retstring() {\n  \"wibble\"\n}\npub fn main() {\n  todo as { retstring() <> \"wobble\" }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([retstring/0, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_named_args_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_named_args_count_once.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 72
 expression: "\n        pub type Wibble(a, b) {\n            Wibble(a, b)\n        }\n\n        pub fn wibble() -> Wibble(a, a) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/0]).
 -export_type([wibble/2]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_nested_named_args_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_nested_named_args_count_once.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 87
 expression: "\n        pub type Wibble(a, b) {\n            Wibble(a, b)\n        }\n\n        pub fn wibble() -> Wibble(a, Wibble(a, b)) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/0]).
 -export_type([wibble/2]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_nested_result_type_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_nested_result_type_count_once.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 46
 expression: "\n        pub type Wibble(a) {\n            Oops\n        }\n\n        pub fn wibble() -> Result(a, Wibble(a)) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/0]).
 -export_type([wibble/1]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_tuple_type_params_count_twice.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__custom_type_tuple_type_params_count_twice.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 102
 expression: "\n        pub type Wibble(a, b) {\n            Wibble(a, b)\n        }\n\n        pub fn wibble() -> #(a, Wibble(a, b)) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/0]).
 -export_type([wibble/2]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__nested_result_type_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__nested_result_type_count_once.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 35
 expression: "\n        pub fn wibble() -> Result(a, Result(a, b)) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_count_once.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 24
 expression: "\n        pub fn wibble() -> Result(a, a) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_inferred_count_once.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__result_type_inferred_count_once.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 5
 expression: "\n        pub fn wibble() {\n            let assert Ok(_) = wobble()\n        }\n\n        pub type Wobble(a) {\n            Wobble\n        }\n\n        pub fn wobble() -> Result(a, Wobble(a)) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wobble/0, wibble/0]).
 -export_type([wobble/1]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__tuple_type_params_count_twice.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__type_params__tuple_type_params_count_twice.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/type_params.rs
-assertion_line: 61
 expression: "\n        pub fn wibble() -> #(a, b) {\n            todo\n        }\n        "
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ snapshot_kind: text
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([wibble/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___arity_1.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___arity_1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/use_.rs
-assertion_line: 5
 expression: "\npub fn main() {\n  use <- pair()\n  123\n}\n\nfn pair(f) {\n  let x = f()\n  #(x, x)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ fn pair(f) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___arity_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___arity_2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/use_.rs
-assertion_line: 22
 expression: "\npub fn main() {\n  use <- pair(1.0)\n  123\n}\n\nfn pair(x, f) {\n  let y = f()\n  #(x, y)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ fn pair(x, f) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___arity_3.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___arity_3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/use_.rs
-assertion_line: 39
 expression: "\npub fn main() {\n  use <- trip(1.0, \"\")\n  123\n}\n\nfn trip(x, y, f) {\n  let z = f()\n  #(x, y, z)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ fn trip(x, y, f) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___no_callback_body.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___no_callback_body.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/use_.rs
-assertion_line: 56
 expression: "\npub fn main() {\n  let thingy = fn(f) { f() }\n  use <- thingy()\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___pipeline_that_returns_fn.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__use___pipeline_that_returns_fn.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/use_.rs
-assertion_line: 69
 expression: "\npub fn main() {\n  use <- 1 |> add\n  1\n}\n\npub fn add(x) {\n  fn(f) { f() + x }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn add(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([add/1, main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__anon_external_fun_name_escaping.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__anon_external_fun_name_escaping.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 70
 expression: "\n@external(erlang, \"one.two\", \"three.four\")\nfn func() -> Nil\n\npub fn main() {\n  func\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -15,7 +13,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__blocks_are_scopes.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__blocks_are_scopes.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 100
 expression: "\npub fn main() {\n  let x = 1\n  {\n    let x = 2\n  }\n  x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,7 @@ pub fn main() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__discarded.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__discarded.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 58
 expression: "pub fn go() {\n  let _r = 1\n  let _r = 2\n  Nil\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go() {
@@ -13,7 +11,7 @@ pub fn go() {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__module_const_vars.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__module_const_vars.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 83
 expression: "const int = 42\nconst int_alias = int\npub fn use_int_alias() { int_alias }\n\nfn int_identity(i: Int) { i }\nconst int_identity_alias: fn(Int) -> Int = int_identity\npub fn use_int_identity_alias() { int_identity_alias(42) }\n\nconst compound: #(Int, fn(Int) -> Int, fn(Int) -> Int) = #(int, int_identity, int_identity_alias)\npub fn use_compound() { compound.1(compound.0) }\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 const int = 42
@@ -19,7 +17,7 @@ pub fn use_compound() { compound.1(compound.0) }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([use_int_alias/0, use_int_identity_alias/0, use_compound/0]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_and_call.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_and_call.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 34
 expression: "\npub fn main(x) {\n  fn(x) { x }(x)\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -13,7 +11,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_let.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_let.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 6
 expression: "\npub fn go(a) {\n  case a {\n    99 -> {\n      let a = a\n      1\n    }\n    _ -> a\n  }\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,7 @@ pub fn go(a) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([go/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_param.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_param.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 23
 expression: "pub fn main(board) {\nfn(board) { board }\n  board\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn main(board) {
@@ -12,7 +10,7 @@ fn(board) { board }
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_pipe.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__variables__shadow_pipe.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/erlang/tests/variables.rs
-assertion_line: 45
 expression: "\npub fn main(x) {\n  x\n  |> fn(x) { x }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -14,7 +12,7 @@ pub fn main(x) {
 
 ----- COMPILED ERLANG
 -module(my@mod).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 8
 expression: "./cases/alias_unqualified_import"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export([id/1]).
 -export_type([empty/0]).
@@ -33,7 +31,7 @@ id(X) ->
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([make/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 74
 expression: "./cases/erlang_bug_752"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export_type([one/1]).
 
@@ -29,7 +27,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export_type([two/1]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 96
 expression: "./cases/erlang_escape_names"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export(['receive'/1]).
 
@@ -30,7 +28,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([qualified_call/0, qualified_value/0, unqualified_call/0, unqualified_value/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 107
 expression: "./cases/erlang_import"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export([unbox/1]).
 
@@ -31,7 +29,7 @@ unbox(X) ->
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export_type([box/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 118
 expression: "./cases/erlang_import_shadowing_prelude"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export_type([error/0]).
 
@@ -29,7 +27,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([main/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 129
 expression: "./cases/erlang_nested"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one/two.gleam").
 -export([main/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 140
 expression: "./cases/erlang_nested_qualified_constant"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one/two.gleam").
 -export_type([a/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 151
 expression: "./cases/hello_joe"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.erl
 -module(hello_joe).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/hello_joe.gleam").
 -export([main/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 184
 expression: "./cases/import_shadowed_name_warning"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export_type([port_/0]).
 
@@ -29,7 +27,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([use_type/1]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 195
 expression: "./cases/imported_constants"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export_type([a/0, b/0, user/0]).
 
@@ -33,7 +31,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([accessors/1, destructure_qualified/1, destructure_unqualified/1, destructure_aliased/1, qualified_fn_a/0, qualified_fn_b/0, unqualified_fn_a/0, unqualified_fn_b/0, aliased_fn_a/0, aliased_fn_b/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 206
 expression: "./cases/imported_external_fns"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one.gleam").
 -export([thing/0, escaped_thing/0]).
 
@@ -35,7 +33,7 @@ escaped_thing() ->
 
 //// /out/lib/the_package/_gleam_artefacts/three.erl
 -module(three).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/three.gleam").
 -export([thing/0, escaped_thing/0]).
 
@@ -58,7 +56,7 @@ escaped_thing() ->
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([fn_reference_qualified/0, fn_reference_qualified_aliased/0, fn_reference_unqualified/0, fn_reference_unqualified_aliased/0, fn_call_qualified/0, fn_call_qualified_aliased/0, fn_call_unqualified/0, fn_call_unqualified_aliased/0, argument_reference_qualified/0, argument_reference_qualified_aliased/0, argument_reference_unqualified/0, argument_reference_unqualified_aliased/0, the_consts/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 217
 expression: "./cases/imported_record_constructors"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/one@one.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.erl
 -module(one@one).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one/one.gleam").
 -export_type([a/0, b/0, user/0]).
 
@@ -33,7 +31,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/one/two.gleam").
 -export_type([a/0, b/0, user/0]).
 
@@ -54,7 +52,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([accessors/1, destructure_qualified/1, destructure_qualified_aliased/1, destructure_unqualified/1, destructure_aliased/1, update_qualified/1, update_qualified_aliased/1, update_unqualified/1, update_aliased/1, qualified_fn_a/0, qualified_fn_b/0, qualified_aliased_fn_a/0, qualified_aliased_fn_b/0, unqualified_fn_a/0, unqualified_fn_b/0, aliased_fn_a/0, aliased_fn_b/0]).
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
@@ -1,8 +1,6 @@
 ---
 source: test-package-compiler/src/generated_tests.rs
-assertion_line: 360
 expression: "./cases/variable_or_module"
-snapshot_kind: text
 ---
 //// /out/lib/the_package/_gleam_artefacts/main.cache
 <.cache binary>
@@ -12,7 +10,7 @@ snapshot_kind: text
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/main.gleam").
 -export([module_function/1, record_field/1]).
 
@@ -35,7 +33,7 @@ record_field(Power) ->
 
 //// /out/lib/the_package/_gleam_artefacts/power.erl
 -module(power).
--compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch]).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/power.gleam").
 -export([to_int/1]).
 -export_type([power/0]).


### PR DESCRIPTION
Now all generated modules include a `inline` compile option to enable the Erlang compiler to perform inlining. We're using the default option which should be pretty conservative when it comes to code size. Despite this, there's some really nice improvements, basically for free:
- With Wisp's benchmark:
  ```
  CORES  INLINING     REQ/S  MB/S
      1       yes  25835.33  2.44  ~15% faster
      1        no  21861.67  2.06 

      4       yes  79477.03  7.50  < 1% difference
      4        no  79117.93  7.47
  ```
- With Lustre's dom diffing benchmark:
  ```
  NO INLINING                              IPS        MIN     P99
  1000 rows                   vdom.diff()  3051.1898  0.2932  0.3984
  1000 rows (shuffled)        vdom.diff()  2997.1366  0.3053  0.4041
  1000 rows (keyed)           vdom.diff()  2690.2535  0.2192  0.4883
  1000 rows (keyed, shuffled) vdom.diff()  2063.8774  0.4704  0.5583
  
  WITH INLINING
  1000 rows                   vdom.diff()  6131.1367  0.1524  0.2293
  1000 rows (shuffled)        vdom.diff()  5977.3581  0.1562  0.2336
  1000 rows (keyed)           vdom.diff()  4669.7401  0.2060  0.2722
  1000 rows (keyed, shuffled) vdom.diff()  2155.2762  0.4480  0.5371
  ```
  Here the results are quite flashy, it's important to note that Lustre is not really representative of most real Gleam packages: here what's getting optimised are mainly all the calls to the `html` functions. Quite impressive nonetheless, server components are about to get way faster!