### PR TITLE
Change "generate function" to be a quickfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,8 +252,8 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- The "generate function" code action is now a quickfix, allowing it to be more
-  easily applied to code which is producing an error.
+- The "generate function" and "generate variant" code actions are now quickfixes,
+  allowing them to be more easily applied to code which is producing an error.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
 ### Formatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,10 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The "generate function" code action is now a quickfix, allowing it to be more
+  easily applied to code which is producing an error.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Formatter
 
 - The formatter now allows more control over how lists are split. By adding a

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5340,9 +5340,9 @@ where
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Generate variant")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::QUICKFIX)
             .changes(variant_module, variant_edits)
-            .preferred(false)
+            .preferred(true)
             .push_to(&mut action);
         action
     }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5117,9 +5117,9 @@ impl<'a> GenerateFunction<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Generate function")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::QUICKFIX)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
-            .preferred(false)
+            .preferred(true)
             .push_to(&mut action);
         action
     }


### PR DESCRIPTION
As suggested [on discord](https://discord.com/channels/768594524158427167/1388635403183194305/1388635403183194305), I have changed the "generate function" code action to be a quickfix, and also made it preferred by default, which makes it easier to apply to erroring code.
edit: I have also applied this change to the "generate variant" code action, which is in a similar position