### PR TITLE
Remove `Result` from JavaScript code generation

### DIFF
--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -407,14 +407,11 @@ where
             TypeScriptDeclarations::None
         };
 
-        JavaScript::new(
-            &self.out,
-            typescript,
-            prelude_location,
-            &self.root,
-            self.target_support,
-        )
-        .render(&self.io, modules, self.stdlib_package())?;
+        JavaScript::new(&self.out, typescript, prelude_location, &self.root).render(
+            &self.io,
+            modules,
+            self.stdlib_package(),
+        )?;
 
         if self.copy_native_files {
             self.copy_project_native_files(&self.out, &mut written)?;

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -1,6 +1,5 @@
 use crate::{
     Result,
-    analyse::TargetSupport,
     build::{
         ErlangAppCodegenConfiguration, Module, module_erlang_name, package_compiler::StdlibPackage,
     },
@@ -171,7 +170,6 @@ pub struct JavaScript<'a> {
     prelude_location: &'a Utf8Path,
     project_root: &'a Utf8Path,
     typescript: TypeScriptDeclarations,
-    target_support: TargetSupport,
 }
 
 impl<'a> JavaScript<'a> {
@@ -180,12 +178,10 @@ impl<'a> JavaScript<'a> {
         typescript: TypeScriptDeclarations,
         prelude_location: &'a Utf8Path,
         project_root: &'a Utf8Path,
-        target_support: TargetSupport,
     ) -> Self {
         Self {
             prelude_location,
             output_directory,
-            target_support,
             project_root,
             typescript,
         }
@@ -243,9 +239,9 @@ impl<'a> JavaScript<'a> {
     ) -> Result<()> {
         let name = format!("{js_name}.d.mts");
         let path = self.output_directory.join(name);
-        let output = javascript::ts_declaration(&module.ast, &module.input_path, &module.code);
+        let output = javascript::ts_declaration(&module.ast);
         tracing::debug!(name = ?js_name, "Generated TS declaration");
-        writer.write(&path, &output?)
+        writer.write(&path, &output)
     }
 
     fn js_module(
@@ -264,11 +260,10 @@ impl<'a> JavaScript<'a> {
             path: &module.input_path,
             project_root: self.project_root,
             src: &module.code,
-            target_support: self.target_support,
             typescript: self.typescript,
             stdlib_package,
         });
         tracing::debug!(name = ?js_name, "Generated js module");
-        writer.write(&path, &output?)
+        writer.write(&path, &output)
     }
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -14,7 +14,7 @@ use crate::type_::error::{
 use crate::type_::printer::{Names, Printer};
 use crate::type_::{FieldAccessUsage, error::PatternMatchKind};
 use crate::{ast::BinOp, parse::error::ParseErrorType, type_::Type};
-use crate::{bit_array, diagnostic::Level, javascript, type_::UnifyErrorSituation};
+use crate::{bit_array, diagnostic::Level, type_::UnifyErrorSituation};
 use ecow::EcoString;
 use itertools::Itertools;
 use pubgrub::Package;
@@ -217,13 +217,6 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
 
     #[error("warnings are not permitted")]
     ForbiddenWarnings { count: usize },
-
-    #[error("javascript codegen failed")]
-    JavaScript {
-        path: Utf8PathBuf,
-        src: EcoString,
-        error: javascript::Error,
-    },
 
     #[error("Invalid runtime for {target} target: {invalid_runtime}")]
     InvalidRuntime {
@@ -4107,24 +4100,6 @@ Fix the warnings and try again."
                     level: Level::Error,
                 }]
             }
-
-            Error::JavaScript { src, path, error } => match error {
-                javascript::Error::Unsupported { feature, location } => vec![Diagnostic {
-                    title: "Unsupported feature for compilation target".into(),
-                    text: format!("{feature} is not supported for JavaScript compilation."),
-                    hint: None,
-                    level: Level::Error,
-                    location: Some(Location {
-                        label: Label {
-                            text: None,
-                            span: *location,
-                        },
-                        path: path.clone(),
-                        src: src.clone(),
-                        extra_labels: vec![],
-                    }),
-                }],
-            },
 
             Error::DownloadPackageError {
                 package_name,

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -737,21 +737,6 @@ pub fn ts_declaration(module: &TypedModule) -> String {
     document.to_pretty_string(80)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Error {
-    Unsupported { feature: String, location: SrcSpan },
-}
-
-impl Error {
-    /// Returns `true` if the error is [`Unsupported`].
-    ///
-    /// [`Unsupported`]: Error::Unsupported
-    #[must_use]
-    pub fn is_unsupported(&self) -> bool {
-        matches!(self, Self::Unsupported { .. })
-    }
-}
-
 fn fun_args(args: &'_ [TypedArg], tail_recursion_used: bool) -> Document<'_> {
     let mut discards = 0;
     wrap_args(args.iter().map(|a| match a.get_variable_name() {

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -649,7 +649,7 @@ impl<'a> Generator<'a> {
 
         let body = generator.function_body(&function.body, function.arguments.as_slice());
 
-        let document = docvec![
+        docvec![
             function_doc,
             head,
             maybe_escape_identifier(name.as_str()),
@@ -658,8 +658,7 @@ impl<'a> Generator<'a> {
             docvec![line(), body].nest(INDENT).group(),
             line(),
             "}",
-        ];
-        document
+        ]
     }
 
     fn register_module_definitions_in_scope(&mut self) {

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -8,7 +8,6 @@ mod typescript;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
-use crate::analyse::TargetSupport;
 use crate::build::Target;
 use crate::build::package_compiler::StdlibPackage;
 use crate::codegen::TypeScriptDeclarations;
@@ -31,8 +30,6 @@ const INDENT: isize = 2;
 pub const PRELUDE: &str = include_str!("../templates/prelude.mjs");
 pub const PRELUDE_TS_DEF: &str = include_str!("../templates/prelude.d.mts");
 
-pub type Output<'a> = Result<Document<'a>, Error>;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JavaScriptCodegenTarget {
     JavaScript,
@@ -46,7 +43,6 @@ pub struct Generator<'a> {
     tracker: UsageTracker,
     module_scope: im::HashMap<EcoString, usize>,
     current_module_name_segments_count: usize,
-    target_support: TargetSupport,
     typescript: TypeScriptDeclarations,
     stdlib_package: StdlibPackage,
     /// Relative path to the module, surrounded in `"`s to make it a string, and with `\`s escaped
@@ -57,7 +53,6 @@ pub struct Generator<'a> {
 impl<'a> Generator<'a> {
     pub fn new(config: ModuleConfig<'a>) -> Self {
         let ModuleConfig {
-            target_support,
             typescript,
             stdlib_package,
             module,
@@ -82,7 +77,6 @@ impl<'a> Generator<'a> {
             src_path,
             tracker: UsageTracker::default(),
             module_scope: Default::default(),
-            target_support,
             typescript,
             stdlib_package,
         }
@@ -105,7 +99,7 @@ impl<'a> Generator<'a> {
         docvec!["/// <reference types=\"./", module, ".d.mts\" />", line()]
     }
 
-    pub fn compile(&mut self) -> Output<'a> {
+    pub fn compile(&mut self) -> Document<'a> {
         // Determine what JavaScript imports we need to generate
         let mut imports = self.collect_imports();
 
@@ -123,8 +117,7 @@ impl<'a> Generator<'a> {
         );
 
         // Two lines between each statement
-        let mut statements: Vec<_> =
-            Itertools::intersperse(statements, Ok(lines(2))).try_collect()?;
+        let mut statements = Itertools::intersperse(statements, lines(2)).collect_vec();
 
         // Import any prelude functions that have been used
 
@@ -231,30 +224,30 @@ impl<'a> Generator<'a> {
         // Put it all together
 
         if imports.is_empty() && statements.is_empty() {
-            Ok(docvec![
+            docvec![
                 type_reference,
                 filepath_definition,
                 "export {}",
                 line(),
                 echo_definition
-            ])
+            ]
         } else if imports.is_empty() {
             statements.push(line());
-            Ok(docvec![
+            docvec![
                 type_reference,
                 filepath_definition,
                 statements,
                 echo_definition
-            ])
+            ]
         } else if statements.is_empty() {
-            Ok(docvec![
+            docvec![
                 type_reference,
                 imports.into_doc(JavaScriptCodegenTarget::JavaScript),
                 filepath_definition,
                 echo_definition,
-            ])
+            ]
         } else {
-            Ok(docvec![
+            docvec![
                 type_reference,
                 imports.into_doc(JavaScriptCodegenTarget::JavaScript),
                 line(),
@@ -262,7 +255,7 @@ impl<'a> Generator<'a> {
                 statements,
                 line(),
                 echo_definition
-            ])
+            ]
         }
     }
 
@@ -298,7 +291,7 @@ impl<'a> Generator<'a> {
         imports.register_module(path, [], [member]);
     }
 
-    pub fn definition(&mut self, definition: &'a TypedDefinition) -> Option<Output<'a>> {
+    pub fn definition(&mut self, definition: &'a TypedDefinition) -> Option<Document<'a>> {
         match definition {
             Definition::TypeAlias(TypeAlias { .. }) => None,
 
@@ -340,7 +333,7 @@ impl<'a> Generator<'a> {
                     return None;
                 }
 
-                self.module_function(function)
+                Some(self.module_function(function))
             }
         }
     }
@@ -350,7 +343,7 @@ impl<'a> Generator<'a> {
         constructors: &'a [TypedRecordConstructor],
         publicity: Publicity,
         opaque: bool,
-    ) -> Vec<Output<'a>> {
+    ) -> Vec<Document<'a>> {
         // If there's no constructors then there's nothing to do here.
         if constructors.is_empty() {
             return vec![];
@@ -359,7 +352,7 @@ impl<'a> Generator<'a> {
         self.tracker.custom_type_used = true;
         constructors
             .iter()
-            .map(|constructor| Ok(self.record_definition(constructor, publicity, opaque)))
+            .map(|constructor| self.record_definition(constructor, publicity, opaque))
             .collect()
     }
 
@@ -426,7 +419,7 @@ impl<'a> Generator<'a> {
         docvec![doc, head, class_body, line(), "}"]
     }
 
-    fn collect_definitions(&mut self) -> Vec<Output<'a>> {
+    fn collect_definitions(&mut self) -> Vec<Document<'a>> {
         self.module
             .definitions
             .iter()
@@ -582,7 +575,7 @@ impl<'a> Generator<'a> {
         name: &'a EcoString,
         value: &'a TypedConstant,
         documentation: &'a Option<(u32, EcoString)>,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let head = if publicity.is_private() {
             "const "
         } else {
@@ -599,7 +592,7 @@ impl<'a> Generator<'a> {
             self.module_scope.clone(),
         );
 
-        let document = generator.constant_expression(Context::Constant, value)?;
+        let document = generator.constant_expression(Context::Constant, value);
 
         let jsdoc = if let Some((_, documentation)) = documentation {
             jsdoc_comment(documentation, publicity).append(line())
@@ -607,21 +600,21 @@ impl<'a> Generator<'a> {
             nil()
         };
 
-        Ok(docvec![
+        docvec![
             jsdoc,
             head,
             maybe_escape_identifier(name),
             " = ",
             document,
             ";",
-        ])
+        ]
     }
 
     fn register_in_scope(&mut self, name: &str) {
         let _ = self.module_scope.insert(name.into(), 0);
     }
 
-    fn module_function(&mut self, function: &'a TypedFunction) -> Option<Output<'a>> {
+    fn module_function(&mut self, function: &'a TypedFunction) -> Document<'a> {
         let (_, name) = function
             .name
             .as_ref()
@@ -654,20 +647,7 @@ impl<'a> Generator<'a> {
             "export function "
         };
 
-        let body = match generator.function_body(&function.body, function.arguments.as_slice()) {
-            // No error, let's continue!
-            Ok(body) => body,
-
-            // There is an error coming from some expression that is not supported on JavaScript
-            // and the target support is not enforced. In this case we do not error, instead
-            // returning nothing which will cause no function to be generated.
-            Err(error) if error.is_unsupported() && !self.target_support.is_enforced() => {
-                return None;
-            }
-
-            // Some other error case which will be returned to the user.
-            Err(error) => return Some(Err(error)),
-        };
+        let body = generator.function_body(&function.body, function.arguments.as_slice());
 
         let document = docvec![
             function_doc,
@@ -679,7 +659,7 @@ impl<'a> Generator<'a> {
             line(),
             "}",
         ];
-        Some(Ok(document))
+        document
     }
 
     fn register_module_definitions_in_scope(&mut self) {
@@ -741,35 +721,20 @@ pub struct ModuleConfig<'a> {
     pub module: &'a TypedModule,
     pub line_numbers: &'a LineNumbers,
     pub src: &'a EcoString,
-    pub target_support: TargetSupport,
     pub typescript: TypeScriptDeclarations,
     pub stdlib_package: StdlibPackage,
     pub path: &'a Utf8Path,
     pub project_root: &'a Utf8Path,
 }
 
-pub fn module(config: ModuleConfig<'_>) -> Result<String, crate::Error> {
-    let path = config.path.to_path_buf();
-    let src = config.src.clone();
-    let document = Generator::new(config)
-        .compile()
-        .map_err(|error| crate::Error::JavaScript { path, src, error })?;
-    Ok(document.to_pretty_string(80))
+pub fn module(config: ModuleConfig<'_>) -> String {
+    let document = Generator::new(config).compile();
+    document.to_pretty_string(80)
 }
 
-pub fn ts_declaration(
-    module: &TypedModule,
-    path: &Utf8Path,
-    src: &EcoString,
-) -> Result<String, crate::Error> {
-    let document = typescript::TypeScriptGenerator::new(module)
-        .compile()
-        .map_err(|error| crate::Error::JavaScript {
-            path: path.to_path_buf(),
-            src: src.clone(),
-            error,
-        })?;
-    Ok(document.to_pretty_string(80))
+pub fn ts_declaration(module: &TypedModule) -> String {
+    let document = typescript::TypeScriptGenerator::new(module).compile();
+    document.to_pretty_string(80)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1000,7 +965,7 @@ pub(crate) fn bit_array_segment_int_value_to_bytes(
     mut value: BigInt,
     size: BigInt,
     endianness: Endianness,
-) -> Result<Vec<u8>, Error> {
+) -> Vec<u8> {
     // Clamp negative sizes to zero
     let size = size.max(BigInt::ZERO);
 
@@ -1029,5 +994,5 @@ pub(crate) fn bit_array_segment_int_value_to_bytes(
         bytes.reverse();
     }
 
-    Ok(bytes)
+    bytes
 }

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -1,5 +1,5 @@
 use super::{
-    Error, INDENT, Output, bit_array_segment_int_value_to_bytes,
+    INDENT, bit_array_segment_int_value_to_bytes,
     expression::{self, Generator, Ordering, float, int},
 };
 use crate::{
@@ -35,11 +35,11 @@ pub fn case<'a>(
     clauses: &'a [TypedClause],
     subjects: &'a [TypedExpr],
     expression_generator: &mut Generator<'_, 'a>,
-) -> Output<'a> {
+) -> Document<'a> {
     let mut variables = Variables::new(expression_generator);
-    let assignments = variables.assign_case_subjects(compiled_case, subjects)?;
-    let decision = CasePrinter { clauses, variables }.decision(&compiled_case.tree)?;
-    Ok(docvec![assignments_to_doc(assignments), decision.into_doc()].force_break())
+    let assignments = variables.assign_case_subjects(compiled_case, subjects);
+    let decision = CasePrinter { clauses, variables }.decision(&compiled_case.tree);
+    docvec![assignments_to_doc(assignments), decision.into_doc()].force_break()
 }
 
 /// The generated code for a decision tree.
@@ -194,13 +194,13 @@ struct CasePrinter<'module, 'generator, 'a> {
 /// the decision tree of let expressions!
 ///
 impl<'a> CasePrinter<'_, '_, 'a> {
-    fn decision(&mut self, decision: &'a Decision) -> Result<CaseBody<'a>, Error> {
+    fn decision(&mut self, decision: &'a Decision) -> CaseBody<'a> {
         match decision {
             Decision::Fail => unreachable!("Invalid decision tree reached code generation"),
             Decision::Run { body } => {
                 let bindings = self.variables.bindings_doc(&body.bindings);
-                let body = self.body_expression(body.clause_index)?;
-                Ok(CaseBody::Statements(join_with_line(bindings, body)))
+                let body = self.body_expression(body.clause_index);
+                CaseBody::Statements(join_with_line(bindings, body))
             }
             Decision::Switch {
                 var,
@@ -216,7 +216,7 @@ impl<'a> CasePrinter<'_, '_, 'a> {
         }
     }
 
-    fn body_expression(&mut self, clause_index: usize) -> Output<'a> {
+    fn body_expression(&mut self, clause_index: usize) -> Document<'a> {
         let body = &self
             .clauses
             .get(clause_index)
@@ -234,7 +234,7 @@ impl<'a> CasePrinter<'_, '_, 'a> {
         choices: &'a [(RuntimeCheck, Box<Decision>)],
         fallback: &'a Decision,
         fallback_check: &'a FallbackCheck,
-    ) -> Result<CaseBody<'a>, Error> {
+    ) -> CaseBody<'a> {
         // If there's just a single choice we can just generate the code for
         // it: no need to do any checking, we know it must match!
         if choices.is_empty() {
@@ -272,15 +272,15 @@ impl<'a> CasePrinter<'_, '_, 'a> {
             //   referenced by this check
             let (check_doc, body, mut segment_assignments) = self.inside_new_scope(|this| {
                 let segment_assignments = this.variables.bit_array_segment_assignments(check);
-                let check_doc =
-                    this.variables
-                        .runtime_check(var, check, CheckNegation::NotNegated)?;
+                let check_doc = this
+                    .variables
+                    .runtime_check(var, check, CheckNegation::NotNegated);
                 let body = this.decision(decision);
-                Ok((check_doc, body, segment_assignments))
-            })?;
+                (check_doc, body, segment_assignments)
+            });
             assignments.append(&mut segment_assignments);
 
-            let (check_doc, body) = match body? {
+            let (check_doc, body) = match body {
                 // If we have a statement like this:
                 // ```javascript
                 // if (x) {
@@ -389,7 +389,7 @@ impl<'a> CasePrinter<'_, '_, 'a> {
             self.variables.record_check_assignments(var, check);
         }
 
-        let else_body = self.inside_new_scope(|this| this.decision(fallback))?;
+        let else_body = self.inside_new_scope(|this| this.decision(fallback));
         let document = if else_body.is_empty() {
             if_
         } else if let CaseBody::If {
@@ -411,14 +411,14 @@ impl<'a> CasePrinter<'_, '_, 'a> {
             ])
         };
 
-        Ok(if assignments.is_empty() {
+        if assignments.is_empty() {
             document
         } else {
             CaseBody::Statements(join_with_line(
                 join(assignments, line()),
                 document.into_doc(),
             ))
-        })
+        }
     }
 
     fn inside_new_scope<A, F>(&mut self, run: F) -> A
@@ -446,7 +446,7 @@ impl<'a> CasePrinter<'_, '_, 'a> {
         guard: usize,
         if_true: &'a Body,
         if_false: &'a Decision,
-    ) -> Result<CaseBody<'a>, Error> {
+    ) -> CaseBody<'a> {
         let guard = self
             .clauses
             .get(guard)
@@ -465,15 +465,15 @@ impl<'a> CasePrinter<'_, '_, 'a> {
             .partition(|(variable, _)| guard_variables.contains(variable));
 
         let check_bindings = self.variables.bindings_ref_doc(&check_bindings);
-        let check = self.variables.expression_generator.guard(guard)?;
+        let check = self.variables.expression_generator.guard(guard);
         let if_true = self.inside_new_scope(|this| {
             // All the other bindings that are not needed by the guard check will
             // end up directly in the body of the if clause.
             let if_true_bindings = this.variables.bindings_ref_doc(&if_true_bindings);
-            let if_true_body = this.body_expression(if_true.clause_index)?;
-            Ok(join_with_line(if_true_bindings, if_true_body))
-        })?;
-        let if_false_body = self.inside_new_scope(|this| this.decision(if_false))?;
+            let if_true_body = this.body_expression(if_true.clause_index);
+            join_with_line(if_true_bindings, if_true_body)
+        });
+        let if_false_body = self.inside_new_scope(|this| this.decision(if_false));
 
         // We can now piece everything together into a case body!
         let if_ = if if_false_body.is_empty() {
@@ -490,11 +490,11 @@ impl<'a> CasePrinter<'_, '_, 'a> {
             }
         };
 
-        Ok(if check_bindings.is_empty() {
+        if check_bindings.is_empty() {
             if_
         } else {
             CaseBody::Statements(join_with_line(check_bindings, if_.into_doc()))
-        })
+        }
     }
 }
 
@@ -508,22 +508,22 @@ pub fn let_<'a>(
     kind: &'a AssignmentKind<TypedExpr>,
     expression_generator: &mut Generator<'_, 'a>,
     pattern_location: SrcSpan,
-) -> Output<'a> {
+) -> Document<'a> {
     let scope_position = expression_generator.scope_position.clone();
     let mut variables = Variables::new(expression_generator);
-    let assignment = variables.assign_let_subject(compiled_case, subject)?;
+    let assignment = variables.assign_let_subject(compiled_case, subject);
     let assignment_name = assignment.name();
     let decision = LetPrinter::new(variables, kind, pattern_location, subject.location())
-        .decision(assignment_name.clone().to_doc(), &compiled_case.tree)?;
+        .decision(assignment_name.clone().to_doc(), &compiled_case.tree);
 
     let doc = docvec![assignments_to_doc(vec![assignment]), decision];
-    Ok(match scope_position {
+    match scope_position {
         expression::Position::NotTail(_ordering) => doc,
         expression::Position::Tail => docvec![doc, line(), "return ", assignment_name, ";"],
         expression::Position::Assign(variable) => {
             docvec![doc, line(), variable, " = ", assignment_name, ";"]
         }
-    })
+    }
 }
 
 struct LetPrinter<'generator, 'module, 'a> {
@@ -577,7 +577,7 @@ impl<'generator, 'module, 'a> LetPrinter<'generator, 'module, 'a> {
         }
     }
 
-    fn decision(&mut self, subject: Document<'a>, decision: &'a Decision) -> Output<'a> {
+    fn decision(&mut self, subject: Document<'a>, decision: &'a Decision) -> Document<'a> {
         let Some(ChecksAndBindings { checks, bindings }) =
             self.positive_checks_and_bindings(decision)
         else {
@@ -606,10 +606,11 @@ impl<'generator, 'module, 'a> LetPrinter<'generator, 'module, 'a> {
                     // those altogether here.
                     RuntimeCheck::Tuple { .. } => None,
                     RuntimeCheck::Variant { .. } if variable.type_.is_nil() => None,
-                    _ => self
-                        .variables
-                        .runtime_check(variable, check, CheckNegation::Negated)
-                        .ok(),
+                    _ => Some(self.variables.runtime_check(
+                        variable,
+                        check,
+                        CheckNegation::Negated,
+                    )),
                 }
             });
 
@@ -622,7 +623,7 @@ impl<'generator, 'module, 'a> LetPrinter<'generator, 'module, 'a> {
         let doc = if checks.is_empty() {
             nil()
         } else {
-            let exception = self.assignment_no_match(subject)?;
+            let exception = self.assignment_no_match(subject);
             docvec!["if (", checks, ") ", break_block(exception)]
         };
 
@@ -630,10 +631,10 @@ impl<'generator, 'module, 'a> LetPrinter<'generator, 'module, 'a> {
             .iter()
             .map(|(name, value)| self.variables.body_binding_doc(name, value));
         let body_bindings = join(body_bindings, line());
-        Ok(join_with_line(doc, body_bindings))
+        join_with_line(doc, body_bindings)
     }
 
-    fn assignment_no_match(&mut self, subject: Document<'a>) -> Output<'a> {
+    fn assignment_no_match(&mut self, subject: Document<'a>) -> Document<'a> {
         let AssignmentKind::Assert {
             location, message, ..
         } = self.kind
@@ -644,11 +645,10 @@ impl<'generator, 'module, 'a> LetPrinter<'generator, 'module, 'a> {
         let generator = &mut self.variables.expression_generator;
         let message = match message {
             None => string("Pattern match failed, no pattern matched the value."),
-            Some(message) => generator.not_in_tail_position(Some(Ordering::Strict), |this| {
-                this.wrap_expression(message)
-            })?,
+            Some(message) => generator
+                .not_in_tail_position(Some(Ordering::Strict), |this| this.wrap_expression(message)),
         };
-        Ok(generator.throw_error(
+        generator.throw_error(
             "let_assert",
             &message,
             *location,
@@ -659,7 +659,7 @@ impl<'generator, 'module, 'a> LetPrinter<'generator, 'module, 'a> {
                 ("pattern_start", self.pattern_location.start.to_doc()),
                 ("pattern_end", self.pattern_location.end.to_doc()),
             ],
-        ))
+        )
     }
 
     /// A let decision tree has a very precise structure since it's made of a
@@ -947,11 +947,11 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
         &mut self,
         compiled_case: &'a CompiledCase,
         subjects: &'a [TypedExpr],
-    ) -> Result<Vec<SubjectAssignment<'a>>, Error> {
-        let assignments: Vec<_> = subjects
+    ) -> Vec<SubjectAssignment<'a>> {
+        let assignments = subjects
             .iter()
             .map(|subject| assign_subject(self.expression_generator, subject, Ordering::Strict))
-            .try_collect()?;
+            .collect_vec();
 
         for (variable, assignment) in compiled_case
             .subject_variables
@@ -964,7 +964,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             self.bind(assignment.name(), variable);
         }
 
-        Ok(assignments)
+        assignments
     }
 
     /// Give a unique name to the subject of a let expression (if it needs one
@@ -975,15 +975,15 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
         &mut self,
         compiled_case: &'a CompiledCase,
         subject: &'a TypedExpr,
-    ) -> Result<SubjectAssignment<'a>, Error> {
+    ) -> SubjectAssignment<'a> {
         let variable = compiled_case
             .subject_variables
             .first()
             .expect("decision tree with no subjects");
-        let assignment = assign_subject(self.expression_generator, subject, Ordering::Loose)?;
+        let assignment = assign_subject(self.expression_generator, subject, Ordering::Loose);
         self.set_value(variable, assignment.name());
         self.bind(assignment.name(), variable);
-        Ok(assignment)
+        assignment
     }
 
     fn local_var(&mut self, name: &EcoString) -> EcoString {
@@ -1124,7 +1124,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
         variable: &Variable,
         runtime_check: &'a RuntimeCheck,
         negation: CheckNegation,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let value = self.get_value(variable);
 
         let equality = if negation.is_negated() {
@@ -1230,7 +1230,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                             expected.clone(),
                             read_action,
                             negation,
-                        )?,
+                        ),
                     BitArrayMatchedValue::Variable(..)
                     | BitArrayMatchedValue::Discard(..)
                     | BitArrayMatchedValue::Assign { .. } => {
@@ -1298,7 +1298,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             }
         };
 
-        Ok(result)
+        result
     }
 
     /// Turns a read action into a document that can be used to extract the
@@ -1602,7 +1602,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
         literal_int: BigInt,
         read_action: &ReadAction,
         check_negation: CheckNegation,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let ReadAction {
             from: start,
             size,
@@ -1622,17 +1622,17 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             // whole number of bytes then we can optimise this by checking that
             // all the bytes starting at the given offset match the int bytes.
             let mut checks = vec![];
-            for byte in bit_array_segment_int_value_to_bytes(literal_int, size * 8, *endianness)? {
+            for byte in bit_array_segment_int_value_to_bytes(literal_int, size * 8, *endianness) {
                 let byte_access = docvec![bit_array.clone(), ".byteAt(", from_byte.clone(), ")"];
                 checks.push(docvec![byte_access, equality, byte]);
                 from_byte += 1;
             }
 
-            Ok(if check_negation.is_negated() {
+            if check_negation.is_negated() {
                 join(checks, break_(" ||", " || ")).group()
             } else {
                 join(checks, break_(" &&", " && ")).nest(INDENT).group()
-            })
+            }
         } else {
             // Otherwise we have to take an int slice out of the bit array and
             // check it matches the expected value.
@@ -1645,7 +1645,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                 (_, _) => docvec![start_doc.clone(), " + ", self.read_size_to_doc(size)],
             };
             let check = self.bit_array_slice_to_int(bit_array, start_doc, end, endianness, *signed);
-            Ok(docvec![check, equality, literal_int])
+            docvec![check, equality, literal_int]
         }
     }
 
@@ -1884,7 +1884,7 @@ fn assign_subject<'a>(
     expression_generator: &mut Generator<'_, 'a>,
     subject: &'a TypedExpr,
     ordering: Ordering,
-) -> Result<SubjectAssignment<'a>, Error> {
+) -> SubjectAssignment<'a> {
     static ASSIGNMENT_VAR_ECO_STR: OnceLock<EcoString> = OnceLock::new();
 
     match subject {
@@ -1893,9 +1893,9 @@ fn assign_subject<'a>(
         // performing computation or side effects multiple times.
         TypedExpr::Var {
             name, constructor, ..
-        } if constructor.is_local_variable() => Ok(SubjectAssignment::AlreadyAVariable {
+        } if constructor.is_local_variable() => SubjectAssignment::AlreadyAVariable {
             name: expression_generator.local_var(name),
-        }),
+        },
 
         // If it's not a variable we need to assign it to a variable
         // to avoid rendering the subject expression multiple times
@@ -1903,9 +1903,9 @@ fn assign_subject<'a>(
             let name = expression_generator
                 .next_local_var(ASSIGNMENT_VAR_ECO_STR.get_or_init(|| ASSIGNMENT_VAR.into()));
             let value = expression_generator
-                .not_in_tail_position(Some(ordering), |this| this.wrap_expression(subject))?;
+                .not_in_tail_position(Some(ordering), |this| this.wrap_expression(subject));
 
-            Ok(SubjectAssignment::BindToVariable { value, name })
+            SubjectAssignment::BindToVariable { value, name }
         }
     }
 }

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -1133,7 +1133,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             " === "
         };
 
-        let result = match runtime_check {
+        match runtime_check {
             RuntimeCheck::String { value: expected } => docvec![value, equality, string(expected)],
             RuntimeCheck::Float { value: expected } => docvec![value, equality, float(expected)],
             RuntimeCheck::Int { value: expected } => docvec![value, equality, int(expected)],
@@ -1296,9 +1296,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                     docvec![value, " instanceof $Empty"]
                 }
             }
-        };
-
-        result
+        }
     }
 
     /// Turns a read action into a document that can be used to extract the

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -232,36 +232,36 @@ impl<'module, 'a> Generator<'module, 'a> {
         &mut self,
         body: &'a [TypedStatement],
         args: &'a [TypedArg],
-    ) -> Output<'a> {
-        let body = self.statements(body)?;
+    ) -> Document<'a> {
+        let body = self.statements(body);
         if self.tail_recursion_used {
             self.tail_call_loop(body, args)
         } else {
-            Ok(body)
+            body
         }
     }
 
-    fn tail_call_loop(&mut self, body: Document<'a>, args: &'a [TypedArg]) -> Output<'a> {
+    fn tail_call_loop(&mut self, body: Document<'a>, args: &'a [TypedArg]) -> Document<'a> {
         let loop_assignments = concat(args.iter().flat_map(Arg::get_variable_name).map(|name| {
             let var = maybe_escape_identifier(name);
             docvec!["let ", var, " = loop$", name, ";", line()]
         }));
-        Ok(docvec![
+        docvec![
             "while (true) {",
             docvec![line(), loop_assignments, body].nest(INDENT),
             line(),
             "}"
-        ])
+        ]
     }
 
-    fn statement(&mut self, statement: &'a TypedStatement) -> Output<'a> {
+    fn statement(&mut self, statement: &'a TypedStatement) -> Document<'a> {
         let expression_doc = match statement {
             Statement::Expression(expression) => self.expression(expression),
             Statement::Assignment(assignment) => self.assignment(assignment),
             Statement::Use(use_) => self.expression(&use_.call),
             Statement::Assert(assert) => self.assert(assert),
-        }?;
-        Ok(self.add_statement_level(expression_doc))
+        };
+        self.add_statement_level(expression_doc)
     }
 
     fn add_statement_level(&mut self, expression: Document<'a>) -> Document<'a> {
@@ -274,18 +274,18 @@ impl<'module, 'a> Generator<'module, 'a> {
         }
     }
 
-    pub fn expression(&mut self, expression: &'a TypedExpr) -> Output<'a> {
+    pub fn expression(&mut self, expression: &'a TypedExpr) -> Document<'a> {
         let document = match expression {
-            TypedExpr::String { value, .. } => Ok(string(value)),
+            TypedExpr::String { value, .. } => string(value),
 
-            TypedExpr::Int { value, .. } => Ok(int(value)),
-            TypedExpr::Float { value, .. } => Ok(float(value)),
+            TypedExpr::Int { value, .. } => int(value),
+            TypedExpr::Float { value, .. } => float(value),
 
             TypedExpr::List { elements, tail, .. } => {
                 self.not_in_tail_position(Some(Ordering::Strict), |this| match tail {
                     Some(tail) => {
                         this.tracker.prepend_used = true;
-                        let tail = this.wrap_expression(tail)?;
+                        let tail = this.wrap_expression(tail);
                         prepend(
                             elements.iter().map(|element| this.wrap_expression(element)),
                             tail,
@@ -351,7 +351,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                 label,
                 constructor,
                 ..
-            } => Ok(self.module_select(module_alias, label, constructor)),
+            } => self.module_select(module_alias, label, constructor),
 
             TypedExpr::NegateBool { value, .. } => self.negate_with("!", value),
 
@@ -366,37 +366,37 @@ impl<'module, 'a> Generator<'module, 'a> {
                     .as_ref()
                     .expect("echo with no expression outside of pipe");
                 let expresion_doc =
-                    self.not_in_tail_position(None, |this| this.wrap_expression(expression))?;
+                    self.not_in_tail_position(None, |this| this.wrap_expression(expression));
                 self.echo(expresion_doc, location)
             }
 
             TypedExpr::Invalid { .. } => {
                 panic!("invalid expressions should not reach code generation")
             }
-        }?;
-        Ok(if expression.handles_own_return() {
+        };
+        if expression.handles_own_return() {
             document
         } else {
             self.wrap_return(document)
-        })
+        }
     }
 
-    fn negate_with(&mut self, with: &'static str, value: &'a TypedExpr) -> Output<'a> {
-        self.not_in_tail_position(None, |this| Ok(docvec![with, this.wrap_expression(value)?]))
+    fn negate_with(&mut self, with: &'static str, value: &'a TypedExpr) -> Document<'a> {
+        self.not_in_tail_position(None, |this| docvec![with, this.wrap_expression(value)])
     }
 
-    fn bit_array(&mut self, segments: &'a [TypedExprBitArraySegment]) -> Output<'a> {
+    fn bit_array(&mut self, segments: &'a [TypedExprBitArraySegment]) -> Document<'a> {
         self.tracker.bit_array_literal_used = true;
 
         // Collect all the values used in segments.
         let segments_array = array(segments.iter().map(|segment| {
             let value = self.not_in_tail_position(Some(Ordering::Strict), |this| {
                 this.wrap_expression(&segment.value)
-            })?;
+            });
 
-            let details = self.bit_array_segment_details(segment)?;
+            let details = self.bit_array_segment_details(segment);
 
-            let segment = match details.type_ {
+            match details.type_ {
                 BitArraySegmentType::BitArray => {
                     if segment.size().is_some() {
                         self.tracker.bit_array_slice_used = true;
@@ -414,7 +414,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                             int_value.clone(),
                             size_value,
                             segment.endianness(),
-                        )?;
+                        );
 
                         u8_slice(&bytes)
                     }
@@ -464,18 +464,16 @@ impl<'module, 'a> Generator<'module, 'a> {
                     let is_big = bool(details.endianness.is_big());
                     docvec!["codepointToUtf32(", value, ", ", is_big, ")"]
                 }
-            };
+            }
+        }));
 
-            Ok(segment)
-        }))?;
-
-        Ok(docvec!["toBitArray(", segments_array, ")"])
+        docvec!["toBitArray(", segments_array, ")"]
     }
 
     fn bit_array_segment_details(
         &mut self,
         segment: &'a TypedExprBitArraySegment,
-    ) -> Result<BitArraySegmentDetails<'a>, Error> {
+    ) -> BitArraySegmentDetails<'a> {
         let size = segment.size();
         let unit = segment.unit();
         let (size_value, size) = match size {
@@ -487,7 +485,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             Some(size) => {
                 let mut size = self.not_in_tail_position(Some(Ordering::Strict), |this| {
                     this.wrap_expression(size)
-                })?;
+                });
 
                 if unit != 1 {
                     size = size.group().append(" * ".to_doc().append(unit.to_doc()));
@@ -504,12 +502,12 @@ impl<'module, 'a> Generator<'module, 'a> {
 
         let type_ = BitArraySegmentType::from_segment(segment);
 
-        Ok(BitArraySegmentDetails {
+        BitArraySegmentDetails {
             type_,
             size,
             size_value,
             endianness: segment.endianness(),
-        })
+        }
     }
 
     pub fn wrap_return(&mut self, document: Document<'a>) -> Document<'a> {
@@ -546,7 +544,7 @@ impl<'module, 'a> Generator<'module, 'a> {
     }
 
     /// Use the `_block` variable if the expression is JS statement.
-    pub fn wrap_expression(&mut self, expression: &'a TypedExpr) -> Output<'a> {
+    pub fn wrap_expression(&mut self, expression: &'a TypedExpr) -> Document<'a> {
         match (expression, &self.scope_position) {
             (_, Position::Tail | Position::Assign(_)) => self.expression(expression),
             (
@@ -582,7 +580,7 @@ impl<'module, 'a> Generator<'module, 'a> {
     /// Wrap an expression using the `_block` variable if required due to being
     /// a JS statement, or in parens if required due to being an operator or
     /// a function literal.
-    pub fn child_expression(&mut self, expression: &'a TypedExpr) -> Output<'a> {
+    pub fn child_expression(&mut self, expression: &'a TypedExpr) -> Document<'a> {
         match expression {
             TypedExpr::BinOp { name, .. } if name.is_operator_to_wrap() => {}
             TypedExpr::Fn { .. } => {}
@@ -590,13 +588,13 @@ impl<'module, 'a> Generator<'module, 'a> {
             _ => return self.wrap_expression(expression),
         }
 
-        let document = self.expression(expression)?;
-        Ok(match &self.scope_position {
+        let document = self.expression(expression);
+        match &self.scope_position {
             // Here the document is a return statement: `return <expr>;`
             // or an assignment: `_block = <expr>;`
             Position::Tail | Position::Assign(_) => document,
             Position::NotTail(_) => docvec!["(", document, ")"],
-        })
+        }
     }
 
     /// Wrap an expression in an immediately invoked function expression
@@ -604,9 +602,9 @@ impl<'module, 'a> Generator<'module, 'a> {
         &mut self,
         statements: &'a T,
         to_doc: ToDoc,
-    ) -> Output<'a>
+    ) -> Document<'a>
     where
-        ToDoc: FnOnce(&mut Self, &'a T) -> Output<'a>,
+        ToDoc: FnOnce(&mut Self, &'a T) -> Document<'a>,
     {
         // Save initial state
         let scope_position = std::mem::replace(&mut self.scope_position, Position::Tail);
@@ -623,13 +621,13 @@ impl<'module, 'a> Generator<'module, 'a> {
 
         // Wrap in iife document
         let doc =
-            immediately_invoked_function_expression_document(self.add_statement_level(result?));
-        Ok(self.wrap_return(doc))
+            immediately_invoked_function_expression_document(self.add_statement_level(result));
+        self.wrap_return(doc)
     }
 
-    fn wrap_block<CompileFn>(&mut self, compile: CompileFn) -> Output<'a>
+    fn wrap_block<CompileFn>(&mut self, compile: CompileFn) -> Document<'a>
     where
-        CompileFn: Fn(&mut Self) -> Output<'a>,
+        CompileFn: Fn(&mut Self) -> Document<'a>,
     {
         let block_variable = self.next_local_var(&BLOCK_VARIABLE.into());
 
@@ -652,12 +650,12 @@ impl<'module, 'a> Generator<'module, 'a> {
 
         self.statement_level
             .push(docvec!["let ", block_variable.clone(), ";"]);
-        self.statement_level.push(statement_doc?);
+        self.statement_level.push(statement_doc);
 
-        Ok(self.wrap_return(block_variable.to_doc()))
+        self.wrap_return(block_variable.to_doc())
     }
 
-    fn variable(&mut self, name: &'a EcoString, constructor: &'a ValueConstructor) -> Output<'a> {
+    fn variable(&mut self, name: &'a EcoString, constructor: &'a ValueConstructor) -> Document<'a> {
         match &constructor.variant {
             ValueConstructorVariant::LocalConstant { literal } => {
                 self.constant_expression(Context::Function, literal)
@@ -665,11 +663,11 @@ impl<'module, 'a> Generator<'module, 'a> {
             ValueConstructorVariant::Record { arity, .. } => {
                 let type_ = constructor.type_.clone();
                 let tracker = &mut self.tracker;
-                Ok(record_constructor(type_, None, name, *arity, tracker))
+                record_constructor(type_, None, name, *arity, tracker)
             }
             ValueConstructorVariant::ModuleFn { .. }
             | ValueConstructorVariant::ModuleConstant { .. }
-            | ValueConstructorVariant::LocalVariable { .. } => Ok(self.local_var(name).to_doc()),
+            | ValueConstructorVariant::LocalVariable { .. } => self.local_var(name).to_doc(),
         }
     }
 
@@ -678,7 +676,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         first_value: &'a TypedPipelineAssignment,
         assignments: &'a [(TypedPipelineAssignment, PipelineAssignmentKind)],
         finally: &'a TypedExpr,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let count = assignments.len();
         let mut documents = Vec::with_capacity((count + 2) * 2);
 
@@ -699,14 +697,14 @@ impl<'module, 'a> Generator<'module, 'a> {
                         .as_ref()
                         .expect("echo with no previous step in a pipe");
                     this.echo(var.to_doc(), location)
-                })?),
+                })),
 
                 // Otherwise we assign the intermediate pipe value to a variable.
                 _ => {
                     let assignment_document = self
                         .not_in_tail_position(Some(Ordering::Strict), |this| {
                             this.simple_variable_assignment(&assignment.name, &assignment.value)
-                        })?;
+                        });
                     documents.push(self.add_statement_level(assignment_document));
                     latest_local_var = Some(self.local_var(&assignment.name));
                 }
@@ -722,28 +720,31 @@ impl<'module, 'a> Generator<'module, 'a> {
                 ..
             } => {
                 let var = latest_local_var.expect("echo with no previous step in a pipe");
-                documents.push(self.echo(var.to_doc(), location)?);
+                documents.push(self.echo(var.to_doc(), location));
             }
             _ => {
-                let finally = self.expression(finally)?;
+                let finally = self.expression(finally);
                 documents.push(self.add_statement_level(finally))
             }
         }
 
-        Ok(documents.to_doc().force_break())
+        documents.to_doc().force_break()
     }
 
-    pub(crate) fn expression_flattening_blocks(&mut self, expression: &'a TypedExpr) -> Output<'a> {
+    pub(crate) fn expression_flattening_blocks(
+        &mut self,
+        expression: &'a TypedExpr,
+    ) -> Document<'a> {
         match expression {
             TypedExpr::Block { statements, .. } => self.statements(statements),
             _ => {
-                let expression_document = self.expression(expression)?;
-                Ok(self.add_statement_level(expression_document))
+                let expression_document = self.expression(expression);
+                self.add_statement_level(expression_document)
             }
         }
     }
 
-    fn block(&mut self, statements: &'a Vec1<TypedStatement>) -> Output<'a> {
+    fn block(&mut self, statements: &'a Vec1<TypedStatement>) -> Document<'a> {
         if statements.len() == 1 {
             match statements.first() {
                 Statement::Expression(expression) => return self.child_expression(expression),
@@ -774,27 +775,22 @@ impl<'module, 'a> Generator<'module, 'a> {
                 // Save previous scope
                 let current_scope_vars = this.current_scope_vars.clone();
 
-                let document = this.block_document(statements)?;
+                let document = this.block_document(statements);
 
                 // Restore previous state
                 this.current_scope_vars = current_scope_vars;
 
-                Ok(document)
+                document
             }),
         }
     }
 
-    fn block_document(&mut self, statements: &'a Vec1<TypedStatement>) -> Output<'a> {
-        let statements = self.statements(statements)?;
-        Ok(docvec![
-            "{",
-            docvec![line(), statements].nest(INDENT),
-            line(),
-            "}"
-        ])
+    fn block_document(&mut self, statements: &'a Vec1<TypedStatement>) -> Document<'a> {
+        let statements = self.statements(statements);
+        docvec!["{", docvec![line(), statements].nest(INDENT), line(), "}"]
     }
 
-    fn statements(&mut self, statements: &'a [TypedStatement]) -> Output<'a> {
+    fn statements(&mut self, statements: &'a [TypedStatement]) -> Document<'a> {
         // If there are any statements that need to be printed at statement level, that's
         // for an outer scope so we don't want to print them inside this one.
         let statement_level = std::mem::take(&mut self.statement_level);
@@ -802,15 +798,17 @@ impl<'module, 'a> Generator<'module, 'a> {
         let mut documents = Vec::with_capacity(count * 3);
         for (i, statement) in statements.iter().enumerate() {
             if i + 1 < count {
-                documents.push(self.not_in_tail_position(Some(Ordering::Loose), |this| {
-                    this.statement(statement)
-                })?);
+                documents.push(
+                    self.not_in_tail_position(Some(Ordering::Loose), |this| {
+                        this.statement(statement)
+                    }),
+                );
                 if requires_semicolon(statement) {
                     documents.push(";".to_doc());
                 }
                 documents.push(line());
             } else {
-                documents.push(self.statement(statement)?);
+                documents.push(self.statement(statement));
             }
 
             // If we've generated code for a statement that always throws, we
@@ -822,9 +820,9 @@ impl<'module, 'a> Generator<'module, 'a> {
         }
         self.statement_level = statement_level;
         if count == 1 {
-            Ok(documents.to_doc())
+            documents.to_doc()
         } else {
-            Ok(documents.to_doc().force_break())
+            documents.to_doc().force_break()
         }
     }
 
@@ -832,10 +830,10 @@ impl<'module, 'a> Generator<'module, 'a> {
         &mut self,
         name: &'a EcoString,
         value: &'a TypedExpr,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         // Subject must be rendered before the variable for variable numbering
         let subject =
-            self.not_in_tail_position(Some(Ordering::Loose), |this| this.wrap_expression(value))?;
+            self.not_in_tail_position(Some(Ordering::Loose), |this| this.wrap_expression(value));
         let js_name = self.next_local_var(name);
         let assignment = docvec!["let ", js_name.clone(), " = ", subject, ";"];
         let assignment = match &self.scope_position {
@@ -851,10 +849,10 @@ impl<'module, 'a> Generator<'module, 'a> {
             ],
         };
 
-        Ok(assignment.force_break())
+        assignment.force_break()
     }
 
-    fn assignment(&mut self, assignment: &'a TypedAssignment) -> Output<'a> {
+    fn assignment(&mut self, assignment: &'a TypedAssignment) -> Document<'a> {
         let TypedAssignment {
             pattern,
             kind,
@@ -874,7 +872,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         decision::let_(compiled_case, value, kind, self, pattern.location())
     }
 
-    fn assert(&mut self, assert: &'a TypedAssert) -> Output<'a> {
+    fn assert(&mut self, assert: &'a TypedAssert) -> Document<'a> {
         let TypedAssert {
             location,
             value,
@@ -885,20 +883,20 @@ impl<'module, 'a> Generator<'module, 'a> {
             Some(m) => self.not_in_tail_position(
                 Some(Ordering::Strict),
                 |this: &mut Generator<'module, 'a>| this.expression(m),
-            )?,
+            ),
             None => string("Assertion failed."),
         };
 
         let check = self.not_in_tail_position(Some(Ordering::Loose), |this| {
             this.assert_check(value, &message, *location)
-        })?;
+        });
 
-        Ok(match &self.scope_position {
+        match &self.scope_position {
             Position::NotTail(_) => check,
             Position::Tail | Position::Assign(_) => {
                 docvec![check, line(), self.wrap_return("undefined".to_doc())]
             }
-        })
+        }
     }
 
     fn assert_check(
@@ -906,32 +904,32 @@ impl<'module, 'a> Generator<'module, 'a> {
         subject: &'a TypedExpr,
         message: &Document<'a>,
         location: SrcSpan,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let (subject_document, mut fields) = match subject {
             TypedExpr::Call { fun, args, .. } => {
-                let argument_variables: Vec<_> = args
+                let argument_variables = args
                     .iter()
                     .map(|element| {
                         self.not_in_tail_position(Some(Ordering::Strict), |this| {
                             this.assign_to_variable(&element.value)
                         })
                     })
-                    .try_collect()?;
+                    .collect_vec();
                 (
-                    self.call_with_doc_args(fun, argument_variables.clone())?,
+                    self.call_with_doc_args(fun, argument_variables.clone()),
                     vec![
                         ("kind", string("function_call")),
                         (
                             "arguments",
                             array(argument_variables.into_iter().zip(args).map(
                                 |(variable, argument)| {
-                                    Ok(self.asserted_expression(
+                                    self.asserted_expression(
                                         AssertExpression::from_expression(&argument.value),
                                         Some(variable),
                                         argument.location(),
-                                    ))
+                                    )
                                 },
-                            ))?,
+                            )),
                         ),
                     ],
                 )
@@ -948,10 +946,10 @@ impl<'module, 'a> Generator<'module, 'a> {
 
                 let left_document = self.not_in_tail_position(Some(Ordering::Loose), |this| {
                     this.assign_to_variable(left)
-                })?;
+                });
                 let right_document = self.not_in_tail_position(Some(Ordering::Loose), |this| {
                     this.assign_to_variable(right)
-                })?;
+                });
 
                 (
                     self.bin_op_with_doc_operands(
@@ -985,7 +983,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             }
 
             _ => (
-                self.wrap_expression(subject)?,
+                self.wrap_expression(subject),
                 vec![
                     ("kind", string("expression")),
                     (
@@ -1004,7 +1002,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         fields.push(("end", subject.location().end.to_doc()));
         fields.push(("expression_start", subject.location().start.to_doc()));
 
-        Ok(docvec![
+        docvec![
             "if (",
             docvec!["!", subject_document].nest(INDENT),
             break_("", ""),
@@ -1017,7 +1015,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             line(),
             "}",
         ]
-        .group())
+        .group()
     }
 
     /// In Gleam, the `&&` operator is short-circuiting, meaning that we can't
@@ -1052,7 +1050,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         right: &'a TypedExpr,
         message: &Document<'a>,
         location: SrcSpan,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let left_kind = AssertExpression::from_expression(left);
         let right_kind = AssertExpression::from_expression(right);
 
@@ -1089,10 +1087,10 @@ impl<'module, 'a> Generator<'module, 'a> {
         ];
 
         let left_value =
-            self.not_in_tail_position(Some(Ordering::Loose), |this| this.wrap_expression(left))?;
+            self.not_in_tail_position(Some(Ordering::Loose), |this| this.wrap_expression(left));
 
         let right_value =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.wrap_expression(right))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.wrap_expression(right));
 
         let right_check = docvec![
             line(),
@@ -1108,7 +1106,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             "}",
         ];
 
-        Ok(docvec![
+        docvec![
             "if (",
             left_value.nest(INDENT),
             ") {",
@@ -1122,7 +1120,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             .nest(INDENT),
             line(),
             "}"
-        ])
+        ]
     }
 
     /// Similar to `&&`, `||` is also short-circuiting in Gleam. However, if `||`
@@ -1139,7 +1137,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         right: &'a TypedExpr,
         message: &Document<'a>,
         location: SrcSpan,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let fields = vec![
             ("kind", string("binary_operator")),
             ("operator", string("||")),
@@ -1165,12 +1163,12 @@ impl<'module, 'a> Generator<'module, 'a> {
         ];
 
         let left_value =
-            self.not_in_tail_position(Some(Ordering::Loose), |this| this.child_expression(left))?;
+            self.not_in_tail_position(Some(Ordering::Loose), |this| this.child_expression(left));
 
         let right_value =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right));
 
-        Ok(docvec![
+        docvec![
             line(),
             "if (",
             docvec!["!(", left_value, " || ", right_value, ")"].nest(INDENT),
@@ -1182,18 +1180,18 @@ impl<'module, 'a> Generator<'module, 'a> {
             .nest(INDENT),
             line(),
             "}",
-        ])
+        ]
     }
 
-    fn assign_to_variable(&mut self, value: &'a TypedExpr) -> Output<'a> {
+    fn assign_to_variable(&mut self, value: &'a TypedExpr) -> Document<'a> {
         match value {
             TypedExpr::Var { .. } => self.expression(value),
             _ => {
-                let value = self.wrap_expression(value)?;
+                let value = self.wrap_expression(value);
                 let variable = self.next_local_var(&ASSIGNMENT_VAR.into());
                 let assignment = docvec!["let ", variable.clone(), " = ", value, ";"];
                 self.statement_level.push(assignment);
-                Ok(variable.to_doc())
+                variable.to_doc()
             }
         }
     }
@@ -1230,13 +1228,13 @@ impl<'module, 'a> Generator<'module, 'a> {
         )
     }
 
-    fn tuple(&mut self, elements: &'a [TypedExpr]) -> Output<'a> {
+    fn tuple(&mut self, elements: &'a [TypedExpr]) -> Document<'a> {
         self.not_in_tail_position(Some(Ordering::Strict), |this| {
             array(elements.iter().map(|element| this.wrap_expression(element)))
         })
     }
 
-    fn call(&mut self, fun: &'a TypedExpr, arguments: &'a [TypedCallArg]) -> Output<'a> {
+    fn call(&mut self, fun: &'a TypedExpr, arguments: &'a [TypedCallArg]) -> Document<'a> {
         let arguments = arguments
             .iter()
             .map(|element| {
@@ -1244,7 +1242,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                     this.wrap_expression(&element.value)
                 })
             })
-            .try_collect()?;
+            .collect_vec();
 
         self.call_with_doc_args(fun, arguments)
     }
@@ -1253,14 +1251,14 @@ impl<'module, 'a> Generator<'module, 'a> {
         &mut self,
         fun: &'a TypedExpr,
         arguments: Vec<Document<'a>>,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         match fun {
             // Qualified record construction
             TypedExpr::ModuleSelect {
                 constructor: ModuleValueConstructor::Record { name, .. },
                 module_alias,
                 ..
-            } => Ok(self.wrap_return(construct_record(Some(module_alias), name, arguments))),
+            } => self.wrap_return(construct_record(Some(module_alias), name, arguments)),
 
             // Record construction
             TypedExpr::Var {
@@ -1280,7 +1278,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                         self.tracker.error_used = true;
                     }
                 }
-                Ok(self.wrap_return(construct_record(None, name, arguments)))
+                self.wrap_return(construct_record(None, name, arguments))
             }
 
             // Tail call optimisation. If we are calling the current function
@@ -1317,26 +1315,26 @@ impl<'module, 'a> Generator<'module, 'a> {
                     docs.push(element);
                     docs.push(";".to_doc());
                 }
-                Ok(docs.to_doc())
+                docs.to_doc()
             }
 
             _ => {
-                let fun = self.not_in_tail_position(None, |this| {
+                let fun = self.not_in_tail_position(None, |this| -> Document<'_> {
                     let is_fn_literal = matches!(fun, TypedExpr::Fn { .. });
-                    let fun = this.wrap_expression(fun)?;
+                    let fun = this.wrap_expression(fun);
                     if is_fn_literal {
-                        Ok(docvec!["(", fun, ")"])
+                        docvec!["(", fun, ")"]
                     } else {
-                        Ok(fun)
+                        fun
                     }
-                })?;
-                let arguments = call_arguments(arguments.into_iter().map(Ok))?;
-                Ok(self.wrap_return(docvec![fun, arguments]))
+                });
+                let arguments = call_arguments(arguments);
+                self.wrap_return(docvec![fun, arguments])
             }
         }
     }
 
-    fn fn_(&mut self, arguments: &'a [TypedArg], body: &'a [TypedStatement]) -> Output<'a> {
+    fn fn_(&mut self, arguments: &'a [TypedArg], body: &'a [TypedStatement]) -> Document<'a> {
         // New function, this is now the tail position
         let function_position = std::mem::replace(&mut self.function_position, Position::Tail);
         let scope_position = std::mem::replace(&mut self.scope_position, Position::Tail);
@@ -1361,24 +1359,19 @@ impl<'module, 'a> Generator<'module, 'a> {
         self.current_scope_vars = scope;
         std::mem::swap(&mut self.current_function, &mut current_function);
 
-        Ok(docvec![
-            docvec![
-                fun_args(arguments, false),
-                " => {",
-                break_("", " "),
-                result?
-            ]
-            .nest(INDENT)
-            .append(break_("", " "))
-            .group(),
+        docvec![
+            docvec![fun_args(arguments, false), " => {", break_("", " "), result]
+                .nest(INDENT)
+                .append(break_("", " "))
+                .group(),
             "}",
-        ])
+        ]
     }
 
-    fn record_access(&mut self, record: &'a TypedExpr, label: &'a str) -> Output<'a> {
+    fn record_access(&mut self, record: &'a TypedExpr, label: &'a str) -> Document<'a> {
         self.not_in_tail_position(None, |this| {
-            let record = this.wrap_expression(record)?;
-            Ok(docvec![record, ".", maybe_escape_property(label)])
+            let record = this.wrap_expression(record);
+            docvec![record, ".", maybe_escape_property(label)]
         })
     }
 
@@ -1387,25 +1380,30 @@ impl<'module, 'a> Generator<'module, 'a> {
         record: &'a Option<Box<TypedAssignment>>,
         constructor: &'a TypedExpr,
         args: &'a [TypedCallArg],
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         match record.as_ref() {
-            Some(record) => Ok(docvec![
-                self.not_in_tail_position(None, |this| this.assignment(record))?,
+            Some(record) => docvec![
+                self.not_in_tail_position(None, |this| this.assignment(record)),
                 line(),
-                self.call(constructor, args)?,
-            ]),
+                self.call(constructor, args),
+            ],
             None => self.call(constructor, args),
         }
     }
 
-    fn tuple_index(&mut self, tuple: &'a TypedExpr, index: u64) -> Output<'a> {
+    fn tuple_index(&mut self, tuple: &'a TypedExpr, index: u64) -> Document<'a> {
         self.not_in_tail_position(None, |this| {
-            let tuple = this.wrap_expression(tuple)?;
-            Ok(docvec![tuple, eco_format!("[{index}]")])
+            let tuple = this.wrap_expression(tuple);
+            docvec![tuple, eco_format!("[{index}]")]
         })
     }
 
-    fn bin_op(&mut self, name: &'a BinOp, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
+    fn bin_op(
+        &mut self,
+        name: &'a BinOp,
+        left: &'a TypedExpr,
+        right: &'a TypedExpr,
+    ) -> Document<'a> {
         match name {
             BinOp::And => self.print_bin_op(left, right, "&&"),
             BinOp::Or => self.print_bin_op(left, right, "||"),
@@ -1426,31 +1424,31 @@ impl<'module, 'a> Generator<'module, 'a> {
         }
     }
 
-    fn div_int(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
+    fn div_int(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Document<'a> {
         let left =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left));
         let right =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right));
         self.tracker.int_division_used = true;
-        Ok(docvec!["divideInt", wrap_args([left, right])])
+        docvec!["divideInt", wrap_args([left, right])]
     }
 
-    fn remainder_int(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
+    fn remainder_int(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Document<'a> {
         let left =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left));
         let right =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right));
         self.tracker.int_remainder_used = true;
-        Ok(docvec!["remainderInt", wrap_args([left, right])])
+        docvec!["remainderInt", wrap_args([left, right])]
     }
 
-    fn div_float(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Output<'a> {
+    fn div_float(&mut self, left: &'a TypedExpr, right: &'a TypedExpr) -> Document<'a> {
         let left =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left));
         let right =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right));
         self.tracker.float_division_used = true;
-        Ok(docvec!["divideFloat", wrap_args([left, right])])
+        docvec!["divideFloat", wrap_args([left, right])]
     }
 
     fn equal(
@@ -1458,24 +1456,23 @@ impl<'module, 'a> Generator<'module, 'a> {
         left: &'a TypedExpr,
         right: &'a TypedExpr,
         should_be_equal: bool,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         // If it is a simple scalar type then we can use JS' reference identity
         if is_js_scalar(left.type_()) {
             let left_doc = self
-                .not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left))?;
-            let right_doc = self.not_in_tail_position(Some(Ordering::Strict), |this| {
-                this.child_expression(right)
-            })?;
+                .not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left));
+            let right_doc = self
+                .not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right));
             let operator = if should_be_equal { " === " } else { " !== " };
-            return Ok(docvec![left_doc, operator, right_doc]);
+            return docvec![left_doc, operator, right_doc];
         }
 
         // Other types must be compared using structural equality
         let left =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.wrap_expression(left))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.wrap_expression(left));
         let right =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.wrap_expression(right))?;
-        Ok(self.prelude_equal_call(should_be_equal, left, right))
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.wrap_expression(right));
+        self.prelude_equal_call(should_be_equal, left, right)
     }
 
     fn equal_with_doc_operands(
@@ -1518,12 +1515,12 @@ impl<'module, 'a> Generator<'module, 'a> {
         left: &'a TypedExpr,
         right: &'a TypedExpr,
         op: &'a str,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         let left =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left))?;
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(left));
         let right =
-            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right))?;
-        Ok(docvec![left, " ", op, " ", right])
+            self.not_in_tail_position(Some(Ordering::Strict), |this| this.child_expression(right));
+        docvec![left, " ", op, " ", right]
     }
 
     fn bin_op_with_doc_operands(
@@ -1562,24 +1559,24 @@ impl<'module, 'a> Generator<'module, 'a> {
         }
     }
 
-    fn todo(&mut self, message: Option<&'a TypedExpr>, location: &'a SrcSpan) -> Output<'a> {
+    fn todo(&mut self, message: Option<&'a TypedExpr>, location: &'a SrcSpan) -> Document<'a> {
         let message = match message {
-            Some(m) => self.not_in_tail_position(None, |this| this.wrap_expression(m))?,
+            Some(m) => self.not_in_tail_position(None, |this| this.wrap_expression(m)),
             None => string("`todo` expression evaluated. This code has not yet been implemented."),
         };
         let doc = self.throw_error("todo", &message, *location, vec![]);
 
-        Ok(doc)
+        doc
     }
 
-    fn panic(&mut self, location: &'a SrcSpan, message: Option<&'a TypedExpr>) -> Output<'a> {
+    fn panic(&mut self, location: &'a SrcSpan, message: Option<&'a TypedExpr>) -> Document<'a> {
         let message = match message {
-            Some(m) => self.not_in_tail_position(None, |this| this.wrap_expression(m))?,
+            Some(m) => self.not_in_tail_position(None, |this| this.wrap_expression(m)),
             None => string("`panic` expression evaluated."),
         };
         let doc = self.throw_error("panic", &message, *location, vec![]);
 
-        Ok(doc)
+        doc
     }
 
     pub(crate) fn throw_error<Fields>(
@@ -1629,26 +1626,26 @@ impl<'module, 'a> Generator<'module, 'a> {
         }
     }
 
-    fn echo(&mut self, expression: Document<'a>, location: &'a SrcSpan) -> Output<'a> {
+    fn echo(&mut self, expression: Document<'a>, location: &'a SrcSpan) -> Document<'a> {
         self.tracker.echo_used = true;
 
         let echo_argument = call_arguments(vec![
-            Ok(expression),
-            Ok(self.src_path.clone().to_doc()),
-            Ok(self.line_numbers.line_number(location.start).to_doc()),
-        ])?;
-        Ok(self.wrap_return(docvec!["echo", echo_argument]))
+            expression,
+            self.src_path.clone().to_doc(),
+            self.line_numbers.line_number(location.start).to_doc(),
+        ]);
+        self.wrap_return(docvec!["echo", echo_argument])
     }
 
     pub(crate) fn constant_expression(
         &mut self,
         context: Context,
         expression: &'a TypedConstant,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         match expression {
-            Constant::Int { value, .. } => Ok(int(value)),
-            Constant::Float { value, .. } => Ok(float(value)),
-            Constant::String { value, .. } => Ok(string(value)),
+            Constant::Int { value, .. } => int(value),
+            Constant::Float { value, .. } => float(value),
+            Constant::String { value, .. } => string(value),
             Constant::Tuple { elements, .. } => array(
                 elements
                     .iter()
@@ -1661,21 +1658,21 @@ impl<'module, 'a> Generator<'module, 'a> {
                     elements
                         .iter()
                         .map(|element| self.constant_expression(context, element)),
-                )?;
+                );
 
                 match context {
-                    Context::Constant => Ok(docvec!["/* @__PURE__ */ ", list]),
-                    Context::Function => Ok(list),
+                    Context::Constant => docvec!["/* @__PURE__ */ ", list],
+                    Context::Function => list,
                 }
             }
 
             Constant::Record { type_, name, .. } if type_.is_bool() && name == "True" => {
-                Ok("true".to_doc())
+                "true".to_doc()
             }
             Constant::Record { type_, name, .. } if type_.is_bool() && name == "False" => {
-                Ok("false".to_doc())
+                "false".to_doc()
             }
-            Constant::Record { type_, .. } if type_.is_nil() => Ok("undefined".to_doc()),
+            Constant::Record { type_, .. } if type_.is_nil() => "undefined".to_doc(),
 
             Constant::Record {
                 args,
@@ -1699,20 +1696,14 @@ impl<'module, 'a> Generator<'module, 'a> {
                 if let Some(arity) = type_.fn_arity() {
                     if args.is_empty() && arity != 0 {
                         let arity = arity as u16;
-                        return Ok(record_constructor(
-                            type_.clone(),
-                            None,
-                            name,
-                            arity,
-                            self.tracker,
-                        ));
+                        return record_constructor(type_.clone(), None, name, arity, self.tracker);
                     }
                 }
 
-                let field_values: Vec<_> = args
+                let field_values = args
                     .iter()
                     .map(|arg| self.constant_expression(context, &arg.value))
-                    .try_collect()?;
+                    .collect_vec();
 
                 let constructor = construct_record(
                     module.as_ref().map(|(module, _)| module.as_str()),
@@ -1720,20 +1711,20 @@ impl<'module, 'a> Generator<'module, 'a> {
                     field_values,
                 );
                 match context {
-                    Context::Constant => Ok(docvec!["/* @__PURE__ */ ", constructor]),
-                    Context::Function => Ok(constructor),
+                    Context::Constant => docvec!["/* @__PURE__ */ ", constructor],
+                    Context::Function => constructor,
                 }
             }
 
             Constant::BitArray { segments, .. } => {
-                let bit_array = self.constant_bit_array(segments, context)?;
+                let bit_array = self.constant_bit_array(segments, context);
                 match context {
-                    Context::Constant => Ok(docvec!["/* @__PURE__ */ ", bit_array]),
-                    Context::Function => Ok(bit_array),
+                    Context::Constant => docvec!["/* @__PURE__ */ ", bit_array],
+                    Context::Function => bit_array,
                 }
             }
 
-            Constant::Var { name, module, .. } => Ok({
+            Constant::Var { name, module, .. } => {
                 match module {
                     None => maybe_escape_identifier(name).to_doc(),
                     Some((module, _)) => {
@@ -1743,12 +1734,12 @@ impl<'module, 'a> Generator<'module, 'a> {
                         docvec!["$", module, ".", maybe_escape_identifier(name)]
                     }
                 }
-            }),
+            }
 
             Constant::StringConcatenation { left, right, .. } => {
-                let left = self.constant_expression(context, left)?;
-                let right = self.constant_expression(context, right)?;
-                Ok(docvec![left, " + ", right])
+                let left = self.constant_expression(context, left);
+                let right = self.constant_expression(context, right);
+                docvec![left, " + ", right]
             }
 
             Constant::Invalid { .. } => {
@@ -1761,14 +1752,14 @@ impl<'module, 'a> Generator<'module, 'a> {
         &mut self,
         segments: &'a [TypedConstantBitArraySegment],
         context: Context,
-    ) -> Output<'a> {
+    ) -> Document<'a> {
         self.tracker.bit_array_literal_used = true;
         let segments_array = array(segments.iter().map(|segment| {
-            let value = self.constant_expression(Context::Constant, &segment.value)?;
+            let value = self.constant_expression(Context::Constant, &segment.value);
 
-            let details = self.constant_bit_array_segment_details(segment, context)?;
+            let details = self.constant_bit_array_segment_details(segment, context);
 
-            let document = match details.type_ {
+            match details.type_ {
                 BitArraySegmentType::BitArray => {
                     if segment.size().is_some() {
                         self.tracker.bit_array_slice_used = true;
@@ -1786,7 +1777,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                             int_value.clone(),
                             size_value,
                             segment.endianness(),
-                        )?;
+                        );
 
                         u8_slice(&bytes)
                     }
@@ -1836,18 +1827,17 @@ impl<'module, 'a> Generator<'module, 'a> {
                     let is_big = bool(details.endianness.is_big());
                     docvec!["codepointToUtf32(", value, ", ", is_big, ")"]
                 }
-            };
-            Ok(document)
-        }))?;
+            }
+        }));
 
-        Ok(docvec!["toBitArray(", segments_array, ")"])
+        docvec!["toBitArray(", segments_array, ")"]
     }
 
     fn constant_bit_array_segment_details(
         &mut self,
         segment: &'a TypedConstantBitArraySegment,
         context: Context,
-    ) -> Result<BitArraySegmentDetails<'a>, Error> {
+    ) -> BitArraySegmentDetails<'a> {
         let size = segment.size();
         let unit = segment.unit();
         let (size_value, size) = match size {
@@ -1858,7 +1848,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             }
 
             Some(size) => {
-                let mut size = self.constant_expression(context, size)?;
+                let mut size = self.constant_expression(context, size);
                 if unit != 1 {
                     size = size.group().append(" * ".to_doc().append(unit.to_doc()));
                 }
@@ -1874,145 +1864,141 @@ impl<'module, 'a> Generator<'module, 'a> {
 
         let type_ = BitArraySegmentType::from_segment(segment);
 
-        Ok(BitArraySegmentDetails {
+        BitArraySegmentDetails {
             type_,
             size,
             size_value,
             endianness: segment.endianness(),
-        })
+        }
     }
 
-    pub(crate) fn guard(&mut self, guard: &'a TypedClauseGuard) -> Output<'a> {
+    pub(crate) fn guard(&mut self, guard: &'a TypedClauseGuard) -> Document<'a> {
         match guard {
             ClauseGuard::Equals { left, right, .. } if is_js_scalar(left.type_()) => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " === ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " === ", right]
             }
 
             ClauseGuard::NotEquals { left, right, .. } if is_js_scalar(left.type_()) => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " !== ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " !== ", right]
             }
 
             ClauseGuard::Equals { left, right, .. } => {
-                let left = self.guard(left)?;
-                let right = self.guard(right)?;
-                Ok(self.prelude_equal_call(true, left, right))
+                let left = self.guard(left);
+                let right = self.guard(right);
+                self.prelude_equal_call(true, left, right)
             }
 
             ClauseGuard::NotEquals { left, right, .. } => {
-                let left = self.guard(left)?;
-                let right = self.guard(right)?;
-                Ok(self.prelude_equal_call(false, left, right))
+                let left = self.guard(left);
+                let right = self.guard(right);
+                self.prelude_equal_call(false, left, right)
             }
 
             ClauseGuard::GtFloat { left, right, .. } | ClauseGuard::GtInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " > ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " > ", right]
             }
 
             ClauseGuard::GtEqFloat { left, right, .. }
             | ClauseGuard::GtEqInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " >= ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " >= ", right]
             }
 
             ClauseGuard::LtFloat { left, right, .. } | ClauseGuard::LtInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " < ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " < ", right]
             }
 
             ClauseGuard::LtEqFloat { left, right, .. }
             | ClauseGuard::LtEqInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " <= ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " <= ", right]
             }
 
             ClauseGuard::AddFloat { left, right, .. } | ClauseGuard::AddInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " + ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " + ", right]
             }
 
             ClauseGuard::SubFloat { left, right, .. } | ClauseGuard::SubInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " - ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " - ", right]
             }
 
             ClauseGuard::MultFloat { left, right, .. }
             | ClauseGuard::MultInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " * ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " * ", right]
             }
 
             ClauseGuard::DivFloat { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
                 self.tracker.float_division_used = true;
-                Ok(docvec!["divideFloat", wrap_args([left, right])])
+                docvec!["divideFloat", wrap_args([left, right])]
             }
 
             ClauseGuard::DivInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
                 self.tracker.int_division_used = true;
-                Ok(docvec!["divideInt", wrap_args([left, right])])
+                docvec!["divideInt", wrap_args([left, right])]
             }
 
             ClauseGuard::RemainderInt { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
                 self.tracker.int_remainder_used = true;
-                Ok(docvec!["remainderInt", wrap_args([left, right])])
+                docvec!["remainderInt", wrap_args([left, right])]
             }
 
             ClauseGuard::Or { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " || ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " || ", right]
             }
 
             ClauseGuard::And { left, right, .. } => {
-                let left = self.wrapped_guard(left)?;
-                let right = self.wrapped_guard(right)?;
-                Ok(docvec![left, " && ", right])
+                let left = self.wrapped_guard(left);
+                let right = self.wrapped_guard(right);
+                docvec![left, " && ", right]
             }
 
-            ClauseGuard::Var { name, .. } => Ok(self.local_var(name).to_doc()),
+            ClauseGuard::Var { name, .. } => self.local_var(name).to_doc(),
 
             ClauseGuard::TupleIndex { tuple, index, .. } => {
-                Ok(docvec![self.guard(tuple,)?, "[", index, "]"])
+                docvec![self.guard(tuple,), "[", index, "]"]
             }
 
             ClauseGuard::FieldAccess {
                 label, container, ..
-            } => Ok(docvec![
-                self.guard(container,)?,
-                ".",
-                maybe_escape_property(label)
-            ]),
+            } => docvec![self.guard(container), ".", maybe_escape_property(label)],
 
             ClauseGuard::ModuleSelect {
                 module_alias,
                 label,
                 ..
-            } => Ok(docvec!["$", module_alias, ".", label]),
+            } => docvec!["$", module_alias, ".", label],
 
-            ClauseGuard::Not { expression, .. } => Ok(docvec!["!", self.guard(expression,)?]),
+            ClauseGuard::Not { expression, .. } => docvec!["!", self.guard(expression,)],
 
             ClauseGuard::Constant(constant) => self.guard_constant_expression(constant),
         }
     }
 
-    fn wrapped_guard(&mut self, guard: &'a TypedClauseGuard) -> Result<Document<'a>, Error> {
+    fn wrapped_guard(&mut self, guard: &'a TypedClauseGuard) -> Document<'a> {
         match guard {
             ClauseGuard::Var { .. }
             | ClauseGuard::TupleIndex { .. }
@@ -2041,11 +2027,11 @@ impl<'module, 'a> Generator<'module, 'a> {
             | ClauseGuard::RemainderInt { .. }
             | ClauseGuard::Or { .. }
             | ClauseGuard::And { .. }
-            | ClauseGuard::ModuleSelect { .. } => Ok(docvec!["(", self.guard(guard,)?, ")"]),
+            | ClauseGuard::ModuleSelect { .. } => docvec!["(", self.guard(guard,), ")"],
         }
     }
 
-    fn guard_constant_expression(&mut self, expression: &'a TypedConstant) -> Output<'a> {
+    fn guard_constant_expression(&mut self, expression: &'a TypedConstant) -> Document<'a> {
         match expression {
             Constant::Tuple { elements, .. } => array(
                 elements
@@ -2062,12 +2048,12 @@ impl<'module, 'a> Generator<'module, 'a> {
                 )
             }
             Constant::Record { type_, name, .. } if type_.is_bool() && name == "True" => {
-                Ok("true".to_doc())
+                "true".to_doc()
             }
             Constant::Record { type_, name, .. } if type_.is_bool() && name == "False" => {
-                Ok("false".to_doc())
+                "false".to_doc()
             }
-            Constant::Record { type_, .. } if type_.is_nil() => Ok("undefined".to_doc()),
+            Constant::Record { type_, .. } if type_.is_nil() => "undefined".to_doc(),
 
             Constant::Record {
                 args,
@@ -2091,32 +2077,26 @@ impl<'module, 'a> Generator<'module, 'a> {
                 if let Some(arity) = type_.fn_arity() {
                     if args.is_empty() && arity != 0 {
                         let arity = arity as u16;
-                        return Ok(record_constructor(
-                            type_.clone(),
-                            None,
-                            name,
-                            arity,
-                            self.tracker,
-                        ));
+                        return record_constructor(type_.clone(), None, name, arity, self.tracker);
                     }
                 }
 
-                let field_values: Vec<_> = args
+                let field_values = args
                     .iter()
                     .map(|arg| self.guard_constant_expression(&arg.value))
-                    .try_collect()?;
-                Ok(construct_record(
+                    .collect_vec();
+                construct_record(
                     module.as_ref().map(|(module, _)| module.as_str()),
                     name,
                     field_values,
-                ))
+                )
             }
 
             Constant::BitArray { segments, .. } => {
                 self.constant_bit_array(segments, Context::Function)
             }
 
-            Constant::Var { name, .. } => Ok(self.local_var(name).to_doc()),
+            Constant::Var { name, .. } => self.local_var(name).to_doc(),
 
             expression => self.constant_expression(Context::Function, expression),
         }
@@ -2277,57 +2257,61 @@ pub fn string(value: &str) -> Document<'_> {
     }
 }
 
-pub(crate) fn array<'a, Elements: IntoIterator<Item = Output<'a>>>(
+pub(crate) fn array<'a, Elements: IntoIterator<Item = Document<'a>>>(
     elements: Elements,
-) -> Output<'a> {
-    let elements = Itertools::intersperse(elements.into_iter(), Ok(break_(",", ", ")))
-        .collect::<Result<Vec<_>, _>>()?;
+) -> Document<'a> {
+    let elements = Itertools::intersperse(elements.into_iter(), break_(",", ", ")).collect_vec();
     if elements.is_empty() {
         // Do not add a trailing comma since that adds an 'undefined' element
-        Ok("[]".to_doc())
+        "[]".to_doc()
     } else {
-        Ok(docvec![
+        docvec![
             "[",
             docvec![break_("", ""), elements].nest(INDENT),
             break_(",", ""),
             "]"
         ]
-        .group())
+        .group()
     }
 }
 
-pub(crate) fn list<'a, I: IntoIterator<Item = Output<'a>>>(elements: I) -> Output<'a>
+pub(crate) fn list<'a, I: IntoIterator<Item = Document<'a>>>(elements: I) -> Document<'a>
 where
     I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
 {
     let array = array(elements);
-    Ok(docvec!["toList(", array?, ")"])
+    docvec!["toList(", array, ")"]
 }
 
-fn prepend<'a, I: IntoIterator<Item = Output<'a>>>(elements: I, tail: Document<'a>) -> Output<'a>
+fn prepend<'a, I: IntoIterator<Item = Document<'a>>>(
+    elements: I,
+    tail: Document<'a>,
+) -> Document<'a>
 where
     I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
 {
-    elements.into_iter().rev().try_fold(tail, |tail, element| {
-        let args = call_arguments([element, Ok(tail)])?;
-        Ok(docvec!["listPrepend", args])
+    elements.into_iter().rev().fold(tail, |tail, element| {
+        let args = call_arguments([element, tail]);
+        docvec!["listPrepend", args]
     })
 }
 
-fn call_arguments<'a, Elements: IntoIterator<Item = Output<'a>>>(elements: Elements) -> Output<'a> {
-    let elements = Itertools::intersperse(elements.into_iter(), Ok(break_(",", ", ")))
-        .collect::<Result<Vec<_>, _>>()?
+fn call_arguments<'a, Elements: IntoIterator<Item = Document<'a>>>(
+    elements: Elements,
+) -> Document<'a> {
+    let elements = Itertools::intersperse(elements.into_iter(), break_(",", ", "))
+        .collect_vec()
         .to_doc();
     if elements.is_empty() {
-        return Ok("()".to_doc());
+        return "()".to_doc();
     }
-    Ok(docvec![
+    docvec![
         "(",
         docvec![break_("", ""), elements].nest(INDENT),
         break_(",", ""),
         ")"
     ]
-    .group())
+    .group()
 }
 
 pub(crate) fn construct_record<'a>(

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1564,9 +1564,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             Some(m) => self.not_in_tail_position(None, |this| this.wrap_expression(m)),
             None => string("`todo` expression evaluated. This code has not yet been implemented."),
         };
-        let doc = self.throw_error("todo", &message, *location, vec![]);
-
-        doc
+        self.throw_error("todo", &message, *location, vec![])
     }
 
     fn panic(&mut self, location: &'a SrcSpan, message: Option<&'a TypedExpr>) -> Document<'a> {
@@ -1574,9 +1572,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             Some(m) => self.not_in_tail_position(None, |this| this.wrap_expression(m)),
             None => string("`panic` expression evaluated."),
         };
-        let doc = self.throw_error("panic", &message, *location, vec![]);
-
-        doc
+        self.throw_error("panic", &message, *location, vec![])
     }
 
     pub(crate) fn throw_error<Fields>(

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -41,7 +41,7 @@ pub static CURRENT_PACKAGE: &str = "thepackage";
 macro_rules! assert_js {
     ($(($name:literal, $module_src:literal)),+, $src:literal $(,)?) => {
         let compiled =
-            $crate::javascript::tests::compile_js($src, vec![$(($crate::javascript::tests::CURRENT_PACKAGE, $name, $module_src)),*]).expect("compilation failed");
+            $crate::javascript::tests::compile_js($src, vec![$(($crate::javascript::tests::CURRENT_PACKAGE, $name, $module_src)),*]);
             let mut output = String::from("----- SOURCE CODE\n");
             for (name, src) in [$(($name, $module_src)),*] {
                 output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
@@ -52,8 +52,7 @@ macro_rules! assert_js {
 
     (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr $(,)?) => {{
         let compiled =
-            $crate::javascript::tests::compile_js($src, vec![($dep_package, $dep_name, $dep_src)])
-                .expect("compilation failed");
+            $crate::javascript::tests::compile_js($src, vec![($dep_package, $dep_name, $dep_src)]);
         let output = format!(
             "----- SOURCE CODE\n{}\n\n----- COMPILED JAVASCRIPT\n{}",
             $src, compiled
@@ -63,14 +62,13 @@ macro_rules! assert_js {
 
     (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr, $js:expr $(,)?) => {{
         let output =
-            $crate::javascript::tests::compile_js($src, Some(($dep_package, $dep_name, $dep_src)))
-                .expect("compilation failed");
+            $crate::javascript::tests::compile_js($src, Some(($dep_package, $dep_name, $dep_src)));
         assert_eq!(($src, output), ($src, $js.to_string()));
     }};
 
     ($src:expr $(,)?) => {{
         let compiled =
-            $crate::javascript::tests::compile_js($src, vec![]).expect("compilation failed");
+            $crate::javascript::tests::compile_js($src, vec![]);
         let output = format!(
             "----- SOURCE CODE\n{}\n\n----- COMPILED JAVASCRIPT\n{}",
             $src, compiled
@@ -80,7 +78,7 @@ macro_rules! assert_js {
 
     ($src:expr, $js:expr $(,)?) => {{
         let output =
-            $crate::javascript::tests::compile_js($src, vec![]).expect("compilation failed");
+            $crate::javascript::tests::compile_js($src, vec![]);
         assert_eq!(($src, output), ($src, $js.to_string()));
     }};
 }
@@ -94,8 +92,7 @@ macro_rules! assert_ts_def {
                 ($dep_1_package, $dep_1_name, $dep_1_src),
                 ($dep_2_package, $dep_2_name, $dep_2_src),
             ],
-        )
-        .expect("compilation failed");
+        );
         let output = format!(
             "----- SOURCE CODE\n{}\n\n----- TYPESCRIPT DEFINITIONS\n{}",
             $src, compiled
@@ -105,8 +102,7 @@ macro_rules! assert_ts_def {
 
     (($dep_package:expr, $dep_name:expr, $dep_src:expr), $src:expr $(,)?) => {{
         let compiled =
-            $crate::javascript::tests::compile_ts($src, vec![($dep_package, $dep_name, $dep_src)])
-                .expect("compilation failed");
+            $crate::javascript::tests::compile_ts($src, vec![($dep_package, $dep_name, $dep_src)]);
         let output = format!(
             "----- SOURCE CODE\n{}\n\n----- TYPESCRIPT DEFINITIONS\n{}",
             $src, compiled
@@ -115,8 +111,7 @@ macro_rules! assert_ts_def {
     }};
 
     ($src:expr $(,)?) => {{
-        let compiled =
-            $crate::javascript::tests::compile_ts($src, vec![]).expect("compilation failed");
+        let compiled = $crate::javascript::tests::compile_ts($src, vec![]);
         let output = format!(
             "----- SOURCE CODE\n{}\n\n----- TYPESCRIPT DEFINITIONS\n{}",
             $src, compiled
@@ -190,7 +185,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
     .expect("should successfully infer")
 }
 
-pub fn compile_js(src: &str, deps: Vec<(&str, &str, &str)>) -> Result<String, crate::Error> {
+pub fn compile_js(src: &str, deps: Vec<(&str, &str, &str)>) -> String {
     let ast = compile(src, deps);
     let line_numbers = LineNumbers::new(src);
     let stdlib_package = StdlibPackage::Present;
@@ -198,20 +193,19 @@ pub fn compile_js(src: &str, deps: Vec<(&str, &str, &str)>) -> Result<String, cr
         module: &ast,
         line_numbers: &line_numbers,
         src: &"".into(),
-        target_support: TargetSupport::Enforced,
         typescript: TypeScriptDeclarations::None,
         stdlib_package,
         path: Utf8Path::new("src/module.gleam"),
         project_root: "project/root".into(),
-    })?;
+    });
 
-    Ok(output.replace(
+    output.replace(
         std::include_str!("../../templates/echo.mjs"),
         "// ...omitted code from `templates/echo.mjs`...",
-    ))
+    )
 }
 
-pub fn compile_ts(src: &str, deps: Vec<(&str, &str, &str)>) -> Result<String, crate::Error> {
+pub fn compile_ts(src: &str, deps: Vec<(&str, &str, &str)>) -> String {
     let ast = compile(src, deps);
-    ts_declaration(&ast, Utf8Path::new(""), &src.into())
+    ts_declaration(&ast)
 }


### PR DESCRIPTION
As of a few recent changes, I noticed that we no longer produce errors anywhere during JavaScript code generation. This allows us to remove the `Result` wrappers from all the functions which makes the code generator easier to read and nicer to work with, and brings it in line with the Erlang code generator.