### PR TITLE
Fix JavaScript code generation for `let assert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,6 +393,10 @@
   not be allowed on the JavaScript target.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where invalid code would be generated for `let assert` in some
+  cases on the JavaScript target.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.11.1 - 2025-06-05
 
 ### Compiler

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -92,6 +92,21 @@ impl<'a> CaseBody<'a> {
                 if_body,
                 else_body,
                 ..
+            } if if_body.is_empty() => docvec![
+                "if (!(",
+                break_("", "")
+                    .append(check)
+                    .nest(INDENT)
+                    .append(break_("", ""))
+                    .group(),
+                ")) ",
+                else_body,
+            ],
+            CaseBody::IfElse {
+                check,
+                if_body,
+                else_body,
+                ..
             } => docvec![
                 "if (",
                 break_("", "")

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -869,7 +869,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             return self.simple_variable_assignment(name, value);
         }
 
-        decision::let_(compiled_case, value, kind, self, pattern.location())
+        decision::let_(compiled_case, value, kind, self, pattern)
     }
 
     fn assert(&mut self, assert: &'a TypedAssert) -> Document<'a> {

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -2526,3 +2526,16 @@ pub fn go(x) {
 "
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4712
+#[test]
+fn multiple_variable_size_segments() {
+    assert_js!(
+        "
+pub fn main() {
+  let assert <<a, b:size(a), c:size(b)>> = <<1, 2, 3, 4>>
+  a + b + c
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 16
 expression: "pub fn go(x) { let assert 1 = x }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go(x) { let assert 1 = x }
@@ -13,7 +11,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x !== 1) {
+  if (x === 1) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert.snap
@@ -11,9 +11,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x === 1) {
-    
-  } else {
+  if (!(x === 1)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
@@ -14,9 +14,7 @@ export function go(x) {
   let $ = x[1];
   if ($ === 2) {
     let $1 = x[0];
-    if ($1 === 1) {
-      
-    } else {
+    if (!($1 === 1)) {
       throw makeError(
         "let_assert",
         FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 21
 expression: "pub fn go(x) { let assert #(1, 2) = x }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go(x) { let assert #(1, 2) = x }
@@ -13,7 +11,23 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x[1] !== 2 || x[0] !== 1) {
+  let $ = x[1];
+  if ($ === 2) {
+    let $1 = x[0];
+    if ($1 === 1) {
+      
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        1,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 15, end: 37, pattern_start: 26, pattern_end: 33 }
+      )
+    }
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert_that_always_fails.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert_that_always_fails.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 287
 expression: "\ntype Wibble {\n    Wibble(Int)\n    Wobble(Int)\n}\n\npub fn go() {\n  let assert Wobble(n) = Wibble(1)\n  n\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -38,6 +36,7 @@ class Wobble extends $CustomType {
 
 export function go() {
   let $ = new Wibble(1);
+  let n;
   throw makeError(
     "let_assert",
     FILEPATH,
@@ -47,5 +46,5 @@ export function go() {
     "Pattern match failed, no pattern matched the value.",
     { value: $, start: 66, end: 98, pattern_start: 77, pattern_end: 86 }
   )
-  
+  return n;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert_that_always_succeeds.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert_that_always_succeeds.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 271
 expression: "\ntype Wibble {\n    Wibble(Int)\n}\n\npub fn go() {\n  let assert Wibble(n) = Wibble(1)\n  n\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -28,6 +26,7 @@ class Wibble extends $CustomType {
 
 export function go() {
   let $ = new Wibble(1);
-  let n = $[0];
+  let n;
+  n = $[0];
   return n;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert_with_multiple_variants.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert_with_multiple_variants.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 321
 expression: "\ntype Wibble {\n    Wibble(Int)\n    Wobble(Int)\n    Woo(Int)\n}\n\npub fn go() {\n  let assert Wobble(n) = todo\n  n\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -56,7 +54,10 @@ export function go() {
     {}
   )
   let $ = _block;
-  if (!($ instanceof Wobble)) {
+  let n;
+  if ($ instanceof Wobble) {
+    n = $[0];
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -67,6 +68,5 @@ export function go() {
       { value: $, start: 79, end: 106, pattern_start: 90, pattern_end: 99 }
     )
   }
-  let n = $[0];
   return n;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__case_message.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__case_message.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 256
 expression: "\npub fn expect(value, message) {\n  let assert Ok(inner) = value as case message {\n    Ok(message) -> message\n    Error(_) -> \"No message provided\"\n  }\n  inner\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,10 @@ import { Ok, makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function expect(value, message) {
-  if (!(value instanceof Ok)) {
+  let inner;
+  if (value instanceof Ok) {
+    inner = value[0];
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -39,6 +40,5 @@ export function expect(value, message) {
       { value: value, start: 35, end: 63, pattern_start: 46, pattern_end: 55 }
     )
   }
-  let inner = value[0];
   return inner;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__let_assert_nested_string_prefix.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__let_assert_nested_string_prefix.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 191
 expression: "\ntype Wibble {\n  Wibble(wibble: String)\n}\n\npub fn main() {\n  let assert Wibble(wibble: \"w\" as prefix <> rest) = Wibble(\"wibble\")\n  prefix <> rest\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -30,7 +28,13 @@ class Wibble extends $CustomType {
 
 export function main() {
   let $ = new Wibble("wibble");
-  if (!($ instanceof Wibble) || !$.wibble.startsWith("w")) {
+  let prefix;
+  let rest;
+  let $1 = $.wibble;
+  if ($1.startsWith("w")) {
+    prefix = "w";
+    rest = $1.slice(1);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -41,7 +45,5 @@ export function main() {
       { value: $, start: 61, end: 128, pattern_start: 72, pattern_end: 109 }
     )
   }
-  let prefix = "w";
-  let rest = $.wibble.slice(1);
   return prefix + rest;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__let_assert_string_prefix.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__let_assert_string_prefix.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 179
 expression: "\npub fn main() {\n  let assert \"Game \" <> id = \"Game 1\"\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function main() {
   let $ = "Game 1";
-  if (!$.startsWith("Game ")) {
+  let id;
+  if ($.startsWith("Game ")) {
+    id = $.slice(5);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function main() {
       { value: $, start: 19, end: 54, pattern_start: 30, pattern_end: 43 }
     )
   }
-  let id = $.slice(5);
   return $;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__message.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__message.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 231
 expression: "\npub fn unwrap_or_panic(value) {\n  let assert Ok(inner) = value as \"Oops, there was an error\"\n  inner\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ import { Ok, makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function unwrap_or_panic(value) {
-  if (!(value instanceof Ok)) {
+  let inner;
+  if (value instanceof Ok) {
+    inner = value[0];
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function unwrap_or_panic(value) {
       { value: value, start: 35, end: 63, pattern_start: 46, pattern_end: 55 }
     )
   }
-  let inner = value[0];
   return inner;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 26
 expression: "\npub fn go(x) {\n  let assert #(a, #(b, c, 2) as t, _, 1) = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,30 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x[3] !== 1 || x[1][2] !== 2) {
+  let a;
+  let t;
+  let b;
+  let c;
+  let $ = x[3];
+  if ($ === 1) {
+    let $1 = x[1][2];
+    if ($1 === 2) {
+      a = x[0];
+      t = x[1];
+      b = x[1][0];
+      c = x[1][1];
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 60, pattern_start: 29, pattern_end: 56 }
+      )
+    }
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,9 +49,5 @@ export function go(x) {
       { value: x, start: 18, end: 60, pattern_start: 29, pattern_end: 56 }
     )
   }
-  let a = x[0];
-  let t = x[1];
-  let b = x[1][0];
-  let c = x[1][1];
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__returning_literal_subject.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__returning_literal_subject.snap
@@ -12,9 +12,7 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = x + 1;
-  if ($ === 1) {
-    
-  } else {
+  if (!($ === 1)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__returning_literal_subject.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__returning_literal_subject.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 83
 expression: "pub fn go(x) { let assert 1 = x + 1 }"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 pub fn go(x) { let assert 1 = x + 1 }
@@ -14,7 +12,9 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = x + 1;
-  if ($ !== 1) {
+  if ($ === 1) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 5
 expression: "\npub fn go(x) {\n  let assert #(1, 2) = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,23 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x[1] !== 2 || x[0] !== 1) {
+  let $ = x[1];
+  if ($ === 2) {
+    let $1 = x[0];
+    if ($1 === 1) {
+      
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 40, pattern_start: 29, pattern_end: 36 }
+      )
+    }
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
@@ -18,9 +18,7 @@ export function go(x) {
   let $ = x[1];
   if ($ === 2) {
     let $1 = x[0];
-    if ($1 === 1) {
-      
-    } else {
+    if (!($1 === 1)) {
       throw makeError(
         "let_assert",
         FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__use_matching_assignment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__use_matching_assignment.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 359
 expression: "\nfn fun(f) { f(#(2, 4)) }\n\npub fn go() {\n  use #(_, n) <- fun\n  n\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -22,7 +20,8 @@ function fun(f) {
 export function go() {
   return fun(
     (_use0) => {
-      let n = _use0[1];
+      let n;
+      n = _use0[1];
       return n;
     },
   );

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_message.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_message.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 243
 expression: "\npub fn expect(value, message) {\n  let assert Ok(inner) = value as message\n  inner\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ import { Ok, makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function expect(value, message) {
-  if (!(value instanceof Ok)) {
+  let inner;
+  if (value instanceof Ok) {
+    inner = value[0];
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function expect(value, message) {
       { value: value, start: 35, end: 63, pattern_start: 46, pattern_end: 55 }
     )
   }
-  let inner = value[0];
   return inner;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_renaming.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_renaming.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/assignments.rs
-assertion_line: 37
 expression: "\n\npub fn go(x, wibble) {\n  let a = 1\n  wibble(a)\n  let a = 2\n  wibble(a)\n  let assert #(a, 3) = x\n  let b = a\n  wibble(b)\n  let c = {\n    let a = a\n    #(a, b)\n  }\n  wibble(a)\n  // make sure arguments are counted in initial state\n  let x = c\n  x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -36,7 +34,11 @@ export function go(x, wibble) {
   wibble(a);
   let a$1 = 2;
   wibble(a$1);
-  if (x[1] !== 3) {
+  let a$2;
+  let $ = x[1];
+  if ($ === 3) {
+    a$2 = x[0];
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -47,7 +49,6 @@ export function go(x, wibble) {
       { value: x, start: 75, end: 97, pattern_start: 86, pattern_end: 93 }
     )
   }
-  let a$2 = x[0];
   let b = a$2;
   wibble(b);
   let _block;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_used_in_pattern_and_assignment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_used_in_pattern_and_assignment.snap
@@ -12,6 +12,7 @@ pub fn main(x) {
 ----- COMPILED JAVASCRIPT
 export function main(x) {
   let $ = [x];
-  let x$1 = $[0];
+  let x$1;
+  x$1 = $[0];
   return x$1;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_discard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_discard.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2076
 expression: "\npub fn main() {\n let assert <<_ as number>> = <<10>>\n number\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,10 @@ const FILEPATH = "src/module.gleam";
 
 export function main() {
   let $ = toBitArray([10]);
-  if ($.bitSize !== 8) {
+  let number;
+  if ($.bitSize === 8) {
+    number = $.byteAt(0);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -30,6 +31,5 @@ export function main() {
       { value: $, start: 18, end: 53, pattern_start: 29, pattern_end: 44 }
     )
   }
-  let number = $.byteAt(0);
   return number;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_float.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2020
 expression: "\npub fn main() {\n let assert <<3.14 as pi:float>> = <<3.14>>\n pi\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,10 @@ const FILEPATH = "src/module.gleam";
 
 export function main() {
   let $ = toBitArray([sizedFloat(3.14, 64, true)]);
-  if ($.bitSize !== 64 || bitArraySliceToFloat($, 0, 64, true) !== 3.14) {
+  let pi;
+  if ($.bitSize === 64 && bitArraySliceToFloat($, 0, 64, true) === 3.14) {
+    pi = 3.14;
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -30,6 +31,5 @@ export function main() {
       { value: $, start: 18, end: 60, pattern_start: 29, pattern_end: 49 }
     )
   }
-  let pi = 3.14;
   return pi;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_int.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_int.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1992
 expression: "\npub fn main() {\n let assert <<1 as a>> = <<1>>\n a\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,10 @@ const FILEPATH = "src/module.gleam";
 
 export function main() {
   let $ = toBitArray([1]);
-  if ($.bitSize !== 8 || $.byteAt(0) !== 1) {
+  let a;
+  if ($.bitSize === 8 && $.byteAt(0) === 1) {
+    a = 1;
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -30,6 +31,5 @@ export function main() {
       { value: $, start: 18, end: 47, pattern_start: 29, pattern_end: 39 }
     )
   }
-  let a = 1;
   return a;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_string.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__bit_array_assignment_string.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2048
 expression: "\npub fn main() {\n let assert <<\"Hello, world!\" as message:utf8>> = <<\"Hello, world!\">>\n message\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,22 +17,25 @@ const FILEPATH = "src/module.gleam";
 
 export function main() {
   let $ = toBitArray([stringBits("Hello, world!")]);
+  let message;
   if (
-    $.bitSize !== 104 ||
-    $.byteAt(0) !== 72 ||
-    $.byteAt(1) !== 101 ||
-    $.byteAt(2) !== 108 ||
-    $.byteAt(3) !== 108 ||
-    $.byteAt(4) !== 111 ||
-    $.byteAt(5) !== 44 ||
-    $.byteAt(6) !== 32 ||
-    $.byteAt(7) !== 119 ||
-    $.byteAt(8) !== 111 ||
-    $.byteAt(9) !== 114 ||
-    $.byteAt(10) !== 108 ||
-    $.byteAt(11) !== 100 ||
-    $.byteAt(12) !== 33
+    $.bitSize === 104 &&
+    $.byteAt(0) === 72 &&
+      $.byteAt(1) === 101 &&
+      $.byteAt(2) === 108 &&
+      $.byteAt(3) === 108 &&
+      $.byteAt(4) === 111 &&
+      $.byteAt(5) === 44 &&
+      $.byteAt(6) === 32 &&
+      $.byteAt(7) === 119 &&
+      $.byteAt(8) === 111 &&
+      $.byteAt(9) === 114 &&
+      $.byteAt(10) === 108 &&
+      $.byteAt(11) === 100 &&
+      $.byteAt(12) === 33
   ) {
+    message = "Hello, world!";
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -45,6 +46,5 @@ export function main() {
       { value: $, start: 18, end: 86, pattern_start: 29, pattern_end: 64 }
     )
   }
-  let message = "Hello, world!";
   return message;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__discard_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__discard_sized.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1105
 expression: "\npub fn go(x) {\n  let assert <<_:16, _:8>> = x\n  let assert <<_:16-little-signed, _:8>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 24) {
+  if (x.bitSize >= 16 && x.bitSize === 24) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,7 +29,9 @@ export function go(x) {
       { value: x, start: 18, end: 46, pattern_start: 29, pattern_end: 42 }
     )
   }
-  if (x.bitSize !== 24) {
+  if (x.bitSize >= 16 && x.bitSize === 24) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__discard_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__discard_sized.snap
@@ -16,9 +16,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize >= 16 && x.bitSize === 24) {
-    
-  } else {
+  if (!(x.bitSize >= 16 && x.bitSize === 24)) {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,9 +27,7 @@ export function go(x) {
       { value: x, start: 18, end: 46, pattern_start: 29, pattern_end: 42 }
     )
   }
-  if (x.bitSize >= 16 && x.bitSize === 24) {
-    
-  } else {
+  if (!(x.bitSize >= 16 && x.bitSize === 24)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
@@ -17,13 +17,11 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let size = 3;
-  if (
+  if (!(
     size >= 0 &&
     x.bitSize === size * 2 &&
     bitArraySliceToInt(x, 0, size * 2, true, false) === 1
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__dynamic_size_pattern_with_unit.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1818
 expression: "\npub fn go(x) {\n  let size = 3\n  let assert <<1:size(size)-unit(2)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,10 +18,12 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let size = 3;
   if (
-    size < 0 ||
-    x.bitSize !== size * 2 ||
-    bitArraySliceToInt(x, 0, size * 2, true, false) !== 1
+    size >= 0 &&
+    x.bitSize === size * 2 &&
+    bitArraySliceToInt(x, 0, size * 2, true, false) === 1
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__empty_match.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__empty_match.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 0) {
-    
-  } else {
+  if (!(x.bitSize === 0)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__empty_match.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__empty_match.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 414
 expression: "\npub fn go(x) {\n  let assert <<>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 0) {
+  if (x.bitSize === 0) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_binary_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_binary_size.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1587
 expression: "\npub fn go(x) {\n  let assert <<_, a:2-bytes>> = x\n  let assert <<_, b:bytes-size(2)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ import { makeError, bitArraySlice } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 24) {
+  let a;
+  if (x.bitSize >= 8 && x.bitSize === 24) {
+    a = bitArraySlice(x, 8, 24);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,8 +30,10 @@ export function go(x) {
       { value: x, start: 18, end: 49, pattern_start: 29, pattern_end: 45 }
     )
   }
-  let a = bitArraySlice(x, 8, 24);
-  if (x.bitSize !== 24) {
+  let b;
+  if (x.bitSize >= 8 && x.bitSize === 24) {
+    b = bitArraySlice(x, 8, 24);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -41,6 +44,5 @@ export function go(x) {
       { value: x, start: 52, end: 89, pattern_start: 63, pattern_end: 85 }
     )
   }
-  let b = bitArraySlice(x, 8, 24);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_bits_with_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_bits_with_size.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1487
 expression: "\npub fn go(x) {\n  let assert <<_:4, f:bits-2, _:1>> = <<0x77:7>>\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = toBitArray([sizedInt(0x77, 7, true)]);
-  if ($.bitSize !== 7) {
+  let f;
+  if ($.bitSize >= 4 && $.bitSize >= 6 && $.bitSize === 7) {
+    f = bitArraySlice($, 4, 6);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function go(x) {
       { value: $, start: 18, end: 64, pattern_start: 29, pattern_end: 51 }
     )
   }
-  let f = bitArraySlice($, 4, 6);
   return $;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_bytes.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_bytes.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 439
 expression: "\npub fn go(x) {\n  let assert <<1, y>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 1) {
+  let y;
+  if (x.bitSize >= 8 && x.byteAt(0) === 1 && x.bitSize === 16) {
+    y = x.byteAt(1);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 41, pattern_start: 29, pattern_end: 37 }
     )
   }
-  let y = x.byteAt(1);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_bytes_with_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_bytes_with_size.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1462
 expression: "\npub fn go(x) {\n  let assert <<f:bytes-2>> = <<1, 2>>\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = toBitArray([1, 2]);
-  if ($.bitSize !== 16) {
+  let f;
+  if ($.bitSize === 16) {
+    f = bitArraySlice($, 0, 16);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function go(x) {
       { value: $, start: 18, end: 53, pattern_start: 29, pattern_end: 42 }
     )
   }
-  let f = bitArraySlice($, 0, 16);
   return $;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bits_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bits_size.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1051
 expression: "\npub fn go(x) {\n  let n = 16\n  let assert <<a:bits-size(n)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let n = 16;
-  if (n < 0 || x.bitSize !== n) {
+  let a;
+  if (n >= 0 && x.bitSize === n) {
+    a = bitArraySlice(x, 0, n);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -30,6 +31,5 @@ export function go(x) {
       { value: x, start: 31, end: 64, pattern_start: 42, pattern_end: 60 }
     )
   }
-  let a = bitArraySlice(x, 0, n);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bytes_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_bytes_size.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1078
 expression: "\npub fn go(x) {\n  let n = 3\n  let assert <<a:bytes-size(n)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let n = 3;
-  if (n < 0 || x.bitSize !== n * 8) {
+  let a;
+  if (n >= 0 && x.bitSize === n * 8) {
+    a = bitArraySlice(x, 0, n * 8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -30,6 +31,5 @@ export function go(x) {
       { value: x, start: 30, end: 64, pattern_start: 41, pattern_end: 60 }
     )
   }
-  let a = bitArraySlice(x, 0, n * 8);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 939
 expression: "\npub fn go(x) {\n  let n = 16\n  let assert <<a:size(n)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let n = 16;
-  if (n < 0 || x.bitSize !== n) {
+  let a;
+  if (n >= 0 && x.bitSize === n) {
+    a = bitArraySliceToInt(x, 0, n, true, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -30,6 +31,5 @@ export function go(x) {
       { value: x, start: 31, end: 59, pattern_start: 42, pattern_end: 55 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, n, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_literal_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_literal_value.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1024
 expression: "\npub fn go(x) {\n  let n = 8\n  let assert <<a:size(n), 0b010101:size(8)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,11 +17,15 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let n = 8;
+  let a;
   if (
-    n < 0 ||
-    x.bitSize !== 8 + n ||
-    bitArraySliceToInt(x, n, n + 8, true, false) !== 21
+    n >= 0 &&
+    x.bitSize >= n &&
+    x.bitSize === 8 + n &&
+    bitArraySliceToInt(x, n, n + 8, true, false) === 21
   ) {
+    a = bitArraySliceToInt(x, 0, n, true, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -34,6 +36,5 @@ export function go(x) {
       { value: x, start: 30, end: 76, pattern_start: 41, pattern_end: 72 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, n, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_shadowed_variable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_shadowed_variable.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 995
 expression: "\npub fn go(x) {\n  let n = 16\n  let n = 5\n  let assert <<a:size(n)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,10 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let n = 16;
   let n$1 = 5;
-  if (n$1 < 0 || x.bitSize !== n$1) {
+  let a;
+  if (n$1 >= 0 && x.bitSize === n$1) {
+    a = bitArraySliceToInt(x, 0, n$1, true, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -32,6 +33,5 @@ export function go(x) {
       { value: x, start: 43, end: 71, pattern_start: 54, pattern_end: 67 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, n$1, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_with_other_segments.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_dynamic_size_with_other_segments.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 966
 expression: "\npub fn go(x) {\n  let n = 16\n  let m = 32\n  let assert <<first:size(8), a:size(n), b:size(m), rest:bits>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -21,7 +19,22 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let n = 16;
   let m = 32;
-  if (x.bitSize < 8 + m + n || n < 0 || m < 0) {
+  let first;
+  let a;
+  let b;
+  let rest;
+  if (
+    x.bitSize >= 8 &&
+    n >= 0 &&
+    x.bitSize >= 8 + n &&
+    m >= 0 &&
+    x.bitSize >= 8 + m + n
+  ) {
+    first = x.byteAt(0);
+    a = bitArraySliceToInt(x, 8, 8 + n, true, false);
+    b = bitArraySliceToInt(x, 8 + n, 8 + n + m, true, false);
+    rest = bitArraySlice(x, 8 + m + n);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -32,9 +45,5 @@ export function go(x) {
       { value: x, start: 44, end: 109, pattern_start: 55, pattern_end: 105 }
     )
   }
-  let first = x.byteAt(0);
-  let a = bitArraySliceToInt(x, 8, 8 + n, true, false);
-  let b = bitArraySliceToInt(x, 8 + n, 8 + n + m, true, false);
-  let rest = bitArraySlice(x, 8 + m + n);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1185
 expression: "\npub fn go(x) {\n  let assert <<a:float, b:int>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,16 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 72 || !Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+  let a;
+  let b;
+  if (
+    x.bitSize >= 64 &&
+    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
+    x.bitSize === 72
+  ) {
+    a = bitArraySliceToFloat(x, 0, 64, true);
+    b = x.byteAt(8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,7 +35,5 @@ export function go(x) {
       { value: x, start: 18, end: 51, pattern_start: 29, pattern_end: 47 }
     )
   }
-  let a = bitArraySliceToFloat(x, 0, 64, true);
-  let b = x.byteAt(8);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1412
 expression: "\npub fn go(x) {\n  let assert <<a:float-size(16)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || !Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))) {
+  let a;
+  if (x.bitSize === 16 && Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))) {
+    a = bitArraySliceToFloat(x, 0, 16, true);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 53, pattern_start: 29, pattern_end: 49 }
     )
   }
-  let a = bitArraySliceToFloat(x, 0, 16, true);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_big_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1210
 expression: "\npub fn go(x) {\n  let assert <<a:float-big, b:int>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,16 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 72 || !Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+  let a;
+  let b;
+  if (
+    x.bitSize >= 64 &&
+    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
+    x.bitSize === 72
+  ) {
+    a = bitArraySliceToFloat(x, 0, 64, true);
+    b = x.byteAt(8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,7 +35,5 @@ export function go(x) {
       { value: x, start: 18, end: 55, pattern_start: 29, pattern_end: 51 }
     )
   }
-  let a = bitArraySliceToFloat(x, 0, 64, true);
-  let b = x.byteAt(8);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_little_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1235
 expression: "\npub fn go(x) {\n  let assert <<a:float-little, b:int>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,10 +15,16 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
+  let a;
+  let b;
   if (
-    x.bitSize !== 72 ||
-    !Number.isFinite(bitArraySliceToFloat(x, 0, 64, false))
+    x.bitSize >= 64 &&
+    Number.isFinite(bitArraySliceToFloat(x, 0, 64, false)) &&
+    x.bitSize === 72
   ) {
+    a = bitArraySliceToFloat(x, 0, 64, false);
+    b = x.byteAt(8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -31,7 +35,5 @@ export function go(x) {
       { value: x, start: 18, end: 58, pattern_start: 29, pattern_end: 54 }
     )
   }
-  let a = bitArraySliceToFloat(x, 0, 64, false);
-  let b = x.byteAt(8);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1260
 expression: "\npub fn go(x) {\n  let assert <<a:float-32, b:int>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,16 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 40 || !Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+  let a;
+  let b;
+  if (
+    x.bitSize >= 32 &&
+    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
+    x.bitSize === 40
+  ) {
+    a = bitArraySliceToFloat(x, 0, 32, true);
+    b = x.byteAt(4);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,7 +35,5 @@ export function go(x) {
       { value: x, start: 18, end: 54, pattern_start: 29, pattern_end: 50 }
     )
   }
-  let a = bitArraySliceToFloat(x, 0, 32, true);
-  let b = x.byteAt(4);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_big_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1285
 expression: "\npub fn go(x) {\n  let assert <<a:float-32-big, b:int>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,16 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 40 || !Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+  let a;
+  let b;
+  if (
+    x.bitSize >= 32 &&
+    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
+    x.bitSize === 40
+  ) {
+    a = bitArraySliceToFloat(x, 0, 32, true);
+    b = x.byteAt(4);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,7 +35,5 @@ export function go(x) {
       { value: x, start: 18, end: 58, pattern_start: 29, pattern_end: 54 }
     )
   }
-  let a = bitArraySliceToFloat(x, 0, 32, true);
-  let b = x.byteAt(4);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_little_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1310
 expression: "\npub fn go(x) {\n  let assert <<a:float-32-little, b:int>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,10 +15,16 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
+  let a;
+  let b;
   if (
-    x.bitSize !== 40 ||
-    !Number.isFinite(bitArraySliceToFloat(x, 0, 32, false))
+    x.bitSize >= 32 &&
+    Number.isFinite(bitArraySliceToFloat(x, 0, 32, false)) &&
+    x.bitSize === 40
   ) {
+    a = bitArraySliceToFloat(x, 0, 32, false);
+    b = x.byteAt(4);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -31,7 +35,5 @@ export function go(x) {
       { value: x, start: 18, end: 61, pattern_start: 29, pattern_end: 57 }
     )
   }
-  let a = bitArraySliceToFloat(x, 0, 32, false);
-  let b = x.byteAt(4);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_aligned_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_aligned_float.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1387
 expression: "\npub fn go(x) {\n  let assert <<_, 1.1, _:bits>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,13 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize < 72 || bitArraySliceToFloat(x, 8, 72, true) !== 1.1) {
+  if (
+    x.bitSize >= 8 &&
+    x.bitSize >= 72 &&
+    bitArraySliceToFloat(x, 8, 72, true) === 1.1
+  ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_aligned_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_aligned_float.snap
@@ -15,13 +15,11 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize >= 8 &&
     x.bitSize >= 72 &&
     bitArraySliceToFloat(x, 8, 72, true) === 1.1
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_float.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1335
 expression: "\npub fn go(x) {\n  let assert <<1.4, b:int>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,14 @@ import { makeError, bitArraySliceToFloat } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 72 || bitArraySliceToFloat(x, 0, 64, true) !== 1.4) {
+  let b;
+  if (
+    x.bitSize >= 64 &&
+    bitArraySliceToFloat(x, 0, 64, true) === 1.4 &&
+    x.bitSize === 72
+  ) {
+    b = x.byteAt(8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +33,5 @@ export function go(x) {
       { value: x, start: 18, end: 47, pattern_start: 29, pattern_end: 43 }
     )
   }
-  let b = x.byteAt(8);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_unaligned_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_unaligned_float.snap
@@ -17,14 +17,12 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let n = 1;
-  if (
+  if (!(
     n >= 0 &&
     x.bitSize >= n &&
     x.bitSize >= 64 + n &&
     bitArraySliceToFloat(x, n, n + 64, true) === 1.1
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_unaligned_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_literal_unaligned_float.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1360
 expression: "\npub fn go(x) {\n  let n = 1\n  let assert <<_:size(n), 1.1, _:bits>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,10 +18,13 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let n = 1;
   if (
-    n < 0 ||
-    x.bitSize < 64 + n ||
-    bitArraySliceToFloat(x, n, n + 64, true) !== 1.1
+    n >= 0 &&
+    x.bitSize >= n &&
+    x.bitSize >= 64 + n &&
+    bitArraySliceToFloat(x, n, n + 64, true) === 1.1
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1437
 expression: "\npub fn go(x) {\n  let assert <<_, b:bytes>> = <<1,2,3>>\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = toBitArray([1, 2, 3]);
-  if ($.bitSize < 8 || ($.bitSize - 8) % 8 !== 0) {
+  let b;
+  if ($.bitSize >= 8 && ($.bitSize - 8) % 8 === 0) {
+    b = bitArraySlice($, 8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function go(x) {
       { value: $, start: 18, end: 55, pattern_start: 29, pattern_end: 43 }
     )
   }
-  let b = bitArraySlice($, 8);
   return $;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest_bits.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest_bits.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1537
 expression: "\npub fn go(x) {\n  let assert <<_, b:bits>> = <<1,2,3>>\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = toBitArray([1, 2, 3]);
-  if ($.bitSize < 8) {
+  let b;
+  if ($.bitSize >= 8) {
+    b = bitArraySlice($, 8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function go(x) {
       { value: $, start: 18, end: 54, pattern_start: 29, pattern_end: 42 }
     )
   }
-  let b = bitArraySlice($, 8);
   return $;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest_bits_unaligned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest_bits_unaligned.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1562
 expression: "\npub fn go(x) {\n  let assert <<_:5, b:bits>> = <<1,2,3>>\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = toBitArray([1, 2, 3]);
-  if ($.bitSize < 5) {
+  let b;
+  if ($.bitSize >= 5) {
+    b = bitArraySlice($, 5);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function go(x) {
       { value: $, start: 18, end: 56, pattern_start: 29, pattern_end: 44 }
     )
   }
-  let b = bitArraySlice($, 5);
   return $;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest_bytes.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_rest_bytes.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1512
 expression: "\npub fn go(x) {\n  let assert <<_, b:bytes>> = <<1,2,3>>\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = toBitArray([1, 2, 3]);
-  if ($.bitSize < 8 || ($.bitSize - 8) % 8 !== 0) {
+  let b;
+  if ($.bitSize >= 8 && ($.bitSize - 8) % 8 === 0) {
+    b = bitArraySlice($, 8);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -29,6 +30,5 @@ export function go(x) {
       { value: $, start: 18, end: 55, pattern_start: 29, pattern_end: 43 }
     )
   }
-  let b = bitArraySlice($, 8);
   return $;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 589
 expression: "\npub fn go(x) {\n  let assert <<a:signed>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 8) {
+  let a;
+  if (x.bitSize === 8) {
+    a = bitArraySliceToInt(x, 0, 8, true, true);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 45, pattern_start: 29, pattern_end: 41 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 8, true, true);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 8 && x.byteAt(0) === 255) {
-    
-  } else {
+  if (!(x.bitSize === 8 && x.byteAt(0) === 255)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_signed_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 614
 expression: "\npub fn go(x) {\n  let assert <<-1:signed>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 8 || x.byteAt(0) !== 255) {
+  if (x.bitSize === 8 && x.byteAt(0) === 255) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 464
 expression: "\npub fn go(x) {\n  let assert <<a:16, b:8>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,12 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 24) {
+  let a;
+  let b;
+  if (x.bitSize >= 16 && x.bitSize === 24) {
+    a = bitArraySliceToInt(x, 0, 16, true, false);
+    b = x.byteAt(2);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,7 +31,5 @@ export function go(x) {
       { value: x, start: 18, end: 46, pattern_start: 29, pattern_end: 42 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 16, true, false);
-  let b = x.byteAt(2);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 639
 expression: "\npub fn go(x) {\n  let assert <<a:16-big>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16) {
+  let a;
+  if (x.bitSize === 16) {
+    a = bitArraySliceToInt(x, 0, 16, true, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 45, pattern_start: 29, pattern_end: 41 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 16, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210) {
-    
-  } else {
+  if (!(x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 664
 expression: "\npub fn go(x) {\n  let assert <<1234:16-big>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 4 || x.byteAt(1) !== 210) {
+  if (x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 789
 expression: "\npub fn go(x) {\n  let assert <<a:16-big-signed>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16) {
+  let a;
+  if (x.bitSize === 16) {
+    a = bitArraySliceToInt(x, 0, 16, true, true);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 52, pattern_start: 29, pattern_end: 48 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 16, true, true);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 814
 expression: "\npub fn go(x) {\n  let assert <<1234:16-big-signed>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 4 || x.byteAt(1) !== 210) {
+  if (x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_signed_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210) {
-    
-  } else {
+  if (!(x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 739
 expression: "\npub fn go(x) {\n  let assert <<a:16-big-unsigned>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16) {
+  let a;
+  if (x.bitSize === 16) {
+    a = bitArraySliceToInt(x, 0, 16, true, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 54, pattern_start: 29, pattern_end: 50 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 16, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210) {
-    
-  } else {
+  if (!(x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_big_endian_unsigned_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 764
 expression: "\npub fn go(x) {\n  let assert <<1234:16-big-unsigned>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 4 || x.byteAt(1) !== 210) {
+  if (x.bitSize === 16 && x.byteAt(0) === 4 && x.byteAt(1) === 210) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 514
 expression: "\npub fn go(x) {\n  let assert <<1234:16, 123:8>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,10 +16,13 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize !== 24 ||
-    x.byteAt(0) !== 4 || x.byteAt(1) !== 210 ||
-    x.byteAt(2) !== 123
+    x.bitSize >= 16 &&
+    x.byteAt(0) === 4 && x.byteAt(1) === 210 &&
+    x.bitSize === 24 &&
+    x.byteAt(2) === 123
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_constant_pattern.snap
@@ -15,14 +15,12 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize >= 16 &&
     x.byteAt(0) === 4 && x.byteAt(1) === 210 &&
     x.bitSize === 24 &&
     x.byteAt(2) === 123
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 689
 expression: "\npub fn go(x) {\n  let assert <<a:16-little>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16) {
+  let a;
+  if (x.bitSize === 16) {
+    a = bitArraySliceToInt(x, 0, 16, false, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 48, pattern_start: 29, pattern_end: 44 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 16, false, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4) {
-    
-  } else {
+  if (!(x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 714
 expression: "\npub fn go(x) {\n  let assert <<1234:16-little>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 210 || x.byteAt(1) !== 4) {
+  if (x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 889
 expression: "\npub fn go(x) {\n  let assert <<a:16-little-signed>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16) {
+  let a;
+  if (x.bitSize === 16) {
+    a = bitArraySliceToInt(x, 0, 16, false, true);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 55, pattern_start: 29, pattern_end: 51 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 16, false, true);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 914
 expression: "\npub fn go(x) {\n  let assert <<1234:16-little-signed>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 210 || x.byteAt(1) !== 4) {
+  if (x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_signed_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4) {
-    
-  } else {
+  if (!(x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 839
 expression: "\npub fn go(x) {\n  let assert <<a:16-little-unsigned>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16) {
+  let a;
+  if (x.bitSize === 16) {
+    a = bitArraySliceToInt(x, 0, 16, false, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 57, pattern_start: 29, pattern_end: 53 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 16, false, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 864
 expression: "\npub fn go(x) {\n  let assert <<1234:16-little-unsigned>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 210 || x.byteAt(1) !== 4) {
+  if (x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_little_endian_unsigned_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4) {
-    
-  } else {
+  if (!(x.bitSize === 16 && x.byteAt(0) === 210 && x.byteAt(1) === 4)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_unaligned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_unaligned.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 489
 expression: "\npub fn go(x) {\n  let assert <<a:17, b:7>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,12 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 24) {
+  let a;
+  let b;
+  if (x.bitSize >= 17 && x.bitSize === 24) {
+    a = bitArraySliceToInt(x, 0, 17, true, false);
+    b = bitArraySliceToInt(x, 17, 24, true, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,7 +31,5 @@ export function go(x) {
       { value: x, start: 18, end: 46, pattern_start: 29, pattern_end: 42 }
     )
   }
-  let a = bitArraySliceToInt(x, 0, 17, true, false);
-  let b = bitArraySliceToInt(x, 17, 24, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1135
 expression: "\npub fn go(x) {\n  let assert <<i:16>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16) {
+  let i;
+  if (x.bitSize === 16) {
+    i = bitArraySliceToInt(x, 0, 16, true, false);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 41, pattern_start: 29, pattern_end: 37 }
     )
   }
-  let i = bitArraySliceToInt(x, 0, 16, true, false);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1160
 expression: "\npub fn go(x) {\n  let assert <<258:16>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 16 || x.byteAt(0) !== 1 || x.byteAt(1) !== 2) {
+  if (x.bitSize === 16 && x.byteAt(0) === 1 && x.byteAt(1) === 2) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_sized_value_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 16 && x.byteAt(0) === 1 && x.byteAt(1) === 2) {
-    
-  } else {
+  if (!(x.bitSize === 16 && x.byteAt(0) === 1 && x.byteAt(1) === 2)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 539
 expression: "\npub fn go(x) {\n  let assert <<a:unsigned>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,10 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 8) {
+  let a;
+  if (x.bitSize === 8) {
+    a = x.byteAt(0);
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -28,6 +29,5 @@ export function go(x) {
       { value: x, start: 18, end: 47, pattern_start: 29, pattern_end: 43 }
     )
   }
-  let a = x.byteAt(0);
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned_constant_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize === 8 && x.byteAt(0) === 254) {
-    
-  } else {
+  if (!(x.bitSize === 8 && x.byteAt(0) === 254)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned_constant_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_unsigned_constant_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 564
 expression: "\npub fn go(x) {\n  let assert <<-2:unsigned>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x.bitSize !== 8 || x.byteAt(0) !== 254) {
+  if (x.bitSize === 8 && x.byteAt(0) === 254) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 286
 expression: "\npub fn go(x) {\n  let assert <<\"Gleam 👍\":utf8>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,18 +16,20 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize !== 80 ||
-    x.byteAt(0) !== 71 ||
-    x.byteAt(1) !== 108 ||
-    x.byteAt(2) !== 101 ||
-    x.byteAt(3) !== 97 ||
-    x.byteAt(4) !== 109 ||
-    x.byteAt(5) !== 32 ||
-    x.byteAt(6) !== 240 ||
-    x.byteAt(7) !== 159 ||
-    x.byteAt(8) !== 145 ||
-    x.byteAt(9) !== 141
+    x.bitSize === 80 &&
+    x.byteAt(0) === 71 &&
+      x.byteAt(1) === 108 &&
+      x.byteAt(2) === 101 &&
+      x.byteAt(3) === 97 &&
+      x.byteAt(4) === 109 &&
+      x.byteAt(5) === 32 &&
+      x.byteAt(6) === 240 &&
+      x.byteAt(7) === 159 &&
+      x.byteAt(8) === 145 &&
+      x.byteAt(9) === 141
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8.snap
@@ -15,7 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize === 80 &&
     x.byteAt(0) === 71 &&
       x.byteAt(1) === 108 &&
@@ -27,9 +27,7 @@ export function go(x) {
       x.byteAt(7) === 159 &&
       x.byteAt(8) === 145 &&
       x.byteAt(9) === 141
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8_with_escape_chars.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8_with_escape_chars.snap
@@ -15,7 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize === 80 &&
     x.byteAt(0) === 34 &&
       x.byteAt(1) === 92 &&
@@ -27,9 +27,7 @@ export function go(x) {
       x.byteAt(7) === 159 &&
       x.byteAt(8) === 152 &&
       x.byteAt(9) === 128
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8_with_escape_chars.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_utf8_with_escape_chars.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 275
 expression: "\npub fn go(x) {\n  let assert <<\"\\\"\\\\\\r\\n\\t\\f\\u{1f600}\">> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,18 +16,20 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize !== 80 ||
-    x.byteAt(0) !== 34 ||
-    x.byteAt(1) !== 92 ||
-    x.byteAt(2) !== 13 ||
-    x.byteAt(3) !== 10 ||
-    x.byteAt(4) !== 9 ||
-    x.byteAt(5) !== 12 ||
-    x.byteAt(6) !== 240 ||
-    x.byteAt(7) !== 159 ||
-    x.byteAt(8) !== 152 ||
-    x.byteAt(9) !== 128
+    x.bitSize === 80 &&
+    x.byteAt(0) === 34 &&
+      x.byteAt(1) === 92 &&
+      x.byteAt(2) === 13 &&
+      x.byteAt(3) === 10 &&
+      x.byteAt(4) === 9 &&
+      x.byteAt(5) === 12 &&
+      x.byteAt(6) === 240 &&
+      x.byteAt(7) === 159 &&
+      x.byteAt(8) === 152 &&
+      x.byteAt(9) === 128
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__multiple_variable_size_segments.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__multiple_variable_size_segments.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2533
 expression: "\npub fn main() {\n  let assert <<a, b:size(a), c:size(b)>> = <<1, 2, 3, 4>>\n  a + b + c\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__multiple_variable_size_segments.snap.new
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__multiple_variable_size_segments.snap.new
@@ -1,0 +1,67 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+assertion_line: 2533
+expression: "\npub fn main() {\n  let assert <<a, b:size(a), c:size(b)>> = <<1, 2, 3, 4>>\n  a + b + c\n}\n"
+snapshot_kind: text
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let assert <<a, b:size(a), c:size(b)>> = <<1, 2, 3, 4>>
+  a + b + c
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError, toBitArray, bitArraySliceToInt } from "../gleam.mjs";
+
+const FILEPATH = "src/module.gleam";
+
+export function main() {
+  let $ = toBitArray([1, 2, 3, 4]);
+  let a$1;
+  let b$1;
+  let c;
+  if ($.bitSize >= 8) {
+    let a = $.byteAt(0);
+    if ($.bitSize >= 8 + a) {
+      let b = bitArraySliceToInt($, 8, 8 + a, true, false);
+      if ($.bitSize === 8 + a + b) {
+        a$1 = a;
+        b$1 = b;
+        c = bitArraySliceToInt($, 8 + a, 8 + a + b$1, true, false);
+      } else {
+        throw makeError(
+          "let_assert",
+          FILEPATH,
+          "my/mod",
+          3,
+          "main",
+          "Pattern match failed, no pattern matched the value.",
+          { value: $, start: 19, end: 74, pattern_start: 30, pattern_end: 57 }
+        )
+      }
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "main",
+        "Pattern match failed, no pattern matched the value.",
+        { value: $, start: 19, end: 74, pattern_start: 30, pattern_end: 57 }
+      )
+    }
+  } else {
+    throw makeError(
+      "let_assert",
+      FILEPATH,
+      "my/mod",
+      3,
+      "main",
+      "Pattern match failed, no pattern matched the value.",
+      { value: $, start: 19, end: 74, pattern_start: 30, pattern_end: 57 }
+    )
+  }
+  return (a$1 + b$1) + c;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2171
 expression: "\npub fn go(x) {\n  let assert <<\"Hello\":utf16, _rest:bytes>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,19 +16,21 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize < 80 ||
-    x.byteAt(0) !== 0 ||
-    x.byteAt(1) !== 72 ||
-    x.byteAt(2) !== 0 ||
-    x.byteAt(3) !== 101 ||
-    x.byteAt(4) !== 0 ||
-    x.byteAt(5) !== 108 ||
-    x.byteAt(6) !== 0 ||
-    x.byteAt(7) !== 108 ||
-    x.byteAt(8) !== 0 ||
-    x.byteAt(9) !== 111 ||
-    (x.bitSize - 80) % 8 !== 0
+    x.bitSize >= 80 &&
+    x.byteAt(0) === 0 &&
+      x.byteAt(1) === 72 &&
+      x.byteAt(2) === 0 &&
+      x.byteAt(3) === 101 &&
+      x.byteAt(4) === 0 &&
+      x.byteAt(5) === 108 &&
+      x.byteAt(6) === 0 &&
+      x.byteAt(7) === 108 &&
+      x.byteAt(8) === 0 &&
+      x.byteAt(9) === 111 &&
+    (x.bitSize - 80) % 8 === 0
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16.snap
@@ -15,7 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize >= 80 &&
     x.byteAt(0) === 0 &&
       x.byteAt(1) === 72 &&
@@ -28,9 +28,7 @@ export function go(x) {
       x.byteAt(8) === 0 &&
       x.byteAt(9) === 111 &&
     (x.bitSize - 80) % 8 === 0
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16_little_endian.snap
@@ -15,7 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize >= 80 &&
     x.byteAt(0) === 72 &&
       x.byteAt(1) === 0 &&
@@ -28,9 +28,7 @@ export function go(x) {
       x.byteAt(8) === 111 &&
       x.byteAt(9) === 0 &&
     (x.bitSize - 80) % 8 === 0
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf16_little_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2215
 expression: "\npub fn go(x) {\n  let assert <<\"Hello\":utf16-little, _rest:bytes>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,19 +16,21 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize < 80 ||
-    x.byteAt(0) !== 72 ||
-    x.byteAt(1) !== 0 ||
-    x.byteAt(2) !== 101 ||
-    x.byteAt(3) !== 0 ||
-    x.byteAt(4) !== 108 ||
-    x.byteAt(5) !== 0 ||
-    x.byteAt(6) !== 108 ||
-    x.byteAt(7) !== 0 ||
-    x.byteAt(8) !== 111 ||
-    x.byteAt(9) !== 0 ||
-    (x.bitSize - 80) % 8 !== 0
+    x.bitSize >= 80 &&
+    x.byteAt(0) === 72 &&
+      x.byteAt(1) === 0 &&
+      x.byteAt(2) === 101 &&
+      x.byteAt(3) === 0 &&
+      x.byteAt(4) === 108 &&
+      x.byteAt(5) === 0 &&
+      x.byteAt(6) === 108 &&
+      x.byteAt(7) === 0 &&
+      x.byteAt(8) === 111 &&
+      x.byteAt(9) === 0 &&
+    (x.bitSize - 80) % 8 === 0
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2182
 expression: "\npub fn go(x) {\n  let assert <<\"Hello\":utf32, _rest:bytes>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,29 +16,31 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize < 160 ||
-    x.byteAt(0) !== 0 ||
-    x.byteAt(1) !== 0 ||
-    x.byteAt(2) !== 0 ||
-    x.byteAt(3) !== 72 ||
-    x.byteAt(4) !== 0 ||
-    x.byteAt(5) !== 0 ||
-    x.byteAt(6) !== 0 ||
-    x.byteAt(7) !== 101 ||
-    x.byteAt(8) !== 0 ||
-    x.byteAt(9) !== 0 ||
-    x.byteAt(10) !== 0 ||
-    x.byteAt(11) !== 108 ||
-    x.byteAt(12) !== 0 ||
-    x.byteAt(13) !== 0 ||
-    x.byteAt(14) !== 0 ||
-    x.byteAt(15) !== 108 ||
-    x.byteAt(16) !== 0 ||
-    x.byteAt(17) !== 0 ||
-    x.byteAt(18) !== 0 ||
-    x.byteAt(19) !== 111 ||
-    (x.bitSize - 160) % 8 !== 0
+    x.bitSize >= 160 &&
+    x.byteAt(0) === 0 &&
+      x.byteAt(1) === 0 &&
+      x.byteAt(2) === 0 &&
+      x.byteAt(3) === 72 &&
+      x.byteAt(4) === 0 &&
+      x.byteAt(5) === 0 &&
+      x.byteAt(6) === 0 &&
+      x.byteAt(7) === 101 &&
+      x.byteAt(8) === 0 &&
+      x.byteAt(9) === 0 &&
+      x.byteAt(10) === 0 &&
+      x.byteAt(11) === 108 &&
+      x.byteAt(12) === 0 &&
+      x.byteAt(13) === 0 &&
+      x.byteAt(14) === 0 &&
+      x.byteAt(15) === 108 &&
+      x.byteAt(16) === 0 &&
+      x.byteAt(17) === 0 &&
+      x.byteAt(18) === 0 &&
+      x.byteAt(19) === 111 &&
+    (x.bitSize - 160) % 8 === 0
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32.snap
@@ -15,7 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize >= 160 &&
     x.byteAt(0) === 0 &&
       x.byteAt(1) === 0 &&
@@ -38,9 +38,7 @@ export function go(x) {
       x.byteAt(18) === 0 &&
       x.byteAt(19) === 111 &&
     (x.bitSize - 160) % 8 === 0
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32_little_endian.snap
@@ -15,7 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize >= 160 &&
     x.byteAt(0) === 72 &&
       x.byteAt(1) === 0 &&
@@ -38,9 +38,7 @@ export function go(x) {
       x.byteAt(18) === 0 &&
       x.byteAt(19) === 0 &&
     (x.bitSize - 160) % 8 === 0
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_utf32_little_endian.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 2226
 expression: "\npub fn go(x) {\n  let assert <<\"Hello\":utf32-little, _rest:bytes>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,29 +16,31 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize < 160 ||
-    x.byteAt(0) !== 72 ||
-    x.byteAt(1) !== 0 ||
-    x.byteAt(2) !== 0 ||
-    x.byteAt(3) !== 0 ||
-    x.byteAt(4) !== 101 ||
-    x.byteAt(5) !== 0 ||
-    x.byteAt(6) !== 0 ||
-    x.byteAt(7) !== 0 ||
-    x.byteAt(8) !== 108 ||
-    x.byteAt(9) !== 0 ||
-    x.byteAt(10) !== 0 ||
-    x.byteAt(11) !== 0 ||
-    x.byteAt(12) !== 108 ||
-    x.byteAt(13) !== 0 ||
-    x.byteAt(14) !== 0 ||
-    x.byteAt(15) !== 0 ||
-    x.byteAt(16) !== 111 ||
-    x.byteAt(17) !== 0 ||
-    x.byteAt(18) !== 0 ||
-    x.byteAt(19) !== 0 ||
-    (x.bitSize - 160) % 8 !== 0
+    x.bitSize >= 160 &&
+    x.byteAt(0) === 72 &&
+      x.byteAt(1) === 0 &&
+      x.byteAt(2) === 0 &&
+      x.byteAt(3) === 0 &&
+      x.byteAt(4) === 101 &&
+      x.byteAt(5) === 0 &&
+      x.byteAt(6) === 0 &&
+      x.byteAt(7) === 0 &&
+      x.byteAt(8) === 108 &&
+      x.byteAt(9) === 0 &&
+      x.byteAt(10) === 0 &&
+      x.byteAt(11) === 0 &&
+      x.byteAt(12) === 108 &&
+      x.byteAt(13) === 0 &&
+      x.byteAt(14) === 0 &&
+      x.byteAt(15) === 0 &&
+      x.byteAt(16) === 111 &&
+      x.byteAt(17) === 0 &&
+      x.byteAt(18) === 0 &&
+      x.byteAt(19) === 0 &&
+    (x.bitSize - 160) % 8 === 0
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_with_unit.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-assertion_line: 1793
 expression: "\npub fn go(x) {\n  let assert <<1:size(2)-unit(2), 2:size(3)-unit(4)>> = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -18,10 +16,13 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   if (
-    x.bitSize !== 16 ||
-    bitArraySliceToInt(x, 0, 4, true, false) !== 1 ||
-    bitArraySliceToInt(x, 4, 16, true, false) !== 2
+    x.bitSize >= 4 &&
+    bitArraySliceToInt(x, 0, 4, true, false) === 1 &&
+    x.bitSize === 16 &&
+    bitArraySliceToInt(x, 4, 16, true, false) === 2
   ) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_with_unit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_with_unit.snap
@@ -15,14 +15,12 @@ import { makeError, bitArraySliceToInt } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (
+  if (!(
     x.bitSize >= 4 &&
     bitArraySliceToInt(x, 0, 4, true, false) === 1 &&
     x.bitSize === 16 &&
     bitArraySliceToInt(x, 4, 16, true, false) === 2
-  ) {
-    
-  } else {
+  )) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array.snap
@@ -16,9 +16,7 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let $ = x[0];
-  if ($.bitSize === 0) {
-    
-  } else {
+  if (!($.bitSize === 0)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array.snap
@@ -15,7 +15,10 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x[0].bitSize !== 0) {
+  let $ = x[0];
+  if ($.bitSize === 0) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
@@ -25,9 +25,7 @@ export function go(x) {
     let $1 = x[1];
     if ($1.bitSize === 8 && $1.byteAt(0) === 1) {
       let $2 = x[0];
-      if ($2.bitSize === 0) {
-        
-      } else {
+      if (!($2.bitSize === 0)) {
         throw makeError(
           "let_assert",
           FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
@@ -15,14 +15,41 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
+  let $ = x[2];
   if (
-    x[2].bitSize !== 16 ||
-    x[2].byteAt(0) !== 2 ||
-    x[2].byteAt(1) !== 3 ||
-    x[1].bitSize !== 8 ||
-    x[1].byteAt(0) !== 1 ||
-    x[0].bitSize !== 0
+    $.bitSize >= 8 &&
+    $.byteAt(0) === 2 &&
+    $.bitSize === 16 &&
+    $.byteAt(1) === 3
   ) {
+    let $1 = x[1];
+    if ($1.bitSize === 8 && $1.byteAt(0) === 1) {
+      let $2 = x[0];
+      if ($2.bitSize === 0) {
+        
+      } else {
+        throw makeError(
+          "let_assert",
+          FILEPATH,
+          "my/mod",
+          3,
+          "go",
+          "Pattern match failed, no pattern matched the value.",
+          { value: x, start: 18, end: 57, pattern_start: 29, pattern_end: 53 }
+        )
+      }
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 57, pattern_start: 29, pattern_end: 53 }
+      )
+    }
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_message_no_lifted.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_message_no_lifted.snap
@@ -29,9 +29,7 @@ function side_effects(x) {
 
 export function main() {
   let $ = side_effects(new Ok(10));
-  if ($ instanceof Error) {
-    
-  } else {
+  if (!($ instanceof Error)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_message_no_lifted.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__let_assert_message_no_lifted.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/blocks.rs
-assertion_line: 330
 expression: "\nfn side_effects(x) {\n  // Some side effects\n  x\n}\n\npub fn main() {\n  let assert Error(Nil) = side_effects(Ok(10))\n    as {\n    let message = side_effects(\"some message\")\n    message\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -31,7 +29,9 @@ function side_effects(x) {
 
 export function main() {
   let $ = side_effects(new Ok(10));
-  if (!($ instanceof Error)) {
+  if ($ instanceof Error) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__pattern_assignment_last_in_block.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__pattern_assignment_last_in_block.snap
@@ -18,8 +18,10 @@ export function main() {
   let _block;
   {
     let b = [1, 2];
-    let x = b[0];
-    let y = b[1];
+    let x;
+    let y;
+    x = b[0];
+    y = b[1];
     _block = b;
   }
   let a = _block;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__assigning.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__assigning.snap
@@ -17,9 +17,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x, y) {
-  if (x) {
-    
-  } else {
+  if (!(x)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__assigning.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__assigning.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bools.rs
-assertion_line: 52
 expression: "\npub fn go(x, y) {\n  let assert True = x\n  let assert False = x\n  let assert Nil = y\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x, y) {
-  if (!x) {
+  if (x) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -40,4 +40,5 @@ export function go(x, y) {
     { value: x, start: 43, end: 63, pattern_start: 54, pattern_end: 59 }
   )
   
+  return y;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/bools.rs
-assertion_line: 67
 expression: "\npub type True { True False Nil }\npub fn go(x, y) {\n  let assert True = x\n  let assert False = x\n  let assert Nil = y\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -26,7 +24,9 @@ export class False extends $CustomType {}
 export class Nil extends $CustomType {}
 
 export function go(x, y) {
-  if (!(x instanceof True)) {
+  if (x instanceof True) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -46,5 +46,18 @@ export function go(x, y) {
     "Pattern match failed, no pattern matched the value.",
     { value: x, start: 76, end: 96, pattern_start: 87, pattern_end: 92 }
   )
-  
+  if (y instanceof Nil) {
+    
+  } else {
+    throw makeError(
+      "let_assert",
+      FILEPATH,
+      "my/mod",
+      6,
+      "go",
+      "Pattern match failed, no pattern matched the value.",
+      { value: y, start: 99, end: 117, pattern_start: 110, pattern_end: 113 }
+    )
+  }
+  return y;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil.snap
@@ -24,9 +24,7 @@ export class False extends $CustomType {}
 export class Nil extends $CustomType {}
 
 export function go(x, y) {
-  if (x instanceof True) {
-    
-  } else {
+  if (!(x instanceof True)) {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -46,9 +44,7 @@ export function go(x, y) {
     "Pattern match failed, no pattern matched the value.",
     { value: x, start: 76, end: 96, pattern_start: 87, pattern_end: 92 }
   )
-  if (y instanceof Nil) {
-    
-  } else {
+  if (!(y instanceof Nil)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_branches_guards_are_wrapped_in_parentheses.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_branches_guards_are_wrapped_in_parentheses.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/case.rs
-assertion_line: 243
 expression: "\npub fn anything() -> a {\n  case [] {\n    [a] if False || True -> a\n    _ -> anything()\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -20,9 +18,7 @@ import { toList, Empty as $Empty } from "../gleam.mjs";
 export function anything() {
   while (true) {
     let $ = toList([]);
-    if ($ instanceof $Empty) {
-      
-    } else {
+    if (!($ instanceof $Empty)) {
       let $1 = $.tail;
       if ($1 instanceof $Empty && false || true) {
         let a = $.head;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_mixed_fields_first_unlabelled.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_mixed_fields_first_unlabelled.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
-assertion_line: 281
 expression: "\npub type Cat {\n  Cat(String, cuteness: Int)\n}\n\npub fn go(cat) {\n  let Cat(x, y) = cat\n  let Cat(cuteness: y, ..) = cat\n  let Cat(x, cuteness: y) = cat\n  x\n}\n\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -31,10 +29,15 @@ export class Cat extends $CustomType {
 }
 
 export function go(cat) {
-  let x = cat[0];
-  let y = cat.cuteness;
-  let y$1 = cat.cuteness;
-  let x$1 = cat[0];
-  let y$2 = cat.cuteness;
+  let x;
+  let y;
+  x = cat[0];
+  y = cat.cuteness;
+  let y$1;
+  y$1 = cat.cuteness;
+  let x$1;
+  let y$2;
+  x$1 = cat[0];
+  y$2 = cat.cuteness;
   return x$1;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_named_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_named_fields.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
-assertion_line: 262
 expression: "\npub type Cat {\n  Cat(name: String, cuteness: Int)\n}\n\npub fn go(cat) {\n  let Cat(x, y) = cat\n  let Cat(name: x, ..) = cat\n  let assert Cat(cuteness: 4, name: x) = cat\n  x\n}\n\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -33,10 +31,17 @@ export class Cat extends $CustomType {
 }
 
 export function go(cat) {
-  let x = cat.name;
-  let y = cat.cuteness;
-  let x$1 = cat.name;
-  if (!(cat instanceof Cat) || cat.cuteness !== 4) {
+  let x;
+  let y;
+  x = cat.name;
+  y = cat.cuteness;
+  let x$1;
+  x$1 = cat.name;
+  let x$2;
+  let $ = cat.cuteness;
+  if ($ === 4) {
+    x$2 = cat.name;
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -47,6 +52,5 @@ export function go(cat) {
       { value: cat, start: 124, end: 166, pattern_start: 135, pattern_end: 160 }
     )
   }
-  let x$2 = cat.name;
   return x$2;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_access_in_pattern_with_reserved_field_name.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_access_in_pattern_with_reserved_field_name.snap
@@ -31,7 +31,8 @@ export class Thing extends $CustomType {
 
 export function main() {
   let a = new Thing(undefined);
-  let ctor = a.constructor$;
+  let ctor;
+  ctor = a.constructor$;
   let a$1 = a;
   if (a$1.constructor$ === ctor) {
     return undefined;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unnamed_fields.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/custom_types.rs
-assertion_line: 168
 expression: "\npub type Ip {\n    Ip(String)\n}\n\npub const local = Ip(\"0.0.0.0\")\n\npub fn build(x) {\n    x(\"1.2.3.4\")\n}\n\npub fn go() {\n    build(Ip)\n    Ip(\"5.6.7.8\")\n}\n\npub fn destructure(x) {\n  let Ip(raw) = x\n  raw\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -47,7 +45,8 @@ export function go() {
 }
 
 export function destructure(x) {
-  let raw = x[0];
+  let raw;
+  raw = x[0];
   return raw;
 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
@@ -19,9 +19,7 @@ import { Empty as $Empty, makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x, y) {
-  if (x instanceof $Empty) {
-    
-  } else {
+  if (!(x instanceof $Empty)) {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -87,9 +85,7 @@ export function go(x, y) {
         let $2 = $.head;
         if ($2 === 2) {
           let $3 = x.head;
-          if ($3 === 1) {
-            
-          } else {
+          if (!($3 === 1)) {
             throw makeError(
               "let_assert",
               FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/lists.rs
-assertion_line: 62
 expression: "\npub fn go(x, y) {\n  let assert [] = x\n  let assert [a] = x\n  let assert [1, 2] = x\n  let assert [_, #(3, b)] = y\n  let assert [head, ..tail] = y\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,12 +14,14 @@ pub fn go(x, y) {
 
 
 ----- COMPILED JAVASCRIPT
-import { Empty as $Empty, NonEmpty as $NonEmpty, makeError } from "../gleam.mjs";
+import { Empty as $Empty, makeError } from "../gleam.mjs";
 
 const FILEPATH = "src/module.gleam";
 
 export function go(x, y) {
-  if (x instanceof $NonEmpty) {
+  if (x instanceof $Empty) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -32,7 +32,8 @@ export function go(x, y) {
       { value: x, start: 21, end: 38, pattern_start: 32, pattern_end: 34 }
     )
   }
-  if (x instanceof $Empty || x.tail instanceof $NonEmpty) {
+  let a;
+  if (x instanceof $Empty) {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -42,15 +43,23 @@ export function go(x, y) {
       "Pattern match failed, no pattern matched the value.",
       { value: x, start: 41, end: 59, pattern_start: 52, pattern_end: 55 }
     )
+  } else {
+    let $ = x.tail;
+    if ($ instanceof $Empty) {
+      a = x.head;
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        4,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 41, end: 59, pattern_start: 52, pattern_end: 55 }
+      )
+    }
   }
-  let a = x.head;
-  if (
-    x instanceof $Empty ||
-    x.tail instanceof $Empty ||
-    x.tail.tail instanceof $NonEmpty ||
-    x.tail.head !== 2 ||
-    x.head !== 1
-  ) {
+  if (x instanceof $Empty) {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -60,13 +69,69 @@ export function go(x, y) {
       "Pattern match failed, no pattern matched the value.",
       { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
     )
+  } else {
+    let $ = x.tail;
+    if ($ instanceof $Empty) {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        5,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
+      )
+    } else {
+      let $1 = $.tail;
+      if ($1 instanceof $Empty) {
+        let $2 = $.head;
+        if ($2 === 2) {
+          let $3 = x.head;
+          if ($3 === 1) {
+            
+          } else {
+            throw makeError(
+              "let_assert",
+              FILEPATH,
+              "my/mod",
+              5,
+              "go",
+              "Pattern match failed, no pattern matched the value.",
+              {
+                value: x,
+                start: 62,
+                end: 83,
+                pattern_start: 73,
+                pattern_end: 79
+              }
+            )
+          }
+        } else {
+          throw makeError(
+            "let_assert",
+            FILEPATH,
+            "my/mod",
+            5,
+            "go",
+            "Pattern match failed, no pattern matched the value.",
+            { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
+          )
+        }
+      } else {
+        throw makeError(
+          "let_assert",
+          FILEPATH,
+          "my/mod",
+          5,
+          "go",
+          "Pattern match failed, no pattern matched the value.",
+          { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
+        )
+      }
+    }
   }
-  if (
-    y instanceof $Empty ||
-    y.tail instanceof $Empty ||
-    y.tail.tail instanceof $NonEmpty ||
-    y.tail.head[0] !== 3
-  ) {
+  let b;
+  if (y instanceof $Empty) {
     throw makeError(
       "let_assert",
       FILEPATH,
@@ -76,8 +141,56 @@ export function go(x, y) {
       "Pattern match failed, no pattern matched the value.",
       { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
     )
+  } else {
+    let $ = y.tail;
+    if ($ instanceof $Empty) {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        6,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
+      )
+    } else {
+      let $1 = $.tail;
+      if ($1 instanceof $Empty) {
+        let $2 = $.head[0];
+        if ($2 === 3) {
+          b = $.head[1];
+        } else {
+          throw makeError(
+            "let_assert",
+            FILEPATH,
+            "my/mod",
+            6,
+            "go",
+            "Pattern match failed, no pattern matched the value.",
+            {
+              value: y,
+              start: 86,
+              end: 113,
+              pattern_start: 97,
+              pattern_end: 109
+            }
+          )
+        }
+      } else {
+        throw makeError(
+          "let_assert",
+          FILEPATH,
+          "my/mod",
+          6,
+          "go",
+          "Pattern match failed, no pattern matched the value.",
+          { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
+        )
+      }
+    }
   }
-  let b = y.tail.head[1];
+  let head;
+  let tail;
   if (y instanceof $Empty) {
     throw makeError(
       "let_assert",
@@ -88,8 +201,9 @@ export function go(x, y) {
       "Pattern match failed, no pattern matched the value.",
       { value: y, start: 116, end: 145, pattern_start: 127, pattern_end: 141 }
     )
+  } else {
+    head = y.head;
+    tail = y.tail;
   }
-  let head = y.head;
-  let tail = y.tail;
   return y;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
@@ -68,8 +68,8 @@ export function go(x, y) {
       { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
     )
   } else {
-    let $ = x.tail;
-    if ($ instanceof $Empty) {
+    let $1 = x.tail;
+    if ($1 instanceof $Empty) {
       throw makeError(
         "let_assert",
         FILEPATH,
@@ -80,12 +80,12 @@ export function go(x, y) {
         { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
       )
     } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        let $2 = $.head;
-        if ($2 === 2) {
-          let $3 = x.head;
-          if (!($3 === 1)) {
+      let $2 = $1.tail;
+      if ($2 instanceof $Empty) {
+        let $3 = $1.head;
+        if ($3 === 2) {
+          let $4 = x.head;
+          if (!($4 === 1)) {
             throw makeError(
               "let_assert",
               FILEPATH,
@@ -138,8 +138,8 @@ export function go(x, y) {
       { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
     )
   } else {
-    let $ = y.tail;
-    if ($ instanceof $Empty) {
+    let $5 = y.tail;
+    if ($5 instanceof $Empty) {
       throw makeError(
         "let_assert",
         FILEPATH,
@@ -150,11 +150,11 @@ export function go(x, y) {
         { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
       )
     } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        let $2 = $.head[0];
-        if ($2 === 3) {
-          b = $.head[1];
+      let $6 = $5.tail;
+      if ($6 instanceof $Empty) {
+        let $7 = $5.head[0];
+        if ($7 === 3) {
+          b = $5.head[1];
         } else {
           throw makeError(
             "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__int_patterns.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__int_patterns.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/numbers.rs
-assertion_line: 146
 expression: "\npub fn go(x) {\n  let assert 4 = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x !== 4) {
+  if (x === 4) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__int_patterns.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__int_patterns.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x === 4) {
-    
-  } else {
+  if (!(x === 4)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_float_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_float_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/numbers.rs
-assertion_line: 308
 expression: "\npub fn main(x) {\n  let assert 09_179.1 = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function main(x) {
-  if (x !== 9_179.1) {
+  if (x === 9_179.1) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_float_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_float_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function main(x) {
-  if (x === 9_179.1) {
-    
-  } else {
+  if (!(x === 9_179.1)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_int_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_int_pattern.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function main(x) {
-  if (x === 9_179) {
-    
-  } else {
+  if (!(x === 9_179)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_int_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__preceeding_zeros_int_pattern.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/numbers.rs
-assertion_line: 296
 expression: "\npub fn main(x) {\n  let assert 09_179 = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function main(x) {
-  if (x !== 9_179) {
+  if (x === 9_179) {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_patterns.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_patterns.snap
@@ -15,9 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x === "Hello") {
-    
-  } else {
+  if (!(x === "Hello")) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_patterns.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_patterns.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/strings.rs
-assertion_line: 60
 expression: "\npub fn go(x) {\n  let assert \"Hello\" = x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -17,7 +15,9 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  if (x !== "Hello") {
+  if (x === "Hello") {
+    
+  } else {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__use___patterns.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__use___patterns.snap
@@ -36,7 +36,8 @@ export function main() {
   return apply(
     new Box(1),
     (_use0) => {
-      let x = _use0[0];
+      let x;
+      x = _use0[0];
       return x;
     },
   );

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -2206,6 +2206,14 @@ fn bit_array_match_tests() {
           i
         })
       }),
+    // https://github.com/gleam-lang/gleam/issues/4712
+    "Multiple variable segments"
+      |> example(fn() {
+        assert_equal(12, {
+          let assert <<a, b:size(a), c:size(b)>> = <<2, 3:2, 7:3>>
+          a + b + c
+        })
+      }),
   ]
 }
 


### PR DESCRIPTION
Fixes #4712
This PR merges the codegen code for `let assert` and `case`, which fixes some edge-cases which were not properly handled by the `let assert` logic.
This does temporarily make some of the `let assert` code a bit bigger and less efficient, however we are planning to further improve this part of the codebase and iron out these inefficiencies in the future.