### PR TITLE
Fix renaming of prelude types and values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,6 +423,10 @@
   alternative patterns.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where trying to rename a type or value from the Gleam prelude would
+  result in invalid code.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.11.1 - 2025-06-05
 
 ### Compiler

--- a/compiler-core/src/language_server/edits.rs
+++ b/compiler-core/src/language_server/edits.rs
@@ -2,7 +2,7 @@ use ecow::EcoString;
 use lsp_types::{Position, Range, TextEdit};
 
 use crate::{
-    ast::{Definition, Import, TypedDefinition},
+    ast::{Definition, Import, SrcSpan, TypedDefinition},
     build::Module,
     line_numbers::LineNumbers,
 };
@@ -74,4 +74,89 @@ pub fn get_import_edit(
         },
         new_text: ["import ", module_full_name, new_lines].concat(),
     }
+}
+
+pub fn insert_unqualified_import(
+    import: &Import<EcoString>,
+    code: &str,
+    name: String,
+) -> (u32, String) {
+    let SrcSpan { start, end } = import.location;
+
+    let import_code = code
+        .get(start as usize..end as usize)
+        .expect("Import location is invalid");
+    let has_brace = import_code.contains('}');
+
+    if has_brace {
+        insert_into_braced_import(name, import.location, import_code)
+    } else {
+        insert_into_unbraced_import(name, import, import_code)
+    }
+}
+
+// Handle inserting into an unbraced import
+fn insert_into_unbraced_import(
+    name: String,
+    import: &Import<EcoString>,
+    import_code: &str,
+) -> (u32, String) {
+    let location = import.location;
+    if import.as_name.is_none() {
+        // Case: import module
+        (location.end, format!(".{{{name}}}"))
+    } else {
+        // Case: import module as alias
+        let as_pos = import_code
+            .find(" as ")
+            .expect("Expected ' as ' in import statement");
+        let before_as_pos = import_code
+            .get(..as_pos)
+            .and_then(|s| s.rfind(|c: char| !c.is_whitespace()))
+            .map(|pos| location.start as usize + pos + 1)
+            .expect("Expected non-whitespace character before ' as '");
+        (before_as_pos as u32, format!(".{{{name}}}"))
+    }
+}
+
+// Handle inserting into a braced import
+fn insert_into_braced_import(name: String, location: SrcSpan, import_code: &str) -> (u32, String) {
+    if let Some((pos, c)) = find_last_char_before_closing_brace(location, import_code) {
+        // Case: import module.{Existing, } (as alias)
+        if c == ',' {
+            (pos as u32 + 1, format!(" {name}"))
+        } else {
+            // Case: import module.{Existing} (as alias)
+            (pos as u32 + 1, format!(", {name}"))
+        }
+    } else {
+        // Case: import module.{} (as alias)
+        let left_brace_pos = import_code
+            .find('{')
+            .map(|pos| location.start as usize + pos)
+            .expect("Expected '{' in import statement");
+        (left_brace_pos as u32 + 1, name)
+    }
+}
+
+fn find_last_char_before_closing_brace(
+    location: SrcSpan,
+    import_code: &str,
+) -> Option<(usize, char)> {
+    let closing_brace_pos = import_code.rfind('}')?;
+
+    let bytes = import_code.as_bytes();
+    let mut pos = closing_brace_pos;
+    while pos > 0 {
+        pos -= 1;
+        let c = (*bytes.get(pos)?) as char;
+        if c.is_whitespace() {
+            continue;
+        }
+        if c == '{' {
+            break;
+        }
+        return Some((location.start as usize + pos, c));
+    }
+    None
 }

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -1386,6 +1386,32 @@ pub fn main(x) {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/4605
+#[test]
+fn rename_prelude_value() {
+    assert_rename!(
+        "
+pub fn main() {
+  Ok(10)
+}
+",
+        "Success",
+        find_position_of("Ok")
+    );
+}
+#[test]
+fn rename_prelude_type() {
+    assert_rename!(
+        "
+pub fn main() -> Result(Int, Nil) {
+  Ok(10)
+}
+",
+        "SuccessOrFailure",
+        find_position_of("Result")
+    );
+}
+
 #[test]
 fn rename_variable_with_alternative_pattern_with_same_name() {
     assert_rename!(
@@ -1404,5 +1430,81 @@ pub fn main(x) {
 ",
         "new_name",
         find_position_of("some_var")
+    );
+}
+
+#[test]
+fn rename_prelude_value_with_prelude_already_imported() {
+    assert_rename!(
+        "
+import gleam
+
+pub fn main() {
+  Ok(gleam.Error(10))
+}
+",
+        "Success",
+        find_position_of("Ok")
+    );
+}
+
+#[test]
+fn rename_prelude_value_with_prelude_import_with_empty_braces() {
+    assert_rename!(
+        "
+import gleam.{}
+
+pub fn main() {
+  Ok(gleam.Error(10))
+}
+",
+        "Success",
+        find_position_of("Ok")
+    );
+}
+
+#[test]
+fn rename_prelude_value_with_other_prelude_value_imported() {
+    assert_rename!(
+        "
+import gleam.{Error}
+
+pub fn main() {
+  Ok(Error(10))
+}
+",
+        "Success",
+        find_position_of("Ok")
+    );
+}
+
+#[test]
+fn rename_prelude_type_with_prelude_value_imported_with_trailing_comma() {
+    assert_rename!(
+        "
+import gleam.{Error,}
+
+pub fn main() -> Result(Int, Nil) {
+  Error(10)
+}
+",
+        "OkOrError",
+        find_position_of("Result")
+    );
+}
+
+#[test]
+fn rename_prelude_value_with_other_module_imported() {
+    assert_rename!(
+        ("something", "pub type Something"),
+        "
+import something
+
+pub fn main() {
+  Ok(10)
+}
+",
+        "Success",
+        find_position_of("Ok")
     );
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_type.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() -> Result(Int, Nil) {\n  Ok(10)\n}\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+pub fn main() -> Result(Int, Nil) {
+                 ↑▔▔▔▔▔            
+  Ok(10)
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+import gleam.{type Result as SuccessOrFailure}
+
+pub fn main() -> SuccessOrFailure(Int, Nil) {
+  Ok(10)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_type_with_prelude_value_imported_with_trailing_comma.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_type_with_prelude_value_imported_with_trailing_comma.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport gleam.{Error,}\n\npub fn main() -> Result(Int, Nil) {\n  Error(10)\n}\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+import gleam.{Error,}
+
+pub fn main() -> Result(Int, Nil) {
+                 ↑▔▔▔▔▔            
+  Error(10)
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+
+import gleam.{Error, type Result as OkOrError}
+
+pub fn main() -> OkOrError(Int, Nil) {
+  Error(10)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\npub fn main() {\n  Ok(10)\n}\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+pub fn main() {
+  Ok(10)
+  ↑▔    
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+import gleam.{Ok as Success}
+
+pub fn main() {
+  Success(10)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_other_module_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_other_module_imported.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport something\n\npub fn main() {\n  Ok(10)\n}\n"
+---
+----- BEFORE RENAME
+-- something.gleam
+pub type Something
+
+-- app.gleam
+
+import something
+
+pub fn main() {
+  Ok(10)
+  ↑▔    
+}
+
+
+----- AFTER RENAME
+-- something.gleam
+pub type Something
+
+-- app.gleam
+
+import gleam.{Ok as Success}
+import something
+
+pub fn main() {
+  Success(10)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_other_prelude_value_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_other_prelude_value_imported.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport gleam.{Error}\n\npub fn main() {\n  Ok(Error(10))\n}\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+import gleam.{Error}
+
+pub fn main() {
+  Ok(Error(10))
+  ↑▔           
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+
+import gleam.{Error, Ok as Success}
+
+pub fn main() {
+  Success(Error(10))
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_prelude_already_imported.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_prelude_already_imported.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport gleam\n\npub fn main() {\n  Ok(gleam.Error(10))\n}\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+import gleam
+
+pub fn main() {
+  Ok(gleam.Error(10))
+  ↑▔                 
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+
+import gleam.{Ok as Success}
+
+pub fn main() {
+  Success(gleam.Error(10))
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_prelude_import_with_empty_braces.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_prelude_value_with_prelude_import_with_empty_braces.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\nimport gleam.{}\n\npub fn main() {\n  Ok(gleam.Error(10))\n}\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+import gleam.{}
+
+pub fn main() {
+  Ok(gleam.Error(10))
+  ↑▔                 
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+
+import gleam.{Ok as Success}
+
+pub fn main() {
+  Success(gleam.Error(10))
+}


### PR DESCRIPTION
Fixes #4605
I've reused some of the existing code from the `Unqualify constructor` code action for working with imports, and moved it to a different file so it is accessible.