### PR TITLE
Fix generated docs' formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,9 @@
   result in invalid code.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where the generated documentation would not be formatted properly.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.11.1 - 2025-06-05
 
 ### Compiler

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -335,11 +335,14 @@ impl Printer<'_> {
         }
         self.register_local_type_variable_names(return_type);
 
-        let arguments = arguments.iter().map(|argument| {
-            let name = self.variable(self.argument_name(argument));
-            docvec![name, ": ", self.type_(&argument.type_)].group()
-        });
-        let arguments = Self::wrap_arguments(arguments);
+        let arguments = if arguments.is_empty() {
+            "()".to_doc()
+        } else {
+            Self::wrap_arguments(arguments.iter().map(|argument| {
+                let name = self.variable(self.argument_name(argument));
+                docvec![name, ": ", self.type_(&argument.type_)].group()
+            }))
+        };
 
         docvec![
             self.keyword("pub fn "),

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_with_no_arguments_parentheses_are_not_split.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_with_no_arguments_parentheses_are_not_split.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- main.gleam
+
+pub fn aaaaaaaaaaaaaaaaaaaaaaaaaaaa() -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+  todo
+}
+
+
+---- VALUES
+
+--- aaaaaaaaaaaaaaaaaaaaaaaaaaaa
+<pre><code>pub fn aaaaaaaaaaaaaaaaaaaaaaaaaaaa() -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</code></pre>

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -1165,6 +1165,7 @@ pub type Wibble {
         NONE
     );
 }
+
 #[test]
 fn gitea_repository_url_has_no_double_slash() {
     let repo = Repository::Gitea {
@@ -1177,5 +1178,17 @@ fn gitea_repository_url_has_no_double_slash() {
     assert_eq!(
         repo.url().unwrap(),
         "https://code.example.org/person/forgejo_bug"
+    );
+}
+
+#[test]
+fn long_function_with_no_arguments_parentheses_are_not_split() {
+    assert_documentation!(
+        "
+pub fn aaaaaaaaaaaaaaaaaaaaaaaaaaaa() -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+  todo
+}
+",
+        NONE
     );
 }


### PR DESCRIPTION
This fixes a small bug where the generated documentation for functions would be split improperly:
<img width="523" alt="Screenshot 2025-07-06 alle 21 42 37" src="https://github.com/user-attachments/assets/bbc48fba-4209-4469-9c7d-3ccac0665383" />
