### PR TITLE
Do not allow to extract variable used in record update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -515,6 +515,10 @@
   definition of a record from a record update expression.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would allow using the "extract variable"
+  code action on variables used in record updates.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.11.1 - 2025-06-05
 
 ### Compiler

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -1136,7 +1136,7 @@ pub fn visit_typed_expr_panic<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
     message: &'a Option<Box<TypedExpr>>,
-    _type: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -1161,7 +1161,7 @@ pub fn visit_typed_expr_bit_array<'a, V>(
 pub fn visit_typed_expr_record_update<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    _type: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
     record: &'a Option<Box<TypedAssignment>>,
     constructor: &'a TypedExpr,
     arguments: &'a [TypedCallArg],
@@ -1601,7 +1601,7 @@ pub fn visit_typed_pattern_variable<'a, V>(
     _v: &mut V,
     _location: &'a SrcSpan,
     _name: &'a EcoString,
-    _type: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
     _origin: &'a VariableOrigin,
 ) where
     V: Visit<'a> + ?Sized,
@@ -1667,7 +1667,7 @@ pub fn visit_typed_pattern_discard<'a, V>(
     _v: &mut V,
     _location: &'a SrcSpan,
     _name: &'a EcoString,
-    _type: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -1678,7 +1678,7 @@ pub fn visit_typed_pattern_list<'a, V>(
     _location: &'a SrcSpan,
     elements: &'a Vec<TypedPattern>,
     tail: &'a Option<Box<TypedPattern>>,
-    _type: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {
@@ -1700,7 +1700,7 @@ pub fn visit_typed_pattern_constructor<'a, V>(
     _module: &'a Option<(EcoString, SrcSpan)>,
     _constructor: &'a Inferred<PatternConstructor>,
     _spread: &'a Option<SrcSpan>,
-    _type: &'a Arc<Type>,
+    _type_: &'a Arc<Type>,
 ) where
     V: Visit<'a> + ?Sized,
 {

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3119,6 +3119,13 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
             return;
         }
 
+        // An implicit record update arg in inserted by the compiler, we don't
+        // want folks to interact with this since it doesn't translate to
+        // anything in the source code despite having a default position.
+        if let Some(ImplicitCallArgOrigin::RecordUpdate) = arg.implicit {
+            return;
+        }
+
         let position = if arg.is_use_implicit_callback() {
             Some(ExtractVariablePosition::TopLevelStatement)
         } else {

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -5174,6 +5174,17 @@ fn extract_variable_does_not_extract_echo() {
 }
 
 #[test]
+fn extract_variable_does_not_extract_assignment() {
+    assert_no_code_actions!(
+        EXTRACT_VARIABLE,
+        r#"pub fn main() {
+  let x = 1
+}"#,
+        find_position_of("x").to_selection()
+    );
+}
+
+#[test]
 fn extract_variable_from_arg_in_pipelined_call() {
     assert_code_action!(
         EXTRACT_VARIABLE,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -5185,6 +5185,21 @@ fn extract_variable_does_not_extract_assignment() {
 }
 
 #[test]
+fn extract_variable_does_not_extract_record_variable_in_record_update() {
+    assert_no_code_actions!(
+        EXTRACT_VARIABLE,
+        r#"
+type Wibble { Wibble(one: Int, two: Int) }
+
+pub fn main() {
+  let wibble = todo
+  Wibble(..wibble, one: 1)
+}"#,
+        find_position_of("wibble").nth_occurrence(2).to_selection()
+    );
+}
+
+#[test]
 fn extract_variable_from_arg_in_pipelined_call() {
     assert_code_action!(
         EXTRACT_VARIABLE,


### PR DESCRIPTION
This PR fixes a small bug I noticed that would result in the LSP offering the "extract variable" code action for a variable used in a record update expression.