### PR TITLE
Fix record pattern formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,6 +518,10 @@
   code action on variables used in record updates.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where a record pattern with a spread `..` would not be formatted
+  properly.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.11.1 - 2025-06-05
 
 ### Compiler

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1226,6 +1226,7 @@ impl<'comments> Formatter<'comments> {
                 .map(|argument| self.pattern_call_arg(argument))
                 .collect_vec();
             name.append(self.wrap_arguments_with_spread(arguments, location.end))
+                .group()
         } else {
             match arguments {
                 [argument] if is_breakable(&argument.value) => name

--- a/compiler-core/src/format/tests/record_update.rs
+++ b/compiler-core/src/format/tests/record_update.rs
@@ -103,3 +103,21 @@ fn record_update_gets_formatted_like_a_function_call() {
 "#
     );
 }
+
+#[test]
+fn record_with_record_and_spread_field_is_not_needlessly_broken() {
+    assert_format!(
+        "pub fn main() {
+  case todo {
+    Wibble(
+      some_field: Wobble(something: 1, ..),
+      other_field_1:,
+      other_field_2:,
+      other_field_3:,
+      ..,
+    ) -> todo
+  }
+}
+"
+    );
+}


### PR DESCRIPTION
I noticed a small bug in the formatter where it would needlessly break a record pattern if it contained a spread. Turns out I forgot to group it!