### PR TITLE
Fix jump to definition for record updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,11 +480,15 @@
   alternative patterns.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- Fixed a bug where trying to rename a type or value from the Gleam prelude would
-  result in invalid code.
+- Fixed a bug where trying to rename a type or value from the Gleam prelude
+  would result in invalid code.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
 - Fixed a bug where the generated documentation would not be formatted properly.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the language server wouldn't allow you to jump to the
+  definition of a record from a record update expression.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ## v1.11.1 - 2025-06-05

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -875,7 +875,11 @@ impl TypedDefinition {
                     return None;
                 }
 
-                if let Some(found) = function.body.iter().find_map(|s| s.find_node(byte_index)) {
+                if let Some(found) = function
+                    .body
+                    .iter()
+                    .find_map(|statement| statement.find_node(byte_index))
+                {
                     return Some(found);
                 }
 
@@ -896,12 +900,10 @@ impl TypedDefinition {
                 };
 
                 // Check if location is within the return annotation.
-                if let Some(l) = function
-                    .return_annotation
-                    .iter()
-                    .find_map(|a| a.find_node(byte_index, function.return_type.clone()))
-                {
-                    return Some(l);
+                if let Some(located) = function.return_annotation.iter().find_map(|annotation| {
+                    annotation.find_node(byte_index, function.return_type.clone())
+                }) {
+                    return Some(located);
                 };
 
                 // Note that the fn `.location` covers the function head, not
@@ -945,8 +947,8 @@ impl TypedDefinition {
 
             Definition::TypeAlias(alias) => {
                 // Check if location is within the type being aliased.
-                if let Some(l) = alias.type_ast.find_node(byte_index, alias.type_.clone()) {
-                    return Some(l);
+                if let Some(located) = alias.type_ast.find_node(byte_index, alias.type_.clone()) {
+                    return Some(located);
                 }
 
                 if alias.location.contains(byte_index) {

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -403,7 +403,7 @@ impl TypedExpr {
                 .or_else(|| {
                     record_assignment
                         .as_ref()
-                        .and_then(|r| r.find_node(byte_index))
+                        .and_then(|assignment| assignment.find_node(byte_index))
                 })
                 .or_else(|| self.self_if_contains_location(byte_index)),
         }

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -400,6 +400,7 @@ impl TypedExpr {
                 .iter()
                 .filter(|argument| argument.implicit.is_none())
                 .find_map(|argument| argument.find_node(byte_index, constructor, arguments))
+                .or_else(|| constructor.find_node(byte_index))
                 .or_else(|| {
                     record_assignment
                         .as_ref()

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -242,6 +242,19 @@ pub fn main() {
 }
 
 #[test]
+fn goto_definition_record_update() {
+    assert_goto!(
+        "
+pub type Wibble { Wibble(one: Int, two: Int) }
+
+pub fn main() {
+  Wibble(..todo, one: 1)
+}",
+        find_position_of("Wibble").nth_occurrence(3)
+    );
+}
+
+#[test]
 fn goto_definition_same_module_constants() {
     assert_goto!(
         "

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_record_update.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_record_update.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+pub type Wibble { Wibble(one: Int, two: Int) }
+
+pub fn main() {
+  Wibble(..todo, one: 1)
+  ↑                     
+}
+
+----- Jumped to `src/app.gleam`
+
+pub type Wibble { Wibble(one: Int, two: Int) }
+                  ↑▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔  
+
+pub fn main() {
+  Wibble(..todo, one: 1)
+}


### PR DESCRIPTION
I noticed a small bug where the language server wouldn't allow you to jump to the definition of a variant if you are over its name in a record update expression!