### PR TITLE
Code actions to add and remove anonymous functions

### DIFF
--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, iter, sync::Arc};
+use std::{any::Any, collections::HashSet, iter, sync::Arc};
 
 use crate::{
     Error, STDLIB_PACKAGE_NAME, analyse,
@@ -3650,6 +3650,15 @@ impl VariablesNames {
         for statement in statements {
             variables.visit_typed_statement(statement);
         }
+        variables
+    }
+    
+    fn from_expr(expr: &TypedExpr) -> Self {
+        let mut variables = Self {
+            names: HashSet::new(),
+        };
+
+        variables.visit_typed_expr(expr);
         variables
     }
 }
@@ -7497,5 +7506,88 @@ impl<'ast> ast::visit::Visit<'ast> for RemoveBlock<'ast> {
         }
 
         ast::visit::visit_typed_expr_block(self, location, statements);
+    }
+}
+
+struct FunctionToWrap {
+    location: SrcSpan,
+    arguments: Vec<Arc<Type>>,
+    variables_names: VariablesNames,
+}
+
+pub struct WrapInAnonymousFunction<'a> {
+    module: &'a Module,
+    line_numbers: &'a LineNumbers,
+    params: &'a CodeActionParams,
+    targets: Vec<FunctionToWrap>,
+}
+
+impl<'a> WrapInAnonymousFunction<'a> {
+    pub fn new(
+        module: &'a Module,
+        line_numbers: &'a LineNumbers,
+        params: &'a CodeActionParams,
+    ) -> Self {
+        Self {
+            module,
+            line_numbers,
+            params,
+            targets: vec![],
+        }
+    }
+
+    pub fn code_actions(mut self) -> Vec<CodeAction> {
+        self.visit_typed_module(&self.module.ast);
+
+        let mut actions = Vec::with_capacity(self.targets.len());
+        for target in self.targets {
+            let mut name_generator = NameGenerator::new();
+            name_generator.reserve_variable_names(target.variables_names);
+            let arguments = target
+                .arguments
+                .iter()
+                .map(|t| name_generator.generate_name_from_type(t))
+                .join(", ");
+
+            let mut edits = TextEdits::new(self.line_numbers);
+            edits.insert(target.location.start, format!("fn({arguments}) {{ "));
+            edits.insert(target.location.end, format!("({arguments}) }}"));
+
+            CodeActionBuilder::new("Wrap in anonymous function")
+                .kind(CodeActionKind::REFACTOR_REWRITE)
+                .changes(self.params.text_document.uri.clone(), edits.edits)
+                .push_to(&mut actions);
+        }
+        actions
+    }
+}
+
+impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
+    fn visit_typed_call_arg(&mut self, arg: &'ast TypedCallArg) {
+        if let Type::Fn { ref arguments, .. } = *arg.value.type_() {
+            let variables_names = VariablesNames::from_expr(&arg.value);
+
+            self.targets.push(FunctionToWrap {
+                location: arg.location,
+                arguments: arguments.clone(),
+                variables_names,
+            });
+        }
+    }
+
+    fn visit_typed_assignment(&mut self, assignment: &'ast TypedAssignment) {
+        if assignment.kind != AssignmentKind::Let {
+            return;
+        }
+
+        if let Type::Fn { ref arguments, .. } = *assignment.value.type_() {
+            let variables_names = VariablesNames::from_expr(&assignment.value);
+
+            self.targets.push(FunctionToWrap {
+                location: assignment.value.location(),
+                arguments: arguments.clone(),
+                variables_names,
+            });
+        }
     }
 }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::HashSet, iter, sync::Arc};
+use std::{collections::HashSet, iter, sync::Arc};
 
 use crate::{
     Error, STDLIB_PACKAGE_NAME, analyse,

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -3652,7 +3652,7 @@ impl VariablesNames {
         }
         variables
     }
-    
+
     fn from_expr(expr: &TypedExpr) -> Self {
         let mut variables = Self {
             names: HashSet::new(),
@@ -7588,6 +7588,110 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
                 arguments: arguments.clone(),
                 variables_names,
             });
+        }
+    }
+}
+
+pub struct UnwrapAnonymousFunction<'a> {
+    module: &'a Module,
+    line_numbers: &'a LineNumbers,
+    params: &'a CodeActionParams,
+    targets: Vec<FnToUnwrap>,
+}
+
+struct FnToUnwrap {
+    fn_location: SrcSpan,
+    inner_function_location: SrcSpan,
+}
+
+impl<'a> UnwrapAnonymousFunction<'a> {
+    pub fn new(
+        module: &'a Module,
+        line_numbers: &'a LineNumbers,
+        params: &'a CodeActionParams,
+    ) -> Self {
+        Self {
+            module,
+            line_numbers,
+            params,
+            targets: vec![],
+        }
+    }
+
+    pub fn code_actions(mut self) -> Vec<CodeAction> {
+        self.visit_typed_module(&self.module.ast);
+
+        let mut actions = Vec::with_capacity(self.targets.len());
+        for target in self.targets {
+            let mut edits = TextEdits::new(self.line_numbers);
+
+            edits.delete(SrcSpan {
+                start: target.fn_location.start,
+                end: target.inner_function_location.start,
+            });
+            edits.delete(SrcSpan {
+                start: target.inner_function_location.end,
+                end: target.fn_location.end,
+            });
+
+            CodeActionBuilder::new("Unwrap anonymous function")
+                .kind(CodeActionKind::REFACTOR_REWRITE)
+                .changes(self.params.text_document.uri.clone(), edits.edits)
+                .push_to(&mut actions);
+        }
+        actions
+    }
+}
+
+impl<'ast> ast::visit::Visit<'ast> for UnwrapAnonymousFunction<'ast> {
+    fn visit_typed_expr_fn(
+        &mut self,
+        location: &'ast SrcSpan,
+        _type_: &'ast Arc<Type>,
+        kind: &'ast FunctionLiteralKind,
+        arguments: &'ast [TypedArg],
+        body: &'ast Vec1<TypedStatement>,
+        _return_annotation: &'ast Option<ast::TypeAst>,
+    ) {
+        match kind {
+            FunctionLiteralKind::Anonymous { .. } => (),
+            _ => return,
+        }
+
+        // We need the existing argument list for the fn to be a 1:1 match for the args we pass
+        // to the called function. We figure out what the call-arg list needs to look like here,
+        // and bail out if any incoming args are discarded.
+        let mut expected_arguments = Vec::with_capacity(arguments.len());
+        for a in arguments {
+            match &a.names {
+                ArgNames::Named { name, .. } => expected_arguments.push(name),
+                ArgNames::NamedLabelled { name, .. } => expected_arguments.push(name),
+                ArgNames::Discard { .. } => return,
+                ArgNames::LabelledDiscard { .. } => return,
+            }
+        }
+
+        // match fn bodies with only a single function call
+        if let [stmt] = body.as_slice()
+            && let TypedStatement::Expression(expr) = stmt
+            && let TypedExpr::Call { fun, arguments, .. } = expr
+        {
+            let mut call_arguments = Vec::with_capacity(arguments.len());
+            for a in arguments {
+                match &a.value {
+                    TypedExpr::Var { name, .. } => call_arguments.push(name),
+                    _ => return,
+                }
+            }
+
+            if call_arguments != expected_arguments {
+                return;
+            }
+
+            self.targets.push(FnToUnwrap {
+                fn_location: *location,
+                inner_function_location: fun.location(),
+            })
         }
     }
 }

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -43,9 +43,9 @@ use super::{
         FillInMissingLabelledArgs, FillUnusedFields, FixBinaryOperation,
         FixTruncatedBitArraySegment, GenerateDynamicDecoder, GenerateFunction, GenerateJsonEncoder,
         GenerateVariant, InlineVariable, InterpolateString, LetAssertToCase, PatternMatchOnValue,
-        RedundantTupleInCaseSubject, RemoveEchos, RemoveUnusedImports, UseLabelShorthandSyntax,
-        WrapInAnonymousFunction, WrapInBlock, code_action_add_missing_patterns,
-        code_action_convert_qualified_constructor_to_unqualified,
+        RedundantTupleInCaseSubject, RemoveEchos, RemoveUnusedImports, UnwrapAnonymousFunction,
+        UseLabelShorthandSyntax, WrapInAnonymousFunction, WrapInBlock,
+        code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified,
         code_action_convert_unqualified_constructor_to_qualified, code_action_import_module,
         code_action_inexhaustive_let_to_case,
     },
@@ -438,6 +438,7 @@ where
             actions.extend(WrapInBlock::new(module, &lines, &params).code_actions());
             actions.extend(RemoveBlock::new(module, &lines, &params).code_actions());
             actions.extend(WrapInAnonymousFunction::new(module, &lines, &params).code_actions());
+            actions.extend(UnwrapAnonymousFunction::new(module, &lines, &params).code_actions());
             GenerateDynamicDecoder::new(module, &lines, &params, &mut actions).code_actions();
             GenerateJsonEncoder::new(
                 module,

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -44,7 +44,7 @@ use super::{
         FixTruncatedBitArraySegment, GenerateDynamicDecoder, GenerateFunction, GenerateJsonEncoder,
         GenerateVariant, InlineVariable, InterpolateString, LetAssertToCase, PatternMatchOnValue,
         RedundantTupleInCaseSubject, RemoveEchos, RemoveUnusedImports, UseLabelShorthandSyntax,
-        WrapInBlock, code_action_add_missing_patterns,
+        WrapInAnonymousFunction, WrapInBlock, code_action_add_missing_patterns,
         code_action_convert_qualified_constructor_to_unqualified,
         code_action_convert_unqualified_constructor_to_qualified, code_action_import_module,
         code_action_inexhaustive_let_to_case,
@@ -437,6 +437,7 @@ where
             actions.extend(InlineVariable::new(module, &lines, &params).code_actions());
             actions.extend(WrapInBlock::new(module, &lines, &params).code_actions());
             actions.extend(RemoveBlock::new(module, &lines, &params).code_actions());
+            actions.extend(WrapInAnonymousFunction::new(module, &lines, &params).code_actions());
             GenerateDynamicDecoder::new(module, &lines, &params, &mut actions).code_actions();
             GenerateJsonEncoder::new(
                 module,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -132,6 +132,7 @@ const WRAP_IN_BLOCK: &str = "Wrap in block";
 const GENERATE_VARIANT: &str = "Generate variant";
 const REMOVE_BLOCK: &str = "Remove block";
 const WRAP_IN_ANONYMOUS_FUNCTION: &str = "Wrap in anonymous function";
+const UNWRAP_ANONYMOUS_FUNCTION: &str = "Unwrap anonymous function";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -9165,5 +9166,61 @@ fn op_factory(a: Int, b: Int, c: Int) -> fn(Int) -> Int {
 }
 ",
         find_position_of("op_factory").to_selection()
+    );
+}
+
+#[test]
+fn unwrap_trivial_anonymous_function() {
+    assert_code_action!(
+        UNWRAP_ANONYMOUS_FUNCTION,
+        "import gleam/list
+
+pub fn main() {
+    list.map([1, 2, 3], fn(int) { op(int) })
+}
+
+fn op(i: Int) -> Int {
+    todo
+}
+",
+        find_position_of("fn(int)").to_selection()
+    );
+}
+
+#[test]
+fn unwrap_anonymous_function_unavailable_when_args_discarded() {
+    assert_no_code_actions!(
+        UNWRAP_ANONYMOUS_FUNCTION,
+        "import gleam/list
+
+pub fn main() {
+    list.index_map([1, 2, 3], fn(_, int) { op(int) })
+}
+
+fn op(i: Int) -> Int {
+    todo
+}
+",
+        find_position_of("fn(_, int)").to_selection()
+    );
+}
+
+#[test]
+fn unwrap_anonymous_function_unavailable_with_different_args() {
+    assert_no_code_actions!(
+        UNWRAP_ANONYMOUS_FUNCTION,
+        "import gleam/list
+
+const another_int = 7
+        
+pub fn main() {
+    list.map([1, 2, 3], fn(int) { op(another_int) })
+}
+
+fn op(i: Int) -> Int {
+    todo
+}
+",
+        find_position_of("fn(int)").to_selection()
     );
 }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -131,6 +131,7 @@ const REMOVE_ALL_ECHOS_FROM_THIS_MODULE: &str = "Remove all `echo`s from this mo
 const WRAP_IN_BLOCK: &str = "Wrap in block";
 const GENERATE_VARIANT: &str = "Generate variant";
 const REMOVE_BLOCK: &str = "Remove block";
+const WRAP_IN_ANONYMOUS_FUNCTION: &str = "Wrap in anonymous function";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -9130,5 +9131,39 @@ fn remove_block_does_not_unwrap_a_block_with_multiple_statements() {
 }
 ",
         find_position_of("1").to_selection()
+    );
+}
+
+#[test]
+fn wrap_call_arg_in_anonymous_function() {
+    assert_code_action!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "import gleam/list
+
+pub fn main() {
+    list.map([1, 2, 3], op)
+}
+
+fn op(i: Int) -> Int {
+    todo
+}
+",
+        find_position_of("op").to_selection()
+    );
+}
+
+#[test]
+fn wrap_assignment_in_anonymous_function() {
+    assert_code_action!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "pub fn main() {
+    let op = op_factory(1, 2, 3)
+}
+
+fn op_factory(a: Int, b: Int, c: Int) -> fn(Int) -> Int {
+    todo
+}
+",
+        find_position_of("op_factory").to_selection()
     );
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unwrap_trivial_anonymous_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__unwrap_trivial_anonymous_function.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "import gleam/list\n\npub fn main() {\n    list.map([1, 2, 3], fn(int) { op(int) })\n}\n\nfn op(i: Int) -> Int {\n    todo\n}\n"
+---
+----- BEFORE ACTION
+import gleam/list
+
+pub fn main() {
+    list.map([1, 2, 3], fn(int) { op(int) })
+                        ↑                   
+}
+
+fn op(i: Int) -> Int {
+    todo
+}
+
+
+----- AFTER ACTION
+import gleam/list
+
+pub fn main() {
+    list.map([1, 2, 3], op)
+}
+
+fn op(i: Int) -> Int {
+    todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_assignment_in_anonymous_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_assignment_in_anonymous_function.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main() {\n    let op = op_factory(1, 2, 3)\n}\n\nfn op_factory(a: Int, b: Int, c: Int) -> fn(Int) -> Int {\n    todo\n}\n"
+---
+----- BEFORE ACTION
+pub fn main() {
+    let op = op_factory(1, 2, 3)
+             ↑                  
+}
+
+fn op_factory(a: Int, b: Int, c: Int) -> fn(Int) -> Int {
+    todo
+}
+
+
+----- AFTER ACTION
+pub fn main() {
+    let op = fn(int) { op_factory(1, 2, 3)(int) }
+}
+
+fn op_factory(a: Int, b: Int, c: Int) -> fn(Int) -> Int {
+    todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_call_arg_in_anonymous_function.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__wrap_call_arg_in_anonymous_function.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "import gleam/list\n\npub fn main() {\n    list.map([1, 2, 3], op)\n}\n\nfn op(i: Int) -> Int {\n    todo\n}\n"
+---
+----- BEFORE ACTION
+import gleam/list
+
+pub fn main() {
+    list.map([1, 2, 3], op)
+                        ↑  
+}
+
+fn op(i: Int) -> Int {
+    todo
+}
+
+
+----- AFTER ACTION
+import gleam/list
+
+pub fn main() {
+    list.map([1, 2, 3], fn(int) { op(int) })
+}
+
+fn op(i: Int) -> Int {
+    todo
+}


### PR DESCRIPTION
I've had a go at implementing new code actions discussed in #4614, one to wrap a reference to a function in an anonymous function, and one to unwrap a trivial anonymous function into a bare reference.

These seemed pretty straightforward to implement so I'm a bit concerned I've missed a whole slew of edge cases. Any pointers as to more test cases I should add would be great

I know the issue was inconclusive about the names. These ones seemed straightforward but bikeshedding is welcome

Closes #4614 