### PR TITLE
Fix assert formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fixed a bug where the formatter would move a comment before `assert` to be
+  after it.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.12.0-rc1 - 2025-07-18
 
 ### Compiler

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2573,6 +2573,8 @@ impl<'comments> Formatter<'comments> {
     }
 
     fn assert<'a>(&mut self, assert: &'a UntypedAssert) -> Document<'a> {
+        let comments = self.pop_comments(assert.location.start);
+
         let expression = if assert.value.is_binop() || assert.value.is_pipeline() {
             self.expr(&assert.value).nest(INDENT)
         } else {
@@ -2580,7 +2582,7 @@ impl<'comments> Formatter<'comments> {
         };
 
         let doc = self.append_as_message(expression, assert.message.as_ref());
-        docvec!["assert ", doc]
+        commented(docvec!["assert ", doc], comments)
     }
 
     fn bit_array<'a>(

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6490,3 +6490,14 @@ fn assert_with_long_binary_expression() {
 "#
     );
 }
+
+#[test]
+fn comment_is_not_moved_after_assert() {
+    assert_format!(
+        "pub fn main() {
+  // Wibble!
+  assert True
+}
+"
+    );
+}


### PR DESCRIPTION
This PR fixes a small bug with the formatting of assert preceded by comments