### PR TITLE
Make sure CHANGELOG doesn't trigger CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: ci
 on:
   pull_request:
+    paths-ignore:
+      - "CHANGELOG.md"
   push:
     branches:
       - main


### PR DESCRIPTION
So when someone (me) forgets to update the changelog and have to push it, it won't trigger CI a second time