### PR TITLE
Fix formatting of `as` messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   after it.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the message following an `echo`, `panic`, `todo`, `assert`,
+  or `let assert` would not be formatted properly when preceded by a comment.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.12.0-rc1 - 2025-07-18
 
 ### Compiler

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6501,3 +6501,187 @@ fn comment_is_not_moved_after_assert() {
 "
     );
 }
+
+#[test]
+fn todo_as_with_comment() {
+    assert_format!(
+        r#"pub fn main() {
+  todo as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn todo_as_with_comment_on_the_same_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  todo as // A little comment explaining something
+    "wibble"
+}
+"#,
+        r#"pub fn main() {
+  todo as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn todo_as_with_comment_before_the_as() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  todo // A little comment explaining something
+    as "wibble"
+}
+"#,
+        r#"pub fn main() {
+  todo as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn panic_as_with_comment() {
+    assert_format!(
+        r#"pub fn main() {
+  panic as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn panic_as_with_comment_on_the_same_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  panic as // A little comment explaining something
+    "wibble"
+}
+"#,
+        r#"pub fn main() {
+  panic as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn panic_as_with_comment_before_the_as() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  panic // A little comment explaining something
+    as "wibble"
+}
+"#,
+        r#"pub fn main() {
+  panic as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn echo_as_with_comment() {
+    assert_format!(
+        r#"pub fn main() {
+  echo 1 as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn echo_as_with_comment_on_the_same_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  echo 1 as // A little comment explaining something
+    "wibble"
+}
+"#,
+        r#"pub fn main() {
+  echo 1 as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn echo_as_with_comment_before_the_as() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  echo 1 // A little comment explaining something
+    as "wibble"
+}
+"#,
+        r#"pub fn main() {
+  echo 1 as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn assert_as_with_comment() {
+    assert_format!(
+        r#"pub fn main() {
+  assert True as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn assert_as_with_comment_on_the_same_line() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  assert True as // A little comment explaining something
+    "wibble"
+}
+"#,
+        r#"pub fn main() {
+  assert True as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}
+
+#[test]
+fn assert_as_with_comment_before_the_as() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  assert True // A little comment explaining something
+    as "wibble"
+}
+"#,
+        r#"pub fn main() {
+  assert True as
+    // A little comment explaining something
+    "wibble"
+}
+"#
+    );
+}


### PR DESCRIPTION
This PR fixes a bug with the formatter where the formatting of `as` messages following `echo`, `panic`, `todo`, `assert` and `let assert` would not be nested properly when preceded by a comment.

Before:
```gleam
todo as
// Comment
"wibble"
```
After:
```gleam
todo as
  // Comment!
  "wibble"
```
