### PR TITLE
fix assert code generation bug on the JavaScript target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@
   or `let assert` would not be formatted properly when preceded by a comment.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would generate invalid code for an `assert`
+  using pipes on the JavaScript target.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.12.0-rc1 - 2025-07-18
 
 ### Compiler
@@ -360,7 +364,8 @@
 ### Build tool
 
 - `gleam update`, `gleam deps update`, and `gleam deps download` will now print
-  a message when there are new major versions of packages available. For example:
+  a message when there are new major versions of packages available. For
+  example:
 
   ```text
    $ gleam update
@@ -668,8 +673,8 @@
   properly.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- Fixed a bug where fields of custom types named `prototype` would not be properly
-  escaped on the JavaScript target.
+- Fixed a bug where fields of custom types named `prototype` would not be
+  properly escaped on the JavaScript target.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
 ## v1.11.1 - 2025-06-05

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -613,20 +613,21 @@ impl<'module, 'a> Generator<'module, 'a> {
     {
         // Save initial state
         let scope_position = std::mem::replace(&mut self.scope_position, Position::Tail);
+        let statement_level = std::mem::take(&mut self.statement_level);
 
         // Set state for in this iife
         let current_scope_vars = self.current_scope_vars.clone();
 
         // Generate the expression
         let result = to_doc(self, statements);
+        let doc = self.add_statement_level(result);
+        let doc = immediately_invoked_function_expression_document(doc);
 
         // Reset
         self.current_scope_vars = current_scope_vars;
         self.scope_position = scope_position;
+        self.statement_level = statement_level;
 
-        // Wrap in iife document
-        let doc =
-            immediately_invoked_function_expression_document(self.add_statement_level(result));
         self.wrap_return(doc)
     }
 

--- a/compiler-core/src/javascript/tests/assert.rs
+++ b/compiler-core/src/javascript/tests/assert.rs
@@ -187,3 +187,16 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn prova() {
+    assert_js!(
+        "
+pub fn main() {
+  assert Ok([]) == Ok([] |> id)
+}
+
+fn id(x) { x }
+"
+    )
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assert__prova.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assert__prova.snap
@@ -1,0 +1,51 @@
+---
+source: compiler-core/src/javascript/tests/assert.rs
+expression: "\npub fn main() {\n  assert Ok([]) == Ok([] |> id)\n}\n\nfn id(x) { x }\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  assert Ok([]) == Ok([] |> id)
+}
+
+fn id(x) { x }
+
+
+----- COMPILED JAVASCRIPT
+import { Ok, toList, makeError, isEqual } from "../gleam.mjs";
+
+const FILEPATH = "src/module.gleam";
+
+function id(x) {
+  return x;
+}
+
+export function main() {
+  let $ = new Ok(toList([]));
+  let $1 = new Ok(
+    (() => {
+      let _pipe = toList([]);
+      return id(_pipe);
+    })(),
+  );
+  if (!(isEqual($, $1))) {
+    throw makeError(
+      "assert",
+      FILEPATH,
+      "my/mod",
+      3,
+      "main",
+      "Assertion failed.",
+      {
+        kind: "binary_operator",
+        operator: "==",
+        left: { kind: "literal", value: $, start: 26, end: 32 },
+        right: { kind: "expression", value: $1, start: 36, end: 48 },
+        start: 19,
+        end: 48,
+        expression_start: 26
+      }
+    )
+  }
+  return undefined;
+}


### PR DESCRIPTION
This PR fixes #4802 

The compiler would generate invalid JavaScript code for `assert` statements that:
- compared two values using `==`, and
- the second value was a call
- whose argument was a pipeline expression