### PR TITLE
Improve "pattern match on value" code action to make it work on lists and more patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,53 @@
 
 ### Language server
 
+- The "pattern match on variable" can now be triggered on lists. For example:
+
+  ```gleam
+  pub fn is_empty(list: List(a)) -> Bool {
+    //            ^^^^ Triggering the action over here
+  }
+  ```
+
+  Triggering the action over the `list` argument would result in the following
+  code:
+
+  ```gleam
+  pub fn is_empty(list: List(a)) -> Bool {
+    case list {
+      [] -> todo
+      [first, ..rest] -> todo
+    }
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The "pattern match on variable" can now be triggered on variables introduced
+  by other patterns. For example:
+
+  ```gleam
+  pub fn main() {
+    let User(name:, role:) = find_user("lucy")
+    //              ^^^^ Triggering the action over
+  }
+  ```
+
+  Triggering the action over another variable like `role` would result in the
+  following code:
+
+  ```gleam
+  pub fn main() {
+    let User(name:, role:) = find_user("lucy")
+    case role {
+      Admin -> todo
+      Member -> todo
+    }
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server now offers a quick fix to remove `opaque` from a private
   type:
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -4664,6 +4664,14 @@ where
         match type_ {
             Type::Fn { .. } => None,
             Type::Var { type_ } => self.type_var_to_destructure_patterns(&type_.borrow()),
+
+            // We special case lists, they don't have "regular" constructors
+            // like other types. Instead we always add the two branches covering
+            // the empty and non empty list.
+            Type::Named { .. } if type_.is_list() => {
+                Some(vec1!["[]".into(), "[first, ..rest]".into()])
+            }
+
             Type::Named {
                 module: type_module,
                 name: type_name,

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -9162,3 +9162,14 @@ fn remove_opaque_from_private_type() {
         find_position_of("Wibble").to_selection()
     );
 }
+
+#[test]
+fn pattern_match_on_list_variable() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_ARGUMENT,
+        "pub fn main(a_list: List(a)) {
+  todo
+}",
+        find_position_of("a_list").to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -9185,7 +9185,7 @@ fn allow_further_pattern_matching_on_let_record_destructuring() {
 
 pub type Wibble { Wibble(field: Result(Nil, String)) }
 ",
-        find_position_of("one").to_selection()
+        find_position_of("field").to_selection()
     );
 }
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -9164,6 +9164,57 @@ fn remove_opaque_from_private_type() {
 }
 
 #[test]
+fn allow_further_pattern_matching_on_let_tuple_destructuring() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_VARIABLE,
+        "pub fn main(x) {
+  let #(one, other) = #(Ok(1), Error(Nil))
+}
+",
+        find_position_of("one").to_selection()
+    );
+}
+
+#[test]
+fn allow_further_pattern_matching_on_let_record_destructuring() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_VARIABLE,
+        "pub fn main(x) {
+  let Wibble(field:) = Wibble(Ok(Nil))
+}
+
+pub type Wibble { Wibble(field: Result(Nil, String)) }
+",
+        find_position_of("one").to_selection()
+    );
+}
+
+#[test]
+fn allow_further_pattern_matching_on_asserted_result() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_VARIABLE,
+        "pub fn main(x) {
+  let assert Ok(one) = Ok(Error(Nil))
+}
+",
+        find_position_of("one").to_selection()
+    );
+}
+
+#[test]
+fn allow_further_pattern_matching_on_asserted_list() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_VARIABLE,
+        "pub fn main(x) {
+  let assert [first, ..] = [Ok(Nil), ..todo]
+  todo
+}
+",
+        find_position_of("first").to_selection()
+    );
+}
+
+#[test]
 fn pattern_match_on_list_variable() {
     assert_code_action!(
         PATTERN_MATCH_ON_ARGUMENT,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_assert.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_assert.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main(x) {\n  let assert Ok(one) = Ok(Error(Nil))\n}\n"
+---
+----- BEFORE ACTION
+pub fn main(x) {
+  let assert Ok(one) = Ok(Error(Nil))
+                ↑                    
+}
+
+
+----- AFTER ACTION
+pub fn main(x) {
+  let assert Ok(one) = Ok(Error(Nil))
+  case one {
+    Ok(value) -> todo
+    Error(value) -> todo
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_asserted_list.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_asserted_list.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main(x) {\n  let assert [first, ..] = [Ok(Nil), ..todo]\n  todo\n}\n"
+---
+----- BEFORE ACTION
+pub fn main(x) {
+  let assert [first, ..] = [Ok(Nil), ..todo]
+              ↑                             
+  todo
+}
+
+
+----- AFTER ACTION
+pub fn main(x) {
+  let assert [first, ..] = [Ok(Nil), ..todo]
+  case first {
+    Ok(value) -> todo
+    Error(value) -> todo
+  }
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_asserted_result.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_asserted_result.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main(x) {\n  let assert Ok(one) = Ok(Error(Nil))\n}\n"
+---
+----- BEFORE ACTION
+pub fn main(x) {
+  let assert Ok(one) = Ok(Error(Nil))
+                ↑                    
+}
+
+
+----- AFTER ACTION
+pub fn main(x) {
+  let assert Ok(one) = Ok(Error(Nil))
+  case one {
+    Ok(value) -> todo
+    Error(value) -> todo
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_let_record_destructuring.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_let_record_destructuring.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main(x) {\n  let Wibble(field:) = Wibble(Ok(Nil))\n}\n\npub type Wibble { Wibble(field: Result(Nil, String)) }\n"
+---
+----- BEFORE ACTION
+pub fn main(x) {
+  let Wibble(field:) = Wibble(Ok(Nil))
+             ↑                        
+}
+
+pub type Wibble { Wibble(field: Result(Nil, String)) }
+
+
+----- AFTER ACTION
+pub fn main(x) {
+  let Wibble(field:) = Wibble(Ok(Nil))
+  case field {
+    Ok(value) -> todo
+    Error(value) -> todo
+  }
+}
+
+pub type Wibble { Wibble(field: Result(Nil, String)) }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_let_tuple_destructuring.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__allow_further_pattern_matching_on_let_tuple_destructuring.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main(x) {\n  let #(one, other) = #(Ok(1), Error(Nil))\n}\n"
+---
+----- BEFORE ACTION
+pub fn main(x) {
+  let #(one, other) = #(Ok(1), Error(Nil))
+        ↑                                 
+}
+
+
+----- AFTER ACTION
+pub fn main(x) {
+  let #(one, other) = #(Ok(1), Error(Nil))
+  case one {
+    Ok(value) -> todo
+    Error(value) -> todo
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__pattern_match_on_list_variable.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__pattern_match_on_list_variable.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn main(a_list: List(a)) {\n  todo\n}"
+---
+----- BEFORE ACTION
+pub fn main(a_list: List(a)) {
+            ↑                 
+  todo
+}
+
+
+----- AFTER ACTION
+pub fn main(a_list: List(a)) {
+  case a_list {
+    [] -> todo
+    [first, ..rest] -> todo
+  }
+  todo
+}

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -320,6 +320,14 @@ impl Type {
         }
     }
 
+    pub fn is_list(&self) -> bool {
+        match self {
+            Self::Named { module, name, .. } if "List" == name && is_prelude_module(module) => true,
+            Self::Var { type_ } => type_.borrow().is_list(),
+            _ => false,
+        }
+    }
+
     pub fn named_type_name(&self) -> Option<(EcoString, EcoString)> {
         match self {
             Self::Named { module, name, .. } => Some((module.clone(), name.clone())),
@@ -1236,6 +1244,13 @@ impl TypeVar {
         match self {
             Self::Link { type_ } => type_.is_result(),
             Self::Unbound { .. } | Self::Generic { .. } => false,
+        }
+    }
+
+    pub fn is_list(&self) -> bool {
+        match self {
+            TypeVar::Link { type_ } => type_.is_list(),
+            TypeVar::Unbound { .. } | TypeVar::Generic { .. } => false,
         }
     }
 


### PR DESCRIPTION
With this PR the "pattern match on value/argument" code action:
- now works on lists, generating the patterns for the empty and non empty list
- now works on variables inside other destructuring patterns

Here's a little example of what is now possible!

https://github.com/user-attachments/assets/9337831a-fcc6-478c-8917-76b51ed57ee4

Fixes #4806 
Fixes #4807 
