### PR TITLE
Add suggestions for variables with the same name in imported modules when unknown variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 ### Compiler
 
+- The compiler now suggest public values from imported modules when the variable
+  in unknown. These values are suggested based on name and arity.
+
+  Considering this program:
+
+  ```gleam
+  import gleam/io
+
+  pub fn main() -> Nil {
+    println("Hello, World!")
+  }
+  ```
+
+  The compiler will display this error message:
+  ```text
+    error: Unknown variable
+    ┌─ /path/to/project/src/project.gleam:4:3
+    │
+  4 │   println("Hello, World!")
+    │   ^^^^^^^
+
+  The name `println` is not in scope here.
+  Did you mean one of these:
+
+      - io.println
+  ```
+
+  ([raphrous](https://github.com/realraphrous))
+
 - The inference of record update expressions is now more fault tolerant: if
   there's an error in the record being updated, the compiler can still able to
   analyse the fields that are being provided.

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -87,14 +87,14 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         let imported_name = import.as_name.as_ref().unwrap_or(&import.name);
 
         // Register the unqualified import if it is a type constructor
-        let Some(type_info) = module.get_public_type(&import.name) else {
+        let Some(type_info) = module.get_importable_type(&import.name) else {
             // TODO: refine to a type specific error
             self.problems.error(Error::UnknownModuleType {
                 location: import.location,
                 name: import.name.clone(),
                 module_name: module.name.clone(),
                 type_constructors: module.public_type_names(),
-                value_with_same_name: module.get_public_value(&import.name).is_some(),
+                value_with_same_name: module.get_importable_value(&import.name).is_some(),
             });
             return;
         };
@@ -143,7 +143,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         let used_name = import.as_name.as_ref().unwrap_or(&import.name);
 
         // Register the unqualified import if it is a value
-        let variant = match module.get_public_value(import_name) {
+        let variant = match module.get_importable_value(import_name) {
             Some(value) => {
                 let implementations = value.variant.implementations();
                 // Check the target support of the imported value
@@ -171,7 +171,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                     name: import_name.clone(),
                     module_name: module.name.clone(),
                     value_constructors: module.public_value_names(),
-                    type_with_same_name: module.get_public_type(import_name).is_some(),
+                    type_with_same_name: module.get_importable_type(import_name).is_some(),
                     context: crate::type_::error::ModuleValueUsageContext::UnqualifiedImport,
                 });
                 return;

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -627,7 +627,7 @@ fn type_to_definition_locations<'a>(
                 return vec![];
             };
 
-            let Some(type_) = module.get_public_type(&name) else {
+            let Some(type_) = module.get_importable_type(&name) else {
                 return vec![];
             };
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3320,6 +3320,7 @@ but no type in scope with that name."
             discarded_location,
             name,
             type_with_name_in_scope,
+            possible_modules,
         } => {
             let title = String::from("Unknown variable");
 
@@ -3352,17 +3353,24 @@ but no type in scope with that name."
                 let text = if *type_with_name_in_scope {
                     wrap_format!("`{name}` is a type, it cannot be used as a value.")
                 } else {
-                    let is_first_char_uppercase =
-                        name.chars().next().is_some_and(char::is_uppercase);
-
-                    if is_first_char_uppercase {
+                    let mut text = if name.starts_with(char::is_uppercase) {
                         wrap_format!(
-                            "The custom type variant constructor \
-`{name}` is not in scope here."
+                            "The custom type variant constructor `{name}` is not in scope here."
                         )
                     } else {
                         wrap_format!("The name `{name}` is not in scope here.")
+                    };
+
+                    // If there are some suggestions about public values in imported
+                    // modules put a "did you mean" text after the main message
+                    if !possible_modules.is_empty() {
+                        text.push_str("\nDid you mean one of these:\n\n");
+                        for module_name in possible_modules {
+                            text.push_str(&format!("  - {module_name}.{name}\n"))
+                        }
                     }
+
+                    text
                 };
 
                 Diagnostic {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1105,7 +1105,42 @@ pub struct TypeValueConstructorField {
 }
 
 impl ModuleInterface {
+    /// Search for a public value that matches the given `name`
+    ///
     pub fn get_public_value(&self, name: &str) -> Option<&ValueConstructor> {
+        let value = self.values.get(name)?;
+        if value.publicity.is_public() {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    /// Search for a public value that matches the given `name` and `arity`
+    ///
+    pub fn get_public_function(&self, name: &str, arity: usize) -> Option<&ValueConstructor> {
+        self.get_public_value(name).filter(|value_constructor| {
+            match value_constructor.type_.fn_types() {
+                Some((fn_arguments_type, _)) => fn_arguments_type.len() == arity,
+                None => false,
+            }
+        })
+    }
+
+    /// Search for an importable type that matches the given `name`
+    ///
+    pub fn get_public_type(&self, name: &str) -> Option<&TypeConstructor> {
+        let type_ = self.types.get(name)?;
+        if type_.publicity.is_public() {
+            Some(type_)
+        } else {
+            None
+        }
+    }
+
+    /// Search for an importable value that matches the given `name`
+    ///
+    pub fn get_importable_value(&self, name: &str) -> Option<&ValueConstructor> {
         let value = self.values.get(name)?;
         if value.publicity.is_importable() {
             Some(value)
@@ -1114,7 +1149,20 @@ impl ModuleInterface {
         }
     }
 
-    pub fn get_public_type(&self, name: &str) -> Option<&TypeConstructor> {
+    /// Search for an importable function that matches the given `name` and `arity`
+    ///
+    pub fn get_importable_function(&self, name: &str, arity: usize) -> Option<&ValueConstructor> {
+        self.get_importable_value(name).filter(|value_constructor| {
+            match value_constructor.type_.fn_types() {
+                Some((fn_arguments_type, _)) => fn_arguments_type.len() == arity,
+                None => false,
+            }
+        })
+    }
+
+    /// Search for an importable type that matches the given `name`
+    ///
+    pub fn get_importable_type(&self, name: &str) -> Option<&TypeConstructor> {
         let type_ = self.types.get(name)?;
         if type_.publicity.is_importable() {
             Some(type_)
@@ -1701,6 +1749,15 @@ pub enum FieldAccessUsage {
     ///
     RecordUpdate,
     /// Used as `thing.field`
+    Other,
+}
+
+/// This is used to know when a value is used as a call or not.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ValueUsage {
+    /// Used as `function(..)`, `Record(..)`, `left |> right` or `left |> right(..)`
+    Call { arity: usize },
+    /// Used as `variable`
     Other,
 }
 

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -468,7 +468,7 @@ impl Environment<'_> {
                 })?;
                 self.references
                     .register_module_reference(module_name.clone());
-                module.get_public_type(name).ok_or_else(|| {
+                module.get_importable_type(name).ok_or_else(|| {
                     UnknownTypeConstructorError::ModuleType {
                         name: name.clone(),
                         module_name: module.name.clone(),
@@ -534,14 +534,15 @@ impl Environment<'_> {
         name: &EcoString,
     ) -> Result<&ValueConstructor, UnknownValueConstructorError> {
         match module {
-            None => self.scope.get(name).ok_or_else(|| {
-                let type_with_name_in_scope = self.module_types.keys().any(|type_| type_ == name);
-                UnknownValueConstructorError::Variable {
+            None => self
+                .scope
+                .get(name)
+                .ok_or_else(|| UnknownValueConstructorError::Variable {
                     name: name.clone(),
                     variables: self.local_value_names(),
-                    type_with_name_in_scope,
-                }
-            }),
+                    type_with_name_in_scope: self.module_types.contains_key(name),
+                    possible_modules: self.get_possible_modules_with_value(name),
+                }),
 
             Some(module_name) => {
                 let (_, module) = self.imported_modules.get(module_name).ok_or_else(|| {
@@ -553,7 +554,7 @@ impl Environment<'_> {
                 })?;
                 self.references
                     .register_module_reference(module_name.clone());
-                module.get_public_value(name).ok_or_else(|| {
+                module.get_importable_value(name).ok_or_else(|| {
                     UnknownValueConstructorError::ModuleValue {
                         name: name.clone(),
                         module_name: module.name.clone(),
@@ -563,6 +564,46 @@ impl Environment<'_> {
                 })
             }
         }
+    }
+
+    /// Get the name of modules with a value that can be suggested and matches
+    /// the given `name`
+    ///
+    pub fn get_possible_modules_with_value(&self, name: &EcoString) -> Vec<EcoString> {
+        self.imported_modules
+            .iter()
+            .filter_map(|(module_name, (_, module))| {
+                if module.package == self.current_package {
+                    module.get_importable_value(name).map(|_| module_name)
+                } else {
+                    module.get_public_value(name).map(|_| module_name)
+                }
+            })
+            .cloned()
+            .collect_vec()
+    }
+
+    /// Get the name of modules with a function that can be suggested and
+    /// matches the given `name` and `arity`
+    ///
+    pub fn get_possible_modules_with_function(
+        &self,
+        name: &EcoString,
+        arity: usize,
+    ) -> Vec<EcoString> {
+        self.imported_modules
+            .iter()
+            .filter_map(|(module_name, (_, module))| {
+                if module.package == self.current_package {
+                    module
+                        .get_importable_function(name, arity)
+                        .map(|_| module_name)
+                } else {
+                    module.get_public_function(name, arity).map(|_| module_name)
+                }
+            })
+            .cloned()
+            .collect_vec()
     }
 
     pub fn get_type_variants_fields(
@@ -591,7 +632,7 @@ impl Environment<'_> {
             self.scope.get(&variant.name)
         } else {
             let (_, module) = self.imported_modules.get(module)?;
-            module.get_public_value(&variant.name)
+            module.get_importable_value(&variant.name)
         }
     }
 

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -166,6 +166,9 @@ pub enum Error {
         /// this will contain its location.
         discarded_location: Option<SrcSpan>,
         type_with_name_in_scope: bool,
+        /// Filled with the name of imported modules when the module has public value
+        /// with the same name as this variable
+        possible_modules: Vec<EcoString>,
     },
 
     UnknownType {
@@ -1456,6 +1459,7 @@ pub enum UnknownValueConstructorError {
         name: EcoString,
         variables: Vec<EcoString>,
         type_with_name_in_scope: bool,
+        possible_modules: Vec<EcoString>,
     },
 
     Module {
@@ -1481,12 +1485,14 @@ pub fn convert_get_value_constructor_error(
             name,
             variables,
             type_with_name_in_scope,
+            possible_modules,
         } => Error::UnknownVariable {
             location,
             name,
             variables,
             discarded_location: None,
             type_with_name_in_scope,
+            possible_modules,
         },
 
         UnknownValueConstructorError::Module { name, suggestions } => Error::UnknownModule {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -427,9 +427,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 message,
             } => Ok(self.infer_echo(location, keyword_end, expression, message)),
 
-            UntypedExpr::Var { location, name, .. } => {
-                self.infer_var(name, location, ReferenceRegistration::Register)
-            }
+            UntypedExpr::Var { location, name, .. } => self.infer_var(
+                name,
+                location,
+                ValueUsage::Other,
+                ReferenceRegistration::Register,
+            ),
 
             UntypedExpr::Int {
                 location,
@@ -856,6 +859,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // We use `stacker` to prevent overflowing the stack when many `use`
         // expressions are chained. See https://github.com/gleam-lang/gleam/issues/4287
         let infer_call = || {
+            // We need this in the case where `call.function` has a special call path depending
+            // on the type such as `UntypedExpr::Var`. In these cases, `infer_call` does not call
+            // `infer_or_error`. `infer_or_error` is responsible for registering warnings about
+            // unreachable code and thus, warnings about unreachable code are not registered.
+            if self.previous_panics {
+                self.warn_for_unreachable_code(call_location, PanicPosition::PreviousExpression);
+            }
+
             self.infer_call(
                 *call.function,
                 call.arguments,
@@ -1283,10 +1294,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         name: EcoString,
         location: SrcSpan,
+        value_usage: ValueUsage,
         register_reference: ReferenceRegistration,
     ) -> Result<TypedExpr, Error> {
-        let constructor =
-            self.do_infer_value_constructor(&None, &name, &location, register_reference)?;
+        let constructor = self.do_infer_value_constructor(
+            &None,
+            &name,
+            &location,
+            value_usage,
+            register_reference,
+        )?;
         self.narrow_implementations(location, &constructor.variant)?;
         Ok(TypedExpr::Var {
             constructor,
@@ -1372,7 +1389,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             // If the left-hand-side of the record access is a variable, this might actually be
             // module access. In that case, we only want to register a reference to the variable
             // if we actually referencing it in the record access.
-            self.infer_var(name, location, ReferenceRegistration::DoNotRegister)
+            self.infer_var(
+                name,
+                location,
+                ValueUsage::Other,
+                ReferenceRegistration::DoNotRegister,
+            )
         } else {
             self.infer_or_error(container)
         };
@@ -2483,7 +2505,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     fn infer_clause_guard(&mut self, guard: UntypedClauseGuard) -> Result<TypedClauseGuard, Error> {
         match guard {
             ClauseGuard::Var { location, name, .. } => {
-                let constructor = self.infer_value_constructor(&None, &name, &location)?;
+                let constructor =
+                    self.infer_value_constructor(&None, &name, &location, ValueUsage::Other)?;
 
                 // We cannot support all values in guard expressions as the BEAM does not
                 let (definition_location, origin) = match &constructor.variant {
@@ -2803,13 +2826,13 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             let constructor =
                 module
-                    .get_public_value(&label)
+                    .get_importable_value(&label)
                     .ok_or_else(|| Error::UnknownModuleValue {
                         name: label.clone(),
                         location: select_location,
                         module_name: module.name.clone(),
                         value_constructors: module.public_value_names(),
-                        type_with_same_name: module.get_public_type(&label).is_some(),
+                        type_with_same_name: module.get_importable_type(&label).is_some(),
                         context: ModuleValueUsageContext::ModuleAccess,
                     })?;
 
@@ -3516,8 +3539,15 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         module: &Option<(EcoString, SrcSpan)>,
         name: &EcoString,
         location: &SrcSpan,
+        value_usage: ValueUsage,
     ) -> Result<ValueConstructor, Error> {
-        self.do_infer_value_constructor(module, name, location, ReferenceRegistration::Register)
+        self.do_infer_value_constructor(
+            module,
+            name,
+            location,
+            value_usage,
+            ReferenceRegistration::Register,
+        )
     }
 
     fn do_infer_value_constructor(
@@ -3525,6 +3555,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         module: &Option<(EcoString, SrcSpan)>,
         name: &EcoString,
         location: &SrcSpan,
+        value_usage: ValueUsage,
         register_reference: ReferenceRegistration,
     ) -> Result<ValueConstructor, Error> {
         let constructor = match module {
@@ -3533,7 +3564,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .environment
                 .get_variable(name)
                 .cloned()
-                .ok_or_else(|| self.report_name_error(name, location))?,
+                .ok_or_else(|| self.report_name_error(name, location, value_usage))?,
 
             // Look in an imported module for a binding with this name
             Some((module_name, module_location)) => {
@@ -3562,7 +3593,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         module_name: module_name.clone(),
                         name: name.clone(),
                         value_constructors: module.public_value_names(),
-                        type_with_same_name: module.get_public_type(name).is_some(),
+                        type_with_same_name: module.get_importable_type(name).is_some(),
                         context: ModuleValueUsageContext::ModuleAccess,
                     })?
             }
@@ -3700,7 +3731,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         }
     }
 
-    fn report_name_error(&mut self, name: &EcoString, location: &SrcSpan) -> Error {
+    fn report_name_error(
+        &mut self,
+        name: &EcoString,
+        location: &SrcSpan,
+        value_usage: ValueUsage,
+    ) -> Error {
         // First try to see if this is a module alias:
         // `import gleam/io`
         // `io.debug(io)`
@@ -3711,21 +3747,35 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location: *location,
                 name: name.clone(),
             },
-            None => Error::UnknownVariable {
-                location: *location,
-                name: name.clone(),
-                variables: self.environment.local_value_names(),
-                discarded_location: self
-                    .environment
-                    .discarded_names
-                    .get(&eco_format!("_{name}"))
-                    .cloned(),
-                type_with_name_in_scope: self
-                    .environment
-                    .module_types
-                    .keys()
-                    .any(|typ| typ == name),
-            },
+            None => {
+                let possible_modules = match value_usage {
+                    // This is a function call, we need to suggest a public
+                    // value which is a function with the correct arity
+                    ValueUsage::Call { arity } => self
+                        .environment
+                        .get_possible_modules_with_function(name, arity),
+                    // This is a reference to a variable, we need to suggest
+                    // a public value of any type
+                    ValueUsage::Other => self.environment.get_possible_modules_with_value(name),
+                };
+
+                Error::UnknownVariable {
+                    location: *location,
+                    name: name.clone(),
+                    variables: self.environment.local_value_names(),
+                    discarded_location: self
+                        .environment
+                        .discarded_names
+                        .get(&eco_format!("_{name}"))
+                        .cloned(),
+                    type_with_name_in_scope: self
+                        .environment
+                        .module_types
+                        .keys()
+                        .any(|typ| typ == name),
+                    possible_modules,
+                }
+            }
         }
     }
 
@@ -3802,8 +3852,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 self.track_feature_usage(FeatureKind::ConstantRecordUpdate, location);
                 let first_argument_start =
                     arguments.first().map(|argument| argument.location.start);
-
-                let constructor = match self.infer_value_constructor(&module, &name, &location) {
+                let constructor = match self.infer_value_constructor(
+                    &module,
+                    &name,
+                    &location,
+                    ValueUsage::Call {
+                        arity: arguments.len(),
+                    },
+                ) {
                     Ok(constructor) => constructor,
                     Err(error) => {
                         self.problems.error(error);
@@ -4046,7 +4102,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 ..
             } if arguments.is_empty() => {
                 // Type check the record constructor
-                let constructor = match self.infer_value_constructor(&module, &name, &location) {
+                let constructor = match self.infer_value_constructor(
+                    &module,
+                    &name,
+                    &location,
+                    ValueUsage::Other,
+                ) {
                     Ok(constructor) => constructor,
                     Err(error) => {
                         self.problems.error(error);
@@ -4097,7 +4158,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 mut arguments,
                 ..
             } => {
-                let constructor = match self.infer_value_constructor(&module, &name, &location) {
+                let constructor = match self.infer_value_constructor(
+                    &module,
+                    &name,
+                    &location,
+                    ValueUsage::Call {
+                        arity: arguments.len(),
+                    },
+                ) {
                     Ok(constructor) => constructor,
                     Err(error) => {
                         self.problems.error(error);
@@ -4282,7 +4350,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 ..
             } => {
                 // Infer the type of this constant
-                let constructor = match self.infer_value_constructor(&module, &name, &location) {
+                let constructor = match self.infer_value_constructor(
+                    &module,
+                    &name,
+                    &location,
+                    ValueUsage::Other,
+                ) {
                     Ok(constructor) => constructor,
                     Err(error) => {
                         self.problems.error(error);
@@ -4532,6 +4605,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         kind: CallKind,
     ) -> (TypedExpr, Vec<TypedCallArg>, Arc<Type>) {
         let fun = match fun {
+            UntypedExpr::Var { location, name } => {
+                self.infer_called_var(name, location, arguments.len())
+            }
+
             UntypedExpr::FieldAccess {
                 label,
                 container,
@@ -4565,7 +4642,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             | UntypedExpr::Float { .. }
             | UntypedExpr::String { .. }
             | UntypedExpr::Block { .. }
-            | UntypedExpr::Var { .. }
             | UntypedExpr::Fn { .. }
             | UntypedExpr::List { .. }
             | UntypedExpr::Call { .. }
@@ -4586,6 +4662,38 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let (fun, arguments, type_) =
             self.do_infer_call_with_known_fun(fun, arguments, location, kind);
         (fun, arguments, type_)
+    }
+
+    /// Return the type of a called variable.
+    ///
+    /// This function is used everywhere we try to infer the type of a variable
+    /// that is called such as function calls, records constructor, use
+    /// expression and pipelines.
+    ///
+    pub fn infer_called_var(
+        &mut self,
+        name: EcoString,
+        location: SrcSpan,
+        arity: usize,
+    ) -> TypedExpr {
+        match self.infer_var(
+            name.clone(),
+            location,
+            ValueUsage::Call { arity },
+            ReferenceRegistration::Register,
+        ) {
+            Ok(typed_expr) => typed_expr,
+            Err(error) => {
+                let information = if let Error::UnknownVariable { name, .. } = &error {
+                    Some(InvalidExpression::UnknownVariable { name: name.clone() })
+                } else {
+                    None
+                };
+
+                self.problems.error(error);
+                self.error_expr_with_information(location, information)
+            }
+        }
     }
 
     fn infer_fn_with_call_context(
@@ -4952,7 +5060,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             ReferenceRegistration::Register
         };
 
-        match self.infer_var(argument_name.clone(), argument_location, references) {
+        match self.infer_var(
+            argument_name.clone(),
+            argument_location,
+            ValueUsage::Other,
+            references,
+        ) {
             Ok(result) => result,
             Err(error) => {
                 self.problems.error(error);

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -1381,6 +1381,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                     .module_types
                                     .keys()
                                     .any(|type_| type_ == &name),
+                                possible_modules: self
+                                    .environment
+                                    .get_possible_modules_with_value(&name),
                             });
                         }
                     },

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -132,7 +132,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                     location,
                     ..
                 } => {
-                    let fun = self.expr_typer.infer(*fun);
+                    let fun = self.infer_called(*fun, arguments.len() + 1);
 
                     match fun.type_().fn_types() {
                         // Rewrite as right(..args)(left)
@@ -357,7 +357,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
     /// b is the `function` argument.
     fn infer_apply_pipe(&mut self, function: UntypedExpr) -> TypedExpr {
         let function_location = function.location();
-        let function = Box::new(self.expr_typer.infer(function));
+        let function = Box::new(self.infer_called(function, 1));
 
         self.expr_typer.purity = self
             .expr_typer
@@ -389,6 +389,36 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             fun: function,
             arguments: vec![self.typed_left_hand_value_variable_call_argument()],
             open_parenthesis: None,
+        }
+    }
+
+    fn infer_called(&mut self, function: UntypedExpr, arity: usize) -> TypedExpr {
+        match function {
+            // If the function is used as a variable, then we can suggest values
+            // from imported modules with the same name and same arity.
+            UntypedExpr::Var { location, name } => {
+                self.expr_typer.infer_called_var(name, location, arity)
+            }
+            UntypedExpr::Int { .. }
+            | UntypedExpr::Float { .. }
+            | UntypedExpr::String { .. }
+            | UntypedExpr::Block { .. }
+            | UntypedExpr::Fn { .. }
+            | UntypedExpr::List { .. }
+            | UntypedExpr::Call { .. }
+            | UntypedExpr::BinOp { .. }
+            | UntypedExpr::PipeLine { .. }
+            | UntypedExpr::Case { .. }
+            | UntypedExpr::FieldAccess { .. }
+            | UntypedExpr::Tuple { .. }
+            | UntypedExpr::TupleIndex { .. }
+            | UntypedExpr::Todo { .. }
+            | UntypedExpr::Panic { .. }
+            | UntypedExpr::Echo { .. }
+            | UntypedExpr::BitArray { .. }
+            | UntypedExpr::RecordUpdate { .. }
+            | UntypedExpr::NegateBool { .. }
+            | UntypedExpr::NegateInt { .. } => self.expr_typer.infer(function),
         }
     }
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -2908,7 +2908,7 @@ fn infer_label_shorthand_in_record_update_arg() {
 #[test]
 fn public_type_from_internal_module_has_internal_publicity() {
     let module = compile_module("thepackage/internal", "pub type Wibble", None, vec![]).unwrap();
-    let type_ = module.type_info.get_public_type("Wibble").unwrap();
+    let type_ = module.type_info.get_importable_type("Wibble").unwrap();
     assert!(type_.publicity.is_internal());
 }
 
@@ -2921,14 +2921,14 @@ fn internal_type_from_internal_module_has_internal_publicity() {
         vec![],
     )
     .unwrap();
-    let type_ = module.type_info.get_public_type("Wibble").unwrap();
+    let type_ = module.type_info.get_importable_type("Wibble").unwrap();
     assert!(type_.publicity.is_internal());
 }
 
 #[test]
 fn private_type_from_internal_module_is_not_exposed_as_internal() {
     let module = compile_module("thepackage/internal", "type Wibble", None, vec![]).unwrap();
-    assert!(module.type_info.get_public_type("Wibble").is_none());
+    assert!(module.type_info.get_importable_type("Wibble").is_none());
 }
 
 #[test]

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3648,3 +3648,559 @@ pub const wibble = todo as message
 "#
     );
 }
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_from_another_package_with_internal_function() {
+    assert_module_error!(
+        (
+            "anotherpackage",
+            "module",
+            "
+@internal
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Internal function from another modules in another package should not be
+// suggested.
+
+import module
+pub fn main() {
+        add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_from_another_package_with_internal_record_constructor() {
+    assert_module_error!(
+        (
+            "anotherpackage",
+            "module",
+            "
+@internal
+pub type MyType {
+    MyRecord(x: Int, y: Int)
+}"
+        ),
+        "
+// Internal record constructor from another modules in another package should
+// not be suggested.
+
+import module
+pub fn main() {
+    MyRecord(1, 2)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_from_another_package_with_internal_type() {
+    assert_module_error!(
+        (
+            "anotherpackage",
+            "module",
+            "
+@internal
+pub type OneOrTwo {
+    One
+    Two
+}"
+        ),
+        "
+// Internal type from another modules in another package should not be
+// suggested.
+
+import module
+pub fn main() {
+    One
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_from_another_package_with_internal_value() {
+    assert_module_error!(
+        (
+            "anotherpackage",
+            "module",
+            "
+@internal
+pub const one = 1"
+        ),
+        "
+// Internal value from another modules in another package should not be
+// suggested.
+
+import module
+pub fn main() {
+    one
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_with_private_function() {
+    assert_module_error!(
+        (
+            "module",
+            "
+fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Private function from another module should not be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_with_private_record_constructor() {
+    assert_module_error!(
+        (
+            "module",
+            "
+type MyType {
+    MyRecord(x: Int)
+}"
+        ),
+        "
+// Private record constructor from another module should not be suggested.
+
+import module
+pub fn main() {
+    MyRecord(1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_with_private_type() {
+    assert_module_error!(
+        (
+            "module",
+            "
+type OneOrTwo {
+    One
+    Two
+}"
+        ),
+        "
+// Private type from another module should not be suggested.
+
+import module
+pub fn main() {
+    One
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_with_private_value() {
+    assert_module_error!(
+        (
+            "module",
+            "
+const one = 1"
+        ),
+        "
+// Private value from another module should not be suggested.
+
+import module
+pub fn main() {
+    one
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_1() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Int) {
+    x + 1
+}"
+        ),
+        "
+// For functions, we only check the arity and not the type of arguments or the
+// return value.
+// Function with incorrect arity from another module should not be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_2() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Int) {
+    fn(y: Int) { x + y }
+}"
+        ),
+        "
+// For functions, we only check the arity and not the type of arguments or the
+// return value.
+// In pipelines, function calls are considered to have arity arguments.len() + 1.
+// Function with incorrect arity from another module should not be suggested.
+
+import module
+pub fn main() {
+    1 |> add(2)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_3() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Int) {
+    fn(y: Int, z: Int) { x + y + z }
+}"
+        ),
+        "
+// For functions, we only check the arity and not the type of arguments or the
+// return value.
+// In pipelines, function calls are considered to have arity arguments.len() + 1.
+// Function with incorrect arity from another module should not be suggested.
+
+import module
+pub fn main() {
+    1 |> add(2)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_from_the_same_package_with_internal_function() {
+    assert_module_error!(
+        (
+            "module",
+            "
+@internal
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Internal function with correct arity from another module in the same package
+// should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_from_the_same_package_with_internal_record_constructor() {
+    assert_module_error!(
+        (
+            "module",
+            "
+@internal
+pub type MyType {
+    MyRecord(x: Int, y: Int)
+}"
+        ),
+        "
+// Internal record constructor with correct arity from another module in the
+// same package should be suggested.
+
+import module
+pub fn main() {
+    MyRecord(1, 2)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_from_the_same_package_with_internal_type() {
+    assert_module_error!(
+        (
+            "module",
+            "
+@internal
+pub type OneOrTwo {
+    One
+    Two
+}"
+        ),
+        "
+// Internal type from another module in the same package should be suggested.
+
+import module
+pub fn main() {
+    One
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_from_the_same_package_with_internal_value() {
+    assert_module_error!(
+        (
+            "module",
+            "
+@internal
+pub const one = 1"
+        ),
+        "
+// Internal value from another module in the same package should be suggested.
+
+import module
+pub fn main() {
+    one
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_imported_using_an_alias() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Module aliases should be taken into account in the suggestion.
+// Public function with correct arity from another module should be suggested.
+
+import module as wibble
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_multiple_segments() {
+    assert_module_error!(
+        (
+            "gleam/module",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Module with multiple segments should be taken into account in the suggestion.
+// Public function with correct arity from another module should be suggested.
+
+import gleam/module
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_function_with_correct_arity_1() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_function_with_correct_arity_2() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Int) {
+    x + 1
+}"
+        ),
+        "
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    1 |> add
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_function_with_correct_arity_3() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    1 |> add(2)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_function_with_correct_arity_4() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn wibble(_) {
+    1
+}"
+        ),
+        "
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    use <- wibble
+    1
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_function_with_correct_arity_even_if_arguments_type_mismatch()
+ {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub fn add(x: Float, y: Float) {
+    x +. y
+}"
+        ),
+        "
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_record_constructor_with_correct_arity() {
+    assert_module_error!(
+        (
+            "moduleone",
+            "
+pub type MyType {
+    MyRecord(x: Int, y: Int)
+}"
+        ),
+        (
+            "moduletwo",
+            "
+pub type AnotherType {
+    MyRecord(x: Int)
+}"
+        ),
+        "
+// Public record constructor with correct arity from another module should be
+// suggested.
+
+import moduleone
+import moduletwo
+pub fn main() {
+    MyRecord(1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_type() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub type OneOrTwo {
+    One
+    Two
+}"
+        ),
+        "
+// Public type from another module should be suggested.
+
+import module
+pub fn main() {
+    One
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_value_1() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub const one = 1"
+        ),
+        "
+// Public value from another module should be suggested.
+
+import module
+pub fn main() {
+    one
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_modules_with_public_value_2() {
+    assert_module_error!(
+        (
+            "module",
+            "
+pub const add = private_add
+fn private_add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// Public value from another module should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -35,3 +35,6 @@ error: Unknown variable
   │                                  ^^^
 
 The name `zoo` is not in scope here.
+Did you mean one of these:
+
+  - wibble.zoo

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_function.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal function from another modules in another package should not be\n// suggested.\n\nimport module\npub fn main() {\n        add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Internal function from another modules in another package should not be
+// suggested.
+
+import module
+pub fn main() {
+        add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:9
+  │
+7 │         add(1, 1)
+  │         ^^^
+
+The name `add` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_record_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_record_constructor.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal record constructor from another modules in another package should\n// not be suggested.\n\nimport module\npub fn main() {\n    MyRecord(1, 2)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub type MyType {
+    MyRecord(x: Int, y: Int)
+}
+
+-- main.gleam
+
+// Internal record constructor from another modules in another package should
+// not be suggested.
+
+import module
+pub fn main() {
+    MyRecord(1, 2)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     MyRecord(1, 2)
+  │     ^^^^^^^^
+
+The custom type variant constructor `MyRecord` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_type.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal type from another modules in another package should not be\n// suggested.\n\nimport module\npub fn main() {\n    One\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub type OneOrTwo {
+    One
+    Two
+}
+
+-- main.gleam
+
+// Internal type from another modules in another package should not be
+// suggested.
+
+import module
+pub fn main() {
+    One
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     One
+  │     ^^^
+
+The custom type variant constructor `One` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_from_another_package_with_internal_value.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal value from another modules in another package should not be\n// suggested.\n\nimport module\npub fn main() {\n    one\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub const one = 1
+
+-- main.gleam
+
+// Internal value from another modules in another package should not be
+// suggested.
+
+import module
+pub fn main() {
+    one
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     one
+  │     ^^^
+
+The name `one` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_function.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Private function from another module should not be suggested.\n\nimport module\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Private function from another module should not be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_record_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_record_constructor.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Private record constructor from another module should not be suggested.\n\nimport module\npub fn main() {\n    MyRecord(1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+type MyType {
+    MyRecord(x: Int)
+}
+
+-- main.gleam
+
+// Private record constructor from another module should not be suggested.
+
+import module
+pub fn main() {
+    MyRecord(1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     MyRecord(1)
+  │     ^^^^^^^^
+
+The custom type variant constructor `MyRecord` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_type.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Private type from another module should not be suggested.\n\nimport module\npub fn main() {\n    One\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+type OneOrTwo {
+    One
+    Two
+}
+
+-- main.gleam
+
+// Private type from another module should not be suggested.
+
+import module
+pub fn main() {
+    One
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     One
+  │     ^^^
+
+The custom type variant constructor `One` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_private_value.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Private value from another module should not be suggested.\n\nimport module\npub fn main() {\n    one\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+const one = 1
+
+-- main.gleam
+
+// Private value from another module should not be suggested.
+
+import module
+pub fn main() {
+    one
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     one
+  │     ^^^
+
+The name `one` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_1.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// For functions, we only check the arity and not the type of arguments or the\n// return value.\n// Function with incorrect arity from another module should not be suggested.\n\nimport module\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Int) {
+    x + 1
+}
+
+-- main.gleam
+
+// For functions, we only check the arity and not the type of arguments or the
+// return value.
+// Function with incorrect arity from another module should not be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:8:5
+  │
+8 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_2.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// For functions, we only check the arity and not the type of arguments or the\n// return value.\n// In pipelines, function calls are considered to have arity arguments.len() + 1.\n// Function with incorrect arity from another module should not be suggested.\n\nimport module\npub fn main() {\n    1 |> add(2)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Int) {
+    fn(y: Int) { x + y }
+}
+
+-- main.gleam
+
+// For functions, we only check the arity and not the type of arguments or the
+// return value.
+// In pipelines, function calls are considered to have arity arguments.len() + 1.
+// Function with incorrect arity from another module should not be suggested.
+
+import module
+pub fn main() {
+    1 |> add(2)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:9:10
+  │
+9 │     1 |> add(2)
+  │          ^^^
+
+The name `add` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_do_not_suggest_modules_with_public_function_with_incorrect_arity_3.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// For functions, we only check the arity and not the type of arguments or the\n// return value.\n// In pipelines, function calls are considered to have arity arguments.len() + 1.\n// Function with incorrect arity from another module should not be suggested.\n\nimport module\npub fn main() {\n    1 |> add(2)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Int) {
+    fn(y: Int, z: Int) { x + y + z }
+}
+
+-- main.gleam
+
+// For functions, we only check the arity and not the type of arguments or the
+// return value.
+// In pipelines, function calls are considered to have arity arguments.len() + 1.
+// Function with incorrect arity from another module should not be suggested.
+
+import module
+pub fn main() {
+    1 |> add(2)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:9:10
+  │
+9 │     1 |> add(2)
+  │          ^^^
+
+The name `add` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_function.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal function with correct arity from another module in the same package\n// should be suggested.\n\nimport module\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Internal function with correct arity from another module in the same package
+// should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_record_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_record_constructor.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal record constructor with correct arity from another module in the\n// same package should be suggested.\n\nimport module\npub fn main() {\n    MyRecord(1, 2)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub type MyType {
+    MyRecord(x: Int, y: Int)
+}
+
+-- main.gleam
+
+// Internal record constructor with correct arity from another module in the
+// same package should be suggested.
+
+import module
+pub fn main() {
+    MyRecord(1, 2)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     MyRecord(1, 2)
+  │     ^^^^^^^^
+
+The custom type variant constructor `MyRecord` is not in scope here.
+Did you mean one of these:
+
+  - module.MyRecord

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_type.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal type from another module in the same package should be suggested.\n\nimport module\npub fn main() {\n    One\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub type OneOrTwo {
+    One
+    Two
+}
+
+-- main.gleam
+
+// Internal type from another module in the same package should be suggested.
+
+import module
+pub fn main() {
+    One
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     One
+  │     ^^^
+
+The custom type variant constructor `One` is not in scope here.
+Did you mean one of these:
+
+  - module.One

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_value.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Internal value from another module in the same package should be suggested.\n\nimport module\npub fn main() {\n    one\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+@internal
+pub const one = 1
+
+-- main.gleam
+
+// Internal value from another module in the same package should be suggested.
+
+import module
+pub fn main() {
+    one
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     one
+  │     ^^^
+
+The name `one` is not in scope here.
+Did you mean one of these:
+
+  - module.one

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_imported_using_an_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_imported_using_an_alias.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Module aliases should be taken into account in the suggestion.\n// Public function with correct arity from another module should be suggested.\n\nimport module as wibble\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Module aliases should be taken into account in the suggestion.
+// Public function with correct arity from another module should be suggested.
+
+import module as wibble
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - wibble.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_multiple_segments.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_multiple_segments.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Module with multiple segments should be taken into account in the suggestion.\n// Public function with correct arity from another module should be suggested.\n\nimport gleam/module\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- gleam/module.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Module with multiple segments should be taken into account in the suggestion.
+// Public function with correct arity from another module should be suggested.
+
+import gleam/module
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:5
+  │
+7 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_1.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public function with correct arity from another module should be suggested.\n\nimport module\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_2.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public function with correct arity from another module should be suggested.\n\nimport module\npub fn main() {\n    1 |> add\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Int) {
+    x + 1
+}
+
+-- main.gleam
+
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    1 |> add
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:10
+  │
+6 │     1 |> add
+  │          ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_3.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public function with correct arity from another module should be suggested.\n\nimport module\npub fn main() {\n    1 |> add(2)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    1 |> add(2)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:10
+  │
+6 │     1 |> add(2)
+  │          ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_4.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public function with correct arity from another module should be suggested.\n\nimport module\npub fn main() {\n    use <- wibble\n    1\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn wibble(_) {
+    1
+}
+
+-- main.gleam
+
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    use <- wibble
+    1
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:12
+  │
+6 │     use <- wibble
+  │            ^^^^^^
+
+The name `wibble` is not in scope here.
+Did you mean one of these:
+
+  - module.wibble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_even_if_arguments_type_mismatch.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_even_if_arguments_type_mismatch.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public function with correct arity from another module should be suggested.\n\nimport module\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub fn add(x: Float, y: Float) {
+    x +. y
+}
+
+-- main.gleam
+
+// Public function with correct arity from another module should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_record_constructor_with_correct_arity.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_record_constructor_with_correct_arity.snap
@@ -1,0 +1,39 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public record constructor with correct arity from another module should be\n// suggested.\n\nimport moduleone\nimport moduletwo\npub fn main() {\n    MyRecord(1)\n}"
+---
+----- SOURCE CODE
+-- moduleone.gleam
+
+pub type MyType {
+    MyRecord(x: Int, y: Int)
+}
+
+-- moduletwo.gleam
+
+pub type AnotherType {
+    MyRecord(x: Int)
+}
+
+-- main.gleam
+
+// Public record constructor with correct arity from another module should be
+// suggested.
+
+import moduleone
+import moduletwo
+pub fn main() {
+    MyRecord(1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:8:5
+  │
+8 │     MyRecord(1)
+  │     ^^^^^^^^
+
+The custom type variant constructor `MyRecord` is not in scope here.
+Did you mean one of these:
+
+  - moduletwo.MyRecord

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_type.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public type from another module should be suggested.\n\nimport module\npub fn main() {\n    One\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub type OneOrTwo {
+    One
+    Two
+}
+
+-- main.gleam
+
+// Public type from another module should be suggested.
+
+import module
+pub fn main() {
+    One
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     One
+  │     ^^^
+
+The custom type variant constructor `One` is not in scope here.
+Did you mean one of these:
+
+  - module.One

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_1.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public value from another module should be suggested.\n\nimport module\npub fn main() {\n    one\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub const one = 1
+
+-- main.gleam
+
+// Public value from another module should be suggested.
+
+import module
+pub fn main() {
+    one
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     one
+  │     ^^^
+
+The name `one` is not in scope here.
+Did you mean one of these:
+
+  - module.one

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_2.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// Public value from another module should be suggested.\n\nimport module\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- module.gleam
+
+pub const add = private_add
+fn private_add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// Public value from another module should be suggested.
+
+import module
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_after_panic_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_after_panic_1.snap
@@ -14,9 +14,10 @@ expression: "\n        pub fn wibble(_) { 1 }\n        pub fn main() {\n        
 
 ----- WARNING
 warning: Unreachable code
-  ┌─ /src/warning/wrn.gleam:5:20
-  │
-5 │             use <- wibble
-  │                    ^^^^^^
+  ┌─ /src/warning/wrn.gleam:5:13
+  │  
+5 │ ╭             use <- wibble
+6 │ │             1
+  │ ╰─────────────^
 
 This code is unreachable because it comes after a `panic`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_after_panic_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_after_panic_2.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n        import module\n        pub fn a() {\n            panic\n            use <- module.wibble\n            1\n        }\n        "
+---
+----- SOURCE CODE
+-- module.gleam
+pub fn wibble(_) { 1 }
+
+-- main.gleam
+
+        import module
+        pub fn a() {
+            panic
+            use <- module.wibble
+            1
+        }
+        
+
+----- WARNING
+warning: Unreachable code
+  ┌─ /src/warning/wrn.gleam:5:13
+  │  
+5 │ ╭             use <- module.wibble
+6 │ │             1
+  │ ╰─────────────^
+
+This code is unreachable because it comes after a `panic`.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1976,13 +1976,28 @@ fn doesnt_warn_twice_for_unreachable_code_if_has_already_warned_in_a_block_2() {
 }
 
 #[test]
-fn unreachable_use_after_panic() {
+fn unreachable_use_after_panic_1() {
     assert_warning!(
         r#"
         pub fn wibble(_) { 1 }
         pub fn main() {
             panic
             use <- wibble
+            1
+        }
+        "#
+    );
+}
+
+#[test]
+fn unreachable_use_after_panic_2() {
+    assert_warning!(
+        ("package", "module", r#"pub fn wibble(_) { 1 }"#),
+        r#"
+        import module
+        pub fn a() {
+            panic
+            use <- module.wibble
             1
         }
         "#

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -1764,8 +1764,8 @@ impl<'a, IO> QualifiedToUnqualifiedImportFirstPass<'a, IO> {
                 // unqualify: we don't want to offer the action indiscriminately if
                 // it would generate invalid code!
                 let module_exports_constructor = match layer {
-                    ast::Layer::Value => module.get_public_value(constructor).is_some(),
-                    ast::Layer::Type => module.get_public_type(constructor).is_some(),
+                    ast::Layer::Value => module.get_importable_value(constructor).is_some(),
+                    ast::Layer::Type => module.get_importable_type(constructor).is_some(),
                 };
                 if module_exports_constructor {
                     matching_import = Some(import);

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -736,7 +736,7 @@ impl<'a, IO> Completer<'a, IO> {
             // unqualified module types are no longer relevant.
             if selected_module.is_none() {
                 for unqualified in &import.unqualified_types {
-                    if let Some(type_) = module.get_public_type(&unqualified.name) {
+                    if let Some(type_) = module.get_importable_type(&unqualified.name) {
                         completions.push(type_completion(
                             None,
                             unqualified.used_name(),
@@ -1004,7 +1004,7 @@ impl<'a, IO> Completer<'a, IO> {
             // module values are no longer relevant.
             if selected_module.is_none() {
                 for unqualified in &import.unqualified_values {
-                    if let Some(value) = module.get_public_value(&unqualified.name) {
+                    if let Some(value) = module.get_importable_value(&unqualified.name) {
                         let name = unqualified.used_name();
                         completions.push(self.value_completion(
                             None,


### PR DESCRIPTION
closes #2697

As stated on this [Discord message](https://discord.com/channels/768594524158427167/1396106606047133809/1396106606047133809), this is my first contributions to OSS and this project. I would really appreciate any feedback and improvement on my code, this pull request or commits that I made !

## Summary

This PR add more suggestions when an unknown variable is encounter by listing all variables / identifier in imported modules that match the same name. Also, when the variable / identifier is called such as functions, pipeline steps or type constructors, the suggestions are based on the name and number of arguments provided to the call. (ref: https://github.com/gleam-lang/gleam/issues/2697#issuecomment-1997241885)

## Examples

For example, take this invalid program:
```gleam
import gleam/io

pub fn main() -> Nil {
  println("Hello, World!)
}
```

The error message reported by the compiler:
```text
error: Unknown variable
  ┌─ /home/raphrous/code/gleam/module_suggestion/src/mylib/mymodule.gleam:4:3
  │
4 │   println("Hello, World!")
  │   ^^^^^^^

The name `println` is not in scope here.
Consider using one of these variables:

    io.println
```

Also, it works with variables, type constructor, constant etc. Consider this custom module and this program:
```gleam
// mylib/mymodule
pub const my_const = 8

pub type MyType {
  Some(x: Int, y: Int)
}

// main file
import gleam/option
import mylib/mymodule

pub fn main() -> Nil {
  // option.Some need to be suggested but 
  // not mymodule.Some (cause of arity)
  Some(my_const)
}
```

With these changes we have new suggestions about variables / identifier in imported modules:
```text
error: Unknown variable
  ┌─ /path/to/project/src/project.gleam:7:3
  │
7 │   Some(my_const)
  │   ^^^^

The custom type variant constructor `Some` is not in scope here.
Consider using one of these variables:

    option.Some


error: Unknown variable
  ┌─ /path/to/project/src/project.gleam:7:8
  │
7 │   Some(my_const)
  │        ^^^^^^^^

The name `my_const` is not in scope here.
Consider using one of these variables:

    mymodule.my_const
```

## Implementations

The current implementation uses a new enumeration `VarUsage`. This is similar to the enum `FieldAccessUsage` and it helps the function `report_name_error` by giving a little more context about the usage of this variable: a function call or something else. This function can now report about imported modules containing a variable with the same name as the unknown variable and, in case of function call, the same arity.

I tried to experiment another implementation where the function `report_name_error` was not provided with more context. The function was keeped as simple as possible by reporting imported modules containing a variable with the same name, without checking if it was a call or something else. Instead, we were filtering at the call side, inside `infer_call` function for example, if the variable from the imported module was of type "function-like". 
Honestly it does not feel right. We needed to check if an `UnknownVariable` error was emitted, apply a filtering on imported modules that were reported and re-emit the same error with the filter applied. Also, we had to perform this manipulation at every location where a function call was possible, which likely implies code duplication, errors and omissions.

## Shortcomings

### Wording

First thing first, the wording. I am not sure about the error message wording:

- `Consider using one of these variables`

For many developers, `io.println` is a function and `uri.empty` is a constant, not really variables. I wanted to make the error message like:

- `Consider using on of these identifiers`

But the term `identifiers` is not used in the compiler, in error messages that I found or the language tour so it does not feel right. As I can see in the compiler, `Var` refer to what I call `identifier` so I thought it would be best to write `variables`.

### No type checking on arguments

Because we only check name and arity in the case of calls, the suggestions may be wrong because the type of the function parameters does not match the type of arguments provided with the call. If we want that, we need to give more context, such as arguments types, to the `report_name_error` function in order to find the right functions to suggest.

### Suggestions for pipeline calls like `1 |> add(2)`

Also, I had a problem with function call on pipeline. To better explain the situation, take this program:
```gleam
pub fn main() -> Nil {
  1 |> add(2)
}
```

It can be desugared in two ways:
```gleam
pub fn main() -> Nil {
  // First possibility
  add(1, 2)
  // Second possibility
  add(2)(1)
}
```

I didn't know how to implement this case. For sure, the compiler can report function with arity of 2 and a function with arity 1 that has a return type that is also a function with arity 1. I just didn't know what was the right choice ... 

### Tests

To conclude, theses commits does not add tests for now, it might be cool to have some !

## Ending

Thank you in advance for reading and helping me on my journey into OSS. Please feel free to give me feedback on all this work! 💛