### PR TITLE
only suggest the "inline variable" code action when hovering the variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The "inline variable" code action is now only suggested when hovering over the
+  relevant variable.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Bug fixes

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5983,7 +5983,7 @@ impl<'ast> ast::visit::Visit<'ast> for InlineVariable<'ast> {
     ) {
         let range = self.edits.src_span_to_lsp_range(*location);
 
-        if !overlaps(self.params.range, range) {
+        if !within(self.params.range, range) {
             return;
         }
 
@@ -6025,7 +6025,7 @@ impl<'ast> ast::visit::Visit<'ast> for InlineVariable<'ast> {
 
         let range = self.edits.src_span_to_lsp_range(*location);
 
-        if !overlaps(self.params.range, range) {
+        if !within(self.params.range, range) {
             return;
         }
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -8934,6 +8934,23 @@ pub fn main() {
 }
 
 #[test]
+fn no_inline_variable_action_when_spanning_multiple_items() {
+    assert_no_code_actions!(
+        INLINE_VARIABLE,
+        "
+pub fn main(x: Int, y: Int) {
+  let a = 1
+  let b = 2
+  main(a, b)
+}
+",
+        find_position_of("main")
+            .nth_occurrence(2)
+            .select_until(find_position_of(")").nth_occurrence(2))
+    );
+}
+
+#[test]
 fn no_inline_variable_action_for_use_pattern() {
     assert_no_code_actions!(
         INLINE_VARIABLE,


### PR DESCRIPTION
Previously the language server would suggest it even if someone was selecting multiple lines including variables.