### PR TITLE
Improve double negations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@
   errors.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler now emits a single warning for multiple negations in a row, while
+  previously it would emit multiple comments highlighting increasingly longer
+  spans.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - New projects are generated using OTP28 on GitHub Actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,27 @@
 
 ### Formatter
 
+- The formatter now removes needless multiple negations that are safe to remove.
+  For example, this snippet of code:
+
+  ```gleam
+  pub fn useless_negations() {
+    let lucky_number = --11
+    let lucy_is_a_star = !!!False
+  }
+  ```
+
+  Is rewritten as:
+
+  ```gleam
+  pub fn useless_negations() {
+    let lucky_number = 11
+    let lucy_is_a_star = !False
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug fixes
 
 - Fixed a bug where `echo` could crash on JavaScript if the module contains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,3 +103,8 @@
 - Fixed a bug where `echo` could crash on JavaScript if the module contains
   record variants with the same name as some built-in JavaScript objects.
   ([Louis Pilfold](https://github.com/lpil))
+
+- Fixed a bug where the compiler would highlight an entire double negation
+  expression as safe to remove, instead of just highlighting the double
+  negation.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2521,6 +2521,7 @@ impl<'comments> Formatter<'comments> {
 
     fn negate_bool<'a>(&mut self, expr: &'a UntypedExpr) -> Document<'a> {
         match expr {
+            UntypedExpr::NegateBool { value, .. } => self.expr(value),
             UntypedExpr::BinOp { .. } => "!".to_doc().append(wrap_block(self.expr(expr))),
             _ => docvec!["!", self.expr(expr)],
         }
@@ -2528,9 +2529,9 @@ impl<'comments> Formatter<'comments> {
 
     fn negate_int<'a>(&mut self, expr: &'a UntypedExpr) -> Document<'a> {
         match expr {
-            UntypedExpr::BinOp { .. } | UntypedExpr::NegateInt { .. } => {
-                "- ".to_doc().append(self.expr(expr))
-            }
+            UntypedExpr::NegateInt { value, .. } => self.expr(value),
+            UntypedExpr::Int { value, .. } if value.starts_with('-') => self.int(value),
+            UntypedExpr::BinOp { .. } => "- ".to_doc().append(self.expr(expr)),
 
             _ => docvec!["-", self.expr(expr)],
         }

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -4902,7 +4902,7 @@ fn double_negate() {
 "#,
         r#"pub fn main() {
   let a = 3
-  let b = - -a
+  let b = a
 }
 "#
     );
@@ -4918,7 +4918,7 @@ fn triple_negate() {
 "#,
         r#"pub fn main() {
   let a = 3
-  let b = - - -a
+  let b = -a
 }
 "#
     );
@@ -4950,14 +4950,32 @@ fn binary_double_negate() {
 "#,
         r#"pub fn main() {
   let a = 3
-  let b = - -{ a + 3 }
+  let b = { a + 3 }
 }
 "#
     );
 }
 
 #[test]
-fn repeated_negate_after_subtract() {
+fn even_repeated_negate_after_subtract() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  let a = 3
+  let b = 4
+  let c = a-------b
+}
+"#,
+        r#"pub fn main() {
+  let a = 3
+  let b = 4
+  let c = a - b
+}
+"#
+    );
+}
+
+#[test]
+fn odd_repeated_negate_after_subtract() {
     assert_format_rewrite!(
         r#"pub fn main() {
   let a = 3
@@ -4968,9 +4986,23 @@ fn repeated_negate_after_subtract() {
         r#"pub fn main() {
   let a = 3
   let b = 4
-  let c = a - - - - - - - -b
+  let c = a - -b
 }
 "#
+    );
+}
+
+#[test]
+fn double_negation_on_bools_is_removed() {
+    assert_format_rewrite!(
+        r#"pub fn main() {
+  !!True
+}
+"#,
+        "pub fn main() {
+  True
+}
+"
     );
 }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -884,9 +884,18 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .error(convert_unify_error(error, value.location()))
         }
 
-        if let TypedExpr::NegateBool { .. } = value {
+        if let TypedExpr::NegateBool {
+            location: inner_location,
+            ..
+        } = value
+        {
             self.problems
-                .warning(Warning::UnnecessaryDoubleBoolNegation { location });
+                .warning(Warning::UnnecessaryDoubleBoolNegation {
+                    location: SrcSpan {
+                        start: location.start,
+                        end: inner_location.start + 1,
+                    },
+                });
         }
 
         TypedExpr::NegateBool {
@@ -903,16 +912,34 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .error(convert_unify_error(error, value.location()));
         }
 
-        if let TypedExpr::Int { value: ref v, .. } = value
+        if let TypedExpr::Int {
+            value: ref v,
+            location: ref inner_location,
+            ..
+        } = value
             && v.starts_with('-')
         {
             self.problems
-                .warning(Warning::UnnecessaryDoubleIntNegation { location });
+                .warning(Warning::UnnecessaryDoubleIntNegation {
+                    location: SrcSpan {
+                        start: location.start,
+                        end: inner_location.start + 1,
+                    },
+                });
         }
 
-        if let TypedExpr::NegateInt { .. } = value {
+        if let TypedExpr::NegateInt {
+            location: inner_location,
+            ..
+        } = value
+        {
             self.problems
-                .warning(Warning::UnnecessaryDoubleIntNegation { location });
+                .warning(Warning::UnnecessaryDoubleIntNegation {
+                    location: SrcSpan {
+                        start: location.start,
+                        end: inner_location.start + 1,
+                    },
+                });
         }
 
         TypedExpr::NegateInt {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_literal.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_literal.snap
@@ -10,6 +10,4 @@ warning: Unnecessary double negation (!!) on bool
   ┌─ /src/warning/wrn.gleam:1:25
   │
 1 │ pub fn main() { let _ = !!True }
-  │                         ^^^^^^
-
-Hint: You can safely remove this.
+  │                         ^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_variable.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_bool_variable.snap
@@ -15,6 +15,4 @@ warning: Unnecessary double negation (!!) on bool
   ┌─ /src/warning/wrn.gleam:4:21
   │
 4 │             let _ = !!x
-  │                     ^^^
-
-Hint: You can safely remove this.
+  │                     ^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_literal.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_literal.snap
@@ -10,6 +10,4 @@ warning: Unnecessary double negation (--) on integer
   ┌─ /src/warning/wrn.gleam:1:25
   │
 1 │ pub fn main() { let _ = --7 }
-  │                         ^^^
-
-Hint: You can safely remove this.
+  │                         ^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_variable.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_integer_variable.snap
@@ -15,6 +15,4 @@ warning: Unnecessary double negation (--) on integer
   ┌─ /src/warning/wrn.gleam:4:21
   │
 4 │             let _ = --x
-  │                     ^^^
-
-Hint: You can safely remove this.
+  │                     ^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__even_number_of_multiple_bool_negations_raise_a_single_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__even_number_of_multiple_bool_negations_raise_a_single_warning.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub fn main() { let _ = !!!!True }"
+---
+----- SOURCE CODE
+pub fn main() { let _ = !!!!True }
+
+----- WARNING
+warning: Unnecessary double negation (!!) on bool
+  ┌─ /src/warning/wrn.gleam:1:25
+  │
+1 │ pub fn main() { let _ = !!!!True }
+  │                         ^^^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__even_number_of_multiple_integer_negations_raise_a_single_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__even_number_of_multiple_integer_negations_raise_a_single_warning.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub fn main() { let _ = ----7 }"
+---
+----- SOURCE CODE
+pub fn main() { let _ = ----7 }
+
+----- WARNING
+warning: Unnecessary double negation (--) on integer
+  ┌─ /src/warning/wrn.gleam:1:25
+  │
+1 │ pub fn main() { let _ = ----7 }
+  │                         ^^^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__odd_number_of_multiple_bool_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__odd_number_of_multiple_bool_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub fn main() { let _ = !!!!!False }"
+---
+----- SOURCE CODE
+pub fn main() { let _ = !!!!!False }
+
+----- WARNING
+warning: Unnecessary double negation (!!) on bool
+  ┌─ /src/warning/wrn.gleam:1:25
+  │
+1 │ pub fn main() { let _ = !!!!!False }
+  │                         ^^^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__odd_number_of_multiple_integer_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__odd_number_of_multiple_integer_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub fn main() { let _ = -----7 }"
+---
+----- SOURCE CODE
+pub fn main() { let _ = -----7 }
+
+----- WARNING
+warning: Unnecessary double negation (--) on integer
+  ┌─ /src/warning/wrn.gleam:1:25
+  │
+1 │ pub fn main() { let _ = -----7 }
+  │                         ^^^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -464,6 +464,28 @@ fn double_unary_integer_literal() {
     assert_warning!("pub fn main() { let _ = --7 }");
 }
 
+#[test]
+fn even_number_of_multiple_integer_negations_raise_a_single_warning() {
+    assert_warning!("pub fn main() { let _ = ----7 }");
+}
+
+#[test]
+fn odd_number_of_multiple_integer_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones()
+ {
+    assert_warning!("pub fn main() { let _ = -----7 }");
+}
+
+#[test]
+fn even_number_of_multiple_bool_negations_raise_a_single_warning() {
+    assert_warning!("pub fn main() { let _ = !!!!True }");
+}
+
+#[test]
+fn odd_number_of_multiple_bool_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones()
+ {
+    assert_warning!("pub fn main() { let _ = !!!!!False }");
+}
+
 // https://github.com/gleam-lang/gleam/issues/2050
 #[test]
 fn double_unary_integer_variable() {

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -679,13 +679,13 @@ Hint: You can safely remove it.
                 type_::Warning::UnnecessaryDoubleIntNegation { location } => Diagnostic {
                     title: "Unnecessary double negation (--) on integer".into(),
                     text: "".into(),
-                    hint: Some("You can safely remove this.".into()),
+                    hint: None,
                     level: diagnostic::Level::Warning,
                     location: Some(Location {
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: None,
+                            text: Some("You can safely remove this.".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),
@@ -694,13 +694,13 @@ Hint: You can safely remove it.
                 type_::Warning::UnnecessaryDoubleBoolNegation { location } => Diagnostic {
                     title: "Unnecessary double negation (!!) on bool".into(),
                     text: "".into(),
-                    hint: Some("You can safely remove this.".into()),
+                    hint: None,
                     level: diagnostic::Level::Warning,
                     location: Some(Location {
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: None,
+                            text: Some("You can safely remove this.".into()),
                             span: *location,
                         },
                         extra_labels: Vec::new(),


### PR DESCRIPTION
I noticed an error message regarding double negations I was not super happy with:
```txt
warning: Unnecessary double negation (--) on integer
  ┌─ /src/main.gleam:4:3
  │
4 │   --1
  │   ^^^

Hint: You can safely remove this.
```
This is highlighting the entire expression saying it's safe to remove. But what is safe to remove is the double negation, not the entire highlighted expression. So with this PR the compiler is only highlighting the multiple negations that are safe to remove. The error message now looks like this:
```txt
warning: Unnecessary double negation (--) on integer
  ┌─ /Users/giacomocavalieri/Desktop/prova/src/prova.gleam:2:3
  │
2 │   --1
  │   ^^ You can safely remove this.
```

Also, in case of multiple negations the compiler would previously report multiple errors with increasing spans, that was quite confusing. So I've also made sure the compiler now raises a single warning for multiple negations.

**Before and after:**
<details>
Consider this piece of Gleam code
```gleam
pub fn super_negation(bool: Bool) -> Bool {
  !!!!!bool
}
```

Previously the compiler would emit 4 errors:
```text
warning: Unnecessary double negation (!!) on bool
  ┌─ /src/main.gleam:8:6
  │
8 │   !!!!!bool
  │      ^^^^^^

Hint: You can safely remove this.

warning: Unnecessary double negation (!!) on bool
  ┌─ /src/main.gleam:8:5
  │
8 │   !!!!!bool
  │     ^^^^^^^

Hint: You can safely remove this.

warning: Unnecessary double negation (!!) on bool
  ┌─ /src/main.gleam:8:4
  │
8 │   !!!!!bool
  │    ^^^^^^^^

Hint: You can safely remove this.

warning: Unnecessary double negation (!!) on bool
  ┌─ /src/main.gleam:8:3
  │
8 │   !!!!!bool
  │   ^^^^^^^^^

Hint: You can safely remove this.
```
With this PR it emits just a single error, highlighting only the needless negations:
```txt
warning: Unnecessary double negation (!!) on bool
  ┌─ /Users/giacomocavalieri/Desktop/prova/src/prova.gleam:8:3
  │
8 │   !!!!!bool
  │   ^^^^ You can safely remove this.
```
</details>

The last change introduced in this PR is to the formatter, so that it can remove those needless negations.