### PR TITLE
Omit label shorthand ':' in prepare_rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@
   relevant variable.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Renaming a variable from a label shorthand (`name:`) no longer includes the
+  colon in the rename dialog (`name:` -> `name`)
+  ([fruno](https://github.com/frunobulax-the-poodle))
+
 ### Formatter
 
 - The formatter now removes needless multiple negations that are safe to remove.

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -645,11 +645,16 @@ where
                 }) if location.contains(byte_index) => match origin.map(|origin| origin.syntax) {
                     Some(VariableSyntax::Generated) => None,
                     Some(
-                        VariableSyntax::Variable { .. }
-                        | VariableSyntax::AssignmentPattern
-                        | VariableSyntax::LabelShorthand(_),
-                    )
-                    | None => success_response(location),
+                        VariableSyntax::Variable(label) | VariableSyntax::LabelShorthand(label),
+                    ) => success_response(SrcSpan {
+                        start: location.start,
+                        end: label
+                            .len()
+                            .try_into()
+                            .map(|len: u32| location.start + len)
+                            .unwrap_or(location.end),
+                    }),
+                    Some(VariableSyntax::AssignmentPattern) | None => success_response(location),
                 },
                 Some(
                     Referenced::ModuleValue {

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -326,6 +326,24 @@ pub fn main() {
 }
 
 #[test]
+fn rename_local_variable_from_label_shorthand() {
+    assert_rename!(
+        "
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let wibble = todo
+  Wibble(wibble:)
+}
+",
+        "wobble",
+        find_position_of("wibble:)")
+    );
+}
+
+#[test]
 fn rename_local_variable_in_bit_array_pattern() {
     assert_rename!(
         "

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_label_shorthand.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_from_label_shorthand.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+expression: "\ntype Wibble {\n  Wibble(wibble: Int)\n}\n\npub fn main() {\n  let wibble = todo\n  Wibble(wibble:)\n}\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let wibble = todo
+  Wibble(wibble:)
+         ↑▔▔▔▔▔  
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub fn main() {
+  let wobble = todo
+  Wibble(wibble: wobble)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand_from_definition.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_local_variable_label_shorthand_from_definition.snap
@@ -11,7 +11,7 @@ type Wibble {
 
 pub fn main() {
   let Wibble(wibble:) = todo
-             ↑▔▔▔▔▔▔        
+             ↑▔▔▔▔▔         
   wibble + 1
 }
 


### PR DESCRIPTION
As the location of a variable includes the colon, it is also included in the `prepare_rename` response, which is annoying

This PR trims the location to the length of the label. This is done for both declaration in destructuring and usage as argument (for which I've added a new test).

As the trimming only happens in prepare_rename, no other language server operations are affected!

Fixes #4843  