### PR TITLE
stop crashing when there's an invalid version in a `gleam.toml` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,3 +138,7 @@
   expression as safe to remove, instead of just highlighting the double
   negation.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the compiler would crash if there was an invalid version
+  requirement in a project's `gleam.toml`.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/snapshots/gleam_core__requirement__tests__read_wrong_version.snap
+++ b/compiler-core/src/snapshots/gleam_core__requirement__tests__read_wrong_version.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/requirement.rs
+expression: error.to_string()
+---
+>= 2.0 and < 3.0.0 is not a valid version. missing patch version: 2.0 for key `short` at line 2 column 21


### PR DESCRIPTION
Now the compiler will show the error message instead of just crashing!

fixes #4817
