### PR TITLE
Stop suggesting project names starting with the `gleam_` prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,3 +142,7 @@
 - Fixed a bug where the compiler would crash if there was an invalid version
   requirement in a project's `gleam.toml`.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the compiler would suggest a discouraged project name as an
+  alternative to the reserved `gleam` name.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -379,7 +379,13 @@ fn suggest_valid_name(invalid_name: &str, reason: &InvalidProjectNameReason) -> 
             Some(format!("{invalid_name}_app"))
         }
         InvalidProjectNameReason::GleamReservedWord => Some(format!("{invalid_name}_app")),
-        InvalidProjectNameReason::GleamReservedModule => Some(format!("{invalid_name}_app")),
+        InvalidProjectNameReason::GleamReservedModule => {
+            if invalid_name == "gleam" {
+                Some("app_gleam".into())
+            } else {
+                Some(format!("{invalid_name}_app"))
+            }
+        }
         InvalidProjectNameReason::FormatNotLowercase => Some(invalid_name.to_lowercase()),
         InvalidProjectNameReason::Format => {
             let suggestion = regex::Regex::new(r"[^a-z0-9]")

--- a/compiler-cli/src/new/tests.rs
+++ b/compiler-cli/src/new/tests.rs
@@ -412,7 +412,7 @@ fn suggest_valid_names() {
             "gleam",
             &crate::new::InvalidProjectNameReason::GleamReservedModule
         ),
-        Some("gleam_app".to_string())
+        Some("app_gleam".to_string())
     );
 
     assert_eq!(


### PR DESCRIPTION
If someone picked `gleam new gleam`, instead of suggesting `gleam_app` it will now suggest `app_gleam` so it doesn't have the `gleam_` prefix!

Fixes #4844