### PR TITLE
Fix renaming variables in record updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,3 +272,7 @@
 
 - Fixed a bug where `echo .. as ..` message will be omitted in browser target.
   ([Andrey Kozhev](https://github.com/ankddev))
+
+- Fixed a bug where renaming a variable used in a record update would produce
+  invalid code in certain situations.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5947,10 +5947,14 @@ impl<'a> InlineVariable<'a> {
     }
 
     fn maybe_inline(&mut self, location: SrcSpan, name: EcoString) {
-        let reference = match find_variable_references(&self.module.ast, location, name).as_slice()
-        {
-            [only_reference] => *only_reference,
-            _ => return,
+        let references = find_variable_references(&self.module.ast, location, name);
+        let reference = if references.len() == 1 {
+            references
+                .into_iter()
+                .next()
+                .expect("References has length 1")
+        } else {
+            return;
         };
 
         let Some(ast::Statement::Assignment(assignment)) =

--- a/compiler-core/src/language_server/reference.rs
+++ b/compiler-core/src/language_server/reference.rs
@@ -400,10 +400,16 @@ impl<'ast> Visit<'ast> for FindVariableReferences {
                 location: definition_location,
                 ..
             } if definition_location == self.definition_location => {
-                self.references.push(VariableReference {
-                    location: *location,
-                    kind: VariableReferenceKind::Variable,
-                })
+                if !self
+                    .references
+                    .iter()
+                    .any(|reference| reference.location == *location)
+                {
+                    self.references.push(VariableReference {
+                        location: *location,
+                        kind: VariableReferenceKind::Variable,
+                    })
+                }
             }
             _ => {}
         }

--- a/compiler-core/src/language_server/tests/rename.rs
+++ b/compiler-core/src/language_server/tests/rename.rs
@@ -1550,3 +1550,20 @@ pub const something = 10
         find_position_of("something")
     );
 }
+
+#[test]
+fn rename_variable_used_in_record_update() {
+    assert_rename!(
+        "
+type Wibble {
+  Wibble(a: Int, b: Int, c: Int)
+}
+
+fn wibble(wibble: Wibble) {
+  Wibble(..wibble, c: 1)
+}
+",
+        "value",
+        find_position_of("wibble:")
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_variable_used_in_record_update.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_variable_used_in_record_update.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/language_server/tests/rename.rs
-assertion_line: 1556
 expression: "\ntype Wibble {\n  Wibble(a: Int, b: Int, c: Int)\n}\n\nfn wibble(wibble: Wibble) {\n  Wibble(..wibble, c: 1)\n}\n"
-snapshot_kind: text
 ---
 ----- BEFORE RENAME
 -- app.gleam

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_variable_used_in_record_update.snap.new
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__rename__rename_variable_used_in_record_update.snap.new
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/rename.rs
+assertion_line: 1556
+expression: "\ntype Wibble {\n  Wibble(a: Int, b: Int, c: Int)\n}\n\nfn wibble(wibble: Wibble) {\n  Wibble(..wibble, c: 1)\n}\n"
+snapshot_kind: text
+---
+----- BEFORE RENAME
+-- app.gleam
+
+type Wibble {
+  Wibble(a: Int, b: Int, c: Int)
+}
+
+fn wibble(wibble: Wibble) {
+          ↑▔▔▔▔▔           
+  Wibble(..wibble, c: 1)
+}
+
+
+----- AFTER RENAME
+-- app.gleam
+
+type Wibble {
+  Wibble(a: Int, b: Int, c: Int)
+}
+
+fn wibble(value: Wibble) {
+  Wibble(..value, c: 1)
+}


### PR DESCRIPTION
Fixes #4859 
As I mentioned in the issue, this doesn't fix the underlying problem but it avoids this most common situation.