### PR TITLE
fix: message in `echo .. as ..` is omitted in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,3 +269,6 @@
 - Fixed a bug where renaming a constant which is referenced in another module
   inside a guard would generate invalid code.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where `echo .. as ..` message will be omitted in browser target.
+  ([Andrey Kozhev](https://github.com/ankddev))

--- a/compiler-core/templates/echo.mjs
+++ b/compiler-core/templates/echo.mjs
@@ -17,7 +17,7 @@ function echo(value, message, file, line) {
   } else {
     // Otherwise, use `console.log`
     // The browser's console.log doesn't support ansi escape codes
-    const string = `${file_line}\n${string_value}`;
+    const string = `${file_line}${string_message}\n${string_value}`;
     globalThis.console.log(string);
   }
 


### PR DESCRIPTION
Closes #4871.
# Description
Fix of small bug where message in `echo .. as ..` will be omitted in browser target.