### PR TITLE
Fix discarded variable sized string segment patterns not being disallowed

### DIFF
--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -90,36 +90,6 @@ pub fn main() {
 }
 
 #[test]
-fn bit_array_discard() {
-    // https://github.com/gleam-lang/gleam/issues/704
-
-    assert_erl!(
-        r#"
-pub fn bit_array_discard(x) -> Bool {
- case x {
-  <<_:utf8, rest:bytes>> -> True
-   _ -> False
- }
-}
-                    "#
-    );
-}
-
-#[test]
-fn bit_array_discard1() {
-    assert_erl!(
-        r#"
-pub fn bit_array_discard(x) -> Bool {
- case x {
-  <<_discardme:utf8, rest:bytes>> -> True
-   _ -> False
- }
-}
-"#
-    );
-}
-
-#[test]
 fn bit_array_declare_and_use_var() {
     assert_erl!(
         r#"pub fn go(x) {
@@ -180,16 +150,6 @@ pub fn main() {
     <<"a", "b", _:bits>> -> 1
     _ -> 2
   }
-}"#
-    );
-}
-
-#[test]
-fn discard_utf8_pattern() {
-    assert_erl!(
-        r#"
-pub fn main() {
-    let assert <<_:utf8, rest:bits>> = <<>>
 }"#
     );
 }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -521,7 +521,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 });
                 self.environment.new_unbound_var()
             }
-            Pattern::Variable { .. } if segment_type.is_string() => {
+            Pattern::Variable { .. } | Pattern::Discard { .. } if segment_type.is_string() => {
                 self.error(Error::BitArraySegmentError {
                     error: bit_array::ErrorType::VariableUtfSegmentInPattern,
                     location: segment.location,

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -171,6 +171,11 @@ fn bit_array_segment_type_does_not_allow_variable_string() {
 }
 
 #[test]
+fn bit_array_segment_type_does_not_allow_discarded_variable_string() {
+    assert_error!("case <<>> { <<_:utf8>> -> 1 _ -> 2 }");
+}
+
+#[test]
 fn bit_array_segment_type_does_not_allow_aliased_variable_string() {
     assert_error!("case <<>> { <<_ as a:utf8>> -> 1 _ -> 2 }");
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_discarded_variable_string.snap.new
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_segment_type_does_not_allow_discarded_variable_string.snap.new
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+assertion_line: 175
+expression: "case <<>> { <<_:utf8>> -> 1 _ -> 2 }"
+snapshot_kind: text
+---
+----- SOURCE CODE
+case <<>> { <<_:utf8>> -> 1 _ -> 2 }
+
+----- ERROR
+error: Invalid bit array segment
+  ┌─ /src/one/two.gleam:1:15
+  │
+1 │ case <<>> { <<_:utf8>> -> 1 _ -> 2 }
+  │               ^^^^^^ This cannot be a variable
+
+Hint: in patterns utf8, utf16, and utf32  must be an exact string.
+See: https://tour.gleam.run/data-types/bit-arrays/


### PR DESCRIPTION
This fixes the issue where the following code snippets with discarded variables in utf8 bit array patterns are allowed to compile:
```gleam
let assert <<_:utf8>> = <<>>
```
```gleam
case <<>> {
  <<_:utf8>> -> todo
  _ -> todo
```

When the variable is not discarded, the compiler already correctly disallows the pattern, as variable length string matches are not allowed for bit arrays:
```gleam
let assert <<x:utf8>> = <<>> // correctly gives a compiler error
```

Credit to Julian (@julian.nz) in the Gleam Discord server for finding this issue.