### PR TITLE
Remove unnecessary assignments for blocks when the value is unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,10 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The code generated for blocks on the JavaScript target has been improved and
+  is now smaller in certain cases.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - New projects are generated using OTP28 on GitHub Actions.

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -718,7 +718,7 @@ pub fn let_<'a>(
     ];
 
     match scope_position {
-        expression::Position::NotTail(_ordering) => doc,
+        expression::Position::Expression(_) | expression::Position::Statement => doc,
         expression::Position::Tail => docvec![doc, line(), "return ", assignment_name, ";"],
         expression::Position::Assign(variable) => {
             docvec![doc, line(), variable, " = ", assignment_name, ";"]

--- a/compiler-core/src/javascript/tests/blocks.rs
+++ b/compiler-core/src/javascript/tests/blocks.rs
@@ -344,3 +344,27 @@ pub fn main() {
 "#
     )
 }
+
+#[test]
+fn blocks_whose_values_are_unused_do_not_generate_assignments() {
+    // There's no point generating `_block` assignments here, as the values
+    // would be unused.
+    assert_js!(
+        "
+pub fn main() {
+  {
+    let x = 10
+    echo x
+  }
+
+  {
+    let a = 1
+    let b = 2
+    a + b
+  }
+
+  Nil
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_returning_functions.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_returning_functions.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/blocks.rs
-assertion_line: 172
 expression: "\npub fn b() {\n  {\n    fn(cb) { cb(1) }\n  }\n  {\n    fn(cb) { cb(2) }\n  }\n  3\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -19,7 +17,7 @@ pub fn b() {
 
 ----- COMPILED JAVASCRIPT
 export function b() {
-  ((cb) => { return cb(1); });
-  ((cb) => { return cb(2); });
+  (cb) => { return cb(1); };
+  (cb) => { return cb(2); };
   return 3;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_whose_values_are_unused_do_not_generate_assignments.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_whose_values_are_unused_do_not_generate_assignments.snap
@@ -1,0 +1,49 @@
+---
+source: compiler-core/src/javascript/tests/blocks.rs
+expression: "\npub fn main() {\n  {\n    let x = 10\n    echo x\n  }\n\n  {\n    let a = 1\n    let b = 2\n    a + b\n  }\n\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  {
+    let x = 10
+    echo x
+  }
+
+  {
+    let a = 1
+    let b = 2
+    a + b
+  }
+
+  Nil
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $stdlib$dict from "../../gleam_stdlib/dict.mjs";
+import {
+  Empty as $Empty,
+  NonEmpty as $NonEmpty,
+  CustomType as $CustomType,
+  bitArraySlice,
+  bitArraySliceToInt,
+  BitArray as $BitArray,
+  List as $List,
+  UtfCodepoint as $UtfCodepoint,
+} from "../gleam.mjs";
+
+export function main() {
+  {
+    let x = 10;
+    echo(x, undefined, "src/module.gleam", 5)
+  };
+  {
+    let a = 1;
+    let b = 2;
+    a + b
+  };
+  return undefined;
+}
+
+// ...omitted code from `templates/echo.mjs`...

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/blocks.rs
-assertion_line: 75
 expression: "\npub fn go() {\n  let x = {\n    1\n    {\n      2\n      3\n    }\n    4\n  }\n  x\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -24,12 +22,10 @@ export function go() {
   let _block;
   {
     1;
-    let _block$1;
     {
       2;
-      _block$1 = 3;
-    }
-    _block$1;
+      3
+    };
     _block = 4;
   }
   let x = _block;


### PR DESCRIPTION
I noticed that currently, for this code:
```gleam
pub fn main() {
  {
    let x = 10
    echo x
  }

  Nil
}
```

We generate the following JavaScript:
```javascript
export function main() {
  let _block;
  {
    let x = 10;
    _block = echo(x);
  }
  _block;

  return undefined;
} 
```

However, since we are not using the value returned by the first block, it doesn't really make sense to generate the `let _block` part; it just adds unnecessary code.

This PR removes it so it now just generates:
```javascript
export function main() {
  {
    let x = 10;
    echo(x);
  }

  return undefined;
} 
```