### PR TITLE
update the `toml` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1160,7 +1160,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "tokio",
- "toml",
+ "toml 0.9.5",
  "toml_edit",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -1213,7 +1213,7 @@ dependencies = [
  "tar",
  "termcolor",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "unicode-segmentation",
  "vec1",
@@ -1285,9 +1285,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hexpm"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f62182f03cb6894803f78f69dd22720bb9ed5ee6f7e5a64034c67a043e72f81"
+checksum = "a20609f5eaff5bcb81765ccbc70132a67ba03e5e2da78aac9c5ff19049c06122"
 dependencies = [
  "base16",
  "bytes",
@@ -2933,6 +2933,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,7 +3184,7 @@ dependencies = [
  "insta",
  "itertools",
  "regex",
- "toml",
+ "toml 0.9.5",
  "walkdir",
 ]
 
@@ -3201,7 +3210,7 @@ dependencies = [
  "itertools",
  "regex",
  "test-helpers-rs",
- "toml",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -3215,7 +3224,7 @@ dependencies = [
  "itertools",
  "regex",
  "test-helpers-rs",
- "toml",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -3360,10 +3369,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3372,8 +3405,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.9",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow",
 ]
 
@@ -3382,6 +3424,12 @@ name = "toml_write"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -4069,9 +4117,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.9"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/compiler-core/src/snapshots/gleam_core__config__deny_extra_deps_properties.snap
+++ b/compiler-core/src/snapshots/gleam_core__config__deny_extra_deps_properties.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/config.rs
+expression: error.pretty_string()
+---
+error: File IO failure
+
+An error occurred while trying to parse this file:
+
+    gleam.toml
+
+The error message from the file IO library was:
+
+    TOML parse error at line 6, column 18
+  |
+6 | aide_generator = { git = "git@github.com:crowdhailer/aide.git", ref = "f559c5bc", extra = "idk what this is" }
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+data did not match any variant of untagged enum Requirement

--- a/compiler-core/src/snapshots/gleam_core__config__name_with_dash.snap
+++ b/compiler-core/src/snapshots/gleam_core__config__name_with_dash.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/config.rs
+expression: "toml::from_str::<PackageConfig>(input).unwrap_err().to_string()"
+---
+TOML parse error at line 2, column 8
+  |
+2 | name = "one-two"
+  |        ^^^^^^^^^
+Package names may only contain lowercase letters, numbers, and underscores

--- a/compiler-core/src/snapshots/gleam_core__config__name_with_number_start.snap
+++ b/compiler-core/src/snapshots/gleam_core__config__name_with_number_start.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/config.rs
+expression: "toml::from_str::<PackageConfig>(input).unwrap_err().to_string()"
+---
+TOML parse error at line 2, column 8
+  |
+2 | name = "1"
+  |        ^^^
+Package names may only contain lowercase letters, numbers, and underscores

--- a/compiler-core/src/snapshots/gleam_core__requirement__tests__read_wrong_version.snap
+++ b/compiler-core/src/snapshots/gleam_core__requirement__tests__read_wrong_version.snap
@@ -2,4 +2,8 @@
 source: compiler-core/src/requirement.rs
 expression: error.to_string()
 ---
->= 2.0 and < 3.0.0 is not a valid version. missing patch version: 2.0 for key `short` at line 2 column 21
+TOML parse error at line 2, column 21
+  |
+2 |             short = ">= 2.0 and < 3.0.0"
+  |                     ^^^^^^^^^^^^^^^^^^^^
+>= 2.0 and < 3.0.0 is not a valid version. missing patch version: 2.0


### PR DESCRIPTION
This PR closes #4881 

The new version of `toml` also improves on the look of errors, I think they're a bit nicer now! Since the tests were failing and needed updating I turned those into snapshots to make it easier to see and test the new error messages