### PR TITLE
Properly infer variants when `echo` is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,3 +306,7 @@
 - Fixed a bug where renaming a variable used in a record update would produce
   invalid code in certain situations.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where adding `echo` to the subject of a `case` expression would
+  prevent variant inference from working correctly.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -3228,3 +3228,28 @@ pub fn main() {
         vec![("main", "fn() -> Nil")]
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4883
+#[test]
+fn variant_inference_ignores_echo() {
+    assert_module_infer!(
+        "
+pub type Wibble {
+  Wibble(wibble: Int, wobble: String)
+  Wobble(a: String, b: Int)
+}
+
+pub fn get_int(w: Wibble) {
+  case echo w {
+    Wibble(..) -> w.wibble
+    Wobble(..) -> w.b
+  }
+}
+",
+        vec![
+            ("Wibble", "fn(Int, String) -> Wibble"),
+            ("Wobble", "fn(String, Int) -> Wibble"),
+            ("get_int", "fn(Wibble) -> Int"),
+        ]
+    );
+}


### PR DESCRIPTION
Fixes #4883