### PR TITLE
Favour public type aliases over internal names when printing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,32 @@
   of inline tables if they are missing.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- When generating documentation, the build tool will now print the names of
+  public type aliases instead of internal type names when annotating functions
+  and types. For example, for the following code:
+
+  ```gleam
+  import my_package/internal
+
+  pub type ExternalAlias = internal.InternalRepresentation
+
+  pub fn do_thing() -> ExternalAlias { ... }
+  ```
+
+  This is what the build tool used to generate:
+
+  ```gleam
+  pub fn do_thing() -> @internal InternalRepresentation
+  ```
+
+  Whereas now it will not use the internal name, and instead produce:
+
+  ```gleam
+  pub fn do_thing() -> ExternalAlias
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Language server
 
 - The "pattern match on variable" can now be triggered on lists. For example:
@@ -287,6 +313,45 @@
 
   ```gleam
   fn pair(a: a, b: b) -> #(a, b) { #(a, b) }
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+- When showing types of values on hover, or adding type annotations, the language
+  server will now prefer public type aliases to internal types. For example, if
+  the "Add type annotations" code action was triggered on the following code:
+
+  ```gleam
+  import lustre/html
+  import lustre/element
+  import lustre/attribute
+
+  pub fn make_link(attribute, element) {
+    html.a([attribute], [elements])
+  }
+  ```
+
+  Previously, the following code would have been generated:
+
+  ```gleam
+  pub fn make_link(
+    attribute: vattr.Attribute,
+    element: vdom.Element(a)
+  ) -> vdom.Element(a) {
+     html.a([attribute], [elements])
+  }
+  ```
+
+  Which references internal types which should not be imported by the user.
+  However, now the language server will produce the following:
+
+  ```gleam
+  pub fn make_link(
+    attribute: attribute.Attribute,
+    element: element.Element(a)
+  ) -> element.Element(a) {
+     html.a([attribute], [elements])
+  }
   ```
 
   ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/generated/schema_capnp.rs
+++ b/compiler-core/generated/schema_capnp.rs
@@ -2658,11 +2658,19 @@ pub mod type_alias_constructor {
     pub fn has_origin(&self) -> bool {
       !self.reader.get_pointer_field(5).is_null()
     }
+    #[inline]
+    pub fn get_parameters(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema_capnp::type_::Owned>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(6), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_parameters(&self) -> bool {
+      !self.reader.get_pointer_field(6).is_null()
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 6 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 7 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -2816,6 +2824,22 @@ pub mod type_alias_constructor {
     pub fn has_origin(&self) -> bool {
       !self.builder.is_pointer_field_null(5)
     }
+    #[inline]
+    pub fn get_parameters(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema_capnp::type_::Owned>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(6), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_parameters(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::type_::Owned>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(6), value, false)
+    }
+    #[inline]
+    pub fn init_parameters(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema_capnp::type_::Owned> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(6), size)
+    }
+    #[inline]
+    pub fn has_parameters(&self) -> bool {
+      !self.builder.is_pointer_field_null(6)
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -2836,17 +2860,17 @@ pub mod type_alias_constructor {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 127] = [
+    pub static ENCODED_NODE: [::capnp::Word; 147] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(77, 68, 194, 176, 34, 71, 88, 172),
       ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
-      ::capnp::word(6, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(7, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 143, 1, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 199, 1, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
@@ -2855,56 +2879,63 @@ pub mod type_alias_constructor {
       ::capnp::word(110, 115, 116, 114, 117, 99, 116, 111),
       ::capnp::word(114, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(28, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(32, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(181, 0, 0, 0, 82, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(180, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(192, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(189, 0, 0, 0, 58, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(184, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(196, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(193, 0, 0, 0, 42, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(188, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(200, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(3, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(197, 0, 0, 0, 50, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(192, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(204, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(4, 0, 0, 0, 3, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(201, 0, 0, 0, 98, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(200, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(212, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(5, 0, 0, 0, 4, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(209, 0, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(209, 0, 0, 0, 82, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(208, 0, 0, 0, 3, 0, 1, 0),
       ::capnp::word(220, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(6, 0, 0, 0, 5, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(217, 0, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(212, 0, 0, 0, 3, 0, 1, 0),
       ::capnp::word(224, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(221, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(216, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(228, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(3, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(225, 0, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(220, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(232, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(4, 0, 0, 0, 3, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(229, 0, 0, 0, 98, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(228, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(240, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(5, 0, 0, 0, 4, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(237, 0, 0, 0, 114, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(236, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(248, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(6, 0, 0, 0, 5, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(245, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(240, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(252, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(7, 0, 0, 0, 6, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 7, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(249, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(248, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(20, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(112, 117, 98, 108, 105, 99, 105, 116),
       ::capnp::word(121, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
@@ -2964,6 +2995,19 @@ pub mod type_alias_constructor {
       ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(112, 97, 114, 97, 109, 101, 116, 101),
+      ::capnp::word(114, 115, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
@@ -2974,6 +3018,7 @@ pub mod type_alias_constructor {
         4 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         5 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         6 => <crate::schema_capnp::src_span::Owned as ::capnp::introspect::Introspect>::introspect(),
+        7 => <::capnp::struct_list::Owned<crate::schema_capnp::type_::Owned> as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -2986,9 +3031,9 @@ pub mod type_alias_constructor {
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
       members_by_name: MEMBERS_BY_NAME,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5,6,7];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub static MEMBERS_BY_NAME : &[u16] = &[3,4,5,1,6,0,2];
+    pub static MEMBERS_BY_NAME : &[u16] = &[3,4,5,1,6,7,0,2];
     pub const TYPE_ID: u64 = 0xac58_4722_b0c2_444d;
   }
 }
@@ -5825,7 +5870,7 @@ pub mod type_ {
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 5 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 6 };
   }
   impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -5883,6 +5928,7 @@ pub mod type_ {
       self.builder.reborrow().get_pointer_field(2).clear();
       self.builder.reborrow().get_pointer_field(3).clear();
       self.builder.reborrow().get_pointer_field(4).clear();
+      self.builder.reborrow().get_pointer_field(5).clear();
       self.builder.into()
     }
     #[inline]
@@ -5946,7 +5992,7 @@ pub mod type_ {
       ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
       ::capnp::word(13, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(190, 237, 188, 253, 156, 169, 51, 181),
-      ::capnp::word(5, 0, 7, 0, 0, 0, 4, 0),
+      ::capnp::word(6, 0, 7, 0, 0, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 146, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
@@ -6125,11 +6171,19 @@ pub mod type_ {
       pub fn has_inferred_variant(&self) -> bool {
         !self.reader.get_pointer_field(4).is_null()
       }
+      #[inline]
+      pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn has_publicity(&self) -> bool {
+        !self.reader.get_pointer_field(5).is_null()
+      }
     }
 
     pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
     impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 5 };
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 6 };
     }
     impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
@@ -6259,6 +6313,22 @@ pub mod type_ {
       pub fn has_inferred_variant(&self) -> bool {
         !self.builder.is_pointer_field_null(4)
       }
+      #[inline]
+      pub fn get_publicity(self) -> ::capnp::Result<crate::schema_capnp::publicity::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_publicity(&mut self, value: crate::schema_capnp::publicity::Reader<'_>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(5), value, false)
+      }
+      #[inline]
+      pub fn init_publicity(self, ) -> crate::schema_capnp::publicity::Builder<'a> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), 0)
+      }
+      #[inline]
+      pub fn has_publicity(&self) -> bool {
+        !self.builder.is_pointer_field_null(5)
+      }
     }
 
     pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -6271,60 +6341,70 @@ pub mod type_ {
       pub fn get_inferred_variant(&self) -> crate::schema_capnp::inferred_variant::Pipeline {
         ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(4))
       }
+      pub fn get_publicity(&self) -> crate::schema_capnp::publicity::Pipeline {
+        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(5))
+      }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 97] = [
+      pub static ENCODED_NODE: [::capnp::Word; 113] = [
         ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
         ::capnp::word(112, 148, 53, 107, 90, 14, 28, 212),
         ::capnp::word(18, 0, 0, 0, 1, 0, 2, 0),
         ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
-        ::capnp::word(5, 0, 7, 0, 1, 0, 0, 0),
+        ::capnp::word(6, 0, 7, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 178, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 31, 1, 0, 0),
+        ::capnp::word(21, 0, 0, 0, 87, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
         ::capnp::word(97, 112, 110, 112, 58, 84, 121, 112),
         ::capnp::word(101, 46, 97, 112, 112, 0, 0, 0),
-        ::capnp::word(20, 0, 0, 0, 3, 0, 4, 0),
+        ::capnp::word(24, 0, 0, 0, 3, 0, 4, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(125, 0, 0, 0, 42, 0, 0, 0),
+        ::capnp::word(153, 0, 0, 0, 42, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(120, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(132, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(148, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(160, 0, 0, 0, 2, 0, 1, 0),
         ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(129, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(124, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(136, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(133, 0, 0, 0, 90, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(132, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(160, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 7, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(157, 0, 0, 0, 66, 0, 0, 0),
+        ::capnp::word(157, 0, 0, 0, 58, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(152, 0, 0, 0, 3, 0, 1, 0),
         ::capnp::word(164, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(161, 0, 0, 0, 90, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(160, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(188, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 7, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(185, 0, 0, 0, 66, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(180, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(192, 0, 0, 0, 2, 0, 1, 0),
         ::capnp::word(4, 0, 0, 0, 4, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 8, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(161, 0, 0, 0, 130, 0, 0, 0),
+        ::capnp::word(189, 0, 0, 0, 130, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(160, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(172, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(188, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(200, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(5, 0, 0, 0, 5, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 9, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(197, 0, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(196, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(208, 0, 0, 0, 2, 0, 1, 0),
         ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
         ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -6371,6 +6451,15 @@ pub mod type_ {
         ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(112, 117, 98, 108, 105, 99, 105, 116),
+        ::capnp::word(121, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(102, 28, 233, 33, 200, 211, 73, 197),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ];
       pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
         match index {
@@ -6379,6 +6468,7 @@ pub mod type_ {
           2 => <::capnp::struct_list::Owned<crate::schema_capnp::type_::Owned> as ::capnp::introspect::Introspect>::introspect(),
           3 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
           4 => <crate::schema_capnp::inferred_variant::Owned as ::capnp::introspect::Introspect>::introspect(),
+          5 => <crate::schema_capnp::publicity::Owned as ::capnp::introspect::Introspect>::introspect(),
           _ => panic!("invalid field index {}", index),
         }
       }
@@ -6391,9 +6481,9 @@ pub mod type_ {
         members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
         members_by_name: MEMBERS_BY_NAME,
       };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4];
+      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5];
       pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub static MEMBERS_BY_NAME : &[u16] = &[4,1,0,3,2];
+      pub static MEMBERS_BY_NAME : &[u16] = &[4,1,0,3,2,5];
       pub const TYPE_ID: u64 = 0xd41c_0e5a_6b35_9470;
     }
   }
@@ -6479,7 +6569,7 @@ pub mod type_ {
 
     pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
     impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 5 };
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 6 };
     }
     impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
@@ -6580,7 +6670,7 @@ pub mod type_ {
         ::capnp::word(107, 183, 96, 119, 140, 121, 242, 130),
         ::capnp::word(18, 0, 0, 0, 1, 0, 2, 0),
         ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
-        ::capnp::word(5, 0, 7, 0, 1, 0, 0, 0),
+        ::capnp::word(6, 0, 7, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 170, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -6720,7 +6810,7 @@ pub mod type_ {
 
     pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
     impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 5 };
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 6 };
     }
     impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
@@ -6794,7 +6884,7 @@ pub mod type_ {
         ::capnp::word(54, 132, 226, 31, 115, 14, 218, 204),
         ::capnp::word(18, 0, 0, 0, 1, 0, 2, 0),
         ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
-        ::capnp::word(5, 0, 7, 0, 1, 0, 0, 0),
+        ::capnp::word(6, 0, 7, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 178, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -6917,7 +7007,7 @@ pub mod type_ {
 
     pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
     impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 5 };
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 6 };
     }
     impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
@@ -6999,7 +7089,7 @@ pub mod type_ {
         ::capnp::word(61, 216, 21, 128, 12, 226, 23, 140),
         ::capnp::word(18, 0, 0, 0, 1, 0, 2, 0),
         ::capnp::word(0, 7, 151, 64, 46, 128, 246, 130),
-        ::capnp::word(5, 0, 7, 0, 1, 0, 0, 0),
+        ::capnp::word(6, 0, 7, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 194, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/compiler-core/schema.capnp
+++ b/compiler-core/schema.capnp
@@ -71,6 +71,7 @@ struct TypeAliasConstructor {
     deprecation @4 :Text;
     documentation @5 :Text;
     origin @6 :SrcSpan;
+    parameters @7 :List(Type);
 }
 
 struct Version {
@@ -145,6 +146,7 @@ struct Type {
       parameters @2 :List(Type);
       package @7 :Text;
       inferredVariant @8 :InferredVariant;
+      publicity @9 :Publicity;
     }
 
     fn :group {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1398,19 +1398,24 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 },
             )?;
 
-            environment.insert_type_alias(
-                name.clone(),
-                TypeAliasConstructor {
-                    origin: *location,
-                    module: self.module_name.clone(),
-                    type_,
-                    publicity: *publicity,
-                    deprecation: deprecation.clone(),
-                    documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
-                    arity,
-                    parameters,
-                },
-            )?;
+            let alias = TypeAliasConstructor {
+                origin: *location,
+                module: self.module_name.clone(),
+                type_,
+                publicity: *publicity,
+                deprecation: deprecation.clone(),
+                documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
+                arity,
+                parameters,
+            };
+
+            environment.names.maybe_register_reexport_alias(
+                &environment.current_package,
+                &name,
+                &alias,
+            );
+
+            environment.insert_type_alias(name.clone(), alias)?;
 
             if let Some(name) = hydrator.unused_type_variables().next() {
                 return Err(Error::UnusedTypeAliasParameter {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1390,7 +1390,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 TypeConstructor {
                     origin: *location,
                     module: self.module_name.clone(),
-                    parameters,
+                    parameters: parameters.clone(),
                     type_: type_.clone(),
                     deprecation: deprecation.clone(),
                     publicity: *publicity,
@@ -1408,6 +1408,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                     deprecation: deprecation.clone(),
                     documentation: documentation.as_ref().map(|(_, doc)| doc.clone()),
                     arity,
+                    parameters,
                 },
             )?;
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1411,7 +1411,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
             environment.names.maybe_register_reexport_alias(
                 &environment.current_package,
-                &name,
+                name,
                 &alias,
             );
 

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__function_uses_reexport_of_internal_type.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__function_uses_reexport_of_internal_type.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- thepackage/internal.gleam
+pub type Internal
+
+-- main.gleam
+
+import thepackage/internal
+
+pub type External = internal.Internal
+
+pub fn do_thing(value: internal.Internal) -> External {
+  value
+}
+
+
+---- TYPES
+
+--- External
+<pre><code>pub type External =
+  @internal Internal</code></pre>
+
+---- VALUES
+
+--- do_thing
+<pre><code>pub fn do_thing(value: <a href="#External">External</a>) -> <a href="#External">External</a></code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__function_uses_reexport_of_internal_type_in_other_module.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__function_uses_reexport_of_internal_type_in_other_module.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- thepackage/internal.gleam
+pub type Internal
+
+-- thepackage/something.gleam
+
+import thepackage/internal
+
+pub type External = internal.Internal
+
+
+-- main.gleam
+
+import thepackage/something
+
+pub fn do_thing(value: something.External) {
+  value
+}
+
+
+---- VALUES
+
+--- do_thing
+<pre><code>pub fn do_thing(value: <a href="thepackage/something.html#External" title="thepackage/something.{type External}">something.External</a>) -> <a href="thepackage/something.html#External" title="thepackage/something.{type External}">something.External</a></code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__use_reexport_from_other_package.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__use_reexport_from_other_package.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/docs/tests.rs
+expression: output
+---
+---- SOURCE CODE
+-- some_package/internal.gleam
+pub type Internal
+
+-- some_package/api.gleam
+
+import some_package/internal
+pub type External = internal.Internal
+
+
+-- main.gleam
+
+import some_package/api
+
+pub fn do_thing(value: api.External) {
+  value
+}
+
+
+---- VALUES
+
+--- do_thing
+<pre><code>pub fn do_thing(value: <a href="https://hexdocs.pm/some_package/1.0.0/some_package/api.html#External" title="some_package/api.{type External}">api.External</a>) -> <a href="https://hexdocs.pm/some_package/1.0.0/some_package/api.html#External" title="some_package/api.{type External}">api.External</a></code></pre>

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -1124,6 +1124,69 @@ pub type External =
 }
 
 #[test]
+fn use_reexport_from_other_package() {
+    assert_documentation!(
+        ("some_package", "some_package/internal", "pub type Internal"),
+        (
+            "some_package",
+            "some_package/api",
+            "
+import some_package/internal
+pub type External = internal.Internal
+"
+        ),
+        "
+import some_package/api
+
+pub fn do_thing(value: api.External) {
+  value
+}
+",
+        ONLY_LINKS
+    );
+}
+
+#[test]
+fn function_uses_reexport_of_internal_type() {
+    assert_documentation!(
+        ("thepackage/internal", "pub type Internal"),
+        "
+import thepackage/internal
+
+pub type External = internal.Internal
+
+pub fn do_thing(value: internal.Internal) -> External {
+  value
+}
+",
+        ONLY_LINKS
+    );
+}
+
+#[test]
+fn function_uses_reexport_of_internal_type_in_other_module() {
+    assert_documentation!(
+        ("thepackage/internal", "pub type Internal"),
+        (
+            "thepackage/something",
+            "
+import thepackage/internal
+
+pub type External = internal.Internal
+"
+        ),
+        "
+import thepackage/something
+
+pub fn do_thing(value: something.External) {
+  value
+}
+",
+        ONLY_LINKS
+    );
+}
+
+#[test]
 fn constructor_with_long_types_and_many_fields() {
     assert_documentation!(
         ("option", "pub type Option(a)"),

--- a/compiler-core/src/exhaustiveness/printer.rs
+++ b/compiler-core/src/exhaustiveness/printer.rs
@@ -54,10 +54,10 @@ impl<'a> Printer<'a> {
                 ..
             } => {
                 let (module, name) = match self.names.named_constructor(module, name) {
-                    NameContextInformation::Qualified(m, n) => (Some(m), n),
-                    NameContextInformation::Unqualified(n) => (None, n),
-                    NameContextInformation::Unimported(n) => {
-                        (Some(module.split('/').next_back().unwrap_or(module)), n)
+                    NameContextInformation::Qualified(module, name) => (Some(module), name),
+                    NameContextInformation::Unqualified(name) => (None, name),
+                    NameContextInformation::Unimported(module, name) => {
+                        (module.split('/').next_back(), name)
                     }
                 };
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -4902,7 +4902,7 @@ fn pretty_constructor_name(
         .names
         .named_constructor(constructor_module, constructor_name)
     {
-        type_::printer::NameContextInformation::Unimported(_) => None,
+        type_::printer::NameContextInformation::Unimported(_, _) => None,
         type_::printer::NameContextInformation::Unqualified(constructor_name) => {
             Some(eco_format!("{constructor_name}"))
         }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -9544,3 +9544,101 @@ pub fn main() {
         find_position_of("something").to_selection()
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3898
+#[test]
+fn add_type_annotations_public_alias_to_internal_type() {
+    let src = "
+import package
+
+pub fn main() {
+  package.make_wibble()
+}
+";
+
+    assert_code_action!(
+        ADD_ANNOTATION,
+        TestProject::for_source(src)
+            .add_package_module(
+                "package",
+                "package",
+                "
+import package/internal
+
+pub type Wibble = internal.Wibble
+
+pub fn make_wibble() {
+  internal.Wibble
+}
+"
+            )
+            .add_package_module("package", "package/internal", "pub type Wibble { Wibble }"),
+        find_position_of("main").to_selection(),
+    );
+}
+
+#[test]
+fn add_type_annotations_public_alias_to_internal_type_aliased_module() {
+    let src = "
+import package as pkg
+
+pub fn main() {
+  pkg.make_wibble()
+}
+";
+
+    assert_code_action!(
+        ADD_ANNOTATION,
+        TestProject::for_source(src)
+            .add_package_module(
+                "package",
+                "package",
+                "
+import package/internal
+
+pub type Wibble = internal.Wibble
+
+pub fn make_wibble() {
+  internal.Wibble
+}
+"
+            )
+            .add_package_module("package", "package/internal", "pub type Wibble { Wibble }"),
+        find_position_of("main").to_selection(),
+    );
+}
+
+#[test]
+fn add_type_annotations_public_alias_to_internal_generic_type() {
+    let src = "
+import package
+
+pub fn main() {
+  package.make_wibble(10)
+}
+";
+
+    assert_code_action!(
+        ADD_ANNOTATION,
+        TestProject::for_source(src)
+            .add_package_module(
+                "package",
+                "package",
+                "
+import package/internal
+
+pub type Wibble(a, b) = internal.Wibble(a, b)
+
+pub fn make_wibble(x) {
+  internal.Wibble(x)
+}
+"
+            )
+            .add_package_module(
+                "package",
+                "package/internal",
+                "pub type Wibble(a, b) { Wibble(a) }"
+            ),
+        find_position_of("main").to_selection(),
+    );
+}

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -9642,3 +9642,34 @@ pub fn make_wibble(x) {
         find_position_of("main").to_selection(),
     );
 }
+
+#[test]
+fn add_type_annotations_uses_internal_name_for_same_package() {
+    let src = "
+import thepackage/internal
+
+pub fn main() {
+  internal.Constructor
+}
+";
+
+    assert_code_action!(
+        ADD_ANNOTATION,
+        TestProject::for_source(src)
+            .add_module(
+                "thepackage/internal",
+                "
+pub type Internal { Constructor }
+"
+            )
+            .add_module(
+                "thepackage/external",
+                "
+import thepackage/internal
+
+pub type External = internal.Internal
+"
+            ),
+        find_position_of("main").to_selection(),
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_public_alias_to_internal_generic_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_public_alias_to_internal_generic_type.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport package\n\npub fn main() {\n  package.make_wibble(10)\n}\n"
+---
+----- BEFORE ACTION
+
+import package
+
+pub fn main() {
+       ↑       
+  package.make_wibble(10)
+}
+
+
+----- AFTER ACTION
+
+import package
+
+pub fn main() -> package.Wibble(Int, a) {
+  package.make_wibble(10)
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_public_alias_to_internal_type.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_public_alias_to_internal_type.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport package\n\npub fn main() {\n  package.make_wibble()\n}\n"
+---
+----- BEFORE ACTION
+
+import package
+
+pub fn main() {
+       ↑       
+  package.make_wibble()
+}
+
+
+----- AFTER ACTION
+
+import package
+
+pub fn main() -> package.Wibble {
+  package.make_wibble()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_public_alias_to_internal_type_aliased_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_public_alias_to_internal_type_aliased_module.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport package as pkg\n\npub fn main() {\n  pkg.make_wibble()\n}\n"
+---
+----- BEFORE ACTION
+
+import package as pkg
+
+pub fn main() {
+       ↑       
+  pkg.make_wibble()
+}
+
+
+----- AFTER ACTION
+
+import package as pkg
+
+pub fn main() -> pkg.Wibble {
+  pkg.make_wibble()
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_uses_internal_name_for_same_package.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_type_annotations_uses_internal_name_for_same_package.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport thepackage/internal\n\npub fn main() {\n  internal.Constructor\n}\n"
+---
+----- BEFORE ACTION
+
+import thepackage/internal
+
+pub fn main() {
+       ↑       
+  internal.Constructor
+}
+
+
+----- AFTER ACTION
+
+import thepackage/internal
+
+pub fn main() -> internal.Internal {
+  internal.Constructor
+}

--- a/compiler-core/src/metadata/module_decoder.rs
+++ b/compiler-core/src/metadata/module_decoder.rs
@@ -197,6 +197,7 @@ impl ModuleDecoder {
                 message: self.string(deprecation)?,
             }
         };
+        let parameters = read_vec!(&reader.get_parameters()?, self, type_);
         Ok(TypeAliasConstructor {
             publicity: self.publicity(reader.get_publicity()?)?,
             origin: self.src_span(&reader.get_origin()?)?,
@@ -205,6 +206,7 @@ impl ModuleDecoder {
             deprecation,
             documentation: self.optional_string(self.str(reader.get_documentation()?)?),
             arity: reader.get_arity() as usize,
+            parameters,
         })
     }
 
@@ -224,9 +226,10 @@ impl ModuleDecoder {
         let name = self.string(reader.get_name()?)?;
         let arguments = read_vec!(&reader.get_parameters()?, self, type_);
         let inferred_variant = self.inferred_variant(&reader.get_inferred_variant()?)?;
+        let publicity = self.publicity(reader.get_publicity()?)?;
 
         Ok(Arc::new(Type::Named {
-            publicity: Publicity::Public,
+            publicity,
             package,
             module,
             name,

--- a/compiler-core/src/metadata/module_encoder.rs
+++ b/compiler-core/src/metadata/module_encoder.rs
@@ -311,7 +311,12 @@ impl<'a> ModuleEncoder<'a> {
         self.build_type(type_builder, &constructor.type_);
         self.build_src_span(builder.reborrow().init_origin(), constructor.origin);
         builder.set_documentation(constructor.documentation.as_deref().unwrap_or_default());
-        builder.set_arity(constructor.arity as u32)
+        builder.set_arity(constructor.arity as u32);
+
+        let mut parameters_builder = builder.init_parameters(constructor.parameters.len() as u32);
+        for (index, parameter) in constructor.parameters.iter().enumerate() {
+            self.build_type(parameters_builder.reborrow().get(index as u32), parameter);
+        }
     }
 
     fn build_type_value_constructor(
@@ -652,7 +657,7 @@ impl<'a> ModuleEncoder<'a> {
                 module,
                 package,
                 inferred_variant,
-                ..
+                publicity,
             } => {
                 let mut app = builder.init_app();
                 app.set_name(name);
@@ -667,6 +672,7 @@ impl<'a> ModuleEncoder<'a> {
                     app.reborrow().init_parameters(arguments.len() as u32),
                     arguments,
                 );
+                self.build_publicity(app.init_publicity(), *publicity);
             }
 
             Type::Tuple { elements } => self.build_types(

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -1761,14 +1761,18 @@ fn type_with_inferred_variant() {
             "Wibble".into(),
             TypeConstructor {
                 type_: Arc::new(Type::Named {
-                    publicity: Publicity::Public,
+                    publicity: Publicity::Internal {
+                        attribute_location: None,
+                    },
                     package: "some_package".into(),
                     module: "the/module".into(),
                     name: "Wibble".into(),
                     arguments: Vec::new(),
                     inferred_variant: Some(1),
                 }),
-                publicity: Publicity::Public,
+                publicity: Publicity::Internal {
+                    attribute_location: Some(SrcSpan::new(0, 10)),
+                },
                 origin: Default::default(),
                 module: "the/module".into(),
                 parameters: vec![],
@@ -1816,6 +1820,7 @@ fn module_with_type_aliases() {
                 deprecation: Deprecation::NotDeprecated,
                 documentation: Some("Some documentation".into()),
                 origin: Default::default(),
+                parameters: vec![type_::generic_var(0)],
             },
         )]
         .into(),

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -100,6 +100,7 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
+            reexport_aliases: {},
         },
         unused_definition_positions: {},
     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
@@ -69,6 +69,7 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
+            reexport_aliases: {},
         },
         unused_definition_positions: {},
     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -69,6 +69,7 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
+            reexport_aliases: {},
         },
         unused_definition_positions: {},
     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__private_opaque_type_is_parsed.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__private_opaque_type_is_parsed.snap
@@ -53,6 +53,7 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
+            reexport_aliases: {},
         },
         unused_definition_positions: {},
     },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -171,6 +171,7 @@ Parsed {
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},
+            reexport_aliases: {},
         },
         unused_definition_positions: {},
     },

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1495,6 +1495,7 @@ pub struct TypeAliasConstructor {
     pub deprecation: Deprecation,
     pub documentation: Option<EcoString>,
     pub origin: SrcSpan,
+    pub parameters: Vec<Arc<Type>>,
 }
 
 impl ValueConstructor {

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -113,7 +113,7 @@ impl<'a> Environment<'a> {
             .get(PRELUDE_MODULE_NAME)
             .expect("Unable to find prelude in importable modules");
 
-        let names = Self::build_names(&current_package, prelude, importable_modules);
+        let names = Self::build_names(prelude, importable_modules);
 
         Self {
             current_package,
@@ -144,7 +144,6 @@ impl<'a> Environment<'a> {
     }
 
     fn build_names(
-        current_package: &str,
         prelude: &ModuleInterface,
         importable_modules: &im::HashMap<EcoString, ModuleInterface>,
     ) -> Names {
@@ -164,12 +163,6 @@ impl<'a> Environment<'a> {
 
         // Find potential type aliases which reexport internal types
         for module in importable_modules.values() {
-            // Internal types are accessibly within the package they are defined,
-            // so it doesn't make sense to look for reexports within the same
-            // package.
-            if module.package == current_package {
-                continue;
-            }
             // Internal modules are not part of the public API so they are also
             // not considered.
             if module.is_internal {

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -113,21 +113,10 @@ impl<'a> Environment<'a> {
             .get(PRELUDE_MODULE_NAME)
             .expect("Unable to find prelude in importable modules");
 
-        let mut names = Names::new();
-        for name in prelude.values.keys() {
-            names.named_constructor_in_scope(
-                PRELUDE_MODULE_NAME.into(),
-                name.clone(),
-                name.clone(),
-            );
-        }
-
-        for name in prelude.types.keys() {
-            names.named_type_in_scope(PRELUDE_MODULE_NAME.into(), name.clone(), name.clone());
-        }
+        let names = Self::build_names(&current_package, prelude, importable_modules);
 
         Self {
-            current_package: current_package.clone(),
+            current_package,
             gleam_version,
             previous_id: ids.next(),
             ids,
@@ -152,6 +141,49 @@ impl<'a> Environment<'a> {
             references: ReferenceTracker::new(),
             dev_dependencies,
         }
+    }
+
+    fn build_names(
+        current_package: &str,
+        prelude: &ModuleInterface,
+        importable_modules: &im::HashMap<EcoString, ModuleInterface>,
+    ) -> Names {
+        let mut names = Names::new();
+
+        // Insert prelude types and values into scope
+        for name in prelude.values.keys() {
+            names.named_constructor_in_scope(
+                PRELUDE_MODULE_NAME.into(),
+                name.clone(),
+                name.clone(),
+            );
+        }
+        for name in prelude.types.keys() {
+            names.named_type_in_scope(PRELUDE_MODULE_NAME.into(), name.clone(), name.clone());
+        }
+
+        // Find potential type aliases which reexport internal types
+        for module in importable_modules.values() {
+            // Internal types are accessibly within the package they are defined,
+            // so it doesn't make sense to look for reexports within the same
+            // package.
+            if module.package == current_package {
+                continue;
+            }
+            // Internal modules are not part of the public API so they are also
+            // not considered.
+            if module.is_internal {
+                continue;
+            }
+            for (alias_name, alias) in module.type_aliases.iter() {
+                // An alias can only be a public reexport if it is public.
+                if alias.publicity.is_public() {
+                    names.maybe_register_reexport_alias(&module.package, alias_name, alias);
+                }
+            }
+        }
+
+        names
     }
 }
 

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -222,6 +222,8 @@ impl Names {
             .map(|(_, location)| location)
     }
 
+    /// Check whether a particular type alias is reexporting an internal type,
+    /// and if so register it so we can print it correctly.
     pub fn maybe_register_reexport_alias(
         &mut self,
         package: &EcoString,
@@ -251,7 +253,7 @@ impl Names {
                     );
                 }
             }
-            _ => {}
+            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => {}
         }
     }
 

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use crate::{
     ast::SrcSpan,
-    type_::{Type, TypeVar},
+    type_::{Type, TypeAliasConstructor, TypeVar},
 };
 
 /// This class keeps track of what names are used for modules in the current
@@ -117,6 +117,32 @@ pub struct Names {
     /// - value: `"Woo"`
     ///
     local_value_constructors: BiMap<(EcoString, EcoString), EcoString>,
+
+    /// A map containing information about public alias of internal types in
+    /// other packages. This is a common pattern in Gleam, in order to reexport
+    /// an internal type, without exposing its implementation details. Because
+    /// of this, we want to be able to properly handle this case, and use the
+    /// public alias rather than the internal underlying type. Since Gleam type
+    /// aliases are not part of the type system, we have to track them manually
+    /// here.
+    ///
+    /// This is a mapping of internal types to their public aliases that we want
+    /// to favour over the internal types.
+    ///
+    /// For example, if we had the following code:
+    ///
+    /// ```gleam
+    /// // lustre/element.gleam
+    /// import lustre/internal
+    ///
+    /// pub type Element(a) = internal.Element(a)
+    /// ```
+    ///
+    /// This map would contain a key of `("lustre/internal", "Element")` with a
+    /// value of `("lustre/element", "Element")`. This can then be used to look
+    /// up the alias we want to print based on the type we are printing.
+    ///
+    reexport_aliases: HashMap<(EcoString, EcoString), (EcoString, EcoString)>,
 }
 
 /// The `PartialEq` implementation for `Type` doesn't account for `TypeVar::Link`,
@@ -139,6 +165,7 @@ impl Names {
             imported_modules: Default::default(),
             type_variables: Default::default(),
             local_value_constructors: Default::default(),
+            reexport_aliases: Default::default(),
         }
     }
 
@@ -195,6 +222,39 @@ impl Names {
             .map(|(_, location)| location)
     }
 
+    pub fn maybe_register_reexport_alias(
+        &mut self,
+        package: &EcoString,
+        alias_name: &EcoString,
+        alias: &TypeAliasConstructor,
+    ) {
+        match alias.type_.as_ref() {
+            Type::Named {
+                publicity,
+                package: type_package,
+                module,
+                name,
+                arguments,
+                ..
+            } => {
+                // We only count this alias as a reexport if it is:
+                // - aliasing a type in the same package
+                // - the type is internal
+                // - the alias exposes the same type parameters as the internal type
+                if type_package == package
+                    && publicity.is_internal()
+                    && compare_arguments(arguments, &alias.parameters)
+                {
+                    _ = self.reexport_aliases.insert(
+                        (module.clone(), name.clone()),
+                        (alias.module.clone(), alias_name.clone()),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Get the name and optional module qualifier for a named type.
     pub fn named_type<'a>(
         &'a self,
@@ -207,7 +267,7 @@ impl Names {
                 return NameContextInformation::Qualified(module, name.as_str());
             };
 
-            return NameContextInformation::Unimported(name.as_str());
+            return NameContextInformation::Unimported(module, name);
         }
 
         let key = (module.clone(), name.clone());
@@ -218,12 +278,20 @@ impl Names {
             return NameContextInformation::Unqualified(name.as_str());
         }
 
+        if let Some((module, alias)) = self.reexport_aliases.get(&key) {
+            if let Some((module, _)) = self.imported_modules.get(module) {
+                return NameContextInformation::Qualified(module, alias);
+            } else {
+                return NameContextInformation::Unimported(module, alias);
+            }
+        }
+
         // This type is from a module that has been imported
         if let Some((module, _)) = self.imported_modules.get(module) {
             return NameContextInformation::Qualified(module, name.as_str());
         };
 
-        NameContextInformation::Unimported(name.as_str())
+        NameContextInformation::Unimported(module, name)
     }
 
     /// Record a named value in this module.
@@ -257,7 +325,7 @@ impl Names {
             return NameContextInformation::Qualified(module, name.as_str());
         };
 
-        NameContextInformation::Unimported(name.as_str())
+        NameContextInformation::Unimported(module, name)
     }
 
     pub fn is_imported(&self, module: &str) -> bool {
@@ -272,7 +340,7 @@ impl Names {
 #[derive(Debug)]
 pub enum NameContextInformation<'a> {
     /// This type is from a module that has not been imported in this module.
-    Unimported(&'a str),
+    Unimported(&'a str, &'a str),
     /// This type has been imported in an unqualifid fashion in this module.
     Unqualified(&'a str),
     /// This type is from a module that has been imported.
@@ -404,12 +472,12 @@ impl<'a> Printer<'a> {
                 ..
             } => {
                 let (module, name) = match self.names.named_type(module, name, print_mode) {
-                    NameContextInformation::Qualified(m, n) => (Some(m), n),
-                    NameContextInformation::Unqualified(n) => (None, n),
+                    NameContextInformation::Qualified(module, name) => (Some(module), name),
+                    NameContextInformation::Unqualified(name) => (None, name),
                     // TODO: indicate that the module is not import and as such
                     // needs to be, as well as how.
-                    NameContextInformation::Unimported(n) => {
-                        (Some(module.split('/').next_back().unwrap_or(module)), n)
+                    NameContextInformation::Unimported(module, name) => {
+                        (module.split('/').next_back(), name)
                     }
                 };
 
@@ -452,8 +520,8 @@ impl<'a> Printer<'a> {
         let (module, name) = match self.names.named_constructor(module, name) {
             NameContextInformation::Qualified(module, name) => (Some(module), name),
             NameContextInformation::Unqualified(name) => (None, name),
-            NameContextInformation::Unimported(name) => {
-                (Some(module.split('/').next_back().unwrap_or(module)), name)
+            NameContextInformation::Unimported(module, name) => {
+                (module.split('/').next_back(), name)
             }
         };
 

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -256,7 +256,7 @@ impl Names {
     }
 
     /// Get the name and optional module qualifier for a named type.
-    pub fn named_type<'a>(
+    fn named_type<'a>(
         &'a self,
         module: &'a EcoString,
         name: &'a EcoString,
@@ -334,6 +334,14 @@ impl Names {
 
     pub fn get_type_variable(&self, id: u64) -> Option<&EcoString> {
         self.type_variables.get(&id)
+    }
+
+    pub fn reexport_alias(
+        &self,
+        module: EcoString,
+        name: EcoString,
+    ) -> Option<&(EcoString, EcoString)> {
+        self.reexport_aliases.get(&(module, name))
     }
 }
 


### PR DESCRIPTION
This PR closes #3898 and #4838
I've extended the `Names` struct to keep track of all public aliases which alias internal types, across all packages. Then, whenever we're printing an internal type, we check for public aliases which reexport that type, and if there is one, print that instead. I've also applied this process to the documentation printer so generated documentation for packages will use the public type aliases rather than printing `@internal SomeInternalType`.

This doesn't yet apply to public type aliases which do not fully reexport a type. For example, if you have:
```gleam
@internal
pub type SomeInternalType(a)

pub type PartialReexport = SomeInternalType(Int)
```

`PartialReexport` can only be used if referencing `SomeInternalType(Int)`, and not, for example, `SomeInternalType(Float)`. This case is not covered yet, so if generic parameters differ, the internal type name is always used.