### PR TITLE
Warn for unused arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,39 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler now raises a warning when a function's argument is only passed
+  along in a recursive call but not actually used for anything. For example:
+
+  ```gleam
+  import gleam/io
+
+  pub fn greet(x, times) {
+    case times {
+      0 -> Nil
+      _ -> {
+        io.println("Hello, Joe!")
+        greet(x, times - 1)
+      }
+    }
+  }
+  ```
+
+  In this piece of code the `x` argument is actually never used, and the
+  compiler will raise the following warning:
+
+  ```text
+  warning: Unused function argument
+    ┌─ /Users/giacomocavalieri/Desktop/prova/src/prova.gleam:3:14
+    │
+  3 │ pub fn greet(x, times) {
+    │              ^ This argument is unused
+
+  This argument is passed to the function when recursing, but it's never used
+  for anything.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The compiler now emits a better error message for private types marked as
   opaque. For example, the following piece of code:
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -599,6 +599,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 .expect("Could not find hydrator for fn");
 
             let (arguments, body) = expr_typer.infer_fn_with_known_types(
+                Some(name.clone()),
                 typed_arguments.clone(),
                 body,
                 Some(prereg_return_type.clone()),

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -1033,6 +1033,13 @@ impl TypedExpr {
         }
     }
 
+    pub fn var_constructor(&self) -> Option<&ValueConstructor> {
+        match self {
+            TypedExpr::Var { constructor, .. } => Some(constructor),
+            _ => None,
+        }
+    }
+
     #[must_use]
     pub(crate) fn is_panic(&self) -> bool {
         match self {

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -1033,9 +1033,11 @@ impl TypedExpr {
         }
     }
 
-    pub fn var_constructor(&self) -> Option<&ValueConstructor> {
+    pub fn var_constructor(&self) -> Option<(&ValueConstructor, &EcoString)> {
         match self {
-            TypedExpr::Var { constructor, .. } => Some(constructor),
+            TypedExpr::Var {
+                constructor, name, ..
+            } => Some((constructor, name)),
             _ => None,
         }
     }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -6236,7 +6236,7 @@ impl<'ast> ast::visit::Visit<'ast> for InlineVariable<'ast> {
             VariableDeclaration::LetPattern => {}
             VariableDeclaration::UsePattern
             | VariableDeclaration::ClausePattern
-            | VariableDeclaration::FunctionParameter
+            | VariableDeclaration::FunctionParameter { .. }
             | VariableDeclaration::Generated => return,
         }
 
@@ -6256,7 +6256,7 @@ impl<'ast> ast::visit::Visit<'ast> for InlineVariable<'ast> {
             VariableDeclaration::LetPattern => {}
             VariableDeclaration::UsePattern
             | VariableDeclaration::ClausePattern
-            | VariableDeclaration::FunctionParameter
+            | VariableDeclaration::FunctionParameter { .. }
             | VariableDeclaration::Generated => return,
         }
 

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -877,49 +877,6 @@ impl ValueConstructorVariant {
             ValueConstructorVariant::Record { field_map, .. } => field_map.as_ref(),
         }
     }
-
-    /// If this is the constructor of a module function, returns the function's
-    /// module and name.
-    ///
-    fn function_module_and_name(&self) -> Option<(EcoString, EcoString)> {
-        match self {
-            ValueConstructorVariant::ModuleFn { name, module, .. } => {
-                Some((module.clone(), name.clone()))
-            }
-
-            ValueConstructorVariant::ModuleConstant { .. }
-            | ValueConstructorVariant::LocalConstant { .. }
-            | ValueConstructorVariant::LocalVariable { .. }
-            | ValueConstructorVariant::Record { .. } => None,
-        }
-    }
-
-    /// If this is a constructor for an argument, returns the name of the
-    /// function where it is defined and its index in the function's parameter
-    /// list.
-    ///
-    fn argument_function_and_index(&self) -> Option<(EcoString, usize)> {
-        match self {
-            ValueConstructorVariant::LocalVariable {
-                location: _,
-                origin:
-                    VariableOrigin {
-                        syntax: _,
-                        declaration:
-                            VariableDeclaration::FunctionParameter {
-                                function_name,
-                                index,
-                            },
-                    },
-            } => Some((function_name.clone()?, *index)),
-
-            ValueConstructorVariant::LocalVariable { .. }
-            | ValueConstructorVariant::ModuleConstant { .. }
-            | ValueConstructorVariant::LocalConstant { .. }
-            | ValueConstructorVariant::ModuleFn { .. }
-            | ValueConstructorVariant::Record { .. } => None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -877,6 +877,49 @@ impl ValueConstructorVariant {
             ValueConstructorVariant::Record { field_map, .. } => field_map.as_ref(),
         }
     }
+
+    /// If this is the constructor of a module function, returns the function's
+    /// module and name.
+    ///
+    fn function_module_and_name(&self) -> Option<(EcoString, EcoString)> {
+        match self {
+            ValueConstructorVariant::ModuleFn { name, module, .. } => {
+                Some((module.clone(), name.clone()))
+            }
+
+            ValueConstructorVariant::ModuleConstant { .. }
+            | ValueConstructorVariant::LocalConstant { .. }
+            | ValueConstructorVariant::LocalVariable { .. }
+            | ValueConstructorVariant::Record { .. } => None,
+        }
+    }
+
+    /// If this is a constructor for an argument, returns the name of the
+    /// function where it is defined and its index in the function's parameter
+    /// list.
+    ///
+    fn argument_function_and_index(&self) -> Option<(EcoString, usize)> {
+        match self {
+            ValueConstructorVariant::LocalVariable {
+                location: _,
+                origin:
+                    VariableOrigin {
+                        syntax: _,
+                        declaration:
+                            VariableDeclaration::FunctionParameter {
+                                function_name,
+                                index,
+                            },
+                    },
+            } => Some((function_name.clone()?, *index)),
+
+            ValueConstructorVariant::LocalVariable { .. }
+            | ValueConstructorVariant::ModuleConstant { .. }
+            | ValueConstructorVariant::LocalConstant { .. }
+            | ValueConstructorVariant::ModuleFn { .. }
+            | ValueConstructorVariant::Record { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1110,7 +1110,6 @@ pub enum Warning {
     ///
     UnusedRecursiveArgument {
         location: SrcSpan,
-        usages: Vec<SrcSpan>,
     },
 }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4493,7 +4493,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location,
             ),
 
-            // If the argument is a regular var then we specialise.
+            // If the argument is a regular var then we want to add some extra
+            // checks. The value will be inferred regularly, but we also want to
+            // see if this is an argument that is being passed recursively to
+            // the same function that defined it!
             (_, UntypedExpr::Var { location, name }) => {
                 self.infer_variable_call_arg(called_function, name, location, argument_index)
             }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x: Int) {\n  main(x)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x: Int) {
+  main(x)
+}
+
+
+----- WARNING
+warning: Unused function argument
+  ┌─ /src/warning/wrn.gleam:2:13
+  │
+2 │ pub fn main(x: Int) {
+  │             ^ This argument is unused
+3 │   main(x)
+  │        -
+
+This argument is passed to the function when recursing, but it's never used
+for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument.snap
@@ -14,7 +14,7 @@ warning: Unused function argument
   ┌─ /src/warning/wrn.gleam:2:13
   │
 2 │ pub fn main(x: Int) {
-  │             ^ This argument is unused
+  │             ^ This argument is never used
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument.snap
@@ -15,8 +15,6 @@ warning: Unused function argument
   │
 2 │ pub fn main(x: Int) {
   │             ^ This argument is unused
-3 │   main(x)
-  │        -
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument_2.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x, times) {\n  case times {\n    0 -> main(x, 0)\n    _ -> main(x, times - 1)\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, times) {
+  case times {
+    0 -> main(x, 0)
+    _ -> main(x, times - 1)
+  }
+}
+
+
+----- WARNING
+warning: Unused function argument
+  ┌─ /src/warning/wrn.gleam:2:13
+  │
+2 │ pub fn main(x, times) {
+  │             ^ This argument is unused
+3 │   case times {
+4 │     0 -> main(x, 0)
+  │               -
+5 │     _ -> main(x, times - 1)
+  │               -
+
+This argument is passed to the function when recursing, but it's never used
+for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument_2.snap
@@ -18,11 +18,6 @@ warning: Unused function argument
   │
 2 │ pub fn main(x, times) {
   │             ^ This argument is unused
-3 │   case times {
-4 │     0 -> main(x, 0)
-  │               -
-5 │     _ -> main(x, times - 1)
-  │               -
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_argument_2.snap
@@ -17,7 +17,7 @@ warning: Unused function argument
   ┌─ /src/warning/wrn.gleam:2:13
   │
 2 │ pub fn main(x, times) {
-  │             ^ This argument is unused
+  │             ^ This argument is never used
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_inside_anonymous_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_inside_anonymous_function.snap
@@ -15,7 +15,7 @@ warning: Unused function argument
   ┌─ /src/warning/wrn.gleam:2:13
   │
 2 │ pub fn main(x: Int) {
-  │             ^ This argument is unused
+  │             ^ This argument is never used
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_inside_anonymous_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_inside_anonymous_function.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x: Int) {\n  let _useless = fn(_) { main(x) }\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x: Int) {
+  let _useless = fn(_) { main(x) }
+  Nil
+}
+
+
+----- WARNING
+warning: Unused function argument
+  ┌─ /src/warning/wrn.gleam:2:13
+  │
+2 │ pub fn main(x: Int) {
+  │             ^ This argument is unused
+3 │   let _useless = fn(_) { main(x) }
+  │                               -
+
+This argument is passed to the function when recursing, but it's never used
+for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_inside_anonymous_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_inside_anonymous_function.snap
@@ -16,8 +16,6 @@ warning: Unused function argument
   │
 2 │ pub fn main(x: Int) {
   │             ^ This argument is unused
-3 │   let _useless = fn(_) { main(x) }
-  │                               -
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_with_shadowing.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_with_shadowing.snap
@@ -15,7 +15,7 @@ warning: Unused function argument
   ┌─ /src/warning/wrn.gleam:2:13
   │
 2 │ pub fn main(x: Int) {
-  │             ^ This argument is unused
+  │             ^ This argument is never used
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_with_shadowing.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_with_shadowing.snap
@@ -16,9 +16,6 @@ warning: Unused function argument
   │
 2 │ pub fn main(x: Int) {
   │             ^ This argument is unused
-3 │   let _useless = fn(x) { main(x) }
-4 │   main(x)
-  │        -
 
 This argument is passed to the function when recursing, but it's never used
 for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_with_shadowing.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_recursive_function_with_shadowing.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x: Int) {\n  let _useless = fn(x) { main(x) }\n  main(x)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x: Int) {
+  let _useless = fn(x) { main(x) }
+  main(x)
+}
+
+
+----- WARNING
+warning: Unused function argument
+  ┌─ /src/warning/wrn.gleam:2:13
+  │
+2 │ pub fn main(x: Int) {
+  │             ^ This argument is unused
+3 │   let _useless = fn(x) { main(x) }
+4 │   main(x)
+  │        -
+
+This argument is passed to the function when recursing, but it's never used
+for anything.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_variable_warnings_test.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unused_variable_warnings_test.snap
@@ -6,10 +6,10 @@ expression: "pub fn a(b) { 1 }"
 pub fn a(b) { 1 }
 
 ----- WARNING
-warning: Unused variable
+warning: Unused function argument
   ┌─ /src/warning/wrn.gleam:1:10
   │
 1 │ pub fn a(b) { 1 }
-  │          ^ This variable is never used
+  │          ^ This argument is never used
 
 Hint: You can ignore it with an underscore: `_b`.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -4444,3 +4444,90 @@ pub fn wibble(bits) {
 }"#
     );
 }
+
+#[test]
+fn unused_recursive_function_argument() {
+    assert_warning!(
+        "
+pub fn main(x: Int) {
+  main(x)
+}
+"
+    );
+}
+
+#[test]
+fn unused_recursive_function_argument_2() {
+    assert_warning!(
+        "
+pub fn main(x, times) {
+  case times {
+    0 -> main(x, 0)
+    _ -> main(x, times - 1)
+  }
+}
+"
+    );
+}
+
+#[test]
+fn unused_recursive_function_with_shadowing() {
+    assert_warning!(
+        "
+pub fn main(x: Int) {
+  let _useless = fn(x) { main(x) }
+  main(x)
+}
+"
+    );
+}
+
+#[test]
+fn unused_recursive_function_inside_anonymous_function() {
+    assert_warning!(
+        "
+pub fn main(x: Int) {
+  let _useless = fn(_) { main(x) }
+  Nil
+}
+"
+    );
+}
+
+#[test]
+fn unused_recursive_function_with_variable_shadowing() {
+    assert_no_warnings!(
+        "
+pub fn main(x: Int) {
+  let x = x * 2
+  main(x)
+}
+"
+    );
+}
+
+#[test]
+fn unused_recursive_function_passing_argument_in_a_different_position_counts_as_using_it() {
+    assert_no_warnings!(
+        "
+pub fn main(x: Int, y) {
+  case y {
+    0 -> main(1, x)
+    _ -> main(0, 0)
+  }
+}
+"
+    );
+}
+
+#[test]
+fn unused_recursive_function_with_shadowed_function() {
+    assert_no_warnings!(
+        "
+pub fn main(x: Int) {
+  let main = fn(x) { x }
+  main(x)
+}
+"
+    );
+}

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -719,7 +719,7 @@ Hint: You can safely remove it.
                     }),
                 },
 
-                type_::Warning::UnusedRecursiveArgument { location, usages } => Diagnostic {
+                type_::Warning::UnusedRecursiveArgument { location } => Diagnostic {
                     title: "Unused function argument".into(),
                     text: wrap(
                         "This argument is passed to the function when recursing, \
@@ -734,16 +734,7 @@ but it's never used for anything.",
                             text: Some("This argument is unused".into()),
                             span: *location,
                         },
-                        extra_labels: usages
-                            .iter()
-                            .map(|usage| ExtraLabel {
-                                src_info: None,
-                                label: diagnostic::Label {
-                                    text: None,
-                                    span: *usage,
-                                },
-                            })
-                            .collect(),
+                        extra_labels: vec![],
                     }),
                 },
 

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -731,7 +731,7 @@ but it's never used for anything.",
                         src: src.clone(),
                         path: path.to_path_buf(),
                         label: diagnostic::Label {
-                            text: Some("This argument is unused".into()),
+                            text: Some("This argument is never used".into()),
                             span: *location,
                         },
                         extra_labels: vec![],


### PR DESCRIPTION
This PR introduces a new warning for arguments that are never actually used in a recursive function but only passed along the recursive calls. For example:

```gleam
import gleam/io

pub fn greet(x, times) {
  case times {
    0 -> Nil
    _ -> {
      io.println("Hello, Joe!")
      greet(x, times - 1)
    }
  }
}
```

Would raise the following warning:

```txt
warning: Unused function argument
  ┌─ /Users/giacomocavalieri/Desktop/prova/src/prova.gleam:3:14
  │
3 │ pub fn greet(x, times) {
  │              ^ This argument is unused
  ·
8 │       greet(x, times - 1)
  │             -

This argument is passed to the function when recursing, but it's never used
for anything.

```