### PR TITLE
Support "Generate function" code action in other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,35 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The "Generate function" code action now allows generating function in other
+  modules. For example, given the following code:
+
+  ```gleam
+  // maths.gleam
+  pub fn add(a: Int, b: Int) -> Int { a + b }
+
+  // main.gleam
+  import maths
+
+  pub fn main() -> Int {
+    echo maths.add(1, 2)
+    echo maths.subtract(from: 2, subtract: 1)
+    //         ^ Trigger the "Generate function" code action here
+  }
+  ```
+
+  The language sever will edit the `maths.gleam` file:
+
+  ```gleam
+  pub fn add(a: Int, b: Int) -> Int { a + b }
+
+  pub fn subtract(from from: Int, subtract subtract: Int) -> Int {
+    todo
+  }
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 - The "Add type annotations" and "Generate function" code actions now ignore type
   variables defined in other functions, improving the generated code. For example:
 

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -624,6 +624,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                         start: body_location.end,
                         end: body_location.end,
                     },
+                    extra_information: None,
                 }));
                 let implementations = Implementations::supporting_all();
                 (

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -6,7 +6,7 @@ mod untyped;
 mod tests;
 pub mod visit;
 
-pub use self::typed::TypedExpr;
+pub use self::typed::{InvalidExpression, TypedExpr};
 pub use self::untyped::{FunctionLiteralKind, UntypedExpr};
 
 pub use self::constant::{Constant, TypedConstant, UntypedConstant};

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -188,6 +188,10 @@ pub enum TypedExpr {
     Invalid {
         location: SrcSpan,
         type_: Arc<Type>,
+        /// Extra information about the invalid expression, useful for providing
+        /// addition help or information, such as code actions to fix invalid
+        /// states.
+        extra_information: Option<InvalidExpression>,
     },
 }
 
@@ -1161,4 +1165,12 @@ impl bit_array::GetLiteralValue for TypedExpr {
             None
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidExpression {
+    ModuleSelect {
+        module_name: EcoString,
+        label: EcoString,
+    },
 }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -40,7 +40,7 @@
 
 use crate::{
     analyse::Inferred,
-    ast::{BitArraySize, TypedBitArraySize},
+    ast::{BitArraySize, TypedBitArraySize, typed::InvalidExpression},
     exhaustiveness::CompiledCase,
     type_::{
         ModuleValueConstructor, PatternConstructor, TypedCallArg, ValueConstructor,
@@ -335,8 +335,13 @@ pub trait Visit<'ast> {
         visit_typed_expr_negate_int(self, location, value)
     }
 
-    fn visit_typed_expr_invalid(&mut self, location: &'ast SrcSpan, type_: &'ast Arc<Type>) {
-        visit_typed_expr_invalid(self, location, type_);
+    fn visit_typed_expr_invalid(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        extra_information: &'ast Option<InvalidExpression>,
+    ) {
+        visit_typed_expr_invalid(self, location, type_, extra_information);
     }
 
     fn visit_typed_statement(&mut self, stmt: &'ast TypedStatement) {
@@ -903,7 +908,11 @@ where
             v.visit_typed_expr_negate_bool(location, value)
         }
         TypedExpr::NegateInt { location, value } => v.visit_typed_expr_negate_int(location, value),
-        TypedExpr::Invalid { location, type_ } => v.visit_typed_expr_invalid(location, type_),
+        TypedExpr::Invalid {
+            location,
+            type_,
+            extra_information,
+        } => v.visit_typed_expr_invalid(location, type_, extra_information),
         TypedExpr::Echo {
             location,
             expression,
@@ -1843,8 +1852,12 @@ where
 {
 }
 
-pub fn visit_typed_expr_invalid<'a, V>(_v: &mut V, _location: &'a SrcSpan, _type_: &'a Arc<Type>)
-where
+pub fn visit_typed_expr_invalid<'a, V>(
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _type_: &'a Arc<Type>,
+    _extra_information: &'a Option<InvalidExpression>,
+) where
     V: Visit<'a> + ?Sized,
 {
 }

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5142,7 +5142,7 @@ impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
     ) {
         match constructor {
             // Invalid module selects leave the `name` field blank
-            ModuleValueConstructor::Fn { name, .. } if name == "" => {
+            ModuleValueConstructor::Fn { name, .. } if name.is_empty() => {
                 self.try_save_function_from_other_module(module_name, label, type_, None);
             }
             ModuleValueConstructor::Fn { .. }
@@ -5177,7 +5177,7 @@ impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
                     type_,
                     constructor: ModuleValueConstructor::Fn { name, .. },
                     ..
-                } if name == "" => {
+                } if name.is_empty() => {
                     return self.try_save_function_from_other_module(
                         module_name,
                         label,

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -428,7 +428,10 @@ where
             actions.extend(InterpolateString::new(module, &lines, &params).code_actions());
             actions.extend(ExtractVariable::new(module, &lines, &params).code_actions());
             actions.extend(ExtractConstant::new(module, &lines, &params).code_actions());
-            actions.extend(GenerateFunction::new(module, &lines, &params).code_actions());
+            actions.extend(
+                GenerateFunction::new(module, &this.compiler.modules, &lines, &params)
+                    .code_actions(),
+            );
             actions.extend(
                 GenerateVariant::new(module, &this.compiler, &lines, &params).code_actions(),
             );

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_in_other_module.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_in_other_module.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport wibble\n\npub fn main() {\n  wibble.wibble()\n  wibble.wobble()\n}\n"
+---
+----- BEFORE ACTION
+
+import wibble
+
+pub fn main() {
+  wibble.wibble()
+  wibble.wobble()
+         ↑       
+}
+
+
+----- AFTER ACTION
+// --- Edits applied to module 'wibble'
+pub fn wibble() {}
+
+pub fn wobble() -> a {
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generating_function_in_other_module_uses_labels.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generating_function_in_other_module_uses_labels.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport wibble\n\npub fn main() {\n  wibble.wibble(\"Unlabelled\", int: 1, bool: True)\n}\n"
+---
+----- BEFORE ACTION
+
+import wibble
+
+pub fn main() {
+  wibble.wibble("Unlabelled", int: 1, bool: True)
+         ↑                                       
+}
+
+
+----- AFTER ACTION
+// --- Edits applied to module 'wibble'
+
+
+pub fn wibble(string: String, int int: Int, bool bool: Bool) -> a {
+  todo
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generating_function_in_other_module_uses_local_names.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generating_function_in_other_module_uses_local_names.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\nimport wibble\n\npub fn main() -> List(Nil) {\n  wibble.wibble(1, #(True, \"Hello\"))\n}\n"
+---
+----- BEFORE ACTION
+
+import wibble
+
+pub fn main() -> List(Nil) {
+  wibble.wibble(1, #(True, "Hello"))
+         ↑                          
+}
+
+
+----- AFTER ACTION
+// --- Edits applied to module 'wibble'
+import gleam.{type Int as Number, type Bool as Boolean, type String as Text, type Nil as Nothing}
+
+pub fn wibble(int: Number, value: #(Boolean, Text)) -> List(Nothing) {
+  todo
+}

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1452,7 +1452,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     type_: self.new_unbound_var(),
                     label,
                     module_alias: module_name.clone(),
-                    module_name: module_name,
+                    module_name,
                     constructor: ModuleValueConstructor::Fn {
                         location,
                         module: "".into(),

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -63,6 +63,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 TypedExpr::Invalid {
                     location: first_location,
                     type_: expr_typer.new_unbound_var(),
+                    extra_information: None,
                 }
             }
         };
@@ -149,6 +150,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                             TypedExpr::Invalid {
                                 location,
                                 type_: self.expr_typer.new_unbound_var(),
+                                extra_information: None,
                             }
                         }
                     };
@@ -359,6 +361,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 TypedExpr::Invalid {
                     location: function_location,
                     type_: self.expr_typer.new_unbound_var(),
+                    extra_information: None,
                 }
             }
         });


### PR DESCRIPTION
Closes #4407 

I'm not super happy with how I've represented invalid `ModuleSelect`s here. It's more or less the same as what we do for invalid `RecordAccess`, but I wonder if there's a better way to do it. Suggestions welcome.