### PR TITLE
Added warning on `big if -> True` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,4 +381,4 @@
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 - Fixed a bug where the compiler allowed to write a guard with an empty clause.
-  ([Tristan-Mihai Radulescu][https://github.com/Courtcircuits])
+  ([Tristan-Mihai Radulescu](https://github.com/Courtcircuits))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,3 +379,6 @@
 - Fixed a bug where the compiler would suggest to use a discarded value defined
   in a different function.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the compiler allowed to write a guard with an empty clause.
+  ([Tristan-Mihai Radulescu][https://github.com/Courtcircuits])

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1625,16 +1625,16 @@ where
         let Some((start, end)) = self.maybe_one(&Token::If) else {
             return Ok(None);
         };
-        let guard_clause_result = self.parse_clause_guard_inner();
-        // if inner clause is none, a warning should be thrown to prevent that this behaviour
-        // is deprecated
-        if let Ok(None) = guard_clause_result {
+        let clause_guard_result = self.parse_clause_guard_inner();
+        // If inner clause is none, a warning should be shown to let the user
+        // know that empty clauses in guards are deprecated.
+        if let Ok(None) = clause_guard_result {
             self.warnings
-                .push(DeprecatedSyntaxWarning::DeprecatedEmptyGuardClause {
+                .push(DeprecatedSyntaxWarning::DeprecatedEmptyClauseGuard {
                     location: SrcSpan { start, end },
                 });
         }
-        guard_clause_result
+        clause_guard_result
     }
 
     fn parse_clause_guard_inner(&mut self) -> Result<Option<UntypedClauseGuard>, ParseError> {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_guard_clause.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_guard_clause.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n    let wibble = 10\n    case wibble {\n        10 if -> True\n        _ -> False\n    }\n\n}"
+---
+----- SOURCE CODE
+
+pub fn main() {
+    let wibble = 10
+    case wibble {
+        10 if -> True
+        _ -> False
+    }
+
+}
+
+----- WARNING
+warning: Deprecated empty guard clause syntax
+  ┌─ test/path:5:12
+  │
+5 │         10 if -> True
+  │            ^^ This should be followed by a guard or removed!!
+
+
+Empty clause within a guard is deprecated.
+To keep its behaviour, either remove the guard or fill the clause with
+`True` instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_guard_clause.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_guard_clause.snap
@@ -14,13 +14,11 @@ pub fn main() {
 }
 
 ----- WARNING
-warning: Deprecated empty guard clause syntax
+warning: Deprecated empty guard syntax
   ┌─ test/path:5:12
   │
 5 │         10 if -> True
-  │            ^^ This should be followed by a guard or removed!!
+  │            ^^ This can be removed.
 
-
-Empty clause within a guard is deprecated.
-To keep its behaviour, either remove the guard or fill the clause with
-`True` instead.
+This syntax for an empty guard is deprecated. To have a clause without a
+guard, remove this.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -4314,3 +4314,18 @@ pub fn wibble() { x }
 "
     );
 }
+
+#[test]
+fn empty_guard_clause() {
+    assert_warning!(
+        "
+pub fn main() {
+    let wibble = 10
+    case wibble {
+        10 if -> True
+        _ -> False
+    }
+
+}"
+    );
+}

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -380,9 +380,7 @@ To have a clause without a guard, remove this.",
                 level: diagnostic::Level::Warning,
                 location: Some(Location {
                     label: diagnostic::Label {
-                        text: Some(
-                            "This can be removed.".into(),
-                        ),
+                        text: Some("This can be removed.".into()),
                         span: *location,
                     },
                     path: path.clone(),

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -246,10 +246,10 @@ pub enum DeprecatedSyntaxWarning {
     /// ```gleam
     /// case wibble {
     ///     big if -> True
-    ///         ^^ this should be followed by a guard or removed!!
+    ///         ^^ This can be removed.
     /// }
     /// ```
-    DeprecatedEmptyGuardClause {
+    DeprecatedEmptyClauseGuard {
         location: SrcSpan,
     },
 
@@ -369,19 +369,20 @@ To match on all possible lists, use the `_` catch-all pattern instead.",
             Warning::DeprecatedSyntax {
                 path,
                 src,
-                warning: DeprecatedSyntaxWarning::DeprecatedEmptyGuardClause { location },
+                warning: DeprecatedSyntaxWarning::DeprecatedEmptyClauseGuard { location },
             } => Diagnostic {
-                title: "Deprecated empty guard clause syntax".into(),
+                title: "Deprecated empty guard syntax".into(),
                 text: wrap(
-                    "Empty clause within a guard is deprecated.
-To keep its behaviour, either remove the guard or fill the clause with `True` instead.",
+                    "This syntax for an empty guard is deprecated. \
+To have a clause without a guard, remove this.",
                 ),
                 hint: None,
                 level: diagnostic::Level::Warning,
                 location: Some(Location {
                     label: diagnostic::Label {
-                        text: Some("This should be followed by a guard or removed!!
-".into()),
+                        text: Some(
+                            "This can be removed.".into(),
+                        ),
                         span: *location,
                     },
                     path: path.clone(),

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -242,6 +242,17 @@ pub enum DeprecatedSyntaxWarning {
         location: SrcSpan,
     },
 
+    /// If a guard has an empty clause :
+    /// ```gleam
+    /// case wibble {
+    ///     big if -> True
+    ///         ^^ this should be followed by a guard or removed!!
+    /// }
+    /// ```
+    DeprecatedEmptyGuardClause {
+        location: SrcSpan,
+    },
+
     DeprecatedTargetShorthand {
         target: Target,
         location: SrcSpan,
@@ -355,7 +366,29 @@ To match on all possible lists, use the `_` catch-all pattern instead.",
                     extra_labels: vec![],
                 }),
             },
-
+            Warning::DeprecatedSyntax {
+                path,
+                src,
+                warning: DeprecatedSyntaxWarning::DeprecatedEmptyGuardClause { location },
+            } => Diagnostic {
+                title: "Deprecated empty guard clause syntax".into(),
+                text: wrap(
+                    "Empty clause within a guard is deprecated.
+To keep its behaviour, either remove the guard or fill the clause with `True` instead.",
+                ),
+                hint: None,
+                level: diagnostic::Level::Warning,
+                location: Some(Location {
+                    label: diagnostic::Label {
+                        text: Some("This should be followed by a guard or removed!!
+".into()),
+                        span: *location,
+                    },
+                    path: path.clone(),
+                    src: src.clone(),
+                    extra_labels: vec![],
+                }),
+            },
             Warning::DeprecatedSyntax {
                 path,
                 src,

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -40,5 +40,5 @@ compatibility.
 It doesn't make sense to have an `if` guard followed by no condition, but the
 compiler allows this: `case wibble { big if -> True }`
 
-- [ ] Emits warning when used.
+- [x] Emits warning when used.
 - [x] Formatter rewrites it to desired syntax.


### PR DESCRIPTION
These changes solve #4906 
Now when using the `big if -> True` syntax you should be warned with that lovely message : 

```
Snapshot: empty_guard_clause
Source: compiler-core/src/type_/tests/warnings.rs:4320
────────────────────────────────────────────────────────────────────────────────────────────
Expression:
pub fn main() {
    let wibble = 10
    case wibble {
        10 if -> True
        _ -> False
    }

}
────────────────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────────────────
    9     9 │ }
   10    10 │
   11    11 │ ----- WARNING
   12    12 │ warning: Deprecated empty guard clause 
         13 │+  ┌─ test/path:5:12
   14    14 │
         15 │+5 │         10 if -> True
         16 │+  │            ^^ This should be followed by a guard or removed!!
         17 │+
   17    18 │
   18    19 │ Empty clause within a guard is deprecated.
   19    20 │ To keep its behaviour, either remove the guard or fill the clause with
   20    21 │ `True` instead.
────────────┴───────────────────────────────────────────────────────────────────────────────
```

> Snippet from `cargo insta`