### PR TITLE
fix(typing): do not report futher errors, after contructor arity is reported

### DIFF
--- a/compiler-core/src/type_/tests/custom_types.rs
+++ b/compiler-core/src/type_/tests/custom_types.rs
@@ -182,3 +182,22 @@ pub fn main() {
         ]
     );
 }
+
+#[test]
+fn pattern_match_correct_labeled_field() {
+    assert_module_error!(
+        r#"
+type Fish {
+  Starfish()
+  Jellyfish(name: String, jiggly: Bool)
+}
+
+fn handle_fish(fish: Fish) {
+  case fish {
+    Starfish() -> False
+    Jellyfish(jiggly:) -> jiggly  // <- error is here
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__pattern_match_correct_labeled_field.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__pattern_match_correct_labeled_field.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/type_/tests/custom_types.rs
+expression: "\ntype Fish {\n  Starfish()\n  Jellyfish(name: String, jiggly: Bool)\n}\n\nfn handle_fish(fish: Fish) {\n  case fish {\n    Starfish() -> False\n    Jellyfish(jiggly:) -> jiggly  // <- error is here\n  }\n}\n"
+---
+----- SOURCE CODE
+
+type Fish {
+  Starfish()
+  Jellyfish(name: String, jiggly: Bool)
+}
+
+fn handle_fish(fish: Fish) {
+  case fish {
+    Starfish() -> False
+    Jellyfish(jiggly:) -> jiggly  // <- error is here
+  }
+}
+
+
+----- ERROR
+error: Incorrect arity
+   ┌─ /src/one/two.gleam:10:5
+   │
+10 │     Jellyfish(jiggly:) -> jiggly  // <- error is here
+   │     ^^^^^^^^^^^^^^^^^^ Expected 2 arguments, got 1
+
+This pattern accepts these additional labelled arguments:
+
+  - name


### PR DESCRIPTION
This is a very cool and not-so-dirty hack that I decided to try :) 
Now, only 1 error is reported, incorrect typing error is gone.