### PR TITLE
Stop warning for modules that are used only by private functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,8 +304,9 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- The "Add type annotations" and "Generate function" code actions now ignore type
-  variables defined in other functions, improving the generated code. For example:
+- The "Add type annotations" and "Generate function" code actions now ignore
+  type variables defined in other functions, improving the generated code.
+  For example:
 
   ```gleam
   fn something(a: a, b: b, c: c) -> d { todo }
@@ -359,8 +360,8 @@
 
 ### Bug fixes
 
-- Fixed a bug where literals using `\u{XXXX}` syntax in bit array pattern segments were not
-  translated to Erlang's `\x{XXXX}` syntax correctly.
+- Fixed a bug where literals using `\u{XXXX}` syntax in bit array pattern
+  segments were not translated to Erlang's `\x{XXXX}` syntax correctly.
   ([Benjamin Peinhardt](https://github.com/bcpeinhardt))
 
 - Fixed a bug where `echo` could crash on JavaScript if the module contains
@@ -423,3 +424,7 @@
 - Fixed a bug where the compiler would reference a redeclared variable in a let
   assert message, instead of the original variable, on the Erlang target.
   ([Danielle Maywood](https://github.com/DanielleMaywood))
+
+- Fixed a bug where the compiler would report an imported module as unused if it
+  were used by private functions only.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_module_alias_only_referenced_by_unused_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_module_alias_only_referenced_by_unused_function.snap
@@ -20,14 +20,6 @@ fn unused() {
 
 
 ----- WARNING
-warning: Unused imported module
-  ┌─ /src/warning/wrn.gleam:2:1
-  │
-2 │ import wibble as wobble
-  │ ^^^^^^^^^^^^^^^^^^^^^^^ This imported module is never used
-
-Hint: You can safely remove it.
-
 warning: Unused private function
   ┌─ /src/warning/wrn.gleam:4:1
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_module_alias_only_referenced_by_unused_function_with_unqualified.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_module_alias_only_referenced_by_unused_function_with_unqualified.snap
@@ -24,17 +24,6 @@ pub fn main() -> Wibble {
 
 
 ----- WARNING
-warning: Unused imported module alias
-  ┌─ /src/warning/wrn.gleam:2:29
-  │
-2 │ import wibble.{type Wibble} as wobble
-  │                             ^^^^^^^^^ This alias is never used
-
-Hint: You can safely remove it.
-
-    import wibble as _
-
-
 warning: Unused private function
   ┌─ /src/warning/wrn.gleam:4:1
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_module_only_referenced_by_unused_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__dead_code_detection__imported_module_only_referenced_by_unused_function.snap
@@ -20,14 +20,6 @@ fn unused() {
 
 
 ----- WARNING
-warning: Unused imported module
-  ┌─ /src/warning/wrn.gleam:2:1
-  │
-2 │ import wibble
-  │ ^^^^^^^^^^^^^ This imported module is never used
-
-Hint: You can safely remove it.
-
 warning: Unused private function
   ┌─ /src/warning/wrn.gleam:4:1
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__aliased_module_used_by_unused_function_is_not_marked_as_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__aliased_module_used_by_unused_function_is_not_marked_as_unused.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "import wibble as woo\nfn wobble() {\n  woo.a\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub const a = 1
+
+-- main.gleam
+import wibble as woo
+fn wobble() {
+  woo.a
+}
+
+
+----- WARNING
+warning: Unused private function
+  ┌─ /src/warning/wrn.gleam:2:1
+  │
+2 │ fn wobble() {
+  │ ^^^^^^^^^^^ This private function is never used
+
+Hint: You can safely remove it.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__module_used_by_unused_function_is_not_marked_as_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__module_used_by_unused_function_is_not_marked_as_unused.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "import wibble\nfn wobble() {\n  wibble.a\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub const a = 1
+
+-- main.gleam
+import wibble
+fn wobble() {
+  wibble.a
+}
+
+
+----- WARNING
+warning: Unused private function
+  ┌─ /src/warning/wrn.gleam:2:1
+  │
+2 │ fn wobble() {
+  │ ^^^^^^^^^^^ This private function is never used
+
+Hint: You can safely remove it.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1517,6 +1517,30 @@ pub fn main() {
 }
 
 #[test]
+fn module_used_by_unused_function_is_not_marked_as_unused() {
+    assert_warning!(
+        ("wibble", "pub const a = 1"),
+        "import wibble
+fn wobble() {
+  wibble.a
+}
+"
+    );
+}
+
+#[test]
+fn aliased_module_used_by_unused_function_is_not_marked_as_unused() {
+    assert_warning!(
+        ("wibble", "pub const a = 1"),
+        "import wibble as woo
+fn wobble() {
+  woo.a
+}
+"
+    );
+}
+
+#[test]
 fn calling_function_from_other_module_is_not_marked_unused() {
     assert_no_warnings!(
         ("wibble", "wibble", "pub fn println(a) { panic }"),


### PR DESCRIPTION
We were discussing how this should no longer be a warning, so I fixed it!