### PR TITLE
Use correct env when generating assert message for erlang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,3 +415,7 @@
 - Fixed a bug where switching from a hex dependency to a git dependency would
   result in an error from the compiler.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the compiler would reference a redeclared variable in a let
+  assert message, instead of the original variable, on the Erlang target.
+  ([Danielle Maywood](https://github.com/DanielleMaywood))

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1192,6 +1192,11 @@ fn let_assert<'a>(
         return let_(value, pattern, env);
     }
 
+    let message = match message {
+        Some(message) => expr(message, env),
+        None => string("Pattern match failed, no pattern matched the value."),
+    };
+
     let mut vars: Vec<&str> = vec![];
     let subject = maybe_block_expr(value, env);
 
@@ -1255,11 +1260,6 @@ fn let_assert<'a>(
     let mut guards = vec![];
     let pattern_document = pattern::to_doc(pattern, &mut vars, env, &mut guards);
     let clause_guard = optional_clause_guard(None, guards, env);
-
-    let message = match message {
-        Some(message) => expr(message, env),
-        None => string("Pattern match failed, no pattern matched the value."),
-    };
 
     let value_document = match vars.as_slice() {
         _ if is_tail => subject.clone(),

--- a/compiler-core/src/erlang/tests/let_assert.rs
+++ b/compiler-core/src/erlang/tests/let_assert.rs
@@ -288,3 +288,21 @@ pub fn main() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4924
+#[test]
+fn let_assert_should_not_use_redefined_variable() {
+    assert_erl!(
+        r#"
+fn split_once(x: String, y: String) -> Result(#(String, String), String) {
+    Ok(#(x, y))
+}
+
+pub fn main() {
+    let string = "Hello, world!"
+    let assert Ok(#(prefix, string)) = split_once(string, "\n")
+    as { "Failed to split: " <> string }
+}
+        "#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_should_not_use_redefined_variable.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__let_assert__let_assert_should_not_use_redefined_variable.snap
@@ -1,0 +1,50 @@
+---
+source: compiler-core/src/erlang/tests/let_assert.rs
+expression: "\nfn split_once(x: String, y: String) -> Result(#(String, String), String) {\n    Ok(#(x, y))\n}\n\npub fn main() {\n    let string = \"Hello, world!\"\n    let assert Ok(#(prefix, string)) = split_once(string, \"\\n\")\n    as { \"Failed to split: \" <> string }\n}\n        "
+snapshot_kind: text
+---
+----- SOURCE CODE
+
+fn split_once(x: String, y: String) -> Result(#(String, String), String) {
+    Ok(#(x, y))
+}
+
+pub fn main() {
+    let string = "Hello, world!"
+    let assert Ok(#(prefix, string)) = split_once(string, "\n")
+    as { "Failed to split: " <> string }
+}
+        
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-define(FILEPATH, "project/test/my/mod.gleam").
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec split_once(binary(), binary()) -> {ok, {binary(), binary()}} |
+    {error, binary()}.
+split_once(X, Y) ->
+    {ok, {X, Y}}.
+
+-file("project/test/my/mod.gleam", 6).
+-spec main() -> {ok, {binary(), binary()}} | {error, binary()}.
+main() ->
+    String = <<"Hello, world!"/utf8>>,
+    _assert_subject = split_once(String, <<"\n"/utf8>>),
+    case _assert_subject of
+        {ok, {Prefix, String@1}} -> _assert_subject;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => (<<"Failed to split: "/utf8, String/binary>>),
+                        file => <<?FILEPATH/utf8>>,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"main"/utf8>>,
+                        line => 8,
+                        value => _assert_fail,
+                        start => 148,
+                        'end' => 207,
+                        pattern_start => 159,
+                        pattern_end => 180})
+    end.


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/gleam/issues/4924

This moves the code generation for the message step a little earlier so that the passed `env` isn't polluted.