### PR TITLE
Fix error when switching from hex dep to git dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -411,3 +411,7 @@
 
 - Fixed a bug where the compiler allowed to write a guard with an empty clause.
   ([Tristan-Mihai Radulescu](https://github.com/Courtcircuits))
+
+- Fixed a bug where switching from a hex dependency to a git dependency would
+  result in an error from the compiler.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -848,7 +848,7 @@ fn download_git_package(
     // remove the directory because running `git init` in a non-empty directory
     // followed by `git checkout ...` is an error. See
     // https://github.com/gleam-lang/gleam/issues/4488 for details.
-    if !fs::is_inside_git_work_tree(&package_path).unwrap_or(false) {
+    if !fs::is_git_work_tree_root(&package_path) {
         fs::delete_directory(&package_path)?;
     }
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -14,7 +14,7 @@ use gleam_core::{
 use std::{
     collections::HashSet,
     fmt::Debug,
-    fs::File,
+    fs::{File, exists},
     io::{self, BufRead, BufReader, Write},
     sync::{Arc, Mutex, OnceLock},
     time::SystemTime,
@@ -686,7 +686,7 @@ pub fn hardlink(
 /// given path. If git is not installed then we assume we're not in a git work
 /// tree.
 ///
-pub fn is_inside_git_work_tree(path: &Utf8Path) -> Result<bool, Error> {
+fn is_inside_git_work_tree(path: &Utf8Path) -> Result<bool, Error> {
     tracing::trace!(path=?path, "checking_for_git_repo");
 
     let args: Vec<&str> = vec!["rev-parse", "--is-inside-work-tree", "--quiet"];
@@ -713,6 +713,11 @@ pub fn is_inside_git_work_tree(path: &Utf8Path) -> Result<bool, Error> {
             }),
         },
     }
+}
+
+pub(crate) fn is_git_work_tree_root(path: &Utf8Path) -> bool {
+    tracing::trace!(path=?path, "checking_for_git_repo_root");
+    exists(path.join(".git")).unwrap_or(false)
 }
 
 /// Run `git init` in the given path.


### PR DESCRIPTION
This PR fixes a bug with the compiler where switching from a hex dep to a git dep would result in a strange error