### PR TITLE
🐛 Traverse alternative patterns when finding node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,16 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- You can now go to definition, rename, etc. from alternative patterns!
+  ```gleam
+  case wibble {
+    Wibble | Wobble -> 0
+    //         ^- Previously you could not trigger actions from here
+  }
+
+  ```
+  ([fruno](https://github.com/fruno-bulax))
+
 ### Formatter
 
 - The formatter now removes needless multiple negations that are safe to remove.

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1617,6 +1617,12 @@ impl TypedClause {
         self.pattern
             .iter()
             .find_map(|p| p.find_node(byte_index))
+            .or_else(|| {
+                self.alternative_patterns
+                    .iter()
+                    .flat_map(|p| p.iter())
+                    .find_map(|p| p.find_node(byte_index))
+            })
             .or_else(|| self.then.find_node(byte_index))
     }
 

--- a/compiler-core/src/language_server/tests/definition.rs
+++ b/compiler-core/src/language_server/tests/definition.rs
@@ -874,3 +874,22 @@ const my_constant = wibble.Wibble(10)
         find_position_of("= wibble").under_char('w')
     );
 }
+
+#[test]
+fn goto_definition_from_alternative_pattern() {
+    assert_goto!(
+        "
+type Wibble {
+  Wibble
+  Wobble
+}
+
+fn warble(wibble: Wibble) {
+  case wibble {
+    Wibble | Wobble -> 0
+  }
+}
+",
+        find_position_of("Wobble ->")
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_from_alternative_pattern.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__definition__goto_definition_from_alternative_pattern.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/language_server/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+type Wibble {
+  Wibble
+  Wobble
+}
+
+fn warble(wibble: Wibble) {
+  case wibble {
+    Wibble | Wobble -> 0
+             ↑          
+  }
+}
+
+----- Jumped to `src/app.gleam`
+
+type Wibble {
+  Wibble
+  Wobble
+  ↑▔▔▔▔▔
+}
+
+fn warble(wibble: Wibble) {
+  case wibble {
+    Wibble | Wobble -> 0
+  }
+}


### PR DESCRIPTION
Closes #4935

`find_node_at` did not traverse into alternative patterns, so language server actions like go to definition could not be triggered on them.

Note that _clause guards_ are still not traversed! I tried poking at it a little but couldn't figure out how to map them onto the `Located` type. I will open a follow-up issue after this PR is merged.