### PR TITLE
Only offer the "convert to case" code action if hovering a single assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -540,6 +540,10 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The language server now offers the `convert to case` code action only if a
+  single `let assert` expression is selected.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 - The formatter now removes needless multiple negations that are safe to remove.

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -355,7 +355,7 @@ impl<'ast> ast::visit::Visit<'ast> for LetAssertToCase<'_> {
                 .expect("Location must be valid")
         });
 
-        let range = src_span_to_lsp_range(assignment.location, self.edits.line_numbers);
+        let range = self.edits.src_span_to_lsp_range(assignment.location);
 
         // Figure out which variables are assigned in the pattern
         let variables = PatternVariableFinder::find_variables_in_pattern(&assignment.pattern);
@@ -5743,7 +5743,6 @@ impl<'ast, IO> ast::visit::Visit<'ast> for GenerateVariant<'ast, IO> {
         type_: &'ast Arc<Type>,
     ) {
         let pattern_range = src_span_to_lsp_range(*location, self.line_numbers);
-        // TODO)) Solo se il pattern non è valido!!!!!
         if within(self.params.range, pattern_range) {
             if labels_are_correct(arguments) {
                 self.try_save_variant_to_generate(

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -1794,6 +1794,22 @@ pub fn main() {
 }
 
 #[test]
+fn test_convert_assert_does_not_appear_if_the_entire_module_is_selected() {
+    assert_no_code_actions!(
+        CONVERT_TO_CASE,
+        "
+pub type Wibble { Wibble(arg: Int, arg2: Float) }
+pub fn main() {
+  let assert Wibble(arg2:, ..) = Wibble(arg: 1, arg2: 1.0)
+  let assert Wibble(arg2:, ..) = Wibble(arg: 1, arg2: 1.0)
+}
+// end
+",
+        find_position_of("pub").select_until(find_position_of("// end")),
+    );
+}
+
+#[test]
 fn label_shorthand_action_works_on_labelled_call_args() {
     assert_code_action!(
         USE_LABEL_SHORTHAND_SYNTAX,


### PR DESCRIPTION
Previously the language server was a bit too permissive when offering this action, these were the suggestions when I selected an entire module:
<img width="327" height="376" alt="Screenshot 2025-09-14 alle 11 37 01" src="https://github.com/user-attachments/assets/c234073e-a3f6-416d-a794-a8d4d8546350" />
Now we only offer the code action if we are selecting a single `let assert` statement