### PR TITLE
Fix a bug with JS codegen of pattern matching expression using string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,3 +714,7 @@
 - Fixed a bug where running `gleam update` would not properly update git
   dependencies unless `gleam clean` was run first.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the compiler would produce wrong JavaScript code for binary
+  pattern matching expressions using literal strings and byte segments.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -1443,14 +1443,18 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                 from_byte += 1;
             }
         } else {
+            let mut start = start.clone();
+
             // If the string doesn't start at a byte aligned offset then we'll
             // have to take slices out of it to check that each byte matches.
             for byte in bytes {
-                let end = self.offset_to_doc(&start.add_constant(8), false);
-                let from = self.offset_to_doc(start, false);
-                let byte_access =
-                    self.bit_array_slice_to_int(&bit_array, from, end, endianness, *signed);
+                let start_doc = self.offset_to_doc(&start, false);
+                let end = start.add_constant(8);
+                let end_doc = self.offset_to_doc(&end, false);
+                let byte_access = self
+                    .bit_array_slice_to_int(&bit_array, start_doc, end_doc, endianness, *signed);
                 checks.push(docvec![byte_access, equality, byte]);
+                start = end;
             }
         }
 

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -2631,3 +2631,17 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn pattern_match_unknown_size_and_literal_string() {
+    assert_js!(
+        r#"
+pub fn go(x, n) {
+  case x {
+    <<_:size(n), "\r\n">> -> 1
+    _ -> 2
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_unknown_size_and_literal_string.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_match_unknown_size_and_literal_string.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn go(x, n) {\n  case x {\n    <<_:size(n), \"\\r\\n\">> -> 1\n    _ -> 2\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x, n) {
+  case x {
+    <<_:size(n), "\r\n">> -> 1
+    _ -> 2
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { bitArraySliceToInt } from "../gleam.mjs";
+
+export function go(x, n) {
+  if (
+    n >= 0 &&
+    x.bitSize >= n &&
+    x.bitSize === 16 + n &&
+    bitArraySliceToInt(x, n, 8 + n, true, false) === 13 &&
+      bitArraySliceToInt(x, 8 + n, 16 + n, true, false) === 10
+  ) {
+    return 1;
+  } else {
+    return 2;
+  }
+}


### PR DESCRIPTION
This PR fixes #4993 
Luckily the bug happened in the code generation step and not in the exhaustiveness checking one! That made it an easy fix 😁