### PR TITLE
Disable inlining for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,38 +4,6 @@
 
 ### Compiler
 
-- The compiler now performs function inlining optimisations for a specific set
-  of standard library functions, which can allow functions which were previously
-  not tail-recursive on the JavaScript target to become tail-recursive. For
-  example, the following code:
-
-  ```gleam
-  pub fn count(from: Int, to: Int) -> Int {
-    use <- bool.guard(when: from >= to, return: from)
-    io.println(int.to_string())
-    count(from + 1, to)
-  }
-  ```
-
-  Would previously cause a stack overflow on the JavaScript target for large
-  values. Now it is rewritten to:
-
-  ```gleam
-  pub fn count(from: Int, to: Int) -> Int {
-    case from >= to {
-      True -> from
-      False -> {
-        io.println(int.to_string())
-        count(from + 1, to)
-      }
-    }
-  }
-  ```
-
-  Which allows tail-call optimisation to occur.
-
-  ([Surya Rose](https://github.com/GearsDatapacks))
-
 - The compiler now applies an optimisation known as "interference based pruning"
   when compiling bit array pattern matching where matches are performed at the
   start of bit arrays.

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -214,17 +214,20 @@ where
 
         tracing::debug!("performing_code_generation");
 
-        let modules = if self.perform_codegen {
-            modules
-                .into_iter()
-                .map(|mut module| {
-                    module.ast = inline::module(module.ast, &existing_modules);
-                    module
-                })
-                .collect()
-        } else {
-            modules
-        };
+        // Inlining is currently disabled. See
+        // https://github.com/gleam-lang/gleam/pull/5010 for information.
+
+        // let modules = if self.perform_codegen {
+        //     modules
+        //         .into_iter()
+        //         .map(|mut module| {
+        //             module.ast = inline::module(module.ast, &existing_modules);
+        //             module
+        //         })
+        //         .collect()
+        // } else {
+        //     modules
+        // };
 
         if let Err(error) = self.perform_codegen(&modules) {
             return error.into();

--- a/compiler-core/src/inline.rs
+++ b/compiler-core/src/inline.rs
@@ -108,6 +108,8 @@
 //! works.
 //!
 
+#![allow(dead_code)]
+
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,


### PR DESCRIPTION
When [function inlining](https://github.com/gleam-lang/gleam/pull/4677) was first implemented, we tested it and it seemed to work well. Recently though, several bugs in the implementation have been found (#4998, #5002, #5009).
This buggy implementation is affecting the experience of Gleam users and delaying the release of the next version, so for now we are going to disable it. I will work on fixing all of the outstanding issues, then test it as thoroughly as I can. Once the bugs have been fixed, I will open a PR with the fixes, and re-enable inlining once complete.

In this PR I've just disabled inlining in the main compiler, but it still runs in the tests so that CI will still pass for the existing inlining tests.