### PR TITLE
fix: formatter moves comments out of tuple return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -658,6 +658,9 @@
 - The formatter no longer removes blocks from case clause guards.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The formatter now properly formats tuple return annotation with comments.
+  ([Andrey Kozhev](https://github.com/ankddev))
+
 ### Bug fixes
 
 - Fixed a bug where literals using `\u{XXXX}` syntax in bit array pattern

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -834,7 +834,18 @@ impl<'comments> Formatter<'comments> {
                     .expect("Function in a statement must be named")
                     .1,
             )
-            .append(self.wrap_arguments(arguments, function.location.end));
+            .append(
+                self.wrap_arguments(
+                    // We count end location of arguments here.
+                    // Before this change, wrap_arguments consumed all comments
+                    // leading in moving comments from return annotation to argument list
+                    arguments,
+                    function
+                        .return_annotation
+                        .as_ref()
+                        .map_or(function.location.end, |ann| ann.location().start),
+                ),
+            );
 
         // Add return annotation
         let signature = match &function.return_annotation {

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -836,10 +836,9 @@ impl<'comments> Formatter<'comments> {
             )
             .append(
                 self.wrap_arguments(
-                    // We count end location of arguments here.
-                    // Before this change, wrap_arguments consumed all comments
-                    // leading in moving comments from return annotation to argument list
                     arguments,
+                    // Calculate end location of arguments to not consume comments in
+                    // return annotation
                     function
                         .return_annotation
                         .as_ref()

--- a/compiler-core/src/format/tests/function.rs
+++ b/compiler-core/src/format/tests/function.rs
@@ -330,3 +330,25 @@ fn comment_middle_of_inline_function_body() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5004
+#[test]
+fn comment_in_tuple_return_type() {
+    assert_format_rewrite!(
+        r#"pub fn main() -> #(
+  // This is a string
+  String, // This is an awesome string
+) {
+  todo
+}
+"#,
+        r#"pub fn main() -> #(
+  String,
+  // This is a string
+  // This is an awesome string
+) {
+  todo
+}
+"#
+    );
+}


### PR DESCRIPTION
Closes #5004 
Fix formatting of tuple return types: now comments are not moved out.
### Showcase
```
$ cat src\test_gleam.gleam
import gleam/io

pub fn main() -> Nil {
  io.println("Hello from test_gleam!")
}

pub fn hello() -> #(
  // test 0
  String, // test 1
) {
  #("hello")
}

$ ..\..\RustroverProjects\gleam\target\debug\gleam format

$ cat src\test_gleam.gleam
import gleam/io

pub fn main() -> Nil {
  io.println("Hello from test_gleam!")
}

pub fn hello() -> #(
  String,
  // test 0
  // test 1
) {
  #("hello")
}
```