### PR TITLE
Fix incorrect missing patterns

### DIFF
--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
@@ -19,10 +19,10 @@ export function go(x) {
   let t;
   let b;
   let c;
-  let $ = x[3];
-  if ($ === 1) {
-    let $1 = x[1][2];
-    if ($1 === 2) {
+  let $ = x[1][2];
+  if ($ === 2) {
+    let $1 = x[3];
+    if ($1 === 1) {
       a = x[0];
       t = x[1];
       b = x[1][0];

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_same_value_as_two_subjects_one_is_picked.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_same_value_as_two_subjects_one_is_picked.snap
@@ -20,11 +20,15 @@ import { Ok, Error } from "../gleam.mjs";
 
 export function go(x, y) {
   if (y instanceof Ok) {
-    let $ = y[0];
-    if ($ === 1 && x instanceof $gleam.Ok) {
-      let $1 = x[0];
-      if ($1 === 1) {
-        return x;
+    if (x instanceof $gleam.Ok) {
+      let $ = x[0];
+      if ($ === 1) {
+        let $1 = y[0];
+        if ($1 === 1) {
+          return x;
+        } else {
+          return new Error(undefined);
+        }
       } else {
         return new Error(undefined);
       }

--- a/compiler-core/src/type_/tests/exhaustiveness.rs
+++ b/compiler-core/src/type_/tests/exhaustiveness.rs
@@ -1787,3 +1787,19 @@ pub fn main(w: Wibble) {
 "
     );
 }
+
+#[test]
+// https://github.com/gleam-lang/gleam/issues/4278
+fn redundant_missing_patterns() {
+    assert_module_error!(
+        r#"
+fn wibble(b: Bool, i: Int) {
+  case b, i {
+    False, 1 -> todo
+    True, 2 -> todo
+  }
+}
+
+pub fn main() { wibble(False, 1) }"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__nested_type_parameter_usage.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__nested_type_parameter_usage.snap
@@ -26,7 +26,7 @@ one of the other values is used then the assignment will crash.
 
 The missing patterns are:
 
+    Returned([#(), _, ..])
     Returned([])
-    Returned([_, _, ..])
 
 Hint: Use a more general pattern or use `let assert` instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_missing_patterns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__redundant_missing_patterns.snap
@@ -1,0 +1,32 @@
+---
+source: compiler-core/src/type_/tests/exhaustiveness.rs
+expression: "\nfn wibble(b: Bool, i: Int) {\n  case b, i {\n    False, 1 -> todo\n    True, 2 -> todo\n  }\n}\n\npub fn main() { wibble(False, 1) }"
+---
+----- SOURCE CODE
+
+fn wibble(b: Bool, i: Int) {
+  case b, i {
+    False, 1 -> todo
+    True, 2 -> todo
+  }
+}
+
+pub fn main() { wibble(False, 1) }
+
+----- ERROR
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:3:3
+  │  
+3 │ ╭   case b, i {
+4 │ │     False, 1 -> todo
+5 │ │     True, 2 -> todo
+6 │ │   }
+  │ ╰───^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    False, _
+    True, _


### PR DESCRIPTION
Fixes [#4278](https://github.com/gleam-lang/gleam/issues/4278).

Running this code:

```gleam
pub fn wibble(b: Bool, i: Int) {
  case b, i {
    False, 1 -> todo
    True, 2 -> todo
  }
}
```

Produces this error:

```
The missing patterns are:

    False, _
    True, _
    _, _
```

Ideally, one would expect either `_, _` or `False, _` and `True, _`.

The root cause is in the pivot choice for building the decision tree. When we pivot on an infinite subject (like Int) before a finite one (like `Bool`), the "fallback" branch for the infinite split collapses to a textual `_`, which then overlaps with the more specific missing patterns discovered under the finite splits. 

The clean fix is to make the compiler prefer finite-domain subjects first when choosing the pivot. It shrinks the search space and avoids noisy fallbacks. 

So the solution is to teach `find_pivot_check` to prefer finite-branching subjects (tuples, lists, and named types with known constructors) over infinite ones (e.g. ints, floats, strings).

```gleam
pub fn wibble(b: Bool, i: Int) {
  case b, i {
    False, 1 -> todo
    True, 2 -> todo
  }
}
```

This makes `Bool` beat `Int` in the example, so the top split is on b, eliminating the top-level `_, _` catch-all that comes from an infinite fallback:

```
error: Inexhaustive patterns
  ┌─ /Users/adi.salimgereyev/hello_world/src/hello_world.gleam:6:3
  │  
6 │ ╭   case b, i {
7 │ │     False, 1 -> 1
8 │ │     True, 2 -> 2
9 │ │   }
  │ ╰───^

This case expression does not have a pattern for all possible values. If it
is run on one of the values without a pattern then it will crash.

The missing patterns are:

    False, _
    True, _
```

More about creating effective decision trees can be found [here](https://www.cs.tufts.edu/~nr/cs257/archive/luc-maranget/jun08.pdf).