### PR TITLE
Make pattern matching to favour first appearing variable

### DIFF
--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
@@ -11,10 +11,10 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  let $ = x[1];
-  if ($ === 2) {
-    let $1 = x[0];
-    if (!($1 === 1)) {
+  let $ = x[0];
+  if ($ === 1) {
+    let $1 = x[1];
+    if (!($1 === 2)) {
       throw makeError(
         "let_assert",
         FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
@@ -19,10 +19,10 @@ export function go(x) {
   let t;
   let b;
   let c;
-  let $ = x[1][2];
-  if ($ === 2) {
-    let $1 = x[3];
-    if ($1 === 1) {
+  let $ = x[3];
+  if ($ === 1) {
+    let $1 = x[1][2];
+    if ($1 === 2) {
       a = x[0];
       t = x[1];
       b = x[1][0];

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
@@ -15,10 +15,10 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  let $ = x[1];
-  if ($ === 2) {
-    let $1 = x[0];
-    if (!($1 === 1)) {
+  let $ = x[0];
+  if ($ === 1) {
+    let $1 = x[1];
+    if (!($1 === 2)) {
       throw makeError(
         "let_assert",
         FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
@@ -15,17 +15,18 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  let $ = x[2];
-  if (
-    $.bitSize >= 8 &&
-    $.byteAt(0) === 2 &&
-    $.bitSize === 16 &&
-    $.byteAt(1) === 3
-  ) {
+  let $ = x[0];
+  if ($.bitSize === 0) {
     let $1 = x[1];
-    if ($1.bitSize === 8 && $1.byteAt(0) === 1) {
-      let $2 = x[0];
-      if (!($2.bitSize === 0)) {
+    if ($1.bitSize === 8) {
+      let $2 = x[2];
+      if (!(
+        $2.bitSize >= 8 &&
+        $1.byteAt(0) === 1 &&
+        $2.byteAt(0) === 2 &&
+        $2.bitSize === 16 &&
+        $2.byteAt(1) === 3
+      )) {
         throw makeError(
           "let_assert",
           FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays_case.snap
@@ -14,17 +14,18 @@ pub fn go(x) {
 
 ----- COMPILED JAVASCRIPT
 export function go(x) {
-  let $ = x[2];
-  if (
-    $.bitSize >= 8 &&
-    $.byteAt(0) === 2 &&
-    $.bitSize === 16 &&
-    $.byteAt(1) === 3
-  ) {
+  let $ = x[0];
+  if ($.bitSize === 0) {
     let $1 = x[1];
-    if ($1.bitSize === 8 && $1.byteAt(0) === 1) {
-      let $2 = x[0];
-      if ($2.bitSize === 0) {
+    if ($1.bitSize === 8) {
+      let $2 = x[2];
+      if (
+        $2.bitSize >= 8 &&
+        $1.byteAt(0) === 1 &&
+        $2.byteAt(0) === 2 &&
+        $2.bitSize === 16 &&
+        $2.byteAt(1) === 3
+      ) {
         return true;
       } else {
         return false;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_list_matched_by_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_list_matched_by_pattern.snap
@@ -25,9 +25,13 @@ export function go(n, x) {
   } else {
     let $ = x.tail;
     if ($ instanceof $Empty) {
-      let $1 = x.head;
-      if ($1 === 1 && n === 3) {
-        return x;
+      if (n === 3) {
+        let $1 = x.head;
+        if ($1 === 1) {
+          return x;
+        } else {
+          return x;
+        }
       } else {
         return x;
       }
@@ -35,13 +39,15 @@ export function go(n, x) {
       let $1 = $.tail;
       if ($1 instanceof $Empty) {
         return x;
-      } else {
+      } else if (n === 3) {
         let $2 = x.head;
-        if ($2 === 1 && n === 3) {
+        if ($2 === 1) {
           return x;
         } else {
           return x;
         }
+      } else {
+        return x;
       }
     }
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_record_matched_by_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_record_matched_by_pattern.snap
@@ -15,19 +15,19 @@ pub fn go(x, y) {
 import { Ok, Error } from "../gleam.mjs";
 
 export function go(x, y) {
-  if (y instanceof Ok) {
-    if (x instanceof Error) {
-      return y;
+  if (x instanceof Ok) {
+    if (y instanceof Error) {
+      let $ = x[0];
+      if ($ === 1) {
+        return x;
+      } else {
+        return new Error(undefined);
+      }
     } else {
       return new Error(undefined);
     }
-  } else if (x instanceof Ok) {
-    let $ = x[0];
-    if ($ === 1) {
-      return x;
-    } else {
-      return new Error(undefined);
-    }
+  } else if (y instanceof Ok) {
+    return y;
   } else {
     return new Error(undefined);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_same_value_as_two_subjects_one_is_picked.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_same_value_as_two_subjects_one_is_picked.snap
@@ -21,9 +21,9 @@ import { Ok, Error } from "../gleam.mjs";
 export function go(x, y) {
   if (y instanceof Ok) {
     if (x instanceof $gleam.Ok) {
-      let $ = x[0];
+      let $ = y[0];
       if ($ === 1) {
-        let $1 = y[0];
+        let $1 = x[0];
         if ($1 === 1) {
           return x;
         } else {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__multi_subject_catch_all.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__multi_subject_catch_all.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/case.rs
-assertion_line: 95
 expression: "\npub fn go(x, y) {\n  case x, y {\n    True, True -> 1\n    _, _ -> 0\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -16,7 +14,7 @@ pub fn go(x, y) {
 
 ----- COMPILED JAVASCRIPT
 export function go(x, y) {
-  if (y && x) {
+  if (x && y) {
     return 1;
   } else {
     return 0;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/case.rs
-assertion_line: 258
 expression: "\npub fn main() {\n  case Ok([\"a\", \"b c\", \"d\"]) {\n    Ok([\"a\", \"b \" <> _, \"d\"]) -> 1\n    _ -> 1\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -33,12 +31,12 @@ export function main() {
       } else {
         let $4 = $3.tail;
         if ($4 instanceof $Empty) {
-          let $5 = $3.head;
-          if ($5 === "d") {
+          let $5 = $1.head;
+          if ($5 === "a") {
             let $6 = $2.head;
             if ($6.startsWith("b ")) {
-              let $7 = $1.head;
-              if ($7 === "a") {
+              let $7 = $3.head;
+              if ($7 === "d") {
                 return 1;
               } else {
                 return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match_that_would_crash_on_js.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match_that_would_crash_on_js.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/case.rs
-assertion_line: 273
 expression: "\npub fn main() {\n  case Ok([\"b c\", \"d\"]) {\n    Ok([\"b \" <> _, \"d\"]) -> 1\n    _ -> 1\n  }\n}\n"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 
@@ -29,10 +27,10 @@ export function main() {
     } else {
       let $3 = $2.tail;
       if ($3 instanceof $Empty) {
-        let $4 = $2.head;
-        if ($4 === "d") {
-          let $5 = $1.head;
-          if ($5.startsWith("b ")) {
+        let $4 = $1.head;
+        if ($4.startsWith("b ")) {
+          let $5 = $2.head;
+          if ($5 === "d") {
             return 1;
           } else {
             return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_list.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_list.snap
@@ -29,10 +29,10 @@ export function main(xs) {
     } else {
       let $1 = $.tail;
       if ($1 instanceof $Empty) {
-        let $2 = $.head;
-        if ($2 === 2) {
-          let $3 = xs.head;
-          if ($3 === 1) {
+        let $2 = xs.head;
+        if ($2 === 1) {
+          let $3 = $.head;
+          if ($3 === 2) {
             return 0;
           } else {
             return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
@@ -82,10 +82,10 @@ export function go(x, y) {
     } else {
       let $2 = $1.tail;
       if ($2 instanceof $Empty) {
-        let $3 = $1.head;
-        if ($3 === 2) {
-          let $4 = x.head;
-          if (!($4 === 1)) {
+        let $3 = x.head;
+        if ($3 === 1) {
+          let $4 = $1.head;
+          if (!($4 === 2)) {
             throw makeError(
               "let_assert",
               FILEPATH,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_tuple.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__add_missing_patterns_tuple.snap
@@ -17,7 +17,7 @@ pub fn main(two_at_once: #(Bool, Result(Int, Nil))) {
 pub fn main(two_at_once: #(Bool, Result(Int, Nil))) {
   case two_at_once {
     #(False, Error(_)) -> Nil
-    #(True, Error(_)) -> todo
-    #(_, Ok(_)) -> todo
+    #(False, Ok(_)) -> todo
+    #(True, _) -> todo
   }
 }

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_on_literal_record.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__variant_inference_on_literal_record.snap
@@ -30,4 +30,4 @@ is run on one of the values without a pattern then it will crash.
 
 The missing patterns are:
 
-    _, Wobble
+    Wibble, Wobble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_names.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__case_error_prints_module_names.snap
@@ -31,5 +31,5 @@ is run on one of the values without a pattern then it will crash.
 
 The missing patterns are:
 
-    #(_, Thing2(_))
-    #(wibble.Wobble, Thing1)
+    #(wibble.Wibble, Thing2(_))
+    #(wibble.Wobble, _)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__exhaustiveness__inexhaustive_multi_pattern2.snap
@@ -25,6 +25,6 @@ is run on one of the values without a pattern then it will crash.
 
 The missing patterns are:
 
-    Error(_), True
+    Error(_), _
+    Ok(_), False
     Ok(_), True
-    _, False


### PR DESCRIPTION
Looking at the recent change to pattern matching I wanted to try and change it so that in case of ties (both in branching factor and references) the first variable is favoured over following ones. In this case:
```gleam
case wibble, wobble {
  True, False -> todo
}
```
The missing patterns reported are:
```
False, _
True, True
```
Instead of
```
False, False
_, True
```
In general the first variable in the match will have all the patterns enumerated while the following ones will have an `_` instead of it being the other way around. I think that looks a little less foreign but no big deal if this isn't merged.

There's also a small refactoring to avoid doing `usize::MAX` tricks and use a custom type instead.