### PR TITLE
Make sure the "turn into pipe" code action is suggested in final step of a pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@
 - Fixed a bug where triggering the "Generate function" code action to generate
   a function in a different module could cause the generated function to appear
   in the middle of an existing function, resulting in invalid code.
-
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the "turn into pipe" code action would not trigger inside
+  the final step of a pipeline.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 ## v1.13.0-rc1 - 2025-09-29
 

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -6292,10 +6292,13 @@ pub struct ConvertToPipe<'a> {
     params: &'a CodeActionParams,
     edits: TextEdits<'a>,
     argument_to_pipe: Option<ConvertToPipeArg<'a>>,
-    /// this will be true if we're visiting the call on the right hand side of a
-    /// use expression. So we can skip it and not try to turn it into a
-    /// function.
-    visiting_use_call: bool,
+    visited_item: VisitedItem,
+}
+
+pub enum VisitedItem {
+    RegularExpression,
+    UseRightHandSide,
+    PipelineFinalStep,
 }
 
 /// Holds all the data needed by the "convert to pipe" code action to properly
@@ -6336,7 +6339,7 @@ impl<'a> ConvertToPipe<'a> {
             module,
             params,
             edits: TextEdits::new(line_numbers),
-            visiting_use_call: false,
+            visited_item: VisitedItem::RegularExpression,
             argument_to_pipe: None,
         }
     }
@@ -6433,13 +6436,16 @@ impl<'ast> ast::visit::Visit<'ast> for ConvertToPipe<'ast> {
         // If we're visiting the typed function produced by typing a use, we
         // skip the thing itself and only visit its arguments and called
         // function, that is the body of the use.
-        if self.visiting_use_call {
-            self.visiting_use_call = false;
-            ast::visit::visit_typed_expr(self, fun);
-            arguments
-                .iter()
-                .for_each(|arg| ast::visit::visit_typed_call_arg(self, arg));
-            return;
+        match self.visited_item {
+            VisitedItem::RegularExpression => (),
+            VisitedItem::UseRightHandSide | VisitedItem::PipelineFinalStep => {
+                self.visited_item = VisitedItem::RegularExpression;
+                ast::visit::visit_typed_expr(self, fun);
+                arguments
+                    .iter()
+                    .for_each(|arg| ast::visit::visit_typed_call_arg(self, arg));
+                return;
+            }
         }
 
         // We only visit a call if the cursor is somewhere within its location,
@@ -6496,16 +6502,18 @@ impl<'ast> ast::visit::Visit<'ast> for ConvertToPipe<'ast> {
         _location: &'ast SrcSpan,
         first_value: &'ast TypedPipelineAssignment,
         _assignments: &'ast [(TypedPipelineAssignment, PipelineAssignmentKind)],
-        _finally: &'ast TypedExpr,
+        finally: &'ast TypedExpr,
         _finally_kind: &'ast PipelineAssignmentKind,
     ) {
         // We can only apply the action on the first step of a pipeline, so we
         // visit just that one and skip all the others.
         ast::visit::visit_typed_pipeline_assignment(self, first_value);
+        self.visited_item = VisitedItem::PipelineFinalStep;
+        ast::visit::visit_typed_expr(self, finally);
     }
 
     fn visit_typed_use(&mut self, use_: &'ast TypedUse) {
-        self.visiting_use_call = true;
+        self.visited_item = VisitedItem::UseRightHandSide;
         ast::visit::visit_typed_use(self, use_);
     }
 }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -8394,6 +8394,32 @@ pub fn main() {
 }
 
 #[test]
+fn convert_to_pipe_works_in_anonymous_function_inside_a_pipeline() {
+    assert_code_action!(
+        CONVERT_TO_PIPE,
+        "
+pub fn main() {
+  wibble |> wobble(fn() { woo(1) })
+}
+",
+        find_position_of("woo").to_selection()
+    );
+}
+
+#[test]
+fn convert_to_pipe_works_in_final_step_of_a_pipeline() {
+    assert_code_action!(
+        CONVERT_TO_PIPE,
+        "
+pub fn main() {
+  wibble |> wobble(woo(1))
+}
+",
+        find_position_of("woo").to_selection()
+    );
+}
+
+#[test]
 fn convert_to_pipe_with_function_call_with_labelled_arguments_inserts_hole() {
     assert_code_action!(
         CONVERT_TO_PIPE,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_pipe_works_in_anonymous_function_inside_a_pipeline.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_pipe_works_in_anonymous_function_inside_a_pipeline.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  wibble |> wobble(fn() { woo(1) })\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  wibble |> wobble(fn() { woo(1) })
+                          ↑        
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  wibble |> wobble(fn() { 1 |> woo })
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_pipe_works_in_final_step_of_a_pipeline.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__convert_to_pipe_works_in_final_step_of_a_pipeline.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  wibble |> wobble(woo(1))\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  wibble |> wobble(woo(1))
+                   ↑      
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  wibble |> wobble(1 |> woo)
+}


### PR DESCRIPTION
I noticed a small bug where the LS wouldn't suggest the "turn into pipe" code action when triggered on a value inside the final step of a pipeline:
```gleam
wibble
|> wobble(woo(1))
//        ^^^^^^ Wouldn't trigger on this!!
```