### PR TITLE
Use correct line number information for generating functions in other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   incorrect extra patterns in addition to the correct missing patterns.
   ([Adi Salimgereyev](https://github.com/abs0luty))
 
+- Fixed a bug where triggering the "Generate function" code action to generate
+  a function in a different module could cause the generated function to appear
+  in the middle of an existing function, resulting in invalid code.
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.13.0-rc1 - 2025-09-29
 
 ### Compiler

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5208,11 +5208,7 @@ impl<'a> GenerateFunction<'a> {
 
         if let Some(module) = module {
             if let Some(module) = self.modules.get(module) {
-                let insert_at = if module.code.is_empty() {
-                    0
-                } else {
-                    (module.code.len() - 1) as u32
-                };
+                let insert_at = module.code.len() as u32;
                 self.code_action_for_module(
                     module,
                     Publicity::Public,
@@ -5230,7 +5226,7 @@ impl<'a> GenerateFunction<'a> {
 
     fn code_action_for_module(
         mut self,
-        module: &Module,
+        module: &'a Module,
         publicity: Publicity,
         function_to_generate: FunctionToGenerate<'a>,
         insert_at: u32,
@@ -5272,6 +5268,10 @@ impl<'a> GenerateFunction<'a> {
 
         let publicity = if publicity.is_public() { "pub " } else { "" };
 
+        // Make sure we use the line number information of the module we are
+        // editing, which might not be the module where the code action is
+        // triggered.
+        self.edits.line_numbers = &module.ast.type_info.line_numbers;
         self.edits.insert(
             insert_at,
             format!("\n\n{publicity}fn {name}({arguments}) -> {return_type} {{\n  todo\n}}"),

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -10637,3 +10637,26 @@ fn wibble(f: fn() -> Float) -> Float { f() }
             .select_until(find_position_of("}"))
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5036
+#[test]
+fn generate_function_in_other_module_correctly_appends() {
+    let src = "import module_breaker/another
+
+pub fn main() -> Nil {
+  another.function()
+}
+";
+
+    assert_code_action!(
+        GENERATE_FUNCTION,
+        TestProject::for_source(src).add_module(
+            "module_breaker/another",
+            "pub fn useless() {
+  Nil
+}
+"
+        ),
+        find_position_of("function").to_selection()
+    );
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_in_other_module_correctly_appends.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_in_other_module_correctly_appends.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "import module_breaker/another\n\npub fn main() -> Nil {\n  another.function()\n}\n"
+---
+----- BEFORE ACTION
+import module_breaker/another
+
+pub fn main() -> Nil {
+  another.function()
+          ↑         
+}
+
+
+----- AFTER ACTION
+// --- Edits applied to module 'module_breaker/another'
+pub fn useless() {
+  Nil
+}
+
+
+pub fn function() -> Nil {
+  todo
+}


### PR DESCRIPTION
Fixes #5036

I also fixed another bug I found along the way where it would generate the function one character too early if the module did not end in a newline.