### PR TITLE
Improve help text for run, test, and dev commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Build tool
 
+- The help text displayed by `gleam dev --help`, `gleam test --help`, and
+  `gleam run --help` has been improved: now each one states which function it's
+  going to run.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Language server
 
 - The "inline variable" code action can now trigger when used over the let

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -215,6 +215,8 @@ enum Command {
     Shell,
 
     /// Run the project
+    ///
+    /// This command runs the `main` function from the `<PROJECT_NAME>` module.
     #[command(trailing_var_arg = true)]
     Run {
         #[arg(short, long, ignore_case = true, help = target_doc())]
@@ -235,6 +237,8 @@ enum Command {
     },
 
     /// Run the project tests
+    ///
+    /// This command runs the `main` function from the `<PROJECT_NAME>_test` module.
     #[command(trailing_var_arg = true)]
     Test {
         #[arg(short, long, ignore_case = true, help = target_doc())]
@@ -247,6 +251,8 @@ enum Command {
     },
 
     /// Run the project development entrypoint
+    ///
+    /// This command runs the `main` function from the `<PROJECT_NAME>_dev` module.
     #[command(trailing_var_arg = true)]
     Dev {
         #[arg(short, long, ignore_case = true, help = target_doc())]


### PR DESCRIPTION
This PR improves the help text for the `run`, `dev`, and `test` command by saying which function they're going to run in the help text. This is something people usually ignore, especially for `gleam test`, thinking it's doing more than it actually does. So maybe this could help clear some confusion (given someone will read the help text 😆)