### PR TITLE
Trigger inline variable in more places

### DIFF
--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -344,8 +344,8 @@ pub trait Visit<'ast> {
         visit_typed_expr_invalid(self, location, type_, extra_information);
     }
 
-    fn visit_typed_statement(&mut self, stmt: &'ast TypedStatement) {
-        visit_typed_statement(self, stmt);
+    fn visit_typed_statement(&mut self, statement: &'ast TypedStatement) {
+        visit_typed_statement(self, statement);
     }
 
     fn visit_typed_assignment(&mut self, assignment: &'ast TypedAssignment) {
@@ -961,8 +961,8 @@ pub fn visit_typed_expr_block<'a, V>(
 ) where
     V: Visit<'a> + ?Sized,
 {
-    for stmt in statements {
-        v.visit_typed_statement(stmt);
+    for statement in statements {
+        v.visit_typed_statement(statement);
     }
 }
 
@@ -1022,8 +1022,8 @@ pub fn visit_typed_expr_fn<'a, V>(
         v.visit_type_ast(return_);
     }
 
-    for stmt in body {
-        v.visit_typed_statement(stmt);
+    for statement in body {
+        v.visit_typed_statement(statement);
     }
 }
 
@@ -1241,12 +1241,12 @@ where
     v.visit_typed_expr(value);
 }
 
-pub fn visit_typed_statement<'a, V>(v: &mut V, stmt: &'a TypedStatement)
+pub fn visit_typed_statement<'a, V>(v: &mut V, statement: &'a TypedStatement)
 where
     V: Visit<'a> + ?Sized,
 {
-    match stmt {
-        Statement::Expression(expr) => v.visit_typed_expr(expr),
+    match statement {
+        Statement::Expression(expression) => v.visit_typed_expr(expression),
         Statement::Assignment(assignment) => v.visit_typed_assignment(assignment),
         Statement::Use(use_) => v.visit_typed_use(use_),
         Statement::Assert(assert) => v.visit_typed_assert(assert),

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -2793,11 +2793,11 @@ impl<'a> ExtractVariable<'a> {
 }
 
 impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
-    fn visit_typed_statement(&mut self, stmt: &'ast TypedStatement) {
-        let range = self.edits.src_span_to_lsp_range(stmt.location());
+    fn visit_typed_statement(&mut self, statement: &'ast TypedStatement) {
+        let range = self.edits.src_span_to_lsp_range(statement.location());
         if !within(self.params.range, range) {
-            self.latest_statement = Some(stmt.location());
-            ast::visit::visit_typed_statement(self, stmt);
+            self.latest_statement = Some(statement.location());
+            ast::visit::visit_typed_statement(self, statement);
             return;
         }
 
@@ -2808,17 +2808,17 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
             Some(ExtractVariablePosition::InsideCaptureBody) => {}
             Some(ExtractVariablePosition::PipelineCall) => {
                 // Insert above the pipeline start
-                self.latest_statement = Some(stmt.location());
+                self.latest_statement = Some(statement.location());
             }
             _ => {
                 // Insert below the previous statement
-                self.latest_statement = Some(stmt.location());
+                self.latest_statement = Some(statement.location());
                 self.statement_before_selected_expression = self.latest_statement;
             }
         }
 
         self.at_position(ExtractVariablePosition::TopLevelStatement, |this| {
-            ast::visit::visit_typed_statement(this, stmt);
+            ast::visit::visit_typed_statement(this, statement);
         });
     }
 

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -8322,6 +8322,20 @@ pub fn main(x) {
 }
 
 #[test]
+fn inline_variable_when_over_let_keyword() {
+    assert_code_action!(
+        INLINE_VARIABLE,
+        r#"
+pub fn main() {
+  let x = 123
+  x + 1
+}
+"#,
+        find_position_of("let").to_selection()
+    );
+}
+
+#[test]
 fn no_code_action_to_inline_variable_used_multiple_times() {
     let src = r#"
 import gleam/io

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__inline_variable_when_over_let_keyword.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__inline_variable_when_over_let_keyword.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub fn main() {\n  let x = 123\n  x + 1\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let x = 123
+  ↑          
+  x + 1
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  123 + 1
+}


### PR DESCRIPTION
With this PR the inline variable code action can trigger when over the `let` keyword as well, I think it's a nice qol improvement as I've been annoyed by it not showing up in that case.