### PR TITLE
Make gleam deps tree -p and -i mutually exclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   on the Erlang target.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- Analysis it now fault tolerant in the presence of errors in field definitions
+- Analysis is now fault tolerant in the presence of errors in field definitions
   of custom type variants.
   ([Adi Salimgereyev](https://github.com/abs0luty))
 
@@ -18,6 +18,11 @@
   `gleam run --help` has been improved: now each one states which function it's
   going to run.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The `--invert` and `--package` options of `gleam deps tree` are now mutually
+  exclusive; if both options are given the command will fail. Previously,
+  `--invert` would be silently ignored if given together with `--package`.
+  ([Evan Silberman](https://github.com/silby))
 
 ### Language server
 

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -111,6 +111,7 @@ struct TreeOptions {
         short,
         long,
         ignore_case = true,
+        conflicts_with = "invert",
         help = "Package to be used as the root of the tree"
     )]
     package: Option<String>,
@@ -119,6 +120,7 @@ struct TreeOptions {
         short,
         long,
         ignore_case = true,
+        conflicts_with = "package",
         help = "Invert the tree direction and focus on the given package",
         value_name = "PACKAGE"
     )]


### PR DESCRIPTION
`--invert` is currently silently ignored when `--package` is given also. I believe it's more predictable and more unixy for this to be a usage error instead.

Other tweaks to this are conceivable such as making `-i` a flag that doesn't take an arg instead of conflicting with `-p`. (This would raise the question of what you get when you do `gleam deps tree -i` by itself, which I guess would be what you get if you give the name of the current package to `-i` today, which is just your own package's name and version, since nothing in the project depends on it.) But as that is a more breaking change to the option usage I don't propose that here.

You can also decide that silently-ignoring an option is fine and close this; this took five minutes so no harm done.