### PR TITLE
Do not offer generate function code action for unsupported targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Fixed a bug where the "Generate function" code action would be incorrectly
+  offered when calling a function unsupported by the current target, leading to
+  invalid code if the code action was accepted.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Compiler
 
 - Patterns aliasing a string prefix have been optimised to generate faster code

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -1182,4 +1182,7 @@ pub enum InvalidExpression {
         module_name: EcoString,
         label: EcoString,
     },
+    UnknownVariable {
+        name: EcoString,
+    },
 }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -10727,3 +10727,20 @@ pub fn main() -> Nil {
         find_position_of("function").to_selection()
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/4904
+#[test]
+fn no_code_action_to_generate_function_on_unsupported_target() {
+    assert_no_code_actions!(
+        GENERATE_FUNCTION,
+        r#"
+pub fn main() {
+  wibble()
+}
+
+@external(javascript, "./ffi.mjs", "wibble")
+fn wibble() -> Nil
+"#,
+        find_position_of("wibble").to_selection()
+    );
+}


### PR DESCRIPTION
Fixes #4904 

I've reused the `extra_information` field introduced recently as that seemed to make the most sense here.