### PR TITLE
Fix code generation for alternative string prefix patterns with an alias

### DIFF
--- a/compiler-core/src/erlang/tests/case.rs
+++ b/compiler-core/src/erlang/tests/case.rs
@@ -101,3 +101,18 @@ pub fn main() {
 "#,
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5055
+#[test]
+fn alternative_patter_with_string_alias() {
+    assert_erl!(
+        r#"
+pub fn main(x) {
+  case x {
+    "a" as letter <> _ | "b" as letter <> _ -> letter
+    _ -> "wibble"
+  }
+}
+"#,
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__alternative_patter_with_string_alias.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__alternative_patter_with_string_alias.snap
@@ -1,0 +1,35 @@
+---
+source: compiler-core/src/erlang/tests/case.rs
+expression: "\npub fn main(x) {\n  case x {\n    \"a\" as letter <> _ | \"b\" as letter <> _ -> letter\n    _ -> \"wibble\"\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  case x {
+    "a" as letter <> _ | "b" as letter <> _ -> letter
+    _ -> "wibble"
+  }
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-define(FILEPATH, "project/test/my/mod.gleam").
+-export([main/1]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec main(binary()) -> binary().
+main(X) ->
+    case X of
+        <<"a"/utf8, _/binary>> ->
+            Letter = <<"a"/utf8>>,
+            Letter;
+
+        <<"b"/utf8, _/binary>> ->
+            Letter = <<"b"/utf8>>,
+            Letter;
+
+        _ ->
+            <<"wibble"/utf8>>
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__string_prefix_assignment_with_multiple_subjects.snap
@@ -27,7 +27,7 @@ go(X) ->
             Digit;
 
         <<"2"/utf8, _/binary>> ->
-            Digit = <<"1"/utf8>>,
+            Digit = <<"2"/utf8>>,
             Digit;
 
         _ ->


### PR DESCRIPTION
This PR closes #5055

There was a bug in a recently merged change where the generated code would be invalid for alternative patterns with string prefixes. Now that is fixed (I didn't update the changelog as this falls under that same change)