### PR TITLE
Add a missing BitArray constructor return type in the prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,6 @@
   negations from literal integers.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Add a missing BitArray constructor return type in the prelude's TypeScript
+  definitions.
+  ([Richard Viney](https://github.com/richard-viney))

--- a/compiler-core/templates/prelude.d.mts
+++ b/compiler-core/templates/prelude.d.mts
@@ -65,7 +65,7 @@ export interface BitArray {
 /** @deprecated */
 export const BitArray: {
   /** @deprecated */
-  new(buffer: Uint8Array, bitSize?: number, bitOffset?: number);
+  new(buffer: Uint8Array, bitSize?: number, bitOffset?: number): BitArray;
 }
 export function BitArray$BitArray(
   buffer: Uint8Array,


### PR DESCRIPTION
The lack of this return type causes the following error:

```
error TS7013: Construct signature, which lacks return-type annotation, implicitly has an 'any' return type.
```