### PR TITLE
Fix invalid TS definition for long variant constructors with no args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,3 +163,6 @@
   shadow outer scope variables in other branches when compiling to JavaScript.
   ([Elias Haider](https://github.com/EliasDerHai))
 
+- Fix invalid TypeScript definition being generated for variant constructors
+  with long names that take no arguments.
+  ([Richard Viney](https://github.com/richard-viney))

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -670,12 +670,14 @@ impl<'a> TypeScriptGenerator<'a> {
         )
         .to_doc();
 
+        let has_arguments = !arguments.is_empty();
+
         docvec![
             "export function ",
             name_with_generics(function_name, type_parameters),
             "(",
             docvec![break_("", ""), join(arguments, break_(",", ", ")),].nest(INDENT),
-            break_(",", ""),
+            break_(if has_arguments { "," } else { "" }, ""),
             "): ",
             type_name_with_generics.clone(),
             ";"


### PR DESCRIPTION
In v1.13.0 the following Gleam code

```gleam
pub type ValueRepresentation {
  UniversalResourceIdentifier
}
``` 

generates the following invalid TypeScript definition

```ts
export function ValueRepresentation$UniversalResourceIdentifier(
  ,
): ValueRepresentation$;
```

The comma isn't valid there and gives the error `Parameter declaration expected.` from `tsc`.

This issue occurs when the variant constructor function name is long, and it takes no arguments.