### PR TITLE
Add support for HEX_API_URL and HEX_REPOSITORY_URL environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Build tool
+
+- Added support for configuring Hex API and repository URLs via environment
+  variables. Set `HEX_API_URL` to configure the Hex API base URL and
+  `HEX_REPOSITORY_URL` to configure the Hex repository base URL. This is useful
+  for using self-hosted Hex instances or mirrors.
+  ([diemogebhardt](https://github.com/diemogebhardt))
+
 ### Compiler
 
 - Patterns aliasing a string prefix have been optimised to generate faster code

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1093,7 +1093,7 @@ async fn lookup_package(
     match provided.get(name.as_str()) {
         Some(provided_package) => Ok(provided_package.to_manifest_package(name.as_str())),
         None => {
-            let config = hexpm::Config::new();
+            let config = crate::hex::hex_config();
             let release =
                 hex::get_package_release(&name, &version, &config, &HttpClient::new()).await?;
             let build_tools = release
@@ -1183,7 +1183,7 @@ impl dependency::PackageFetcher for PackageFetcher {
         }
 
         tracing::debug!(package = package, "looking_up_hex_package");
-        let config = hexpm::Config::new();
+        let config = crate::hex::hex_config();
         let request = hexpm::repository_v2_get_package_request(package, None, &config);
         let response = self
             .runtime

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -23,7 +23,7 @@ use gleam_core::{
 
 pub fn remove(package: String, version: String) -> Result<()> {
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
-    let hex_config = hexpm::Config::new();
+    let hex_config = crate::hex::hex_config();
     let api_key =
         crate::hex::HexAuthentication::new(&runtime, hex_config.clone()).get_or_create_api_key()?;
     let http = HttpClient::new();
@@ -169,7 +169,7 @@ pub fn publish(paths: &ProjectPaths) -> Result<()> {
     let config = crate::config::root_config(paths)?;
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
-    let hex_config = hexpm::Config::new();
+    let hex_config = crate::hex::hex_config();
     let api_key =
         crate::hex::HexAuthentication::new(&runtime, hex_config.clone()).get_or_create_api_key()?;
 

--- a/compiler-cli/src/owner.rs
+++ b/compiler-cli/src/owner.rs
@@ -15,7 +15,7 @@ Do you wish to transfer ownership of `{package}` to {new_owner_username_or_email
     }
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
-    let hex_config = hexpm::Config::new();
+    let hex_config = crate::hex::hex_config();
     let api_key =
         crate::hex::HexAuthentication::new(&runtime, hex_config.clone()).get_or_create_api_key()?;
 

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -80,7 +80,7 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
     }
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
-    let hex_config = hexpm::Config::new();
+    let hex_config = crate::hex::hex_config();
     let api_key =
         crate::hex::HexAuthentication::new(&runtime, hex_config.clone()).get_or_create_api_key()?;
     let start = Instant::now();


### PR DESCRIPTION
This change allows users to configure custom Hex API and repository URLs via environment variables, enabling the use of self-hosted Hex instances or mirrors. This is particularly useful for organizations that:

- Run their own internal Hex instance
- Need to use Hex mirrors in regions where hex.pm is not accessible
- Want to use custom package repositories for internal packages

Implementation details:
- Added hex_config() function in both compiler-cli and compiler-core that reads HEX_API_URL and HEX_REPOSITORY_URL environment variables
- Updated all hexpm::Config::new() calls to use hex_config() instead
- Provides helpful warnings when invalid URLs are provided
- Falls back to default hex.pm URLs when environment variables are not set

Environment variables:
- HEX_API_URL: Configure the Hex API base URL (default: https://hex.pm/api/)
- HEX_REPOSITORY_URL: Configure the repository base URL (default: https://repo.hex.pm/)

Fixes the issue reported by users needing to use self-hosted Hex instances in corporate environments or regions with restricted access to hex.pm.