### PR TITLE
Fix bug with aliased prefix patterns referenced in guards

### DIFF
--- a/compiler-core/src/erlang/tests/case.rs
+++ b/compiler-core/src/erlang/tests/case.rs
@@ -116,3 +116,18 @@ pub fn main(x) {
 "#,
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5115
+#[test]
+fn aliased_string_prefix_pattern_referenced_in_guard() {
+    assert_erl!(
+        r#"
+pub fn main(x) {
+  case x {
+    "a" as letter <> _ if letter == x -> letter
+    _ -> "wibble"
+  }
+}
+"#,
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__aliased_string_prefix_pattern_referenced_in_guard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__aliased_string_prefix_pattern_referenced_in_guard.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/erlang/tests/case.rs
+expression: "\npub fn main(x) {\n  case x {\n    \"a\" as letter <> _ if letter == x -> letter\n    _ -> \"wibble\"\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  case x {
+    "a" as letter <> _ if letter == x -> letter
+    _ -> "wibble"
+  }
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-define(FILEPATH, "project/test/my/mod.gleam").
+-export([main/1]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec main(binary()) -> binary().
+main(X) ->
+    case X of
+        <<"a"/utf8, _/binary>> when <<"a"/utf8>> =:= X ->
+            Letter = <<"a"/utf8>>,
+            Letter;
+
+        _ ->
+            <<"wibble"/utf8>>
+    end.


### PR DESCRIPTION
This PR fixes #5115
With this fix the referenced variable is always replaced with its literal value so the code is still as fast as it can be.