### PR TITLE
Update MacOS version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
             cargo-tool: cross
             run-integration-tests: false # Cannot run aarch64 binaries on x86_64
           # macos>=14 runs exclusively on aarch64 and will thus fail to execute properly for x64
-          - os: macos-13 # intel
+          - os: macos-15-intel # intel
             target: x86_64-apple-darwin
             binary: x86_64
             cargo-tool: cargo


### PR DESCRIPTION
MacOS version 13 in CI has been [deprecated](https://github.com/actions/runner-images/issues/13046), and it's causing [CI to fail](https://github.com/gleam-lang/gleam/actions/runs/19268935037/job/55091796253?pr=5119). This PR updates the CI to use version 15 instead.