### PR TITLE
Warn for detatched doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,35 @@
   containing scientific notation or trailing zeros (i.e. `100` and `1e2`).
   ([ptdewey](https://github.com/ptdewey))
 
+- The compiler now emits a warning when a doc comment is not attached to a
+  definition due to a regular comment in between. For example, in the following
+  code:
+
+  ```gleam
+  /// This documentation is not attached
+  // This is not a doc comment
+  /// This is actual documentation
+  pub fn wibble() {
+    todo
+  }
+  ```
+
+  Will now produce the following warning:
+
+  ```txt
+    warning: Detached doc comment
+    ┌─ src/main.gleam:1:4
+    │
+  1 │ /// This documentation is not attached
+    │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This is not attached to a definition
+
+  This doc comment is followed by a regular comment so it is not attached to
+  any definition.
+  Hint: Move the comment above the doc comment
+  ```
+
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - The help text displayed by `gleam dev --help`, `gleam test --help`, and

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__detached_doc_comment.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__detached_doc_comment.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n/// This comment is detached\n//\n\n/// This is actual documentation\npub const pi = 3.14\n"
+---
+----- SOURCE CODE
+
+/// This comment is detached
+//
+
+/// This is actual documentation
+pub const pi = 3.14
+
+
+----- WARNING
+warning: Detached doc comment
+  ┌─ test/path:2:4
+  │
+2 │ /// This comment is detached
+  │    ^^^^^^^^^^^^^^^^^^^^^^^^^ This is not attached to a definition
+
+This doc comment is followed by a regular comment so it is not attached to
+any definition.
+Hint: Move the comment above the doc comment

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -4612,3 +4612,16 @@ pub type Wobble
 "#,
     );
 }
+
+#[test]
+fn detached_doc_comment() {
+    assert_warning!(
+        "
+/// This comment is detached
+//
+
+/// This is actual documentation
+pub const pi = 3.14
+"
+    );
+}

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -174,6 +174,12 @@ pub enum Warning {
         path: Utf8PathBuf,
         name: EcoString,
     },
+
+    DetachedDocComment {
+        path: Utf8PathBuf,
+        src: EcoString,
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Copy)]
@@ -423,6 +429,29 @@ To have a clause without a guard, remove this.",
                     }),
                 }
             }
+
+            Warning::DetachedDocComment {
+                path,
+                src,
+                location,
+            } => Diagnostic {
+                title: "Detached doc comment".into(),
+                text: wrap(
+                    "This doc comment is followed by a regular \
+comment so it is not attached to any definition.",
+                ),
+                level: diagnostic::Level::Warning,
+                location: Some(Location {
+                    path: path.to_path_buf(),
+                    src: src.clone(),
+                    label: diagnostic::Label {
+                        text: Some("This is not attached to a definition".into()),
+                        span: *location,
+                    },
+                    extra_labels: Vec::new(),
+                }),
+                hint: Some("Move the comment above the doc comment".into()),
+            },
 
             Warning::Type { path, warning, src } => match warning {
                 type_::Warning::Todo {


### PR DESCRIPTION
Fixes #4758 
This PR adds a warning for when a regular comment is placed between a doc comment and a definition, causing it to not attach to the definition.
I'm still not totally sure on the wording of the warning, so let me know what you think