### PR TITLE
Add 'merge case branches' code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
   from 1.13 has been extended to int segments!
   Aside from the various performance improvements, this allows the compiler to
   mark more branches as unreachable.
+
   ```gleam
   case bits {
     <<"a">> -> 0
@@ -111,6 +112,7 @@
     _ -> 99
   }
   ```
+
   ([fruno](https://github.com/fruno-bulax/))
 
 ### Build tool
@@ -177,6 +179,31 @@
   ([Andrey Kozhev](https://github.com/ankddev))
 
 ### Language server
+
+- The language server can now offer a code action to merge consecutive case
+  branches with the same body. For example:
+
+  ```gleam
+  case user {
+    Admin(name:, ..) -> todo
+  //^^^^^^^^^^^^^^^^^^^^^^^^
+    Guest(name:, ..) -> todo
+  //^^^^^^^^^^^^^^^^ Selecting these two branches you can
+  //                 trigger the "Merge case branches" code action
+    _ -> todo
+  }
+  ```
+
+  Triggering the code action would result in the following code:
+
+  ```gleam
+  case user {
+    Admin(name:, ..) | Guest(name:, ..) -> todo
+    _ -> todo
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 - The "inline variable" code action can now trigger when used over the let
   keyword of a variable to inline.

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -9279,3 +9279,251 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
         }
     }
 }
+
+/// Code action to merge two identical branches together.
+///
+pub struct MergeCaseBranches<'a> {
+    module: &'a Module,
+    params: &'a CodeActionParams,
+    edits: TextEdits<'a>,
+    /// These are the positions of the patterns of all the consecutive branches
+    /// we've determined can be merged, for example if we're mergin the first
+    /// two branches here:
+    ///
+    /// ```gleam
+    ///   case wibble {
+    ///     1 -> todo
+    /// //  ^ this location here
+    ///     20 -> todo
+    /// //  ^^ and this location here
+    ///   _ -> todo
+    /// }
+    /// ```
+    ///
+    /// We need those to delete all the space between each consecutive pattern,
+    /// replacing it with the `|` for alternatives
+    ///
+    patterns_to_merge: Option<MergeableBranches>,
+}
+
+struct MergeableBranches {
+    /// The span of the body to keep when merging multiple branches. For
+    /// example:
+    ///
+    /// ```gleam
+    /// case n {
+    ///   // Imagine we're merging the first three branches together...
+    ///   1 -> todo
+    ///   2 -> n * 2
+    /// //     ^^^^^ This would be the location of the one body to keep
+    ///   3 -> todo
+    ///   _ -> todo
+    /// }
+    /// ```
+    ///
+    body_to_keep: SrcSpan,
+
+    /// The location body of the last of the branches that are going to be
+    /// merged; that is where we're going to place the code of the body to keep
+    /// once the action is done. For example:
+    ///
+    /// ```gleam
+    /// case n {
+    ///   // Imagine we're merging the first three branches together...
+    ///   1 -> todo
+    ///   2 -> n * 2
+    ///   3 -> todo
+    /// //     ^^^^ This would be the location of the final body
+    ///   _ -> todo
+    /// }
+    /// ```
+    ///
+    final_body: SrcSpan,
+
+    /// The span of the patterns whose branches are going to be merged. For
+    /// example:
+    ///
+    /// ```gleam
+    /// case n {
+    ///   // Imagine we're merging the first three branches together...
+    ///    1 -> todo
+    /// // ^
+    ///    2 -> n * 2
+    /// // ^
+    ///    3 -> todo
+    /// // ^ These would be the locations of the patterns
+    ///   _ -> todo
+    /// }
+    /// ```
+    ///
+    patterns_to_merge: Vec<SrcSpan>,
+}
+
+impl<'a> MergeCaseBranches<'a> {
+    pub fn new(
+        module: &'a Module,
+        line_numbers: &'a LineNumbers,
+        params: &'a CodeActionParams,
+    ) -> Self {
+        Self {
+            module,
+            params,
+            edits: TextEdits::new(line_numbers),
+            patterns_to_merge: None,
+        }
+    }
+
+    pub fn code_actions(mut self) -> Vec<CodeAction> {
+        self.visit_typed_module(&self.module.ast);
+
+        let Some(mergeable_branches) = self.patterns_to_merge else {
+            return vec![];
+        };
+
+        for (one, next) in mergeable_branches.patterns_to_merge.iter().tuple_windows() {
+            self.edits
+                .replace(SrcSpan::new(one.end, next.start), " | ".into());
+        }
+
+        self.edits.replace(
+            mergeable_branches.final_body,
+            code_at(self.module, mergeable_branches.body_to_keep).into(),
+        );
+
+        let mut action = Vec::with_capacity(1);
+        CodeActionBuilder::new("Merge case branches")
+            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .changes(self.params.text_document.uri.clone(), self.edits.edits)
+            .preferred(false)
+            .push_to(&mut action);
+        action
+    }
+
+    fn select_mergeable_branches(
+        &self,
+        clauses: &'a [ast::TypedClause],
+    ) -> Option<MergeableBranches> {
+        let mut clauses = clauses
+            .iter()
+            // We want to skip all the branches at the beginning of the case
+            // expression that the cursor is not hovering over. For example:
+            //
+            // ```gleam
+            // case wibble {
+            //   a -> 1   <- we want to skip this one here that is not selected
+            //   b -> 2
+            //     ^^^^   this is the selection
+            //   _ -> 3
+            //   ^^
+            // }
+            // ```
+            .skip_while(|clause| {
+                let clause_range = self.edits.src_span_to_lsp_range(clause.location);
+                !overlaps(self.params.range, clause_range)
+            })
+            // Then we only want to take the clauses that we're hovering over
+            // with our selection (even partially!)
+            // In the provious example they would be `b -> 2` and `_ -> 3`.
+            .take_while(|clause| {
+                let clause_range = self.edits.src_span_to_lsp_range(clause.location);
+                overlaps(self.params.range, clause_range)
+            });
+
+        let first_hovered_clause = clauses.next()?;
+
+        // This is the clause we're comparing all the others with. We need to
+        // make sure that all the clauses we're going to join can be merged with
+        // this one.
+        let mut reference_clause = first_hovered_clause;
+        let mut clause_patterns_to_merge = vec![reference_clause.pattern_location()];
+        let mut final_body = first_hovered_clause.then.location();
+
+        for clause in clauses {
+            // As soon as we find a clause that can't be merged with the current
+            // reference we know we're done looking for consecutive clauses to
+            // merge.
+            if !clauses_can_be_merged(reference_clause, clause) {
+                break;
+            }
+
+            clause_patterns_to_merge.push(clause.pattern_location());
+            final_body = clause.then.location();
+
+            // If the current reference is a `todo` expression, we want to use
+            // the newly found mergeable clause as the next reference. The
+            // reference clause is the one whose body will be kept around, so if
+            // we can we avoid keeping `todo`s
+            if reference_clause.then.is_todo_with_no_message() {
+                reference_clause = clause;
+            }
+        }
+
+        // We only offer the code action if we have found two or more clauses
+        // to merge.
+        if clause_patterns_to_merge.len() >= 2 {
+            Some(MergeableBranches {
+                final_body,
+                body_to_keep: reference_clause.then.location(),
+                patterns_to_merge: clause_patterns_to_merge,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+fn clauses_can_be_merged(one: &ast::TypedClause, other: &ast::TypedClause) -> bool {
+    // Two clauses cannot be merged if any of those has an if guard
+    if one.guard.is_some() || other.guard.is_some() {
+        return false;
+    }
+
+    // Two clauses can only be merged if they define the same variables,
+    // otherwise joining them would result in invalid code.
+    let variables_one = one
+        .bound_variables()
+        .map(|variable| variable.name())
+        .collect::<HashSet<_>>();
+
+    let variables_other = other
+        .bound_variables()
+        .map(|variable| variable.name())
+        .collect::<HashSet<_>>();
+
+    if variables_one != variables_other {
+        return false;
+    }
+
+    // Anything can be merged with a simple todo, or the two bodies must be
+    // syntactically equal.
+    one.then.is_todo_with_no_message()
+        || other.then.is_todo_with_no_message()
+        || one.then.syntactically_eq(&other.then)
+}
+
+impl<'ast> ast::visit::Visit<'ast> for MergeCaseBranches<'ast> {
+    fn visit_typed_expr_case(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        subjects: &'ast [TypedExpr],
+        clauses: &'ast [ast::TypedClause],
+        compiled_case: &'ast CompiledCase,
+    ) {
+        // We only trigger the code action if we are within a case expression,
+        // otherwise there's no point in exploring the expression any further.
+        let case_range = self.edits.src_span_to_lsp_range(*location);
+        if !within(self.params.range, case_range) {
+            return;
+        }
+
+        if let result @ Some(_) = self.select_mergeable_branches(clauses) {
+            self.patterns_to_merge = result
+        }
+
+        // We still need to visit the case expression in case we want to apply
+        // the code action to some case expression that is nested in one of its
+        // branches!
+        ast::visit::visit_typed_expr_case(self, location, type_, subjects, clauses, compiled_case);
+    }
+}

--- a/compiler-core/src/language_server/engine.rs
+++ b/compiler-core/src/language_server/engine.rs
@@ -13,7 +13,7 @@ use crate::{
     io::{BeamCompiler, CommandExecutor, FileSystemReader, FileSystemWriter},
     language_server::{
         code_action::{
-            AddOmittedLabels, CollapseNestedCase, ExtractFunction, RemoveBlock,
+            AddOmittedLabels, CollapseNestedCase, ExtractFunction, MergeCaseBranches, RemoveBlock,
             RemovePrivateOpaque, RemoveUnreachableCaseClauses,
         },
         compiler::LspProjectCompiler,
@@ -420,6 +420,7 @@ where
                 &this.error,
                 &mut actions,
             );
+            actions.extend(MergeCaseBranches::new(module, &lines, &params).code_actions());
             actions.extend(FixBinaryOperation::new(module, &lines, &params).code_actions());
             actions
                 .extend(FixTruncatedBitArraySegment::new(module, &lines, &params).code_actions());

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -136,6 +136,7 @@ const COLLAPSE_NESTED_CASE: &str = "Collapse nested case";
 const REMOVE_UNREACHABLE_CLAUSES: &str = "Remove unreachable clauses";
 const ADD_OMITTED_LABELS: &str = "Add omitted labels";
 const EXTRACT_FUNCTION: &str = "Extract function";
+const MERGE_CASE_BRANCHES: &str = "Merge case branches";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -10843,5 +10844,226 @@ pub fn main() {
 fn wibble() -> Nil
 "#,
         find_position_of("wibble").to_selection()
+    );
+}
+
+#[test]
+fn merge_case_branch() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> todo
+    2 -> todo
+    _ -> todo
+  }
+  }"#,
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
+fn merge_case_branch_with_todo_keeps_the_non_todo_body() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> todo
+    2 -> n * 2
+    3 -> todo
+    _ -> todo
+  }
+  }"#,
+        find_position_of("1").select_until(find_position_of("3"))
+    );
+}
+
+#[test]
+fn merge_case_branch_with_todo_keeps_the_non_todo_body_1() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> todo
+    2 -> todo
+    3 -> n * 2
+    _ -> todo
+  }
+  }"#,
+        find_position_of("1").select_until(find_position_of("3"))
+    );
+}
+
+#[test]
+fn merge_case_branch_with_todo_keeps_the_non_todo_body_2() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> n * 2
+    2 -> todo
+    3 -> todo
+    _ -> todo
+  }
+  }"#,
+        find_position_of("1").select_until(find_position_of("3"))
+    );
+}
+
+#[test]
+fn merge_case_branch_with_complex_bodies_1() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> Ok("one or two")
+    2 -> Ok("one or two")
+    _ -> Error("neither one or two")
+  }
+  }"#,
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
+fn merge_case_branch_with_complex_bodies_2() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> n
+    2 -> n
+    _ -> panic as "neither one nor two"
+  }
+  }"#,
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
+fn merge_case_branch_with_complex_bodies_3() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> go(n - 1)
+    2 -> go(n - 1)
+    _ -> 10
+  }
+}"#,
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
+fn merge_case_branch_with_complex_bodies_4() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 -> {
+      let a = go(n - 1)
+      a * 10
+    }
+    2 -> {
+      let a = go(n - 1)
+      a * 10
+    }
+    _ -> 10
+  }
+}"#,
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
+fn merge_case_branch_will_not_merge_branches_with_guards() {
+    assert_no_code_actions!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(n: Int) {
+  case n {
+    1 if True -> todo
+    2 -> todo
+    _ -> todo
+  }
+  }"#,
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
+fn merge_case_branch_will_not_merge_branches_defining_different_variables() {
+    assert_no_code_actions!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(result) {
+  case result {
+    Ok(value) -> todo
+    Error(error) -> todo
+    _ -> todo
+  }
+  }"#,
+        find_position_of("Ok").select_until(find_position_of("error"))
+    );
+}
+
+#[test]
+fn merge_case_branch_can_merge_branches_defining_the_same_variables() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(result) {
+  case result {
+    [Ok(value), ..] -> todo
+    [_, Error(value)] -> todo
+    _ -> todo
+  }
+}"#,
+        find_position_of("Ok").select_until(find_position_of("todo").nth_occurrence(2))
+    );
+}
+
+#[test]
+fn merge_case_branch_can_merge_multiple_branches() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(result) {
+  case result {
+    [_] -> 1
+    [Ok(value), ..] -> todo
+    [_, Error(value)] -> todo
+    [_, _, Error(value)] -> todo
+    [_, _] -> 1
+    _ -> 2
+  }
+}"#,
+        find_position_of("todo").select_until(find_position_of("todo").nth_occurrence(3))
+    );
+}
+
+#[test]
+fn merge_case_branch_does_not_pop_up_with_a_single_selected_branch() {
+    assert_no_code_actions!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(result) {
+  case result {
+    [] -> todo
+    _ -> 2
+  }
+}"#,
+        find_position_of("[]").to_selection()
+    );
+}
+
+#[test]
+fn merge_case_branch_works_with_existing_alternative_patterns() {
+    assert_code_action!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(result) {
+  case result {
+    [] | [_, _, ..]-> todo
+    [_] -> todo
+    _ -> 2
+  }
+}"#,
+        find_position_of("[]").select_until(find_position_of("[_]"))
     );
 }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> todo\n    2 -> todo\n    _ -> todo\n  }\n  }"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> todo
+    ▔▔▔▔▔▔▔▔▔
+    2 -> todo
+▔▔▔▔↑        
+    _ -> todo
+  }
+  }
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 -> todo
+    _ -> todo
+  }
+  }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_can_merge_branches_defining_the_same_variables.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_can_merge_branches_defining_the_same_variables.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(result) {\n  case result {\n    [Ok(value), ..] -> todo\n    [_, Error(value)] -> todo\n    _ -> todo\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn go(result) {
+  case result {
+    [Ok(value), ..] -> todo
+     ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    [_, Error(value)] -> todo
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+    _ -> todo
+  }
+}
+
+
+----- AFTER ACTION
+pub fn go(result) {
+  case result {
+    [Ok(value), ..] | [_, Error(value)] -> todo
+    _ -> todo
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_can_merge_multiple_branches.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_can_merge_multiple_branches.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(result) {\n  case result {\n    [_] -> 1\n    [Ok(value), ..] -> todo\n    [_, Error(value)] -> todo\n    [_, _, Error(value)] -> todo\n    [_, _] -> 1\n    _ -> 2\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn go(result) {
+  case result {
+    [_] -> 1
+    [Ok(value), ..] -> todo
+                       ▔▔▔▔
+    [_, Error(value)] -> todo
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    [_, _, Error(value)] -> todo
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑   
+    [_, _] -> 1
+    _ -> 2
+  }
+}
+
+
+----- AFTER ACTION
+pub fn go(result) {
+  case result {
+    [_] -> 1
+    [Ok(value), ..] | [_, Error(value)] | [_, _, Error(value)] -> todo
+    [_, _] -> 1
+    _ -> 2
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_1.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_1.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> Ok(\"one or two\")\n    2 -> Ok(\"one or two\")\n    _ -> Error(\"neither one or two\")\n  }\n  }"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> Ok("one or two")
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    2 -> Ok("one or two")
+▔▔▔▔↑                    
+    _ -> Error("neither one or two")
+  }
+  }
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 -> Ok("one or two")
+    _ -> Error("neither one or two")
+  }
+  }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_2.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> n\n    2 -> n\n    _ -> panic as \"neither one nor two\"\n  }\n  }"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> n
+    ▔▔▔▔▔▔
+    2 -> n
+▔▔▔▔↑     
+    _ -> panic as "neither one nor two"
+  }
+  }
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 -> n
+    _ -> panic as "neither one nor two"
+  }
+  }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_3.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_3.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> go(n - 1)\n    2 -> go(n - 1)\n    _ -> 10\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> go(n - 1)
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    2 -> go(n - 1)
+▔▔▔▔↑             
+    _ -> 10
+  }
+}
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 -> go(n - 1)
+    _ -> 10
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_4.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_complex_bodies_4.snap
@@ -1,0 +1,35 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> {\n      let a = go(n - 1)\n      a * 10\n    }\n    2 -> {\n      let a = go(n - 1)\n      a * 10\n    }\n    _ -> 10\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> {
+    ▔▔▔▔▔▔
+      let a = go(n - 1)
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+      a * 10
+▔▔▔▔▔▔▔▔▔▔▔▔
+    }
+▔▔▔▔▔
+    2 -> {
+▔▔▔▔↑     
+      let a = go(n - 1)
+      a * 10
+    }
+    _ -> 10
+  }
+}
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 -> {
+      let a = go(n - 1)
+      a * 10
+    }
+    _ -> 10
+  }
+}

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_todo_keeps_the_non_todo_body.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_todo_keeps_the_non_todo_body.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> todo\n    2 -> n * 2\n    3 -> todo\n    _ -> todo\n  }\n  }"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> todo
+    ▔▔▔▔▔▔▔▔▔
+    2 -> n * 2
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    3 -> todo
+▔▔▔▔↑        
+    _ -> todo
+  }
+  }
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 | 3 -> n * 2
+    _ -> todo
+  }
+  }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_todo_keeps_the_non_todo_body_1.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_todo_keeps_the_non_todo_body_1.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> todo\n    2 -> todo\n    3 -> n * 2\n    _ -> todo\n  }\n  }"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> todo
+    ▔▔▔▔▔▔▔▔▔
+    2 -> todo
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+    3 -> n * 2
+▔▔▔▔↑         
+    _ -> todo
+  }
+  }
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 | 3 -> n * 2
+    _ -> todo
+  }
+  }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_todo_keeps_the_non_todo_body_2.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_with_todo_keeps_the_non_todo_body_2.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(n: Int) {\n  case n {\n    1 -> n * 2\n    2 -> todo\n    3 -> todo\n    _ -> todo\n  }\n  }"
+---
+----- BEFORE ACTION
+pub fn go(n: Int) {
+  case n {
+    1 -> n * 2
+    ▔▔▔▔▔▔▔▔▔▔
+    2 -> todo
+▔▔▔▔▔▔▔▔▔▔▔▔▔
+    3 -> todo
+▔▔▔▔↑        
+    _ -> todo
+  }
+  }
+
+
+----- AFTER ACTION
+pub fn go(n: Int) {
+  case n {
+    1 | 2 | 3 -> n * 2
+    _ -> todo
+  }
+  }

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_works_with_existing_alternative_patterns.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__merge_case_branch_works_with_existing_alternative_patterns.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "pub fn go(result) {\n  case result {\n    [] | [_, _, ..]-> todo\n    [_] -> todo\n    _ -> 2\n  }\n}"
+---
+----- BEFORE ACTION
+pub fn go(result) {
+  case result {
+    [] | [_, _, ..]-> todo
+    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+    [_] -> todo
+▔▔▔▔↑          
+    _ -> 2
+  }
+}
+
+
+----- AFTER ACTION
+pub fn go(result) {
+  case result {
+    [] | [_, _, ..] | [_] -> todo
+    _ -> 2
+  }
+}


### PR DESCRIPTION
With this PR I've implemented the code action to merge consecutive case branches. For now it's quite limited as it only supports branches whose body is a single `todo`; @lpil do you think we should be comparing the ASTs to check if they can be safely merged?