### PR TITLE
Fix generation of unused opaque types referencing private types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,3 +265,7 @@
 - Typos in the error message shown when trying to install a non-existent package
   have been fixed.
   ([Ioan Clarke](https://github.com/ioanclarke))
+
+- Fixed a bug where the compiler would generate invalid Erlang and TypeScript
+  code for unused opaque types referencing private types.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -181,7 +181,6 @@ fn module_document<'a>(
             &mut type_defs,
             &module.name,
             &overridden_publicity,
-            &module.unused_definition_positions,
         );
     }
 
@@ -303,13 +302,7 @@ fn register_imports_and_exports(
     type_defs: &mut Vec<Document<'_>>,
     module_name: &str,
     overridden_publicity: &im::HashSet<EcoString>,
-    unused_definition_positions: &HashSet<u32>,
 ) {
-    // Do not generate any code for unused items
-    if unused_definition_positions.contains(&definition.location().start) {
-        return;
-    }
-
     match definition {
         Definition::Function(Function {
             publicity,

--- a/compiler-core/src/erlang/tests/custom_types.rs
+++ b/compiler-core/src/erlang/tests/custom_types.rs
@@ -27,3 +27,19 @@ pub fn get(dict: Dict(key, value), key: key) -> Result(value, Nil)
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5127
+#[test]
+fn unused_opaque_constructor_is_generated_correctly() {
+    assert_erl!(
+        "
+type Wibble {
+  Wibble
+}
+
+pub opaque type Wobble {
+  Wobble(Wibble)
+}
+"
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__custom_types__unused_opaque_constructor_is_generated_correctly.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__custom_types__unused_opaque_constructor_is_generated_correctly.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/erlang/tests/custom_types.rs
+expression: "\ntype Wibble {\n  Wibble\n}\n\npub opaque type Wobble {\n  Wobble(Wibble)\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble
+}
+
+pub opaque type Wobble {
+  Wobble(Wibble)
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-define(FILEPATH, "project/test/my/mod.gleam").
+-export_type([wibble/0, wobble/0]).
+
+-type wibble() :: wibble.
+
+-opaque wobble() :: {wobble, wibble()}.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__private_unused_records.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__private_unused_records.snap
@@ -18,9 +18,13 @@ pub fn main(x: Int) -> Int {
 -compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "project/test/my/mod.gleam").
 -export([main/1]).
--export_type([a/0]).
+-export_type([a/0, b/0, c/0]).
 
 -type a() :: {a, integer()}.
+
+-type b() :: {b, binary()}.
+
+-type c() :: {c, integer()}.
 
 -file("project/test/my/mod.gleam", 5).
 -spec main(integer()) -> integer().

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -960,3 +960,19 @@ pub fn get(dict: Dict(key, value), key: key) -> Result(value, Nil)
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5127
+#[test]
+fn unused_opaque_constructor_is_generated_correctly() {
+    assert_ts_def!(
+        "
+type Wibble {
+  Wibble
+}
+
+pub opaque type Wobble {
+  Wobble(Wibble)
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unused_opaque_constructor_is_generated_correctly.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__unused_opaque_constructor_is_generated_correctly.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\ntype Wibble {\n  Wibble\n}\n\npub opaque type Wobble {\n  Wobble(Wibble)\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble
+}
+
+pub opaque type Wobble {
+  Wobble(Wibble)
+}
+
+
+----- TYPESCRIPT DEFINITIONS
+import type * as _ from "../gleam.d.mts";
+
+declare class Wibble extends _.CustomType {}
+
+type Wibble$ = Wibble;
+
+declare class Wobble extends _.CustomType {
+  /** @deprecated */
+  constructor(argument$0: Wibble$);
+  /** @deprecated */
+  0: Wibble$;
+}
+
+export type Wobble$ = Wobble;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__private_type_in_opaque_type.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__type_alias__private_type_in_opaque_type.snap
@@ -16,6 +16,10 @@ pub opaque type OpaqueType {
 ----- TYPESCRIPT DEFINITIONS
 import type * as _ from "../gleam.d.mts";
 
+declare class PrivateType extends _.CustomType {}
+
+type PrivateType$ = PrivateType;
+
 declare class OpaqueType extends _.CustomType {
   /** @deprecated */
   constructor(argument$0: PrivateType$);

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -36,6 +36,7 @@ expression: "./cases/import_shadowed_name_warning"
 -compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
 -define(FILEPATH, "src/two.gleam").
 -export([use_type/1]).
+-export_type([shadowing/0]).
 
 -if(?OTP_RELEASE >= 27).
 -define(MODULEDOC(Str), -moduledoc(Str)).
@@ -46,6 +47,8 @@ expression: "./cases/import_shadowed_name_warning"
 -endif.
 
 ?MODULEDOC(" https://github.com/gleam-lang/otp/pull/22\n").
+
+-type shadowing() :: port.
 
 -file("src/two.gleam", 14).
 -spec use_type(one:port_()) -> nil.


### PR DESCRIPTION
Fixes #5127

While testing I found this applied to TypeScript declaration generation as well, so I fixed it there too

I went with the approach of always generating private types, as that seemed to most straightforward way to go, and I wasn't sure if the other solution worked in TypeScript