### PR TITLE
Fix type-checking bug with several mutually recursive functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,3 +291,7 @@
 - Fixed a bug where the compiler would generate invalid Erlang and TypeScript
   code for unused opaque types referencing private types.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the type checker would allow invalid programs when a large
+  group of functions were all mutually recursive.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -628,11 +628,11 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 Some(prereg_return_type.clone()),
             )?;
             let arguments_types = arguments.iter().map(|a| a.type_.clone()).collect();
-            let type_ = fn_(
-                arguments_types,
-                body.last()
-                    .map_or(prereg_return_type.clone(), |last| last.type_()),
-            );
+            let return_type = body
+                .last()
+                .map_or(prereg_return_type.clone(), |last| last.type_());
+
+            let type_ = fn_(arguments_types, return_type);
             Ok((
                 type_,
                 body,

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -653,7 +653,7 @@ fn more_complex_cycle() {
     ];
     assert_eq!(
         parse_and_order(functions.as_slice(), [].as_slice()).unwrap(),
-        vec![vec!["a2", "a1"], vec!["a3"]]
+        vec![vec!["a2", "a3", "a1"]]
     );
 }
 

--- a/compiler-core/src/graph.rs
+++ b/compiler-core/src/graph.rs
@@ -43,7 +43,7 @@ fn pop_leaf_or_cycle<N, E>(graph: &mut StableGraph<N, E>) -> Vec<NodeIndex> {
     nodes
 }
 
-/// Return a leaf from the graph. If there are no leaves then the smallest cycle
+/// Return a leaf from the graph. If there are no leaves then the largest cycle
 /// is returned instead.
 ///
 /// If there are no leaves or cycles then an empty vector is returned.
@@ -125,7 +125,7 @@ fn leaf_or_cycle<N, E>(graph: &StableGraph<N, E>) -> Vec<NodeIndex> {
 
     cycles
         .into_iter()
-        .min_by(|x, y| x.len().cmp(&y.len()))
+        .max_by_key(|x| x.len())
         .expect("Could not find cycle for toposort returned start node")
 }
 

--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__correct_type_check_for_multiple_mutually_recursive_functions.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__correct_type_check_for_multiple_mutually_recursive_functions.snap
@@ -1,0 +1,49 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "\npub fn wibble(id) {\n  wobble(id, True)\n}\n\npub fn wobble(id, bool) {\n  case bool {\n    True -> wibble(id)\n    False -> wubble(id, bool)\n  }\n}\n\npub fn wubble(id, bool) {\n  case bool {\n    True -> final(id)\n    False -> wobble(id, bool)\n  }\n}\n\npub fn final(id) {\n  let #(a, b) = id\n  echo #(a, b)\n}\n\npub fn main() {\n  wibble(#(\"a\", \"b\"))\n  wibble(2)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn wibble(id) {
+  wobble(id, True)
+}
+
+pub fn wobble(id, bool) {
+  case bool {
+    True -> wibble(id)
+    False -> wubble(id, bool)
+  }
+}
+
+pub fn wubble(id, bool) {
+  case bool {
+    True -> final(id)
+    False -> wobble(id, bool)
+  }
+}
+
+pub fn final(id) {
+  let #(a, b) = id
+  echo #(a, b)
+}
+
+pub fn main() {
+  wibble(#("a", "b"))
+  wibble(2)
+}
+
+
+----- ERROR
+error: Type mismatch
+   ┌─ /src/one/two.gleam:27:10
+   │
+27 │   wibble(2)
+   │          ^
+
+Expected type:
+
+    #(a, b)
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -3273,3 +3273,38 @@ pub fn get_int(w: Wibble) {
         ]
     );
 }
+
+#[test]
+fn correct_type_check_for_multiple_mutually_recursive_functions() {
+    assert_module_error!(
+        r#"
+pub fn wibble(id) {
+  wobble(id, True)
+}
+
+pub fn wobble(id, bool) {
+  case bool {
+    True -> wibble(id)
+    False -> wubble(id, bool)
+  }
+}
+
+pub fn wubble(id, bool) {
+  case bool {
+    True -> final(id)
+    False -> wobble(id, bool)
+  }
+}
+
+pub fn final(id) {
+  let #(a, b) = id
+  echo #(a, b)
+}
+
+pub fn main() {
+  wibble(#("a", "b"))
+  wibble(2)
+}
+"#
+    );
+}


### PR DESCRIPTION
Fixes #5149 

Seems there was a bug in the `into_dependency_order` function causing some of the functions to be generalised before fully being type-checked.