### PR TITLE
Bugfix: Modules with same original name wrongly being marked as unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,11 @@
 
 ### Bug fixes
 
+- Fixed a bug where aliasing a top-level module import to avoid conflict with
+  a nested module import would cause the nested import to be wrongly marked as
+  unused.
+  ([Hari Mohan](https://github.com/seafoamteal))
+
 - Fixed a bug where renaming a variable from an alternative pattern would not
   rename all its occurrences.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -3,7 +3,7 @@ use ecow::EcoString;
 use crate::{
     ast::{Publicity, SrcSpan, UnqualifiedImport, UntypedImport},
     build::Origin,
-    reference::{EntityKind, ReferenceKind},
+    reference::{EntityKind, EntityLayer, ReferenceKind},
     type_::{
         Environment, Error, ModuleInterface, Problems, ValueConstructorVariant, Warning,
         error::InvalidImportKind,
@@ -297,9 +297,10 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 import.location,
             );
         } else {
-            self.environment.references.register_unaliased_module(
+            self.environment.references.register_module(
                 used_name.clone(),
                 import.module.clone(),
+                EntityLayer::Module,
                 import.location,
             );
         }

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -297,7 +297,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 import.location,
             );
         } else {
-            self.environment.references.register_module(
+            self.environment.references.register_unaliased_module(
                 used_name.clone(),
                 import.module.clone(),
                 import.location,

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -446,7 +446,7 @@ impl Environment<'_> {
                     }
                 })?;
                 self.references
-                    .register_module_reference(module_name.clone());
+                    .register_module_reference_with_used_name(module_name.clone());
                 module.get_public_type(name).ok_or_else(|| {
                     UnknownTypeConstructorError::ModuleType {
                         name: name.clone(),
@@ -531,7 +531,7 @@ impl Environment<'_> {
                     }
                 })?;
                 self.references
-                    .register_module_reference(module_name.clone());
+                    .register_module_reference_with_used_name(module_name.clone());
                 module.get_public_value(name).ok_or_else(|| {
                     UnknownValueConstructorError::ModuleValue {
                         name: name.clone(),

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -3018,7 +3018,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             self.environment
                 .references
-                .register_module_reference(module_alias.clone());
+                .register_module_reference_with_used_name(module_alias.clone());
 
             (module.name.clone(), constructor.clone())
         };
@@ -3598,7 +3598,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
                 self.environment
                     .references
-                    .register_module_reference(module_name.clone());
+                    .register_module_reference_with_used_name(module_name.clone());
 
                 module
                     .values

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -331,11 +331,11 @@ macro_rules! assert_js_no_warnings_with_gleam_version {
 
 #[macro_export]
 macro_rules! assert_no_warnings {
-    ($src:expr $(,)?) => {
+    ($src:literal $(,)?) => {
         let warnings = $crate::type_::tests::get_warnings($src, vec![], crate::build::Target::Erlang, None);
         assert_eq!(warnings, vec![]);
     };
-    ($(($name:expr, $module_src:literal)),+, $src:expr $(,)?) => {
+    ($(($name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
         let warnings = $crate::type_::tests::get_warnings(
             $src,
             vec![$(("thepackage", $name, $module_src)),*],
@@ -344,7 +344,7 @@ macro_rules! assert_no_warnings {
         );
         assert_eq!(warnings, vec![]);
     };
-    ($(($package:expr, $name:expr, $module_src:literal)),+, $src:expr $(,)?) => {
+    ($(($package:expr, $name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
         let warnings = $crate::type_::tests::get_warnings(
             $src,
             vec![$(($package, $name, $module_src)),*],

--- a/compiler-core/src/type_/tests/dead_code_detection.rs
+++ b/compiler-core/src/type_/tests/dead_code_detection.rs
@@ -595,3 +595,36 @@ pub fn main() -> Wibble {
 "
     );
 }
+
+#[test]
+//  https://github.com/gleam-lang/gleam/issues/5145
+fn imported_module_aliased_to_avoid_conflict_with_another_import() {
+    assert_no_warnings!(
+        (
+            "wobble",
+            "
+pub fn womble() {
+    Nil
+}
+"
+        ),
+        (
+            "wibble/wobble",
+            "
+pub fn wimble() {
+    Nil
+}
+"
+        ),
+        "
+import wibble/wobble
+import wobble as wob
+
+pub fn main() {
+    let _ = wobble.wimble()
+    let _ = wob.womble()
+    Nil
+}
+        "
+    );
+}


### PR DESCRIPTION
# Description

This resolves #5145.

Three changes were made:
1. When a module was aliased, the entity for the original name has to be placed in the `Shadowed` layer and not the `Module` layer. This prevents it from shadowing previous imports with the same module name.
2. When registering a module reference from a module access site, the `module_name_to_node` map should not be checked. This map contains full original names of modules (e.g. `wibble/wobble` and `wobble`) and hence isn't guaranteed to point us to the correct node when we have limited information (e.g. just `wobble`). We skip this check and directly look up the entity in the Module layer. The `module_name_to_node` map is only needed/used when registering references from unqualified imports and aliases, since we are guaranteed to have information only about the original name of the module in those cases.
3. This is not directly related to the bugfix, but the `assert_no_warnings!` macro was defined ambiguously. If `src` was any `expr`, then the compiler would not know whether a second module tuple was part of the repeated list of module tuples or `src`. Changing `src` to be a `literal` fixes this.

# Example
## Before

```gleam
import wibble/wobble
import wobble as wob

pub fn main() {
  wobble.wimble()
  wob.womble()
}
```

Here, at `wobble.wimble()`, a lookup in the `module_name_to_node` map would return the top-level `wobble` module that is aliased to `wob`. Hence, no reference to `wibble/wobble` is registered and it is incorrectly marked unused.

A less visible problem is that `wibble/wobble` is added to the `Module` layer as entity with name `wobble`. Then, on the next line, `wobble` is once again added to the `Module` layer with the same name, shadowing the first import.

## After

At `wobble.wimble()`, we look up the `wobble` entity in the `Module` layer instead. This gives us the correct `wibble/wobble` module.

The `Module` layer contains two entities: `wobble` and `wob`. The `Shadowed` layer contains one entity: `wobble`.