### PR TITLE
👷 Update cargo-deny to support CVSS 4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -368,7 +368,7 @@ jobs:
       - name: Install cargo-deny
         run: |
           set -e
-          curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.14.18/cargo-deny-0.14.18-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+          curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.18.6/cargo-deny-0.18.6-x86_64-unknown-linux-musl.tar.gz | tar xzf -
           mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
           echo `pwd` >> $GITHUB_PATH
 


### PR DESCRIPTION
See #5152 for details.

Recently our CI failed for a few hours because the advisory db started publishing some advisories using the CVSS 4.0 standard, which wasn't supported in `cargo-deny` yet.

They quickly converted them back to 3.1, but it's still nice to be ready for when 4.0 does come for real.