### PR TITLE
Fix bugs with merge case branches code action

### DIFF
--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -11026,7 +11026,7 @@ fn merge_case_branch_will_not_merge_branches_with_guards() {
 fn merge_case_branch_will_not_merge_branches_defining_different_variables() {
     assert_no_code_actions!(
         MERGE_CASE_BRANCHES,
-        r#"pub fn go(result) {
+        r#"pub fn go(result: Result(Int, Int)) {
   case result {
     Ok(value) -> todo
     Error(error) -> todo
@@ -11096,5 +11096,19 @@ fn merge_case_branch_works_with_existing_alternative_patterns() {
   }
 }"#,
         find_position_of("[]").select_until(find_position_of("[_]"))
+    );
+}
+
+#[test]
+fn merge_case_branch_does_not_merge_branches_with_variables_with_same_name_and_different_types() {
+    assert_no_code_actions!(
+        MERGE_CASE_BRANCHES,
+        r#"pub fn go(result: Result(Int, String)) {
+  case result {
+    Ok(one) -> todo
+    Error(one) -> todo
+  }
+}"#,
+        find_position_of("Ok").select_until(find_position_of("Error"))
     );
 }


### PR DESCRIPTION
There were a couple of bugs that I didn't catch in the first PR
- no longer allows to merge branches defining variables with the same name but a different type
- allows to merge branches where variables both have unbound types since that will never result in a type error after applying the code action