### PR TITLE
Pick better names when generating functions whose arguments are record accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,31 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The "generate function" code action can now pick better names for arguments
+  that use the record access syntax. For example:
+
+  ```gleam
+  pub type User {
+    User(id: Int, name: String)
+  }
+
+  pub fn go(user: User) {
+    authenticate(user.id, user.name)
+    todo
+  }
+  ```
+
+  Having the language server generate the missing `authenticate` function will
+  produce the following code:
+
+  ```gleam
+  pub fn authenticate(id: Int, name: String) {
+    todo
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The "inline variable" code action can now trigger when used over the let
   keyword of a variable to inline.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/language_server/code_action.rs
+++ b/compiler-core/src/language_server/code_action.rs
@@ -5981,6 +5981,14 @@ impl NameGenerator {
             {
                 Some(self.rename_to_avoid_shadowing(name.clone()))
             }
+
+            // If the argument is a record access, we generate a name from the
+            // label used.
+            // For example if we have `wibble.id` we would end up picking `id`.
+            TypedExpr::RecordAccess { label, .. } => {
+                Some(self.rename_to_avoid_shadowing(label.clone()))
+            }
+
             _ => None,
         }
     }

--- a/compiler-core/src/language_server/tests/action.rs
+++ b/compiler-core/src/language_server/tests/action.rs
@@ -7636,6 +7636,23 @@ pub fn main() {
 }
 
 #[test]
+fn generate_function_picks_argument_name_based_on_record_access() {
+    assert_code_action!(
+        GENERATE_FUNCTION,
+        "
+pub type User {
+    User(id: Int, name: String)
+}
+
+pub fn go(user: User) {
+  authenticate(user.id, user.name)
+}
+",
+        find_position_of("authenticate").to_selection()
+    );
+}
+
+#[test]
 fn generate_function_wont_generate_two_arguments_with_the_same_name_if_they_have_the_same_type() {
     assert_code_action!(
         GENERATE_FUNCTION,

--- a/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_picks_argument_name_based_on_record_access.snap
+++ b/compiler-core/src/language_server/tests/snapshots/gleam_core__language_server__tests__action__generate_function_picks_argument_name_based_on_record_access.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/language_server/tests/action.rs
+expression: "\npub type User {\n    User(id: Int, name: String)\n}\n\npub fn go(user: User) {\n  authenticate(user.id, user.name)\n}\n"
+---
+----- BEFORE ACTION
+
+pub type User {
+    User(id: Int, name: String)
+}
+
+pub fn go(user: User) {
+  authenticate(user.id, user.name)
+  ↑                               
+}
+
+
+----- AFTER ACTION
+
+pub type User {
+    User(id: Int, name: String)
+}
+
+pub fn go(user: User) {
+  authenticate(user.id, user.name)
+}
+
+fn authenticate(id: Int, name: String) -> a {
+  todo
+}


### PR DESCRIPTION
I noticed Rust can do this and thought this is a cute improvement we could have as well!