### PR TITLE
Remove unreferenced insta snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ test: ## Run the compiler unit tests
 	cd test/running_modules && make test
 	cd test/subdir_ffi && make
 
+.PHONY: insta-check-unused
+insta-check-unused: ## Check for unused cargo insta snapshots
+	cargo insta test --unreferenced=warn
+
+.PHONY: insta-fix-unused
+insta-fix-unused: ## Remove unused cargo insta snapshots
+	cargo insta test --unreferenced=delete
+
 .PHONY: language-test
 language-test: ## Run the language integration tests for all targets
 	cd test/language && make


### PR DESCRIPTION
- While working on #5061, updating test names and trying to remove old snapshots, I found 11 not related insta snapshot files that are no longer referenced by any tests. 

This pull request removes these unused snapshots ~~and adds a CI check to prevent unreferenced snapshots from being introduced in the future~~.