### PR TITLE
Fix formatter removing `@external` annotations from types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fixed a bug where the formatter would remove `@external` attributes from
+  custom types.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.14.0-rc1 - 2025-12-15
 
 ### Compiler

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1793,6 +1793,8 @@ impl<'comments> Formatter<'comments> {
         let attributes = AttributesPrinter::new()
             .set_deprecation(&ct.deprecation)
             .set_internal(ct.publicity)
+            .set_external_erlang(&ct.external_erlang)
+            .set_external_javascript(&ct.external_javascript)
             .to_doc();
 
         let doc = attributes

--- a/compiler-core/src/format/tests/custom_type.rs
+++ b/compiler-core/src/format/tests/custom_type.rs
@@ -352,3 +352,13 @@ It even has multiple lines!
 "#
     );
 }
+
+#[test]
+fn external_custom_type() {
+    assert_format!(
+        r#"@external(erlang, "erlang", "map")
+@external(javascript, "../dict.d.mts", "Dict")
+pub type Dict(key, value)
+"#
+    );
+}


### PR DESCRIPTION
I noticed the formatter would remove `@external` annotations on external custom types. This PR fixes that