### PR TITLE
Prevent new annotations from being overlooked in the formatter

### DIFF
--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -838,10 +838,10 @@ impl<'comments> Formatter<'comments> {
         } = function;
 
         let attributes = AttributesPrinter::new()
-            .set_deprecation(&deprecation)
+            .set_deprecation(deprecation)
             .set_internal(*publicity)
-            .set_external_erlang(&external_erlang)
-            .set_external_javascript(&external_javascript)
+            .set_external_erlang(external_erlang)
+            .set_external_javascript(external_javascript)
             .to_doc();
 
         // Fn name and args
@@ -883,7 +883,7 @@ impl<'comments> Formatter<'comments> {
 
         // Format body
 
-        let body = self.statements(&body);
+        let body = self.statements(body);
 
         // Add any trailing comments
         let body = match printed_comments(self.pop_comments(*end_position), false) {
@@ -1816,10 +1816,10 @@ impl<'comments> Formatter<'comments> {
         let _ = self.pop_empty_lines(location.end);
 
         let attributes = AttributesPrinter::new()
-            .set_deprecation(&deprecation)
+            .set_deprecation(deprecation)
             .set_internal(*publicity)
-            .set_external_erlang(&external_erlang)
-            .set_external_javascript(&external_javascript)
+            .set_external_erlang(external_erlang)
+            .set_external_javascript(external_javascript)
             .to_doc();
 
         let doc = attributes


### PR DESCRIPTION
As discussed in #5204, this PR changes the formatter to destructure every definition with no catch-alls, which will force future AST changes to be considered in the formatter, and hopefully prevent this issue from happening in future.