### PR TITLE
Typecheck unlabelled fields in const record updates

### DIFF
--- a/compiler-core/src/type_/snapshots/gleam_core__type___tests__generic_unlabelled_field_in_updated_const_record_wrong_type.snap
+++ b/compiler-core/src/type_/snapshots/gleam_core__type___tests__generic_unlabelled_field_in_updated_const_record_wrong_type.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests.rs
+expression: "pub type Wibble(a) {\n            Wibble(a, b: Int, c: a)\n        }\n\n        const w = Wibble(1, 2, 3)\n        const w2 = Wibble(..w, c: False)"
+---
+----- SOURCE CODE
+pub type Wibble(a) {
+            Wibble(a, b: Int, c: a)
+        }
+
+        const w = Wibble(1, 2, 3)
+        const w2 = Wibble(..w, c: False)
+
+----- ERROR
+error: Incomplete record update
+  ┌─ /src/one/two.gleam:6:29
+  │
+6 │         const w2 = Wibble(..w, c: False)
+  │                             ^ This is a `Wibble(Int)`
+
+The 1st field of this value is a `Int`, but the arguments given to the
+record update indicate that it should be a `Bool`.
+
+Note: Unlabelled fields cannot be updated in a record update, so either add
+a label or use a record constructor.

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -2481,6 +2481,18 @@ fn const_record_update_generic_respecialization() {
 }
 
 #[test]
+fn generic_unlabelled_field_in_updated_const_record_wrong_type() {
+    assert_module_error!(
+        "pub type Wibble(a) {
+            Wibble(a, b: Int, c: a)
+        }
+
+        const w = Wibble(1, 2, 3)
+        const w2 = Wibble(..w, c: False)"
+    );
+}
+
+#[test]
 fn module_constant_functions() {
     assert_module_infer!(
         "pub fn int_identity(i: Int) -> Int { i }


### PR DESCRIPTION
- No idea how it slipped through, when I was making #5061 😅

While this code produces correct type mismatch error:

```gleam
pub type Wibble(a) {
  Wibble(a: a, b: Int, c: a)
}

const w = Wibble(1, 2, 4)
const w2 = Wibble(..w, c: False) // w is Wibble(Int), incomplete record update
```

This worked without any issues, breaching type safety:

```gleam
pub type Wibble(a) {
  Wibble(a, b: Int, c: a)
}

const w = Wibble(1, 2, 4)
const w2 = Wibble(..w, c: False) // Wibble(1, 2, False)
```

Here is a little explanation: previously `remaining_fields` only contained labelled fields that weren't overridden! So what happens is:
  - `remaining_fields` starts as `{"b": 1, "c": 2}`
  - We override `c`, so it's removed: `remaining_fields = {"b": 1}`
  - The loop only checks field `b` (index `1`)
  - The unlabelled first field (index `0`) is **NEVER** checked!

https://github.com/gleam-lang/gleam/blob/41cb403f0049f1d30c9aad494ac730c79d4a32f4/compiler-core/src/type_/expression.rs#L4026-L4037

- As this pull request is more of an addition to #5201, we will have to wait for it to be merged. Specifically this PR modifies an incomplete record update error message to handle unlabelled fields.