### PR TITLE
Enable clippy lint to prevent wildcard matching

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -148,7 +148,10 @@ impl UntypedModule {
                 Definition::Import(Import {
                     module, location, ..
                 }) => Some((module.clone(), *location)),
-                _ => None,
+                Definition::Function(_)
+                | Definition::TypeAlias(_)
+                | Definition::CustomType(_)
+                | Definition::ModuleConstant(_) => None,
             })
             .collect()
     }
@@ -223,7 +226,10 @@ impl<A> Arg<A> {
     pub fn is_capture_hole(&self) -> bool {
         match &self.names {
             ArgNames::Named { name, .. } if name == CAPTURE_VARIABLE => true,
-            _ => false,
+            ArgNames::Discard { .. }
+            | ArgNames::LabelledDiscard { .. }
+            | ArgNames::Named { .. }
+            | ArgNames::NamedLabelled { .. } => false,
         }
     }
 }
@@ -402,7 +408,7 @@ impl TypeAst {
                             .zip(o_arguments)
                             .all(|a| a.0.is_logically_equal(a.1))
                 }
-                _ => false,
+                TypeAst::Fn(_) | TypeAst::Var(_) | TypeAst::Tuple(_) | TypeAst::Hole(_) => false,
             },
             TypeAst::Fn(TypeAstFn {
                 arguments,
@@ -421,14 +427,19 @@ impl TypeAst {
                             .all(|a| a.0.is_logically_equal(a.1))
                         && return_.is_logically_equal(o_return_)
                 }
-                _ => false,
+                TypeAst::Constructor(_)
+                | TypeAst::Var(_)
+                | TypeAst::Tuple(_)
+                | TypeAst::Hole(_) => false,
             },
             TypeAst::Var(TypeAstVar { name, location: _ }) => match other {
                 TypeAst::Var(TypeAstVar {
                     name: o_name,
                     location: _,
                 }) => name == o_name,
-                _ => false,
+                TypeAst::Constructor(_) | TypeAst::Fn(_) | TypeAst::Tuple(_) | TypeAst::Hole(_) => {
+                    false
+                }
             },
             TypeAst::Tuple(TypeAstTuple {
                 elements,
@@ -444,14 +455,18 @@ impl TypeAst {
                             .zip(other_elements)
                             .all(|a| a.0.is_logically_equal(a.1))
                 }
-                _ => false,
+                TypeAst::Constructor(_) | TypeAst::Fn(_) | TypeAst::Var(_) | TypeAst::Hole(_) => {
+                    false
+                }
             },
             TypeAst::Hole(TypeAstHole { name, location: _ }) => match other {
                 TypeAst::Hole(TypeAstHole {
                     name: o_name,
                     location: _,
                 }) => name == o_name,
-                _ => false,
+                TypeAst::Constructor(_) | TypeAst::Fn(_) | TypeAst::Var(_) | TypeAst::Tuple(_) => {
+                    false
+                }
             },
         }
     }
@@ -1334,7 +1349,26 @@ impl BinOp {
     fn is_bool_operator(&self) -> bool {
         match self {
             BinOp::And | BinOp::Or => true,
-            _ => false,
+            BinOp::Eq
+            | BinOp::NotEq
+            | BinOp::LtInt
+            | BinOp::LtEqInt
+            | BinOp::LtFloat
+            | BinOp::LtEqFloat
+            | BinOp::GtEqInt
+            | BinOp::GtInt
+            | BinOp::GtEqFloat
+            | BinOp::GtFloat
+            | BinOp::AddInt
+            | BinOp::AddFloat
+            | BinOp::SubInt
+            | BinOp::SubFloat
+            | BinOp::MultInt
+            | BinOp::MultFloat
+            | BinOp::DivInt
+            | BinOp::DivFloat
+            | BinOp::RemainderInt
+            | BinOp::Concatenate => false,
         }
     }
 
@@ -1376,7 +1410,20 @@ impl BinOp {
             BinOp::SubInt => Some(BinOp::SubFloat),
             BinOp::MultInt => Some(BinOp::MultFloat),
             BinOp::DivInt => Some(BinOp::DivFloat),
-            _ => None,
+            BinOp::And
+            | BinOp::Or
+            | BinOp::Eq
+            | BinOp::NotEq
+            | BinOp::LtFloat
+            | BinOp::LtEqFloat
+            | BinOp::GtEqFloat
+            | BinOp::GtFloat
+            | BinOp::AddFloat
+            | BinOp::SubFloat
+            | BinOp::MultFloat
+            | BinOp::DivFloat
+            | BinOp::RemainderInt
+            | BinOp::Concatenate => None,
         }
     }
 
@@ -1390,7 +1437,20 @@ impl BinOp {
             BinOp::SubFloat => Some(BinOp::SubInt),
             BinOp::MultFloat => Some(BinOp::MultInt),
             BinOp::DivFloat => Some(BinOp::DivInt),
-            _ => None,
+            BinOp::And
+            | BinOp::Or
+            | BinOp::Eq
+            | BinOp::NotEq
+            | BinOp::LtInt
+            | BinOp::LtEqInt
+            | BinOp::GtEqInt
+            | BinOp::GtInt
+            | BinOp::AddInt
+            | BinOp::SubInt
+            | BinOp::MultInt
+            | BinOp::DivInt
+            | BinOp::RemainderInt
+            | BinOp::Concatenate => None,
         }
     }
 }
@@ -1515,7 +1575,29 @@ impl CallArg<TypedExpr> {
     pub fn is_capture_hole(&self) -> bool {
         match &self.value {
             TypedExpr::Var { name, .. } => name == CAPTURE_VARIABLE,
-            _ => false,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::Call { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => false,
         }
     }
 }
@@ -1554,7 +1636,26 @@ impl CallArg<UntypedExpr> {
     pub fn is_capture_hole(&self) -> bool {
         match &self.value {
             UntypedExpr::Var { name, .. } => name == CAPTURE_VARIABLE,
-            _ => false,
+            UntypedExpr::Int { .. }
+            | UntypedExpr::Float { .. }
+            | UntypedExpr::String { .. }
+            | UntypedExpr::Block { .. }
+            | UntypedExpr::Fn { .. }
+            | UntypedExpr::List { .. }
+            | UntypedExpr::Call { .. }
+            | UntypedExpr::BinOp { .. }
+            | UntypedExpr::PipeLine { .. }
+            | UntypedExpr::Case { .. }
+            | UntypedExpr::FieldAccess { .. }
+            | UntypedExpr::Tuple { .. }
+            | UntypedExpr::TupleIndex { .. }
+            | UntypedExpr::Todo { .. }
+            | UntypedExpr::Panic { .. }
+            | UntypedExpr::Echo { .. }
+            | UntypedExpr::BitArray { .. }
+            | UntypedExpr::RecordUpdate { .. }
+            | UntypedExpr::NegateBool { .. }
+            | UntypedExpr::NegateInt { .. } => false,
         }
     }
 }
@@ -1943,7 +2044,30 @@ fn pattern_and_expression_are_the_same(pattern: &TypedPattern, expression: &Type
                         })
             }
 
-            _ => false,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Var { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::Call { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => false,
         },
 
         // A pattern for a constructor with no arguments:
@@ -2991,10 +3115,7 @@ impl<A> Pattern<A> {
 
     #[must_use]
     pub fn is_variable(&self) -> bool {
-        match self {
-            Pattern::Variable { .. } => true,
-            _ => false,
-        }
+        matches!(self, Pattern::Variable { .. })
     }
 
     #[must_use]
@@ -3656,7 +3777,22 @@ impl<Value, Type> BitArraySegment<Value, Type> {
     pub fn size(&self) -> Option<&Value> {
         self.options.iter().find_map(|x| match x {
             BitArrayOption::Size { value, .. } => Some(value.as_ref()),
-            _ => None,
+            BitArrayOption::Bytes { .. }
+            | BitArrayOption::Int { .. }
+            | BitArrayOption::Float { .. }
+            | BitArrayOption::Bits { .. }
+            | BitArrayOption::Utf8 { .. }
+            | BitArrayOption::Utf16 { .. }
+            | BitArrayOption::Utf32 { .. }
+            | BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. }
+            | BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. }
+            | BitArrayOption::Unit { .. } => None,
         })
     }
 
@@ -3666,23 +3802,35 @@ impl<Value, Type> BitArraySegment<Value, Type> {
             .find_map(|option| match option {
                 BitArrayOption::Unit { value, .. } => Some(*value),
                 BitArrayOption::Bytes { .. } => Some(8),
-                _ => None,
+                BitArrayOption::Int { .. }
+                | BitArrayOption::Float { .. }
+                | BitArrayOption::Bits { .. }
+                | BitArrayOption::Utf8 { .. }
+                | BitArrayOption::Utf16 { .. }
+                | BitArrayOption::Utf32 { .. }
+                | BitArrayOption::Utf8Codepoint { .. }
+                | BitArrayOption::Utf16Codepoint { .. }
+                | BitArrayOption::Utf32Codepoint { .. }
+                | BitArrayOption::Signed { .. }
+                | BitArrayOption::Unsigned { .. }
+                | BitArrayOption::Big { .. }
+                | BitArrayOption::Little { .. }
+                | BitArrayOption::Native { .. }
+                | BitArrayOption::Size { .. } => None,
             })
             .unwrap_or(1)
     }
 
     pub(crate) fn has_bits_option(&self) -> bool {
-        self.options.iter().any(|option| match option {
-            BitArrayOption::Bits { .. } => true,
-            _ => false,
-        })
+        self.options
+            .iter()
+            .any(|option| matches!(option, BitArrayOption::Bits { .. }))
     }
 
     pub(crate) fn has_bytes_option(&self) -> bool {
-        self.options.iter().any(|option| match option {
-            BitArrayOption::Bytes { .. } => true,
-            _ => false,
-        })
+        self.options
+            .iter()
+            .any(|option| matches!(option, BitArrayOption::Bytes { .. }))
     }
 }
 
@@ -3901,7 +4049,22 @@ impl<A> BitArrayOption<A> {
     pub fn value(&self) -> Option<&A> {
         match self {
             BitArrayOption::Size { value, .. } => Some(value),
-            _ => None,
+            BitArrayOption::Bytes { .. }
+            | BitArrayOption::Int { .. }
+            | BitArrayOption::Float { .. }
+            | BitArrayOption::Bits { .. }
+            | BitArrayOption::Utf8 { .. }
+            | BitArrayOption::Utf16 { .. }
+            | BitArrayOption::Utf32 { .. }
+            | BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. }
+            | BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. }
+            | BitArrayOption::Unit { .. } => None,
         }
     }
 
@@ -4284,10 +4447,7 @@ impl<T, E> Statement<T, E> {
 
     #[must_use]
     pub(crate) fn is_use(&self) -> bool {
-        match self {
-            Self::Use(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::Use(_))
     }
 }
 

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -208,16 +208,21 @@ pub enum TypedExpr {
 
 impl TypedExpr {
     pub fn is_println(&self) -> bool {
-        let fun = match self {
-            TypedExpr::Call { fun, arguments, .. } if arguments.len() == 1 => fun.as_ref(),
-            _ => return false,
+        let fun = if let TypedExpr::Call { fun, arguments, .. } = self
+            && arguments.len() == 1
+        {
+            fun.as_ref()
+        } else {
+            return false;
         };
 
-        match fun {
-            TypedExpr::ModuleSelect {
-                label, module_name, ..
-            } => label == "println" && module_name == "gleam/io",
-            _ => false,
+        if let TypedExpr::ModuleSelect {
+            label, module_name, ..
+        } = fun
+        {
+            label == "println" && module_name == "gleam/io"
+        } else {
+            false
         }
     }
 
@@ -601,7 +606,28 @@ impl TypedExpr {
         match self {
             Self::Int { int_value, .. } => int_value != &BigInt::ZERO,
             Self::Float { value, .. } => is_non_zero_number(value),
-            _ => false,
+            Self::String { .. }
+            | Self::Block { .. }
+            | Self::Pipeline { .. }
+            | Self::Var { .. }
+            | Self::Fn { .. }
+            | Self::List { .. }
+            | Self::Call { .. }
+            | Self::BinOp { .. }
+            | Self::Case { .. }
+            | Self::RecordAccess { .. }
+            | Self::PositionalAccess { .. }
+            | Self::ModuleSelect { .. }
+            | Self::Tuple { .. }
+            | Self::TupleIndex { .. }
+            | Self::Todo { .. }
+            | Self::Panic { .. }
+            | Self::Echo { .. }
+            | Self::BitArray { .. }
+            | Self::RecordUpdate { .. }
+            | Self::NegateBool { .. }
+            | Self::NegateInt { .. }
+            | Self::Invalid { .. } => false,
         }
     }
 
@@ -609,7 +635,28 @@ impl TypedExpr {
         match self {
             Self::Int { int_value, .. } => int_value == &BigInt::ZERO,
             Self::Float { value, .. } => !is_non_zero_number(value),
-            _ => false,
+            Self::String { .. }
+            | Self::Block { .. }
+            | Self::Pipeline { .. }
+            | Self::Var { .. }
+            | Self::Fn { .. }
+            | Self::List { .. }
+            | Self::Call { .. }
+            | Self::BinOp { .. }
+            | Self::Case { .. }
+            | Self::RecordAccess { .. }
+            | Self::PositionalAccess { .. }
+            | Self::ModuleSelect { .. }
+            | Self::Tuple { .. }
+            | Self::TupleIndex { .. }
+            | Self::Todo { .. }
+            | Self::Panic { .. }
+            | Self::Echo { .. }
+            | Self::BitArray { .. }
+            | Self::RecordUpdate { .. }
+            | Self::NegateBool { .. }
+            | Self::NegateInt { .. }
+            | Self::Invalid { .. } => false,
         }
     }
 
@@ -771,7 +818,23 @@ impl TypedExpr {
                 ..
             } => true,
 
-            _ => false,
+            Self::Block { .. }
+            | Self::Pipeline { .. }
+            | Self::Var { .. }
+            | Self::Fn { .. }
+            | Self::BinOp { .. }
+            | Self::Case { .. }
+            | Self::RecordAccess { .. }
+            | Self::PositionalAccess { .. }
+            | Self::ModuleSelect { .. }
+            | Self::TupleIndex { .. }
+            | Self::Todo { .. }
+            | Self::Panic { .. }
+            | Self::Echo { .. }
+            | Self::RecordUpdate { .. }
+            | Self::NegateBool { .. }
+            | Self::NegateInt { .. }
+            | Self::Invalid { .. } => false,
         }
     }
 
@@ -781,15 +844,34 @@ impl TypedExpr {
                 left, right, name, ..
             } if name.is_bool_operator() => left.is_known_bool() && right.is_known_bool(),
             TypedExpr::NegateBool { value, .. } => value.is_known_bool(),
-            _ => self.is_literal(),
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Var { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::Call { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => self.is_literal(),
         }
     }
 
     pub fn is_literal_string(&self) -> bool {
-        match self {
-            Self::String { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::String { .. })
     }
 
     /// Returns `true` if the typed expr is [`Var`].
@@ -797,10 +879,7 @@ impl TypedExpr {
     /// [`Var`]: TypedExpr::Var
     #[must_use]
     pub fn is_var(&self) -> bool {
-        match self {
-            Self::Var { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::Var { .. })
     }
 
     pub(crate) fn get_documentation(&self) -> Option<&str> {
@@ -838,10 +917,7 @@ impl TypedExpr {
     /// [`Case`]: TypedExpr::Case
     #[must_use]
     pub fn is_case(&self) -> bool {
-        match self {
-            Self::Case { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::Case { .. })
     }
 
     /// Returns `true` if the typed expr is [`Pipeline`].
@@ -849,10 +925,7 @@ impl TypedExpr {
     /// [`Pipeline`]: TypedExpr::Pipeline
     #[must_use]
     pub fn is_pipeline(&self) -> bool {
-        match self {
-            Self::Pipeline { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::Pipeline { .. })
     }
 
     pub fn is_pure_value_constructor(&self) -> bool {
@@ -1008,7 +1081,28 @@ impl TypedExpr {
                 constructor: ModuleValueConstructor::Record { .. },
                 ..
             } => true,
-            _ => false,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => false,
         }
     }
 
@@ -1031,7 +1125,30 @@ impl TypedExpr {
                 ..
             } => *arity > 0,
 
-            _ => false,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Var { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::Call { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => false,
         }
     }
 
@@ -1053,12 +1170,34 @@ impl TypedExpr {
                 constructor: ModuleValueConstructor::Record { variant_index, .. },
                 ..
             } => Some(*variant_index),
-            _ => None,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Var { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => None,
         }
     }
 
     #[must_use]
-    /// If `self` is a record constructor, returns the nuber of arguments it
+    /// If `self` is a record constructor, returns the number of arguments it
     /// needs to be called. Otherwise, returns `None`.
     ///
     pub fn record_constructor_arity(&self) -> Option<u16> {
@@ -1072,38 +1211,61 @@ impl TypedExpr {
                     },
                 ..
             } => Some(*arity),
-            _ => None,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Var { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => None,
         }
     }
 
     pub fn var_constructor(&self) -> Option<(&ValueConstructor, &EcoString)> {
-        match self {
-            TypedExpr::Var {
-                constructor, name, ..
-            } => Some((constructor, name)),
-            _ => None,
+        if let TypedExpr::Var {
+            constructor, name, ..
+        } = self
+        {
+            Some((constructor, name))
+        } else {
+            None
         }
     }
 
     #[must_use]
     pub(crate) fn is_panic(&self) -> bool {
-        match self {
-            TypedExpr::Panic { .. } => true,
-            _ => false,
-        }
+        matches!(self, TypedExpr::Panic { .. })
     }
 
     pub(crate) fn call_arguments(&self) -> Option<&Vec<TypedCallArg>> {
-        match self {
-            TypedExpr::Call { arguments, .. } => Some(arguments),
-            _ => None,
+        if let TypedExpr::Call { arguments, .. } = self {
+            Some(arguments)
+        } else {
+            None
         }
     }
 
     pub(crate) fn fn_expression_body(&self) -> Option<&Vec1<TypedStatement>> {
-        match self {
-            TypedExpr::Fn { body, .. } => Some(body),
-            _ => None,
+        if let TypedExpr::Fn { body, .. } = self {
+            Some(body)
+        } else {
+            None
         }
     }
 
@@ -1174,10 +1336,7 @@ impl TypedExpr {
     }
 
     pub(crate) fn is_invalid(&self) -> bool {
-        match self {
-            TypedExpr::Invalid { .. } => true,
-            _ => false,
-        }
+        matches!(self, TypedExpr::Invalid { .. })
     }
 
     /// Checks that two expressions are written in the same (ignoring
@@ -1483,10 +1642,7 @@ impl TypedExpr {
     }
 
     pub(crate) fn is_todo_with_no_message(&self) -> bool {
-        match self {
-            TypedExpr::Todo { message: None, .. } => true,
-            _ => false,
-        }
+        matches!(self, TypedExpr::Todo { message: None, .. })
     }
 }
 

--- a/compiler-core/src/ast/untyped.rs
+++ b/compiler-core/src/ast/untyped.rs
@@ -182,7 +182,25 @@ impl UntypedExpr {
         match self {
             Self::Block { location, .. } => location.start,
             Self::PipeLine { expressions, .. } => expressions.first().start_byte_index(),
-            _ => self.location().start,
+            Self::Int { .. }
+            | Self::Float { .. }
+            | Self::String { .. }
+            | Self::Var { .. }
+            | Self::Fn { .. }
+            | Self::List { .. }
+            | Self::Call { .. }
+            | Self::BinOp { .. }
+            | Self::Case { .. }
+            | Self::FieldAccess { .. }
+            | Self::Tuple { .. }
+            | Self::TupleIndex { .. }
+            | Self::Todo { .. }
+            | Self::Panic { .. }
+            | Self::Echo { .. }
+            | Self::BitArray { .. }
+            | Self::RecordUpdate { .. }
+            | Self::NegateBool { .. }
+            | Self::NegateInt { .. } => self.location().start,
         }
     }
 
@@ -190,14 +208,33 @@ impl UntypedExpr {
         match self {
             Self::BinOp { name, .. } => name.precedence(),
             Self::PipeLine { .. } => 5,
-            _ => u8::MAX,
+            Self::Int { .. }
+            | Self::Float { .. }
+            | Self::String { .. }
+            | Self::Block { .. }
+            | Self::Var { .. }
+            | Self::Fn { .. }
+            | Self::List { .. }
+            | Self::Call { .. }
+            | Self::Case { .. }
+            | Self::FieldAccess { .. }
+            | Self::Tuple { .. }
+            | Self::TupleIndex { .. }
+            | Self::Todo { .. }
+            | Self::Panic { .. }
+            | Self::Echo { .. }
+            | Self::BitArray { .. }
+            | Self::RecordUpdate { .. }
+            | Self::NegateBool { .. }
+            | Self::NegateInt { .. } => u8::MAX,
         }
     }
 
     pub fn bin_op_name(&self) -> Option<&BinOp> {
-        match self {
-            UntypedExpr::BinOp { name, .. } => Some(name),
-            _ => None,
+        if let UntypedExpr::BinOp { name, .. } = self {
+            Some(name)
+        } else {
+            None
         }
     }
 
@@ -232,10 +269,7 @@ impl UntypedExpr {
     }
 
     pub fn is_tuple(&self) -> bool {
-        match self {
-            UntypedExpr::Tuple { .. } => true,
-            _ => false,
-        }
+        matches!(self, UntypedExpr::Tuple { .. })
     }
 
     /// Returns `true` if the untyped expr is [`Call`].

--- a/compiler-core/src/bit_array.rs
+++ b/compiler-core/src/bit_array.rs
@@ -347,7 +347,18 @@ impl GetLiteralValue for ast::TypedPattern {
             | ast::Pattern::BitArraySize(ast::BitArraySize::Int { int_value, .. }) => {
                 Some(int_value.clone())
             }
-            _ => None,
+            ast::Pattern::Float { .. }
+            | ast::Pattern::String { .. }
+            | ast::Pattern::Variable { .. }
+            | ast::Pattern::BitArraySize(_)
+            | ast::Pattern::Assign { .. }
+            | ast::Pattern::Discard { .. }
+            | ast::Pattern::List { .. }
+            | ast::Pattern::Constructor { .. }
+            | ast::Pattern::Tuple { .. }
+            | ast::Pattern::BitArray { .. }
+            | ast::Pattern::StringPrefix { .. }
+            | ast::Pattern::Invalid { .. } => None,
         }
     }
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1182,7 +1182,7 @@ your app.src file \"{app_ver}\"."
                             Distro::Other => (),
                         }
                     }
-                    _ => (),
+                    OS::Windows | OS::Other => (),
                 }
 
                 text.push('\n');
@@ -4620,7 +4620,29 @@ fn std_io_error_kind_text(kind: &std::io::ErrorKind) -> String {
         }
         ErrorKind::Interrupted => "The operation was interrupted".into(),
         ErrorKind::UnexpectedEof => "The end of file was reached before it was expected".into(),
-        _ => "An unknown error occurred".into(),
+        ErrorKind::HostUnreachable
+        | ErrorKind::NetworkUnreachable
+        | ErrorKind::NetworkDown
+        | ErrorKind::NotADirectory
+        | ErrorKind::IsADirectory
+        | ErrorKind::DirectoryNotEmpty
+        | ErrorKind::ReadOnlyFilesystem
+        | ErrorKind::StaleNetworkFileHandle
+        | ErrorKind::StorageFull
+        | ErrorKind::NotSeekable
+        | ErrorKind::QuotaExceeded
+        | ErrorKind::FileTooLarge
+        | ErrorKind::ResourceBusy
+        | ErrorKind::ExecutableFileBusy
+        | ErrorKind::Deadlock
+        | ErrorKind::CrossesDevices
+        | ErrorKind::TooManyLinks
+        | ErrorKind::InvalidFilename
+        | ErrorKind::ArgumentListTooLong
+        | ErrorKind::Unsupported
+        | ErrorKind::OutOfMemory
+        | ErrorKind::Other
+        | _ => "An unknown error occurred".into(),
     }
 }
 
@@ -4663,7 +4685,28 @@ fn hint_alternative_operator(op: &BinOp, given: &Type) -> Option<String> {
         BinOp::AddInt if given.is_string() => Some(hint_string_message()),
         BinOp::AddFloat if given.is_string() => Some(hint_string_message()),
 
-        _ => None,
+        BinOp::And
+        | BinOp::Or
+        | BinOp::Eq
+        | BinOp::NotEq
+        | BinOp::LtInt
+        | BinOp::LtEqInt
+        | BinOp::LtFloat
+        | BinOp::LtEqFloat
+        | BinOp::GtEqInt
+        | BinOp::GtInt
+        | BinOp::GtEqFloat
+        | BinOp::GtFloat
+        | BinOp::AddInt
+        | BinOp::AddFloat
+        | BinOp::SubInt
+        | BinOp::SubFloat
+        | BinOp::MultInt
+        | BinOp::MultFloat
+        | BinOp::DivInt
+        | BinOp::DivFloat
+        | BinOp::RemainderInt
+        | BinOp::Concatenate => None,
     }
 }
 

--- a/compiler-core/src/exhaustiveness/printer.rs
+++ b/compiler-core/src/exhaustiveness/printer.rs
@@ -172,7 +172,10 @@ impl<'a> Printer<'a> {
 
                     match term {
                         Term::EmptyList { .. } => {}
-                        _ => {
+                        Term::Variant { .. }
+                        | Term::Tuple { .. }
+                        | Term::Infinite { .. }
+                        | Term::List { .. } => {
                             buffer.push_str(", ");
                             self.print_list(term, terms, mapping, buffer)
                         }

--- a/compiler-core/src/inline.rs
+++ b/compiler-core/src/inline.rs
@@ -1404,7 +1404,30 @@ fn expand_block(expression: TypedExpr) -> TypedExpr {
                 }
             }
         }
-        _ => expression,
+        TypedExpr::Int { .. }
+        | TypedExpr::Float { .. }
+        | TypedExpr::String { .. }
+        | TypedExpr::Block { .. }
+        | TypedExpr::Pipeline { .. }
+        | TypedExpr::Var { .. }
+        | TypedExpr::Fn { .. }
+        | TypedExpr::List { .. }
+        | TypedExpr::Call { .. }
+        | TypedExpr::BinOp { .. }
+        | TypedExpr::Case { .. }
+        | TypedExpr::RecordAccess { .. }
+        | TypedExpr::PositionalAccess { .. }
+        | TypedExpr::ModuleSelect { .. }
+        | TypedExpr::Tuple { .. }
+        | TypedExpr::TupleIndex { .. }
+        | TypedExpr::Todo { .. }
+        | TypedExpr::Panic { .. }
+        | TypedExpr::Echo { .. }
+        | TypedExpr::BitArray { .. }
+        | TypedExpr::RecordUpdate { .. }
+        | TypedExpr::NegateBool { .. }
+        | TypedExpr::NegateInt { .. }
+        | TypedExpr::Invalid { .. } => expression,
     }
 }
 

--- a/compiler-core/src/language_server/completer.rs
+++ b/compiler-core/src/language_server/completer.rs
@@ -797,7 +797,7 @@ impl<'a, IO> Completer<'a, IO> {
                 .and_then(|i| i.accessors.get(name))
                 .filter(|a| a.publicity.is_importable() || module == &self.module.name)
                 .map(|a| a.accessors_for_variant(*inferred_variant)),
-            _ => None,
+            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => None,
         }
     }
 
@@ -830,7 +830,28 @@ impl<'a, IO> Completer<'a, IO> {
                 .get(module_name)
                 .and_then(|i| i.values.get(label))
                 .and_then(|a| a.field_map()),
-            _ => None,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::Call { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => None,
         }
     }
 

--- a/compiler-core/src/language_server/reference.rs
+++ b/compiler-core/src/language_server/reference.rs
@@ -97,7 +97,9 @@ pub fn reference_for_ast_node(
                     origin: Some(origin.clone()),
                     name: name.clone(),
                 }),
-                _ => None,
+                ValueConstructorVariant::ModuleConstant { .. }
+                | ValueConstructorVariant::ModuleFn { .. }
+                | ValueConstructorVariant::Record { .. } => None,
             }),
         Located::Pattern(Pattern::Assign { location, name, .. }) => {
             Some(Referenced::LocalVariable {
@@ -279,7 +281,18 @@ pub fn reference_for_ast_node(
             location: *name_location,
             target_kind: RenameTarget::Definition,
         }),
-        _ => None,
+        Located::Pattern(_)
+        | Located::PatternSpread { .. }
+        | Located::Statement(_)
+        | Located::Expression { .. }
+        | Located::FunctionBody(_)
+        | Located::UnqualifiedImport(_)
+        | Located::Label(..)
+        | Located::ModuleName { .. }
+        | Located::Constant(_)
+        | Located::ModuleFunction(_)
+        | Located::ModuleImport(_)
+        | Located::ModuleTypeAlias(_) => None,
     }
 }
 
@@ -483,7 +496,7 @@ impl FindVariableReferences {
                 };
             }
 
-            _ => (),
+            DefinitionLocation::Regular { .. } | DefinitionLocation::Alternative { .. } => (),
         };
     }
 
@@ -524,7 +537,10 @@ impl<'ast> Visit<'ast> for FindVariableReferences {
                     kind: VariableReferenceKind::Variable,
                 });
             }
-            _ => {}
+            ValueConstructorVariant::LocalVariable { .. }
+            | ValueConstructorVariant::ModuleConstant { .. }
+            | ValueConstructorVariant::ModuleFn { .. }
+            | ValueConstructorVariant::Record { .. } => {}
         }
     }
 
@@ -647,7 +663,10 @@ impl<'ast> Visit<'ast> for FindVariableReferences {
                     kind: VariableReferenceKind::Variable,
                 });
             }
-            _ => {}
+            ValueConstructorVariant::LocalVariable { .. }
+            | ValueConstructorVariant::ModuleConstant { .. }
+            | ValueConstructorVariant::ModuleFn { .. }
+            | ValueConstructorVariant::Record { .. } => {}
         }
     }
 
@@ -671,7 +690,10 @@ impl<'ast> Visit<'ast> for FindVariableReferences {
                     });
                     return;
                 }
-                _ => {}
+                ValueConstructorVariant::LocalVariable { .. }
+                | ValueConstructorVariant::ModuleConstant { .. }
+                | ValueConstructorVariant::ModuleFn { .. }
+                | ValueConstructorVariant::Record { .. } => {}
             }
         }
 

--- a/compiler-core/src/language_server/signature_help.rs
+++ b/compiler-core/src/language_server/signature_help.rs
@@ -53,7 +53,7 @@ pub fn for_expression(expr: &TypedExpr) -> Option<SignatureHelp> {
             signature_help(name, fun, arguments, field_map)
         }
 
-        // If the function bein called is an invalid node we don't want to
+        // If the function being called is an invalid node we don't want to
         // provide any hint, otherwise one might be under the impression that
         // that function actually exists somewhere.
         //
@@ -67,7 +67,27 @@ pub fn for_expression(expr: &TypedExpr) -> Option<SignatureHelp> {
         //                  ^ When the cursor is here we are going to show
         //                    "fn(a: a) -> a" as the help signature.
         //
-        _ => signature_help("fn".into(), fun, arguments, None),
+        TypedExpr::Int { .. }
+        | TypedExpr::Float { .. }
+        | TypedExpr::String { .. }
+        | TypedExpr::Block { .. }
+        | TypedExpr::Pipeline { .. }
+        | TypedExpr::Fn { .. }
+        | TypedExpr::List { .. }
+        | TypedExpr::Call { .. }
+        | TypedExpr::BinOp { .. }
+        | TypedExpr::Case { .. }
+        | TypedExpr::RecordAccess { .. }
+        | TypedExpr::PositionalAccess { .. }
+        | TypedExpr::Tuple { .. }
+        | TypedExpr::TupleIndex { .. }
+        | TypedExpr::Todo { .. }
+        | TypedExpr::Panic { .. }
+        | TypedExpr::Echo { .. }
+        | TypedExpr::BitArray { .. }
+        | TypedExpr::RecordUpdate { .. }
+        | TypedExpr::NegateBool { .. }
+        | TypedExpr::NegateInt { .. } => signature_help("fn".into(), fun, arguments, None),
     }
 }
 

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -29,6 +29,7 @@
     unexpected_cfgs,
     unused_import_braces,
     unused_qualifications,
+    clippy::wildcard_enum_match_arm
 )]
 #![deny(
     clippy::await_holding_lock,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3758,7 +3758,76 @@ where
                     IntOperator::Remainder,
                 ))
             }
-            _ => {
+            Token::Name { .. }
+            | Token::UpName { .. }
+            | Token::DiscardName { .. }
+            | Token::Int { .. }
+            | Token::Float { .. }
+            | Token::String { .. }
+            | Token::CommentDoc { .. }
+            | Token::LeftParen
+            | Token::RightParen
+            | Token::LeftSquare
+            | Token::RightSquare
+            | Token::LeftBrace
+            | Token::RightBrace
+            | Token::Less
+            | Token::Greater
+            | Token::LessEqual
+            | Token::GreaterEqual
+            | Token::PlusDot
+            | Token::MinusDot
+            | Token::StarDot
+            | Token::SlashDot
+            | Token::LessDot
+            | Token::GreaterDot
+            | Token::LessEqualDot
+            | Token::GreaterEqualDot
+            | Token::LtGt
+            | Token::Colon
+            | Token::Comma
+            | Token::Hash
+            | Token::Bang
+            | Token::Equal
+            | Token::EqualEqual
+            | Token::NotEqual
+            | Token::Vbar
+            | Token::VbarVbar
+            | Token::AmperAmper
+            | Token::LtLt
+            | Token::GtGt
+            | Token::Pipe
+            | Token::Dot
+            | Token::RArrow
+            | Token::LArrow
+            | Token::DotDot
+            | Token::At
+            | Token::EndOfFile
+            | Token::CommentNormal
+            | Token::CommentModule
+            | Token::NewLine
+            | Token::As
+            | Token::Assert
+            | Token::Auto
+            | Token::Case
+            | Token::Const
+            | Token::Delegate
+            | Token::Derive
+            | Token::Echo
+            | Token::Else
+            | Token::Fn
+            | Token::If
+            | Token::Implement
+            | Token::Import
+            | Token::Let
+            | Token::Macro
+            | Token::Opaque
+            | Token::Panic
+            | Token::Pub
+            | Token::Test
+            | Token::Todo
+            | Token::Type
+            | Token::Use => {
                 self.tok0 = Some((start, token, end));
                 Ok(left)
             }
@@ -3883,31 +3952,29 @@ where
                     // If provided a Name, map to a more detailed error
                     // message to nudge the user.
                     // Else, handle as an unexpected token.
-                    let field = match token {
-                        Token::Name { name } => name,
-                        token => {
-                            let hint = match (&token, self.tok0.take()) {
-                                (&Token::Fn, _) | (&Token::Pub, Some((_, Token::Fn, _))) => {
-                                    let text =
-                                        "Gleam is not an object oriented programming language so
+                    let field = if let Token::Name { name } = token {
+                        name
+                    } else {
+                        let hint = match (&token, self.tok0.take()) {
+                            (&Token::Fn, _) | (&Token::Pub, Some((_, Token::Fn, _))) => {
+                                let text = "Gleam is not an object oriented programming language so
 functions are declared separately from types.";
-                                    Some(wrap(text).into())
-                                }
-                                (_, _) => None,
-                            };
+                                Some(wrap(text).into())
+                            }
+                            (_, _) => None,
+                        };
 
-                            return parse_error(
-                                ParseErrorType::UnexpectedToken {
-                                    token,
-                                    expected: vec![
-                                        Token::RightBrace.to_string().into(),
-                                        "a record constructor".into(),
-                                    ],
-                                    hint,
-                                },
-                                SrcSpan { start, end },
-                            );
-                        }
+                        return parse_error(
+                            ParseErrorType::UnexpectedToken {
+                                token,
+                                expected: vec![
+                                    Token::RightBrace.to_string().into(),
+                                    "a record constructor".into(),
+                                ],
+                                hint,
+                            },
+                            SrcSpan { start, end },
+                        );
                     };
                     let field_type = match self.parse_type_annotation(&Token::Colon) {
                         Ok(Some(annotation)) => Some(Box::new(annotation)),
@@ -3952,7 +4019,78 @@ functions are declared separately from types.";
                     ParseErrorType::UnexpectedReservedWord,
                     SrcSpan { start, end },
                 ),
-                _ => parse_error(ParseErrorType::ExpectedName, SrcSpan { start, end }),
+                Token::Int { .. }
+                | Token::Float { .. }
+                | Token::String { .. }
+                | Token::CommentDoc { .. }
+                | Token::LeftParen
+                | Token::RightParen
+                | Token::LeftSquare
+                | Token::RightSquare
+                | Token::LeftBrace
+                | Token::RightBrace
+                | Token::Plus
+                | Token::Minus
+                | Token::Star
+                | Token::Slash
+                | Token::Less
+                | Token::Greater
+                | Token::LessEqual
+                | Token::GreaterEqual
+                | Token::Percent
+                | Token::PlusDot
+                | Token::MinusDot
+                | Token::StarDot
+                | Token::SlashDot
+                | Token::LessDot
+                | Token::GreaterDot
+                | Token::LessEqualDot
+                | Token::GreaterEqualDot
+                | Token::LtGt
+                | Token::Colon
+                | Token::Comma
+                | Token::Hash
+                | Token::Bang
+                | Token::Equal
+                | Token::EqualEqual
+                | Token::NotEqual
+                | Token::Vbar
+                | Token::VbarVbar
+                | Token::AmperAmper
+                | Token::LtLt
+                | Token::GtGt
+                | Token::Pipe
+                | Token::Dot
+                | Token::RArrow
+                | Token::LArrow
+                | Token::DotDot
+                | Token::At
+                | Token::EndOfFile
+                | Token::CommentNormal
+                | Token::CommentModule
+                | Token::NewLine
+                | Token::As
+                | Token::Assert
+                | Token::Auto
+                | Token::Case
+                | Token::Const
+                | Token::Delegate
+                | Token::Derive
+                | Token::Echo
+                | Token::Else
+                | Token::Fn
+                | Token::If
+                | Token::Implement
+                | Token::Import
+                | Token::Let
+                | Token::Macro
+                | Token::Opaque
+                | Token::Panic
+                | Token::Pub
+                | Token::Test
+                | Token::Todo
+                | Token::Type
+                | Token::Use => parse_error(ParseErrorType::ExpectedName, SrcSpan { start, end }),
             },
             None => parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 }),
         }
@@ -3963,18 +4101,82 @@ functions are declared separately from types.";
         let t = self.next_tok();
         match t {
             Some((start, tok, end)) => match tok {
-                Token::Name { .. } => {
+                Token::Name { .. } | Token::DiscardName { .. } => {
                     parse_error(ParseErrorType::IncorrectUpName, SrcSpan { start, end })
                 }
-                _ => match tok {
-                    Token::UpName { name } => Ok((start, name, end)),
-                    _ => match tok {
-                        Token::DiscardName { .. } => {
-                            parse_error(ParseErrorType::IncorrectUpName, SrcSpan { start, end })
-                        }
-                        _ => parse_error(ParseErrorType::ExpectedUpName, SrcSpan { start, end }),
-                    },
-                },
+                Token::UpName { name } => Ok((start, name, end)),
+                Token::Int { .. }
+                | Token::Float { .. }
+                | Token::String { .. }
+                | Token::CommentDoc { .. }
+                | Token::LeftParen
+                | Token::RightParen
+                | Token::LeftSquare
+                | Token::RightSquare
+                | Token::LeftBrace
+                | Token::RightBrace
+                | Token::Plus
+                | Token::Minus
+                | Token::Star
+                | Token::Slash
+                | Token::Less
+                | Token::Greater
+                | Token::LessEqual
+                | Token::GreaterEqual
+                | Token::Percent
+                | Token::PlusDot
+                | Token::MinusDot
+                | Token::StarDot
+                | Token::SlashDot
+                | Token::LessDot
+                | Token::GreaterDot
+                | Token::LessEqualDot
+                | Token::GreaterEqualDot
+                | Token::LtGt
+                | Token::Colon
+                | Token::Comma
+                | Token::Hash
+                | Token::Bang
+                | Token::Equal
+                | Token::EqualEqual
+                | Token::NotEqual
+                | Token::Vbar
+                | Token::VbarVbar
+                | Token::AmperAmper
+                | Token::LtLt
+                | Token::GtGt
+                | Token::Pipe
+                | Token::Dot
+                | Token::RArrow
+                | Token::LArrow
+                | Token::DotDot
+                | Token::At
+                | Token::EndOfFile
+                | Token::CommentNormal
+                | Token::CommentModule
+                | Token::NewLine
+                | Token::As
+                | Token::Assert
+                | Token::Auto
+                | Token::Case
+                | Token::Const
+                | Token::Delegate
+                | Token::Derive
+                | Token::Echo
+                | Token::Else
+                | Token::Fn
+                | Token::If
+                | Token::Implement
+                | Token::Import
+                | Token::Let
+                | Token::Macro
+                | Token::Opaque
+                | Token::Panic
+                | Token::Pub
+                | Token::Test
+                | Token::Todo
+                | Token::Type
+                | Token::Use => parse_error(ParseErrorType::ExpectedUpName, SrcSpan { start, end }),
             },
             None => parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 }),
         }
@@ -3990,8 +4192,8 @@ functions are declared separately from types.";
                 return parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 });
             }
         };
-        match t {
-            Token::Name { name } => match name.as_str() {
+        if let Token::Name { name } = t {
+            match name.as_str() {
                 "javascript" => Ok(Target::JavaScript),
                 "erlang" => Ok(Target::Erlang),
                 "js" => {
@@ -4011,8 +4213,9 @@ functions are declared separately from types.";
                     Ok(Target::Erlang)
                 }
                 _ => parse_error(ParseErrorType::UnknownTarget, SrcSpan::new(start, end)),
-            },
-            _ => parse_error(ParseErrorType::ExpectedTargetName, paren_location),
+            }
+        } else {
+            parse_error(ParseErrorType::ExpectedTargetName, paren_location)
         }
     }
 
@@ -4462,7 +4665,59 @@ fn tok_to_binop(t: &Token) -> Option<BinOp> {
         Token::Slash => Some(BinOp::DivInt),
         Token::SlashDot => Some(BinOp::DivFloat),
         Token::LtGt => Some(BinOp::Concatenate),
-        _ => None,
+        Token::Name { .. }
+        | Token::UpName { .. }
+        | Token::DiscardName { .. }
+        | Token::Int { .. }
+        | Token::Float { .. }
+        | Token::String { .. }
+        | Token::CommentDoc { .. }
+        | Token::LeftParen
+        | Token::RightParen
+        | Token::LeftSquare
+        | Token::RightSquare
+        | Token::LeftBrace
+        | Token::RightBrace
+        | Token::Colon
+        | Token::Comma
+        | Token::Hash
+        | Token::Bang
+        | Token::Equal
+        | Token::Vbar
+        | Token::LtLt
+        | Token::GtGt
+        | Token::Pipe
+        | Token::Dot
+        | Token::RArrow
+        | Token::LArrow
+        | Token::DotDot
+        | Token::At
+        | Token::EndOfFile
+        | Token::CommentNormal
+        | Token::CommentModule
+        | Token::NewLine
+        | Token::As
+        | Token::Assert
+        | Token::Auto
+        | Token::Case
+        | Token::Const
+        | Token::Delegate
+        | Token::Derive
+        | Token::Echo
+        | Token::Else
+        | Token::Fn
+        | Token::If
+        | Token::Implement
+        | Token::Import
+        | Token::Let
+        | Token::Macro
+        | Token::Opaque
+        | Token::Panic
+        | Token::Pub
+        | Token::Test
+        | Token::Todo
+        | Token::Type
+        | Token::Use => None,
     }
 }
 /// Simple-Precedence-Parser, perform reduction for expression
@@ -4493,14 +4748,11 @@ fn expr_op_reduction(
     r: UntypedExpr,
 ) -> UntypedExpr {
     if token == Token::Pipe {
-        let expressions = match l {
-            UntypedExpr::PipeLine { mut expressions } => {
-                expressions.push(r);
-                expressions
-            }
-            _ => {
-                vec1![l, r]
-            }
+        let expressions = if let UntypedExpr::PipeLine { mut expressions } = l {
+            expressions.push(r);
+            expressions
+        } else {
+            vec1![l, r]
         };
         UntypedExpr::PipeLine { expressions }
     } else {
@@ -4663,7 +4915,60 @@ fn clause_guard_reduction(
             right,
         },
 
-        _ => panic!("Token could not be converted to Guard Op."),
+        Token::Name { .. }
+        | Token::UpName { .. }
+        | Token::DiscardName { .. }
+        | Token::Int { .. }
+        | Token::Float { .. }
+        | Token::String { .. }
+        | Token::CommentDoc { .. }
+        | Token::LeftParen
+        | Token::RightParen
+        | Token::LeftSquare
+        | Token::RightSquare
+        | Token::LeftBrace
+        | Token::RightBrace
+        | Token::LtGt
+        | Token::Colon
+        | Token::Comma
+        | Token::Hash
+        | Token::Bang
+        | Token::Equal
+        | Token::Vbar
+        | Token::LtLt
+        | Token::GtGt
+        | Token::Pipe
+        | Token::Dot
+        | Token::RArrow
+        | Token::LArrow
+        | Token::DotDot
+        | Token::At
+        | Token::EndOfFile
+        | Token::CommentNormal
+        | Token::CommentModule
+        | Token::NewLine
+        | Token::As
+        | Token::Assert
+        | Token::Auto
+        | Token::Case
+        | Token::Const
+        | Token::Delegate
+        | Token::Derive
+        | Token::Echo
+        | Token::Else
+        | Token::Fn
+        | Token::If
+        | Token::Implement
+        | Token::Import
+        | Token::Let
+        | Token::Macro
+        | Token::Opaque
+        | Token::Panic
+        | Token::Pub
+        | Token::Test
+        | Token::Todo
+        | Token::Type
+        | Token::Use => panic!("Token could not be converted to Guard Op."),
     }
 }
 

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -439,7 +439,74 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                     Token::DiscardName { .. } => "a discard name".to_string(),
                     Token::Name { .. } | Token::UpName { .. } => "a name".to_string(),
                     _ if token.is_reserved_word() => format!("the keyword {token}"),
-                    _ => token.to_string(),
+                    Token::LeftParen
+                    | Token::RightParen
+                    | Token::LeftSquare
+                    | Token::RightSquare
+                    | Token::LeftBrace
+                    | Token::RightBrace
+                    | Token::Plus
+                    | Token::Minus
+                    | Token::Star
+                    | Token::Slash
+                    | Token::Less
+                    | Token::Greater
+                    | Token::LessEqual
+                    | Token::GreaterEqual
+                    | Token::Percent
+                    | Token::PlusDot
+                    | Token::MinusDot
+                    | Token::StarDot
+                    | Token::SlashDot
+                    | Token::LessDot
+                    | Token::GreaterDot
+                    | Token::LessEqualDot
+                    | Token::GreaterEqualDot
+                    | Token::LtGt
+                    | Token::Colon
+                    | Token::Comma
+                    | Token::Hash
+                    | Token::Bang
+                    | Token::Equal
+                    | Token::EqualEqual
+                    | Token::NotEqual
+                    | Token::Vbar
+                    | Token::VbarVbar
+                    | Token::AmperAmper
+                    | Token::LtLt
+                    | Token::GtGt
+                    | Token::Pipe
+                    | Token::Dot
+                    | Token::RArrow
+                    | Token::LArrow
+                    | Token::DotDot
+                    | Token::At
+                    | Token::EndOfFile
+                    | Token::CommentNormal
+                    | Token::CommentModule
+                    | Token::NewLine
+                    | Token::As
+                    | Token::Assert
+                    | Token::Auto
+                    | Token::Case
+                    | Token::Const
+                    | Token::Delegate
+                    | Token::Derive
+                    | Token::Echo
+                    | Token::Else
+                    | Token::Fn
+                    | Token::If
+                    | Token::Implement
+                    | Token::Import
+                    | Token::Let
+                    | Token::Macro
+                    | Token::Opaque
+                    | Token::Panic
+                    | Token::Pub
+                    | Token::Test
+                    | Token::Todo
+                    | Token::Type
+                    | Token::Use => token.to_string(),
                 };
 
                 let messages = std::iter::once(format!("Found {found}, expected one of: "))

--- a/compiler-core/src/parse/token.rs
+++ b/compiler-core/src/parse/token.rs
@@ -129,7 +129,60 @@ impl Token {
 
             Self::Star | Self::StarDot | Self::Slash | Self::SlashDot | Self::Percent => Some(6),
 
-            _ => None,
+            Self::Name { .. }
+            | Self::UpName { .. }
+            | Self::DiscardName { .. }
+            | Self::Int { .. }
+            | Self::Float { .. }
+            | Self::String { .. }
+            | Self::CommentDoc { .. }
+            | Self::LeftParen
+            | Self::RightParen
+            | Self::LeftSquare
+            | Self::RightSquare
+            | Self::LeftBrace
+            | Self::RightBrace
+            | Self::LtGt
+            | Self::Colon
+            | Self::Comma
+            | Self::Hash
+            | Self::Bang
+            | Self::Equal
+            | Self::Vbar
+            | Self::LtLt
+            | Self::GtGt
+            | Self::Pipe
+            | Self::Dot
+            | Self::RArrow
+            | Self::LArrow
+            | Self::DotDot
+            | Self::At
+            | Self::EndOfFile
+            | Self::CommentNormal
+            | Self::CommentModule
+            | Self::NewLine
+            | Self::As
+            | Self::Assert
+            | Self::Auto
+            | Self::Case
+            | Self::Const
+            | Self::Delegate
+            | Self::Derive
+            | Self::Echo
+            | Self::Else
+            | Self::Fn
+            | Self::If
+            | Self::Implement
+            | Self::Import
+            | Self::Let
+            | Self::Macro
+            | Self::Opaque
+            | Self::Panic
+            | Self::Pub
+            | Self::Test
+            | Self::Todo
+            | Self::Type
+            | Self::Use => None,
         }
     }
 

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -870,7 +870,7 @@ impl Environment<'_> {
                     Imported::Value(name) if module_info.get_public_value(name).is_some() => {
                         Some(ModuleSuggestion::Importable(importable.clone()))
                     }
-                    _ => None,
+                    Imported::Module | Imported::Type(_) | Imported::Value(_) => None,
                 }
             })
             .collect_vec();

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1328,14 +1328,14 @@ impl Error {
     }
 
     pub fn with_unify_error_situation(mut self, new_situation: UnifyErrorSituation) -> Self {
-        match self {
-            Error::CouldNotUnify {
-                ref mut situation, ..
-            } => {
-                *situation = Some(new_situation);
-                self
-            }
-            _ => self,
+        if let Error::CouldNotUnify {
+            ref mut situation, ..
+        } = self
+        {
+            *situation = Some(new_situation);
+            self
+        } else {
+            self
         }
     }
 }
@@ -1395,10 +1395,7 @@ impl Warning {
     }
 
     pub(crate) fn is_todo(&self) -> bool {
-        match self {
-            Self::Todo { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::Todo { .. })
     }
 }
 
@@ -1615,7 +1612,10 @@ pub fn flip_unify_error(e: UnifyError) -> UnifyError {
             given: expected,
             situation: note,
         },
-        other => other,
+        UnifyError::ExtraVarInAlternativePattern { .. }
+        | UnifyError::MissingVarInAlternativePattern { .. }
+        | UnifyError::DuplicateVarInPattern { .. }
+        | UnifyError::RecursiveType => e,
     }
 }
 
@@ -1847,7 +1847,10 @@ impl UnifyError {
                 given,
                 situation: Some(situation),
             },
-            other => other,
+            Self::ExtraVarInAlternativePattern { .. }
+            | Self::MissingVarInAlternativePattern { .. }
+            | Self::DuplicateVarInPattern { .. }
+            | Self::RecursiveType => self,
         }
     }
 
@@ -1951,7 +1954,11 @@ impl UnifyError {
             },
 
             // In all other cases we fallback to the generic cannot unify error.
-            _ => self.into_error(body_location),
+            Self::CouldNotUnify { .. }
+            | Self::ExtraVarInAlternativePattern { .. }
+            | Self::MissingVarInAlternativePattern { .. }
+            | Self::DuplicateVarInPattern { .. }
+            | Self::RecursiveType => self.into_error(body_location),
         }
     }
 }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -360,7 +360,29 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 expression: Some(subject),
                 ..
             } => Self::subject_variable(subject),
-            _ => None,
+            TypedExpr::Int { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::String { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::Call { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => None,
         }
     }
 
@@ -444,7 +466,17 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     })
                 }
 
-                _ => (),
+                Pattern::Int { .. }
+                | Pattern::Variable { .. }
+                | Pattern::BitArraySize(_)
+                | Pattern::Assign { .. }
+                | Pattern::Discard { .. }
+                | Pattern::List { .. }
+                | Pattern::Constructor { .. }
+                | Pattern::Tuple { .. }
+                | Pattern::BitArray { .. }
+                | Pattern::StringPrefix { .. }
+                | Pattern::Invalid { .. } => (),
             }
         }
 
@@ -484,7 +516,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             for option in options.iter() {
                 match option {
                     // Use of the `bits` segment type
-                    BitArrayOption::<TypedPattern>::Bits { location } => {
+                    BitArrayOption::Bits { location } => {
                         self.track_feature_usage(
                             FeatureKind::JavaScriptUnalignedBitArray,
                             *location,
@@ -492,23 +524,48 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     }
 
                     // Int segments that aren't a whole number of bytes
-                    BitArrayOption::<TypedPattern>::Size { value, .. } if segment_type.is_int() => {
-                        match &**value {
-                            Pattern::BitArraySize(BitArraySize::Int {
-                                location,
-                                int_value,
-                                ..
-                            }) if int_value % 8 != BigInt::ZERO => {
-                                self.track_feature_usage(
-                                    FeatureKind::JavaScriptUnalignedBitArray,
-                                    *location,
-                                );
-                            }
-                            _ => (),
+                    BitArrayOption::Size { value, .. } if segment_type.is_int() => match &**value {
+                        Pattern::BitArraySize(BitArraySize::Int {
+                            location,
+                            int_value,
+                            ..
+                        }) if int_value % 8 != BigInt::ZERO => {
+                            self.track_feature_usage(
+                                FeatureKind::JavaScriptUnalignedBitArray,
+                                *location,
+                            );
                         }
-                    }
+                        Pattern::Int { .. }
+                        | Pattern::Float { .. }
+                        | Pattern::String { .. }
+                        | Pattern::Variable { .. }
+                        | Pattern::BitArraySize(_)
+                        | Pattern::Assign { .. }
+                        | Pattern::Discard { .. }
+                        | Pattern::List { .. }
+                        | Pattern::Constructor { .. }
+                        | Pattern::Tuple { .. }
+                        | Pattern::BitArray { .. }
+                        | Pattern::StringPrefix { .. }
+                        | Pattern::Invalid { .. } => (),
+                    },
 
-                    _ => (),
+                    BitArrayOption::Bytes { .. }
+                    | BitArrayOption::Int { .. }
+                    | BitArrayOption::Float { .. }
+                    | BitArrayOption::Utf8 { .. }
+                    | BitArrayOption::Utf16 { .. }
+                    | BitArrayOption::Utf32 { .. }
+                    | BitArrayOption::Utf8Codepoint { .. }
+                    | BitArrayOption::Utf16Codepoint { .. }
+                    | BitArrayOption::Utf32Codepoint { .. }
+                    | BitArrayOption::Signed { .. }
+                    | BitArrayOption::Unsigned { .. }
+                    | BitArrayOption::Big { .. }
+                    | BitArrayOption::Little { .. }
+                    | BitArrayOption::Native { .. }
+                    | BitArrayOption::Size { .. }
+                    | BitArrayOption::Unit { .. } => (),
                 }
             }
         }
@@ -528,7 +585,19 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 });
                 self.environment.new_unbound_var()
             }
-            _ => segment_type,
+            Pattern::Int { .. }
+            | Pattern::Float { .. }
+            | Pattern::String { .. }
+            | Pattern::Variable { .. }
+            | Pattern::BitArraySize(_)
+            | Pattern::Assign { .. }
+            | Pattern::Discard { .. }
+            | Pattern::List { .. }
+            | Pattern::Constructor { .. }
+            | Pattern::Tuple { .. }
+            | Pattern::BitArray { .. }
+            | Pattern::StringPrefix { .. }
+            | Pattern::Invalid { .. } => segment_type,
         };
 
         let typed_value = self.unify(*segment.value, type_.clone(), None);
@@ -553,7 +622,19 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     location: *location,
                 });
             }
-            _ => {}
+            Pattern::Int { .. }
+            | Pattern::Float { .. }
+            | Pattern::String { .. }
+            | Pattern::Variable { .. }
+            | Pattern::BitArraySize(_)
+            | Pattern::Assign { .. }
+            | Pattern::Discard { .. }
+            | Pattern::List { .. }
+            | Pattern::Constructor { .. }
+            | Pattern::Tuple { .. }
+            | Pattern::BitArray { .. }
+            | Pattern::StringPrefix { .. }
+            | Pattern::Invalid { .. } => {}
         };
 
         BitArraySegment {
@@ -767,7 +848,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 elements,
                 tail,
                 ..
-            } => match type_.get_app_arguments(
+            } => match type_.named_type_arguments(
                 Publicity::Public,
                 PRELUDE_PACKAGE_NAME,
                 PRELUDE_MODULE_NAME,
@@ -850,7 +931,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     Pattern::Tuple { elements, location }
                 }
 
-                _ => {
+                Type::Named { .. } | Type::Fn { .. } => {
                     let elements_types = (0..(elements.len()))
                         .map(|_| self.environment.new_unbound_var())
                         .collect();
@@ -1182,7 +1263,9 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         }
                     }
 
-                    _ => panic!("Unexpected constructor type for a constructor pattern."),
+                    Type::Var { .. } | Type::Tuple { .. } => {
+                        panic!("Unexpected constructor type for a constructor pattern.")
+                    }
                 }
             }
         }

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -185,7 +185,25 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 }
 
                 // right(left)
-                call => (
+                UntypedExpr::Int { .. }
+                | UntypedExpr::Float { .. }
+                | UntypedExpr::String { .. }
+                | UntypedExpr::Block { .. }
+                | UntypedExpr::Var { .. }
+                | UntypedExpr::List { .. }
+                | UntypedExpr::BinOp { .. }
+                | UntypedExpr::PipeLine { .. }
+                | UntypedExpr::Case { .. }
+                | UntypedExpr::FieldAccess { .. }
+                | UntypedExpr::Tuple { .. }
+                | UntypedExpr::TupleIndex { .. }
+                | UntypedExpr::Todo { .. }
+                | UntypedExpr::Panic { .. }
+                | UntypedExpr::Echo { .. }
+                | UntypedExpr::BitArray { .. }
+                | UntypedExpr::RecordUpdate { .. }
+                | UntypedExpr::NegateBool { .. }
+                | UntypedExpr::NegateInt { .. } => (
                     PipelineAssignmentKind::FunctionCall,
                     self.infer_apply_pipe(call),
                 ),
@@ -367,7 +385,10 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
             UnifyError::CouldNotUnify {
                 expected, given, ..
             } => (expected.as_ref(), given.as_ref()),
-            _ => return false,
+            UnifyError::ExtraVarInAlternativePattern { .. }
+            | UnifyError::MissingVarInAlternativePattern { .. }
+            | UnifyError::DuplicateVarInPattern { .. }
+            | UnifyError::RecursiveType => return false,
         };
 
         match types {


### PR DESCRIPTION
This PR enables a clippy lint which prevents using wildcard (`_`) matches when matching on enums. It also fixes all the places that caused a warning after enabling that lint (which was a lot).

In most cases I expanded the wildcard to all the variants it was implicitly matching, but in some cases where it was clear only one variant was needed (and not future variants), I used `if let` or `matches!` (For example, in the `is_x_variant` functions).