### PR TITLE
Fix singleton inequality when using qualified syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   invalid code.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where checking for equality with a variant with no fields using
+  qualified syntax would generate invalid code on the JavaScript target.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.14.0-rc1 - 2025-12-15
 
 ### Compiler

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__variant_defined_in_another_module_qualified_clause_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__variant_defined_in_another_module_qualified_clause_guard.snap
@@ -23,7 +23,7 @@ import * as $other_module from "../other_module.mjs";
 
 export function process(e) {
   let value = e;
-  if (value instanceof Variant) {
+  if (value instanceof $other_module.Variant) {
     return "match";
   } else {
     return "no match";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__variant_defined_in_another_module_qualified_expression.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__variant_defined_in_another_module_qualified_expression.snap
@@ -16,9 +16,8 @@ pub fn check(x) -> Bool {
 
 
 ----- COMPILED JAVASCRIPT
-import { isEqual } from "../gleam.mjs";
 import * as $other_module from "../other_module.mjs";
 
 export function check(x) {
-  return isEqual(x, new $other_module.Variant());
+  return x instanceof $other_module.Variant;
 }


### PR DESCRIPTION
Fixes #5211 

I've also fixed a related bug where the optimisation would not occur at all when using qualified syntax and not in a guard clause.
There were already tests for both these cases so I have simply updated their snapshots.