### PR TITLE
Improve error message when failing to publish a package which already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Build tool
+
+- The build tool now prints a better error message when the user does not have
+  permission to publish a package which already exists on Hex.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.14.0-rc3 - 2025-12-21
 
 ### Bug fixes

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -87,6 +87,7 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
     cli::print_publishing(&config.name, &config.version);
 
     runtime.block_on(hex::publish_package(
+        &config.name,
         package_tarball,
         config.version.to_string(),
         &api_key,

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -323,6 +323,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
     #[error("Version already published")]
     HexPublishReplaceRequired { version: String },
 
+    #[error("No permission to publish package")]
+    HexPublishForbidden { version: String, package: EcoString },
+
     #[error("The gleam version constraint is wrong and so cannot be published")]
     CannotPublishWrongVersion {
         minimum_required_version: SmallVersion,
@@ -4582,6 +4585,19 @@ or you can publish it using a different version number"
                 hint: Some(
                     "Please add the --replace flag if you want to replace the release.".into(),
                 ),
+            }],
+
+            Error::HexPublishForbidden { package, version } => vec![Diagnostic {
+                title: "No permission to publish package".into(),
+                text: wrap_format!(
+                    "I couldn't publish v{version} of {package}. That name is \
+already taken on hex and you don't have permission to publish it."
+                ),
+                level: Level::Error,
+                location: None,
+                hint: Some(format!(
+                    "Choose a new name or make sure you are authorised to publish {package}."
+                )),
             }],
 
             Error::CannotAddSelfAsDependency { name } => vec![Diagnostic {

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -28,6 +28,7 @@ fn key_name(hostname: &str) -> String {
 }
 
 pub async fn publish_package<Http: HttpClient>(
+    name: &ecow::EcoString,
     release_tarball: Vec<u8>,
     version: String,
     api_key: &str,
@@ -40,6 +41,10 @@ pub async fn publish_package<Http: HttpClient>(
     let response = http.send(request).await?;
     hexpm::api_publish_package_response(response).map_err(|e| match e {
         ApiError::NotReplacing => Error::HexPublishReplaceRequired { version },
+        ApiError::Forbidden => Error::HexPublishForbidden {
+            version,
+            package: name.clone(),
+        },
         err => Error::hex(err),
     })
 }


### PR DESCRIPTION
As discussed [on discord](https://discord.com/channels/768594524158427167/768594524158427170/1453017773411401740), the current error message can be a little confusing when trying to publish a package that already exists, and you don't have permission to modify it. This PR updates it to be more helpful