### PR TITLE
Set language server version to 1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "gleam-language-server"
-version = "1.14.0-rc1"
+version = "1.14.0"
 dependencies = [
  "camino",
  "debug-ignore",

--- a/language-server/Cargo.toml
+++ b/language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam-language-server"
-version = "1.14.0-rc1"
+version = "1.14.0"
 authors = ["Louis Pilfold <louis@lpil.uk>"]
 edition = "2024"
 license-file = "LICENCE"


### PR DESCRIPTION
While working on #5213, I noticed language server package is still on 1.14.0-rc1, even though 1.14.0 was already released!