### PR TITLE
bump max number of use expressions without segfaulting from 73 to 139

### DIFF
--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -857,7 +857,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 },
             )
         };
-        let call = stacker::maybe_grow(64 * 1024, 1024 * 1024, infer_call);
+        let call = stacker::maybe_grow(64 * 1024, 2 * 1024 * 1024, infer_call);
 
         // After typing the call we know that the last argument must be an
         // anonymous function and the first assignments in its body are the


### PR DESCRIPTION
hello I have no idea what I'm doing

I could reprod a segfault compiling and https://github.com/dinkelspiel/seg_fault_gleam/ and https://github.com/bondiano/telega-gleam (not my project, a dependency I'm using) with a locally-built gleam compiler compiled to use musl libc with `cross build --release --target x86_64-unknown-linux-musl` (as well as released gleam 1.13 or 1.14)

looking back through previous issues, this sounded similar to https://github.com/gleam-lang/gleam/issues/4287, which was fixed by https://github.com/gleam-lang/gleam/pull/4577/ . I experimented with the values of the arguments passed to `stacker::maybe_grow` and found that if I bumped the second arg to 2MB I could no longer reprod the segfault... at least with 100 decoders, on experimentation it looks like 2MB allows up to 139. so the max number is ~linear with max stack size, which makes sense

clearly this isn't in some sense a proper fix, 139 is no less arbitrary than 73. but at least it means that telega which compiled with gleam 1.12 can be used with a newer gleam version, pending a better fix by someone who has a better idea what they're doing. (I don't know what changed in 1.13 to cause the regression).