### PR TITLE
Fix bug with case expressions and assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
   if the last argument was followed by a trailing comment.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would generate invalid code on the JavaScript
+  target when using a `case` expression as the right hand side of an equality
+  check in an `assert`.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server no longer recommends the deprecated `@target` attribute.
   ([Hari Mohan](https://github.com/seafoamteal))
 

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -39,6 +39,7 @@ pub fn case<'a>(
         kind: DecisionKind::Case { clauses },
     }
     .decision(&compiled_case.tree);
+
     docvec![assignments_to_doc(assignments), decision.into_doc()].force_break()
 }
 

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -776,8 +776,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         if let TypedExpr::Block { statements, .. } = expression {
             self.statements(statements)
         } else {
-            let expression_document = self.expression(expression);
-            self.add_statement_level(expression_document)
+            self.expression(expression)
         }
     }
 
@@ -924,10 +923,9 @@ impl<'module, 'a> Generator<'module, 'a> {
         } = assert;
 
         let message = match message {
-            Some(m) => self.not_in_tail_position(
-                Some(Ordering::Strict),
-                |this: &mut Generator<'module, 'a>| this.expression(m),
-            ),
+            Some(message) => {
+                self.not_in_tail_position(Some(Ordering::Strict), |this| this.expression(message))
+            }
             None => string("Assertion failed."),
         };
 

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -871,3 +871,19 @@ pub fn main() {
 }"#
     );
 }
+
+#[test]
+fn var_true() {
+    assert_js!(
+        r#"
+fn true() { True }
+pub fn main() {
+    let true_ = true()
+    assert 0 == case Nil {
+        _ if true_ -> 0
+        _ -> 1
+    }
+}
+"#
+    )
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__var_true.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__var_true.snap
@@ -1,0 +1,57 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\nfn true() { True }\npub fn main() {\n    let true_ = true()\n    assert 0 == case Nil {\n        _ if true_ -> 0\n        _ -> 1\n    }\n}\n"
+---
+----- SOURCE CODE
+
+fn true() { True }
+pub fn main() {
+    let true_ = true()
+    assert 0 == case Nil {
+        _ if true_ -> 0
+        _ -> 1
+    }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError } from "../gleam.mjs";
+
+const FILEPATH = "src/module.gleam";
+
+function true$() {
+  return true;
+}
+
+export function main() {
+  let true_ = true$();
+  let $ = 0;
+  let _block;
+  let $1 = undefined;
+  if (true_) {
+    _block = 0;
+  } else {
+    _block = 1;
+  }
+  let $2 = _block;
+  if (!($ === $2)) {
+    throw makeError(
+      "assert",
+      FILEPATH,
+      "my/mod",
+      5,
+      "main",
+      "Assertion failed.",
+      {
+        kind: "binary_operator",
+        operator: "==",
+        left: { kind: "literal", value: $, start: 70, end: 71 },
+        right: { kind: "expression", value: $2, start: 75, end: 130 },
+        start: 63,
+        end: 130,
+        expression_start: 70
+      }
+    )
+  }
+  return undefined;
+}

--- a/test/language/gleam.toml
+++ b/test/language/gleam.toml
@@ -6,5 +6,7 @@ gleeunit = ">= 1.9.0 and < 2.0.0"
 
 [javascript.deno]
 allow_read = [
-  "./build"
+  "./build",
+  "gleam.toml",
+  "test"
 ]


### PR DESCRIPTION
This PR fixes a test that is failing on the main branch.
The compiler no longer generates invalid code when a case expression is used on the right hand side of an equality check in an assert!