### PR TITLE
Fix a bug where the formatter would not be able to format an internal const list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@
   items.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the formatter would not be able to consistently format a
+  constant list with an `@internal` attribute.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server no longer recommends the deprecated `@target` attribute.
   ([Hari Mohan](https://github.com/seafoamteal))
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -466,7 +466,7 @@ impl<'comments> Formatter<'comments> {
                     None => head,
                     Some(t) => head.append(": ").append(self.type_ast(t)),
                 };
-                head.append(" = ").append(self.const_expr(value))
+                head.append(" = ").append(self.const_expr(value).group())
             }
         }
     }
@@ -3272,6 +3272,7 @@ impl<'a> Documentable<'a> for &'a BinOp {
 }
 
 #[allow(clippy::enum_variant_names)]
+#[derive(Debug)]
 /// This is used to determine how to fit the items of a list, or the segments of
 /// a bit array in a line.
 ///

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6823,3 +6823,16 @@ fn can_format_big_list_without_stack_overflowing() {
 "
     ));
 }
+
+// https://github.com/gleam-lang/gleam/issues/5323
+#[test]
+fn internal_const_list_is_kept_on_multiple_lines() {
+    assert_format!(
+        "@internal
+pub const list = [
+  LeftToRight,
+  RightToLeft,
+]
+"
+    );
+}


### PR DESCRIPTION
This PR closes #5323 

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
