### PR TITLE
Fix global caching issue for republished versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,3 +176,7 @@
 - Fixed a bug where generics in custom types would not be properly generated
   when emitting TypeScript declarations.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where the package cache would not properly be reset when a version
+  of a package was replaced on Hex.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -191,10 +191,7 @@ impl Downloader {
             }
         };
 
-        let tarball_path = paths::global_package_cache_package_tarball(
-            &package.name,
-            &package.version.to_string(),
-        );
+        let tarball_path = paths::global_package_cache_package_tarball(outer_checksum);
         if self.fs_reader.is_file(&tarball_path) {
             tracing::info!(
                 package = package.name.as_str(),
@@ -232,22 +229,32 @@ impl Downloader {
         package: &ManifestPackage,
     ) -> Result<bool> {
         let _ = self.ensure_package_downloaded(package).await?;
-        self.extract_package_from_cache(&package.name, &package.version)
+        self.extract_package_from_cache(package)
     }
 
     // It would be really nice if this was async but the library is sync
-    pub fn extract_package_from_cache(&self, name: &str, version: &Version) -> Result<bool> {
+    pub fn extract_package_from_cache(&self, package: &ManifestPackage) -> Result<bool> {
         let contents_path = Utf8Path::new("contents.tar.gz");
-        let destination = self.paths.build_packages_package(name);
+        let destination = self.paths.build_packages_package(&package.name);
+
+        let outer_checksum = match &package.source {
+            ManifestPackageSource::Hex { outer_checksum } => outer_checksum,
+            ManifestPackageSource::Git { .. } | ManifestPackageSource::Local { .. } => {
+                panic!("Attempt to download non-hex package from hex")
+            }
+        };
 
         // If the directory already exists then there's nothing for us to do
         if self.fs_reader.is_directory(&destination) {
-            tracing::info!(package = name, "Package already in build directory");
+            tracing::info!(
+                package = package.name.as_str(),
+                "Package already in build directory"
+            );
             return Ok(false);
         }
 
-        tracing::info!(package = name, "writing_package_to_target");
-        let tarball = paths::global_package_cache_package_tarball(name, &version.to_string());
+        tracing::info!(package = package.name.as_str(), "writing_package_to_target");
+        let tarball = paths::global_package_cache_package_tarball(outer_checksum);
         let reader = self.fs_reader.reader(&tarball)?;
         let mut archive = Archive::new(reader);
 

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -1,4 +1,7 @@
-use crate::build::{Mode, Target};
+use crate::{
+    build::{Mode, Target},
+    manifest::Base16Checksum,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -126,8 +129,8 @@ impl ProjectPaths {
     }
 }
 
-pub fn global_package_cache_package_tarball(package_name: &str, version: &str) -> Utf8PathBuf {
-    global_packages_cache().join(format!("{package_name}-{version}.tar"))
+pub fn global_package_cache_package_tarball(checksum: &Base16Checksum) -> Utf8PathBuf {
+    global_packages_cache().join(format!("{}.tar", checksum.to_string()))
 }
 
 pub fn global_hexpm_credentials_path() -> Utf8PathBuf {
@@ -166,12 +169,12 @@ fn paths() {
     assert!(global_packages_cache().ends_with("hex/hexpm/packages"));
 
     assert!(
-        global_package_cache_package_tarball("gleam_stdlib", "0.17.1")
-            .ends_with("hex/hexpm/packages/gleam_stdlib-0.17.1.tar")
+        global_package_cache_package_tarball(&Base16Checksum(vec![0, 0, 0, 0]))
+            .ends_with("hex/hexpm/packages/00000000.tar")
     );
 
     assert!(
-        global_package_cache_package_tarball("elli", "1.0.0")
-            .ends_with("hex/hexpm/packages/elli-1.0.0.tar")
+        global_package_cache_package_tarball(&Base16Checksum(vec![0x3A, 0x21, 0xF4]))
+            .ends_with("hex/hexpm/packages/3A21F4.tar")
     );
 }


### PR DESCRIPTION
Fixes #4698

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

For now I've gone with using the checksum as the key as it seemed more straightforward, but it shouldn't be too difficult to change if we want to retain name-version key and compare checksums.

I haven't added any tests yet. I'm not sure if there's a good way to test this change or if tests are needed. I have run this locally and it seems to behave fine.