### PR TITLE
Fix bad_generator crash when linked OTP process exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,10 @@
   of a package was replaced on Hex.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a crash (`bad_generator`) that could occur when a linked OTP process
+  exits with a non-standard exit reason.
+  ([John Downey](https://github.com/jtdowney))
+
 - Fixed a bug where diagnostic about incorrect `size` and `unit` options would
   use incorrect error location.
   ([Andrey Kozhev](https://github.com/ankddev))

--- a/test-output/cases/linked_process_exit/gleam.toml
+++ b/test-output/cases/linked_process_exit/gleam.toml
@@ -1,0 +1,2 @@
+name = "linked_process_exit"
+version = "1.0.0"

--- a/test-output/cases/linked_process_exit/src/main.gleam
+++ b/test-output/cases/linked_process_exit/src/main.gleam
@@ -1,0 +1,6 @@
+@external(erlang, "main_ffi", "spawn_and_exit")
+fn spawn_and_exit() -> Nil
+
+pub fn main() {
+  spawn_and_exit()
+}

--- a/test-output/cases/linked_process_exit/src/main_ffi.erl
+++ b/test-output/cases/linked_process_exit/src/main_ffi.erl
@@ -1,0 +1,12 @@
+-module(main_ffi).
+-export([spawn_and_exit/0]).
+
+%% Spawn a linked process that exits with a non-standard reason.
+%% This tests that the @@main.erl template handles exit reasons
+%% that aren't {Reason, StackTrace} tuples (issue #4766).
+spawn_and_exit() ->
+    spawn_link(fun() ->
+        exit({shutdown, <<"test reason">>})
+    end),
+    %% Wait briefly to ensure the linked process exits and kills us
+    receive after 100 -> nil end.

--- a/test-output/src/tests/echo.rs
+++ b/test-output/src/tests/echo.rs
@@ -221,3 +221,8 @@ fn echo_singleton() {
 fn echo_with_message() {
     assert_echo!("echo_with_message");
 }
+
+#[test]
+fn linked_process_exit() {
+    assert_echo!(Target::Erlang, "linked_process_exit");
+}

--- a/test-output/src/tests/snapshots/test_output__tests__echo__erlang-linked_process_exit.snap
+++ b/test-output/src/tests/snapshots/test_output__tests__echo__erlang-linked_process_exit.snap
@@ -1,0 +1,20 @@
+---
+source: test-output/src/tests/echo.rs
+expression: output
+---
+--- main.gleam ----------------------
+@external(erlang, "main_ffi", "spawn_and_exit")
+fn spawn_and_exit() -> Nil
+
+pub fn main() {
+  spawn_and_exit()
+}
+
+
+--- gleam run output ----------------
+[31;1mruntime error[39m: Erlang exit[0m
+
+An error occurred outside of Gleam.
+
+exit reason:
+  {shutdown,<<"test reason">>}


### PR DESCRIPTION
Handle exit reasons that aren't `{Reason, StackTrace}` tuples, such as those from OTP supervisors or gen_servers. Previously, these caused the runtime to crash with `bad_generator` when formatting the error.

Fixes #4766

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
