### PR TITLE
Increase infer_use stacker red zone from 64KiB to 128KiB

### DIFF
--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -857,7 +857,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 },
             )
         };
-        let call = stacker::maybe_grow(64 * 1024, 2 * 1024 * 1024, infer_call);
+        let call = stacker::maybe_grow(128 * 1024, 2 * 1024 * 1024, infer_call);
 
         // After typing the call we know that the last argument must be an
         // anonymous function and the first assignments in its body are the


### PR DESCRIPTION
Fixes #5338 - a stack overflow in
type_::tests::no_stack_overflow_for_nested_use when debug symbols are enabled.

The regression bisects to the const record updates feature in #5061, but CI disables debug symbols CARGO_PROFILE_TEST_DEBUG=0 so this slipped in.

Stack frames with debuginfo exhaust in stacker's [red zone](https://docs.rs/stacker/latest/stacker/index.html) more quickly. Empirically, it fails at red zone 72KiB, passes at 80KiB. 128KiB gives us some headroom.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
   - Fixing existing test
- [x] The changelog has been updated for any user-facing changes
   - Bugfix, not user-visible
