### PR TITLE
fix annoying pipeline behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,10 @@
   constant list with an `@internal` attribute.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The "convert to pipe" code action now works on nested function calls as well,
+  rather than always being applied to the outermost one.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server no longer recommends the deprecated `@target` attribute.
   ([Hari Mohan](https://github.com/seafoamteal))
 

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -7147,7 +7147,22 @@ impl<'ast> ast::visit::Visit<'ast> for ConvertToPipe<'ast> {
             next_arg: arguments
                 .get(position + 1)
                 .map(|argument| argument.location),
-        })
+        });
+
+        // We still want to visit the arguments so that if we're hovering a
+        // nested pipeline, that's going to be the one we transform:
+        //
+        // ```gleam
+        // wibble(Wobble(
+        //   field: call(other(last(1)))
+        //  //      ^^^^ We want to convert this one if we hover over it,
+        //  //           not the outer `wibble(Wobble(...))` call
+        // ))
+        // ```
+        //
+        for argument in arguments {
+            ast::visit::visit_typed_call_arg(self, argument);
+        }
     }
 
     fn visit_typed_expr_pipeline(

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -8955,6 +8955,21 @@ fn bug() {
     );
 }
 
+#[test]
+fn convert_to_pipe_with_nested_calls_picks_the_innermost_one() {
+    assert_code_action!(
+        CONVERT_TO_PIPE,
+        "
+fn bug() {
+    wibble(Wobble(
+      field: woo(other_call(last))
+    ))
+}
+",
+        find_position_of("woo").to_selection()
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/4342
 #[test]
 fn inline_variable_in_record_update() {

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__convert_to_pipe_pipes_the_outermost_argument.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__convert_to_pipe_pipes_the_outermost_argument.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/action.rs
+source: language-server/src/tests/action.rs
 expression: "\npub fn main() {\n  wibble(wobble(woo))\n}\n"
 ---
 ----- BEFORE ACTION
@@ -13,5 +13,5 @@ pub fn main() {
 ----- AFTER ACTION
 
 pub fn main() {
-  wobble(woo) |> wibble
+  wibble(woo |> wobble)
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__convert_to_pipe_with_nested_calls_picks_the_innermost_one.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__convert_to_pipe_with_nested_calls_picks_the_innermost_one.snap
@@ -1,0 +1,21 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\nfn bug() {\n    wibble(Wobble(\n      field: woo(other_call(last))\n    ))\n}\n"
+---
+----- BEFORE ACTION
+
+fn bug() {
+    wibble(Wobble(
+      field: woo(other_call(last))
+             ↑                    
+    ))
+}
+
+
+----- AFTER ACTION
+
+fn bug() {
+    wibble(Wobble(
+      field: other_call(last) |> woo
+    ))
+}


### PR DESCRIPTION
Previously the "convert to pipe" code action could only work on the outermost call ignoring any nested call. I thought that was a bit annoying and Louis agreed, so here's a fix!

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
