### PR TITLE
fix purity for dict.each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,10 @@
   unreachable.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the Gleam standard library's `dict.each` function would
+  incorrectly be assumed to be pure.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The compiler now correctly tracks the minimum required version for constant
   record updates to be `>= 1.14.0`.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -324,8 +324,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         };
 
         let purity = if is_trusted_pure_module(environment) {
-            // The standard library uses a lot of FFI, but as we are the maintainers we know that
-            // it can be trusted to pure pure.
+            // The standard library uses a lot of FFI, but as we are the
+            // maintainers we know that it can be trusted to be pure.
             Purity::TrustedPure
         } else if uses_externals {
             Purity::Impure
@@ -5335,11 +5335,10 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
     }
 }
 
-/// Returns `true` if the current function is one that the Gleam core team
+/// Returns `true` if the current module is one that the Gleam core team
 /// maintains and we know it to be pure.
 /// Used in purity tracking.
 fn is_trusted_pure_module(environment: &Environment<'_>) -> bool {
-    // We only t
     if environment.current_package != STDLIB_PACKAGE_NAME {
         return false;
     }


### PR DESCRIPTION
This has been reported by Rebecca and Chouquette, I couldn't find the related issue so it might have been talked about only on Discord.

This fixes the bug where the compiler would think `dict.each` is pure and then warn about it being unused.

- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
