### PR TITLE
refactor: use more cryptic name for JS entrypoint

### DIFF
--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -10,6 +10,7 @@ use gleam_core::{
     io::{Command, CommandExecutor, Stdio},
     paths::ProjectPaths,
     type_::ModuleFunction,
+    version::COMPILER_VERSION,
 };
 
 use crate::{config::PackageKind, fs::ProjectIO};
@@ -252,7 +253,7 @@ fn write_javascript_entrypoint(
     let path = paths
         .build_directory_for_package(Mode::Dev, Target::JavaScript, package)
         .to_path_buf()
-        .join("gleam.main.mjs");
+        .join(format!("gleam@@private_main_v{}.mjs", COMPILER_VERSION));
     let module = format!(
         r#"import {{ main }} from "./{module}.mjs";
 main();


### PR DESCRIPTION
Closes #4835.
#### Showcase
<img width="1193" height="197" alt="showcase" src="https://github.com/user-attachments/assets/b85a9baf-bc35-44bd-9d5e-64c80d718756" />

***
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
