### PR TITLE
Fallback to hardlinking if can't symlink on Windows w/o dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
 - More readable error message when trying to revert an old release.
   ([Moritz Böhme](https://github.com/MoritzBoehme))
 
+- The build tool now falls back to copying directories when it fails to symlink
+  one. This often occurs on Windows without "Developer mode" enabled.
+  ([Andrey Kozhev](https://github.com/ankddev))
+
 ### Language server
 
 - The language server now supports go-to-definition, find-references and rename

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@
 - More readable error message when trying to revert an old release.
   ([Moritz Böhme](https://github.com/MoritzBoehme))
 
-- The build tool now falls back to copying directories when it fails to symlink
-  one. This often occurs on Windows without "Developer mode" enabled.
+- The build tool now falls back to recursively hardlinking directories on
+  Windows when it fails to symlink one due to disabled "Developer mode".
   ([Andrey Kozhev](https://github.com/ankddev))
 
 ### Language server

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -705,10 +705,18 @@ pub fn copy_dir(path: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> Result<
     .map(|_| ())
 }
 
-pub fn symlink_dir(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Result<(), Error> {
+/// Symlink directory.
+/// If it couldn't symlink directory on Windows because of error 1314, which
+/// occurs without Developer Mode enabled, it falls back to hardlinking each
+/// file in directory.
+///
+pub fn symlink_dir(
+    src: impl AsRef<Utf8Path> + Debug,
+    dest: impl AsRef<Utf8Path> + Debug,
+) -> Result<(), Error> {
+    tracing::debug!(src=?src, dest=?dest, "symlinking");
     let src = src.as_ref();
     let dest = dest.as_ref();
-    tracing::debug!(src=?src, dest=?dest, "symlinking");
     let src = canonicalise(src)?;
 
     #[cfg(target_family = "windows")]
@@ -727,7 +735,7 @@ pub fn symlink_dir(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
         Err(err) => Err(Error::FileIo {
             action: FileIoAction::Link,
             kind: FileKind::File,
-            path: Utf8PathBuf::from(dest.as_ref()),
+            path: Utf8PathBuf::from(dest),
             err: Some(err.to_string()),
         }),
     }

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -719,8 +719,9 @@ pub fn symlink_dir(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
     match result {
         Ok(()) => Ok(()),
 
-        // Fallback to hardlinking if we can't symlink. This occurs on Windows without Developer Mode enabled.
-        // We match on the raw OS code, since this error has no specific error kind.
+        // Fallback to hardlinking if we can't symlink. This occurs on Windows
+        // without Developer Mode enabled. We match on the raw OS code, since
+        // this error has no specific error kind.
         #[cfg(target_family = "windows")]
         Err(err) if err.raw_os_error() == Some(1314) => hardlink_dir(src, dest),
         Err(err) => Err(Error::FileIo {

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -198,6 +198,10 @@ impl FileSystemWriter for ProjectIO {
         hardlink(from, to)
     }
 
+    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error> {
+        hardlink_dir(from, to)
+    }
+
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error> {
         symlink_dir(from, to)
     }
@@ -715,10 +719,10 @@ pub fn symlink_dir(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
     match result {
         Ok(()) => Ok(()),
 
-        // Fallback to copying if we can't symlink. This occurs on Windows without Developer Mode enabled.
+        // Fallback to hardlinking if we can't symlink. This occurs on Windows without Developer Mode enabled.
         // We match on the raw OS code, since this error has no specific error kind.
         #[cfg(target_family = "windows")]
-        Err(err) if err.raw_os_error() == Some(1314) => copy_dir(src, dest),
+        Err(err) if err.raw_os_error() == Some(1314) => hardlink_dir(src, dest),
         Err(err) => Err(Error::FileIo {
             action: FileIoAction::Link,
             kind: FileKind::File,
@@ -740,6 +744,50 @@ pub fn hardlink(from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> Result<
             err: Some(err.to_string()),
         })
         .map(|_| ())
+}
+
+/// Hardlink directory.
+/// This is done by deleting destination directory if it exists and recursively
+/// creating directories and hardlinking files inside the directory.
+///
+pub fn hardlink_dir(
+    src: impl AsRef<Utf8Path> + Debug,
+    dest: impl AsRef<Utf8Path> + Debug,
+) -> Result<(), Error> {
+    tracing::trace!(src=?src, dest=?dest, "hardlinking_dir");
+
+    let src = src.as_ref();
+    let dest = dest.as_ref();
+
+    // Recreate destination directory to avoid getting it in weird state.
+    delete_directory(dest)?;
+    mkdir(dest)?;
+
+    for entry in read_dir(src)? {
+        let entry = entry.map_err(|e| Error::FileIo {
+            action: FileIoAction::Read,
+            kind: FileKind::Directory,
+            path: src.to_path_buf(),
+            err: Some(e.to_string()),
+        })?;
+
+        let path = entry.path();
+
+        let file_name = path.file_name().ok_or_else(|| Error::NonUtf8Path {
+            path: path.to_path_buf().into(),
+        })?;
+
+        let destination = &dest.join(file_name);
+
+        if path.is_dir() {
+            // Recursively hardlink directory.
+            hardlink_dir(path, destination)?;
+        } else {
+            hardlink(path, destination)?;
+        }
+    }
+
+    Ok(())
 }
 
 /// Check if the given path is inside a git work tree.

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -760,7 +760,8 @@ pub fn hardlink_directory(
     let src = src.as_ref();
     let dest = dest.as_ref();
 
-    // Recreate destination directory to avoid getting it in weird state.
+    // Recreate destination directory to avoid presence of old files,
+    // that don't exist in source directory already.
     delete_directory(dest)?;
     mkdir(dest)?;
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -198,8 +198,8 @@ impl FileSystemWriter for ProjectIO {
         hardlink(from, to)
     }
 
-    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error> {
-        hardlink_dir(from, to)
+    fn hardlink_directory(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error> {
+        hardlink_directory(from, to)
     }
 
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error> {
@@ -723,7 +723,7 @@ pub fn symlink_dir(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
         // without Developer Mode enabled. We match on the raw OS code, since
         // this error has no specific error kind.
         #[cfg(target_family = "windows")]
-        Err(err) if err.raw_os_error() == Some(1314) => hardlink_dir(src, dest),
+        Err(err) if err.raw_os_error() == Some(1314) => hardlink_directory(src, dest),
         Err(err) => Err(Error::FileIo {
             action: FileIoAction::Link,
             kind: FileKind::File,
@@ -751,7 +751,7 @@ pub fn hardlink(from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> Result<
 /// This is done by deleting destination directory if it exists and recursively
 /// creating directories and hardlinking files inside the directory.
 ///
-pub fn hardlink_dir(
+pub fn hardlink_directory(
     src: impl AsRef<Utf8Path> + Debug,
     dest: impl AsRef<Utf8Path> + Debug,
 ) -> Result<(), Error> {
@@ -782,7 +782,7 @@ pub fn hardlink_dir(
 
         if path.is_dir() {
             // Recursively hardlink directory.
-            hardlink_dir(path, destination)?;
+            hardlink_directory(path, destination)?;
         } else {
             hardlink(path, destination)?;
         }

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -15,7 +15,7 @@ use gleam_core::{
 };
 use gleam_language_server::{DownloadDependencies, Locker, MakeLocker};
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     fmt::Debug,
     fs::{File, exists},
     io::{self, BufRead, BufReader, Write},
@@ -763,29 +763,33 @@ pub fn hardlink_directory(
     // Recreate destination directory to avoid presence of old files,
     // that don't exist in source directory already.
     delete_directory(dest)?;
-    mkdir(dest)?;
 
-    for entry in read_dir(src)? {
-        let entry = entry.map_err(|e| Error::FileIo {
-            action: FileIoAction::Read,
-            kind: FileKind::Directory,
-            path: src.to_path_buf(),
-            err: Some(e.to_string()),
-        })?;
+    let mut stack: VecDeque<(Utf8PathBuf, Utf8PathBuf)> = VecDeque::new();
+    stack.push_back((src.to_path_buf(), dest.to_path_buf()));
 
-        let path = entry.path();
+    while let Some((source_directory, destination_directory)) = stack.pop_front() {
+        mkdir(&destination_directory)?;
+        for entry in read_dir(source_directory)? {
+            let entry = entry.map_err(|e| Error::FileIo {
+                action: FileIoAction::Read,
+                kind: FileKind::Directory,
+                path: src.to_path_buf(),
+                err: Some(e.to_string()),
+            })?;
 
-        let file_name = path.file_name().ok_or_else(|| Error::NonUtf8Path {
-            path: path.to_path_buf().into(),
-        })?;
+            let path = entry.path().to_path_buf();
 
-        let destination = &dest.join(file_name);
+            let file_name = path.file_name().ok_or_else(|| Error::NonUtf8Path {
+                path: path.to_path_buf().into(),
+            })?;
 
-        if path.is_dir() {
-            // Recursively hardlink directory.
-            hardlink_directory(path, destination)?;
-        } else {
-            hardlink(path, destination)?;
+            let destination = destination_directory.join(file_name).to_path_buf();
+
+            if path.is_dir() {
+                stack.push_back((path, destination));
+            } else {
+                hardlink(path, destination)?;
+            }
         }
     }
 

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -712,9 +712,20 @@ pub fn symlink_dir(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
     #[cfg(not(target_family = "windows"))]
     let result = std::os::unix::fs::symlink(&src, dest);
 
-    // Fallback to copying if we can't symlink. This occurs, for example,
-    // on Windows without developer mode enabled.
-    result.or_else(|_| copy_dir(src, dest))
+    match result {
+        Ok(()) => Ok(()),
+
+        // Fallback to copying if we can't symlink. This occurs on Windows without Developer Mode enabled.
+        // We match on the raw OS code, since this error has no specific error kind.
+        #[cfg(target_family = "windows")]
+        Err(err) if err.raw_os_error() == Some(1314) => copy_dir(src, dest),
+        Err(err) => Err(Error::FileIo {
+            action: FileIoAction::Link,
+            kind: FileKind::File,
+            path: Utf8PathBuf::from(dest.as_ref()),
+            err: Some(err.to_string()),
+        }),
+    }
 }
 
 pub fn hardlink(from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> Result<(), Error> {

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -708,17 +708,13 @@ pub fn symlink_dir(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
     let src = canonicalise(src)?;
 
     #[cfg(target_family = "windows")]
-    let result = std::os::windows::fs::symlink_dir(src, dest);
+    let result = std::os::windows::fs::symlink_dir(&src, dest);
     #[cfg(not(target_family = "windows"))]
-    let result = std::os::unix::fs::symlink(src, dest);
+    let result = std::os::unix::fs::symlink(&src, dest);
 
-    result.map_err(|err| Error::FileIo {
-        action: FileIoAction::Link,
-        kind: FileKind::File,
-        path: Utf8PathBuf::from(dest),
-        err: Some(err.to_string()),
-    })?;
-    Ok(())
+    // Fallback to copying if we can't symlink. This occurs, for example,
+    // on Windows without developer mode enabled.
+    result.or_else(|_| copy_dir(src, dest))
 }
 
 pub fn hardlink(from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> Result<(), Error> {

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -343,7 +343,7 @@ pub trait FileSystemWriter {
     fn copy(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn copy_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn hardlink(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
-    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
+    fn hardlink_directory(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn delete_file(&self, path: &Utf8Path) -> Result<(), Error>;
     fn exists(&self, path: &Utf8Path) -> bool;

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -343,6 +343,7 @@ pub trait FileSystemWriter {
     fn copy(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn copy_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn hardlink(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
+    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<(), Error>;
     fn delete_file(&self, path: &Utf8Path) -> Result<(), Error>;
     fn exists(&self, path: &Utf8Path) -> bool;

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -192,7 +192,7 @@ impl FileSystemWriter for InMemoryFileSystem {
         Ok(())
     }
 
-    fn hardlink_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
+    fn hardlink_directory(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
         panic!("unimplemented") // TODO
     }
 

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -192,6 +192,10 @@ impl FileSystemWriter for InMemoryFileSystem {
         Ok(())
     }
 
+    fn hardlink_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
+        panic!("unimplemented") // TODO
+    }
+
     fn symlink_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
         panic!("unimplemented") // TODO
     }

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -62,7 +62,7 @@ impl FileSystemWriter for WasmFileSystem {
         Ok(())
     }
 
-    fn hardlink_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
+    fn hardlink_directory(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
         Ok(())
     }
 

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -62,6 +62,10 @@ impl FileSystemWriter for WasmFileSystem {
         Ok(())
     }
 
+    fn hardlink_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
+        Ok(())
+    }
+
     fn symlink_dir(&self, _: &Utf8Path, _: &Utf8Path) -> Result<(), Error> {
         Ok(())
     }

--- a/language-server/src/files.rs
+++ b/language-server/src/files.rs
@@ -95,8 +95,8 @@ where
         self.io.hardlink(from, to)
     }
 
-    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
-        self.io.hardlink_dir(from, to)
+    fn hardlink_directory(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+        self.io.hardlink_directory(from, to)
     }
 
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {

--- a/language-server/src/files.rs
+++ b/language-server/src/files.rs
@@ -95,6 +95,10 @@ where
         self.io.hardlink(from, to)
     }
 
+    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+        self.io.hardlink_dir(from, to)
+    }
+
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         self.io.symlink_dir(from, to)
     }

--- a/language-server/src/tests.rs
+++ b/language-server/src/tests.rs
@@ -215,6 +215,10 @@ impl FileSystemWriter for LanguageServerTestIO {
         self.io.hardlink(from, to)
     }
 
+    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+        self.io.hardlink_dir(from, to)
+    }
+
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
         self.io.symlink_dir(from, to)
     }

--- a/language-server/src/tests.rs
+++ b/language-server/src/tests.rs
@@ -215,8 +215,8 @@ impl FileSystemWriter for LanguageServerTestIO {
         self.io.hardlink(from, to)
     }
 
-    fn hardlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
-        self.io.hardlink_dir(from, to)
+    fn hardlink_directory(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+        self.io.hardlink_directory(from, to)
     }
 
     fn symlink_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {


### PR DESCRIPTION
* Closes https://github.com/gleam-lang/gleam/issues/3015

Hardlinking is only supported for files on most filesystems, so it falls back to copying directory.
I haven't written a test, since it's hard to write that test and the logic is quite trivial.
***
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
