### PR TITLE
chore(deps): ⬆️ bump actions/checkout from v4 to v6 in gleam new command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 
 ### Build tool
 
+- Upgraded `actions/checkout` from v4 to v6 in the GitHub Actions workflow used by `gleam new`.
+  ([Christian Widlund](https://github.com/chrillep))
+
 - When adding a package that does not exist on Hex, the message is a bit
   friendlier.
   ([Ameen Radwan](https://github.com/Acepie))

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -185,7 +185,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "{ERLANG_OTP_VERSION}"


### PR DESCRIPTION
* Upgraded `actions/checkout` from v4 to v6 in the GitHub Actions workflow in `compiler-cli/src/new.rs`

- [ ] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

closes #5385
