### PR TITLE
Fix links in docs/compiler/README.md

### DIFF
--- a/docs/compiler/README.md
+++ b/docs/compiler/README.md
@@ -4,11 +4,11 @@ Hello! Welcome to the documentation for the Gleam compiler. I hope you have fun
 with the project!
 
 <!-- vscode-markdown-toc -->
-* [Project structure](#Projectstructure)
-* [Compilation flow](#Compilationflow)
-* [Testing](#Testing)
-	* [Running the tests](#Runningthetests)
-	* [Snapshot testing](#Snapshottesting)
+* [Project structure](#project-structure)
+* [Compilation flow](#compilation-flow)
+* [Testing](#testing)
+	* [Running the tests](#running-the-tests)
+	* [Snapshot testing](#snapshot-testing)
 
 <!-- vscode-markdown-toc-config
 	numbering=false


### PR DESCRIPTION
- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes

Looking at the `CONTRIBUTING.md`, these above boxes appear to be for code changes, so I haven't checked any.

In `docs/compiler/README.md`, the links for the table of contents don't work, since they were formatted wrong. This PR fixes the links.