### PR TITLE
autocomplete keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server now suggests completions for keywords like `echo`,
+  `panic`, and `todo`.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server now suggests adding missing type parameters
   to custom generic types.
   ([Andi Pabst](https://github.com/andipabst))

--- a/language-server/src/tests/completion.rs
+++ b/language-server/src/tests/completion.rs
@@ -22,7 +22,7 @@ pub fn show_complete(code: &str, position: Position) -> String {
     str
 }
 
-fn apply_conversion(src: &str, completions: Vec<CompletionItem>, value: &str) -> String {
+fn apply_completion(src: &str, completions: Vec<CompletionItem>, value: &str) -> String {
     let completion = completions
         .iter()
         .find(|c| c.label == value)
@@ -43,7 +43,7 @@ macro_rules! assert_apply_completion {
         let output = format!(
             "{}\n\n----- After applying completion -----\n{}",
             show_complete(src, $position),
-            apply_conversion(src, completions, $name)
+            apply_completion(src, completions, $name)
         );
         insta::assert_snapshot!(insta::internals::AutoName, output, src);
     };
@@ -2319,5 +2319,32 @@ pub fn new() {
     assert_completion!(
         TestProject::for_source(code).add_dep_module("gleam/list", dep),
         Position::new(4, 8)
+    );
+}
+
+#[test]
+fn complete_keyword_being_typed() {
+    assert_apply_completion!(
+        TestProject::for_source("pub fn main() { t }"),
+        "todo",
+        Position::new(0, 17)
+    );
+}
+
+#[test]
+fn complete_echo_keyword() {
+    assert_apply_completion!(
+        TestProject::for_source("pub fn main() { e wibble }"),
+        "echo",
+        Position::new(0, 17)
+    );
+}
+
+#[test]
+fn complete_panic_keyword() {
+    assert_apply_completion!(
+        TestProject::for_source("pub fn main() { wibble(p) }"),
+        "panic",
+        Position::new(0, 24)
     );
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__argument_shadowing.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__argument_shadowing.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn main(x: Int) {\n  fn(x: Float) {\n\n  }\n}\n"
 ---
 pub fn main(x: Int) {
@@ -13,34 +13,34 @@ pub fn main(x: Int) {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn(Int) -> fn(Float) -> a
-  sort:   02_main
+  sort:   03_main
   desc:   app
   edits:
     [3:0-3:0]: "main"
 x
   kind:   Variable
   detail: Float
-  sort:   2_x
+  sort:   3_x
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__argument_variable_shadowing.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__argument_variable_shadowing.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn main(x: Int) {\n  let x = [1, 2]\n\n}\n"
 ---
 pub fn main(x: Int) {
@@ -12,34 +12,34 @@ pub fn main(x: Int) {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn(Int) -> List(Int)
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [3:0-3:0]: "main"
 x
   kind:   Variable
   detail: List(Int)
-  sort:   2_x
+  sort:   3_x
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__complete_echo_keyword.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__complete_echo_keyword.snap
@@ -1,0 +1,9 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "pub fn main() { e wibble }"
+---
+pub fn main() { e| wibble }
+
+
+----- After applying completion -----
+pub fn main() { echo wibble }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__complete_keyword_being_typed.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__complete_keyword_being_typed.snap
@@ -1,0 +1,9 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "pub fn main() { t }"
+---
+pub fn main() { t| }
+
+
+----- After applying completion -----
+pub fn main() { todo }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__complete_panic_keyword.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__complete_panic_keyword.snap
@@ -1,0 +1,9 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "pub fn main() { wibble(p) }"
+---
+pub fn main() { wibble(p|) }
+
+
+----- After applying completion -----
+pub fn main() { wibble(panic) }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completion_for_partially_correct_existing_module_select.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completion_for_partially_correct_existing_module_select.snap
@@ -14,7 +14,7 @@ pub fn new() {
 list.filter
   kind:   Function
   detail: fn() -> a
-  sort:   3_list.filter
+  sort:   4_list.filter
   desc:   app
   edits:
     [4:2-4:10]: "list.filter"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completion_for_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completion_for_type.snap
@@ -9,5 +9,5 @@ pub fn new() -> wibble.|Wibble {}
 wibble.Wibble
   kind:   Class
   detail: Type
-  sort:   5_wibble.Wibble
+  sort:   6_wibble.Wibble
     [0:0-0:0]: "import wibble\n\n"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_const_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_const_annotation.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n\nconst wibble: Int = 7\n\npub fn main() {\n  let wibble: Int = 7\n}\n"
 ---
 const wibble: In|t = 7
@@ -13,36 +13,36 @@ pub fn main() {
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_function_arg_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_function_arg_annotation.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 pub fn wibble(
@@ -13,36 +13,36 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_function_return_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_function_return_annotation.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 pub fn wibble(
@@ -13,36 +13,36 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_var_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_a_var_annotation.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn main() {\n  let wibble: Int = 7\n}\n"
 ---
 pub fn main() {
@@ -11,36 +11,36 @@ pub fn main() {
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_unqualified_import.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_unqualified_import.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep.{}\n\npub fn main() {\n  0\n}"
 ---
 import dep.{|}
@@ -13,27 +13,27 @@ pub fn main() {
 Wibble
   kind:   Class
   detail: Type
-  sort:   3_Wibble
+  sort:   4_Wibble
   edits:
     [1:12-1:12]: "type Wibble"
 myfun
   kind:   Function
   detail: fn() -> Int
-  sort:   3_myfun
+  sort:   4_myfun
   desc:   dep
   edits:
     [1:12-1:12]: "myfun"
 wabble
   kind:   Constant
   detail: String
-  sort:   3_wabble
+  sort:   4_wabble
   desc:   dep
   edits:
     [1:12-1:12]: "wabble"
 wibble
   kind:   Constant
   detail: String
-  sort:   3_wibble
+  sort:   4_wibble
   desc:   dep
   edits:
     [1:12-1:12]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_unqualified_import_already_imported.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep.{wibble,wabble,type Wibble}\n\npub fn main() {\n  0\n}"
 ---
 import dep.{|wibble,wabble,type Wibble}
@@ -13,7 +13,7 @@ pub fn main() {
 myfun
   kind:   Function
   detail: fn() -> Int
-  sort:   3_myfun
+  sort:   4_myfun
   desc:   dep
   edits:
     [1:12-1:12]: "myfun"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_unqualified_import_on_new_line.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep.{\n  wibble,\n\n}\n\npub fn main() {\n  0\n}"
 ---
 import dep.{
@@ -16,13 +16,13 @@ pub fn main() {
 Wibble
   kind:   Class
   detail: Type
-  sort:   3_Wibble
+  sort:   4_Wibble
   edits:
     [3:0-3:0]: "type Wibble"
 myfun
   kind:   Function
   detail: fn() -> Int
-  sort:   3_myfun
+  sort:   4_myfun
   desc:   dep
   edits:
     [3:0-3:0]: "myfun"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_function_labels.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_function_labels.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nfn wibble(wibble arg1: String, wobble arg2: String) {\n  arg1 <> arg2\n}\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = wibble()\n}\n"
 ---
 fn wibble(wibble arg1: String, wobble arg2: String) {
@@ -15,42 +15,42 @@ fn fun() { // completion inside parens below includes labels
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 fun
   kind:   Function
   detail: fn() -> String
-  sort:   2_fun
+  sort:   3_fun
   desc:   app
   edits:
     [6:22-6:22]: "fun"
 wibble
   kind:   Function
   detail: fn(String, String) -> String
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   edits:
     [6:22-6:22]: "wibble"
 wibble:
   kind:   Field
   detail: String
-  sort:   0_wibble:
+  sort:   1_wibble:
 wobble:
   kind:   Field
   detail: String
-  sort:   0_wobble:
+  sort:   1_wobble:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_imported_function_labels.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_imported_function_labels.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = dep.wibble()\n}\n"
 ---
 import dep
@@ -13,42 +13,42 @@ fn fun() { // completion inside parens below includes labels
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wibble
   kind:   Function
   detail: fn(String, String) -> String
-  sort:   3_dep.wibble
+  sort:   4_dep.wibble
   desc:   app
   edits:
     [4:26-4:26]: "dep.wibble"
 fun
   kind:   Function
   detail: fn() -> String
-  sort:   2_fun
+  sort:   3_fun
   desc:   app
   edits:
     [4:26-4:26]: "fun"
 wibble:
   kind:   Field
   detail: String
-  sort:   0_wibble:
+  sort:   1_wibble:
 wobble:
   kind:   Field
   detail: String
-  sort:   0_wobble:
+  sort:   1_wobble:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_imported_record_labels.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_imported_record_labels.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = dep.Wibble()\n}\n"
 ---
 import dep
@@ -13,42 +13,42 @@ fn fun() { // completion inside parens below includes labels
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.Wibble
   kind:   Constructor
   detail: fn(String, Int) -> Wibble
-  sort:   3_dep.Wibble
+  sort:   4_dep.Wibble
   desc:   app
   edits:
     [4:26-4:26]: "dep.Wibble"
 fun
   kind:   Function
   detail: fn() -> Wibble
-  sort:   2_fun
+  sort:   3_fun
   desc:   app
   edits:
     [4:26-4:26]: "fun"
 wibble:
   kind:   Field
   detail: String
-  sort:   0_wibble:
+  sort:   1_wibble:
 wobble:
   kind:   Field
   detail: Int
-  sort:   0_wobble:
+  sort:   1_wobble:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_prelude_values.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_prelude_values.snap
@@ -11,27 +11,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [2:16-2:17]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_private_record_access.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_private_record_access.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\ntype Wibble {\n  Wibble(wibble: Int, wobble: Int)\n  Wobble(wabble: Int, wobble: Int)\n}\n\nfn fun() {\n  let wibble = Wibble(1, 2)\n  wibble.wobble\n}\n"
 ---
 type Wibble {
@@ -17,8 +17,8 @@ fn fun() {
 wibble
   kind:   Field
   detail: Int
-  sort:   01_wibble
+  sort:   02_wibble
 wobble
   kind:   Field
   detail: Int
-  sort:   01_wobble
+  sort:   02_wobble

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_access.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_access.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Int)\n  Wobble(wabble: Int, wobble: Int)\n}\n\nfn fun() {\n  let wibble = Wibble(1, 2)\n  wibble.wobble\n}\n"
 ---
 pub type Wibble {
@@ -17,8 +17,8 @@ fn fun() {
 wibble
   kind:   Field
   detail: Int
-  sort:   01_wibble
+  sort:   02_wibble
 wobble
   kind:   Field
   detail: Int
-  sort:   01_wobble
+  sort:   02_wobble

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_access_known_variant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_access_known_variant.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\ntype Wibble {\n  Wibble(a: Int, b: Int, c: Int, d: Int)\n  Wobble(z: Bool)\n}\n\nfn fun(some_wibble: Wibble) {\n  case some_wibble {\n    Wibble(..) as w -> w.a\n    Wobble(..) -> panic\n  }\n}\n"
 ---
 type Wibble {
@@ -19,16 +19,16 @@ fn fun(some_wibble: Wibble) {
 a
   kind:   Field
   detail: Int
-  sort:   01_a
+  sort:   02_a
 b
   kind:   Field
   detail: Int
-  sort:   01_b
+  sort:   02_b
 c
   kind:   Field
   detail: Int
-  sort:   01_c
+  sort:   02_c
 d
   kind:   Field
   detail: Int
-  sort:   01_d
+  sort:   02_d

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_access_unknown_variant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_access_unknown_variant.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\ntype Wibble {\n  Wibble(a: Int, b: Int, c: Int, d: Int)\n  Wobble(a: Int, z: Bool)\n}\n\nfn fun(some_wibble: Wibble) {\n  some_wibble.a\n}\n"
 ---
 type Wibble {
@@ -16,4 +16,4 @@ fn fun(some_wibble: Wibble) {
 a
   kind:   Field
   detail: Int
-  sort:   01_a
+  sort:   02_a

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_labels.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_record_labels.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Wibble {\n  Wibble(wibble: String, wobble: Int)\n}\n\nfn fun() { // completion inside parens below includes labels\n  let wibble = Wibble()\n}\n"
 ---
 pub type Wibble {
@@ -15,42 +15,42 @@ fn fun() { // completion inside parens below includes labels
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wibble
   kind:   Constructor
   detail: fn(String, Int) -> Wibble
-  sort:   2_Wibble
+  sort:   3_Wibble
   desc:   app
   edits:
     [6:22-6:22]: "Wibble"
 fun
   kind:   Function
   detail: fn() -> Wibble
-  sort:   2_fun
+  sort:   3_fun
   desc:   app
   edits:
     [6:22-6:22]: "fun"
 wibble:
   kind:   Field
   detail: String
-  sort:   0_wibble:
+  sort:   1_wibble:
 wobble:
   kind:   Field
   detail: Int
-  sort:   0_wobble:
+  sort:   1_wobble:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_type_import_completions_without_brackets.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_type_import_completions_without_brackets.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: import dep.
 ---
 import dep.|
@@ -9,6 +9,6 @@ import dep.|
 Wibble
   kind:   Class
   detail: Type
-  sort:   3_Wibble
+  sort:   4_Wibble
   edits:
     [0:11-0:11]: "{type Wibble}"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__constant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__constant.snap
@@ -10,34 +10,34 @@ const world = he|
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 hello
   kind:   Constant
   detail: Int
-  sort:   2_hello
+  sort:   3_hello
   desc:   app
   edits:
     [2:14-2:16]: "hello"
 world
   kind:   Constant
   detail: a
-  sort:   2_world
+  sort:   3_world
   desc:   app
   edits:
     [2:14-2:16]: "world"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__constant_with_many_options.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__constant_with_many_options.snap
@@ -21,69 +21,69 @@ const my_constant = a|
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wibble
   kind:   EnumMember
   detail: Wibble
-  sort:   2_Wibble
+  sort:   3_Wibble
   desc:   app
   edits:
     [13:20-13:21]: "Wibble"
 Wobble
   kind:   EnumMember
   detail: Wibble
-  sort:   3_Wobble
+  sort:   4_Wobble
   desc:   app
   edits:
     [13:20-13:21]: "Wobble"
 my_constant
   kind:   Constant
   detail: a
-  sort:   2_my_constant
+  sort:   3_my_constant
   desc:   app
   edits:
     [13:20-13:21]: "my_constant"
 pi
   kind:   Constant
   detail: Float
-  sort:   2_pi
+  sort:   3_pi
   desc:   app
   edits:
     [13:20-13:21]: "pi"
 some_function
   kind:   Function
   detail: fn() -> a
-  sort:   2_some_function
+  sort:   3_some_function
   desc:   app
   edits:
     [13:20-13:21]: "some_function"
 wibble.Wobble
   kind:   EnumMember
   detail: Wibble
-  sort:   3_wibble.Wobble
+  sort:   4_wibble.Wobble
   desc:   app
   edits:
     [13:20-13:21]: "wibble.Wobble"
 wibble.Wubble
   kind:   EnumMember
   detail: Wibble
-  sort:   3_wibble.Wubble
+  sort:   4_wibble.Wubble
   desc:   app
   edits:
     [13:20-13:21]: "wibble.Wubble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__constant_with_module_select.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__constant_with_module_select.snap
@@ -21,28 +21,28 @@ const my_constant = wibble.W|
 wibble.Wobble
   kind:   EnumMember
   detail: Wibble
-  sort:   3_wibble.Wobble
+  sort:   4_wibble.Wobble
   desc:   app
   edits:
     [13:20-13:28]: "wibble.Wobble"
 wibble.Wubble
   kind:   EnumMember
   detail: Wibble
-  sort:   3_wibble.Wubble
+  sort:   4_wibble.Wubble
   desc:   app
   edits:
     [13:20-13:28]: "wibble.Wubble"
 wibble.some_constant
   kind:   Constant
   detail: Int
-  sort:   3_wibble.some_constant
+  sort:   4_wibble.some_constant
   desc:   app
   edits:
     [13:20-13:28]: "wibble.some_constant"
 wibble.some_function
   kind:   Function
   detail: fn() -> a
-  sort:   3_wibble.some_function
+  sort:   4_wibble.some_function
   desc:   app
   edits:
     [13:20-13:28]: "wibble.some_function"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__for_custom_type_definition.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__for_custom_type_definition.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Wibble {\n  Wobble\n}"
 ---
 pub type Wibble {
@@ -11,42 +11,42 @@ pub type Wibble {
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 Wibble
   kind:   Class
   detail: Type
-  sort:   2_Wibble
+  sort:   3_Wibble
   edits:
     [2:0-2:0]: "Wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__for_function_arguments.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__for_function_arguments.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 pub fn wibble(
@@ -13,36 +13,36 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__for_type_alias.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__for_type_alias.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Wibble = Result(\n  String,\n  String\n)\n"
 ---
 pub type Wibble = Result(
@@ -12,42 +12,42 @@ pub type Wibble = Result(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 Wibble
   kind:   Class
   detail: Type
-  sort:   2_Wibble
+  sort:   3_Wibble
   edits:
     [2:0-2:0]: "Wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_adds_extra_new_line_if_import_exists_below_other_definitions.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_adds_extra_new_line_if_import_exists_below_other_definitions.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep2\n"
 ---
 |
@@ -10,27 +10,27 @@ import dep2
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   5_dep.wobble
+  sort:   6_dep.wobble
   desc:   dep
   edits:
     [1:0-1:0]: "dep.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_adds_extra_new_line_if_no_imports.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_adds_extra_new_line_if_no_imports.snap
@@ -1,32 +1,32 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: ""
 ---
 ----- Completion content -----
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   5_dep.wobble
+  sort:   6_dep.wobble
   desc:   dep
   edits:
     [1:0-1:0]: "dep.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_does_not_add_extra_new_line_if_imports_exist.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_does_not_add_extra_new_line_if_imports_exist.snap
@@ -1,32 +1,32 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: ""
 ---
 ----- Completion content -----
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   5_dep.wobble
+  sort:   6_dep.wobble
   desc:   dep
   edits:
     [3:0-3:0]: "dep.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_does_not_add_extra_new_line_if_newline_exists.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_does_not_add_extra_new_line_if_newline_exists.snap
@@ -1,32 +1,32 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: ""
 ---
 ----- Completion content -----
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   5_dep.wobble
+  sort:   6_dep.wobble
   desc:   dep
   edits:
     [2:0-2:0]: "dep.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_module_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_module_function.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n"
 ---
 |
@@ -9,27 +9,27 @@ expression: "\n"
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   5_dep.wobble
+  sort:   6_dep.wobble
   desc:   dep
   edits:
     [1:0-1:0]: "dep.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_module_function_from_deep_module.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_module_function_from_deep_module.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n"
 ---
 |
@@ -9,27 +9,27 @@ expression: "\n"
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   5_dep.wobble
+  sort:   6_dep.wobble
   desc:   a/b/dep
   edits:
     [1:0-1:0]: "dep.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_module_function_with_existing_imports.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_module_function_with_existing_imports.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n//// Some module comments\n// Some other whitespace\n\nimport dep2\n"
 ---
 |
@@ -13,27 +13,27 @@ import dep2
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   5_dep.wobble
+  sort:   6_dep.wobble
   desc:   dep
   edits:
     [1:0-1:0]: "dep.wobble"
@@ -41,7 +41,7 @@ dep.wobble
 dep2.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   3_dep2.wobble
+  sort:   4_dep2.wobble
   desc:   app
   edits:
     [1:0-1:0]: "dep2.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 pub fn wibble(
@@ -13,43 +13,43 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   5_dep.Zoo
+  sort:   6_dep.Zoo
   edits:
     [3:0-3:0]: "dep.Zoo"
     [0:0-0:0]: "import dep\n"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type_from_deep_module.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type_from_deep_module.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 pub fn wibble(
@@ -13,43 +13,43 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   5_dep.Zoo
+  sort:   6_dep.Zoo
   edits:
     [3:0-3:0]: "dep.Zoo"
     [0:0-0:0]: "import a/b/dep\n"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type_with_existing_imports.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type_with_existing_imports.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n//// Some module comments\n// Some other whitespace\n\nimport dep2\n\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 //// Some module comments
@@ -18,49 +18,49 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   5_dep.Zoo
+  sort:   6_dep.Zoo
   edits:
     [7:0-7:0]: "dep.Zoo"
     [4:0-4:0]: "import dep\n"
 dep2.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep2.Zoo
+  sort:   4_dep2.Zoo
   edits:
     [7:0-7:0]: "dep2.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type_with_existing_imports_at_top.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__importable_type_with_existing_imports_at_top.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "import dep2\n\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 import dep2
@@ -15,49 +15,49 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   5_dep.Zoo
+  sort:   6_dep.Zoo
   edits:
     [3:0-3:0]: "dep.Zoo"
     [0:0-0:0]: "import dep\n"
 dep2.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep2.Zoo
+  sort:   4_dep2.Zoo
   edits:
     [3:0-3:0]: "dep2.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_module_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_module_function.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep\n"
 ---
 |
@@ -10,27 +10,27 @@ import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   3_dep.wobble
+  sort:   4_dep.wobble
   desc:   app
   edits:
     [1:0-1:0]: "dep.wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_public_enum.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_public_enum.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep\n"
 ---
 |
@@ -10,34 +10,34 @@ import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.Left
   kind:   EnumMember
   detail: Direction
-  sort:   3_dep.Left
+  sort:   4_dep.Left
   desc:   app
   edits:
     [1:0-1:0]: "dep.Left"
 dep.Right
   kind:   EnumMember
   detail: Direction
-  sort:   3_dep.Right
+  sort:   4_dep.Right
   desc:   app
   edits:
     [1:0-1:0]: "dep.Right"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_public_record.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_public_record.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep\n"
 ---
 |
@@ -10,27 +10,27 @@ import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.Box
   kind:   Constructor
   detail: fn(Int) -> Box
-  sort:   3_dep.Box
+  sort:   4_dep.Box
   desc:   app
   edits:
     [1:0-1:0]: "dep.Box"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "import dep\n\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 import dep
@@ -15,42 +15,42 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep.Zoo
+  sort:   4_dep.Zoo
   edits:
     [3:0-3:0]: "dep.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot.snap
@@ -15,4 +15,4 @@ pub fn wibble(
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep.Zoo
+  sort:   4_dep.Zoo

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_matching_modules.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_matching_modules.snap
@@ -16,4 +16,4 @@ pub fn wibble(
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep.Zoo
+  sort:   4_dep.Zoo

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_modules.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_modules.snap
@@ -15,4 +15,4 @@ pub fn wibble(
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep.Zoo
+  sort:   4_dep.Zoo

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_mid_phrase_other_modules.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_mid_phrase_other_modules.snap
@@ -15,4 +15,4 @@ pub fn wibble(
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep.Zoo
+  sort:   4_dep.Zoo

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_unqualified_module_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_unqualified_module_function.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep.{wobble}\n"
 ---
 |
@@ -10,34 +10,34 @@ import dep.{wobble}
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   3_dep.wobble
+  sort:   4_dep.wobble
   desc:   app
   edits:
     [1:0-1:0]: "dep.wobble"
 wobble
   kind:   Function
   detail: fn() -> Nil
-  sort:   3_wobble
+  sort:   4_wobble
   desc:   app
   edits:
     [1:0-1:0]: "wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_unqualified_public_enum.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_unqualified_public_enum.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep.{Left}\n"
 ---
 |
@@ -10,41 +10,41 @@ import dep.{Left}
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Left
   kind:   EnumMember
   detail: Direction
-  sort:   3_Left
+  sort:   4_Left
   desc:   app
   edits:
     [1:0-1:0]: "Left"
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.Left
   kind:   EnumMember
   detail: Direction
-  sort:   3_dep.Left
+  sort:   4_dep.Left
   desc:   app
   edits:
     [1:0-1:0]: "dep.Left"
 dep.Right
   kind:   EnumMember
   detail: Direction
-  sort:   3_dep.Right
+  sort:   4_dep.Right
   desc:   app
   edits:
     [1:0-1:0]: "dep.Right"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_unqualified_public_record.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_unqualified_public_record.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nimport dep.{Box}\n"
 ---
 |
@@ -10,34 +10,34 @@ import dep.{Box}
 Box
   kind:   Constructor
   detail: fn(Int) -> Box
-  sort:   3_Box
+  sort:   4_Box
   desc:   app
   edits:
     [1:0-1:0]: "Box"
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.Box
   kind:   Constructor
   detail: fn(Int) -> Box
-  sort:   3_dep.Box
+  sort:   4_dep.Box
   desc:   app
   edits:
     [1:0-1:0]: "dep.Box"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__in_custom_type_definition.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__in_custom_type_definition.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: import dep
 ---
 |import dep
@@ -9,20 +9,20 @@ expression: import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_types_from_a_dependency_are_ignored.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_types_from_a_dependency_are_ignored.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "import dep\n\npub fn wibble(\n    _: String,\n) -> Nil {\n    Nil\n}"
 ---
 import dep
@@ -15,36 +15,36 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_types_from_root_package_are_in_the_completions.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_types_from_root_package_are_in_the_completions.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "import dep\n\npub fn wibble(\n    _: String,\n) -> Nil {\n    Nil\n}"
 ---
 import dep
@@ -15,48 +15,48 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 dep.Alias
   kind:   Class
   detail: Type
-  sort:   3_dep.Alias
+  sort:   4_dep.Alias
   edits:
     [3:0-3:0]: "dep.Alias"
 dep.AnotherType
   kind:   Class
   detail: Type
-  sort:   3_dep.AnotherType
+  sort:   4_dep.AnotherType
   edits:
     [3:0-3:0]: "dep.AnotherType"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_types_from_the_same_module_are_in_the_completions.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_types_from_the_same_module_are_in_the_completions.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n@internal pub type Alias = Result(Int, String)\n@internal pub type AnotherType {\n  Wibble\n}\n"
 ---
 @internal pub type Alias = Result(Int, String)
@@ -12,48 +12,48 @@ expression: "\n@internal pub type Alias = Result(Int, String)\n@internal pub typ
 Alias
   kind:   Class
   detail: Type
-  sort:   2_Alias
+  sort:   3_Alias
   edits:
     [3:0-3:0]: "Alias"
 AnotherType
   kind:   Class
   detail: Type
-  sort:   2_AnotherType
+  sort:   3_AnotherType
   edits:
     [3:0-3:0]: "AnotherType"
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_values_from_a_dependency_are_ignored.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_values_from_a_dependency_are_ignored.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: import dep
 ---
 |import dep
@@ -9,20 +9,20 @@ expression: import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_values_from_root_package_are_in_the_completions.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: import dep
 ---
 |import dep
@@ -9,48 +9,48 @@ expression: import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 dep.Wobble
   kind:   EnumMember
   detail: Wibble
-  sort:   3_dep.Wobble
+  sort:   4_dep.Wobble
   desc:   app
   edits:
     [1:0-1:0]: "dep.Wobble"
 dep.main
   kind:   Function
   detail: fn() -> Int
-  sort:   3_dep.main
+  sort:   4_dep.main
   desc:   app
   edits:
     [1:0-1:0]: "dep.main"
 dep.random_float
   kind:   Function
   detail: fn() -> Float
-  sort:   3_dep.random_float
+  sort:   4_dep.random_float
   desc:   app
   edits:
     [1:0-1:0]: "dep.random_float"
 dep.wibble
   kind:   Constant
   detail: Int
-  sort:   3_dep.wibble
+  sort:   4_dep.wibble
   desc:   app
   edits:
     [1:0-1:0]: "dep.wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__internal_values_from_the_same_module_are_in_the_completions.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n@external(erlang, \"rand\", \"uniform\")\n@internal pub fn random_float() -> Float\n@internal pub fn main() { 0 }\n@internal pub type Wibble { Wobble }\n@internal pub const wibble = 1\n"
 ---
 |
@@ -14,48 +14,48 @@ expression: "\n@external(erlang, \"rand\", \"uniform\")\n@internal pub fn random
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wobble
   kind:   EnumMember
   detail: Wibble
-  sort:   2_Wobble
+  sort:   3_Wobble
   desc:   app
   edits:
     [1:0-1:0]: "Wobble"
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [1:0-1:0]: "main"
 random_float
   kind:   Function
   detail: fn() -> Float
-  sort:   2_random_float
+  sort:   3_random_float
   desc:   app
   edits:
     [1:0-1:0]: "random_float"
 wibble
   kind:   Constant
   detail: Int
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   edits:
     [1:0-1:0]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments.snap
@@ -15,42 +15,42 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wibble
   kind:   Constructor
   detail: fn(Int, Float) -> Wibble
-  sort:   2_Wibble
+  sort:   3_Wibble
   desc:   app
   edits:
     [6:9-6:10]: "Wibble"
 main
   kind:   Function
   detail: fn() -> Wibble
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [6:9-6:10]: "main"
 wibble:
   kind:   Field
   detail: Int
-  sort:   0_wibble:
+  sort:   1_wibble:
 wobble:
   kind:   Field
   detail: Float
-  sort:   0_wobble:
+  sort:   1_wobble:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_after_label.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_after_label.snap
@@ -15,34 +15,34 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wibble
   kind:   Constructor
   detail: fn(Int, Float) -> Wibble
-  sort:   2_Wibble
+  sort:   3_Wibble
   desc:   app
   edits:
     [6:17-6:18]: "Wibble"
 main
   kind:   Function
   detail: fn() -> Wibble
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [6:17-6:18]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_from_different_module.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_from_different_module.snap
@@ -13,38 +13,38 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 by:
   kind:   Field
   detail: Int
-  sort:   0_by:
+  sort:   1_by:
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [4:20-4:21]: "main"
 wibble.divide
   kind:   Function
   detail: fn(Int, Int) -> Int
-  sort:   3_wibble.divide
+  sort:   4_wibble.divide
   desc:   app
   edits:
     [4:20-4:21]: "wibble.divide"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_function_call.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_function_call.snap
@@ -13,38 +13,38 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 by:
   kind:   Field
   detail: Int
-  sort:   0_by:
+  sort:   1_by:
 divide
   kind:   Function
   detail: fn(Int, Int) -> Int
-  sort:   2_divide
+  sort:   3_divide
   desc:   app
   edits:
     [4:13-4:14]: "divide"
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [4:13-4:14]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_with_existing_label.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__labelled_arguments_with_existing_label.snap
@@ -15,38 +15,38 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wibble
   kind:   Constructor
   detail: fn(Int, Float) -> Wibble
-  sort:   2_Wibble
+  sort:   3_Wibble
   desc:   app
   edits:
     [6:21-6:22]: "Wibble"
 main
   kind:   Function
   detail: fn() -> Wibble
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [6:21-6:22]: "main"
 wobble:
   kind:   Field
   detail: Float
-  sort:   0_wobble:
+  sort:   1_wobble:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_private_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_private_type.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\ntype Zoo = Int\n\npub fn wibble(\n  x: String,\n) -> String {\n  \"ok\"\n}\n"
 ---
 type Zoo = Int
@@ -15,42 +15,42 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 Zoo
   kind:   Class
   detail: Type
-  sort:   2_Zoo
+  sort:   3_Zoo
   edits:
     [4:0-4:0]: "Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_enum.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_enum.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Direction {\n  Left\n  Right\n}\n"
 ---
 |
@@ -13,34 +13,34 @@ pub type Direction {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Left
   kind:   EnumMember
   detail: Direction
-  sort:   2_Left
+  sort:   3_Left
   desc:   app
   edits:
     [1:0-1:0]: "Left"
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 Right
   kind:   EnumMember
   detail: Direction
-  sort:   2_Right
+  sort:   3_Right
   desc:   app
   edits:
     [1:0-1:0]: "Right"
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_enum_with_documentation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_enum_with_documentation.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Direction {\n  /// Hello\n  Left\n  /// Goodbye\n  Right\n}\n"
 ---
 |
@@ -15,15 +15,15 @@ pub type Direction {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Left
   kind:   EnumMember
   detail: Direction
-  sort:   2_Left
+  sort:   3_Left
   desc:   app
   docs:   " Hello\n"
   edits:
@@ -31,15 +31,15 @@ Left
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 Right
   kind:   EnumMember
   detail: Direction
-  sort:   2_Right
+  sort:   3_Right
   desc:   app
   docs:   " Goodbye\n"
   edits:
@@ -47,4 +47,4 @@ Right
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_function.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn main() {\n  0\n}"
 ---
 |
@@ -12,27 +12,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [1:0-1:0]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_function_with_documentation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_function_with_documentation.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\n/// Hello\npub fn main() {\n  0\n}"
 ---
 |
@@ -13,27 +13,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   docs:   " Hello\n"
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_record.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_record.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Box {\n/// Hello\n  Box(Int, Int, Float)\n}\n"
 ---
 |
@@ -13,7 +13,7 @@ pub type Box {
 Box
   kind:   Constructor
   detail: fn(Int, Int, Float) -> Box
-  sort:   2_Box
+  sort:   3_Box
   desc:   app
   docs:   " Hello\n"
   edits:
@@ -21,20 +21,20 @@ Box
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_record_with_documentation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_public_record_with_documentation.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub type Box {\n  Box(Int, Int, Float)\n}\n"
 ---
 |
@@ -12,27 +12,27 @@ pub type Box {
 Box
   kind:   Constructor
   detail: fn(Int, Int, Float) -> Box
-  sort:   2_Box
+  sort:   3_Box
   desc:   app
   edits:
     [1:0-1:0]: "Box"
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable.snap
@@ -14,34 +14,34 @@ pub fn main(wibble: Int) {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn(Int) -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [3:2-3:3]: "main"
 wibble
   kind:   Variable
   detail: Int
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -49,7 +49,7 @@ wibble
 wobble
   kind:   Variable
   detail: Int
-  sort:   2_wobble
+  sort:   3_wobble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_anonymous_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_anonymous_function.snap
@@ -12,34 +12,34 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   02_main
+  sort:   03_main
   desc:   app
   edits:
     [2:34-2:40]: "main"
 wibble
   kind:   Variable
   detail: Int
-  sort:   02_wibble
+  sort:   03_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_as.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_as.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nfn wibble() {\n  let b as c = 5\n\n}\n"
 ---
 fn wibble() {
@@ -12,27 +12,27 @@ fn wibble() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 b
   kind:   Variable
   detail: Int
-  sort:   2_b
+  sort:   3_b
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -40,7 +40,7 @@ b
 c
   kind:   Variable
   detail: Int
-  sort:   2_c
+  sort:   3_c
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -48,7 +48,7 @@ c
 wibble
   kind:   Function
   detail: fn() -> Int
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   edits:
     [3:0-3:0]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_bit_array.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_bit_array.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nfn wibble() {\n  let assert <<h:1>> as i = <<1:1>>\n\n}\n"
 ---
 fn wibble() {
@@ -12,27 +12,27 @@ fn wibble() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 h
   kind:   Variable
   detail: Int
-  sort:   2_h
+  sort:   3_h
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -40,7 +40,7 @@ h
 i
   kind:   Variable
   detail: BitArray
-  sort:   2_i
+  sort:   3_i
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -48,7 +48,7 @@ i
 wibble
   kind:   Function
   detail: fn() -> BitArray
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   edits:
     [3:0-3:0]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_case_expression.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_case_expression.snap
@@ -14,34 +14,37 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [3:24-3:25]: "main"
+todo
+  kind:   Keyword
+  sort:   00_todo
 wibble
   kind:   Variable
   detail: Bool
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_function_call.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_function_call.snap
@@ -16,41 +16,41 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 add_one
   kind:   Function
   detail: fn(Int) -> Int
-  sort:   2_add_one
+  sort:   3_add_one
   desc:   app
   edits:
     [7:10-7:16]: "add_one"
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [7:10-7:16]: "main"
 wobble
   kind:   Variable
   detail: Int
-  sort:   2_wobble
+  sort:   3_wobble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_args.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_args.snap
@@ -13,27 +13,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 add_one
   kind:   Variable
   detail: fn(Int) -> Int
-  sort:   2_add_one
+  sort:   3_add_one
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -41,14 +41,14 @@ add_one
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [4:2-4:3]: "main"
 wobble
   kind:   Variable
   detail: Int
-  sort:   2_wobble
+  sort:   3_wobble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_args_nested.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_args_nested.snap
@@ -16,27 +16,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 add_two
   kind:   Variable
   detail: fn(Int) -> Int
-  sort:   02_add_two
+  sort:   03_add_two
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -44,14 +44,14 @@ add_two
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   02_main
+  sort:   03_main
   desc:   app
   edits:
     [5:4-5:10]: "main"
 wabble
   kind:   Variable
   detail: Int
-  sort:   02_wabble
+  sort:   03_wabble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -59,7 +59,7 @@ wabble
 wibble
   kind:   Variable
   detail: Int
-  sort:   02_wibble
+  sort:   03_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_returned.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_returned.snap
@@ -15,27 +15,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 add_two
   kind:   Variable
   detail: fn(Int) -> Int
-  sort:   02_add_two
+  sort:   03_add_two
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -43,14 +43,14 @@ add_two
 main
   kind:   Function
   detail: fn() -> fn(Int) -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [5:4-5:10]: "main"
 wabble
   kind:   Variable
   detail: Int
-  sort:   02_wabble
+  sort:   03_wabble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -58,7 +58,7 @@ wabble
 wibble
   kind:   Variable
   detail: Int
-  sort:   02_wibble
+  sort:   03_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignored.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignored.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nfn wibble() {\n  let a = 1\n  let _b = 2\n\n}\n"
 ---
 fn wibble() {
@@ -13,27 +13,27 @@ fn wibble() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 a
   kind:   Variable
   detail: Int
-  sort:   2_a
+  sort:   3_a
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -41,7 +41,7 @@ a
 wibble
   kind:   Function
   detail: fn() -> Int
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   edits:
     [4:0-4:0]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_inside_nested_exprs.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_inside_nested_exprs.snap
@@ -16,34 +16,34 @@ fn wibble() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   04_False
+  sort:   05_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   04_True
+  sort:   05_True
 Wobble
   kind:   Constructor
   detail: fn(List(#(Bool))) -> Wibble
-  sort:   2_Wobble
+  sort:   3_Wobble
   desc:   app
   edits:
     [5:4-5:7]: "Wobble"
 wibble
   kind:   Variable
   detail: Bool
-  sort:   02_wibble
+  sort:   03_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -51,5 +51,5 @@ wibble
 wibble
   kind:   Function
   detail: fn() -> a
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_nested_anonymous_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_nested_anonymous_function.snap
@@ -16,34 +16,34 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   02_main
+  sort:   03_main
   desc:   app
   edits:
     [4:36-4:42]: "main"
 wabble
   kind:   Variable
   detail: Int
-  sort:   02_wabble
+  sort:   03_wabble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -51,7 +51,7 @@ wabble
 wibble
   kind:   Variable
   detail: Int
-  sort:   02_wibble
+  sort:   03_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -59,7 +59,7 @@ wibble
 wobble
   kind:   Variable
   detail: Int
-  sort:   02_wobble
+  sort:   03_wobble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_pipe.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_pipe.snap
@@ -13,27 +13,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 add_one
   kind:   Variable
   detail: fn(Int) -> Int
-  sort:   02_add_one
+  sort:   03_add_one
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -41,14 +41,14 @@ add_one
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [4:12-4:19]: "main"
 wobble
   kind:   Variable
   detail: Int
-  sort:   2_wobble
+  sort:   3_wobble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_pipe_with_args.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_pipe_with_args.snap
@@ -14,27 +14,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 add_one
   kind:   Variable
   detail: fn(Int, Int) -> Int
-  sort:   2_add_one
+  sort:   3_add_one
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -42,14 +42,14 @@ add_one
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [5:23-5:29]: "main"
 wibble
   kind:   Variable
   detail: Int
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -57,7 +57,7 @@ wibble
 wobble
   kind:   Variable
   detail: Int
-  sort:   2_wobble
+  sort:   3_wobble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_string.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_string.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nfn wibble() {\n  let assert \"a\" <> j = \"ab\"\n\n}\n"
 ---
 fn wibble() {
@@ -12,27 +12,27 @@ fn wibble() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 j
   kind:   Variable
   detail: String
-  sort:   2_j
+  sort:   3_j
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -40,7 +40,7 @@ j
 wibble
   kind:   Function
   detail: fn() -> String
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   edits:
     [3:0-3:0]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_tuple.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_tuple.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nfn wibble() {\n  let assert #([d, e] as f, g) = #([0, 1], 2)\n\n}\n"
 ---
 fn wibble() {
@@ -12,27 +12,27 @@ fn wibble() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 d
   kind:   Variable
   detail: Int
-  sort:   2_d
+  sort:   3_d
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -40,7 +40,7 @@ d
 e
   kind:   Variable
   detail: Int
-  sort:   2_e
+  sort:   3_e
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -48,7 +48,7 @@ e
 f
   kind:   Variable
   detail: List(Int)
-  sort:   2_f
+  sort:   3_f
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -56,7 +56,7 @@ f
 g
   kind:   Variable
   detail: Int
-  sort:   2_g
+  sort:   3_g
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -64,7 +64,7 @@ g
 wibble
   kind:   Function
   detail: fn() -> #(List(Int), Int)
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   edits:
     [3:0-3:0]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_label_completions_in_nested_expression.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_label_completions_in_nested_expression.snap
@@ -15,34 +15,34 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wibble
   kind:   Constructor
   detail: fn(Int, Float) -> Wibble
-  sort:   2_Wibble
+  sort:   3_Wibble
   desc:   app
   edits:
     [6:10-6:11]: "Wibble"
 main
   kind:   Function
   detail: fn() -> Wibble
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [6:10-6:11]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_anonymous_function_scope.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_anonymous_function_scope.snap
@@ -14,27 +14,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [5:2-5:3]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_block_scope.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_block_scope.snap
@@ -14,27 +14,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [5:2-5:3]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_case_clause_scope.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_case_clause_scope.snap
@@ -15,34 +15,34 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   04_Nil
+  sort:   05_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [4:22-4:23]: "main"
 something_else
   kind:   Variable
   detail: a
-  sort:   02_something_else
+  sort:   03_something_else
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_case_scope.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_case_scope.snap
@@ -14,27 +14,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [5:2-5:3]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_case_clause.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_case_clause.snap
@@ -15,34 +15,34 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   04_Nil
+  sort:   05_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [3:17-3:18]: "main"
 something
   kind:   Variable
   detail: a
-  sort:   02_something
+  sort:   03_something
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_declaration_in_anonymous_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_declaration_in_anonymous_function.snap
@@ -14,27 +14,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [3:4-3:5]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_declaration_in_block.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_declaration_in_block.snap
@@ -14,27 +14,27 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [3:4-3:5]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__opaque_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__opaque_type.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub opaque type Wibble {\n  Wobble\n}\n"
 ---
 |
@@ -12,27 +12,27 @@ pub opaque type Wibble {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wobble
   kind:   EnumMember
   detail: Wibble
-  sort:   2_Wobble
+  sort:   3_Wobble
   desc:   app
   edits:
     [1:0-1:0]: "Wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_generic_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_generic_type.snap
@@ -13,34 +13,34 @@ pub fn main() -> Result(Int, Nil) {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   04_Error
+  sort:   05_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   04_Ok
+  sort:   05_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Result(Int, Nil)
-  sort:   02_main
+  sort:   03_main
   desc:   app
   edits:
     [4:2-4:3]: "main"
 result
   kind:   Variable
   detail: Result(Int, a)
-  sort:   02_result
+  sort:   03_result
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -48,7 +48,7 @@ result
 result2
   kind:   Variable
   detail: Result(a, Bool)
-  sort:   2_result2
+  sort:   3_result2
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_type.snap
@@ -15,48 +15,48 @@ fn addf(a, b) { a +. b }
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 add
   kind:   Function
   detail: fn(Int, Int) -> Int
-  sort:   02_add
+  sort:   03_add
   desc:   app
   edits:
     [2:2-2:3]: "add"
 addf
   kind:   Function
   detail: fn(Float, Float) -> Float
-  sort:   2_addf
+  sort:   3_addf
   desc:   app
   edits:
     [2:2-2:3]: "addf"
 main
   kind:   Function
   detail: fn() -> Int
-  sort:   02_main
+  sort:   03_main
   desc:   app
   edits:
     [2:2-2:3]: "main"
 sub
   kind:   Function
   detail: fn(Int, Int) -> Int
-  sort:   02_sub
+  sort:   03_sub
   desc:   app
   edits:
     [2:2-2:3]: "sub"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_values_matching_expected_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_values_matching_expected_type.snap
@@ -14,34 +14,34 @@ pub fn main() -> Bool {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   04_False
+  sort:   05_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   04_True
+  sort:   05_True
 main
   kind:   Function
   detail: fn() -> Bool
-  sort:   02_main
+  sort:   03_main
   desc:   app
   edits:
     [5:2-5:3]: "main"
 wibble
   kind:   Variable
   detail: Int
-  sort:   2_wibble
+  sort:   3_wibble
   desc:   app
   docs:   "A locally defined variable."
   edits:
@@ -49,7 +49,7 @@ wibble
 wubble
   kind:   Variable
   detail: Bool
-  sort:   02_wubble
+  sort:   03_wubble
   desc:   app
   docs:   "A locally defined variable."
   edits:

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_function.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\nfn private() {\n  1\n}\n"
 ---
 |
@@ -12,27 +12,27 @@ fn private() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 private
   kind:   Function
   detail: fn() -> Int
-  sort:   2_private
+  sort:   3_private
   desc:   app
   edits:
     [1:0-1:0]: "private"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_function_in_dep.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_function_in_dep.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: import dep
 ---
 |import dep
@@ -9,20 +9,20 @@ expression: import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_type.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\ntype Wibble {\n  Wobble\n}\n"
 ---
 |
@@ -12,27 +12,27 @@ type Wibble {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 Wobble
   kind:   EnumMember
   detail: Wibble
-  sort:   2_Wobble
+  sort:   3_Wobble
   desc:   app
   edits:
     [1:0-1:0]: "Wobble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_type_in_dep.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__private_type_in_dep.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: import dep
 ---
 |import dep
@@ -9,20 +9,20 @@ expression: import dep
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__unqualified_imported_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__unqualified_imported_type.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "import dep.{type Zoo}\n\npub fn wibble(\n  _: String,\n) -> Nil {\n  Nil\n}\n"
 ---
 import dep.{type Zoo}
@@ -15,48 +15,48 @@ pub fn wibble(
 BitArray
   kind:   Class
   detail: Type
-  sort:   4_BitArray
+  sort:   5_BitArray
 Bool
   kind:   Class
   detail: Type
-  sort:   4_Bool
+  sort:   5_Bool
 Float
   kind:   Class
   detail: Type
-  sort:   4_Float
+  sort:   5_Float
 Int
   kind:   Class
   detail: Type
-  sort:   4_Int
+  sort:   5_Int
 List
   kind:   Class
   detail: Type
-  sort:   4_List
+  sort:   5_List
 Nil
   kind:   Class
   detail: Type
-  sort:   4_Nil
+  sort:   5_Nil
 Result
   kind:   Class
   detail: Type
-  sort:   4_Result
+  sort:   5_Result
 String
   kind:   Class
   detail: Type
-  sort:   4_String
+  sort:   5_String
 UtfCodepoint
   kind:   Class
   detail: Type
-  sort:   4_UtfCodepoint
+  sort:   5_UtfCodepoint
 Zoo
   kind:   Class
   detail: Type
-  sort:   3_Zoo
+  sort:   4_Zoo
   edits:
     [3:0-3:0]: "Zoo"
 dep.Zoo
   kind:   Class
   detail: Type
-  sort:   3_dep.Zoo
+  sort:   4_dep.Zoo
   edits:
     [3:0-3:0]: "dep.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__variable_shadowing.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__variable_shadowing.snap
@@ -1,5 +1,5 @@
 ---
-source: compiler-core/src/language_server/tests/completion.rs
+source: language-server/src/tests/completion.rs
 expression: "\npub fn main() {\n  let x = 1\n  let x = [1, 2]\n\n}\n"
 ---
 pub fn main() {
@@ -13,34 +13,34 @@ pub fn main() {
 Error
   kind:   Constructor
   detail: gleam
-  sort:   4_Error
+  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
-  sort:   4_False
+  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
-  sort:   4_Nil
+  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
-  sort:   4_Ok
+  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam
-  sort:   4_True
+  sort:   5_True
 main
   kind:   Function
   detail: fn() -> List(Int)
-  sort:   2_main
+  sort:   3_main
   desc:   app
   edits:
     [4:0-4:0]: "main"
 x
   kind:   Variable
   detail: List(Int)
-  sort:   2_x
+  sort:   3_x
   desc:   app
   docs:   "A locally defined variable."
   edits:


### PR DESCRIPTION
This PR closes #5386 by adding completions for keywords that can be used as values: `todo`, `panic`, and `echo`.
Those have higher priority, so sadly this had to update all the existing snapshots 😔

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
