### PR TITLE
do not show completions for numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,9 @@
   in a project's dependencies.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server no longer shows completions when typing a number.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server no longer recommends the deprecated `@target` attribute.
   ([Hari Mohan](https://github.com/seafoamteal))
 

--- a/language-server/src/tests/completion.rs
+++ b/language-server/src/tests/completion.rs
@@ -2348,3 +2348,17 @@ fn complete_panic_keyword() {
         Position::new(0, 24)
     );
 }
+
+#[test]
+fn do_not_show_completions_when_typing_a_number() {
+    assert_completion!(
+        TestProject::for_source(
+            "
+pub fn main() { 2 }
+pub fn window_by_2() {}
+pub fn to_base_32() {}
+"
+        ),
+        Position::new(1, 17)
+    );
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_when_typing_a_number.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_when_typing_a_number.snap
@@ -1,0 +1,10 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\npub fn main() { 2 }\npub fn window_by_2() {}\npub fn to_base_32() {}\n"
+---
+pub fn main() { 2| }
+pub fn window_by_2() {}
+pub fn to_base_32() {}
+
+
+----- Completion content -----


### PR DESCRIPTION
This PR makes sure the completer won't return any completions when typing a number.
Right now when typing a number makes completions for functions with such number in the name pop up:
```gleam
  2
// ^ [list.window_by_2]
//   [int.to_base32]
//   ...
```
This usually happens in IDEs like Zed that still ask for completions even if the programmer is typing in a number.
We can't control when an IDE asks for completions, but we can avoid replying with completions that are most likely not useful in this context.

---

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
