### PR TITLE
feat: delete build caches after removing dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,3 +397,7 @@
 - The formatter now properly formats binary operations in bit array size
   segments.
   ([Andrey Kozhev](https://github.com/ankddev))
+
+- Fixed a bug where after removing dependencies with `gleam remove` if a
+  removed dependency is still used the build would succeed, resulting in
+  runtime crash due to missing files.

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -299,18 +299,23 @@ pub fn cleanup<Telem: Telemetry>(paths: &ProjectPaths, telemetry: Telem) -> Resu
     let changes = PackageChanges::between_manifests(&old_manifest, &manifest);
     telemetry.resolved_package_versions(&changes);
 
-    // Invalidate build caches after removing package
-    let target = config.target;
-    let name = config.name.clone();
+    // Cleanup build cache of the root package if there are some changes.
+    // Without this, if a removed dependency is still used, teh build will
+    // succeed, resulting in runtime crash due to missing files.
+    if changes.any_changes() {
+        tracing::debug!("cleaning_root_package_build_cache");
+        for mode in Mode::iter() {
+            for target in Target::iter() {
+                let lock = BuildLock::new_target(paths, mode, target)?;
+                let _guard = lock.lock(&telemetry)?;
 
-    // We need to clean build directory for the top level package for both dev
-    // and prod modes
-    for mode in [Mode::Dev, Mode::Prod] {
-        let lock = BuildLock::new_target(paths, mode, target)?;
-        let _guard = lock.lock(&telemetry)?;
-
-        let build_directory_path = paths.build_directory_for_package(mode, target, &name);
-        fs::delete_directory(build_directory_path.as_ref())?;
+                let build_directory_path =
+                    paths.build_directory_for_package(mode, target, &config.name);
+                if build_directory_path.exists() {
+                    fs::delete_directory(build_directory_path.as_ref())?;
+                }
+            }
+        }
     }
 
     Ok(manifest)

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -299,10 +299,19 @@ pub fn cleanup<Telem: Telemetry>(paths: &ProjectPaths, telemetry: Telem) -> Resu
     let changes = PackageChanges::between_manifests(&old_manifest, &manifest);
     telemetry.resolved_package_versions(&changes);
 
-    // Invalidate build caches after removing package. This deletes the entire
-    // build directory.
-    let build_directory_path = paths.build_directory();
-    fs::delete_directory(build_directory_path.as_ref())?;
+    // Invalidate build caches after removing package
+    let target = config.target;
+    let name = config.name.clone();
+
+    // We need to clean build directory for the top level package for both dev
+    // and prod modes
+    for mode in [Mode::Dev, Mode::Prod] {
+        let lock = BuildLock::new_target(paths, mode, target)?;
+        let _guard = lock.lock(&telemetry)?;
+
+        let build_directory_path = paths.build_directory_for_package(mode, target, &name);
+        fs::delete_directory(build_directory_path.as_ref())?;
+    }
 
     Ok(manifest)
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -299,6 +299,11 @@ pub fn cleanup<Telem: Telemetry>(paths: &ProjectPaths, telemetry: Telem) -> Resu
     let changes = PackageChanges::between_manifests(&old_manifest, &manifest);
     telemetry.resolved_package_versions(&changes);
 
+    // Invalidate build caches after removing package. This deletes the entire
+    // build directory.
+    let build_directory_path = paths.build_directory();
+    fs::delete_directory(build_directory_path.as_ref())?;
+
     Ok(manifest)
 }
 


### PR DESCRIPTION
* Closes https://github.com/gleam-lang/gleam/issues/5363
* Now it deletes the entire build directory after removing dependencies via `gleam remove`
***
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
