### PR TITLE
Do now wrap multiple tuple and field access in a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,9 @@
 
 ### Formatter
 
+- The formatter no longer wraps multiple tuple or field access into a block.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Bug fixes
 
 - The compiler now emits correctly-scoped JavaScript code for `case` expressions

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1118,13 +1118,7 @@ impl<'comments> Formatter<'comments> {
 
             UntypedExpr::FieldAccess {
                 label, container, ..
-            } => if let UntypedExpr::TupleIndex { .. } = container.as_ref() {
-                self.expr(container).surround("{ ", " }")
-            } else {
-                self.expr(container)
-            }
-            .append(".")
-            .append(label.as_str()),
+            } => self.expr(container).append(".").append(label.as_str()),
 
             UntypedExpr::Tuple { elements, location } => self.tuple(elements, location),
 

--- a/compiler-core/src/format/tests.rs
+++ b/compiler-core/src/format/tests.rs
@@ -6836,3 +6836,24 @@ pub const list = [
 "
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5401
+#[test]
+fn multiple_field_access_are_not_put_in_a_block() {
+    assert_format!(
+        "pub fn main() {
+  a.wib.wob
+}
+"
+    );
+}
+
+#[test]
+fn multiple_tuple_field_access_are_not_put_in_a_block() {
+    assert_format!(
+        "pub fn main() {
+  #(1, 2).1.2
+}
+"
+    );
+}


### PR DESCRIPTION
This PR closes #5401 

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
