### PR TITLE
Warn when Erlang shipment is run on a different OTP version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@
 
   ([John Downey](https://github.com/jtdowney))
 
+- Erlang shipments now warn when run on a different OTP version than they were
+  built with.
+  ([Joris Hartog](https://github.com/nootr))
+
 ### Language server
 
 - The language server now supports go-to-definition, find-references and rename

--- a/compiler-cli/src/beam_compiler.rs
+++ b/compiler-cli/src/beam_compiler.rs
@@ -24,6 +24,7 @@ pub struct BeamCompilerInstance {
     process: Child,
     stdin: Option<ChildStdin>,
     stdout: BufReader<ChildStdout>,
+    pub otp_version: u64,
     // A guard held for cleaning up the temporary file used to start the BEAM instance.
     _source: tempfile::NamedTempFile,
 }
@@ -131,11 +132,27 @@ impl BeamCompilerInstance {
 
         let stdin = process.stdin.take().expect("could not get child stdin");
         let stdout = process.stdout.take().expect("could not get child stdout");
+        let mut stdout = BufReader::new(stdout);
+
+        let mut version_line = String::new();
+        let _ = stdout
+            .read_line(&mut version_line)
+            .map_err(|e| Error::ShellCommand {
+                program: "escript".into(),
+                reason: ShellCommandFailureReason::IoError(e.kind()),
+            })?;
+        let otp_version = version_line
+            .trim()
+            .strip_prefix("gleam-otp-version:")
+            .expect("BEAM compiler did not report OTP version")
+            .parse()
+            .expect("BEAM compiler reported invalid OTP version");
 
         Ok(Self {
             process,
             stdin: Some(stdin),
-            stdout: BufReader::new(stdout),
+            stdout,
+            otp_version,
             _source: escript_file,
         })
     }

--- a/compiler-cli/src/export.rs
+++ b/compiler-cli/src/export.rs
@@ -174,11 +174,17 @@ pub(crate) fn erlang_shipment(paths: &ProjectPaths) -> Result<()> {
         }
     }
 
+    let otp_version = built
+        .otp_version
+        .expect("OTP version not available after Erlang compilation");
+    let otp_version = otp_version.to_string();
+
     // PowerShell entry point script.
     write_entrypoint_script(
         &out.join(ENTRYPOINT_FILENAME_POWERSHELL),
         ENTRYPOINT_TEMPLATE_POWERSHELL,
         &built.root_package.config.name,
+        &otp_version,
     )?;
 
     // POSIX Shell entry point script.
@@ -186,6 +192,7 @@ pub(crate) fn erlang_shipment(paths: &ProjectPaths) -> Result<()> {
         &out.join(ENTRYPOINT_FILENAME_POSIX_SHELL),
         ENTRYPOINT_TEMPLATE_POSIX_SHELL,
         &built.root_package.config.name,
+        &otp_version,
     )?;
 
     crate::cli::print_exported(&built.root_package.config.name);
@@ -206,10 +213,13 @@ one of the following scripts:
 
 fn write_entrypoint_script(
     entrypoint_output_path: &Utf8PathBuf,
-    entrypoint_template_path: &str,
+    entrypoint_template: &str,
     package_name: &str,
+    otp_version: &str,
 ) -> Result<()> {
-    let text = entrypoint_template_path.replace("$PACKAGE_NAME_FROM_GLEAM", package_name);
+    let text = entrypoint_template
+        .replace("$PACKAGE_NAME_FROM_GLEAM", package_name)
+        .replace("$OTP_VERSION_FROM_GLEAM", otp_version);
     fs::write(entrypoint_output_path, &text)?;
     fs::make_executable(entrypoint_output_path)?;
     Ok(())

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -279,6 +279,17 @@ impl BeamCompilerIO for ProjectIO {
             }
         }
     }
+
+    fn otp_version(&self) -> u64 {
+        let guard = self
+            .beam_compiler
+            .lock()
+            .expect("could not lock beam_compiler");
+        guard
+            .as_ref()
+            .expect("OTP version not available after Erlang compilation")
+            .otp_version
+    }
 }
 
 impl MakeLocker for ProjectIO {

--- a/compiler-cli/templates/erlang-shipment-entrypoint.ps1
+++ b/compiler-cli/templates/erlang-shipment-entrypoint.ps1
@@ -3,19 +3,35 @@ $ErrorActionPreference = "Stop"
 $PackageName = "$PACKAGE_NAME_FROM_GLEAM"
 $BaseDirectory = $PSScriptRoot
 $ScriptCommand = $args[0]
+$OtpVersion = "$OTP_VERSION_FROM_GLEAM"
+$OtpVersionCheck = "case erlang:system_info(otp_release) of `"$OtpVersion`" -> ok; V -> io:format(standard_error, `"warning: This Erlang shipment was built with Erlang/OTP $OtpVersion but you are running Erlang/OTP ~s.~nThe shipment may fail to run. Please use Erlang/OTP $OtpVersion or rebuild the shipment with your current version.~n`", [V]) end"
 
 $CodePath = Join-Path -Path $BaseDirectory -ChildPath "\*\ebin" -Resolve
+
+function CheckOtpVersion {
+  erl `
+    -noshell `
+    -eval $OtpVersionCheck `
+    -eval 'halt().'
+
+  if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+  }
+}
 
 function Run {
   erl `
     -pa $CodePath `
+    -eval $OtpVersionCheck `
     -eval "$PackageName@@main:run($PackageName)" `
     -noshell `
     -extra $args
 }
 
 function Shell {
-  erl -pa $CodePath
+  CheckOtpVersion
+  erl `
+    -pa $CodePath
 }
 
 switch ($ScriptCommand) {

--- a/compiler-cli/templates/erlang-shipment-entrypoint.sh
+++ b/compiler-cli/templates/erlang-shipment-entrypoint.sh
@@ -7,17 +7,29 @@ set -eu
 PACKAGE=$PACKAGE_NAME_FROM_GLEAM
 BASE=$(dirname "$0")
 COMMAND="${1-default}"
+OTP_VERSION=$OTP_VERSION_FROM_GLEAM
+OTP_VERSION_CHECK="case erlang:system_info(otp_release) of \"$OTP_VERSION\" -> ok; V -> io:format(standard_error, \"warning: This Erlang shipment was built with Erlang/OTP $OTP_VERSION but you are running Erlang/OTP ~s.~nThe shipment may fail to run. Please use Erlang/OTP $OTP_VERSION or rebuild the shipment with your current version.~n\", [V]) end"
+
+check_otp_version() {
+  erl \
+    -noshell \
+    -eval "$OTP_VERSION_CHECK" \
+    -eval 'halt().'
+}
 
 run() {
   exec erl \
     -pa "$BASE"/*/ebin \
+    -eval "$OTP_VERSION_CHECK" \
     -eval "$PACKAGE@@main:run($PACKAGE)" \
     -noshell \
     -extra "$@"
 }
 
 shell() {
-  erl -pa "$BASE"/*/ebin
+  check_otp_version
+  erl \
+    -pa "$BASE"/*/ebin
 }
 
 case "$COMMAND" in

--- a/compiler-cli/templates/gleam@@compile.erl
+++ b/compiler-cli/templates/gleam@@compile.erl
@@ -7,6 +7,7 @@
 main(_) ->
     ok = io:setopts([binary, {encoding, utf8}]),
     ok = configure_logging(),
+    io:put_chars("gleam-otp-version:" ++ erlang:system_info(otp_release) ++ "\n"),
     compile_package_loop().
 
 compile_package_loop() ->

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -74,6 +74,7 @@ pub struct Built {
     pub root_package: Package,
     pub module_interfaces: im::HashMap<EcoString, type_::ModuleInterface>,
     compiled_dependency_modules: Vec<Module>,
+    pub otp_version: Option<u64>,
 }
 
 impl Built {
@@ -231,10 +232,17 @@ where
             });
         }
 
+        let otp_version = if self.target().is_erlang() && self.options.codegen == Codegen::All {
+            Some(self.io.otp_version())
+        } else {
+            None
+        };
+
         Ok(Built {
             root_package,
             module_interfaces: self.importable_modules,
             compiled_dependency_modules,
+            otp_version,
         })
     }
 

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -348,6 +348,8 @@ pub trait BeamCompilerIO {
         modules: &HashSet<Utf8PathBuf>,
         stdio: Stdio,
     ) -> Result<Vec<String>, Error>;
+
+    fn otp_version(&self) -> u64;
 }
 
 /// A trait used to write files.

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -462,6 +462,10 @@ impl BeamCompilerIO for InMemoryFileSystem {
     ) -> Result<Vec<String>, Error> {
         Ok(Vec::new()) // Always succeed.
     }
+
+    fn otp_version(&self) -> u64 {
+        unimplemented!()
+    }
 }
 
 #[test]

--- a/compiler-wasm/src/wasm_filesystem.rs
+++ b/compiler-wasm/src/wasm_filesystem.rs
@@ -38,6 +38,10 @@ impl BeamCompilerIO for WasmFileSystem {
     ) -> Result<Vec<String>, Error> {
         Ok(Vec::new()) // Always succeed.
     }
+
+    fn otp_version(&self) -> u64 {
+        unimplemented!()
+    }
 }
 
 impl FileSystemWriter for WasmFileSystem {

--- a/language-server/src/files.rs
+++ b/language-server/src/files.rs
@@ -182,4 +182,8 @@ where
     ) -> Result<Vec<String>, Error> {
         panic!("The language server is not permitted to create subprocesses")
     }
+
+    fn otp_version(&self) -> u64 {
+        unimplemented!()
+    }
 }

--- a/language-server/src/tests.rs
+++ b/language-server/src/tests.rs
@@ -266,6 +266,10 @@ impl BeamCompilerIO for LanguageServerTestIO {
     ) -> Result<Vec<String>> {
         panic!("compile_beam({out:?}, {lib:?}, {modules:?}, {stdio:?}) is not implemented")
     }
+
+    fn otp_version(&self) -> u64 {
+        unimplemented!()
+    }
 }
 
 impl MakeLocker for LanguageServerTestIO {


### PR DESCRIPTION
When an Erlang shipment is built with one OTP version and run with a different one, the program crashes with a cryptic `undef` error. This commit embeds a version check into the generated entrypoint scripts that prints a clear warning to stderr when a mismatch is detected, without booting the Erlang VM twice.

Closes #4769

## Test plan

- [x] `cargo check` / `cargo clippy` / `cargo fmt` pass
- [x] `cargo test -p gleam-core -p gleam-cli` passes
- [x] Created a test project, exported shipment, verified OTP version is embedded in both scripts
- [x] Test POSIX entrypoint, with matching version and version mismatch
- [x] Test PowerShell entrypoint, with matching version and version mismatch