### PR TITLE
set mode 0x600 on hex credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
   an empty README.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- When create a Hex credentials file, use mode 0600 so only the user can read it.
+  ([Peter Bhat Harkins](https://github.com/peterbhatharkins))
+
 ### Language server
 
 - The language server now allows extracting the start of a pipeline into a

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -1,5 +1,7 @@
 use crate::{cli, http::HttpClient};
 use ecow::EcoString;
+use std::fs::Permissions;
+use std::os::unix::fs::PermissionsExt;
 use gleam_core::{
     Error, Result, encryption,
     error::{FileIoAction, FileKind},
@@ -133,6 +135,8 @@ impl<'runtime> HexAuthentication<'runtime> {
             },
         };
         let toml = toml::to_string(&credentials).expect("OAuth credentials TOML encoding");
+        let perm = Permissions::from_mode(0o600);
+        std::fs::set_permissions(&path, perm)?;
         crate::fs::write(&path, &toml)?;
         Ok(())
     }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -562,6 +562,14 @@ impl From<capnp::NotInSchema> for Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Error::MetadataDecodeError {
+            error: Some(error.to_string()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InvalidProjectNameReason {
     Format,


### PR DESCRIPTION
Implements #5424. I'm new to Rust but it looked enough like Gleam that I could muddle through based on the compiler errors.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Existing tests pass, but I didn't see test that named `encrypt_and_store_oauth_refresh_token` or `credentials.toml`. Writing one from scratch is beyond me, so I marked this PR to 'allow edits by maintainers' if you'd like to. I won't be bothered if you close this to wait for a PR with tests, this was a fun puzzle.