### PR TITLE
Fix Rust 1.94 ambiguity error

### DIFF
--- a/compiler-core/src/dep_tree.rs
+++ b/compiler-core/src/dep_tree.rs
@@ -90,7 +90,7 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{assert_eq, *};
 
     #[test]
     fn toposort_deps_test() {


### PR DESCRIPTION
As of Rust 1.94, there seems to be an error when running the tests due to ambiguity between an imported and built-in macro. I'm a little surprised at this, as this seems to me like a breaking change, but I'm not sure. Either way, it's an easy fix.