### PR TITLE
show some completions for record updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server now shows completions for the labelled argument of a
+  record when writing a record update.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Bug fixes

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -1097,7 +1097,17 @@ impl<'a, IO> Completer<'a, IO> {
         let fun_type = fun.type_().fn_types().map(|(arguments, _)| arguments);
         let already_included_labels = existing_arguments
             .iter()
-            .filter_map(|a| a.label.clone())
+            .filter_map(|argument| {
+                // Record updates can have implicit arguments added as placeholders
+                // by the compiler. Those are still arguments that could be typed
+                // by the developer and used, so we don't want to include those
+                // in the ones that have already been included and won't be recommended.
+                if argument.is_implicit() && !argument.is_use_implicit_callback() {
+                    None
+                } else {
+                    argument.label.clone()
+                }
+            })
             .collect_vec();
         let Some(field_map) =
             self.callable_field_map(fun, self.compiler.project_compiler.get_importable_modules())

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -301,7 +301,13 @@ where
                 }
                 | Located::Constant(Constant::String { .. }) => None,
                 Located::Expression {
-                    expression: TypedExpr::Call { fun, arguments, .. },
+                    expression:
+                        TypedExpr::Call { fun, arguments, .. }
+                        | TypedExpr::RecordUpdate {
+                            constructor: fun,
+                            arguments,
+                            ..
+                        },
                     ..
                 } => {
                     let mut completions = vec![];

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_labels_in_record_update.snap.new
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_labels_in_record_update.snap.new
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/completion.rs
+assertion_line: 2430
+expression: "\npub type Wibble {\n  Wibble(wibble: Int, wobble: Int, woo: Int)\n}\n\npub fn main() {\n  Wibble(..todo, w)\n}\n\npub fn wibble() { todo }\n"
+snapshot_kind: text
+---
+pub type Wibble {
+  Wibble(wibble: Int, wobble: Int, woo: Int)
+}
+
+pub fn main() {
+  Wibble(..todo, w|)
+}
+
+pub fn wibble() { todo }
+
+
+----- Completion content -----


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

This adds label completions for record updates, just like function calls. This works when the code goes from a compiling state, eg. I'm typing `Wibble(..todo, |)`, to an invalid state with a syntax error, `Wibble(..todo, w|)` because it relies on an outdated view of the LS of the project which happens to be good enough to provide completions.

I can't think of a good way of testing this, I'd like to hear what you think we could do for tests.