### PR TITLE
add code action to replace underscore with corresponding type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@
   branches.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server now has a code action to replace a `_` in a type
+  annotation with the corresponding type. For example:
+
+  ```gleam
+  pub fn load_user(id: Int) -> Result(_, Error) {
+    //                                ^
+    //      Triggering the code action here
+    sql.find_by_id(id)
+    |> result.map_error(CannotLoadUser)
+  }
+  ```
+
+  Triggering the code action over the `_` will result in the following code:
+
+  ```gleam
+  pub fn load_user(id: Int) -> Result(User, Error) {
+    sql.find_by_id(id)
+    |> result.map_error(CannotLoadUser)
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Bug fixes

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -594,8 +594,15 @@ pub trait Visit<'ast> {
         visit_typed_pattern_invalid(self, location, type_);
     }
 
-    fn visit_type_ast(&mut self, node: &'ast TypeAst) {
-        visit_type_ast(self, node);
+    fn visit_type_ast(
+        &mut self,
+        node: &'ast TypeAst,
+        // The type inferred for this annotation.
+        // It might not always be possible to infer one in presence of type
+        // errors, so this is optional!
+        inferred_type: Option<Arc<Type>>,
+    ) {
+        visit_type_ast(self, node, inferred_type);
     }
 
     fn visit_type_ast_constructor(
@@ -604,30 +611,58 @@ pub trait Visit<'ast> {
         name_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
-        arguments: &'ast Vec<TypeAst>,
+        arguments: &'ast [TypeAst],
+        inferred_arguments_types: Option<Vec<Arc<Type>>>,
     ) {
-        visit_type_ast_constructor(self, location, name_location, module, name, arguments);
+        visit_type_ast_constructor(
+            self,
+            location,
+            name_location,
+            module,
+            name,
+            arguments,
+            inferred_arguments_types,
+        );
     }
 
     fn visit_type_ast_fn(
         &mut self,
         location: &'ast SrcSpan,
-        arguments: &'ast Vec<TypeAst>,
+        arguments: &'ast [TypeAst],
+        arguments_types: Option<Vec<Arc<Type>>>,
         return_: &'ast TypeAst,
+        return_type: Option<Arc<Type>>,
     ) {
-        visit_type_ast_fn(self, location, arguments, return_);
+        visit_type_ast_fn(
+            self,
+            location,
+            arguments,
+            arguments_types,
+            return_,
+            return_type,
+        );
     }
 
     fn visit_type_ast_var(&mut self, location: &'ast SrcSpan, name: &'ast EcoString) {
         visit_type_ast_var(self, location, name);
     }
 
-    fn visit_type_ast_tuple(&mut self, location: &'ast SrcSpan, elements: &'ast Vec<TypeAst>) {
-        visit_type_ast_tuple(self, location, elements);
+    fn visit_type_ast_tuple(
+        &mut self,
+        location: &'ast SrcSpan,
+        elements: &'ast [TypeAst],
+        elements_types: Option<&Vec<Arc<Type>>>,
+    ) {
+        visit_type_ast_tuple(self, location, elements, elements_types);
     }
 
-    fn visit_type_ast_hole(&mut self, location: &'ast SrcSpan, name: &'ast EcoString) {
-        visit_type_ast_hole(self, location, name);
+    fn visit_type_ast_hole(
+        &mut self,
+        location: &'ast SrcSpan,
+        name: &'ast EcoString,
+        type_: Option<Arc<Type>>,
+    ) {
+        visit_type_ast_hole(self, location, name, type_);
     }
 
     fn visit_typed_constant(&mut self, constant: &'ast TypedConstant) {
@@ -925,11 +960,11 @@ where
 {
     for argument in fun.arguments.iter() {
         if let Some(annotation) = &argument.annotation {
-            v.visit_type_ast(annotation);
+            v.visit_type_ast(annotation, Some(argument.type_.clone()));
         }
     }
     if let Some(annotation) = &fun.return_annotation {
-        v.visit_type_ast(annotation);
+        v.visit_type_ast(annotation, Some(fun.return_type.clone()));
     }
 
     for statement in &fun.body {
@@ -937,7 +972,7 @@ where
     }
 }
 
-pub fn visit_type_ast<'a, V>(v: &mut V, node: &'a TypeAst)
+pub fn visit_type_ast<'a, V>(v: &mut V, node: &'a TypeAst, type_: Option<Arc<Type>>)
 where
     V: Visit<'a> + ?Sized,
 {
@@ -950,23 +985,40 @@ where
             name,
             start_parentheses: _,
         }) => {
-            v.visit_type_ast_constructor(location, name_location, module, name, arguments);
+            v.visit_type_ast_constructor(
+                location,
+                name_location,
+                module,
+                name,
+                arguments,
+                type_.and_then(|type_| type_.constructor_types()),
+            );
         }
         TypeAst::Fn(super::TypeAstFn {
             location,
             arguments,
             return_,
         }) => {
-            v.visit_type_ast_fn(location, arguments, return_);
+            let (arguments_types, return_type) = match type_.and_then(|type_| type_.fn_types()) {
+                Some((arguments_types, return_type)) => (Some(arguments_types), Some(return_type)),
+                None => (None, None),
+            };
+
+            v.visit_type_ast_fn(location, arguments, arguments_types, return_, return_type);
         }
         TypeAst::Var(super::TypeAstVar { location, name }) => {
             v.visit_type_ast_var(location, name);
         }
         TypeAst::Tuple(super::TypeAstTuple { location, elements }) => {
-            v.visit_type_ast_tuple(location, elements);
+            let elements_types = if let Some(Type::Tuple { elements }) = type_.as_deref() {
+                Some(elements)
+            } else {
+                None
+            };
+            v.visit_type_ast_tuple(location, elements, elements_types);
         }
         TypeAst::Hole(super::TypeAstHole { location, name }) => {
-            v.visit_type_ast_hole(location, name);
+            v.visit_type_ast_hole(location, name, type_);
         }
     }
 }
@@ -977,27 +1029,39 @@ pub fn visit_type_ast_constructor<'a, V>(
     _name_location: &'a SrcSpan,
     _module: &'a Option<(EcoString, SrcSpan)>,
     _name: &'a EcoString,
-    arguments: &'a Vec<TypeAst>,
+    arguments: &'a [TypeAst],
+    inferred_arguments_types: Option<Vec<Arc<Type>>>,
 ) where
     V: Visit<'a> + ?Sized,
 {
-    for argument in arguments {
-        v.visit_type_ast(argument);
+    for (i, argument) in arguments.iter().enumerate() {
+        let argument_type = inferred_arguments_types
+            .as_ref()
+            .and_then(|types| types.get(i));
+        v.visit_type_ast(argument, argument_type.cloned());
     }
 }
 
 pub fn visit_type_ast_fn<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    arguments: &'a Vec<TypeAst>,
+    arguments: &'a [TypeAst],
+    arguments_types: Option<Vec<Arc<Type>>>,
     return_: &'a TypeAst,
+    return_type: Option<Arc<Type>>,
 ) where
     V: Visit<'a> + ?Sized,
 {
-    for argument in arguments {
-        v.visit_type_ast(argument);
+    for (i, argument) in arguments.iter().enumerate() {
+        v.visit_type_ast(
+            argument,
+            arguments_types
+                .as_ref()
+                .and_then(|types| types.get(i))
+                .cloned(),
+        );
     }
-    v.visit_type_ast(return_);
+    v.visit_type_ast(return_, return_type.clone());
 }
 
 pub fn visit_type_ast_var<'a, V>(_v: &mut V, _location: &'a SrcSpan, _name: &'a EcoString)
@@ -1007,17 +1071,29 @@ where
     // No further traversal needed for variables
 }
 
-pub fn visit_type_ast_tuple<'a, V>(v: &mut V, _location: &'a SrcSpan, elements: &'a Vec<TypeAst>)
-where
+pub fn visit_type_ast_tuple<'a, V>(
+    v: &mut V,
+    _location: &'a SrcSpan,
+    elements: &'a [TypeAst],
+    elements_types: Option<&Vec<Arc<Type>>>,
+) where
     V: Visit<'a> + ?Sized,
 {
-    for element in elements {
-        v.visit_type_ast(element);
+    for (i, element) in elements.iter().enumerate() {
+        let element_type = elements_types
+            .as_ref()
+            .and_then(|types| types.get(i))
+            .cloned();
+        v.visit_type_ast(element, element_type);
     }
 }
 
-pub fn visit_type_ast_hole<'a, V>(_v: &mut V, _location: &'a SrcSpan, _name: &'a EcoString)
-where
+pub fn visit_type_ast_hole<'a, V>(
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _name: &'a EcoString,
+    _type_: Option<Arc<Type>>,
+) where
     V: Visit<'a> + ?Sized,
 {
     // No further traversal needed for holes
@@ -1027,6 +1103,9 @@ pub fn visit_typed_module_constant<'a, V>(v: &mut V, constant: &'a TypedModuleCo
 where
     V: Visit<'a> + ?Sized,
 {
+    if let Some(annotation) = &constant.annotation {
+        v.visit_type_ast(annotation, Some(constant.type_.clone()));
+    }
     v.visit_typed_constant(&constant.value);
 }
 
@@ -1124,7 +1203,7 @@ where
 {
     for record in &custom_type.constructors {
         for argument in &record.arguments {
-            v.visit_type_ast(&argument.ast);
+            v.visit_type_ast(&argument.ast, Some(argument.type_.clone()));
         }
     }
 }
@@ -1133,7 +1212,7 @@ pub fn visit_typed_type_alias<'a, V>(v: &mut V, type_alias: &'a TypedTypeAlias)
 where
     V: Visit<'a> + ?Sized,
 {
-    v.visit_type_ast(&type_alias.type_ast);
+    v.visit_type_ast(&type_alias.type_ast, Some(type_alias.type_.clone()));
 }
 
 pub fn visit_typed_import<'a, V>(_v: &mut V, _import: &'a TypedImport)
@@ -1390,7 +1469,7 @@ pub fn visit_typed_expr_var<'a, V>(
 pub fn visit_typed_expr_fn<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    _type_: &'a Arc<Type>,
+    type_: &'a Arc<Type>,
     _kind: &'a FunctionLiteralKind,
     arguments: &'a [TypedArg],
     body: &'a Vec1<TypedStatement>,
@@ -1400,11 +1479,14 @@ pub fn visit_typed_expr_fn<'a, V>(
 {
     for argument in arguments {
         if let Some(annotation) = &argument.annotation {
-            v.visit_type_ast(annotation);
+            v.visit_type_ast(annotation, Some(argument.type_.clone()));
         }
     }
     if let Some(return_) = return_annotation {
-        v.visit_type_ast(return_);
+        v.visit_type_ast(
+            return_,
+            type_.fn_types().map(|(_, return_)| return_.clone()),
+        );
     }
 
     for statement in body {
@@ -1643,7 +1725,7 @@ where
     V: Visit<'a> + ?Sized,
 {
     if let Some(annotation) = &assignment.annotation {
-        v.visit_type_ast(annotation);
+        v.visit_type_ast(annotation, Some(assignment.type_()));
     }
     v.visit_typed_expr(&assignment.value);
     v.visit_typed_pattern(&assignment.pattern);

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -1750,7 +1750,8 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         name_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
-        arguments: &'ast Vec<ast::TypeAst>,
+        arguments: &'ast [ast::TypeAst],
+        arguments_types: Option<Vec<Arc<Type>>>,
     ) {
         let range = src_span_to_lsp_range(*location, self.line_numbers);
         if overlaps(self.params.range, range)
@@ -1771,6 +1772,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
             module,
             name,
             arguments,
+            arguments_types,
         );
     }
 
@@ -2001,7 +2003,8 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
         name_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
-        arguments: &'ast Vec<ast::TypeAst>,
+        arguments: &'ast [ast::TypeAst],
+        arguments_types: Option<Vec<Arc<Type>>>,
     ) {
         if let Some((module_name, _)) = module {
             let QualifiedConstructor {
@@ -2022,6 +2025,7 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
             module,
             name,
             arguments,
+            arguments_types,
         );
     }
 
@@ -2265,7 +2269,8 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
         name_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
-        arguments: &'ast Vec<ast::TypeAst>,
+        arguments: &'ast [ast::TypeAst],
+        arguments_types: Option<Vec<Arc<Type>>>,
     ) {
         if module.is_none()
             && overlaps(
@@ -2283,6 +2288,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
             module,
             name,
             arguments,
+            arguments_types,
         );
     }
 
@@ -2507,7 +2513,8 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
         name_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
-        arguments: &'ast Vec<ast::TypeAst>,
+        arguments: &'ast [ast::TypeAst],
+        arguments_types: Option<Vec<Arc<Type>>>,
     ) {
         if module.is_none() {
             let UnqualifiedConstructor {
@@ -2524,6 +2531,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
             module,
             name,
             arguments,
+            arguments_types,
         );
     }
 
@@ -10990,6 +10998,91 @@ impl<'ast> ast::visit::Visit<'ast> for AddMissingTypeParameter<'ast> {
                     let _ = self.missing_parameters.insert(name);
                 }
             }
+        }
+    }
+}
+
+/// Code action to replace a `_` with its actual type in an annotation.
+///
+/// Before:
+/// ```gleam
+/// fn wibble() -> Ok(_) { Ok(1) }
+/// //                ^ Trigger it here
+/// ```
+///
+/// After:
+/// ```gleam
+/// fn wibble() -> Ok(Int) { Ok(1) }
+/// ```
+///
+pub struct ReplaceUnderscoreWithType<'a> {
+    module: &'a Module,
+    params: &'a CodeActionParams,
+    edits: TextEdits<'a>,
+    hovered_hole: Option<HoveredHole>,
+}
+
+struct HoveredHole {
+    type_: Arc<Type>,
+    location: SrcSpan,
+}
+
+impl<'a> ReplaceUnderscoreWithType<'a> {
+    pub fn new(
+        module: &'a Module,
+        line_numbers: &'a LineNumbers,
+        params: &'a CodeActionParams,
+    ) -> Self {
+        Self {
+            module,
+            params,
+            edits: TextEdits::new(line_numbers),
+            hovered_hole: None,
+        }
+    }
+
+    pub fn code_actions(mut self) -> Vec<CodeAction> {
+        self.visit_typed_module(&self.module.ast);
+
+        let mut action = Vec::with_capacity(1);
+
+        let Some(HoveredHole { type_, location }) = self.hovered_hole else {
+            return vec![];
+        };
+        let mut printer = Printer::new(&self.module.ast.names);
+        self.edits
+            .replace(location, format!("{}", printer.print_type(&type_)));
+
+        CodeActionBuilder::new("Replace `_` with type")
+            .kind(CodeActionKind::QUICKFIX)
+            .changes(self.params.text_document.uri.clone(), self.edits.edits)
+            .preferred(true)
+            .push_to(&mut action);
+        action
+    }
+}
+
+impl<'ast> ast::visit::Visit<'ast> for ReplaceUnderscoreWithType<'ast> {
+    fn visit_type_ast(&mut self, node: &'ast ast::TypeAst, inferred_type: Option<Arc<Type>>) {
+        // We never traverse a type annotation we're not hovering
+        let node_location = self.edits.src_span_to_lsp_range(node.location());
+        if !within(self.params.range, node_location) {
+            return;
+        }
+        ast::visit::visit_type_ast(self, node, inferred_type);
+    }
+
+    fn visit_type_ast_hole(
+        &mut self,
+        location: &'ast SrcSpan,
+        _name: &'ast EcoString,
+        type_: Option<Arc<Type>>,
+    ) {
+        if let Some(type_) = type_ {
+            self.hovered_hole = Some(HoveredHole {
+                type_,
+                location: *location,
+            })
         }
     }
 }

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -32,7 +32,7 @@ use lsp_types::{
 };
 use std::{collections::HashSet, sync::Arc};
 
-use crate::rename::rename_module_alias;
+use crate::{code_action::ReplaceUnderscoreWithType, rename::rename_module_alias};
 
 use super::{
     DownloadDependencies, MakeLocker,
@@ -474,6 +474,7 @@ where
             actions
                 .extend(AnnotateTopLevelDefinitions::new(module, &lines, &params).code_actions());
             actions.extend(AddMissingTypeParameter::new(module, &lines, &params).code_actions());
+            actions.extend(ReplaceUnderscoreWithType::new(module, &lines, &params).code_actions());
             Ok(if actions.is_empty() {
                 None
             } else {
@@ -1020,11 +1021,11 @@ where
                     .get_module_interface(module_name.as_str())
                     .and_then(|module_interface| {
                         if is_type {
-                            module_interface.types.get(name).map(|t| {
+                            module_interface.types.get(name).map(|constructor| {
                                 hover_for_annotation(
                                     *location,
-                                    t.type_.as_ref(),
-                                    Some(t),
+                                    constructor.type_.as_ref(),
+                                    Some(constructor),
                                     lines,
                                     module,
                                 )
@@ -1457,7 +1458,7 @@ fn hover_for_annotation(
 ) -> Hover {
     let empty_str = EcoString::from("");
     let documentation = type_constructor
-        .and_then(|t| t.documentation.as_ref())
+        .and_then(|constructor| constructor.documentation.as_ref())
         .unwrap_or(&empty_str);
     // If a user is hovering an annotation, it's not very useful to show the
     // local representation of that type, since that's probably what they see

--- a/language-server/src/reference.rs
+++ b/language-server/src/reference.rs
@@ -920,7 +920,8 @@ impl<'ast> Visit<'ast> for FindModuleNameReferences<'_> {
         name_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
-        arguments: &'ast Vec<ast::TypeAst>,
+        arguments: &'ast [ast::TypeAst],
+        arguments_types: Option<Vec<std::sync::Arc<Type>>>,
     ) {
         if let Some((module_alias, module_location)) = module
             && module_alias == self.module_alias
@@ -938,6 +939,7 @@ impl<'ast> Visit<'ast> for FindModuleNameReferences<'_> {
             module,
             name,
             arguments,
+            arguments_types,
         );
     }
 
@@ -1007,14 +1009,6 @@ impl<'ast> Visit<'ast> for FindModuleNameReferences<'_> {
             type_,
             field_map,
         )
-    }
-
-    fn visit_typed_module_constant(&mut self, constant: &'ast ast::TypedModuleConstant) {
-        if let Some(annotation) = &constant.annotation {
-            ast::visit::visit_type_ast(self, annotation);
-        }
-
-        ast::visit::visit_typed_constant(self, &constant.value);
     }
 
     fn visit_typed_constant_var(

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -139,6 +139,7 @@ const ADD_OMITTED_LABELS: &str = "Add omitted labels";
 const EXTRACT_FUNCTION: &str = "Extract function";
 const MERGE_CASE_BRANCHES: &str = "Merge case branches";
 const ADD_MISSING_TYPE_PARAMETER: &str = "Add missing type parameter";
+const REPLACE_UNDERSCORE_WITH_TYPE: &str = "Replace `_` with type";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range:expr $(,)?) => {
@@ -12686,5 +12687,109 @@ pub type Nothing {
             .add_hex_module("gleam/dict", "pub type Dict(key, value)"),
         find_position_of("pub type Nothing {")
             .select_until(find_position_of("}").nth_occurrence(2))
+    );
+}
+
+#[test]
+fn replace_underscore_with_function_return_type() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble() -> _ {
+    12
+}
+    "#,
+        find_position_of("_").to_selection()
+    );
+}
+
+#[test]
+fn replace_nested_underscore_with_generic_type() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble() -> Result(a, _) {
+    Ok(todo)
+}
+    "#,
+        find_position_of("_").to_selection()
+    );
+}
+
+#[test]
+fn replace_nested_underscore_with_function_return_type() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble() -> Result(Result(_, Nil), Int) {
+    Ok(Ok("hello"))
+}
+    "#,
+        find_position_of("_").to_selection()
+    );
+}
+
+#[test]
+fn replace_nested_underscore_in_let_annotation() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble() {
+    let a: Result(Result(_, Nil), Nil) = Ok(Ok("hello"))
+}
+    "#,
+        find_position_of("_").to_selection()
+    );
+}
+
+#[test]
+fn replace_underscore_in_let_annotation() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble() {
+    let a: _ = Ok(Ok("hello"))
+}
+    "#,
+        find_position_of("_").to_selection()
+    );
+}
+
+#[test]
+fn replace_nested_underscore_with_tuple_type() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble() {
+    let a: #(Int, _, Int) = #(1, "hello", 2)
+}
+    "#,
+        find_position_of("_").to_selection()
+    );
+}
+
+#[test]
+fn replace_underscore_in_function_argument() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble(a: _) -> Int {
+    a + 2
+}
+    "#,
+        find_position_of("_").to_selection()
+    );
+}
+
+#[test]
+fn replace_underscore_in_fn_expr_argument() {
+    assert_code_action!(
+        REPLACE_UNDERSCORE_WITH_TYPE,
+        r#"
+pub fn wibble() {
+    fn(a: _) { a + 2 }
+}
+    "#,
+        find_position_of("_").to_selection()
     );
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_in_let_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_in_let_annotation.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() {\n    let a: Result(Result(_, Nil), Nil) = Ok(Ok(\"hello\"))\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() {
+    let a: Result(Result(_, Nil), Nil) = Ok(Ok("hello"))
+                         ↑                              
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() {
+    let a: Result(Result(String, Nil), Nil) = Ok(Ok("hello"))
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_with_function_return_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_with_function_return_type.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() -> Result(Result(_, Nil), Int) {\n    Ok(Ok(\"hello\"))\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() -> Result(Result(_, Nil), Int) {
+                                 ↑              
+    Ok(Ok("hello"))
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() -> Result(Result(String, Nil), Int) {
+    Ok(Ok("hello"))
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_with_generic_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_with_generic_type.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() -> Result(a, _) {\n    Ok(todo)\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() -> Result(a, _) {
+                             ↑   
+    Ok(todo)
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() -> Result(a, b) {
+    Ok(todo)
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_with_tuple_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_nested_underscore_with_tuple_type.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() {\n    let a: #(Int, _, Int) = #(1, \"hello\", 2)\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() {
+    let a: #(Int, _, Int) = #(1, "hello", 2)
+                  ↑                         
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() {
+    let a: #(Int, String, Int) = #(1, "hello", 2)
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_in_fn_expr_argument.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_in_fn_expr_argument.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() {\n    fn(a: _) { a + 2 }\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() {
+    fn(a: _) { a + 2 }
+          ↑           
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() {
+    fn(a: Int) { a + 2 }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_in_function_argument.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_in_function_argument.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble(a: _) -> Int {\n    a + 2\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble(a: _) -> Int {
+                 ↑          
+    a + 2
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble(a: Int) -> Int {
+    a + 2
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_in_let_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_in_let_annotation.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() {\n    let a: _ = Ok(Ok(\"hello\"))\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() {
+    let a: _ = Ok(Ok("hello"))
+           ↑                  
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() {
+    let a: Result(Result(String, a), b) = Ok(Ok("hello"))
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_with_function_return_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_with_function_return_type.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() -> _ {\n    12\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() -> _ {
+                   ↑  
+    12
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() -> Int {
+    12
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_with_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__replace_underscore_with_type.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble() -> Result(Result(_, Nil), Int) {\n    Ok(Ok(\"hello\"))\n}\n    "
+---
+----- BEFORE ACTION
+
+pub fn wibble() -> Result(Result(_, Nil), Int) {
+                                 ↑              
+    Ok(Ok("hello"))
+}
+    
+
+
+----- AFTER ACTION
+
+pub fn wibble() -> Result(Result(String, Nil), Int) {
+    Ok(Ok("hello"))
+}


### PR DESCRIPTION
This PR closes #5447 
```diff
//                trigger here! v
-pub fn wibble() -> Result(List(_), String) {
+pub fn wibble() -> Result(List(Int), String) {
  Ok([1 + 1])
}
```


---

- [ ] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes