### PR TITLE
Make record updates fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The analysis of record update expressions is now fault tolerant, meaning the
+  compiler will no longer stop reporting errors at the first invalid field it
+  finds.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - When publishing, the package manager now uses the full term instead of the

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -3028,9 +3028,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let value_constructor = self
             .environment
             .get_value_constructor(module.map(|(module, _)| module), name)
-            .map_err(|e| {
+            .map_err(|error| {
                 convert_get_value_constructor_error(
-                    e,
+                    error,
                     location,
                     module.map(|(_, location)| *location),
                 )
@@ -3045,8 +3045,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let (record_var, record_assignment) = if record.is_var() {
             (record, None)
         } else {
-            // We create an Assignment for the old record expression and will use a Var expression
-            // to refer back to it while constructing the arguments.
+            // We create an Assignment for the old record expression and will
+            // use a Var expression to refer back to it while constructing the
+            // arguments.
             let record_assignment = Assignment {
                 location: record_location,
                 pattern: Pattern::Variable {
@@ -3104,62 +3105,64 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let record_type = record.type_();
         let return_type = variant.return_type.clone();
 
-        // We clone the fields to remove all explicitly mentioned fields in the record update.
+        // We clone the fields to remove all explicitly mentioned fields in the
+        // record update.
         let mut fields = variant.field_map.fields.clone();
 
-        // collect explicit arguments given in the record update
-        let explicit_arguments = arguments
-            .iter()
-            .map(
-                |arg @ UntypedRecordUpdateArg {
-                     label,
-                     value,
-                     location,
-                 }| {
-                    let value = self.infer_or_error(value.clone())?;
+        // We go over all arguments used in the record update and infer those.
+        let mut explicit_arguments = vec![];
+        for argument in arguments.iter() {
+            let UntypedRecordUpdateArg {
+                label,
+                value,
+                location,
+            } = argument;
+            let value = self.infer(value.clone());
+            if argument.uses_label_shorthand() {
+                self.track_feature_usage(FeatureKind::LabelShorthandSyntax, *location);
+            }
 
-                    if arg.uses_label_shorthand() {
-                        self.track_feature_usage(FeatureKind::LabelShorthandSyntax, *location);
-                    }
+            if let Some(index) = fields.remove(label) {
+                // If the variant has the given field, we need to check it's
+                // inferred type is correct.
+                // If an error happens we record it, but don't early return.
+                // We still want to accumulate errors for all field to come!
+                if let Err(error) = unify(variant.arg_type(index), value.type_()) {
+                    self.problems.error(convert_unify_error(error, *location));
+                };
 
-                    match fields.remove(label) {
-                        Some(index) => {
-                            unify(variant.arg_type(index), value.type_())
-                                .map_err(|e| convert_unify_error(e, *location))?;
+                explicit_arguments.push((
+                    index,
+                    CallArg {
+                        label: Some(label.clone()),
+                        location: *location,
+                        value,
+                        implicit: None,
+                    },
+                ))
+            } else if variant.has_field(label) {
+                // The variant has this field but it was already removed in a
+                // previous iteration. This means we've found a duplicate field!
+                self.problems.error(Error::DuplicateArgument {
+                    location: *location,
+                    label: label.clone(),
+                })
+            } else {
+                // Otherwise, it's just an unknown field!
+                self.problems.error(self.unknown_field_error(
+                    variant.field_names(),
+                    record_type.clone(),
+                    *location,
+                    label.clone(),
+                    FieldAccessUsage::RecordUpdate,
+                ))
+            };
+        }
 
-                            Ok((
-                                index,
-                                CallArg {
-                                    label: Some(label.clone()),
-                                    location: *location,
-                                    value,
-                                    implicit: None,
-                                },
-                            ))
-                        }
-                        _ => {
-                            if variant.has_field(label) {
-                                Err(Error::DuplicateArgument {
-                                    location: *location,
-                                    label: label.clone(),
-                                })
-                            } else {
-                                Err(self.unknown_field_error(
-                                    variant.field_names(),
-                                    record_type.clone(),
-                                    *location,
-                                    label.clone(),
-                                    FieldAccessUsage::RecordUpdate,
-                                ))
-                            }
-                        }
-                    }
-                },
-            )
-            .collect::<Result<Vec<_>, _>>()?;
-
-        // Generate the remaining copied arguments, making sure they unify with our return type.
-        let convert_incompatible_fields_error = |e: UnifyError, field: RecordField| match e {
+        // Generate the remaining copied arguments, making sure they unify with
+        // our return type.
+        let convert_incompatible_fields_error = |error: UnifyError, field: RecordField| match error
+        {
             UnifyError::CouldNotUnify {
                 expected, given, ..
             } => Error::UnsafeRecordUpdate {
@@ -3175,7 +3178,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             UnifyError::ExtraVarInAlternativePattern { .. }
             | UnifyError::MissingVarInAlternativePattern { .. }
             | UnifyError::DuplicateVarInPattern { .. }
-            | UnifyError::RecursiveType => convert_unify_error(e, record_location),
+            | UnifyError::RecursiveType => convert_unify_error(error, record_location),
         };
 
         let indices_to_labels = variant.field_map.indices_to_labels();
@@ -3306,7 +3309,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             }
         }
 
-        if explicit_arguments.is_empty() {
+        if arguments.is_empty() {
             self.problems
                 .warning(Warning::NoFieldsRecordUpdate { location });
         }

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3477,3 +3477,73 @@ pub fn go(value: Type) {
 }"
     );
 }
+
+#[test]
+fn record_update_does_not_stop_at_first_invalid_field_1() {
+    assert_module_error!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, c: 1, a: 1.0)
+}"
+    );
+}
+
+#[test]
+fn record_update_does_not_stop_at_first_invalid_field_2() {
+    assert_module_error!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: 1.0, a: 2, c: 2)
+}"
+    );
+}
+
+#[test]
+fn record_update_does_not_stop_at_first_invalid_field_3() {
+    assert_module_error!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: 1.0, a: 2)
+}"
+    );
+}
+
+#[test]
+fn record_update_does_not_stop_at_first_invalid_field_4() {
+    assert_module_error!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: 2, a: 3, b: 1)
+}"
+    );
+}
+
+#[test]
+fn record_update_does_not_stop_at_first_invalid_field_5() {
+    assert_module_error!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, b: 1, a: True, c: 2)
+}"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_1.snap
@@ -1,0 +1,43 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, c: 1, a: 1.0)\n}"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, c: 1, a: 1.0)
+}
+
+----- ERROR
+error: Unknown record field
+  ┌─ /src/one/two.gleam:7:22
+  │
+7 │     Wibble(..wibble, c: 1, a: 1.0)
+  │                      ^^^^ Did you mean `a`?
+
+The value being accessed has this type:
+
+    Wibble
+
+It has these accessible fields:
+
+    .a
+    .b
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:28
+  │
+7 │     Wibble(..wibble, c: 1, a: 1.0)
+  │                            ^^^^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Float

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_2.snap
@@ -1,0 +1,51 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, a: 1.0, a: 2, c: 2)\n}"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: 1.0, a: 2, c: 2)
+}
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:22
+  │
+7 │     Wibble(..wibble, a: 1.0, a: 2, c: 2)
+  │                      ^^^^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Float
+
+error: Duplicate argument
+  ┌─ /src/one/two.gleam:7:30
+  │
+7 │     Wibble(..wibble, a: 1.0, a: 2, c: 2)
+  │                              ^^^^
+
+The labelled argument `a` has already been supplied.
+
+error: Unknown record field
+  ┌─ /src/one/two.gleam:7:36
+  │
+7 │     Wibble(..wibble, a: 1.0, a: 2, c: 2)
+  │                                    ^^^^ Did you mean `a`?
+
+The value being accessed has this type:
+
+    Wibble
+
+It has these accessible fields:
+
+    .a
+    .b

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_3.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, a: 1.0, a: 2)\n}"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: 1.0, a: 2)
+}
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:22
+  │
+7 │     Wibble(..wibble, a: 1.0, a: 2)
+  │                      ^^^^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Float
+
+error: Duplicate argument
+  ┌─ /src/one/two.gleam:7:30
+  │
+7 │     Wibble(..wibble, a: 1.0, a: 2)
+  │                              ^^^^
+
+The labelled argument `a` has already been supplied.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_4.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, a: 2, a: 3, b: 1)\n}"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: 2, a: 3, b: 1)
+}
+
+----- ERROR
+error: Duplicate argument
+  ┌─ /src/one/two.gleam:7:28
+  │
+7 │     Wibble(..wibble, a: 2, a: 3, b: 1)
+  │                            ^^^^
+
+The labelled argument `a` has already been supplied.
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:34
+  │
+7 │     Wibble(..wibble, a: 2, a: 3, b: 1)
+  │                                  ^^^^
+
+Expected type:
+
+    Bool
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__record_update_does_not_stop_at_first_invalid_field_5.snap
@@ -1,0 +1,57 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, b: 1, a: True, c: 2)\n}"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, b: 1, a: True, c: 2)
+}
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:22
+  │
+7 │     Wibble(..wibble, b: 1, a: True, c: 2)
+  │                      ^^^^
+
+Expected type:
+
+    Bool
+
+Found type:
+
+    Int
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:7:28
+  │
+7 │     Wibble(..wibble, b: 1, a: True, c: 2)
+  │                            ^^^^^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Bool
+
+error: Unknown record field
+  ┌─ /src/one/two.gleam:7:37
+  │
+7 │     Wibble(..wibble, b: 1, a: True, c: 2)
+  │                                     ^^^^ Did you mean `a`?
+
+The value being accessed has this type:
+
+    Wibble
+
+It has these accessible fields:
+
+    .a
+    .b

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__record_update_with_wrong_types_but_all_fields_produces_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__record_update_with_wrong_types_but_all_fields_produces_warning.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub type Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn main() {\n  let original = Wibble(a: 1, b: True)\n  Wibble(..original, a: True, b: 1)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn main() {
+  let original = Wibble(a: 1, b: True)
+  Wibble(..original, a: True, b: 1)
+}
+
+
+----- WARNING
+warning: Redundant record update
+  ┌─ /src/warning/wrn.gleam:8:3
+  │
+8 │   Wibble(..original, a: True, b: 1)
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This record update specifies all fields
+
+Hint: It is better style to use the record creation syntax.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -4830,3 +4830,51 @@ pub fn main(x) {
 }",
     );
 }
+
+#[test]
+fn record_update_with_all_wrong_fields_produces_no_warnings_1() {
+    assert_no_warnings!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn main() {
+  let original = Wibble(a: 1, b: True)
+  Wibble(..original, c: 2)
+}
+",
+    );
+}
+
+#[test]
+fn record_update_with_all_wrong_fields_produces_no_warnings_2() {
+    assert_no_warnings!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn main() {
+  let original = Wibble(a: 1, b: True)
+  Wibble(..original, a: True)
+}
+",
+    );
+}
+
+#[test]
+fn record_update_with_wrong_types_but_all_fields_produces_warning() {
+    assert_warning!(
+        "
+pub type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn main() {
+  let original = Wibble(a: 1, b: True)
+  Wibble(..original, a: True, b: 1)
+}
+"
+    );
+}

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -2098,3 +2098,51 @@ pub fn go(x: mod.Wibble) {
             .nth_occurrence(2)
     );
 }
+
+#[test]
+fn hover_for_invalid_record_update_1() {
+    assert_hover!(
+        "
+type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: True, b: 1)
+}
+",
+        find_position_of("True")
+    );
+}
+
+#[test]
+fn hover_for_invalid_record_update_2() {
+    assert_hover!(
+        "
+type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: True, b: 1)
+}
+",
+        find_position_of("1")
+    );
+}
+
+#[test]
+fn hover_for_invalid_record_update_3() {
+    assert_hover!(
+        "
+type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: True, b: 1)
+}
+",
+        find_position_of("Wibble").nth_occurrence(4)
+    );
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_1.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_1.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\ntype Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, a: True, b: 1)\n}\n"
+---
+type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: True, b: 1)
+                        ↑▔▔▔       
+}
+
+
+----- Hover content (markdown) -----
+```gleam
+Bool
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_2.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_2.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\ntype Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, a: True, b: 1)\n}\n"
+---
+type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: True, b: 1)
+                                 ↑ 
+}
+
+
+----- Hover content (markdown) -----
+```gleam
+Int
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_3.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_3.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\ntype Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, a: True, b: 1)\n}\n"
+---
+type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: True, b: 1)
+    ↑▔▔▔▔▔                         
+}
+
+
+----- Hover content (markdown) -----
+```gleam
+fn(Int, Bool) -> Wibble
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_4.snap.new
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_invalid_record_update_4.snap.new
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/hover.rs
+assertion_line: 2134
+expression: "\ntype Wibble {\n  Wibble(a: Int, b: Bool)\n}\n\npub fn go(wibble: Wibble) {\n    Wibble(..wibble, a: True, b: 1)\n}\n"
+snapshot_kind: text
+---
+type Wibble {
+  Wibble(a: Int, b: Bool)
+}
+
+pub fn go(wibble: Wibble) {
+    Wibble(..wibble, a: True, b: 1)
+                     ↑▔▔▔▔▔▔       
+}
+
+
+----- Hover content (markdown) -----
+```gleam
+Bool
+```


### PR DESCRIPTION
I noticed that record update expressions were not fault tolerant, an error in the first field meant all other fields would be ignored by the compiler and language server (for example to trigger code action, hovers, etc).
Now it's fault tolerant!

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
