### PR TITLE
Support `textDocument/documentHighlight` for usages of values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,25 @@
 
   ([Gavin Morrow](https://github.com/gavinmorrow))
 
+- The language server now supports `textDocument/documentHighlight` anywhere
+  that `textDocument/references` is available.
+
+  For example, triggering it with the cursor over any instance of `vec` will
+  result in all of the instances of it being highlighted.
+
+  ```gleam
+  fn to_cartesian(vec) {
+  //              ^^^
+    let x = vec.rho * cos(vec.theta)
+    //      ^^^           ^^^
+    let y = vec.rho * sin(vec.theta)
+    //      ^^^           ^^^
+    #(x, y)
+  }
+  ```
+
+  ([Gavin Morrow](https://github.com/gavinmorrow))
+
 ### Formatter
 
 ### Bug fixes

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -1018,6 +1018,120 @@ where
         })
     }
 
+    pub fn document_highlight(
+        &mut self,
+        params: lsp::DocumentHighlightParams,
+    ) -> Response<Option<Vec<lsp::DocumentHighlight>>> {
+        self.respond(|this| {
+            let position = &params.text_document_position_params;
+
+            let (lines, found) = match this.node_at_position(position) {
+                Some(value) => value,
+                None => return Ok(None),
+            };
+
+            let uri = position.text_document.uri.clone();
+
+            let Some(module) = this.module_for_uri(&uri) else {
+                return Ok(None);
+            };
+
+            let byte_index = lines.byte_index(position.position);
+
+            let referenced = reference_for_ast_node(found, &module.name);
+
+            Ok(match referenced {
+                Some(Referenced::LocalVariable {
+                    origin,
+                    definition_location,
+                    location,
+                    name,
+                }) if location.contains(byte_index) => match origin.map(|origin| origin.syntax) {
+                    Some(VariableSyntax::Generated) => None,
+                    Some(
+                        VariableSyntax::LabelShorthand(_)
+                        | VariableSyntax::AssignmentPattern
+                        | VariableSyntax::Variable { .. },
+                    )
+                    | None => {
+                        let variable_references =
+                            FindVariableReferences::new(definition_location, name)
+                                .find_in_module(&module.ast);
+
+                        let mut reference_locations =
+                            Vec::with_capacity(variable_references.len() + 1);
+                        reference_locations.push(lsp::DocumentHighlight {
+                            range: src_span_to_lsp_range(definition_location, &lines),
+                            kind: Some(lsp::DocumentHighlightKind::WRITE),
+                        });
+
+                        for reference in variable_references {
+                            let range = src_span_to_lsp_range(reference.location, &lines);
+                            reference_locations.push(lsp::DocumentHighlight {
+                                range,
+                                kind: Some(lsp::DocumentHighlightKind::WRITE),
+                            })
+                        }
+
+                        Some(reference_locations)
+                    }
+                },
+                Some(Referenced::ModuleValue {
+                    module: module_name,
+                    name,
+                    location,
+                    ..
+                }) if location.contains(byte_index) => {
+                    match this.compiler.get_module_interface(&module.name) {
+                        Some(module) => Some(
+                            find_module_references(
+                                module_name,
+                                name,
+                                // Only search in the current module
+                                &im::HashMap::unit(module.name.clone(), module.clone()),
+                                &this.compiler.sources,
+                                ast::Layer::Value,
+                            )
+                            .into_iter()
+                            .map(|location| lsp::DocumentHighlight {
+                                range: location.range,
+                                kind: None,
+                            })
+                            .collect(),
+                        ),
+                        None => None,
+                    }
+                }
+                Some(Referenced::ModuleType {
+                    module: module_name,
+                    name,
+                    location,
+                    ..
+                }) if location.contains(byte_index) => {
+                    match this.compiler.get_module_interface(&module.name) {
+                        Some(module) => Some(
+                            find_module_references(
+                                module_name,
+                                name,
+                                &im::HashMap::unit(module.name.clone(), module.clone()),
+                                &this.compiler.sources,
+                                ast::Layer::Type,
+                            )
+                            .into_iter()
+                            .map(|location| lsp::DocumentHighlight {
+                                range: location.range,
+                                kind: None,
+                            })
+                            .collect(),
+                        ),
+                        None => None,
+                    }
+                }
+                _ => None,
+            })
+        })
+    }
+
     fn respond<T>(&mut self, handler: impl FnOnce(&mut Self) -> Result<T>) -> Response<T> {
         let result = handler(self);
         let warnings = self.take_warnings();

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -989,7 +989,7 @@ where
                 location,
                 ..
             }) if location.contains(byte_index) => match search_scope {
-                FindReferencesSearchScope::AllImportableModules => Some(find_module_references(
+                FindReferencesSearchScope::AllModules => Some(find_module_references(
                     module,
                     name,
                     self.compiler.project_compiler.get_importable_modules(),
@@ -1014,7 +1014,7 @@ where
                 location,
                 ..
             }) if location.contains(byte_index) => match search_scope {
-                FindReferencesSearchScope::AllImportableModules => Some(find_module_references(
+                FindReferencesSearchScope::AllModules => Some(find_module_references(
                     module,
                     name,
                     self.compiler.project_compiler.get_importable_modules(),
@@ -1043,10 +1043,7 @@ where
     ) -> Response<Option<Vec<lsp::Location>>> {
         self.respond(|this| {
             let position = &params.text_document_position_params;
-            Ok(this.find_references_in_scope(
-                position,
-                FindReferencesSearchScope::AllImportableModules,
-            ))
+            Ok(this.find_references_in_scope(position, FindReferencesSearchScope::AllModules))
         })
     }
 
@@ -2094,6 +2091,6 @@ fn make_deprecated_symbol_tag(deprecation: &Deprecation) -> Option<Vec<SymbolTag
 }
 
 enum FindReferencesSearchScope {
-    AllImportableModules,
+    AllModules,
     CurrentModule,
 }

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -934,7 +934,7 @@ where
     }
 
     /// Shared core of find references and document highlight.
-    fn find_references_in_modules(
+    fn find_references_in_scope(
         &mut self,
         position: &lsp_types::TextDocumentPositionParams,
         search_scope: FindReferencesSearchScope,
@@ -1043,7 +1043,7 @@ where
     ) -> Response<Option<Vec<lsp::Location>>> {
         self.respond(|this| {
             let position = &params.text_document_position_params;
-            Ok(this.find_references_in_modules(
+            Ok(this.find_references_in_scope(
                 position,
                 FindReferencesSearchScope::AllImportableModules,
             ))
@@ -1057,7 +1057,7 @@ where
         self.respond(|this| {
             let position = &params.text_document_position_params;
             Ok(this
-                .find_references_in_modules(position, FindReferencesSearchScope::CurrentModule)
+                .find_references_in_scope(position, FindReferencesSearchScope::CurrentModule)
                 .map(|references| {
                     references
                         .into_iter()

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -933,6 +933,7 @@ where
         })
     }
 
+    /// Shared core of find references and document highlight.
     fn find_references_in_modules(
         &mut self,
         position: &lsp_types::TextDocumentPositionParams,

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -34,6 +34,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use crate::{
     code_action::{RemoveRedundantRecordUpdate, ReplaceUnderscoreWithType, type_errors_for_module},
+    reference::find_module_references_in_module,
     rename::rename_module_alias,
 };
 
@@ -932,89 +933,119 @@ where
         })
     }
 
+    fn find_references_in_modules(
+        &mut self,
+        position: &lsp_types::TextDocumentPositionParams,
+        search_scope: FindReferencesSearchScope,
+    ) -> Option<Vec<lsp::Location>> {
+        let (lines, found) = self.node_at_position(position)?;
+
+        let uri = position.text_document.uri.clone();
+
+        let source_module = self.module_for_uri(&uri)?;
+
+        let byte_index = lines.byte_index(position.position);
+
+        let referenced = reference_for_ast_node(found, &source_module.name);
+
+        match referenced {
+            Some(Referenced::LocalVariable {
+                origin,
+                definition_location,
+                location,
+                name,
+            }) if location.contains(byte_index) => match origin.map(|origin| origin.syntax) {
+                Some(VariableSyntax::Generated) => None,
+                Some(
+                    VariableSyntax::LabelShorthand(_)
+                    | VariableSyntax::AssignmentPattern
+                    | VariableSyntax::Variable { .. },
+                )
+                | None => {
+                    let variable_references =
+                        FindVariableReferences::new(definition_location, name)
+                            .find_in_module(&source_module.ast);
+
+                    let mut reference_locations = Vec::with_capacity(variable_references.len() + 1);
+                    reference_locations.push(lsp::Location {
+                        uri: uri.clone(),
+                        range: src_span_to_lsp_range(definition_location, &lines),
+                    });
+
+                    for reference in variable_references {
+                        reference_locations.push(lsp::Location {
+                            uri: uri.clone(),
+                            range: src_span_to_lsp_range(reference.location, &lines),
+                        })
+                    }
+
+                    Some(reference_locations)
+                }
+            },
+            Some(Referenced::ModuleValue {
+                module,
+                name,
+                location,
+                ..
+            }) if location.contains(byte_index) => match search_scope {
+                FindReferencesSearchScope::AllImportableModules => Some(find_module_references(
+                    module,
+                    name,
+                    self.compiler.project_compiler.get_importable_modules(),
+                    &self.compiler.sources,
+                    ast::Layer::Value,
+                )),
+                FindReferencesSearchScope::CurrentModule => {
+                    let source_information = self.compiler.get_source(&source_module.name)?;
+                    let source_module = self.compiler.get_module_interface(&source_module.name)?;
+                    Some(find_module_references_in_module(
+                        module,
+                        name,
+                        source_module,
+                        source_information,
+                        ast::Layer::Value,
+                    ))
+                }
+            },
+            Some(Referenced::ModuleType {
+                module,
+                name,
+                location,
+                ..
+            }) if location.contains(byte_index) => match search_scope {
+                FindReferencesSearchScope::AllImportableModules => Some(find_module_references(
+                    module,
+                    name,
+                    self.compiler.project_compiler.get_importable_modules(),
+                    &self.compiler.sources,
+                    ast::Layer::Type,
+                )),
+                FindReferencesSearchScope::CurrentModule => {
+                    let source_information = self.compiler.get_source(&source_module.name)?;
+                    let source_module = self.compiler.get_module_interface(&source_module.name)?;
+                    Some(find_module_references_in_module(
+                        module,
+                        name,
+                        source_module,
+                        source_information,
+                        ast::Layer::Type,
+                    ))
+                }
+            },
+            _ => None,
+        }
+    }
+
     pub fn find_references(
         &mut self,
         params: lsp::ReferenceParams,
     ) -> Response<Option<Vec<lsp::Location>>> {
         self.respond(|this| {
             let position = &params.text_document_position_params;
-
-            let (lines, found) = match this.node_at_position(position) {
-                Some(value) => value,
-                None => return Ok(None),
-            };
-
-            let uri = position.text_document.uri.clone();
-
-            let Some(module) = this.module_for_uri(&uri) else {
-                return Ok(None);
-            };
-
-            let byte_index = lines.byte_index(position.position);
-
-            let referenced = reference_for_ast_node(found, &module.name);
-
-            Ok(match referenced {
-                Some(Referenced::LocalVariable {
-                    origin,
-                    definition_location,
-                    location,
-                    name,
-                }) if location.contains(byte_index) => match origin.map(|origin| origin.syntax) {
-                    Some(VariableSyntax::Generated) => None,
-                    Some(
-                        VariableSyntax::LabelShorthand(_)
-                        | VariableSyntax::AssignmentPattern
-                        | VariableSyntax::Variable { .. },
-                    )
-                    | None => {
-                        let variable_references =
-                            FindVariableReferences::new(definition_location, name)
-                                .find_in_module(&module.ast);
-
-                        let mut reference_locations =
-                            Vec::with_capacity(variable_references.len() + 1);
-                        reference_locations.push(lsp::Location {
-                            uri: uri.clone(),
-                            range: src_span_to_lsp_range(definition_location, &lines),
-                        });
-
-                        for reference in variable_references {
-                            reference_locations.push(lsp::Location {
-                                uri: uri.clone(),
-                                range: src_span_to_lsp_range(reference.location, &lines),
-                            })
-                        }
-
-                        Some(reference_locations)
-                    }
-                },
-                Some(Referenced::ModuleValue {
-                    module,
-                    name,
-                    location,
-                    ..
-                }) if location.contains(byte_index) => Some(find_module_references(
-                    module,
-                    name,
-                    this.compiler.project_compiler.get_importable_modules(),
-                    &this.compiler.sources,
-                    ast::Layer::Value,
-                )),
-                Some(Referenced::ModuleType {
-                    module,
-                    name,
-                    location,
-                    ..
-                }) if location.contains(byte_index) => Some(find_module_references(
-                    module,
-                    name,
-                    this.compiler.project_compiler.get_importable_modules(),
-                    &this.compiler.sources,
-                    ast::Layer::Type,
-                )),
-                _ => None,
-            })
+            Ok(this.find_references_in_modules(
+                position,
+                FindReferencesSearchScope::AllImportableModules,
+            ))
         })
     }
 
@@ -1024,111 +1055,17 @@ where
     ) -> Response<Option<Vec<lsp::DocumentHighlight>>> {
         self.respond(|this| {
             let position = &params.text_document_position_params;
-
-            let (lines, found) = match this.node_at_position(position) {
-                Some(value) => value,
-                None => return Ok(None),
-            };
-
-            let uri = position.text_document.uri.clone();
-
-            let Some(module) = this.module_for_uri(&uri) else {
-                return Ok(None);
-            };
-
-            let byte_index = lines.byte_index(position.position);
-
-            let referenced = reference_for_ast_node(found, &module.name);
-
-            Ok(match referenced {
-                Some(Referenced::LocalVariable {
-                    origin,
-                    definition_location,
-                    location,
-                    name,
-                }) if location.contains(byte_index) => match origin.map(|origin| origin.syntax) {
-                    Some(VariableSyntax::Generated) => None,
-                    Some(
-                        VariableSyntax::LabelShorthand(_)
-                        | VariableSyntax::AssignmentPattern
-                        | VariableSyntax::Variable { .. },
-                    )
-                    | None => {
-                        let variable_references =
-                            FindVariableReferences::new(definition_location, name)
-                                .find_in_module(&module.ast);
-
-                        let mut reference_locations =
-                            Vec::with_capacity(variable_references.len() + 1);
-                        reference_locations.push(lsp::DocumentHighlight {
-                            range: src_span_to_lsp_range(definition_location, &lines),
-                            kind: Some(lsp::DocumentHighlightKind::WRITE),
-                        });
-
-                        for reference in variable_references {
-                            let range = src_span_to_lsp_range(reference.location, &lines);
-                            reference_locations.push(lsp::DocumentHighlight {
-                                range,
-                                kind: Some(lsp::DocumentHighlightKind::WRITE),
-                            })
-                        }
-
-                        Some(reference_locations)
-                    }
-                },
-                Some(Referenced::ModuleValue {
-                    module: module_name,
-                    name,
-                    location,
-                    ..
-                }) if location.contains(byte_index) => {
-                    match this.compiler.get_module_interface(&module.name) {
-                        Some(module) => Some(
-                            find_module_references(
-                                module_name,
-                                name,
-                                // Only search in the current module
-                                &im::HashMap::unit(module.name.clone(), module.clone()),
-                                &this.compiler.sources,
-                                ast::Layer::Value,
-                            )
-                            .into_iter()
-                            .map(|location| lsp::DocumentHighlight {
-                                range: location.range,
-                                kind: None,
-                            })
-                            .collect(),
-                        ),
-                        None => None,
-                    }
-                }
-                Some(Referenced::ModuleType {
-                    module: module_name,
-                    name,
-                    location,
-                    ..
-                }) if location.contains(byte_index) => {
-                    match this.compiler.get_module_interface(&module.name) {
-                        Some(module) => Some(
-                            find_module_references(
-                                module_name,
-                                name,
-                                &im::HashMap::unit(module.name.clone(), module.clone()),
-                                &this.compiler.sources,
-                                ast::Layer::Type,
-                            )
-                            .into_iter()
-                            .map(|location| lsp::DocumentHighlight {
-                                range: location.range,
-                                kind: None,
-                            })
-                            .collect(),
-                        ),
-                        None => None,
-                    }
-                }
-                _ => None,
-            })
+            Ok(this
+                .find_references_in_modules(position, FindReferencesSearchScope::CurrentModule)
+                .map(|references| {
+                    references
+                        .into_iter()
+                        .map(|loc| lsp::DocumentHighlight {
+                            range: loc.range,
+                            kind: None,
+                        })
+                        .collect()
+                }))
         })
     }
 
@@ -2153,4 +2090,9 @@ fn make_deprecated_symbol_tag(deprecation: &Deprecation) -> Option<Vec<SymbolTag
     deprecation
         .is_deprecated()
         .then(|| vec![SymbolTag::Deprecated])
+}
+
+enum FindReferencesSearchScope {
+    AllImportableModules,
+    CurrentModule,
 }

--- a/language-server/src/messages.rs
+++ b/language-server/src/messages.rs
@@ -3,9 +3,9 @@ use lsp::{DefinitionRequest, DidChangeWatchedFilesNotification, DidOpenTextDocum
 use lsp_types::{
     self as lsp, CodeActionRequest, CompletionRequest, DidChangeTextDocumentNotification,
     DidCloseTextDocumentNotification, DidSaveTextDocumentNotification, DocumentFormattingRequest,
-    DocumentSymbolRequest, FoldingRangeRequest, HoverRequest, PrepareRenameRequest,
-    ReferencesRequest, RenameRequest, SignatureHelpRequest, TextDocumentContentChangeEvent,
-    TypeDefinitionRequest,
+    DocumentHighlightRequest, DocumentSymbolRequest, FoldingRangeRequest, HoverRequest,
+    PrepareRenameRequest, ReferencesRequest, RenameRequest, SignatureHelpRequest,
+    TextDocumentContentChangeEvent, TypeDefinitionRequest,
 };
 use std::time::Duration;
 
@@ -29,6 +29,7 @@ pub enum Request {
     PrepareRename(lsp::PrepareRenameParams),
     Rename(lsp::RenameParams),
     FindReferences(lsp::ReferenceParams),
+    DocumentHighlight(lsp::DocumentHighlightParams),
 }
 
 impl Request {
@@ -82,6 +83,10 @@ impl Request {
             "textDocument/references" => {
                 let params = cast_request::<ReferencesRequest>(request);
                 Some(Message::Request(id, Request::FindReferences(params)))
+            }
+            "textDocument/documentHighlight" => {
+                let params = cast_request::<DocumentHighlightRequest>(request);
+                Some(Message::Request(id, Request::DocumentHighlight(params)))
             }
             _ => None,
         }

--- a/language-server/src/reference.rs
+++ b/language-server/src/reference.rs
@@ -403,6 +403,27 @@ pub fn find_module_references(
     reference_locations
 }
 
+pub fn find_module_references_in_module(
+    module_name: EcoString,
+    name: EcoString,
+    module: &ModuleInterface,
+    source_information: &ModuleSourceInformation,
+    layer: ast::Layer,
+) -> Vec<Location> {
+    let mut reference_locations = Vec::new();
+
+    find_references_in_module(
+        &module_name,
+        &name,
+        module,
+        source_information,
+        &mut reference_locations,
+        layer,
+    );
+
+    reference_locations
+}
+
 fn find_references_in_module(
     module_name: &EcoString,
     name: &EcoString,

--- a/language-server/src/server.rs
+++ b/language-server/src/server.rs
@@ -109,6 +109,7 @@ where
             Request::Rename(param) => self.rename(param),
             Request::GoToTypeDefinition(param) => self.goto_type_definition(param),
             Request::FindReferences(param) => self.find_references(param),
+            Request::DocumentHighlight(param) => self.document_highlight(param),
         };
 
         self.publish_feedback(feedback);
@@ -439,6 +440,14 @@ where
         self.respond_with_engine(path, |engine| engine.find_references(params))
     }
 
+    fn document_highlight(
+        &mut self,
+        params: lsp_types::DocumentHighlightParams,
+    ) -> (Result<Json, ResponseError>, Feedback) {
+        let path = super::path(&params.text_document_position_params.text_document.uri);
+        self.respond_with_engine(path, |engine| engine.document_highlight(params))
+    }
+
     fn cache_file_in_memory(&mut self, path: Utf8PathBuf, text: String) -> Feedback {
         self.project_changed(&path);
         if let Err(error) = self.io.write_mem_cache(&path, &text) {
@@ -533,7 +542,7 @@ fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializePa
         type_definition_provider: Some(true.into()),
         implementation_provider: None,
         references_provider: Some(true.into()),
-        document_highlight_provider: None,
+        document_highlight_provider: Some(true.into()),
         document_symbol_provider: Some(true.into()),
         workspace_symbol_provider: None,
         code_action_provider: Some(true.into()),

--- a/language-server/src/tests.rs
+++ b/language-server/src/tests.rs
@@ -2,6 +2,7 @@ mod action;
 mod compilation;
 mod completion;
 mod definition;
+mod document_highlight;
 mod document_symbols;
 mod folding_range;
 mod hover;

--- a/language-server/src/tests/document_highlight.rs
+++ b/language-server/src/tests/document_highlight.rs
@@ -1,0 +1,1046 @@
+use lsp_types::{
+    DocumentHighlightParams, PartialResultParams, Position, Range, TextDocumentPositionParams,
+    WorkDoneProgressParams,
+};
+
+use super::{TestProject, find_position_of};
+
+fn find_highlights(tester: &TestProject<'_>, position: Position) -> Option<(String, Vec<Range>)> {
+    tester.at(position, |engine, params, _| {
+        let params = DocumentHighlightParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: params.text_document,
+                position,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let module_name = tester
+            .module_name_from_url(&params.text_document_position_params.text_document.uri)
+            .expect("Valid uri");
+        engine
+            .document_highlight(params)
+            .result
+            .unwrap()
+            .map(|highlights| {
+                highlights
+                    .into_iter()
+                    .map(|highlight| highlight.range)
+                    .collect()
+            })
+            .map(|highlights| (module_name, highlights))
+    })
+}
+
+fn show_highlights(code: &str, position: Option<Position>, ranges: &[Range]) -> String {
+    let mut buffer = String::new();
+
+    for (line_number, line) in code.lines().enumerate() {
+        let mut underline = String::new();
+        let mut underline_empty = true;
+        let line_number = line_number as u32;
+
+        for (column_number, _) in line.chars().enumerate() {
+            let current_position = Position::new(line_number, column_number as u32);
+
+            // Check if any range covers this specific character
+            let is_in_range = ranges
+                .iter()
+                .any(|range| range.start <= current_position && current_position < range.end);
+
+            if Some(current_position) == position {
+                underline_empty = false;
+                underline.push('↑');
+            } else if is_in_range {
+                underline_empty = false;
+                underline.push('▔');
+            } else {
+                underline.push(' ');
+            }
+        }
+
+        buffer.push_str(line);
+        if !underline_empty {
+            buffer.push('\n');
+            buffer.push_str(&underline);
+        }
+        buffer.push('\n');
+    }
+
+    buffer
+}
+
+macro_rules! assert_highlights {
+    ($code:literal, $position:expr $(,)?) => {
+        assert_highlights!(TestProject::for_source($code), $position);
+    };
+
+    (($module_name:literal, $module_src:literal), $code:literal, $position:expr $(,)?) => {
+        assert_highlights!(
+            TestProject::for_source($code).add_module($module_name, $module_src),
+            $position
+        );
+    };
+
+    ($project:expr, $position:expr $(,)?) => {
+        let project = $project;
+        let src = project.src;
+        let position = $position.find_position(src);
+        let (module_name, result) =
+            find_highlights(&project, position).expect("Higlights not found");
+
+        let mut output = String::new();
+        for (name, src) in project.root_package_modules.iter() {
+            let highlights_in_module = if *name == module_name {
+                &result
+            } else {
+                &Vec::new()
+            };
+            output.push_str(&format!(
+                "-- {name}.gleam\n{}\n\n",
+                show_highlights(src, None, highlights_in_module)
+            ));
+        }
+        let highlights_in_app_module = if module_name == "app" {
+            &result
+        } else {
+            &Vec::new()
+        };
+        output.push_str(&format!(
+            "-- app.gleam\n{}",
+            show_highlights(src, Some(position), highlights_in_app_module)
+        ));
+
+        insta::assert_snapshot!(insta::internals::AutoName, output, src);
+    };
+}
+
+macro_rules! assert_no_highlights {
+    ($code:literal, $position:expr $(,)?) => {
+        let project = TestProject::for_source($code);
+        assert_no_highlights!(&project, $position);
+    };
+
+    ($project:expr, $position:expr $(,)?) => {
+        let src = $project.src;
+        let position = $position.find_position(src);
+        let result = find_highlights($project, position);
+        assert_eq!(result, None);
+    };
+}
+
+#[test]
+fn highlights_for_local_variable() {
+    assert_highlights!(
+        "
+pub fn main() {
+  let wibble = 10
+  let wobble = wibble + 1
+  wibble + wobble
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn highlights_for_local_variable_from_definition() {
+    assert_highlights!(
+        "
+pub fn main() {
+  let wibble = 10
+  let wobble = wibble + 1
+  wibble + wobble
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn highlights_for_private_function() {
+    assert_highlights!(
+        "
+fn wibble() {
+  wibble()
+}
+
+pub fn main() {
+  let _ = wibble()
+  wibble() + 4
+}
+
+fn wobble() {
+  wibble() || wobble()
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn highlights_for_private_function_from_reference() {
+    assert_highlights!(
+        "
+fn wibble() {
+  wibble()
+}
+
+pub fn main() {
+  let _ = wibble()
+  wibble() + 4
+}
+
+fn wobble() {
+  wibble() || wobble()
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn highlights_for_public_function() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import mod.{wibble}
+
+fn wobble() {
+  mod.wibble()
+}
+
+fn other() {
+  wibble()
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn highlights_for_function_from_qualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import mod
+
+pub fn main() {
+  let value = mod.wibble()
+  mod.wibble()
+  value
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn highlights_for_function_from_unqualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import mod.{wibble}
+
+pub fn main() {
+  let value = wibble()
+  mod.wibble()
+  value
+}
+",
+        find_position_of("wibble()"),
+    );
+}
+
+#[test]
+fn highlights_for_private_constant() {
+    assert_highlights!(
+        "
+const wibble = 10
+
+pub fn main() {
+  let _ = wibble
+  wibble + 4
+}
+
+fn wobble() {
+  wibble + wobble()
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn highlights_for_private_constant_from_reference() {
+    assert_highlights!(
+        "
+const wibble = 10
+
+pub fn main() {
+  let _ = wibble
+  wibble + 4
+}
+
+fn wobble() {
+  wibble + wobble()
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn highlights_for_public_constant() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub const wibble = 10
+
+pub fn main() {
+  wibble
+}
+"
+        ),
+        "
+import mod.{wibble}
+
+fn wobble() {
+  mod.wibble
+}
+
+fn other() {
+  wibble
+}
+",
+        find_position_of("wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn highlights_for_constant_from_qualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+"
+        ),
+        "
+import mod
+
+pub fn main() {
+  let value = mod.wibble
+  mod.wibble + value
+}
+",
+        find_position_of("wibble"),
+    );
+}
+
+#[test]
+fn highlights_for_constant_from_unqualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+"
+        ),
+        "
+import mod.{wibble}
+
+pub fn main() {
+  let value = mod.wibble
+  wibble + value
+}
+",
+        find_position_of("wibble +"),
+    );
+}
+
+#[test]
+fn higlights_for_private_type_variant() {
+    assert_highlights!(
+        "
+type Wibble { Wibble }
+
+fn main() {
+  let _ = Wibble
+  Wibble
+}
+
+fn wobble() {
+  Wibble
+  wobble()
+}
+",
+        find_position_of("Wibble }"),
+    );
+}
+
+#[test]
+fn higlights_for_private_type_variant_from_reference() {
+    assert_highlights!(
+        "
+type Wibble { Wibble }
+
+fn main() {
+  let _ = Wibble
+  Wibble
+}
+
+fn wobble() {
+  Wibble
+  wobble()
+}
+",
+        find_position_of(" = Wibble").under_char('W'),
+    );
+}
+
+#[test]
+fn higlights_for_public_type_variant() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+pub fn main() {
+  Wibble
+}
+"
+        ),
+        "
+import mod.{Wibble}
+
+fn wobble() {
+  mod.Wibble
+}
+
+fn other() {
+  Wibble
+}
+",
+        find_position_of("Wibble").nth_occurrence(3),
+    );
+}
+
+#[test]
+fn higlights_for_type_variant_from_qualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+"
+        ),
+        "
+import mod
+
+pub fn main() {
+  let value = mod.Wibble
+  mod.Wibble
+  value
+}
+",
+        find_position_of("Wibble"),
+    );
+}
+
+#[test]
+fn higlights_for_type_variant_from_unqualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+"
+        ),
+        "
+import mod.{Wibble}
+
+pub fn main() {
+  let value = mod.Wibble
+  Wibble
+}
+",
+        find_position_of("Wibble").nth_occurrence(3),
+    );
+}
+
+#[test]
+fn no_higlights_for_keyword() {
+    assert_no_highlights!(
+        "
+pub fn wibble() {
+  todo
+}
+",
+        find_position_of("fn")
+    );
+}
+
+#[test]
+fn higlights_for_aliased_value() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+pub fn main() {
+  Wibble
+}
+"
+        ),
+        "
+import mod.{Wibble as Wobble}
+
+fn wobble() {
+  Wobble
+}
+",
+        find_position_of("Wobble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn higlights_for_private_type() {
+    assert_highlights!(
+        "
+type Wibble { Wibble }
+
+fn main() -> Wibble {
+  todo
+}
+
+fn wobble(w: Wibble) {
+  todo
+}
+",
+        find_position_of("Wibble"),
+    );
+}
+
+#[test]
+fn higlights_for_private_type_from_reference() {
+    assert_highlights!(
+        "
+type Wibble { Wibble }
+
+fn main() -> Wibble {
+  todo
+}
+
+fn wobble(w: Wibble) {
+  todo
+}
+",
+        find_position_of("-> Wibble").under_char('W'),
+    );
+}
+
+#[test]
+fn higlights_for_public_type() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+pub fn main() -> Wibble {
+  todo
+}
+"
+        ),
+        "
+import mod.{type Wibble}
+
+fn wobble() -> Wibble {
+  todo
+}
+
+fn other(w: mod.Wibble) {
+  todo
+}
+",
+        find_position_of("-> Wibble").under_char('W'),
+    );
+}
+
+#[test]
+fn higlights_for_type_from_qualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+"
+        ),
+        "
+import mod
+
+pub fn main() -> mod.Wibble {
+  let _: mod.Wibble = todo
+}
+",
+        find_position_of("Wibble"),
+    );
+}
+
+#[test]
+fn higlights_for_type_from_unqualified_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+"
+        ),
+        "
+import mod.{type Wibble}
+
+pub fn main() -> Wibble {
+  let _: mod.Wibble = todo
+}
+",
+        find_position_of("Wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn higlights_for_aliased_type() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+pub fn main() -> Wibble {
+  todo
+}
+"
+        ),
+        "
+import mod.{type Wibble as Wobble}
+
+fn wobble() -> Wobble {
+  todo
+}
+
+fn other(w: mod.Wibble) {
+  todo
+}
+",
+        find_position_of("-> Wobble").under_char('W'),
+    );
+}
+
+#[test]
+fn higlights_for_type_from_let_annotation() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+"
+        ),
+        "
+import mod.{type Wibble}
+
+pub fn main() -> Wibble {
+  let _: mod.Wibble = todo
+}
+",
+        find_position_of("mod.Wibble").under_char('W'),
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_in_case() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let rest = case wibble {
+    \"1\" <> rest -> rest
+    other -> other
+  }
+  rest
+}
+",
+        find_position_of("rest").nth_occurrence(2)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_in_case_triggered_from_usage() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let rest = case wibble {
+    \"1\" <> rest -> rest
+    other -> other
+  }
+  rest
+}
+",
+        find_position_of("rest").nth_occurrence(3)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_with_alternative_definition_in_case() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let rest = case wibble {
+    \"1\" <> rest | \"2\" <> rest -> rest
+    other -> other
+  }
+  rest
+}
+",
+        find_position_of("rest").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_with_alternative_definition_triggered_from_second_pattern()
+ {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let rest = case wibble {
+    \"1\" <> rest | \"2\" <> rest -> rest
+    other -> other
+  }
+  rest
+}
+",
+        find_position_of("rest").nth_occurrence(3),
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_with_alternative_definition_triggered_from_usage() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let rest = case wibble {
+    \"1\" <> rest | \"2\" <> rest -> rest
+    other -> other
+  }
+  rest
+}
+",
+        find_position_of("rest").nth_occurrence(4),
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_in_let_assert() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let assert \"1\" <> rest = \"1-wibble\"
+  rest
+}
+",
+        find_position_of("rest").nth_occurrence(1),
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_in_let_assert_triggered_from_usage() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let assert \"1\" <> rest = \"1-wibble\"
+  rest
+}
+",
+        find_position_of("rest").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_in_case() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let digit = case wibble {
+    \"1\" as digit <> _rest -> digit
+    other -> other
+  }
+  digit
+}
+",
+        find_position_of("digit").nth_occurrence(2)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_in_case_triggered_from_usage() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let digit = case wibble {
+    \"1\" as digit <> _rest -> digit
+    other -> other
+  }
+  digit
+}
+",
+        find_position_of("digit").nth_occurrence(3)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_with_alternative_definitions_in_case() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let digit = case wibble {
+    \"1\" as digit <> _rest | \"2\" as digit <> _rest -> digit
+    other -> other
+  }
+  digit
+}
+",
+        find_position_of("digit").nth_occurrence(2)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_with_alternative_definitions_triggered_from_second_pattern() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let digit = case wibble {
+    \"1\" as digit <> _rest | \"2\" as digit <> _rest -> digit
+    other -> other
+  }
+  digit
+}
+",
+        find_position_of("digit").nth_occurrence(3)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_with_alternative_definitions_triggered_from_usage() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let wibble = \"1-wibble\"
+  let digit = case wibble {
+    \"1\" as digit <> _rest | \"2\" as digit <> _rest -> digit
+    other -> other
+  }
+  digit
+}
+",
+        find_position_of("digit").nth_occurrence(4)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_in_let_assert() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let assert \"1\" as digit <> _rest = \"1-wibble\"
+  digit
+}
+",
+        find_position_of("digit").nth_occurrence(1)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_in_let_assert_triggered_from_usage() {
+    assert_highlights!(
+        "
+pub fn main() -> String {
+  let assert \"1\" as digit <> _rest = \"1-wibble\"
+  digit
+}
+",
+        find_position_of("digit").nth_occurrence(2)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_variable_nested_in_tuple() {
+    assert_highlights!(
+        "
+fn main() {
+  case #(\"1-wibble\", 0) {
+    #(\"1\" <> rest, _) -> rest
+    _ -> \"\"
+  }
+}
+",
+        find_position_of("rest").nth_occurrence(1)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_used_in_guard() {
+    assert_highlights!(
+        "
+fn main() {
+  case \"1-wibble\" {
+    \"1\" as digit <> _rest if digit == \"1\" -> digit
+    _ -> \"\"
+  }
+}
+",
+        find_position_of("digit").nth_occurrence(1)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_used_in_guard() {
+    assert_highlights!(
+        "
+fn main() {
+  case \"1-wibble\" {
+    \"1\" <> rest if rest == \"-wibble\" -> rest
+    _ -> \"\"
+  }
+}
+",
+        find_position_of("rest").nth_occurrence(1)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_suffix_shadowing_outer_variable() {
+    assert_highlights!(
+        "
+fn main() {
+  let rest = \"outer\"
+  case \"1-wibble\" {
+    \"1\" <> rest -> rest
+    _ -> rest
+  }
+}
+",
+        find_position_of("rest").nth_occurrence(2)
+    );
+}
+
+#[test]
+fn higlights_for_prefix_string_alias_and_suffix_complex_guard() {
+    assert_highlights!(
+        "
+fn main() {
+  case \"1-wibble\" {
+    \"1\" as digit <> rest if digit == \"1\" && rest == \"-wibble\" -> #(digit, rest)
+    _ -> #(\"\", \"\")
+  }
+}
+",
+        find_position_of("digit").nth_occurrence(1)
+    );
+}
+
+#[test]
+fn higlights_for_local_variable_from_guard() {
+    assert_highlights!(
+        "
+pub fn main() {
+  let wibble = True
+  let wobble = False
+  case wibble {
+    True if wobble -> !wibble
+    False if !wobble -> wibble
+    _ -> wobble
+  }
+}
+",
+        find_position_of("wobble").nth_occurrence(2).under_char('o')
+    );
+}
+
+#[test]
+fn higlights_for_module_select_from_guard() {
+    assert_highlights!(
+        ("mod", "pub const wibble = 10"),
+        "
+import mod
+
+pub fn main() {
+  let wibble = True
+  case wibble {
+    True if mod.wibble < 5 -> !wibble
+    False if mod.wibble != 10 -> wibble
+    _ -> mod.wibble + 1
+  }
+}
+",
+        find_position_of("mod.wibble").under_char('w')
+    );
+}

--- a/language-server/src/tests/document_highlight.rs
+++ b/language-server/src/tests/document_highlight.rs
@@ -274,6 +274,30 @@ pub fn main() {
 }
 
 #[test]
+fn highlights_for_function_from_unqualified_aliased_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub fn wibble() {
+  wibble()
+}
+"
+        ),
+        "
+import mod.{wibble as wobble}
+
+pub fn main() {
+  let value = wobble()
+  mod.wibble()
+  value
+}
+",
+        find_position_of("wobble()"),
+    );
+}
+
+#[test]
 fn highlights_for_private_constant() {
     assert_highlights!(
         "
@@ -386,6 +410,31 @@ pub fn main() {
 }
 ",
         find_position_of("wibble +"),
+    );
+}
+
+#[test]
+fn highlights_for_constant_from_unqualified_aliased_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+"
+        ),
+        "
+import mod.{wibble as wobble}
+
+pub fn main() {
+  let value = mod.wibble
+  wobble + value
+}
+",
+        find_position_of("wobble +"),
     );
 }
 
@@ -505,6 +554,31 @@ pub fn main() {
 }
 ",
         find_position_of("Wibble").nth_occurrence(3),
+    );
+}
+
+#[test]
+fn higlights_for_type_variant_from_unqualified_aliased_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+"
+        ),
+        "
+import mod.{Wibble as Wobble}
+
+pub fn main() {
+  let value = mod.Wibble
+  Wobble
+}
+",
+        find_position_of("Wobble").nth_occurrence(2),
     );
 }
 
@@ -653,6 +727,30 @@ pub fn main() -> Wibble {
 }
 ",
         find_position_of("Wibble").nth_occurrence(2),
+    );
+}
+
+#[test]
+fn higlights_for_type_from_unqualified_aliased_reference() {
+    assert_highlights!(
+        (
+            "mod",
+            "
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+"
+        ),
+        "
+import mod.{type Wibble as Wobble}
+
+pub fn main() -> Wobble {
+  let _: mod.Wibble = todo
+}
+",
+        find_position_of("Wobble").nth_occurrence(2),
     );
 }
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_constant_from_qualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_constant_from_qualified_reference.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod\n\npub fn main() {\n  let value = mod.wibble\n  mod.wibble + value\n}\n"
+---
+-- mod.gleam
+
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() {
+  let value = mod.wibble
+                  ↑▔▔▔▔▔
+  mod.wibble + value
+      ▔▔▔▔▔▔        
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_constant_from_unqualified_aliased_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_constant_from_unqualified_aliased_reference.snap
@@ -1,0 +1,24 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{wibble as wobble}\n\npub fn main() {\n  let value = mod.wibble\n  wobble + value\n}\n"
+---
+-- mod.gleam
+
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+
+
+-- app.gleam
+
+import mod.{wibble as wobble}
+            ▔▔▔▔▔▔           
+
+pub fn main() {
+  let value = mod.wibble
+                  ▔▔▔▔▔▔
+  wobble + value
+  ↑▔▔▔▔▔        
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_constant_from_unqualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_constant_from_unqualified_reference.snap
@@ -1,0 +1,24 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{wibble}\n\npub fn main() {\n  let value = mod.wibble\n  wibble + value\n}\n"
+---
+-- mod.gleam
+
+pub const wibble = 10
+
+fn wobble() {
+  wibble
+}
+
+
+-- app.gleam
+
+import mod.{wibble}
+            ▔▔▔▔▔▔ 
+
+pub fn main() {
+  let value = mod.wibble
+                  ▔▔▔▔▔▔
+  wibble + value
+  ↑▔▔▔▔▔        
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_function_from_qualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_function_from_qualified_reference.snap
@@ -1,0 +1,22 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod\n\npub fn main() {\n  let value = mod.wibble()\n  mod.wibble()\n  value\n}\n"
+---
+-- mod.gleam
+
+pub fn wibble() {
+  wibble()
+}
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() {
+  let value = mod.wibble()
+                  ↑▔▔▔▔▔  
+  mod.wibble()
+      ▔▔▔▔▔▔  
+  value
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_function_from_unqualified_aliased_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_function_from_unqualified_aliased_reference.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{wibble as wobble}\n\npub fn main() {\n  let value = wobble()\n  mod.wibble()\n  value\n}\n"
+---
+-- mod.gleam
+
+pub fn wibble() {
+  wibble()
+}
+
+
+-- app.gleam
+
+import mod.{wibble as wobble}
+            ▔▔▔▔▔▔           
+
+pub fn main() {
+  let value = wobble()
+              ↑▔▔▔▔▔  
+  mod.wibble()
+      ▔▔▔▔▔▔  
+  value
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_function_from_unqualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_function_from_unqualified_reference.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{wibble}\n\npub fn main() {\n  let value = wibble()\n  mod.wibble()\n  value\n}\n"
+---
+-- mod.gleam
+
+pub fn wibble() {
+  wibble()
+}
+
+
+-- app.gleam
+
+import mod.{wibble}
+            ▔▔▔▔▔▔ 
+
+pub fn main() {
+  let value = wibble()
+              ↑▔▔▔▔▔  
+  mod.wibble()
+      ▔▔▔▔▔▔  
+  value
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_local_variable.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_local_variable.snap
@@ -1,0 +1,14 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  let wobble = wibble + 1\n  wibble + wobble\n}\n"
+---
+-- app.gleam
+
+pub fn main() {
+  let wibble = 10
+      ▔▔▔▔▔▔     
+  let wobble = wibble + 1
+               ↑▔▔▔▔▔    
+  wibble + wobble
+  ▔▔▔▔▔▔         
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_local_variable_from_definition.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_local_variable_from_definition.snap
@@ -1,0 +1,14 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() {\n  let wibble = 10\n  let wobble = wibble + 1\n  wibble + wobble\n}\n"
+---
+-- app.gleam
+
+pub fn main() {
+  let wibble = 10
+      ↑▔▔▔▔▔     
+  let wobble = wibble + 1
+               ▔▔▔▔▔▔    
+  wibble + wobble
+  ▔▔▔▔▔▔         
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_constant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_constant.snap
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nconst wibble = 10\n\npub fn main() {\n  let _ = wibble\n  wibble + 4\n}\n\nfn wobble() {\n  wibble + wobble()\n}\n"
+---
+-- app.gleam
+
+const wibble = 10
+      ↑▔▔▔▔▔     
+
+pub fn main() {
+  let _ = wibble
+          ▔▔▔▔▔▔
+  wibble + 4
+  ▔▔▔▔▔▔    
+}
+
+fn wobble() {
+  wibble + wobble()
+  ▔▔▔▔▔▔           
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_constant_from_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_constant_from_reference.snap
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nconst wibble = 10\n\npub fn main() {\n  let _ = wibble\n  wibble + 4\n}\n\nfn wobble() {\n  wibble + wobble()\n}\n"
+---
+-- app.gleam
+
+const wibble = 10
+      ▔▔▔▔▔▔     
+
+pub fn main() {
+  let _ = wibble
+          ↑▔▔▔▔▔
+  wibble + 4
+  ▔▔▔▔▔▔    
+}
+
+fn wobble() {
+  wibble + wobble()
+  ▔▔▔▔▔▔           
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_function.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nfn wibble() {\n  wibble()\n}\n\npub fn main() {\n  let _ = wibble()\n  wibble() + 4\n}\n\nfn wobble() {\n  wibble() || wobble()\n}\n"
+---
+-- app.gleam
+
+fn wibble() {
+   ↑▔▔▔▔▔    
+  wibble()
+  ▔▔▔▔▔▔  
+}
+
+pub fn main() {
+  let _ = wibble()
+          ▔▔▔▔▔▔  
+  wibble() + 4
+  ▔▔▔▔▔▔      
+}
+
+fn wobble() {
+  wibble() || wobble()
+  ▔▔▔▔▔▔              
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_function_from_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_private_function_from_reference.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nfn wibble() {\n  wibble()\n}\n\npub fn main() {\n  let _ = wibble()\n  wibble() + 4\n}\n\nfn wobble() {\n  wibble() || wobble()\n}\n"
+---
+-- app.gleam
+
+fn wibble() {
+   ▔▔▔▔▔▔    
+  wibble()
+  ↑▔▔▔▔▔  
+}
+
+pub fn main() {
+  let _ = wibble()
+          ▔▔▔▔▔▔  
+  wibble() + 4
+  ▔▔▔▔▔▔      
+}
+
+fn wobble() {
+  wibble() || wobble()
+  ▔▔▔▔▔▔              
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_public_constant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_public_constant.snap
@@ -1,0 +1,27 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{wibble}\n\nfn wobble() {\n  mod.wibble\n}\n\nfn other() {\n  wibble\n}\n"
+---
+-- mod.gleam
+
+pub const wibble = 10
+
+pub fn main() {
+  wibble
+}
+
+
+-- app.gleam
+
+import mod.{wibble}
+            ▔▔▔▔▔▔ 
+
+fn wobble() {
+  mod.wibble
+      ↑▔▔▔▔▔
+}
+
+fn other() {
+  wibble
+  ▔▔▔▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_public_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__highlights_for_public_function.snap
@@ -1,0 +1,25 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{wibble}\n\nfn wobble() {\n  mod.wibble()\n}\n\nfn other() {\n  wibble()\n}\n"
+---
+-- mod.gleam
+
+pub fn wibble() {
+  wibble()
+}
+
+
+-- app.gleam
+
+import mod.{wibble}
+            ▔▔▔▔▔▔ 
+
+fn wobble() {
+  mod.wibble()
+      ↑▔▔▔▔▔  
+}
+
+fn other() {
+  wibble()
+  ▔▔▔▔▔▔  
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_aliased_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_aliased_type.snap
@@ -1,0 +1,27 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{type Wibble as Wobble}\n\nfn wobble() -> Wobble {\n  todo\n}\n\nfn other(w: mod.Wibble) {\n  todo\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+pub fn main() -> Wibble {
+  todo
+}
+
+
+-- app.gleam
+
+import mod.{type Wibble as Wobble}
+                 ▔▔▔▔▔▔           
+
+fn wobble() -> Wobble {
+               ↑▔▔▔▔▔  
+  todo
+}
+
+fn other(w: mod.Wibble) {
+                ▔▔▔▔▔▔   
+  todo
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_aliased_value.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_aliased_value.snap
@@ -1,0 +1,22 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{Wibble as Wobble}\n\nfn wobble() {\n  Wobble\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+pub fn main() {
+  Wibble
+}
+
+
+-- app.gleam
+
+import mod.{Wibble as Wobble}
+            ▔▔▔▔▔▔           
+
+fn wobble() {
+  Wobble
+  ↑▔▔▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_local_variable_from_guard.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_local_variable_from_guard.snap
@@ -1,0 +1,19 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() {\n  let wibble = True\n  let wobble = False\n  case wibble {\n    True if wobble -> !wibble\n    False if !wobble -> wibble\n    _ -> wobble\n  }\n}\n"
+---
+-- app.gleam
+
+pub fn main() {
+  let wibble = True
+  let wobble = False
+      ▔▔▔▔▔▔        
+  case wibble {
+    True if wobble -> !wibble
+            ▔↑▔▔▔▔           
+    False if !wobble -> wibble
+              ▔▔▔▔▔▔          
+    _ -> wobble
+         ▔▔▔▔▔▔
+  }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_module_select_from_guard.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_module_select_from_guard.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod\n\npub fn main() {\n  let wibble = True\n  case wibble {\n    True if mod.wibble < 5 -> !wibble\n    False if mod.wibble != 10 -> wibble\n    _ -> mod.wibble + 1\n  }\n}\n"
+---
+-- mod.gleam
+pub const wibble = 10
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() {
+  let wibble = True
+  case wibble {
+    True if mod.wibble < 5 -> !wibble
+                ↑▔▔▔▔▔               
+    False if mod.wibble != 10 -> wibble
+                 ▔▔▔▔▔▔                
+    _ -> mod.wibble + 1
+             ▔▔▔▔▔▔    
+  }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_and_suffix_complex_guard.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_and_suffix_complex_guard.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nfn main() {\n  case \"1-wibble\" {\n    \"1\" as digit <> rest if digit == \"1\" && rest == \"-wibble\" -> #(digit, rest)\n    _ -> #(\"\", \"\")\n  }\n}\n"
+---
+-- app.gleam
+
+fn main() {
+  case "1-wibble" {
+    "1" as digit <> rest if digit == "1" && rest == "-wibble" -> #(digit, rest)
+           ↑▔▔▔▔            ▔▔▔▔▔                                  ▔▔▔▔▔       
+    _ -> #("", "")
+  }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_case.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_case.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let digit = case wibble {\n    \"1\" as digit <> _rest -> digit\n    other -> other\n  }\n  digit\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let digit = case wibble {
+    "1" as digit <> _rest -> digit
+           ↑▔▔▔▔             ▔▔▔▔▔
+    other -> other
+  }
+  digit
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_case_triggered_from_usage.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_case_triggered_from_usage.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let digit = case wibble {\n    \"1\" as digit <> _rest -> digit\n    other -> other\n  }\n  digit\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let digit = case wibble {
+    "1" as digit <> _rest -> digit
+           ▔▔▔▔▔             ↑▔▔▔▔
+    other -> other
+  }
+  digit
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_let_assert.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_let_assert.snap
@@ -1,0 +1,12 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let assert \"1\" as digit <> _rest = \"1-wibble\"\n  digit\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let assert "1" as digit <> _rest = "1-wibble"
+                    ↑▔▔▔▔                      
+  digit
+  ▔▔▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_let_assert_triggered_from_usage.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_in_let_assert_triggered_from_usage.snap
@@ -1,0 +1,12 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let assert \"1\" as digit <> _rest = \"1-wibble\"\n  digit\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let assert "1" as digit <> _rest = "1-wibble"
+                    ▔▔▔▔▔                      
+  digit
+  ↑▔▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_used_in_guard.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_used_in_guard.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nfn main() {\n  case \"1-wibble\" {\n    \"1\" as digit <> _rest if digit == \"1\" -> digit\n    _ -> \"\"\n  }\n}\n"
+---
+-- app.gleam
+
+fn main() {
+  case "1-wibble" {
+    "1" as digit <> _rest if digit == "1" -> digit
+           ↑▔▔▔▔             ▔▔▔▔▔           ▔▔▔▔▔
+    _ -> ""
+  }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_with_alternative_definitions_in_case.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_with_alternative_definitions_in_case.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let digit = case wibble {\n    \"1\" as digit <> _rest | \"2\" as digit <> _rest -> digit\n    other -> other\n  }\n  digit\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let digit = case wibble {
+    "1" as digit <> _rest | "2" as digit <> _rest -> digit
+           ↑▔▔▔▔                   ▔▔▔▔▔             ▔▔▔▔▔
+    other -> other
+  }
+  digit
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_with_alternative_definitions_triggered_from_second_pattern.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_with_alternative_definitions_triggered_from_second_pattern.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let digit = case wibble {\n    \"1\" as digit <> _rest | \"2\" as digit <> _rest -> digit\n    other -> other\n  }\n  digit\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let digit = case wibble {
+    "1" as digit <> _rest | "2" as digit <> _rest -> digit
+           ▔▔▔▔▔                   ↑▔▔▔▔             ▔▔▔▔▔
+    other -> other
+  }
+  digit
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_with_alternative_definitions_triggered_from_usage.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_alias_with_alternative_definitions_triggered_from_usage.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let digit = case wibble {\n    \"1\" as digit <> _rest | \"2\" as digit <> _rest -> digit\n    other -> other\n  }\n  digit\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let digit = case wibble {
+    "1" as digit <> _rest | "2" as digit <> _rest -> digit
+           ▔▔▔▔▔                   ▔▔▔▔▔             ↑▔▔▔▔
+    other -> other
+  }
+  digit
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_shadowing_outer_variable.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_shadowing_outer_variable.snap
@@ -1,0 +1,14 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nfn main() {\n  let rest = \"outer\"\n  case \"1-wibble\" {\n    \"1\" <> rest -> rest\n    _ -> rest\n  }\n}\n"
+---
+-- app.gleam
+
+fn main() {
+  let rest = "outer"
+  case "1-wibble" {
+    "1" <> rest -> rest
+           ↑▔▔▔    ▔▔▔▔
+    _ -> rest
+  }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_used_in_guard.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_used_in_guard.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nfn main() {\n  case \"1-wibble\" {\n    \"1\" <> rest if rest == \"-wibble\" -> rest\n    _ -> \"\"\n  }\n}\n"
+---
+-- app.gleam
+
+fn main() {
+  case "1-wibble" {
+    "1" <> rest if rest == "-wibble" -> rest
+           ↑▔▔▔    ▔▔▔▔                 ▔▔▔▔
+    _ -> ""
+  }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_case.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_case.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let rest = case wibble {\n    \"1\" <> rest -> rest\n    other -> other\n  }\n  rest\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let rest = case wibble {
+    "1" <> rest -> rest
+           ↑▔▔▔    ▔▔▔▔
+    other -> other
+  }
+  rest
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_case_triggered_from_usage.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_case_triggered_from_usage.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let rest = case wibble {\n    \"1\" <> rest -> rest\n    other -> other\n  }\n  rest\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let rest = case wibble {
+    "1" <> rest -> rest
+           ▔▔▔▔    ↑▔▔▔
+    other -> other
+  }
+  rest
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_let_assert.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_let_assert.snap
@@ -1,0 +1,12 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let assert \"1\" <> rest = \"1-wibble\"\n  rest\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let assert "1" <> rest = "1-wibble"
+                    ↑▔▔▔             
+  rest
+  ▔▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_let_assert_triggered_from_usage.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_in_let_assert_triggered_from_usage.snap
@@ -1,0 +1,12 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let assert \"1\" <> rest = \"1-wibble\"\n  rest\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let assert "1" <> rest = "1-wibble"
+                    ▔▔▔▔             
+  rest
+  ↑▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_nested_in_tuple.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_nested_in_tuple.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nfn main() {\n  case #(\"1-wibble\", 0) {\n    #(\"1\" <> rest, _) -> rest\n    _ -> \"\"\n  }\n}\n"
+---
+-- app.gleam
+
+fn main() {
+  case #("1-wibble", 0) {
+    #("1" <> rest, _) -> rest
+             ↑▔▔▔        ▔▔▔▔
+    _ -> ""
+  }
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_with_alternative_definition_in_case.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_with_alternative_definition_in_case.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let rest = case wibble {\n    \"1\" <> rest | \"2\" <> rest -> rest\n    other -> other\n  }\n  rest\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let rest = case wibble {
+    "1" <> rest | "2" <> rest -> rest
+           ↑▔▔▔          ▔▔▔▔    ▔▔▔▔
+    other -> other
+  }
+  rest
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_with_alternative_definition_triggered_from_second_pattern.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_with_alternative_definition_triggered_from_second_pattern.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let rest = case wibble {\n    \"1\" <> rest | \"2\" <> rest -> rest\n    other -> other\n  }\n  rest\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let rest = case wibble {
+    "1" <> rest | "2" <> rest -> rest
+           ▔▔▔▔          ↑▔▔▔    ▔▔▔▔
+    other -> other
+  }
+  rest
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_with_alternative_definition_triggered_from_usage.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_prefix_string_suffix_variable_with_alternative_definition_triggered_from_usage.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\npub fn main() -> String {\n  let wibble = \"1-wibble\"\n  let rest = case wibble {\n    \"1\" <> rest | \"2\" <> rest -> rest\n    other -> other\n  }\n  rest\n}\n"
+---
+-- app.gleam
+
+pub fn main() -> String {
+  let wibble = "1-wibble"
+  let rest = case wibble {
+    "1" <> rest | "2" <> rest -> rest
+           ▔▔▔▔          ▔▔▔▔    ↑▔▔▔
+    other -> other
+  }
+  rest
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\ntype Wibble { Wibble }\n\nfn main() -> Wibble {\n  todo\n}\n\nfn wobble(w: Wibble) {\n  todo\n}\n"
+---
+-- app.gleam
+
+type Wibble { Wibble }
+     ↑▔▔▔▔▔           
+
+fn main() -> Wibble {
+             ▔▔▔▔▔▔  
+  todo
+}
+
+fn wobble(w: Wibble) {
+             ▔▔▔▔▔▔   
+  todo
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type_from_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type_from_reference.snap
@@ -1,0 +1,18 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\ntype Wibble { Wibble }\n\nfn main() -> Wibble {\n  todo\n}\n\nfn wobble(w: Wibble) {\n  todo\n}\n"
+---
+-- app.gleam
+
+type Wibble { Wibble }
+     ▔▔▔▔▔▔           
+
+fn main() -> Wibble {
+             ↑▔▔▔▔▔  
+  todo
+}
+
+fn wobble(w: Wibble) {
+             ▔▔▔▔▔▔   
+  todo
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type_variant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type_variant.snap
@@ -1,0 +1,21 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\ntype Wibble { Wibble }\n\nfn main() {\n  let _ = Wibble\n  Wibble\n}\n\nfn wobble() {\n  Wibble\n  wobble()\n}\n"
+---
+-- app.gleam
+
+type Wibble { Wibble }
+              ↑▔▔▔▔▔  
+
+fn main() {
+  let _ = Wibble
+          ▔▔▔▔▔▔
+  Wibble
+  ▔▔▔▔▔▔
+}
+
+fn wobble() {
+  Wibble
+  ▔▔▔▔▔▔
+  wobble()
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type_variant_from_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_private_type_variant_from_reference.snap
@@ -1,0 +1,21 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\ntype Wibble { Wibble }\n\nfn main() {\n  let _ = Wibble\n  Wibble\n}\n\nfn wobble() {\n  Wibble\n  wobble()\n}\n"
+---
+-- app.gleam
+
+type Wibble { Wibble }
+              ▔▔▔▔▔▔  
+
+fn main() {
+  let _ = Wibble
+          ↑▔▔▔▔▔
+  Wibble
+  ▔▔▔▔▔▔
+}
+
+fn wobble() {
+  Wibble
+  ▔▔▔▔▔▔
+  wobble()
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_public_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_public_type.snap
@@ -1,0 +1,27 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{type Wibble}\n\nfn wobble() -> Wibble {\n  todo\n}\n\nfn other(w: mod.Wibble) {\n  todo\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+pub fn main() -> Wibble {
+  todo
+}
+
+
+-- app.gleam
+
+import mod.{type Wibble}
+                 ▔▔▔▔▔▔ 
+
+fn wobble() -> Wibble {
+               ↑▔▔▔▔▔  
+  todo
+}
+
+fn other(w: mod.Wibble) {
+                ▔▔▔▔▔▔   
+  todo
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_public_type_variant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_public_type_variant.snap
@@ -1,0 +1,27 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{Wibble}\n\nfn wobble() {\n  mod.Wibble\n}\n\nfn other() {\n  Wibble\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+pub fn main() {
+  Wibble
+}
+
+
+-- app.gleam
+
+import mod.{Wibble}
+            ▔▔▔▔▔▔ 
+
+fn wobble() {
+  mod.Wibble
+      ▔▔▔▔▔▔
+}
+
+fn other() {
+  Wibble
+  ↑▔▔▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_let_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_let_annotation.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{type Wibble}\n\npub fn main() -> Wibble {\n  let _: mod.Wibble = todo\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+
+
+-- app.gleam
+
+import mod.{type Wibble}
+                 ▔▔▔▔▔▔ 
+
+pub fn main() -> Wibble {
+                 ▔▔▔▔▔▔  
+  let _: mod.Wibble = todo
+             ↑▔▔▔▔▔       
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_qualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_qualified_reference.snap
@@ -1,0 +1,22 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod\n\npub fn main() -> mod.Wibble {\n  let _: mod.Wibble = todo\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() -> mod.Wibble {
+                     ↑▔▔▔▔▔  
+  let _: mod.Wibble = todo
+             ▔▔▔▔▔▔       
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_unqualified_aliased_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_unqualified_aliased_reference.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{type Wibble as Wobble}\n\npub fn main() -> Wobble {\n  let _: mod.Wibble = todo\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+
+
+-- app.gleam
+
+import mod.{type Wibble as Wobble}
+                 ▔▔▔▔▔▔           
+
+pub fn main() -> Wobble {
+                 ↑▔▔▔▔▔  
+  let _: mod.Wibble = todo
+             ▔▔▔▔▔▔       
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_unqualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_from_unqualified_reference.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{type Wibble}\n\npub fn main() -> Wibble {\n  let _: mod.Wibble = todo\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+fn wobble() -> Wibble {
+  todo
+}
+
+
+-- app.gleam
+
+import mod.{type Wibble}
+                 ▔▔▔▔▔▔ 
+
+pub fn main() -> Wibble {
+                 ↑▔▔▔▔▔  
+  let _: mod.Wibble = todo
+             ▔▔▔▔▔▔       
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_variant_from_qualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_variant_from_qualified_reference.snap
@@ -1,0 +1,24 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod\n\npub fn main() {\n  let value = mod.Wibble\n  mod.Wibble\n  value\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+
+
+-- app.gleam
+
+import mod
+
+pub fn main() {
+  let value = mod.Wibble
+                  ↑▔▔▔▔▔
+  mod.Wibble
+      ▔▔▔▔▔▔
+  value
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_variant_from_unqualified_aliased_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_variant_from_unqualified_aliased_reference.snap
@@ -1,0 +1,24 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{Wibble as Wobble}\n\npub fn main() {\n  let value = mod.Wibble\n  Wobble\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+
+
+-- app.gleam
+
+import mod.{Wibble as Wobble}
+            ▔▔▔▔▔▔           
+
+pub fn main() {
+  let value = mod.Wibble
+                  ▔▔▔▔▔▔
+  Wobble
+  ↑▔▔▔▔▔
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_variant_from_unqualified_reference.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__document_highlight__higlights_for_type_variant_from_unqualified_reference.snap
@@ -1,0 +1,24 @@
+---
+source: language-server/src/tests/document_highlight.rs
+expression: "\nimport mod.{Wibble}\n\npub fn main() {\n  let value = mod.Wibble\n  Wibble\n}\n"
+---
+-- mod.gleam
+
+pub type Wibble { Wibble }
+
+fn wobble() {
+  Wibble
+}
+
+
+-- app.gleam
+
+import mod.{Wibble}
+            ▔▔▔▔▔▔ 
+
+pub fn main() {
+  let value = mod.Wibble
+                  ▔▔▔▔▔▔
+  Wibble
+  ↑▔▔▔▔▔
+}


### PR DESCRIPTION
Closes #5441 and #5445. (They're bundled together because it uses the same code as `textDocument/references`, and that's what find references supports.)

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
