### PR TITLE
Set read-write permissions for the Hex credentials file when writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@
   using OAuth.
   ([Louis Pilfold](https://github.com/lpil))
 
+- The Hex credentials file is now written with read-write permissions for the
+  owner only (0600 on Unix), preventing other users from reading it.
+  ([bala-bhargav](https://github.com/bala-bhargav))
+
 - The build tool will now refuse to publish any package that has no README, or
   an empty README.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -338,24 +338,49 @@ pub fn make_executable(_path: impl AsRef<Utf8Path>) -> Result<(), Error> {
 }
 
 #[cfg(target_family = "unix")]
-pub fn make_private(path: impl AsRef<Utf8Path>) -> Result<(), Error> {
-    use std::os::unix::fs::PermissionsExt;
-    tracing::debug!(path = ?path.as_ref(), "setting_permissions");
+pub fn write_private(path: &Utf8Path, text: &str) -> Result<(), Error> {
+    use std::os::unix::fs::OpenOptionsExt;
+    tracing::debug!(path=?path, "writing_private_file");
 
-    std::fs::set_permissions(path.as_ref(), std::fs::Permissions::from_mode(0o600)).map_err(
-        |e| Error::FileIo {
-            action: FileIoAction::UpdatePermissions,
+    let dir_path = path.parent().ok_or_else(|| Error::FileIo {
+        action: FileIoAction::FindParent,
+        kind: FileKind::Directory,
+        path: path.to_path_buf(),
+        err: None,
+    })?;
+
+    std::fs::create_dir_all(dir_path).map_err(|e| Error::FileIo {
+        action: FileIoAction::Create,
+        kind: FileKind::Directory,
+        path: dir_path.to_path_buf(),
+        err: Some(e.to_string()),
+    })?;
+
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| Error::FileIo {
+            action: FileIoAction::Create,
             kind: FileKind::File,
-            path: path.as_ref().to_path_buf(),
+            path: path.to_path_buf(),
             err: Some(e.to_string()),
-        },
-    )?;
+        })?;
+
+    f.write_all(text.as_bytes()).map_err(|e| Error::FileIo {
+        action: FileIoAction::WriteTo,
+        kind: FileKind::File,
+        path: path.to_path_buf(),
+        err: Some(e.to_string()),
+    })?;
     Ok(())
 }
 
 #[cfg(not(target_family = "unix"))]
-pub fn make_private(_path: impl AsRef<Utf8Path>) -> Result<(), Error> {
-    Ok(())
+pub fn write_private(path: &Utf8Path, text: &str) -> Result<(), Error> {
+    write(path, text)
 }
 
 pub fn write_bytes(path: &Utf8Path, bytes: &[u8]) -> Result<(), Error> {

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -337,6 +337,27 @@ pub fn make_executable(_path: impl AsRef<Utf8Path>) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(target_family = "unix")]
+pub fn make_private(path: impl AsRef<Utf8Path>) -> Result<(), Error> {
+    use std::os::unix::fs::PermissionsExt;
+    tracing::debug!(path = ?path.as_ref(), "setting_permissions");
+
+    std::fs::set_permissions(path.as_ref(), std::fs::Permissions::from_mode(0o600)).map_err(
+        |e| Error::FileIo {
+            action: FileIoAction::UpdatePermissions,
+            kind: FileKind::File,
+            path: path.as_ref().to_path_buf(),
+            err: Some(e.to_string()),
+        },
+    )?;
+    Ok(())
+}
+
+#[cfg(not(target_family = "unix"))]
+pub fn make_private(_path: impl AsRef<Utf8Path>) -> Result<(), Error> {
+    Ok(())
+}
+
 pub fn write_bytes(path: &Utf8Path, bytes: &[u8]) -> Result<(), Error> {
     tracing::debug!(path=?path, "writing_file");
 

--- a/compiler-cli/src/fs/tests.rs
+++ b/compiler-cli/src/fs/tests.rs
@@ -187,3 +187,20 @@ HOME_URL=\"https://www.ubuntu.com/\"
         "id first"
     );
 }
+
+#[cfg(target_family = "unix")]
+#[test]
+fn make_private_sets_owner_only_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let path = Utf8Path::from_path(tmp_dir.path()).expect("Non Utf-8 Path");
+    let file_path = path.join("secret.toml");
+
+    super::write(&file_path, "secret content").unwrap();
+    super::make_private(&file_path).unwrap();
+
+    let metadata = std::fs::metadata(file_path.as_std_path()).unwrap();
+    let mode = metadata.permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600);
+}

--- a/compiler-cli/src/fs/tests.rs
+++ b/compiler-cli/src/fs/tests.rs
@@ -190,17 +190,19 @@ HOME_URL=\"https://www.ubuntu.com/\"
 
 #[cfg(target_family = "unix")]
 #[test]
-fn make_private_sets_owner_only_permissions() {
+fn write_private_sets_owner_only_permissions() {
     use std::os::unix::fs::PermissionsExt;
 
     let tmp_dir = tempfile::tempdir().unwrap();
     let path = Utf8Path::from_path(tmp_dir.path()).expect("Non Utf-8 Path");
     let file_path = path.join("secret.toml");
 
-    super::write(&file_path, "secret content").unwrap();
-    super::make_private(&file_path).unwrap();
+    super::write_private(&file_path, "secret content").unwrap();
 
     let metadata = std::fs::metadata(file_path.as_std_path()).unwrap();
     let mode = metadata.permissions().mode() & 0o777;
     assert_eq!(mode, 0o600);
+
+    let content = std::fs::read_to_string(file_path.as_std_path()).unwrap();
+    assert_eq!(content, "secret content");
 }

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -133,8 +133,7 @@ impl<'runtime> HexAuthentication<'runtime> {
             },
         };
         let toml = toml::to_string(&credentials).expect("OAuth credentials TOML encoding");
-        crate::fs::write(&path, &toml)?;
-        crate::fs::make_private(&path)?;
+        crate::fs::write_private(&path, &toml)?;
         Ok(())
     }
 

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -134,6 +134,7 @@ impl<'runtime> HexAuthentication<'runtime> {
         };
         let toml = toml::to_string(&credentials).expect("OAuth credentials TOML encoding");
         crate::fs::write(&path, &toml)?;
+        crate::fs::make_private(&path)?;
         Ok(())
     }
 


### PR DESCRIPTION
After writing the Hex OAuth credentials file (`credentials.toml`), set its permissions to `0600` (owner read-write only) on Unix systems, preventing other users from reading it.
#5424 