### PR TITLE
Fix BitArray$BitArray's TypeScript definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Marked the `bitSize` and `bitOffset` fields of `BitArray$BitArray` TypeScript
+  definition as optional.
+  ([acandoo](https://github.com/acandoo))
+
 ## v1.15.0-rc1 - 2026-03-04
 
 ### Compiler

--- a/compiler-core/templates/prelude.d.mts
+++ b/compiler-core/templates/prelude.d.mts
@@ -69,8 +69,8 @@ export const BitArray: {
 }
 export function BitArray$BitArray(
   buffer: Uint8Array,
-  bitSize: number,
-  bitOffset: number,
+  bitSize?: number,
+  bitOffset?: number,
 ): BitArray;
 export function BitArray$isBitArray(value: any): value is BitArray;
 export function BitArray$BitArray$data(value: BitArray): DataView;


### PR DESCRIPTION
Fixes #5460

This pull request makes a small change to the `BitArray$BitArray` function signature in `prelude.d.mts`, marking the `bitSize` and `bitOffset` parameters optional instead of required.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes 