### PR TITLE
Fix invalid JS for ints with 0s as prefix (#5459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,3 +413,6 @@
   updates if the constructor definition has a positional field defined after
   labelled fields.
   ([Hari Mohan](https://gituhub.com/seafoamteal))
+
+- Fixed invalid JavaScript code generation when ints or floats had prefixed `0`s
+  before and after an `_` (e.g. `000_001`).

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -2464,15 +2464,10 @@ pub fn eco_string_int<'a>(value: EcoString) -> Document<'a> {
         value
     };
 
-    let value = value.trim_start_matches('0');
+    let value = value.trim_start_matches(['0', '_']);
     if value.is_empty() {
         out.push('0');
     }
-
-    // If the number starts with a `0` then an underscore, the `0` will be stripped,
-    // leaving the number to look something like `_1_2_3`, which is not valid syntax.
-    // Therefore, we strip the `_` to avoid this case.
-    let value = value.trim_start_matches('_');
 
     out.push_str(value);
 
@@ -2489,7 +2484,7 @@ pub fn float(value: &str) -> Document<'_> {
     };
     let value = value.trim_start_matches(['+', '-'].as_ref());
 
-    let value = value.trim_start_matches('0');
+    let value = value.trim_start_matches(['0', '_']);
     if value.starts_with(['.', 'e', 'E']) {
         out.push('0');
     }

--- a/compiler-core/src/javascript/tests/numbers.rs
+++ b/compiler-core/src/javascript/tests/numbers.rs
@@ -256,6 +256,18 @@ pub fn main() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5459
+#[test]
+fn many_preceeding_zeros_int() {
+    assert_js!(
+        r#"
+pub fn main() {
+  0000_000_00_9_179
+}
+"#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/2412
 #[test]
 fn preceeding_zeros_float() {
@@ -263,6 +275,18 @@ fn preceeding_zeros_float() {
         r#"
 pub fn main() {
   09_179.1
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5459
+#[test]
+fn many_preceeding_zeros_float() {
+    assert_js!(
+        r#"
+pub fn main() {
+  0000_000_00_9_179.1
 }
 "#
     );
@@ -278,12 +302,32 @@ pub const x = 09_179
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5459
+#[test]
+fn many_preceeding_zeros_int_const() {
+    assert_js!(
+        r#"
+pub const x = 0000_000_00_9_179
+"#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/2412
 #[test]
 fn preceeding_zeros_float_const() {
     assert_js!(
         r#"
 pub const x = 09_179.1
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5459
+#[test]
+fn many_preceeding_zeros_float_const() {
+    assert_js!(
+        r#"
+pub const x = 0000_000_00_9_179.1
 "#
     );
 }
@@ -300,6 +344,18 @@ pub fn main(x) {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5459
+#[test]
+fn many_preceeding_zeros_int_pattern() {
+    assert_js!(
+        r#"
+pub fn main(x) {
+  let assert 0000_000_00_9_179 = x
+}
+"#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/2412
 #[test]
 fn preceeding_zeros_float_pattern() {
@@ -307,6 +363,18 @@ fn preceeding_zeros_float_pattern() {
         r#"
 pub fn main(x) {
   let assert 09_179.1 = x
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5459
+#[test]
+fn many_preceeding_zeros_float_pattern() {
+    assert_js!(
+        r#"
+pub fn main(x) {
+  let assert 0000_000_00_9_179.1 = x
 }
 "#
     );

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_float.snap
@@ -1,15 +1,15 @@
 ---
 source: compiler-core/src/javascript/tests/numbers.rs
-expression: "\npub fn main() {\n  0b_0_1_0_1\n}\n"
+expression: "\npub fn main() {\n  0000_000_00_9_179.1\n}\n"
 ---
 ----- SOURCE CODE
 
 pub fn main() {
-  0b_0_1_0_1
+  0000_000_00_9_179.1
 }
 
 
 ----- COMPILED JAVASCRIPT
 export function main() {
-  return 0b1_0_1;
+  return 9179.1;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_float_const.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_float_const.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/javascript/tests/numbers.rs
+expression: "\npub const x = 0000_000_00_9_179.1\n"
+---
+----- SOURCE CODE
+
+pub const x = 0000_000_00_9_179.1
+
+
+----- COMPILED JAVASCRIPT
+export const x = 9_179.1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_float_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_float_pattern.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/javascript/tests/numbers.rs
+expression: "\npub fn main(x) {\n  let assert 0000_000_00_9_179.1 = x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  let assert 0000_000_00_9_179.1 = x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError } from "../gleam.mjs";
+
+const FILEPATH = "src/module.gleam";
+
+export function main(x) {
+  if (!(x === 9179.1)) {
+    throw makeError(
+      "let_assert",
+      FILEPATH,
+      "my/mod",
+      3,
+      "main",
+      "Pattern match failed, no pattern matched the value.",
+      { value: x, start: 20, end: 54, pattern_start: 31, pattern_end: 50 }
+    )
+  }
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_int.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_int.snap
@@ -1,15 +1,15 @@
 ---
 source: compiler-core/src/javascript/tests/numbers.rs
-expression: "\npub fn main() {\n  0b_0_1_0_1\n}\n"
+expression: "\npub fn main() {\n  0000_000_00_9_179\n}\n"
 ---
 ----- SOURCE CODE
 
 pub fn main() {
-  0b_0_1_0_1
+  0000_000_00_9_179
 }
 
 
 ----- COMPILED JAVASCRIPT
 export function main() {
-  return 0b1_0_1;
+  return 9_179;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_int_const.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_int_const.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/javascript/tests/numbers.rs
+expression: "\npub const x = 0000_000_00_9_179\n"
+---
+----- SOURCE CODE
+
+pub const x = 0000_000_00_9_179
+
+
+----- COMPILED JAVASCRIPT
+export const x = 9_179;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_int_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__many_preceeding_zeros_int_pattern.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/javascript/tests/numbers.rs
+expression: "\npub fn main(x) {\n  let assert 0000_000_00_9_179 = x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  let assert 0000_000_00_9_179 = x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError } from "../gleam.mjs";
+
+const FILEPATH = "src/module.gleam";
+
+export function main(x) {
+  if (!(x === 9179)) {
+    throw makeError(
+      "let_assert",
+      FILEPATH,
+      "my/mod",
+      3,
+      "main",
+      "Pattern match failed, no pattern matched the value.",
+      { value: x, start: 20, end: 52, pattern_start: 31, pattern_end: 48 }
+    )
+  }
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__zero_after_underscore_after_hex_prefix.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__zero_after_underscore_after_hex_prefix.snap
@@ -11,5 +11,5 @@ pub fn main() {
 
 ----- COMPILED JAVASCRIPT
 export function main() {
-  return 0x0_1_2_3;
+  return 0x1_2_3;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__zero_after_underscore_after_octal_prefix.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__numbers__zero_after_underscore_after_octal_prefix.snap
@@ -11,5 +11,5 @@ pub fn main() {
 
 ----- COMPILED JAVASCRIPT
 export function main() {
-  return 0o0_1_2_3;
+  return 0o1_2_3;
 }


### PR DESCRIPTION
Fixes #5459.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
