### PR TITLE
fix rc pattern bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug where the language server wouldn't show the correct hover for some
+  patterns.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.15.0-rc2 - 2026-03-16
 
 ### Bug fixes

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -3131,35 +3131,35 @@ impl TypedPattern {
                 .or_else(|| Some(Located::Pattern(self))),
 
             Pattern::Constructor {
-                module: Some((module_alias, module_location)),
-                constructor: Inferred::Known(constructor),
+                module,
+                spread,
+                arguments,
+                constructor,
                 ..
             } => {
-                if !module_location.contains(byte_index) {
-                    return None;
-                }
-
-                Some(Located::ModuleName {
-                    location: *module_location,
-                    module_name: constructor.module.clone(),
-                    module_alias: module_alias.clone(),
-                    layer: Layer::Value,
-                })
-            }
-            Pattern::Constructor {
-                spread, arguments, ..
-            } => match spread {
-                Some(spread_location) if spread_location.contains(byte_index) => {
+                if let Some((module_alias, module_location)) = module
+                    && let Inferred::Known(constructor) = constructor
+                    && module_location.contains(byte_index)
+                {
+                    Some(Located::ModuleName {
+                        location: *module_location,
+                        module_name: constructor.module.clone(),
+                        module_alias: module_alias.clone(),
+                        layer: Layer::Value,
+                    })
+                } else if let Some(spread_location) = spread
+                    && spread_location.contains(byte_index)
+                {
                     Some(Located::PatternSpread {
                         spread_location: *spread_location,
                         pattern: self,
                     })
+                } else {
+                    arguments
+                        .iter()
+                        .find_map(|argument| argument.find_node(byte_index))
                 }
-
-                Some(_) | None => arguments
-                    .iter()
-                    .find_map(|argument| argument.find_node(byte_index)),
-            },
+            }
 
             Pattern::List { elements, tail, .. } => elements
                 .iter()

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -2080,3 +2080,21 @@ pub fn main() {
         find_position_of("== mod.Wibble").under_char('i')
     );
 }
+
+#[test]
+fn hover_for_module_select_pattern() {
+    let src = "
+import mod
+pub fn go(x: mod.Wibble) {
+  case x {
+    mod.Wibble -> 1
+  }
+}
+";
+    assert_hover!(
+        TestProject::for_source(src).add_module("mod", "pub type Wibble { Wibble }"),
+        find_position_of("mod.Wibble")
+            .under_char('W')
+            .nth_occurrence(2)
+    );
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_module_select_pattern.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_for_module_select_pattern.snap
@@ -1,0 +1,17 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nimport mod\npub fn go(x: mod.Wibble) {\n  case x {\n    mod.Wibble -> 1\n  }\n}\n"
+---
+import mod
+pub fn go(x: mod.Wibble) {
+  case x {
+    mod.Wibble -> 1
+    ▔▔▔▔↑▔▔▔▔▔     
+  }
+}
+
+
+----- Hover content (markdown) -----
+```gleam
+mod.Wibble
+```


### PR DESCRIPTION
Playing around with the RC I noticed a bug where the language server would no longer show hover tooltips/renames/docs for hovered qualified patterns. This PR fixes the bug!

---

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
