### PR TITLE
Fix byteOffset typo in BitArray DataView construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,8 @@
 ### Formatter
 
 ### Bug fixes
+
+- Fixed a bug where `BitArray$BitArray$data` constructed a `DataView` with
+  offset 0 instead of the slice's actual byte offset, causing sliced bit arrays
+  to read from the wrong position in the underlying buffer on JavaScript.
+  ([John Downey](https://github.com/jtdowney))

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -301,7 +301,7 @@ export const BitArray$BitArray$data = (bitArray) => {
   if (bitArray.bitSize % 8 !== 0)
     throw new Error("BitArray$BitArray$data called on un-aligned bit array");
   const array = bitArray.rawBuffer;
-  return new DataView(array.buffer, array.byteOffest, bitArray.byteLength);
+  return new DataView(array.buffer, array.byteOffset, bitArray.byteLength);
 };
 
 /**

--- a/test/language/test/ffi.gleam
+++ b/test/language/test/ffi.gleam
@@ -27,3 +27,7 @@ pub fn to_dynamic(a: x) -> Dynamic
 @external(erlang, "ffi_erlang", "to_codepoint")
 @external(javascript, "./ffi_javascript.mjs", "toCodepoint")
 pub fn utf_codepoint(a: Int) -> UtfCodepoint
+
+@external(erlang, "ffi_erlang", "read_uint16_from_bit_array")
+@external(javascript, "./ffi_javascript.mjs", "readUint16FromBitArray")
+pub fn read_uint16_from_bit_array(a: BitArray) -> Int

--- a/test/language/test/ffi_erlang.erl
+++ b/test/language/test/ffi_erlang.erl
@@ -1,7 +1,8 @@
 -module(ffi_erlang).
 
 -export([
-    to_string/1, append/2, print/1, file_exists/1, halt/1, to_dynamic/1, to_codepoint/1
+    to_string/1, append/2, print/1, file_exists/1, halt/1, to_dynamic/1, to_codepoint/1,
+    read_uint16_from_bit_array/1
 ]).
 
 append(A, B) ->
@@ -25,3 +26,7 @@ to_dynamic(X) ->
     X.
 
 to_codepoint(X) -> X.
+
+read_uint16_from_bit_array(BitArray) ->
+    <<Value:16/big-unsigned-integer, _/binary>> = BitArray,
+    Value.

--- a/test/language/test/ffi_javascript.mjs
+++ b/test/language/test/ffi_javascript.mjs
@@ -1,4 +1,4 @@
-import { UtfCodepoint } from "./gleam.mjs";
+import { UtfCodepoint, BitArray$BitArray$data } from "./gleam.mjs";
 
 let fs;
 
@@ -55,4 +55,8 @@ export function toDynamic(a) {
 
 export function toCodepoint(x) {
   return new UtfCodepoint(x);
+}
+
+export function readUint16FromBitArray(bitArray) {
+  return BitArray$BitArray$data(bitArray).getUint16(0);
 }

--- a/test/language/test/language/bit_array_test.gleam
+++ b/test/language/test/language/bit_array_test.gleam
@@ -1,4 +1,5 @@
 import ffi
+import gleam/bit_array
 
 pub fn utf8_emoji_equal_test() {
   let left = <<"Gleam":utf8, "👍":utf8>>
@@ -173,4 +174,12 @@ pub fn unicode_overflow_test() {
   // See: https://github.com/gleam-lang/gleam/issues/457
   let string = "5"
   assert "🌵" != string
+}
+
+pub fn sliced_bit_array_data_view_offset_test() {
+  let data = <<0xAA, 0xBB, 0xCC, 0xDD>>
+  let assert Ok(sliced) = bit_array.slice(data, 1, 3)
+  assert sliced == <<0xBB, 0xCC, 0xDD>>
+  let value = ffi.read_uint16_from_bit_array(sliced)
+  assert value == 48_076
 }


### PR DESCRIPTION
I went to try out the new `BitArray$BitArray$data` JS FFI function and ran into an issue. There's a typo that results in `undefined`, which is then treated as a zero offset. So if you're using a bit array with an offset, the offset will be ignored, and the read will start at the beginning of the array.
