### PR TITLE
Fix BitArray$BitArray$data DataView byte length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   modules containing large constants.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where `BitArray$BitArray$data` constructed a `DataView` with
+  incorrect byte length instead of the slice's actual size, causing sliced bit
+  arrays to include extra bytes from the underlying buffer on JavaScript.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.15.1 - 2026-03-17
 
 ### Bug fixes

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -301,7 +301,7 @@ export const BitArray$BitArray$data = (bitArray) => {
   if (bitArray.bitSize % 8 !== 0)
     throw new Error("BitArray$BitArray$data called on un-aligned bit array");
   const array = bitArray.rawBuffer;
-  return new DataView(array.buffer, array.byteOffset, bitArray.byteLength);
+  return new DataView(array.buffer, array.byteOffset, bitArray.byteSize);
 };
 
 /**

--- a/test/language/test/language/bit_array_test.gleam
+++ b/test/language/test/language/bit_array_test.gleam
@@ -183,3 +183,9 @@ pub fn sliced_bit_array_data_view_offset_test() {
   let value = ffi.read_uint16_from_bit_array(sliced)
   assert value == 48_076
 }
+
+pub fn sliced_bit_array_data_view_byte_length_test() {
+  let data = <<0xAA, 0xBB, 0xCC, 0xDD>>
+  let assert Ok(sliced) = bit_array.slice(data, 1, 2)
+  assert sliced == <<0xBB, 0xCC>>
+}


### PR DESCRIPTION
As I got back to adopting the new `BitArray$BitArray$data` FFI in kryptos, I noticed another bug. This time with the length instead of the offset. Because `BitArray` doesn't have a `byteLength` property (it's `byteSize`), the DataView gets constructed with a length of `undefined`, which gets changed to just be the buffer's length.