### PR TITLE
#5389 ls code action to generate new type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,15 +120,15 @@
   is not defined:
 
   ```gleam
-  pub fn wibble(argument: Wibble) { todo }
+  pub fn run(data: Wibble(Int)) { todo }
   ```
 
   The code action will generate:
 
   ```gleam
-  pub type Wibble
+  pub type Wibble(a)
 
-  pub fn wibble(argument: Wibble) { todo }
+  pub fn run(data: Wibble(Int)) { todo }
   ```
 
   ([Daniele Scaratti](https://github.com/lupodevelop))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,24 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The language server now offers a code action to generate a missing type
+  definition when an unknown type is referenced. For example, if `Wibble`
+  is not defined:
+
+  ```gleam
+  pub fn wibble(argument: Wibble) { todo }
+  ```
+
+  The code action will generate:
+
+  ```gleam
+  pub type Wibble
+
+  pub fn wibble(argument: Wibble) { todo }
+  ```
+
+  ([Daniele Scaratti](https://github.com/lupodevelop))
+
 ### Formatter
 
 ### Bug fixes

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3344,6 +3344,7 @@ a label or use a record constructor.",
             location,
             name,
             hint,
+            ..
         } => {
             let label_text = match hint {
                 UnknownTypeHint::AlternativeTypes(types) => did_you_mean(name, types),

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -178,6 +178,7 @@ pub enum Error {
         location: SrcSpan,
         name: EcoString,
         hint: UnknownTypeHint,
+        parameter_names: Vec<EcoString>,
     },
 
     /// This happens when someone writes `module_name.` with no type name after
@@ -1574,12 +1575,14 @@ pub fn convert_get_type_constructor_error(
     error: UnknownTypeConstructorError,
     location: &SrcSpan,
     module_location: Option<SrcSpan>,
+    parameter_names: Vec<EcoString>,
 ) -> Error {
     match error {
         UnknownTypeConstructorError::Type { name, hint } => Error::UnknownType {
             location: *location,
             name,
             hint,
+            parameter_names,
         },
 
         UnknownTypeConstructorError::Module { name, suggestions } => Error::UnknownModule {

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -170,10 +170,12 @@ impl Hydrator {
                 } = environment
                     .get_type_constructor(&module, name)
                     .map_err(|error| {
+                        let parameter_names = generate_parameter_names(arguments);
                         convert_get_type_constructor_error(
                             error,
                             location,
                             module.as_ref().map(|(_, location)| *location),
+                            parameter_names,
                         )
                     })?
                     .clone();
@@ -320,6 +322,7 @@ impl Hydrator {
                             name: name.clone(),
                             location: *location,
                             hint,
+                            parameter_names: vec![],
                         })
                     }
                 }
@@ -373,4 +376,55 @@ impl Hydrator {
 pub struct CreatedTypeVariable {
     pub type_: Arc<Type>,
     pub usage_count: usize,
+}
+
+/// Names for the parameters of an unknown type, used to suggest a definition.
+/// Type variables keep their name; other parameters get a generated one.
+fn generate_parameter_names(arguments: &[TypeAst]) -> Vec<EcoString> {
+    // Reserve the type variable names so generated ones don't collide with them.
+    let mut used: HashSet<EcoString> = arguments
+        .iter()
+        .filter_map(|argument| match argument {
+            TypeAst::Var(TypeAstVar { name, .. }) => Some(name.clone()),
+            TypeAst::Constructor(_) | TypeAst::Fn(_) | TypeAst::Tuple(_) | TypeAst::Hole(_) => None,
+        })
+        .collect();
+
+    let mut next = 0;
+    arguments
+        .iter()
+        .map(|argument| match argument {
+            TypeAst::Var(TypeAstVar { name, .. }) => name.clone(),
+            TypeAst::Constructor(_) | TypeAst::Fn(_) | TypeAst::Tuple(_) | TypeAst::Hole(_) => {
+                loop {
+                    let candidate = type_parameter_name(next);
+                    next += 1;
+                    if used.insert(candidate.clone()) {
+                        break candidate;
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
+/// `0 -> "a"`, `25 -> "z"`, `26 -> "aa"`, ...
+fn type_parameter_name(index: usize) -> EcoString {
+    let alphabet_length = 26;
+    let char_offset = 97;
+    let mut chars = vec![];
+    let mut rest = index;
+
+    loop {
+        let n = rest % alphabet_length;
+        rest /= alphabet_length;
+        chars.push((n as u8 + char_offset) as char);
+
+        if rest == 0 {
+            break;
+        }
+        rest -= 1;
+    }
+
+    chars.into_iter().rev().collect()
 }

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -1282,6 +1282,102 @@ pub fn code_action_import_module(
     }
 }
 
+pub fn code_action_generate_type(
+    module: &Module,
+    line_numbers: &LineNumbers,
+    params: &CodeActionParams,
+    error: &Option<Error>,
+    actions: &mut Vec<CodeAction>,
+) {
+    let uri = &params.text_document.uri;
+    let Some(errors) = type_errors_for_module(error, module) else {
+        return;
+    };
+
+    for error in errors {
+        let type_::Error::UnknownType {
+            location,
+            name,
+            parameter_names,
+            ..
+        } = error
+        else {
+            continue;
+        };
+
+        let range = src_span_to_lsp_range(*location, line_numbers);
+        if !within(params.range, range) {
+            continue;
+        }
+
+        // Insert the new type stub before the top-level definition that
+        // contains the error, so it appears close to where it is used.
+        let (insert_at, is_public) =
+            definition_start_and_publicity_containing(&module.ast.definitions, location.start)
+                .unwrap_or((module.code.len() as u32, false));
+        let insert_range = src_span_to_lsp_range(
+            SrcSpan {
+                start: insert_at,
+                end: insert_at,
+            },
+            line_numbers,
+        );
+
+        let pub_prefix = if is_public { "pub " } else { "" };
+        let new_text = if parameter_names.is_empty() {
+            format!("{pub_prefix}type {name}\n\n")
+        } else {
+            let parameters = parameter_names.join(", ");
+            format!("{pub_prefix}type {name}({parameters})\n\n")
+        };
+
+        let edit = TextEdit {
+            range: insert_range,
+            new_text,
+        };
+
+        CodeActionBuilder::new("Generate type")
+            .kind(CodeActionKind::QuickFix)
+            .changes(uri.clone(), vec![edit])
+            .preferred(true)
+            .push_to(actions);
+    }
+}
+
+/// Returns the source offset and publicity of the top-level definition that
+/// contains `position`, so the caller can insert code before it.
+fn definition_start_and_publicity_containing(
+    definitions: &TypedDefinitions,
+    position: u32,
+) -> Option<(u32, bool)> {
+    let functions = definitions
+        .functions
+        .iter()
+        .map(|function| (function.full_location(), function.publicity.is_public()));
+    let custom_types = definitions.custom_types.iter().map(|custom_type| {
+        (
+            custom_type.full_location(),
+            custom_type.publicity.is_public(),
+        )
+    });
+    let type_aliases = definitions
+        .type_aliases
+        .iter()
+        .map(|type_alias| (type_alias.location, type_alias.publicity.is_public()));
+    let constants = definitions
+        .constants
+        .iter()
+        .map(|constant| (constant.location, constant.publicity.is_public()));
+
+    functions
+        .chain(custom_types)
+        .chain(type_aliases)
+        .chain(constants)
+        .filter(|(span, _)| span.start <= position && position <= span.end)
+        .map(|(span, is_public)| (span.start, is_public))
+        .next()
+}
+
 fn suggest_imports(
     location: SrcSpan,
     importable_modules: &[ModuleSuggestion],

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -57,8 +57,8 @@ use super::{
         RemoveEchos, RemovePrivateOpaque, RemoveUnreachableCaseClauses, RemoveUnusedImports,
         UnwrapAnonymousFunction, UseLabelShorthandSyntax, WrapInAnonymousFunction, WrapInBlock,
         code_action_add_missing_patterns, code_action_convert_qualified_constructor_to_unqualified,
-        code_action_convert_unqualified_constructor_to_qualified, code_action_import_module,
-        code_action_inexhaustive_let_to_case,
+        code_action_convert_unqualified_constructor_to_qualified, code_action_generate_type,
+        code_action_import_module, code_action_inexhaustive_let_to_case,
     },
     compiler::LspProjectCompiler,
     completer::Completer,
@@ -443,6 +443,7 @@ where
             actions.extend(RemoveUnusedImports::new(module, &lines, &params).code_actions());
             code_action_fix_names(module, &lines, &params, &this.error, &mut actions);
             code_action_import_module(module, &lines, &params, &this.error, &mut actions);
+            code_action_generate_type(module, &lines, &params, &this.error, &mut actions);
             code_action_add_missing_patterns(module, &lines, &params, &this.error, &mut actions);
             actions
                 .extend(RemoveUnreachableCaseClauses::new(module, &lines, &params).code_actions());

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -185,6 +185,7 @@ const PATTERN_MATCH_ON_ARGUMENT: &str = "Pattern match on argument";
 const PATTERN_MATCH_ON_VARIABLE: &str = "Pattern match on variable";
 const PATTERN_MATCH_ON_VALUE: &str = "Pattern match on value";
 const GENERATE_FUNCTION: &str = "Generate function";
+const GENERATE_TYPE: &str = "Generate type";
 const CONVERT_TO_FUNCTION_CALL: &str = "Convert to function call";
 const INLINE_VARIABLE: &str = "Inline variable";
 const CONVERT_TO_PIPE: &str = "Convert to pipe";
@@ -8770,6 +8771,89 @@ pub fn main() -> Bool {
 }
 ",
         find_position_of("wibble").to_selection()
+    );
+}
+
+#[test]
+fn generate_type_works_for_unknown_type() {
+    assert_code_action!(
+        GENERATE_TYPE,
+        "
+pub fn main() {
+  let x: Wobble = todo
+}
+",
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_type_works_for_unknown_type_with_parameters() {
+    assert_code_action!(
+        GENERATE_TYPE,
+        "
+type Wibble {
+  Wibble(Wobble(Int, String))
+}
+",
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_type_works_for_unknown_type_in_argument_annotation() {
+    assert_code_action!(
+        GENERATE_TYPE,
+        "
+pub fn wibble(argument: Wibble(some, generics)) { todo }
+",
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
+fn generate_type_works_for_unknown_type_in_private_function() {
+    assert_code_action!(
+        GENERATE_TYPE,
+        "
+fn wibble(argument: Wobble) { todo }
+",
+        find_position_of("Wobble").to_selection()
+    );
+}
+
+#[test]
+fn generate_type_generates_non_colliding_parameter_names() {
+    assert_code_action!(
+        GENERATE_TYPE,
+        "
+pub fn wibble(argument: Wibble(b, Int)) { todo }
+",
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
+fn generate_type_generates_names_for_more_than_26_parameters() {
+    assert_code_action!(
+        GENERATE_TYPE,
+        "
+pub fn wibble(argument: Wibble(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)) { todo }
+",
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
+fn generate_type_not_offered_when_cursor_is_elsewhere() {
+    assert_no_code_actions!(
+        GENERATE_TYPE,
+        "
+pub fn main() {
+  let x: Wobble = todo
+}
+",
+        find_position_of("main").to_selection()
     );
 }
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_generates_names_for_more_than_26_parameters.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_generates_names_for_more_than_26_parameters.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble(argument: Wibble(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)) { todo }\n"
+---
+----- BEFORE ACTION
+
+pub fn wibble(argument: Wibble(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)) { todo }
+                        ↑                                                                                                                                                                     
+
+
+----- AFTER ACTION
+
+pub type Wibble(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, ab, ac, ad)
+
+pub fn wibble(argument: Wibble(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)) { todo }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_generates_non_colliding_parameter_names.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_generates_non_colliding_parameter_names.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble(argument: Wibble(b, Int)) { todo }\n"
+---
+----- BEFORE ACTION
+
+pub fn wibble(argument: Wibble(b, Int)) { todo }
+                        ↑                       
+
+
+----- AFTER ACTION
+
+pub type Wibble(b, a)
+
+pub fn wibble(argument: Wibble(b, Int)) { todo }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type.snap
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn main() {\n  let x: Wobble = todo\n}\n"
+snapshot_kind: text
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let x: Wobble = todo
+         ↑            
+}
+
+
+----- AFTER ACTION
+
+pub type Wobble
+
+pub fn main() {
+  let x: Wobble = todo
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type_in_argument_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type_in_argument_annotation.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn wibble(argument: Wibble(some, generics)) { todo }\n"
+---
+----- BEFORE ACTION
+
+pub fn wibble(argument: Wibble(some, generics)) { todo }
+                        ↑                               
+
+
+----- AFTER ACTION
+
+pub type Wibble(some, generics)
+
+pub fn wibble(argument: Wibble(some, generics)) { todo }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type_in_private_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type_in_private_function.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\nfn wibble(argument: Wobble) { todo }\n"
+---
+----- BEFORE ACTION
+
+fn wibble(argument: Wobble) { todo }
+                    ↑               
+
+
+----- AFTER ACTION
+
+type Wobble
+
+fn wibble(argument: Wobble) { todo }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type_with_parameters.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__generate_type_works_for_unknown_type_with_parameters.snap
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\ntype Wibble {\n  Wibble(Wobble(Int, String))\n}\n"
+snapshot_kind: text
+---
+----- BEFORE ACTION
+
+type Wibble {
+  Wibble(Wobble(Int, String))
+         ↑                   
+}
+
+
+----- AFTER ACTION
+
+type Wobble(a, b)
+
+type Wibble {
+  Wibble(Wobble(Int, String))
+}


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

This pull request introduces a new "Generate type" code action to the language server, allowing users to quickly generate missing type definitions for unknown types directly from the editor. The implementation tracks the arity of unknown types, ensuring generated types have the correct parameterization. 

New code action feature:

* Added `code_action_generate_type` function to generate type definitions for unknown types, including proper handling of type parameters based on arity.
* Integrated the new code action into the language server's code action pipeline, so it is offered alongside other quick fixes. [[1]](diffhunk://#diff-8bfba7ed626aeef6d13e57616558399e9eb1846aeeaf22ca7bf1a719212ea269L50-R51) [[2]](diffhunk://#diff-8bfba7ed626aeef6d13e57616558399e9eb1846aeeaf22ca7bf1a719212ea269R417)

Issue: #5389 