### PR TITLE
fix bug where add missing type parameter would trigger on invalid types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,7 @@
   offset 0 instead of the slice's actual byte offset, causing sliced bit arrays
   to read from the wrong position in the underlying buffer on JavaScript.
   ([John Downey](https://github.com/jtdowney))
+
+- Fixed a bug where the "Add missing type parameter" code action could be
+  triggered on types that do not exist instead of type variables.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -10962,13 +10962,12 @@ impl<'a> AddMissingTypeParameter<'a> {
 
 impl<'ast> ast::visit::Visit<'ast> for AddMissingTypeParameter<'ast> {
     fn visit_typed_custom_type(&mut self, custom_type: &'ast ast::TypedCustomType) {
-        let full_type_definition_range = self.edits.src_span_to_lsp_range(SrcSpan::new(
-            custom_type.location.start,
-            custom_type.end_position,
-        ));
+        let custom_type_range = self
+            .edits
+            .src_span_to_lsp_range(custom_type.full_location());
 
         // Only continue, if the action was selected anywhere within the custom type definition.
-        if !overlaps(self.params.range, full_type_definition_range) {
+        if !overlaps(self.params.range, custom_type_range) {
             return;
         }
 
@@ -10979,15 +10978,19 @@ impl<'ast> ast::visit::Visit<'ast> for AddMissingTypeParameter<'ast> {
 
         self.has_existing_parameters = !custom_type.typed_parameters.is_empty();
 
+        let existing_names: HashSet<_> = custom_type
+            .parameters
+            .iter()
+            .map(|(_, name)| name)
+            .collect();
+
         // Collect the remaining type parameters from the variant constructors.
         for record in &custom_type.constructors {
             for argument in &record.arguments {
-                if let Type::Var { .. } = argument.type_.as_ref()
-                    && !custom_type.typed_parameters.contains(&argument.type_)
+                if let ast::TypeAst::Var(ast::TypeAstVar { name, .. }) = &argument.ast
+                    && !existing_names.contains(name)
                 {
-                    let mut name = EcoString::new();
-                    argument.ast.print(&mut name);
-                    let _ = self.missing_parameters.insert(name);
+                    let _ = self.missing_parameters.insert(name.clone());
                 }
             }
         }

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -12241,6 +12241,19 @@ type Wibble {
     );
 }
 
+#[test]
+fn add_missing_type_parameter_does_not_add_types_that_do_not_exist() {
+    assert_no_code_actions!(
+        ADD_MISSING_TYPE_PARAMETER,
+        r#"
+type Wibble {
+  Wibble(Wobble)
+}
+"#,
+        find_position_of("Wibble").nth_occurrence(2).to_selection()
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/5288
 #[test]
 fn extract_anonymous_function_without_variable_capture_1() {


### PR DESCRIPTION
I noticed the "add missing type parameters" code action could be triggered on types that do not exists rather than type variables, generating invalid code.
This PR fixes the bug!

<img width="852" height="170" alt="wrong_action" src="https://github.com/user-attachments/assets/7c010af2-a145-4c81-ac0d-82e48fc8b1a1" />

---

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
