### PR TITLE
Adding special handling for when hex OAuth session get revoked by hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@
 
   ([Daniele Scaratti](https://github.com/lupodevelop))
 
+- The package manager now has a specific error and automatic re-authentication
+  flow for when a Hex session has been revoked or has expired.
+  ([Sahil Upasane](https://github.com/404salad))
+
 ### Language server
 
 - The language server can now help with completions when typing a list's tail:

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -188,10 +188,9 @@ It will be used to locally encrypt your Hex API tokens.
 
         match self.read_and_decrypt_and_refresh_stored_tokens() {
             Ok(Some(tokens)) => return Ok(tokens.as_credentials()),
-            Ok(None) => (),
+            Ok(None) => {}
             Err(Error::HexSessionRevoked) => {
-                println!("\nYour Hex session has been revoked or has expired.");
-                println!("Restarting the authentication flow to get a new token...\n");
+                // we get this error when refresh token can’t be used anymore
             }
             Err(e) => return Err(e),
         }

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -186,8 +186,14 @@ It will be used to locally encrypt your Hex API tokens.
             return Ok(key);
         }
 
-        if let Some(tokens) = self.read_and_decrypt_and_refresh_stored_tokens()? {
-            return Ok(tokens.as_credentials());
+        match self.read_and_decrypt_and_refresh_stored_tokens() {
+            Ok(Some(tokens)) => return Ok(tokens.as_credentials()),
+            Ok(None) => (),
+            Err(Error::HexSessionRevoked) => {
+                println!("\nYour Hex session has been revoked or has expired.");
+                println!("Restarting the authentication flow to get a new token...\n");
+            }
+            Err(e) => return Err(e),
         }
 
         self.create_and_store_new_credentials_via_oauth()

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -190,7 +190,12 @@ It will be used to locally encrypt your Hex API tokens.
             Ok(Some(tokens)) => return Ok(tokens.as_credentials()),
             Ok(None) => {}
             Err(Error::HexSessionRevoked) => {
-                // we get this error when refresh token can’t be used anymore
+                // This error occurs when the refresh token is no longer valid, typically
+                // because the user manually revoked the session in the Hex console.
+                // This is a recoverable error so instead of erroring out with a
+                // non-actionable message, we catch this and proceed to the OAuth flow
+                // to create a fresh set of credentials.
+                // Since the old token is already invalid, there is no need to revoke it.
             }
             Err(e) => return Err(e),
         }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -407,6 +407,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
     #[error("Cannot add a package with the same name as a dependency")]
     CannotAddSelfAsDependency { name: EcoString },
 
+    #[error("Hex session revoked")]
+    HexSessionRevoked,
+
     #[error("Incorrect Hex one-time-password")]
     IncorrectHexOneTimePassword,
 }
@@ -525,8 +528,9 @@ impl Error {
             | hexpm::ApiError::LateModification
             | hexpm::ApiError::OAuthTimeout
             | hexpm::ApiError::OAuthAccessDenied
-            | hexpm::ApiError::ExpiredToken
-            | hexpm::ApiError::OAuthRefreshTokenRejected => Self::Hex(error.to_string()),
+            | hexpm::ApiError::ExpiredToken => Self::Hex(error.to_string()),
+
+            hexpm::ApiError::OAuthRefreshTokenRejected => Self::HexSessionRevoked,
 
             hexpm::ApiError::IncorrectOneTimePassword => Self::IncorrectHexOneTimePassword,
         }
@@ -971,6 +975,17 @@ errors."
 
     pub fn to_diagnostics(&self) -> Vec<Diagnostic> {
         match self {
+            Error::HexSessionRevoked => vec![Diagnostic {
+                title: "Hex session revoked".into(),
+                text: "Your Hex session has been revoked or has expired.
+
+You'll need to re-authenticate to continue using Hex."
+                    .into(),
+                hint: Some("Run 'gleam hex authenticate' to log in again.".into()),
+                level: Level::Error,
+                location: None,
+            }],
+
             Error::IncorrectHexOneTimePassword => {
                 let text =
                     "That two-factor authentication code was rejected by Hex, please try again.

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__hex_session_revoked.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__hex_session_revoked.snap
@@ -1,7 +1,13 @@
 ---
 source: compiler-core/src/error/tests.rs
-expression: "err[0].text"
+expression: "err[0]"
 ---
-Your Hex session has been revoked or has expired.
-
-You'll need to re-authenticate to continue using Hex.
+Diagnostic {
+    title: "Hex session revoked",
+    text: "Your Hex session has been revoked or has expired.\n\nYou'll need to re-authenticate to continue using Hex.",
+    level: Error,
+    location: None,
+    hint: Some(
+        "Run 'gleam hex authenticate' to log in again.",
+    ),
+}

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__hex_session_revoked.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__hex_session_revoked.snap
@@ -1,0 +1,7 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: "err[0].text"
+---
+Your Hex session has been revoked or has expired.
+
+You'll need to re-authenticate to continue using Hex.

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -35,3 +35,17 @@ fn test_shell_program_not_found_error() {
         }
     }
 }
+
+#[test]
+fn hex_session_revoked() {
+    let err = Error::HexSessionRevoked.to_diagnostics();
+    assert_snapshot!("hex_session_revoked", err[0].text);
+}
+
+#[test]
+fn hex_error_conversion() {
+    assert_eq!(
+        Error::hex(hexpm::ApiError::OAuthRefreshTokenRejected),
+        Error::HexSessionRevoked
+    );
+}

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use insta::assert_debug_snapshot;
 use insta::assert_snapshot;
 
 #[test]
@@ -39,7 +40,7 @@ fn test_shell_program_not_found_error() {
 #[test]
 fn hex_session_revoked() {
     let err = Error::HexSessionRevoked.to_diagnostics();
-    assert_snapshot!("hex_session_revoked", err[0].text);
+    assert_debug_snapshot!(err[0]);
 }
 
 #[test]


### PR DESCRIPTION
fixes [#5423](https://github.com/gleam-lang/gleam/issues/5423) 

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
