### PR TITLE
feat(cli): added hex owner add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
 
 ### Build tool
 
+- The `gleam hex owner add` command has been added, which allows adding
+  owners to the package.
+  ([Niklas Kirschall](https://github.com/nkxxll))
+
 - When publishing, the package manager now uses the full term instead of the
   shorthand "MFA" in the prompt and error message.
   ([Luka Ivanović](https://github.com/luka-hash))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -87,36 +87,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -445,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -455,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -467,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -479,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -496,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
@@ -1250,6 +1251,7 @@ version = "1.15.1"
 dependencies = [
  "base16",
  "bytes",
+ "clap",
  "ecow",
  "flate2",
  "http",
@@ -1709,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1943,7 +1945,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2010,6 +2012,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -3612,9 +3620,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ members = [
 
 # common dependencies
 [workspace.dependencies]
+# Command line interface
+clap = { version = "4", features = ["derive"] }
 # Immutable data structures
 im = { version = "15", features = ["serde"] }
 # Extra iter methods

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -12,8 +12,6 @@ gleam-core = { path = "../compiler-core" }
 gleam-language-server = { path = "../language-server" }
 # OS SIGINT and SIGTERM signal handling
 ctrlc = { version = "3", features = ["termination"] }
-# Command line interface
-clap = { version = "4", features = ["derive"] }
 # Recursively traversing directories
 ignore = "0"
 # Allow user to type in sensitive information without showing it in the shell
@@ -39,6 +37,7 @@ same-file = "1"
 async-trait.workspace = true
 base16.workspace = true
 camino = { workspace = true, features = ["serde1"] }
+clap = { workspace = true, features = ["derive"] }
 debug-ignore.workspace = true
 ecow.workspace = true
 flate2.workspace = true

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -199,6 +199,14 @@ pub(crate) fn print_transferred_ownership() {
     print_colourful_prefix("Transferred", "ownership");
 }
 
+pub(crate) fn print_adding_owner() {
+    print_colourful_prefix("Adding", "owner");
+}
+
+pub(crate) fn print_added_owner() {
+    print_colourful_prefix("Added", "owner");
+}
+
 fn print_packages_downloaded(start: Instant, count: usize) {
     let elapsed = seconds(start.elapsed());
     let msg = match count {

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -591,6 +591,25 @@ enum Hex {
 
 #[derive(Subcommand, Debug)]
 enum Owner {
+    /// Adds a new owner to the given package on Hex
+    ///
+    /// This command uses this environment variable:
+    ///
+    /// - HEXPM_API_KEY: (optional) A Hex API key to authenticate against the Hex package manager.
+    ///
+    #[command(verbatim_doc_comment)]
+    Add {
+        package: String,
+
+        /// The username or email of the additional owner
+        #[arg(long = "user")]
+        username_or_email: String,
+
+        /// The ownership level
+        #[arg(long, default_value = "maintainer")]
+        level: hexpm::OwnerLevel,
+    },
+
     /// Transfers ownership of the given package to a new Hex user
     ///
     /// This command uses this environment variable:
@@ -816,6 +835,12 @@ fn parse_and_run_command() -> Result<(), Error> {
             let paths = find_project_paths()?;
             hex::revert(&paths, package, version)
         }
+
+        Command::Hex(Hex::Owner(Owner::Add {
+            package,
+            username_or_email,
+            level,
+        })) => owner::add(package, username_or_email, level),
 
         Command::Hex(Hex::Owner(Owner::Transfer {
             package,

--- a/compiler-cli/src/owner.rs
+++ b/compiler-cli/src/owner.rs
@@ -1,6 +1,31 @@
 use crate::{cli, http::HttpClient};
 use gleam_core::{Result, hex};
 
+pub fn add(
+    package: String,
+    new_owner_username_or_email: String,
+    level: hexpm::OwnerLevel,
+) -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
+    let http = HttpClient::new();
+    let hex_config = hexpm::Config::new();
+    let credentials = crate::hex::HexAuthentication::new(&runtime, &http, hex_config.clone())
+        .get_or_create_api_credentials()?;
+
+    cli::print_adding_owner();
+    runtime.block_on(hex::add_owner(
+        &crate::hex::write_credentials(&credentials)?,
+        package,
+        new_owner_username_or_email,
+        level,
+        &hex_config,
+        &http,
+    ))?;
+    cli::print_added_owner();
+
+    Ok(())
+}
+
 pub fn transfer(package: String, new_owner_username_or_email: String) -> Result<()> {
     println!(
         "Transferring ownership of this package will remove all current owners and make

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -66,6 +66,30 @@ pub async fn publish_package<Http: HttpClient>(
     })
 }
 
+pub async fn add_owner<Http: HttpClient>(
+    api_key: &WriteActionCredentials,
+    package_name: String,
+    new_owner_username_or_email: String,
+    level: hexpm::OwnerLevel,
+    config: &hexpm::Config,
+    http: &Http,
+) -> Result<()> {
+    tracing::info!(
+        "Adding {} as owner of `{}`",
+        new_owner_username_or_email,
+        package_name
+    );
+    let request = hexpm::api_add_owner_request(
+        &package_name,
+        &new_owner_username_or_email,
+        level,
+        api_key,
+        config,
+    );
+    let response = http.send(request).await?;
+    hexpm::api_add_owner_response(response).map_err(Error::hex)
+}
+
 pub async fn transfer_owner<Http: HttpClient>(
     api_key: &WriteActionCredentials,
     package_name: String,

--- a/hexpm/Cargo.toml
+++ b/hexpm/Cargo.toml
@@ -28,6 +28,7 @@ http-auth-basic = "0.3"
 prost = "0.13.5"
 
 base16 = { workspace = true, features = ["alloc"] }
+clap = { workspace = true, features = ["derive"] }
 ecow = { workspace = true, features = ["serde"] }
 http.workspace = true
 pubgrub.workspace = true

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -7,6 +7,7 @@ pub mod version;
 
 use crate::proto::{signed::Signed, versions::Versions};
 use bytes::buf::Buf;
+use clap::ValueEnum;
 use ecow::EcoString;
 use flate2::read::GzDecoder;
 use http::{Method, StatusCode};
@@ -596,7 +597,7 @@ pub fn api_revert_release_response(response: http::Response<Vec<u8>>) -> Result<
 }
 
 /// See: https://github.com/hexpm/hex/blob/main/lib/mix/tasks/hex.owner.ex#L47
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum OwnerLevel {
     /// Has every package permission EXCEPT the ability to change who owns the package
     Maintainer,


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour (NA: because its a CLI change tested manually)
- [x] The changelog has been updated for any user-facing changes
- [x] clippy checked

related issue #5396

Implementation is heavily oriented on `gleam hex owner transfer`.

Though I did not add tests. I did test the functionality by adding you @lpil to a test package I created on hex.pm. The only thing I did not test is the distinction between `"owner"` and `"maintainer"` (because I actually don't know how I can remove someone from the package :smile:).

Help output:
```bash
$ gleam hex owner add --help
Adds a new owner to the given package on Hex

This command uses this environment variable:

- HEXPM_API_KEY: (optional) A Hex API key to authenticate against the Hex package manager.

Usage: gleam hex owner add [OPTIONS] --user <USERNAME_OR_EMAIL> <PACKAGE>

Arguments:
  <PACKAGE>


Options:
      --user <USERNAME_OR_EMAIL>
          The username or email of the new owner

      --level <LEVEL>
          The ownership level: "full" or "maintainer"

          [default: full]
          [possible values: full, maintainer]

  -h, --help
          Print help (see a summary with '-h')
```