### PR TITLE
feat: support .jsx, .tsx, .mts, and .cts as FFI file extensions

### DIFF
--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -432,7 +432,7 @@ pub trait TarUnpacker {
 pub fn is_native_file_extension(extension: &str) -> bool {
     matches!(
         extension,
-        "erl" | "hrl" | "ex" | "js" | "mjs" | "cjs" | "ts"
+        "erl" | "hrl" | "ex" | "js" | "mjs" | "cjs" | "mts" | "cts" | "ts" | "jsx" | "tsx"
     )
 }
 


### PR DESCRIPTION
## Summary

Adds `.jsx`, `.tsx`, `.mts`, and `.cts` to the FFI file extension whitelist. These files are now copied alongside existing `.js`, `.mjs`, `.cjs`, and `.ts` files.

## Why this matters

Modern JS/TS tooling (Vite, esbuild, Bun) uses these extensions. JSX files in particular are required by React/Solid/Vue frameworks. The compiler already supports `.ts` - adding `.tsx` and the module-type variants (`.mts`, `.cts`) is consistent with that. See #5368 for the full rationale from @ghivert.

## Changes

- `compiler-core/src/io.rs`: Added `"mts" | "cts" | "jsx" | "tsx"` to the `matches!` macro in `is_native_file_extension()` (line 435).

## Testing

`cargo check -p gleam-core` passes.

Closes #5368

This contribution was developed with AI assistance (Claude Code).