### PR TITLE
make qualified type annotations more fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@
   record when writing a record update.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server no longer shows completions for values when editing a
+  qualified type.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 - The formatter no longer moves comments out of type annotations.

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -2150,14 +2150,18 @@ fn get_type_dependencies(type_: &TypeAst) -> Vec<EcoString> {
         TypeAst::Var(TypeAstVar { .. }) => (),
         TypeAst::Hole(TypeAstHole { .. }) => (),
         TypeAst::Constructor(TypeAstConstructor {
-            name,
-            arguments,
-            module,
-            ..
+            name, arguments, ..
         }) => {
-            deps.push(match module {
-                Some((module, _)) => format!("{name}.{module}").into(),
-                None => name.clone(),
+            deps.push(match name {
+                ast::TypeAstConstructorName::Unqualified { name, .. } => name.clone(),
+                ast::TypeAstConstructorName::Qualified {
+                    module,
+                    name: Some((name, _)),
+                    ..
+                } => format!("{module}.{name}").into(),
+                ast::TypeAstConstructorName::Qualified {
+                    module, name: None, ..
+                } => format!("{module}.").into(),
             });
 
             for arg in arguments {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -328,11 +328,112 @@ impl<T: PartialEq> RecordConstructorArg<T> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeAstConstructor {
     pub location: SrcSpan,
-    pub name_location: SrcSpan,
-    pub module: Option<(EcoString, SrcSpan)>,
-    pub name: EcoString,
+    pub name: TypeAstConstructorName,
     pub arguments: Vec<TypeAst>,
     pub start_parentheses: Option<u32>,
+}
+
+/// This represents a type constructor name, that can either be qualified, or
+/// unqualified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeAstConstructorName {
+    /// ```gleam
+    /// pub fn wibble() -> wibble.Wibble
+    /// //                 ^^^^^^ module
+    /// //                        ^^^^^^ name
+    /// ```
+    /// Notice how the name could be missing, this is an error! However, instead
+    /// of treating it like a syntax error we allow parsing it and report it
+    /// later. This way the language server can provide better help!
+    Qualified {
+        module: EcoString,
+        module_location: SrcSpan,
+        dot_location: u32,
+        name: Option<(EcoString, SrcSpan)>,
+    },
+
+    /// ```gleam
+    /// pub fn wibble() -> Wibble
+    /// //                 ^^^^^^ name
+    /// ```
+    Unqualified { name: EcoString, location: SrcSpan },
+}
+
+impl TypeAstConstructorName {
+    pub fn is_qualified(&self) -> bool {
+        match self {
+            TypeAstConstructorName::Qualified { .. } => true,
+            TypeAstConstructorName::Unqualified { .. } => false,
+        }
+    }
+
+    pub fn module_name(&self) -> Option<&EcoString> {
+        match self {
+            TypeAstConstructorName::Qualified { module, .. } => Some(module),
+            TypeAstConstructorName::Unqualified { .. } => None,
+        }
+    }
+
+    pub fn name(&self) -> Option<&EcoString> {
+        match self {
+            TypeAstConstructorName::Unqualified { name, .. }
+            | TypeAstConstructorName::Qualified {
+                name: Some((name, _)),
+                ..
+            } => Some(name),
+
+            TypeAstConstructorName::Qualified { name: None, .. } => None,
+        }
+    }
+
+    pub fn name_location(&self) -> Option<SrcSpan> {
+        match self {
+            TypeAstConstructorName::Unqualified { location, .. }
+            | TypeAstConstructorName::Qualified {
+                name: Some((_, location)),
+                ..
+            } => Some(*location),
+
+            TypeAstConstructorName::Qualified { name: None, .. } => None,
+        }
+    }
+
+    fn is_logically_equal(&self, other: &TypeAstConstructorName) -> bool {
+        match (self, other) {
+            (
+                TypeAstConstructorName::Qualified { module, name, .. },
+                TypeAstConstructorName::Qualified {
+                    module: other_module,
+                    name: other_name,
+                    ..
+                },
+            ) => {
+                module == other_module
+                    && match (name, other_name) {
+                        (Some((name, _)), Some((other_name, _))) => name == other_name,
+                        (None, Some(_)) | (Some(_), None) => false,
+                        (None, None) => true,
+                    }
+            }
+
+            (
+                TypeAstConstructorName::Unqualified { name, location: _ },
+                TypeAstConstructorName::Unqualified {
+                    name: other_name,
+                    location: _,
+                },
+            ) => name == other_name,
+
+            (
+                TypeAstConstructorName::Qualified { .. },
+                TypeAstConstructorName::Unqualified { .. },
+            )
+            | (
+                TypeAstConstructorName::Unqualified { .. },
+                TypeAstConstructorName::Qualified { .. },
+            ) => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -383,30 +484,23 @@ impl TypeAst {
     pub fn is_logically_equal(&self, other: &TypeAst) -> bool {
         match self {
             TypeAst::Constructor(TypeAstConstructor {
-                module,
                 name,
                 arguments,
                 location: _,
-                name_location: _,
                 start_parentheses: _,
             }) => match other {
                 TypeAst::Constructor(TypeAstConstructor {
-                    module: o_module,
-                    name: o_name,
-                    arguments: o_arguments,
+                    name: other_name,
+                    arguments: other_arguments,
                     location: _,
-                    name_location: _,
                     start_parentheses: _,
                 }) => {
-                    let module_name =
-                        |m: &Option<(EcoString, _)>| m.as_ref().map(|(m, _)| m.clone());
-                    module_name(module) == module_name(o_module)
-                        && name == o_name
-                        && arguments.len() == o_arguments.len()
+                    name.is_logically_equal(other_name)
+                        && arguments.len() == other_arguments.len()
                         && arguments
                             .iter()
-                            .zip(o_arguments)
-                            .all(|a| a.0.is_logically_equal(a.1))
+                            .zip(other_arguments)
+                            .all(|argument| argument.0.is_logically_equal(argument.1))
                 }
                 TypeAst::Fn(_) | TypeAst::Var(_) | TypeAst::Tuple(_) | TypeAst::Hole(_) => false,
             },
@@ -497,32 +591,39 @@ impl TypeAst {
                 })
                 .or(Some(Located::Annotation { ast: self, type_ })),
             TypeAst::Constructor(TypeAstConstructor {
-                arguments, module, ..
-            }) => type_
-                .named_type_information()
-                .and_then(|(module_name, _, arg_types)| {
-                    if let Some(arg) = arguments
-                        .iter()
-                        .zip(arg_types)
-                        .find_map(|(arg, arg_type)| arg.find_node(byte_index, arg_type.clone()))
-                    {
-                        return Some(arg);
-                    }
+                arguments, name, ..
+            }) => {
+                //
+                type_
+                    .named_type_information()
+                    .and_then(|(module_name, _, arg_types)| {
+                        if let Some(arg) = arguments
+                            .iter()
+                            .zip(arg_types)
+                            .find_map(|(arg, arg_type)| arg.find_node(byte_index, arg_type.clone()))
+                        {
+                            return Some(arg);
+                        }
 
-                    if let Some((module_alias, location)) = module
-                        && location.contains(byte_index)
-                    {
-                        return Some(Located::ModuleName {
-                            location: *location,
-                            module_name,
-                            module_alias: module_alias.clone(),
-                            layer: Layer::Type,
-                        });
-                    }
+                        if let TypeAstConstructorName::Qualified {
+                            module_location,
+                            module: module_alias,
+                            ..
+                        } = name
+                            && module_location.contains(byte_index)
+                        {
+                            return Some(Located::ModuleName {
+                                location: *module_location,
+                                module_name,
+                                module_alias: module_alias.clone(),
+                                layer: Layer::Type,
+                            });
+                        }
 
-                    None
-                })
-                .or(Some(Located::Annotation { ast: self, type_ })),
+                        None
+                    })
+                    .or(Some(Located::Annotation { ast: self, type_ }))
+            }
             TypeAst::Tuple(TypeAstTuple { elements, .. }) => type_
                 .tuple_types()
                 .and_then(|elem_types| {
@@ -569,11 +670,17 @@ impl TypeAst {
                 func.return_.print(buffer);
             }
             TypeAst::Constructor(constructor) => {
-                if let Some((module, _)) = &constructor.module {
-                    buffer.push_str(module);
-                    buffer.push('.');
-                }
-                buffer.push_str(&constructor.name);
+                match &constructor.name {
+                    TypeAstConstructorName::Unqualified { name, .. } => buffer.push_str(name),
+                    TypeAstConstructorName::Qualified { module, name, .. } => {
+                        buffer.push_str(module);
+                        buffer.push('.');
+                        if let Some((name, _name_location)) = name {
+                            buffer.push_str(name);
+                        }
+                    }
+                };
+
                 if !constructor.arguments.is_empty() {
                     buffer.push('(');
                     for (i, argument) in constructor.arguments.iter().enumerate() {
@@ -617,10 +724,13 @@ fn type_ast_print_fn() {
 fn type_ast_print_constructor() {
     let mut buffer = EcoString::new();
     let ast = TypeAst::Constructor(TypeAstConstructor {
-        name: "SomeType".into(),
-        module: Some(("some_module".into(), SrcSpan { start: 1, end: 1 })),
+        name: TypeAstConstructorName::Qualified {
+            module: "some_module".into(),
+            dot_location: 1,
+            module_location: SrcSpan { start: 1, end: 1 },
+            name: Some(("SomeType".into(), SrcSpan { start: 1, end: 1 })),
+        },
         location: SrcSpan { start: 1, end: 1 },
-        name_location: SrcSpan { start: 1, end: 1 },
         arguments: vec![
             TypeAst::Var(TypeAstVar {
                 location: SrcSpan { start: 1, end: 1 },
@@ -644,10 +754,13 @@ fn type_ast_print_tuple() {
         location: SrcSpan { start: 1, end: 1 },
         elements: vec![
             TypeAst::Constructor(TypeAstConstructor {
-                name: "SomeType".into(),
-                module: Some(("some_module".into(), SrcSpan { start: 1, end: 1 })),
+                name: TypeAstConstructorName::Qualified {
+                    module: "some_module".into(),
+                    module_location: SrcSpan { start: 1, end: 1 },
+                    dot_location: 1,
+                    name: Some(("SomeType".into(), SrcSpan { start: 1, end: 1 })),
+                },
                 location: SrcSpan { start: 1, end: 1 },
-                name_location: SrcSpan { start: 1, end: 1 },
                 arguments: vec![
                     TypeAst::Var(TypeAstVar {
                         location: SrcSpan { start: 1, end: 1 },

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -41,8 +41,9 @@
 use crate::{
     analyse::Inferred,
     ast::{
-        BitArraySize, RecordBeingUpdated, TypedBitArraySize, TypedConstantBitArraySegment,
-        TypedDefinitions, TypedImport, TypedTailPattern, TypedTypeAlias, typed::InvalidExpression,
+        BitArraySize, RecordBeingUpdated, TypeAstConstructorName, TypedBitArraySize,
+        TypedConstantBitArraySegment, TypedDefinitions, TypedImport, TypedTailPattern,
+        TypedTypeAlias, typed::InvalidExpression,
     },
     exhaustiveness::CompiledCase,
     parse::LiteralFloatValue,
@@ -608,21 +609,11 @@ pub trait Visit<'ast> {
     fn visit_type_ast_constructor(
         &mut self,
         location: &'ast SrcSpan,
-        name_location: &'ast SrcSpan,
-        module: &'ast Option<(EcoString, SrcSpan)>,
-        name: &'ast EcoString,
+        name: &'ast TypeAstConstructorName,
         arguments: &'ast [TypeAst],
         inferred_arguments_types: Option<Vec<Arc<Type>>>,
     ) {
-        visit_type_ast_constructor(
-            self,
-            location,
-            name_location,
-            module,
-            name,
-            arguments,
-            inferred_arguments_types,
-        );
+        visit_type_ast_constructor(self, location, name, arguments, inferred_arguments_types);
     }
 
     fn visit_type_ast_fn(
@@ -984,16 +975,12 @@ where
     match node {
         TypeAst::Constructor(super::TypeAstConstructor {
             location,
-            name_location,
             arguments,
-            module,
             name,
             start_parentheses: _,
         }) => {
             v.visit_type_ast_constructor(
                 location,
-                name_location,
-                module,
                 name,
                 arguments,
                 type_.and_then(|type_| type_.constructor_types()),
@@ -1031,9 +1018,7 @@ where
 pub fn visit_type_ast_constructor<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
-    _name_location: &'a SrcSpan,
-    _module: &'a Option<(EcoString, SrcSpan)>,
-    _name: &'a EcoString,
+    _name: &'a TypeAstConstructorName,
     arguments: &'a [TypeAst],
     inferred_arguments_types: Option<Vec<Arc<Type>>>,
 ) where

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2583,6 +2583,22 @@ a label or use a record constructor.",
                         }
                     },
 
+                    TypeError::QualifiedTypeMissingName { location } => Diagnostic {
+                        title: "Invalid type".into(),
+                        text: "".into(),
+                        hint: None,
+                        level: Level::Error,
+                        location: Some(Location {
+                            label: Label {
+                                text: Some("This is not a valid type".into()),
+                                span: *location,
+                            },
+                            path: path.clone(),
+                            src: src.clone(),
+                            extra_labels: vec![],
+                        }),
+                    },
+
                     TypeError::UnknownType {
                         location,
                         name,

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -752,16 +752,19 @@ impl<'comments> Formatter<'comments> {
 
     fn type_ast_constructor<'a>(
         &mut self,
-        module: &'a Option<(EcoString, SrcSpan)>,
-        name: &'a str,
+        name: &'a TypeAstConstructorName,
         arguments: &'a [TypeAst],
         location: &SrcSpan,
-        _name_location: &SrcSpan,
     ) -> Document<'a> {
-        let head = module
-            .as_ref()
-            .map(|(qualifier, _)| qualifier.to_doc().append(".").append(name))
-            .unwrap_or_else(|| name.to_doc());
+        let head = match name {
+            TypeAstConstructorName::Unqualified { name, .. } => name.to_doc(),
+            TypeAstConstructorName::Qualified { module, name, .. } => {
+                module.to_doc().append(".").append(
+                    name.as_ref()
+                        .map_or(nil(), |(name, _name_location)| name.to_doc()),
+                )
+            }
+        };
 
         if arguments.is_empty() {
             head
@@ -779,11 +782,9 @@ impl<'comments> Formatter<'comments> {
             TypeAst::Constructor(TypeAstConstructor {
                 name,
                 arguments,
-                module,
                 location,
-                name_location,
                 start_parentheses: _,
-            }) => self.type_ast_constructor(module, name, arguments, location, name_location),
+            }) => self.type_ast_constructor(name, arguments, location),
 
             TypeAst::Fn(TypeAstFn {
                 arguments,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -62,10 +62,11 @@ use crate::ast::{
     CustomType, Definition, Function, FunctionLiteralKind, HasLocation, Import, IntOperator,
     Module, ModuleConstant, Pattern, Publicity, RecordBeingUpdated, RecordConstructor,
     RecordConstructorArg, RecordUpdateArg, SrcSpan, Statement, TailPattern, TargetedDefinition,
-    TodoKind, TypeAlias, TypeAst, TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple,
-    TypeAstVar, UnqualifiedImport, UntypedArg, UntypedClause, UntypedClauseGuard, UntypedConstant,
-    UntypedDefinition, UntypedExpr, UntypedModule, UntypedPattern, UntypedRecordUpdateArg,
-    UntypedStatement, UntypedUseAssignment, Use, UseAssignment,
+    TodoKind, TypeAlias, TypeAst, TypeAstConstructor, TypeAstConstructorName, TypeAstFn,
+    TypeAstHole, TypeAstTuple, TypeAstVar, UnqualifiedImport, UntypedArg, UntypedClause,
+    UntypedClauseGuard, UntypedConstant, UntypedDefinition, UntypedExpr, UntypedModule,
+    UntypedPattern, UntypedRecordUpdateArg, UntypedStatement, UntypedUseAssignment, Use,
+    UseAssignment,
 };
 use crate::build::Target;
 use crate::error::wrap;
@@ -2798,25 +2799,43 @@ where
             // Constructor function
             Some((start, Token::UpName { name }, end)) => {
                 self.advance();
-                self.parse_type_name_finish(start, start, None, name, end)
+                let name = TypeAstConstructorName::Unqualified {
+                    name,
+                    location: SrcSpan::new(start, end),
+                };
+                self.parse_type_name_finish(start, end, name)
             }
 
             // Constructor Module or type Variable
-            Some((start, Token::Name { name: mod_name }, end)) => {
+            Some((start, Token::Name { name: module }, end)) => {
                 self.advance();
-                if self.maybe_one(&Token::Dot).is_some() {
-                    let (name_start, upname, upname_e) = self.expect_upname()?;
-                    self.parse_type_name_finish(
-                        start,
-                        name_start,
-                        Some((mod_name, SrcSpan { start, end })),
-                        upname,
-                        upname_e,
-                    )
+
+                if let Some((_, dot_end)) = self.maybe_one(&Token::Dot) {
+                    let module_location = SrcSpan::new(start, end);
+                    match self.maybe_upname() {
+                        Some((name_start, name, name_end)) => {
+                            let name = TypeAstConstructorName::Qualified {
+                                module,
+                                module_location,
+                                dot_location: dot_end,
+                                name: Some((name, SrcSpan::new(name_start, name_end))),
+                            };
+                            self.parse_type_name_finish(start, name_end, name)
+                        }
+                        None => {
+                            let name = TypeAstConstructorName::Qualified {
+                                module,
+                                module_location,
+                                dot_location: dot_end,
+                                name: None,
+                            };
+                            self.parse_type_name_finish(start, dot_end, name)
+                        }
+                    }
                 } else {
                     Ok(Some(TypeAst::Var(TypeAstVar {
                         location: SrcSpan { start, end },
-                        name: mod_name,
+                        name: module,
                     })))
                 }
             }
@@ -2832,46 +2851,67 @@ where
     fn parse_type_name_finish(
         &mut self,
         start: u32,
-        name_start: u32,
-        module: Option<(EcoString, SrcSpan)>,
-        name: EcoString,
         end: u32,
+        name: TypeAstConstructorName,
     ) -> Result<Option<TypeAst>, ParseError> {
-        if let Some((par_s, _)) = self.maybe_one(&Token::LeftParen) {
+        if let Some((left_paren_start, left_paren_end)) = self.maybe_one(&Token::LeftParen) {
+            // In case the type is qualified and is missing a name, it doesn't
+            // make sense to parse a types list: we don't want to accept
+            // something like `wibble.(a, b)`.
+            // Instead we want to say that `(` is unexpected and we were
+            // expecting a type name instead:
+            if name.name().is_none() {
+                return Err(ParseError {
+                    error: ParseErrorType::ExpectedUpName,
+                    location: SrcSpan::new(left_paren_start, left_paren_end),
+                });
+            }
+
             let arguments = self.parse_types()?;
-            let (_, par_e) = self.expect_one(&Token::RightParen)?;
+            let (_, right_paren_end) = self.expect_one(&Token::RightParen)?;
             Ok(Some(TypeAst::Constructor(TypeAstConstructor {
-                location: SrcSpan { start, end: par_e },
-                name_location: SrcSpan {
-                    start: name_start,
-                    end,
-                },
-                module,
+                location: SrcSpan::new(start, right_paren_end),
                 name,
                 arguments,
-                start_parentheses: Some(par_s),
+                start_parentheses: Some(left_paren_start),
             })))
         } else if let Some((less_start, less_end)) = self.maybe_one(&Token::Less) {
+            let location = SrcSpan::new(less_start, less_end);
+            let (module, name) = match name {
+                TypeAstConstructorName::Qualified {
+                    module,
+                    name: Some((name, _)),
+                    ..
+                } => (Some(module), name),
+                TypeAstConstructorName::Unqualified { name, .. } => (None, name),
+
+                // If we're here it means someone has typed something truly
+                // wrong that looks like this: `wibble.<`.
+                // In this case the hint about angle brackets wouldn't make much
+                // sense, so we fallback to just reporting an invalid token
+                // error saying we were expecting an uppercase name
+                TypeAstConstructorName::Qualified { name: None, .. } => {
+                    return Err(ParseError {
+                        error: ParseErrorType::ExpectedUpName,
+                        location,
+                    });
+                }
+            };
+
+            // Otherwise we try and report a nicer error, suggesting one should
+            // use `(a, b)` instead of `<a, b>`.
             let arguments = self.parse_types()?;
             Err(ParseError {
+                location,
                 error: ParseErrorType::TypeUsageAngleGenerics {
                     name,
-                    module: module.map(|(module_name, _)| module_name),
+                    module,
                     arguments,
-                },
-                location: SrcSpan {
-                    start: less_start,
-                    end: less_end,
                 },
             })
         } else {
             Ok(Some(TypeAst::Constructor(TypeAstConstructor {
                 location: SrcSpan { start, end },
-                name_location: SrcSpan {
-                    start: name_start,
-                    end,
-                },
-                module,
                 name,
                 arguments: vec![],
                 start_parentheses: None,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
@@ -50,12 +50,13 @@ Parsed {
                                                     start: 30,
                                                     end: 36,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 30,
-                                                    end: 36,
+                                                name: Unqualified {
+                                                    name: "String",
+                                                    location: SrcSpan {
+                                                        start: 30,
+                                                        end: 36,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "String",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },
@@ -83,12 +84,13 @@ Parsed {
                                                     start: 43,
                                                     end: 46,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 43,
-                                                    end: 46,
+                                                name: Unqualified {
+                                                    name: "Int",
+                                                    location: SrcSpan {
+                                                        start: 43,
+                                                        end: 46,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "Int",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },
@@ -116,12 +118,13 @@ Parsed {
                                                     start: 54,
                                                     end: 60,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 54,
-                                                    end: 60,
+                                                name: Unqualified {
+                                                    name: "String",
+                                                    location: SrcSpan {
+                                                        start: 54,
+                                                        end: 60,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "String",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
@@ -50,12 +50,13 @@ Parsed {
                                                     start: 30,
                                                     end: 36,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 30,
-                                                    end: 36,
+                                                name: Unqualified {
+                                                    name: "String",
+                                                    location: SrcSpan {
+                                                        start: 30,
+                                                        end: 36,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "String",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },
@@ -83,12 +84,13 @@ Parsed {
                                                     start: 43,
                                                     end: 46,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 43,
-                                                    end: 46,
+                                                name: Unqualified {
+                                                    name: "Int",
+                                                    location: SrcSpan {
+                                                        start: 43,
+                                                        end: 46,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "Int",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
@@ -50,12 +50,13 @@ Parsed {
                                                     start: 30,
                                                     end: 36,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 30,
-                                                    end: 36,
+                                                name: Unqualified {
+                                                    name: "String",
+                                                    location: SrcSpan {
+                                                        start: 30,
+                                                        end: 36,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "String",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },
@@ -83,12 +84,13 @@ Parsed {
                                                     start: 43,
                                                     end: 46,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 43,
-                                                    end: 46,
+                                                name: Unqualified {
+                                                    name: "Int",
+                                                    location: SrcSpan {
+                                                        start: 43,
+                                                        end: 46,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "Int",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__error_for_greater_sign_after_invalid_qualified_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__error_for_greater_sign_after_invalid_qualified_type.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "pub fn main() -> wibble.<a> { todo }"
+---
+----- SOURCE CODE
+pub fn main() -> wibble.<a> { todo }
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:25
+  │
+1 │ pub fn main() -> wibble.<a> { todo }
+  │                         ^ I was expecting a type name here

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_error_for_greater_sign_after_invalid_qualified_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_error_for_greater_sign_after_invalid_qualified_type.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "pub fn main() -> wibble.<a> { todo }"
+---
+----- SOURCE CODE
+pub fn main() -> wibble.<a> { todo }
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:25
+  │
+1 │ pub fn main() -> wibble.<a> { todo }
+  │                         ^ I was expecting a type name here

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_error_for_type_list_after_invalid_qualified_type_1.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_error_for_type_list_after_invalid_qualified_type_1.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "pub fn main() -> wibble.() { todo }"
+---
+----- SOURCE CODE
+pub fn main() -> wibble.() { todo }
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:25
+  │
+1 │ pub fn main() -> wibble.() { todo }
+  │                         ^ I was expecting a type name here

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_error_for_type_list_after_invalid_qualified_type_2.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__parse_error_for_type_list_after_invalid_qualified_type_2.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "pub fn main() -> wibble.(a, b) { todo }"
+---
+----- SOURCE CODE
+pub fn main() -> wibble.(a, b) { todo }
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:25
+  │
+1 │ pub fn main() -> wibble.(a, b) { todo }
+  │                         ^ I was expecting a type name here

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -50,12 +50,13 @@ Parsed {
                                                     start: 34,
                                                     end: 40,
                                                 },
-                                                name_location: SrcSpan {
-                                                    start: 34,
-                                                    end: 40,
+                                                name: Unqualified {
+                                                    name: "String",
+                                                    location: SrcSpan {
+                                                        start: 34,
+                                                        end: 40,
+                                                    },
                                                 },
-                                                module: None,
-                                                name: "String",
                                                 arguments: [],
                                                 start_parentheses: None,
                                             },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__with_let_binding3_and_annotation.snap
@@ -69,12 +69,13 @@ expression: "let assert [x]: List(Int) = [2]"
                             start: 16,
                             end: 25,
                         },
-                        name_location: SrcSpan {
-                            start: 16,
-                            end: 20,
+                        name: Unqualified {
+                            name: "List",
+                            location: SrcSpan {
+                                start: 16,
+                                end: 20,
+                            },
                         },
-                        module: None,
-                        name: "List",
                         arguments: [
                             Constructor(
                                 TypeAstConstructor {
@@ -82,12 +83,13 @@ expression: "let assert [x]: List(Int) = [2]"
                                         start: 21,
                                         end: 24,
                                     },
-                                    name_location: SrcSpan {
-                                        start: 21,
-                                        end: 24,
+                                    name: Unqualified {
+                                        name: "Int",
+                                        location: SrcSpan {
+                                            start: 21,
+                                            end: 24,
+                                        },
                                     },
-                                    module: None,
-                                    name: "Int",
                                     arguments: [],
                                     start_parentheses: None,
                                 },

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -2159,3 +2159,18 @@ const wobble = [..wibble, 4, 5]
 "
     );
 }
+
+#[test]
+fn parse_error_for_greater_sign_after_invalid_qualified_type() {
+    assert_module_error!("pub fn main() -> wibble.<a> { todo }");
+}
+
+#[test]
+fn parse_error_for_type_list_after_invalid_qualified_type_1() {
+    assert_module_error!("pub fn main() -> wibble.() { todo }");
+}
+
+#[test]
+fn parse_error_for_type_list_after_invalid_qualified_type_2() {
+    assert_module_error!("pub fn main() -> wibble.(a, b) { todo }");
+}

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -175,6 +175,12 @@ pub enum Error {
         hint: UnknownTypeHint,
     },
 
+    /// This happens when someone writes `module_name.` with no type name after
+    /// it.
+    QualifiedTypeMissingName {
+        location: SrcSpan,
+    },
+
     UnknownModule {
         location: SrcSpan,
         name: EcoString,
@@ -1364,6 +1370,7 @@ impl Error {
             | Error::SrcImportingDevDependency { location, .. }
             | Error::ExternalTypeWithConstructors { location, .. }
             | Error::RecordUpdateVariantWithNoFields { location }
+            | Error::QualifiedTypeMissingName { location }
             | Error::LowercaseBoolPattern { location } => location.start,
             Error::UnknownLabels { unknown, .. } => {
                 unknown.iter().map(|(_, s)| s.start).min().unwrap_or(0)
@@ -1558,11 +1565,11 @@ pub enum UnknownTypeConstructorError {
 }
 
 pub fn convert_get_type_constructor_error(
-    e: UnknownTypeConstructorError,
+    error: UnknownTypeConstructorError,
     location: &SrcSpan,
     module_location: Option<SrcSpan>,
 ) -> Error {
-    match e {
+    match error {
         UnknownTypeConstructorError::Type { name, hint } => Error::UnknownType {
             location: *location,
             name,

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -1,7 +1,10 @@
 use super::*;
 use crate::{
     analyse::name::check_name_case,
-    ast::{Layer, TypeAst, TypeAstConstructor, TypeAstFn, TypeAstHole, TypeAstTuple, TypeAstVar},
+    ast::{
+        Layer, TypeAst, TypeAstConstructor, TypeAstConstructorName, TypeAstFn, TypeAstHole,
+        TypeAstTuple, TypeAstVar,
+    },
     reference::ReferenceKind,
 };
 use std::sync::Arc;
@@ -114,8 +117,6 @@ impl Hydrator {
         match ast {
             TypeAst::Constructor(TypeAstConstructor {
                 location,
-                name_location,
-                module,
                 name,
                 arguments,
                 start_parentheses,
@@ -127,6 +128,36 @@ impl Hydrator {
                     argument_types.push((argument.location(), type_));
                 }
 
+                let module = match name {
+                    TypeAstConstructorName::Unqualified { .. } => None,
+                    TypeAstConstructorName::Qualified {
+                        module,
+                        module_location,
+                        ..
+                    } => Some((module.clone(), *module_location)),
+                };
+
+                // If the constructor has been typed incorrectly with no name,
+                // we can't figure out what type it's supposed to be, so it's
+                // going to be an error: `wibble.` <- the name is missing!
+                let (name, name_location) = match name {
+                    TypeAstConstructorName::Unqualified { name, location }
+                    | TypeAstConstructorName::Qualified {
+                        name: Some((name, location)),
+                        ..
+                    } => (name, location),
+                    TypeAstConstructorName::Qualified {
+                        name: None,
+                        module_location,
+                        dot_location,
+                        ..
+                    } => {
+                        return Err(Error::QualifiedTypeMissingName {
+                            location: SrcSpan::new(module_location.start, *dot_location),
+                        });
+                    }
+                };
+
                 // Look up the constructor
                 let TypeConstructor {
                     parameters,
@@ -134,10 +165,10 @@ impl Hydrator {
                     deprecation,
                     ..
                 } = environment
-                    .get_type_constructor(module, name)
-                    .map_err(|e| {
+                    .get_type_constructor(&module, name)
+                    .map_err(|error| {
                         convert_get_type_constructor_error(
-                            e,
+                            error,
                             location,
                             module.as_ref().map(|(_, location)| *location),
                         )

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3575,3 +3575,8 @@ pub const wobble = Wibble(..wobble)
 "
     );
 }
+
+#[test]
+fn qualified_type_with_no_name_results_in_an_error() {
+    assert_module_error!("pub fn main() -> wibble. { todo }");
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_with_no_name_results_in_an_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__qualified_type_with_no_name_results_in_an_error.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "pub fn main() -> wibble. { todo }"
+---
+----- SOURCE CODE
+pub fn main() -> wibble. { todo }
+
+----- ERROR
+error: Invalid type
+  ┌─ /src/one/two.gleam:1:18
+  │
+1 │ pub fn main() -> wibble. { todo }
+  │                  ^^^^^^^ This is not a valid type

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -8,10 +8,10 @@ use gleam_core::{
         self, ArgNames, AssignName, AssignmentKind, BitArraySegmentTruncation, BoundVariable,
         BoundVariableName, CallArg, CustomType, FunctionLiteralKind, ImplicitCallArgOrigin, Import,
         InvalidExpression, PIPE_PRECEDENCE, Pattern, PatternUnusedArguments,
-        PipelineAssignmentKind, Publicity, RecordConstructor, SrcSpan, TodoKind, TypedArg,
-        TypedAssignment, TypedClauseGuard, TypedDefinitions, TypedExpr, TypedFunction,
-        TypedModuleConstant, TypedPattern, TypedPipelineAssignment, TypedRecordConstructor,
-        TypedStatement, TypedTailPattern, TypedUse, visit::Visit as _,
+        PipelineAssignmentKind, Publicity, RecordConstructor, SrcSpan, TodoKind,
+        TypeAstConstructorName, TypedArg, TypedAssignment, TypedClauseGuard, TypedDefinitions,
+        TypedExpr, TypedFunction, TypedModuleConstant, TypedPattern, TypedPipelineAssignment,
+        TypedRecordConstructor, TypedStatement, TypedTailPattern, TypedUse, visit::Visit as _,
     },
     build::{Located, Module},
     config::PackageConfig,
@@ -1747,15 +1747,14 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
     fn visit_type_ast_constructor(
         &mut self,
         location: &'ast SrcSpan,
-        name_location: &'ast SrcSpan,
-        module: &'ast Option<(EcoString, SrcSpan)>,
-        name: &'ast EcoString,
+        name: &'ast TypeAstConstructorName,
         arguments: &'ast [ast::TypeAst],
         arguments_types: Option<Vec<Arc<Type>>>,
     ) {
         let range = src_span_to_lsp_range(*location, self.line_numbers);
         if overlaps(self.params.range, range)
-            && let Some((module_alias, _)) = module
+            && let Some(module_alias) = name.module_name()
+            && let Some(name) = name.name()
             && let Some(import) = self.get_module_import(module_alias, name, ast::Layer::Type)
         {
             self.qualified_constructor = Some(QualifiedConstructor {
@@ -1765,15 +1764,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
                 layer: ast::Layer::Type,
             });
         }
-        ast::visit::visit_type_ast_constructor(
-            self,
-            location,
-            name_location,
-            module,
-            name,
-            arguments,
-            arguments_types,
-        );
+        ast::visit::visit_type_ast_constructor(self, location, name, arguments, arguments_types);
     }
 
     fn visit_typed_expr_module_select(
@@ -2000,13 +1991,13 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
     fn visit_type_ast_constructor(
         &mut self,
         location: &'ast SrcSpan,
-        name_location: &'ast SrcSpan,
-        module: &'ast Option<(EcoString, SrcSpan)>,
-        name: &'ast EcoString,
+        name: &'ast TypeAstConstructorName,
         arguments: &'ast [ast::TypeAst],
         arguments_types: Option<Vec<Arc<Type>>>,
     ) {
-        if let Some((module_name, _)) = module {
+        if let Some(module_name) = name.module_name()
+            && let Some(name) = name.name()
+        {
             let QualifiedConstructor {
                 used_name,
                 constructor,
@@ -2018,15 +2009,7 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
                 self.remove_module_qualifier(*location);
             }
         }
-        ast::visit::visit_type_ast_constructor(
-            self,
-            location,
-            name_location,
-            module,
-            name,
-            arguments,
-            arguments_types,
-        );
+        ast::visit::visit_type_ast_constructor(self, location, name, arguments, arguments_types);
     }
 
     fn visit_typed_expr_module_select(
@@ -2266,13 +2249,12 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
     fn visit_type_ast_constructor(
         &mut self,
         location: &'ast SrcSpan,
-        name_location: &'ast SrcSpan,
-        module: &'ast Option<(EcoString, SrcSpan)>,
-        name: &'ast EcoString,
+        name: &'ast TypeAstConstructorName,
         arguments: &'ast [ast::TypeAst],
         arguments_types: Option<Vec<Arc<Type>>>,
     ) {
-        if module.is_none()
+        if !name.is_qualified()
+            && let Some(name) = name.name()
             && overlaps(
                 self.params.range,
                 src_span_to_lsp_range(*location, self.line_numbers),
@@ -2281,15 +2263,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
             self.get_module_import_from_type_constructor(name);
         }
 
-        ast::visit::visit_type_ast_constructor(
-            self,
-            location,
-            name_location,
-            module,
-            name,
-            arguments,
-            arguments_types,
-        );
+        ast::visit::visit_type_ast_constructor(self, location, name, arguments, arguments_types);
     }
 
     fn visit_typed_expr_var(
@@ -2510,13 +2484,13 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
     fn visit_type_ast_constructor(
         &mut self,
         location: &'ast SrcSpan,
-        name_location: &'ast SrcSpan,
-        module: &'ast Option<(EcoString, SrcSpan)>,
-        name: &'ast EcoString,
+        name: &'ast TypeAstConstructorName,
         arguments: &'ast [ast::TypeAst],
         arguments_types: Option<Vec<Arc<Type>>>,
     ) {
-        if module.is_none() {
+        if !name.is_qualified()
+            && let Some(name) = name.name()
+        {
             let UnqualifiedConstructor {
                 constructor, layer, ..
             } = &self.unqualified_constructor;
@@ -2524,15 +2498,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
                 self.add_module_qualifier(*location);
             }
         }
-        ast::visit::visit_type_ast_constructor(
-            self,
-            location,
-            name_location,
-            module,
-            name,
-            arguments,
-            arguments_types,
-        );
+        ast::visit::visit_type_ast_constructor(self, location, name, arguments, arguments_types);
     }
 
     fn visit_typed_expr_var(

--- a/language-server/src/reference.rs
+++ b/language-server/src/reference.rs
@@ -7,7 +7,8 @@ use gleam_core::{
     analyse,
     ast::{
         self, ArgNames, AssignName, BitArraySize, ClauseGuard, CustomType, Function,
-        ModuleConstant, Pattern, RecordConstructor, SrcSpan, TypedExpr, TypedModule, visit::Visit,
+        ModuleConstant, Pattern, RecordConstructor, SrcSpan, TypeAstConstructorName, TypedExpr,
+        TypedModule, visit::Visit,
     },
     build::Located,
     type_::{
@@ -263,12 +264,13 @@ pub fn reference_for_ast_node(
             Some((module, name)) => {
                 let (target_kind, location) = match ast {
                     ast::TypeAst::Constructor(constructor) => {
-                        let kind = if constructor.module.is_some() {
+                        let kind = if constructor.name.is_qualified() {
                             RenameTarget::Qualified
                         } else {
                             RenameTarget::Unqualified
                         };
-                        (kind, constructor.name_location)
+                        let name_location = constructor.name.name_location()?;
+                        (kind, name_location)
                     }
                     ast::TypeAst::Fn(_)
                     | ast::TypeAst::Var(_)
@@ -917,13 +919,15 @@ impl<'ast> Visit<'ast> for FindModuleNameReferences<'_> {
     fn visit_type_ast_constructor(
         &mut self,
         location: &'ast SrcSpan,
-        name_location: &'ast SrcSpan,
-        module: &'ast Option<(EcoString, SrcSpan)>,
-        name: &'ast EcoString,
+        name: &'ast TypeAstConstructorName,
         arguments: &'ast [ast::TypeAst],
         arguments_types: Option<Vec<std::sync::Arc<Type>>>,
     ) {
-        if let Some((module_alias, module_location)) = module
+        if let TypeAstConstructorName::Qualified {
+            module: module_alias,
+            module_location,
+            ..
+        } = name
             && module_alias == self.module_alias
         {
             self.references.push(ModuleNameReference {
@@ -932,15 +936,7 @@ impl<'ast> Visit<'ast> for FindModuleNameReferences<'_> {
             })
         }
 
-        ast::visit::visit_type_ast_constructor(
-            self,
-            location,
-            name_location,
-            module,
-            name,
-            arguments,
-            arguments_types,
-        );
+        ast::visit::visit_type_ast_constructor(self, location, name, arguments, arguments_types);
     }
 
     fn visit_typed_constant_record(

--- a/language-server/src/tests/completion.rs
+++ b/language-server/src/tests/completion.rs
@@ -2424,3 +2424,68 @@ pub fn to_base_32() {}
         Position::new(1, 17)
     );
 }
+
+const OPTION_MODULE: &str = "
+pub type Option(a) { Some(a) None }
+pub fn all() {}
+";
+
+#[test]
+fn do_not_show_completions_for_module_values_when_typing_an_argument_type() {
+    assert_completion!(
+        TestProject::for_source(
+            "
+import option
+pub fn main(n: option.) {}
+"
+        )
+        .add_dep_module("option", OPTION_MODULE),
+        Position::new(2, 22)
+    );
+}
+
+#[test]
+fn do_not_show_completions_for_module_values_when_typing_a_return_type() {
+    assert_completion!(
+        TestProject::for_source(
+            "
+import option
+pub fn main() -> option. {}
+"
+        )
+        .add_dep_module("option", OPTION_MODULE),
+        Position::new(2, 24)
+    );
+}
+
+#[test]
+fn do_not_show_completions_for_module_values_when_typing_a_constructor_type() {
+    assert_completion!(
+        TestProject::for_source(
+            "
+import option
+pub type Wibble {
+  Wibble(option.)
+}
+"
+        )
+        .add_dep_module("option", OPTION_MODULE),
+        Position::new(3, 16)
+    );
+}
+
+#[test]
+fn do_not_show_completions_for_module_values_when_typing_an_annotation() {
+    assert_completion!(
+        TestProject::for_source(
+            "
+import option
+pub fn main() {
+  let a: option. = todo
+}
+"
+        )
+        .add_dep_module("option", OPTION_MODULE),
+        Position::new(3, 16)
+    );
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_a_constructor_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_a_constructor_type.snap
@@ -1,0 +1,17 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\nimport option\npub type Wibble {\n  Wibble(option.)\n}\n"
+---
+import option
+pub type Wibble {
+  Wibble(option.|)
+}
+
+
+----- Completion content -----
+option.Option
+  kind:   Class
+  detail: Type
+  sort:   4_option.Option
+  edits:
+    [3:9-3:16]: "option.Option"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_a_return_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_a_return_type.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\nimport option\npub fn main() -> option. {}\n"
+---
+import option
+pub fn main() -> option.| {}
+
+
+----- Completion content -----
+option.Option
+  kind:   Class
+  detail: Type
+  sort:   4_option.Option
+  edits:
+    [2:17-2:24]: "option.Option"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_an_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_an_annotation.snap
@@ -1,0 +1,17 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\nimport option\npub fn main() {\n  let a: option. = todo\n}\n"
+---
+import option
+pub fn main() {
+  let a: option.| = todo
+}
+
+
+----- Completion content -----
+option.Option
+  kind:   Class
+  detail: Type
+  sort:   4_option.Option
+  edits:
+    [3:9-3:16]: "option.Option"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_an_argument_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__do_not_show_completions_for_module_values_when_typing_an_argument_type.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\nimport option\npub fn main(n: option.) {}\n"
+---
+import option
+pub fn main(n: option.|) {}
+
+
+----- Completion content -----
+option.Option
+  kind:   Class
+  detail: Type
+  sort:   4_option.Option
+  edits:
+    [2:15-2:22]: "option.Option"


### PR DESCRIPTION
This PR closes #3558 
Actually that issue already stopped happening on main (I'm not sure when) but it fixes a similar bug I found when investigating that: right now when typing a qualified type one is presented with completions for values rather than types.
<img width="799" height="298" alt="Screenshot 2026-03-25 alle 19 34 39" src="https://github.com/user-attachments/assets/c3b903aa-9f30-4e1a-ac94-12f2bd564bd2" />

That was due to a combination of wrong spans and the parsing not being fault tolerant in case of incomplete qualified types of the form `wibble.` (with no uppercase name).

For regular values we deal with that by allowing the parser to parse a module select with no actual value name `module_name.` rather than failing at the parsing step.
I ended up doing the same for the type ast as well.

---

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
