### PR TITLE
add some more formatter tests for case expressions

### DIFF
--- a/compiler-core/src/format/tests/cases.rs
+++ b/compiler-core/src/format/tests/cases.rs
@@ -193,3 +193,52 @@ fn case_in_call_is_not_broken_if_it_goes_over_the_limit_with_branches() {
 "#
     );
 }
+
+#[test]
+fn long_alternative_patterns_1() {
+    assert_format!(
+        r#"fn test_1() {
+  case a, b, c {
+    _ignored, _ignored, _ignored
+    | _ignored, _ignored, _ignored
+    | _ignored, _ignored, _ignored
+    -> True
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn long_alternative_patterns_2() {
+    assert_format!(
+        r#"fn test_2() {
+  case a, b, c {
+    _, _, _
+    | _, _, _
+    | this_is_long_and_is_going_to_split_on_multiple,
+      lines,
+      and_force_the_arrow_to_break
+    -> True
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn long_alternative_patterns_3() {
+    assert_format!(
+        r#"fn test_3() {
+  case a, b, c {
+    _, _, _
+    | this_is_long_and_is_going_to_split_on_multiple,
+      lines,
+      and_force_the_alternative_to_break
+    | _, _, _
+    -> True
+  }
+}
+"#
+    );
+}


### PR DESCRIPTION
I was looking at #3136 and noticed I commented with some tests that should succeed but they had never been included in the codebase to make sure there's no regressions. So this PR adds those back.

Also, I think that issue could be closed, I think the formatting there is reasonable and consistent. Changing it for all branches but the last one would be oddly not consistent I think