### PR TITLE
fix: correct supplied argument count in use<- arity error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Compiler
 
+- Fixed the `use` expression arity error message so it reports how many
+  arguments were supplied (excluding the callback) instead of the wrong count.
+  ([Wei Cui](https://github.com/cuiweixie))
+
 - The compiler now supports list prepending in constants. For example:
 
   ```gleam

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3818,7 +3818,7 @@ See: https://tour.gleam.run/advanced-features/use/",
                         let supplied_arguments_string = match supplied_arguments {
                             0 => "no arguments".into(),
                             1 => "1 argument".into(),
-                            _ => format!("{given} arguments"),
+                            _ => format!("{supplied_arguments} arguments"),
                         };
                         let label = format!("Expected {expected_string}, got {given}");
                         let mut text: String = format!(


### PR DESCRIPTION
## Summary

Fixes the plural branch of the `UseFnIncorrectArity` diagnostic: it used `given` (total arity including the `use` callback) when describing how many arguments were supplied, instead of the count of non-callback arguments (`given - 1`).

## Checklist

- [x] Updated `CHANGELOG.md` under **Unreleased** → **Compiler**.