### PR TITLE
fix: check max bit inference size before representability in int_to_bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Compiler
 
+- Fixed bit array pattern integer segments so that when the read size exceeds
+  the maximum width used for inference, the compiler reports
+  `ExceedsMaximumSize` instead of incorrectly reporting `Unrepresentable` first.
+  ([Wei Cui](https://github.com/cuiweixie))
+
 - The compiler now supports list prepending in constants. For example:
 
   ```gleam

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -3647,10 +3647,11 @@ fn int_to_bits(
         .to_u32()
         .ok_or(IntToBitsError::ExceedsMaximumSize)?;
 
+    if size > BitArrayMatchedValue::MAX_BITS_INTERFERENCE {
+        return Err(IntToBitsError::ExceedsMaximumSize);
+    }
     if !representable_with_bits(value, size, signed) {
         return Err(IntToBitsError::Unrepresentable { size });
-    } else if size > BitArrayMatchedValue::MAX_BITS_INTERFERENCE {
-        return Err(IntToBitsError::ExceedsMaximumSize);
     }
 
     // Pad negative numbers with 1s (true) and non-negative numbers with 0s (false)


### PR DESCRIPTION
## Summary

In `int_to_bits`, the `MAX_BITS_INTERFERENCE` check ran after `representable_with_bits`. For oversized read sizes where the value is not representable in that width, the compiler could return `IntToBitsError::Unrepresentable` instead of `ExceedsMaximumSize`. This change checks the maximum inference width first.

## Checklist

- [x] Updated `CHANGELOG.md` under **Unreleased** → **Compiler**.