### PR TITLE
fix: use digit index for integer thousands separators in formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Compiler
 
+- Fixed the formatter so thousands separators in integer literals are inserted
+  based on digit position rather than character index in the reversed string,
+  which corrects grouping when the input already contains underscores.
+  ([Wei Cui](https://github.com/cuiweixie))
+
 - The compiler now supports list prepending in constants. For example:
 
   ```gleam

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -1259,7 +1259,7 @@ impl<'comments> Formatter<'comments> {
                 continue;
             }
 
-            if insert_underscores && i != 0 && ch != minus_ch && i < len && j % 3 == 0 {
+            if insert_underscores && j != 0 && ch != minus_ch && j % 3 == 0 {
                 new_value.push(underscore_ch);
             }
             new_value.push(ch);


### PR DESCRIPTION
## Summary

`underscore_integer_string` walks the reversed string with two counters: iterator index `i` and digit index `j` (skipping `_`). The condition for inserting thousands separators mixed `i` and `j`, so when the input already contained underscores, `i` and `j` could diverge and `_` ended up in the wrong places. The guard now uses `j` consistently, matching digit grouping.

## Checklist

- [x] Updated `CHANGELOG.md` under **Unreleased** → **Compiler**.