### PR TITLE
Better Git repo discovery in `gleam publish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@
 - New packages are created requesting Erlang/OTP version 29 on GitHub actions.
   ([Louis Pilfold](https://github.com/lpil))
 
+- `gleam publish` will now better discover Git repository in monorepos. This
+  improves suggestions to push a tag, if it doesn't exists.
+  ([Andrey Kozhev](https://github.com/ankddev))
+
 ### Language server
 
 - The language server can now help with completions when typing a list's tail:

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -793,3 +793,17 @@ impl WarningEmitterIO for ConsoleWarningEmitter {
             .expect("Writing warning to stderr");
     }
 }
+
+/// Returns root of Git repository in base path if it is initialised.
+pub fn get_git_repository_root(mut path: Utf8PathBuf) -> Option<Utf8PathBuf> {
+    loop {
+        if path.join(".git").is_dir() {
+            return Some(path);
+        }
+
+        path = match path.parent() {
+            Some(path) => path.into(),
+            None => return None,
+        }
+    }
+}

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -18,7 +18,11 @@ use gleam_core::{
 use hexpm::version::{Range, Version};
 use itertools::Itertools;
 use sha2::Digest;
-use std::{collections::HashMap, io::Write, path::PathBuf};
+use std::{
+    collections::HashMap,
+    io::Write,
+    process::{Command, Stdio},
+};
 
 use crate::{build, cli, docs, fs, http::HttpClient, new::default_readme};
 
@@ -116,19 +120,40 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
 
     // Prompt the user to make a git tag if they have not.
     let has_repo = config.repository.is_some();
-    let git = PathBuf::from(".git");
-    let tag_name = config.tag_for_version(&config.version);
-    let git_tag = git.join("refs").join("tags").join(&tag_name);
-    if has_repo && git.exists() && !git_tag.exists() {
-        println!(
-            "
-Please push a git tag for this release so source code links in the
-HTML documentation will work:
+    let is_repository = Command::new("git")
+        .arg("rev-parse")
+        .arg("--is-inside-work-tree")
+        // We don't need Git's output, since it will exit with code 0 if we are
+        // inside work tree
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
 
-    git tag {tag_name}
-    git push origin {tag_name}
-"
-        )
+    if has_repo && is_repository {
+        let tag_name = config.tag_for_version(&config.version);
+        let tag_exists = Command::new("git")
+            .args(["rev-parse", "--verify", &tag_name])
+            // We don't need Git's output, since it will exit with code 0 if the
+            // tag exists
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !tag_exists {
+            println!(
+                "
+    Please push a git tag for this release so source code links in the
+    HTML documentation will work:
+
+        git tag {tag_name}
+        git push origin {tag_name}
+    "
+            )
+        }
     }
     Ok(())
 }

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -116,7 +116,7 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
 
     // Prompt the user to make a git tag if they have not.
     let has_repo = config.repository.is_some();
-    let repository_root = get_git_repository_root(".".into());
+    let repository_root = fs::get_git_repository_root(".".into());
     if has_repo && let Some(repository_root) = repository_root {
         let git = repository_root.join(".git");
 
@@ -137,20 +137,6 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
         }
     }
     Ok(())
-}
-
-/// Returns root of Git repository in base path if it is initialised.
-fn get_git_repository_root(mut path: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    loop {
-        if path.join(".git").is_dir() {
-            return Some(path);
-        }
-
-        path = match path.parent() {
-            Some(path) => path.into(),
-            None => return None,
-        }
-    }
 }
 
 fn check_for_invalid_readme(config: &PackageConfig, paths: &ProjectPaths) -> Result<(), Error> {
@@ -1135,7 +1121,7 @@ fn find_git_repo_root_at_same_level() {
 
     fs::mkdir(path.join(".git")).expect("Create directory");
 
-    let repository_root = get_git_repository_root(path);
+    let repository_root = fs::get_git_repository_root(path);
     assert!(
         repository_root
             .expect("There should be repo root")
@@ -1148,7 +1134,7 @@ fn find_missing_git_repo_root_at_same_level() {
     let tmp = tempfile::tempdir().unwrap();
     let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
 
-    let repository_root = get_git_repository_root(path);
+    let repository_root = fs::get_git_repository_root(path);
     assert!(repository_root.is_none());
 }
 
@@ -1162,7 +1148,7 @@ fn find_git_repo_root_at_lower_level() {
     let current_path = path.join("subdirectory").join("another_subdirectory");
     fs::mkdir(&current_path).expect("Create directory");
 
-    let repository_root = get_git_repository_root(current_path);
+    let repository_root = fs::get_git_repository_root(current_path);
     assert!(
         repository_root
             .expect("There should be repo root")
@@ -1178,6 +1164,6 @@ fn find_missing_git_repo_root_at_lower_level() {
     let current_path = path.join("subdirectory").join("another_subdirectory");
     fs::mkdir(&current_path).expect("Create directory");
 
-    let repository_root = get_git_repository_root(current_path);
+    let repository_root = fs::get_git_repository_root(current_path);
     assert!(repository_root.is_none());
 }

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -17,6 +17,7 @@ use gleam_core::{
 };
 use hexpm::version::{Range, Version};
 use itertools::Itertools;
+use reqwest::get;
 use sha2::Digest;
 use std::{
     collections::HashMap,
@@ -120,28 +121,13 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
 
     // Prompt the user to make a git tag if they have not.
     let has_repo = config.repository.is_some();
-    let is_repository = Command::new("git")
-        .arg("rev-parse")
-        .arg("--is-inside-work-tree")
-        // We don't need Git's output, since it will exit with code 0 if we are
-        // inside work tree
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let repository_root = get_git_repository_root(".".into());
+    if has_repo && let Some(repository_root) = repository_root {
+        let git = repository_root.join(".git");
 
-    if has_repo && is_repository {
         let tag_name = config.tag_for_version(&config.version);
-        let tag_exists = Command::new("git")
-            .args(["rev-parse", "--verify", &tag_name])
-            // We don't need Git's output, since it will exit with code 0 if the
-            // tag exists
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+        let git_tag = git.join("refs").join("tags").join(&tag_name);
+        let tag_exists = git_tag.exists();
 
         if !tag_exists {
             println!(
@@ -156,6 +142,20 @@ pub fn command(paths: &ProjectPaths, replace: bool, i_am_sure: bool) -> Result<(
         }
     }
     Ok(())
+}
+
+/// Returns root of Git repository in base path if it is initialised.
+fn get_git_repository_root(mut path: Utf8PathBuf) -> Option<Utf8PathBuf> {
+    loop {
+        if path.join(".git").is_dir() {
+            return Some(path);
+        }
+
+        path = match path.parent() {
+            Some(path) => path.into(),
+            None => return None,
+        }
+    }
 }
 
 fn check_for_invalid_readme(config: &PackageConfig, paths: &ProjectPaths) -> Result<(), Error> {

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -17,13 +17,8 @@ use gleam_core::{
 };
 use hexpm::version::{Range, Version};
 use itertools::Itertools;
-use reqwest::get;
 use sha2::Digest;
-use std::{
-    collections::HashMap,
-    io::Write,
-    process::{Command, Stdio},
-};
+use std::{collections::HashMap, io::Write};
 
 use crate::{build, cli, docs, fs, http::HttpClient, new::default_readme};
 
@@ -1131,4 +1126,58 @@ src/also-ignored.gleam";
         .collect_vec();
 
     assert_eq!(expected_exported_files, chosen_exported_files);
+}
+
+#[test]
+fn find_git_repo_root_at_same_level() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
+
+    fs::mkdir(path.join(".git")).expect("Create directory");
+
+    let repository_root = get_git_repository_root(path);
+    assert!(
+        repository_root
+            .expect("There should be repo root")
+            .ends_with("my_project")
+    );
+}
+
+#[test]
+fn find_missing_git_repo_root_at_same_level() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
+
+    let repository_root = get_git_repository_root(path);
+    assert!(repository_root.is_none());
+}
+
+#[test]
+fn find_git_repo_root_at_lower_level() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
+
+    fs::mkdir(path.join(".git")).expect("Create directory");
+
+    let current_path = path.join("subdirectory").join("another_subdirectory");
+    fs::mkdir(&current_path).expect("Create directory");
+
+    let repository_root = get_git_repository_root(current_path);
+    assert!(
+        repository_root
+            .expect("There should be repo root")
+            .ends_with("my_project")
+    );
+}
+
+#[test]
+fn find_missing_git_repo_root_at_lower_level() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = Utf8PathBuf::from_path_buf(tmp.path().join("my_project")).expect("Non Utf8 Path");
+
+    let current_path = path.join("subdirectory").join("another_subdirectory");
+    fs::mkdir(&current_path).expect("Create directory");
+
+    let repository_root = get_git_repository_root(current_path);
+    assert!(repository_root.is_none());
 }


### PR DESCRIPTION
* Related to #5418 (that issue contains some other items, so this PR won't close it)
* We now use `git rev-parse` with flags to check presence of repo and tag
* Now we don't use paths here entirely, though other items in #5418 will probably require to get path of the `.git` directory.
***
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour (N/A)
- [x] The changelog has been updated for any user-facing changes
