### PR TITLE
Fix Windows builds

### DIFF
--- a/test-output/src/tests/echo.rs
+++ b/test-output/src/tests/echo.rs
@@ -19,11 +19,15 @@ fn run_and_produce_pretty_snapshot(
 ) -> String {
     let project_root = fs::get_project_root(project_directory).expect("project root");
     let paths = match (cfg!(windows), target, runtime) {
-        (true, Some(Target::JavaScript), Some(Runtime::NodeJs)) =>
-            ProjectPaths::new(project_root.to_string().strip_prefix(r"\\?\").unwrap().into()),
+        (true, Some(Target::JavaScript), Some(Runtime::NodeJs)) => ProjectPaths::new(
+            project_root
+                .to_string()
+                .strip_prefix(r"\\?\")
+                .unwrap()
+                .into(),
+        ),
 
-        _ =>
-            ProjectPaths::new(project_root)
+        _ => ProjectPaths::new(project_root),
     };
 
     let output = run_and_capture_output(&paths, "main", target, runtime)


### PR DESCRIPTION
This PR fixes the issue that was causing tests to fail on Windows targets, which subsequently caused CI/CD to fail.

The issue was specifically affecting the Node.js runtime, and was caused by the UNC prefix being present in the path to the JavaScript output file in the echo tests; which was coming from the `canonicalize()` calls.

While Bun and Deno worked fine, both Node.js 24 (LTS) and 25 (Stable) suffered from this issue. Here's a similar issue: https://github.com/vercel-labs/agent-browser/issues/393

The issue was fixed by stripping the prefix from the project path before running the runtime commands when:
- Target platform is `Windows`
- Target language is `JavaScript`
- Target runtime is `NodeJs`
