### PR TITLE
Improve output of outdated dependency command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,27 @@
   source control repository.
   ([Louis Pilfold](https://github.com/lpil))
 
+- The `gleam deps outdated` command now always prints a summary showing how many
+  packages have newer versions available. For example:
+
+  ```txt
+  $ gleam deps outdated
+  1 of 12 packages have newer versions available.
+
+  Package       Current  Latest
+  -------       -------  ------
+  gleam_stdlib  0.70.0   0.71.0
+  ```
+
+  When no packages are outdated, only the summary line is printed:
+
+  ```txt
+  $ gleam deps outdated
+  0 of 12 packages have newer versions available.
+  ```
+
+  ([Daniele Scaratti](https://github.com/lupodevelop))
+
 ### Language server
 
 - The language server can now help with completions when typing a list's tail:

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -222,14 +222,18 @@ fn list_dependencies_tree(
 pub fn outdated(paths: &ProjectPaths) -> Result<()> {
     let (_, manifest) = get_manifest_details(paths)?;
 
+    let total_packages = manifest
+        .packages
+        .iter()
+        .filter(|package| matches!(package.source, ManifestPackageSource::Hex { .. }))
+        .count();
+
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio async runtime");
     let package_fetcher = PackageFetcher::new(runtime.handle().clone());
 
     let version_updates = dependency::check_for_version_updates(&manifest, &package_fetcher);
 
-    if !version_updates.is_empty() {
-        print!("{}", pretty_print_version_updates(version_updates));
-    }
+    print!("{}", pretty_print_outdated_versions(total_packages, version_updates));
 
     Ok(())
 }
@@ -434,6 +438,22 @@ fn pretty_print_major_versions_available(versions: dependency::PackageVersionDif
 fn pretty_print_version_updates(versions: dependency::PackageVersionDiffs) -> EcoString {
     let versions = format_versions_and_extract_longest_parts(versions);
     space_table(&["Package", "Current", "Latest"], &versions)
+}
+
+fn pretty_print_outdated_versions(
+    total_packages: usize,
+    versions: dependency::PackageVersionDiffs,
+) -> EcoString {
+    if versions.is_empty() {
+        EcoString::new()
+    } else {
+        let summary = eco_format!(
+            "{} out of {} packages are out of date.",
+            versions.len(),
+            total_packages
+        );
+        eco_format!("{}\n\n{}", summary, pretty_print_version_updates(versions))
+    }
 }
 
 async fn add_missing_packages<Telem: Telemetry>(

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -448,7 +448,7 @@ fn pretty_print_outdated_versions(
     versions: dependency::PackageVersionDiffs,
 ) -> EcoString {
     let summary = eco_format!(
-        "{} out of {} packages have newer versions available.",
+        "{} of {} packages have newer versions available.",
         versions.len(),
         total_packages
     );

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -233,7 +233,10 @@ pub fn outdated(paths: &ProjectPaths) -> Result<()> {
 
     let version_updates = dependency::check_for_version_updates(&manifest, &package_fetcher);
 
-    print!("{}", pretty_print_outdated_versions(total_packages, version_updates));
+    print!(
+        "{}",
+        pretty_print_outdated_versions(total_packages, version_updates)
+    );
 
     Ok(())
 }
@@ -444,14 +447,15 @@ fn pretty_print_outdated_versions(
     total_packages: usize,
     versions: dependency::PackageVersionDiffs,
 ) -> EcoString {
+    let summary = eco_format!(
+        "{} out of {} packages have newer versions available.",
+        versions.len(),
+        total_packages
+    );
+
     if versions.is_empty() {
-        EcoString::new()
+        eco_format!("{}\n", summary)
     } else {
-        let summary = eco_format!(
-            "{} out of {} packages are out of date.",
-            versions.len(),
-            total_packages
-        );
         eco_format!("{}\n\n{}", summary, pretty_print_version_updates(versions))
     }
 }

--- a/compiler-cli/src/dependencies/snapshots/gleam_cli__dependencies__tests__pretty_print_outdated_versions.snap
+++ b/compiler-cli/src/dependencies/snapshots/gleam_cli__dependencies__tests__pretty_print_outdated_versions.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-cli/src/dependencies/tests.rs
+expression: output
+---
+3 of 12 packages have newer versions available.
+
+Package                 Current   Latest
+-------                 -------   ------
+gleam_stdlib            0.45.0    0.46.0
+very_long_package_name  12.12.12  120.12.12
+wisp                    2.1.0     2.1.1

--- a/compiler-cli/src/dependencies/snapshots/gleam_cli__dependencies__tests__pretty_print_outdated_versions_no_updates.snap
+++ b/compiler-cli/src/dependencies/snapshots/gleam_cli__dependencies__tests__pretty_print_outdated_versions_no_updates.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-cli/src/dependencies/tests.rs
+expression: output
+---
+0 of 12 packages have newer versions available.

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -1485,7 +1485,7 @@ fn test_pretty_print_outdated_versions() {
 
     assert_eq!(
         output,
-        "3 out of 12 packages have newer versions available.\n\nPackage                 Current   Latest\n-------                 -------   ------\ngleam_stdlib            0.45.0    0.46.0\nvery_long_package_name  12.12.12  120.12.12\nwisp                    2.1.0     2.1.1\n"
+        "3 of 12 packages have newer versions available.\n\nPackage                 Current   Latest\n-------                 -------   ------\ngleam_stdlib            0.45.0    0.46.0\nvery_long_package_name  12.12.12  120.12.12\nwisp                    2.1.0     2.1.1\n"
     );
 }
 
@@ -1497,7 +1497,7 @@ fn test_pretty_print_outdated_versions_no_updates() {
 
     assert_eq!(
         output,
-        "0 out of 12 packages have newer versions available.\n"
+        "0 of 12 packages have newer versions available.\n"
     );
 }
 

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -1483,7 +1483,10 @@ fn test_pretty_print_outdated_versions() {
 
     let output = pretty_print_outdated_versions(12, versions);
 
-    assert_eq!(output, "3 out of 12 packages are out of date.\n\nPackage                 Current   Latest\n-------                 -------   ------\ngleam_stdlib            0.45.0    0.46.0\nvery_long_package_name  12.12.12  120.12.12\nwisp                    2.1.0     2.1.1\n");
+    assert_eq!(
+        output,
+        "3 out of 12 packages have newer versions available.\n\nPackage                 Current   Latest\n-------                 -------   ------\ngleam_stdlib            0.45.0    0.46.0\nvery_long_package_name  12.12.12  120.12.12\nwisp                    2.1.0     2.1.1\n"
+    );
 }
 
 #[test]
@@ -1492,7 +1495,10 @@ fn test_pretty_print_outdated_versions_no_updates() {
 
     let output = pretty_print_outdated_versions(12, versions);
 
-    assert!(output.is_empty());
+    assert_eq!(
+        output,
+        "0 out of 12 packages have newer versions available.\n"
+    );
 }
 
 #[test]

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -1463,6 +1463,39 @@ fn test_pretty_print_version_updates() {
 }
 
 #[test]
+fn test_pretty_print_outdated_versions() {
+    let versions = vec![
+        (
+            "gleam_stdlib".to_string(),
+            (Version::new(0, 45, 0), Version::new(0, 46, 0)),
+        ),
+        (
+            "wisp".to_string(),
+            (Version::new(2, 1, 0), Version::new(2, 1, 1)),
+        ),
+        (
+            "very_long_package_name".to_string(),
+            (Version::new(12, 12, 12), Version::new(120, 12, 12)),
+        ),
+    ]
+    .into_iter()
+    .collect();
+
+    let output = pretty_print_outdated_versions(12, versions);
+
+    assert_eq!(output, "3 out of 12 packages are out of date.\n\nPackage                 Current   Latest\n-------                 -------   ------\ngleam_stdlib            0.45.0    0.46.0\nvery_long_package_name  12.12.12  120.12.12\nwisp                    2.1.0     2.1.1\n");
+}
+
+#[test]
+fn test_pretty_print_outdated_versions_no_updates() {
+    let versions: HashMap<String, (Version, Version)> = HashMap::new();
+
+    let output = pretty_print_outdated_versions(12, versions);
+
+    assert!(output.is_empty());
+}
+
+#[test]
 fn test_ensure_packages_exist_locally_all_present() {
     let manifest = Manifest {
         requirements: HashMap::new(),

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -1483,10 +1483,7 @@ fn test_pretty_print_outdated_versions() {
 
     let output = pretty_print_outdated_versions(12, versions);
 
-    assert_eq!(
-        output,
-        "3 of 12 packages have newer versions available.\n\nPackage                 Current   Latest\n-------                 -------   ------\ngleam_stdlib            0.45.0    0.46.0\nvery_long_package_name  12.12.12  120.12.12\nwisp                    2.1.0     2.1.1\n"
-    );
+    insta::assert_snapshot!(output);
 }
 
 #[test]
@@ -1495,7 +1492,7 @@ fn test_pretty_print_outdated_versions_no_updates() {
 
     let output = pretty_print_outdated_versions(12, versions);
 
-    assert_eq!(output, "0 of 12 packages have newer versions available.\n");
+    insta::assert_snapshot!(output);
 }
 
 #[test]

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -1495,10 +1495,7 @@ fn test_pretty_print_outdated_versions_no_updates() {
 
     let output = pretty_print_outdated_versions(12, versions);
 
-    assert_eq!(
-        output,
-        "0 of 12 packages have newer versions available.\n"
-    );
+    assert_eq!(output, "0 of 12 packages have newer versions available.\n");
 }
 
 #[test]


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

The `gleam deps outdated` command now it always prints a summary of outdated packages, even when all dependencies are up to date.

`# of # packages have newer versions available` 

It also introduces a new summary line to the output.


ISSUE:  #5573

