### PR TITLE
Improve parser diagnostics for incomplete @external attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler now gives a better error message when an `@external`
+  attribute is incomplete. For example:
+
+  ```gleam
+  @external
+  pub fn wibble()
+  ```
+
+  now points to the attribute itself and explains that it is incomplete.
+  ([Asish Kumar](https://github.com/officialasishkumar))
+
 - The compiler now raises a warning on the JavaScript target when defining an
   integer segment with a size higher than 52 bits. For example, this code:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@
   deprecated.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The compiler now gives a better error message when an `@external`
+  attribute is incomplete. For example:
+
+  ```gleam
+  @external
+  pub fn wibble()
+  ```
+
+  now points to the attribute itself and explains that it is incomplete.
+  ([Asish Kumar](https://github.com/officialasishkumar))
+
 ### Build tool
 
 - The build tool now generates Hexdocs URLs using the new format of

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -4484,7 +4484,10 @@ functions are declared separately from types.";
 
         let end = match name.as_str() {
             "external" => {
-                let _ = self.expect_one(&Token::LeftParen)?;
+                let _ = self.maybe_one(&Token::LeftParen).ok_or(ParseError {
+                    error: ParseErrorType::ExpectedExternalArguments,
+                    location: SrcSpan { start, end },
+                })?;
                 self.parse_external_attribute(start, end, attributes)
             }
             "target" => self.parse_target_attribute(start, end, attributes),

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -4594,7 +4594,10 @@ functions are declared separately from types.";
 
         let end = match name.as_str() {
             "external" => {
-                let _ = self.expect_one(&Token::LeftParen)?;
+                let _ = self.maybe_one(&Token::LeftParen).ok_or(ParseError {
+                    error: ParseErrorType::ExpectedExternalArguments,
+                    location: SrcSpan { start, end },
+                })?;
                 self.parse_external_attribute(start, end, attributes)
             }
             "target" => self.parse_target_attribute(start, end, attributes),

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -69,6 +69,7 @@ pub enum ParseErrorType {
     ExpectedValue,              // no value after "="
     ExpectedDefinition,         // after attributes
     ExpectedDeprecationMessage, // after "deprecated"
+    ExpectedExternalArguments,  // after "@external"
     ExpectedFunctionDefinition, // after function-only attributes
     ExpectedTargetName,         // after "@target("
     ExprLparStart,              // it seems "(" was used to start an expression
@@ -219,6 +220,13 @@ impl ParseErrorType {
                 text: "See: https://tour.gleam.run/functions/deprecations/".into(),
                 hint: None,
                 label_text: "A deprecation attribute must have a string message.".into(),
+                extra_labels: vec![],
+            },
+
+            ParseErrorType::ExpectedExternalArguments => ParseErrorDetails {
+                text: "".into(),
+                hint: Some("See https://tour.gleam.run/advanced-features/externals/".into()),
+                label_text: "This attribute is incomplete".into(),
                 extra_labels: vec![],
             },
 

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -91,6 +91,7 @@ pub enum ParseErrorType {
     ExpectedValue,              // no value after "="
     ExpectedDefinition,         // after attributes
     ExpectedDeprecationMessage, // after "deprecated"
+    ExpectedExternalArguments,  // after "@external"
     ExpectedFunctionDefinition, // after function-only attributes
     ExpectedTargetName,         // after "@target("
     ExprLparStart,              // it seems "(" was used to start an expression
@@ -251,6 +252,13 @@ impl ParseErrorType {
                 text: "See: https://tour.gleam.run/functions/deprecations/".into(),
                 hint: None,
                 label_text: "A deprecation attribute must have a string message.".into(),
+                extra_labels: vec![],
+            },
+
+            ParseErrorType::ExpectedExternalArguments => ParseErrorDetails {
+                text: "".into(),
+                hint: Some("See https://tour.gleam.run/advanced-features/externals/".into()),
+                label_text: "This attribute is incomplete".into(),
                 extra_labels: vec![],
             },
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__external_with_no_arguments.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__external_with_no_arguments.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\n@external\npub fn one(x: Int) -> Int {\n  todo\n}"
+---
+----- SOURCE CODE
+
+@external
+pub fn one(x: Int) -> Int {
+  todo
+}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:1
+  │
+2 │ @external
+  │ ^^^^^^^^^ This attribute is incomplete
+
+Hint: See https://tour.gleam.run/advanced-features/externals/

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -718,6 +718,17 @@ pub fn one(x: Int) -> Int {
 }
 
 #[test]
+fn external_with_no_arguments() {
+    assert_module_error!(
+        r#"
+@external
+pub fn one(x: Int) -> Int {
+  todo
+}"#
+    );
+}
+
+#[test]
 fn unknown_target() {
     assert_module_error!(
         r#"

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -748,6 +748,17 @@ pub fn one(x: Int) -> Int {
 }
 
 #[test]
+fn external_with_no_arguments() {
+    assert_module_error!(
+        r#"
+@external
+pub fn one(x: Int) -> Int {
+  todo
+}"#
+    );
+}
+
+#[test]
 fn unknown_target() {
     assert_module_error!(
         r#"


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Fixes #5561

This improves the parser diagnostic for incomplete `@external` attributes so the error points at the attribute itself, with a direct hint to the externals documentation, instead of failing later on the following definition.