### PR TITLE
LSP: Support finding references of modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,10 @@
 
 ### Language server
 
+- The language server can now find references for module names across project
+  modules.
+  ([Asish Kumar](https://github.com/officialasishkumar))
+
 - The language server now offers code actions to wrap a function reference in an
   anonymous function, or to remove a trivial anonymous function, leaving its
   contents. For example:

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -55,8 +55,8 @@ use super::{
     files::FileSystemProxy,
     progress::ProgressReporter,
     reference::{
-        FindVariableReferences, Referenced, VariableReferenceKind, find_module_references,
-        reference_for_ast_node,
+        FindVariableReferences, Referenced, VariableReferenceKind, find_module_name_references,
+        find_module_references, reference_for_ast_node,
     },
     rename::{RenameOutcome, RenameTarget, Renamed, rename_local_variable, rename_module_entity},
     signature_help, src_span_to_lsp_range,
@@ -955,6 +955,15 @@ where
                     this.compiler.project_compiler.get_importable_modules(),
                     &this.compiler.sources,
                     ast::Layer::Type,
+                )),
+                Some(Referenced::ModuleName {
+                    module_name,
+                    location,
+                    ..
+                }) if location.contains(byte_index) => Some(find_module_name_references(
+                    &module_name,
+                    &this.compiler.modules,
+                    &this.compiler.sources,
                 )),
                 _ => None,
             })

--- a/language-server/src/reference.rs
+++ b/language-server/src/reference.rs
@@ -10,7 +10,7 @@ use gleam_core::{
         ModuleConstant, Pattern, RecordConstructor, SrcSpan, TypeAstConstructorName, TypedExpr,
         TypedModule, visit::Visit,
     },
-    build::Located,
+    build::{Located, Module},
     type_::{
         ModuleInterface, ModuleValueConstructor, Type, ValueConstructor, ValueConstructorVariant,
         error::{Named, VariableOrigin},
@@ -398,6 +398,63 @@ pub fn find_module_references(
                 &mut reference_locations,
                 layer,
             );
+        }
+    }
+
+    reference_locations
+}
+
+pub fn find_module_name_references(
+    module_name: &EcoString,
+    modules: &HashMap<EcoString, Module>,
+    sources: &HashMap<EcoString, ModuleSourceInformation>,
+) -> Vec<Location> {
+    let mut reference_locations = Vec::new();
+
+    for module in modules.values() {
+        let Some(source_information) = sources.get(&module.name) else {
+            continue;
+        };
+
+        let Some(uri) = url_from_path(source_information.path.as_str()) else {
+            continue;
+        };
+
+        for import in module
+            .ast
+            .definitions
+            .imports
+            .iter()
+            .filter(|import| import.module == *module_name)
+        {
+            let module_alias = match import.as_name.as_ref() {
+                Some((AssignName::Variable(alias) | AssignName::Discard(alias), _)) => {
+                    alias.clone()
+                }
+                None => import
+                    .module
+                    .split('/')
+                    .next_back()
+                    .map(EcoString::from)
+                    .unwrap_or_else(|| import.module.clone()),
+            };
+
+            let mut finder = FindModuleNameReferences {
+                references: Vec::new(),
+                module_name,
+                module_alias: &module_alias,
+            };
+            finder.visit_typed_module(&module.ast);
+
+            for reference in finder.references {
+                reference_locations.push(Location {
+                    uri: uri.clone(),
+                    range: src_span_to_lsp_range(
+                        reference.location,
+                        &source_information.line_numbers,
+                    ),
+                });
+            }
         }
     }
 
@@ -832,7 +889,7 @@ impl<'ast> Visit<'ast> for FindModuleNameReferences<'_> {
             None => {
                 if import.module == *self.module_name {
                     self.references.push(ModuleNameReference {
-                        location: import.location,
+                        location: import.module_location,
                         kind: ModuleNameReferenceKind::Import,
                     })
                 }

--- a/language-server/src/tests/reference.rs
+++ b/language-server/src/tests/reference.rs
@@ -736,6 +736,60 @@ pub fn main() -> Wibble {
 }
 
 #[test]
+fn references_for_module_name() {
+    assert_references!(
+        (
+            "maths",
+            "
+pub fn pi() -> Float {
+  3.14
+}
+"
+        ),
+        "
+import maths
+
+pub fn main() {
+  maths.pi()
+}
+",
+        find_position_of("maths"),
+    );
+}
+
+#[test]
+fn references_for_module_name_across_modules() {
+    assert_references!(
+        TestProject::for_source(
+            "
+import mod
+
+pub fn main() {
+  let _: mod.Foo = mod.Bar
+}
+"
+        )
+        .add_module(
+            "mod",
+            "
+pub type Foo { Bar }
+",
+        )
+        .add_module(
+            "mod2",
+            "
+import mod
+
+pub fn fob() {
+  mod.Bar
+}
+",
+        ),
+        find_position_of("mod"),
+    );
+}
+
+#[test]
 fn references_for_type_from_let_annotation() {
     assert_references!(
         (

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_module_name.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_module_name.snap
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/reference.rs
+expression: "\nimport maths\n\npub fn main() {\n  maths.pi()\n}\n"
+---
+-- maths.gleam
+
+pub fn pi() -> Float {
+  3.14
+}
+
+
+-- app.gleam
+
+import maths
+       ↑▔▔▔▔
+
+pub fn main() {
+  maths.pi()
+  ▔▔▔▔▔     
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_module_name_across_modules.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_module_name_across_modules.snap
@@ -1,0 +1,29 @@
+---
+source: language-server/src/tests/reference.rs
+expression: "\nimport mod\n\npub fn main() {\n  let _: mod.Foo = mod.Bar\n}\n"
+---
+-- mod.gleam
+
+pub type Foo { Bar }
+
+
+-- mod2.gleam
+
+import mod
+       ▔▔▔
+
+pub fn fob() {
+  mod.Bar
+  ▔▔▔    
+}
+
+
+-- app.gleam
+
+import mod
+       ↑▔▔
+
+pub fn main() {
+  let _: mod.Foo = mod.Bar
+         ▔▔▔       ▔▔▔    
+}


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Fixes #5543

This teaches `textDocument/references` to return module-name references across project modules, covering both import sites and qualified module uses.