### PR TITLE
Avoid false target-support edges from imported module aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   finds.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler no longer treats module-select expressions as dependencies on
+  same-named local functions, which avoids false target-support ordering in
+  dependency packages.
+  ([Asish Kumar](https://github.com/officialasishkumar))
+
 - The compiler now shows a better error message when trying to use the record
   update syntax with variants that have no labelled fields.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -261,6 +261,12 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         }
 
         // Infer the types of each statement in the module
+        let imported_module_names = definitions
+            .imports
+            .iter()
+            .filter_map(|import| import.used_name())
+            .collect_vec();
+
         let typed_imports = definitions
             .imports
             .into_iter()
@@ -284,11 +290,14 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         // first, then ones that depend on those, etc.
         let mut typed_functions = Vec::with_capacity(definitions.functions.len());
         let mut typed_constants = Vec::with_capacity(definitions.constants.len());
-        let definition_groups =
-            match into_dependency_order(definitions.functions, definitions.constants) {
-                Ok(definition_groups) => definition_groups,
-                Err(error) => return self.all_errors(error),
-            };
+        let definition_groups = match into_dependency_order(
+            definitions.functions,
+            definitions.constants,
+            imported_module_names,
+        ) {
+            Ok(definition_groups) => definition_groups,
+            Err(error) => return self.all_errors(error),
+        };
 
         let mut working_constants = vec![];
         let mut working_functions = vec![];

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -13,13 +13,16 @@ use crate::{
     },
     type_::Error,
 };
+use ecow::EcoString;
 use itertools::Itertools;
 use petgraph::stable_graph::NodeIndex;
 use petgraph::{Directed, stable_graph::StableGraph};
+use std::collections::HashSet;
 
 #[derive(Debug, Default)]
 struct CallGraphBuilder<'a> {
     names: im::HashMap<&'a str, Option<(NodeIndex, SrcSpan)>>,
+    imported_module_names: HashSet<EcoString>,
     graph: StableGraph<(), (), Directed>,
     current_function: NodeIndex,
 }
@@ -134,6 +137,12 @@ impl<'a> CallGraphBuilder<'a> {
         let Some((target, _)) = target else { return };
 
         _ = self.graph.add_edge(self.current_function, *target, ());
+    }
+
+    fn is_imported_module_name(&self, name: &str) -> bool {
+        self.imported_module_names
+            .iter()
+            .any(|module_name| module_name.as_str() == name)
     }
 
     fn statements(&mut self, statements: &'a [UntypedStatement]) {
@@ -263,9 +272,10 @@ impl<'a> CallGraphBuilder<'a> {
             | UntypedExpr::FieldAccess {
                 container: expression,
                 ..
-            } => {
-                self.expression(expression);
-            }
+            } => match expression.as_ref() {
+                UntypedExpr::Var { name, .. } if self.is_imported_module_name(name) => (),
+                _ => self.expression(expression),
+            },
 
             UntypedExpr::BitArray { segments, .. } => {
                 for segment in segments {
@@ -444,9 +454,16 @@ impl<'a> CallGraphBuilder<'a> {
 
             ClauseGuard::TupleIndex { tuple, .. } => self.guard(tuple),
 
-            ClauseGuard::FieldAccess { container, .. } => self.guard(container),
+            ClauseGuard::FieldAccess { container, .. } => match container.as_ref() {
+                ClauseGuard::Var { name, .. } if self.is_imported_module_name(name) => (),
+                _ => self.guard(container),
+            },
 
-            ClauseGuard::ModuleSelect { module_name, .. } => self.referenced(module_name),
+            ClauseGuard::ModuleSelect { module_name, .. } => {
+                if !self.is_imported_module_name(module_name) {
+                    self.referenced(module_name)
+                }
+            }
 
             ClauseGuard::Constant(constant) => self.constant(constant),
         }
@@ -511,8 +528,12 @@ impl<'a> CallGraphBuilder<'a> {
 pub fn into_dependency_order(
     functions: Vec<UntypedFunction>,
     constants: Vec<UntypedModuleConstant>,
+    imported_module_names: Vec<EcoString>,
 ) -> Result<Vec<Vec<CallGraphNode>>, Error> {
-    let mut grapher = CallGraphBuilder::default();
+    let mut grapher = CallGraphBuilder {
+        imported_module_names: imported_module_names.into_iter().collect(),
+        ..Default::default()
+    };
 
     for function in &functions {
         grapher.register_module_function_existence(function)?;

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -15,6 +15,14 @@ fn parse_and_order(
     functions: &[FuncInput],
     constants: &[ConstInput],
 ) -> Result<Vec<Vec<EcoString>>, Error> {
+    parse_and_order_with_imports(functions, constants, &[])
+}
+
+fn parse_and_order_with_imports(
+    functions: &[FuncInput],
+    constants: &[ConstInput],
+    imported_module_names: &[&str],
+) -> Result<Vec<Vec<EcoString>>, Error> {
     let functions = functions
         .iter()
         .map(|(name, arguments, src)| Function {
@@ -79,18 +87,26 @@ fn parse_and_order(
         })
         .collect_vec();
 
-    Ok(into_dependency_order(functions, constants)?
-        .into_iter()
-        .map(|level| {
-            level
-                .into_iter()
-                .map(|function| match function {
-                    CallGraphNode::Function(f) => f.name.map(|(_, name)| name).unwrap(),
-                    CallGraphNode::ModuleConstant(c) => c.name,
-                })
-                .collect_vec()
-        })
-        .collect())
+    Ok(into_dependency_order(
+        functions,
+        constants,
+        imported_module_names
+            .iter()
+            .copied()
+            .map(EcoString::from)
+            .collect_vec(),
+    )?
+    .into_iter()
+    .map(|level| {
+        level
+            .into_iter()
+            .map(|function| match function {
+                CallGraphNode::Function(f) => f.name.map(|(_, name)| name).unwrap(),
+                CallGraphNode::ModuleConstant(c) => c.name,
+            })
+            .collect_vec()
+    })
+    .collect())
 }
 
 #[test]
@@ -205,6 +221,19 @@ fn pipeline() {
     assert_eq!(
         parse_and_order(functions.as_slice(), [].as_slice()).unwrap(),
         vec![vec!["b"], vec!["c"], vec!["a"]]
+    );
+}
+
+#[test]
+fn imported_module_names_do_not_create_false_edges() {
+    let functions = [
+        ("wibble", [].as_slice(), r#"option.Some(1)"#),
+        ("option", [].as_slice(), r#"wibble()"#),
+    ];
+
+    assert_eq!(
+        parse_and_order_with_imports(functions.as_slice(), [].as_slice(), &["option"]).unwrap(),
+        vec![vec!["wibble"], vec!["option"]]
     );
 }
 

--- a/compiler-core/src/type_/tests/target_implementations.rs
+++ b/compiler-core/src/type_/tests/target_implementations.rs
@@ -1,8 +1,21 @@
+use std::{
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
+
+use camino::Utf8PathBuf;
 use ecow::EcoString;
 use itertools::Itertools;
 
 use crate::{
-    analyse::TargetSupport, assert_module_error, build::Target, type_::expression::Implementations,
+    analyse::TargetSupport,
+    assert_module_error,
+    build::{Origin, Target},
+    config::PackageConfig,
+    line_numbers::LineNumbers,
+    type_::{build_prelude, expression::Implementations, prelude::PRELUDE_MODULE_NAME},
+    uid::UniqueIdGenerator,
+    warning::{TypeWarningEmitter, VectorWarningEmitterIO, WarningEmitter, WarningEmitterIO},
 };
 
 use super::compile_module_with_opts;
@@ -28,6 +41,78 @@ pub fn implementations(src: &str) -> Vec<(EcoString, Implementations)> {
         TargetSupport::NotEnforced,
         None,
     )
+    .expect("compile src")
+    .type_info
+    .values
+    .into_iter()
+    .map(|(name, value)| (name, value.variant.implementations()))
+    .sorted()
+    .collect_vec()
+}
+
+fn dependency_implementations(
+    module_name: &str,
+    src: &str,
+    dep: Vec<(&str, &str, &str)>,
+) -> Vec<(EcoString, Implementations)> {
+    let ids = UniqueIdGenerator::new();
+    let warnings: Rc<dyn WarningEmitterIO> = Rc::new(VectorWarningEmitterIO::default());
+    let emitter = WarningEmitter::new(warnings);
+    let mut modules = im::HashMap::new();
+
+    let _ = modules.insert(PRELUDE_MODULE_NAME.into(), build_prelude(&ids));
+    let mut direct_dependencies = HashMap::new();
+
+    for (package, name, module_src) in dep {
+        let parsed =
+            crate::parse::parse_module(Utf8PathBuf::from("test/path"), module_src, &emitter)
+                .expect("syntax error");
+        let mut ast = parsed.module;
+        ast.name = name.into();
+        let line_numbers = LineNumbers::new(module_src);
+        let mut config = PackageConfig::default();
+        config.name = package.into();
+
+        let module = crate::analyse::ModuleAnalyzerConstructor::<()> {
+            target: Target::Erlang,
+            ids: &ids,
+            origin: Origin::Src,
+            importable_modules: &modules,
+            warnings: &TypeWarningEmitter::null(),
+            direct_dependencies: &HashMap::new(),
+            dev_dependencies: &HashSet::new(),
+            target_support: TargetSupport::NotEnforced,
+            package_config: &config,
+        }
+        .infer_module(ast, line_numbers, "".into())
+        .expect("should successfully infer");
+
+        let _ = modules.insert(name.into(), module.type_info);
+
+        if package != "non-dependency-package" {
+            let _ = direct_dependencies.insert(package.into(), ());
+        }
+    }
+
+    let parsed = crate::parse::parse_module(Utf8PathBuf::from("test/path"), src, &emitter)
+        .expect("syntax error");
+    let mut ast = parsed.module;
+    ast.name = module_name.into();
+    let mut config = PackageConfig::default();
+    config.name = "thepackage".into();
+
+    crate::analyse::ModuleAnalyzerConstructor::<()> {
+        target: Target::Erlang,
+        ids: &ids,
+        origin: Origin::Src,
+        importable_modules: &modules,
+        warnings: &TypeWarningEmitter::null(),
+        direct_dependencies: &direct_dependencies,
+        dev_dependencies: &HashSet::new(),
+        target_support: TargetSupport::NotEnforced,
+        package_config: &config,
+    }
+    .infer_module(ast, LineNumbers::new(src), "".into())
     .expect("compile src")
     .type_info
     .values
@@ -136,6 +221,67 @@ pub fn all_externals_2() { all_externals_1() * 2 }
             )
         ],
     );
+}
+
+#[test]
+pub fn imported_module_select_does_not_create_false_cycle() {
+    let result = dependency_implementations(
+        "test_module",
+        r#"
+import option
+
+@external(javascript, "../gleam_stdlib/gleam/function.mjs", "identity")
+pub fn id(a: a) -> a
+
+fn wibble() -> option.Option(Int) {
+  option.Some(id(42))
+}
+
+pub fn option() -> option.Option(Int) {
+  wibble()
+}
+"#,
+        vec![(
+            "thepackage",
+            "option",
+            "pub type Option(a) { Some(a) None }",
+        )],
+    );
+
+    let expected = vec![
+        (
+            "id".into(),
+            Implementations {
+                gleam: false,
+                uses_erlang_externals: false,
+                uses_javascript_externals: true,
+                can_run_on_erlang: false,
+                can_run_on_javascript: true,
+            },
+        ),
+        (
+            "option".into(),
+            Implementations {
+                gleam: false,
+                uses_erlang_externals: false,
+                uses_javascript_externals: true,
+                can_run_on_erlang: false,
+                can_run_on_javascript: true,
+            },
+        ),
+        (
+            "wibble".into(),
+            Implementations {
+                gleam: false,
+                uses_erlang_externals: false,
+                uses_javascript_externals: true,
+                can_run_on_erlang: false,
+                can_run_on_javascript: true,
+            },
+        ),
+    ];
+
+    assert_eq!(expected, result);
 }
 
 #[test]


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Fixes #5507

This excludes imported module aliases from the local call graph used for dependency ordering, preventing module-select expressions such as `option.Some(...)` from creating false edges to same-named local functions.