### PR TITLE
Add path field support for git dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,6 +270,13 @@ jobs:
         working-directory: ./test/project_git_deps
         if: ${{ matrix.run-integration-tests }}
 
+      - name: test/project_git_deps_path
+        run: ./test.sh
+        working-directory: ./test/project_git_deps_path
+        if: ${{ matrix.run-integration-tests }}
+        env:
+          GLEAM_COMMAND: gleam
+
       - name: Test project generation
         run: |
           gleam new lib_project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,17 @@
 
 ### Build tool
 
+- Git dependencies now support an optional `path` field to specify a
+  subdirectory within the repository. This is useful for monorepos that
+  contain multiple Gleam packages. For example:
+
+  ```toml
+  [dependencies]
+  my_package = { git = "https://github.com/example/monorepo", ref = "main", path = "packages/my_package" }
+  ```
+
+  ([John Downey](https://github.com/jtdowney))
+
 - The `gleam hex owner add` command has been added, which allows adding
   owners to the package.
   ([Niklas Kirschall](https://github.com/nkxxll))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,5 @@ vec1 = "1"
 pubgrub = "0.3"
 # Open the user's web browser
 opener = "0"
+# Checksums
+xxhash-rust = { version = "0", features = ["xxh3"] }

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -59,6 +59,7 @@ termcolor.workspace = true
 toml.workspace = true
 tracing.workspace = true
 pubgrub.workspace = true
+xxhash-rust.workspace = true
 
 [dev-dependencies]
 # Creation of temporary directories

--- a/compiler-cli/src/config.rs
+++ b/compiler-cli/src/config.rs
@@ -117,6 +117,7 @@ mod tests {
             source: ManifestPackageSource::Git {
                 repo: "repo".into(),
                 commit: "commit".into(),
+                path: None,
             },
         };
         assert_eq!(

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -476,10 +476,10 @@ async fn add_missing_packages<Telem: Telemetry>(
             .download_hex_packages(missing_hex_packages, &project_name)
             .await?;
         for package in missing_git_packages {
-            let ManifestPackageSource::Git { repo, commit } = &package.source else {
+            let ManifestPackageSource::Git { repo, commit, path } = &package.source else {
                 continue;
             };
-            let _ = download_git_package(&package.name, repo, commit, paths)?;
+            let _ = download_git_package(&package.name, repo, commit, path.as_deref(), paths)?;
         }
         telemetry.packages_downloaded(start, num_to_download);
     }
@@ -728,8 +728,14 @@ struct ProvidedPackage {
 
 #[derive(Clone, Eq, Debug)]
 enum ProvidedPackageSource {
-    Git { repo: EcoString, commit: EcoString },
-    Local { path: Utf8PathBuf },
+    Git {
+        repo: EcoString,
+        commit: EcoString,
+        path: Option<Utf8PathBuf>,
+    },
+    Local {
+        path: Utf8PathBuf,
+    },
 }
 
 impl ProvidedPackage {
@@ -780,9 +786,10 @@ impl ProvidedPackage {
 impl ProvidedPackageSource {
     fn to_manifest_package_source(&self) -> ManifestPackageSource {
         match self {
-            Self::Git { repo, commit } => ManifestPackageSource::Git {
+            Self::Git { repo, commit, path } => ManifestPackageSource::Git {
                 repo: repo.clone(),
                 commit: commit.clone(),
+                path: path.clone(),
             },
             Self::Local { path } => ManifestPackageSource::Local { path: path.clone() },
         }
@@ -790,9 +797,12 @@ impl ProvidedPackageSource {
 
     fn to_toml(&self) -> String {
         match self {
-            Self::Git { repo, commit } => {
-                format!(r#"{{ repo: "{repo}", commit: "{commit}" }}"#)
-            }
+            Self::Git { repo, commit, path } => match path {
+                Some(path) => {
+                    format!(r#"{{ repo: "{repo}", commit: "{commit}", path: "{path}" }}"#)
+                }
+                None => format!(r#"{{ repo: "{repo}", commit: "{commit}" }}"#),
+            },
             Self::Local { path } => {
                 format!(r#"{{ path: "{path}" }}"#)
             }
@@ -811,12 +821,14 @@ impl PartialEq for ProvidedPackageSource {
                 Self::Git {
                     repo: own_repo,
                     commit: own_commit,
+                    path: own_path,
                 },
                 Self::Git {
                     repo: other_repo,
                     commit: other_commit,
+                    path: other_path,
                 },
-            ) => own_repo == other_repo && own_commit == other_commit,
+            ) => own_repo == other_repo && own_commit == other_commit && own_path == other_path,
 
             (Self::Git { .. }, Self::Local { .. }) | (Self::Local { .. }, Self::Git { .. }) => {
                 false
@@ -881,6 +893,41 @@ fn execute_command(command: &mut Command) -> Result<std::process::Output> {
     }
 }
 
+fn git_repo_dir_name(repo: &str, ref_: &str) -> String {
+    let sanitized = repo
+        .trim_end_matches(".git")
+        .replace("://", "-")
+        .replace('/', "-")
+        .replace(':', "-")
+        .replace('@', "-");
+    let sanitized = sanitized.trim_matches('-');
+    let hash = xxhash_rust::xxh3::xxh3_64(format!("{repo}\0{ref_}").as_bytes());
+    format!("{sanitized}-{hash:016x}")
+}
+
+/// Reject paths that escape the repository root via `..` components or absolute
+/// paths so that typos like `path = "../oops"` fail early with a clear error
+/// instead of silently linking the wrong directory.
+fn validate_git_dependency_path(package_name: &str, path: &Utf8Path, repo: &str) -> Result<()> {
+    if path.is_absolute() {
+        return Err(Error::GitDependencyPathNotFound {
+            package: package_name.into(),
+            path: path.to_string(),
+            repo: repo.into(),
+        });
+    }
+    for component in path.components() {
+        if matches!(component, camino::Utf8Component::ParentDir) {
+            return Err(Error::GitDependencyPathNotFound {
+                package: package_name.into(),
+                path: path.to_string(),
+                repo: repo.into(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Downloads a git package from a remote repository. The commands that are run
 /// looks like this:
 ///
@@ -915,21 +962,33 @@ fn download_git_package(
     package_name: &str,
     repo: &str,
     ref_: &str,
+    path: Option<&Utf8Path>,
     project_paths: &ProjectPaths,
 ) -> Result<EcoString> {
-    let package_path = project_paths.build_packages_package(package_name);
+    // When a subdirectory path is specified, clone to a staging area.
+    // Otherwise clone directly to the package directory.
+    let (clone_path, subdir) = match path {
+        None => (project_paths.build_packages_package(package_name), None),
+        Some(subdir) => {
+            validate_git_dependency_path(package_name, subdir, repo)?;
 
-    // If the package path exists but is not inside a git work tree, we need to
+            let staging_name = git_repo_dir_name(repo, ref_);
+            let staging_path = project_paths.build_git_repo(&staging_name);
+            (staging_path, Some(subdir))
+        }
+    };
+
+    // If the clone path exists but is not inside a git work tree, we need to
     // remove the directory because running `git init` in a non-empty directory
     // followed by `git checkout ...` is an error. See
     // https://github.com/gleam-lang/gleam/issues/4488 for details.
-    if !fs::is_git_work_tree_root(&package_path) {
-        fs::delete_directory(&package_path)?;
+    if !fs::is_git_work_tree_root(&clone_path) {
+        fs::delete_directory(&clone_path)?;
     }
 
-    fs::mkdir(&package_path)?;
+    fs::mkdir(&clone_path)?;
 
-    let _ = execute_command(Command::new("git").arg("init").current_dir(&package_path))?;
+    let _ = execute_command(Command::new("git").arg("init").current_dir(&clone_path))?;
 
     // If this directory already exists, but the remote URL has been edited in
     // `gleam.toml` without a `gleam clean`, `git remote add` will fail, causing
@@ -941,7 +1000,7 @@ fn download_git_package(
         .arg("remote")
         .arg("remove")
         .arg("origin")
-        .current_dir(&package_path)
+        .current_dir(&clone_path)
         .output();
 
     let _ = execute_command(
@@ -950,34 +1009,51 @@ fn download_git_package(
             .arg("add")
             .arg("origin")
             .arg(repo)
-            .current_dir(&package_path),
+            .current_dir(&clone_path),
     )?;
 
     let _ = execute_command(
         Command::new("git")
             .arg("fetch")
             .arg("origin")
-            .current_dir(&package_path),
+            .current_dir(&clone_path),
     )?;
 
     let _ = execute_command(
         Command::new("git")
             .arg("checkout")
             .arg(ref_)
-            .current_dir(&package_path),
+            .current_dir(&clone_path),
     )?;
 
     let output = execute_command(
         Command::new("git")
             .arg("rev-parse")
             .arg("HEAD")
-            .current_dir(&package_path),
+            .current_dir(&clone_path),
     )?;
 
     let commit = String::from_utf8(output.stdout)
         .expect("Output should be UTF-8")
         .trim()
         .into();
+
+    // If a subdirectory was specified, hard-link it into the package directory
+    if let Some(subdir) = subdir {
+        let subdir_source = clone_path.join(subdir);
+        if !subdir_source.is_dir() {
+            return Err(Error::GitDependencyPathNotFound {
+                package: package_name.into(),
+                path: subdir.to_string(),
+                repo: repo.into(),
+            });
+        }
+
+        let package_path = project_paths.build_packages_package(package_name);
+        fs::delete_directory(&package_path)?;
+        fs::mkdir(&package_path)?;
+        fs::hardlink_dir(&subdir_source, &package_path)?;
+    }
 
     Ok(commit)
 }
@@ -988,18 +1064,30 @@ fn provide_git_package(
     repo: &str,
     // A git ref, such as a branch name, commit hash or tag name
     ref_: &str,
+    path: Option<Utf8PathBuf>,
     project_paths: &ProjectPaths,
     provided: &mut HashMap<EcoString, ProvidedPackage>,
     parents: &mut Vec<EcoString>,
 ) -> Result<hexpm::version::Range> {
-    let commit = download_git_package(&package_name, repo, ref_, project_paths)?;
+    let commit = download_git_package(&package_name, repo, ref_, path.as_deref(), project_paths)?;
 
     let package_source = ProvidedPackageSource::Git {
         repo: repo.into(),
         commit,
+        path: path.clone(),
     };
 
-    let package_path = fs::canonicalise(&project_paths.build_packages_package(&package_name))?;
+    // When a subdirectory path is used, resolve the package from the staging
+    // clone so that transitive path dependencies (e.g. `../sibling`) resolve
+    // against the original repository structure rather than build/packages/.
+    let package_path = match path {
+        Some(ref subdir) => {
+            let staging_name = git_repo_dir_name(repo, ref_);
+            let staging_path = project_paths.build_git_repo(&staging_name);
+            fs::canonicalise(&staging_path.join(subdir))?
+        }
+        None => fs::canonicalise(&project_paths.build_packages_package(&package_name))?,
+    };
 
     provide_package(
         package_name,
@@ -1077,9 +1165,15 @@ fn provide_package(
                     parents,
                 )?
             }
-            Requirement::Git { git, ref_ } => {
-                provide_git_package(name.clone(), &git, &ref_, project_paths, provided, parents)?
-            }
+            Requirement::Git { git, ref_, path } => provide_git_package(
+                name.clone(),
+                &git,
+                &ref_,
+                path,
+                project_paths,
+                provided,
+                parents,
+            )?,
         };
         let _ = requirements.insert(name, version);
     }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -897,9 +897,7 @@ fn git_repo_dir_name(repo: &str, ref_: &str) -> String {
     let sanitized = repo
         .trim_end_matches(".git")
         .replace("://", "-")
-        .replace('/', "-")
-        .replace(':', "-")
-        .replace('@', "-");
+        .replace(['/', ':', '@'], "-");
     let sanitized = sanitized.trim_matches('-');
     let hash = xxhash_rust::xxh3::xxh3_64(format!("{repo}\0{ref_}").as_bytes());
     format!("{sanitized}-{hash:016x}")

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -907,7 +907,7 @@ fn git_repo_dir_name(repo: &str, ref_: &str) -> String {
 /// paths so that typos like `path = "../oops"` fail early with a clear error
 /// instead of silently linking the wrong directory.
 fn validate_git_dependency_path(package_name: &str, path: &Utf8Path, repo: &str) -> Result<()> {
-    if path.is_absolute() {
+    if path.is_absolute() || path.as_str().starts_with('/') {
         return Err(Error::GitDependencyPathNotFound {
             package: package_name.into(),
             path: path.to_string(),

--- a/compiler-cli/src/dependencies/dependency_manager.rs
+++ b/compiler-cli/src/dependencies/dependency_manager.rs
@@ -256,7 +256,7 @@ where
                     &mut provided_packages,
                     &mut vec![],
                 )?,
-                Requirement::Git { git, ref_ } => {
+                Requirement::Git { git, ref_, path } => {
                     // If this package is locked and we already resolved a commit
                     // hash for it, we want to use that hash rather than pulling
                     // the latest commit.
@@ -279,6 +279,7 @@ where
                         name.clone(),
                         &git,
                         ref_to_use,
+                        path,
                         project_paths,
                         &mut provided_packages,
                         &mut Vec::new(),

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -680,6 +680,7 @@ fn provided_git_to_hex() {
         source: ProvidedPackageSource::Git {
             repo: "https://github.com/gleam-lang/gleam.git".into(),
             commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+            path: None,
         },
         requirements: [
             (
@@ -776,6 +777,7 @@ fn provided_git_to_manifest() {
         source: ProvidedPackageSource::Git {
             repo: "https://github.com/gleam-lang/gleam.git".into(),
             commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+            path: None,
         },
         requirements: [
             (
@@ -799,12 +801,92 @@ fn provided_git_to_manifest() {
         source: ManifestPackageSource::Git {
             repo: "https://github.com/gleam-lang/gleam.git".into(),
             commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+            path: None,
         },
     };
 
     assert_eq!(
         provided_package.to_manifest_package("package"),
         manifest_package
+    );
+}
+
+#[test]
+fn validate_git_dependency_path_accepts_subdir() {
+    assert!(validate_git_dependency_path(
+        "package",
+        Utf8Path::new("subdir"),
+        "https://github.com/gleam-lang/gleam.git"
+    )
+    .is_ok());
+}
+
+#[test]
+fn validate_git_dependency_path_accepts_nested_subdir() {
+    assert!(validate_git_dependency_path(
+        "package",
+        Utf8Path::new("packages/subdir"),
+        "https://github.com/gleam-lang/gleam.git"
+    )
+    .is_ok());
+}
+
+#[test]
+fn validate_git_dependency_path_rejects_parent_traversal() {
+    let result = validate_git_dependency_path(
+        "package",
+        Utf8Path::new("../escape"),
+        "https://github.com/gleam-lang/gleam.git",
+    );
+    assert!(matches!(
+        result,
+        Err(Error::GitDependencyPathNotFound { .. })
+    ));
+}
+
+#[test]
+fn validate_git_dependency_path_rejects_nested_parent_traversal() {
+    let result = validate_git_dependency_path(
+        "package",
+        Utf8Path::new("packages/../../escape"),
+        "https://github.com/gleam-lang/gleam.git",
+    );
+    assert!(matches!(
+        result,
+        Err(Error::GitDependencyPathNotFound { .. })
+    ));
+}
+
+#[test]
+fn validate_git_dependency_path_rejects_absolute_path() {
+    let result = validate_git_dependency_path(
+        "package",
+        Utf8Path::new("/etc/passwd"),
+        "https://github.com/gleam-lang/gleam.git",
+    );
+    assert!(matches!(
+        result,
+        Err(Error::GitDependencyPathNotFound { .. })
+    ));
+}
+
+#[test]
+fn git_repo_dir_name_produces_expected_name() {
+    assert_eq!(
+        git_repo_dir_name("https://github.com/gleam-lang/gleam.git", "main"),
+        "https-github.com-gleam-lang-gleam-edfec3bb6bbeb6c1"
+    );
+}
+
+#[test]
+fn git_repo_dir_name_different_refs_produce_different_names() {
+    assert_eq!(
+        git_repo_dir_name("https://github.com/gleam-lang/gleam.git", "main"),
+        "https-github.com-gleam-lang-gleam-edfec3bb6bbeb6c1"
+    );
+    assert_eq!(
+        git_repo_dir_name("https://github.com/gleam-lang/gleam.git", "v1.0.0"),
+        "https-github.com-gleam-lang-gleam-90203c669cc91eee"
     );
 }
 

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -813,22 +813,26 @@ fn provided_git_to_manifest() {
 
 #[test]
 fn validate_git_dependency_path_accepts_subdir() {
-    assert!(validate_git_dependency_path(
-        "package",
-        Utf8Path::new("subdir"),
-        "https://github.com/gleam-lang/gleam.git"
-    )
-    .is_ok());
+    assert!(
+        validate_git_dependency_path(
+            "package",
+            Utf8Path::new("subdir"),
+            "https://github.com/gleam-lang/gleam.git"
+        )
+        .is_ok()
+    );
 }
 
 #[test]
 fn validate_git_dependency_path_accepts_nested_subdir() {
-    assert!(validate_git_dependency_path(
-        "package",
-        Utf8Path::new("packages/subdir"),
-        "https://github.com/gleam-lang/gleam.git"
-    )
-    .is_ok());
+    assert!(
+        validate_git_dependency_path(
+            "package",
+            Utf8Path::new("packages/subdir"),
+            "https://github.com/gleam-lang/gleam.git"
+        )
+        .is_ok()
+    );
 }
 
 #[test]

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -685,6 +685,69 @@ pub fn hardlink(
         .map(|_| ())
 }
 
+pub fn hardlink_dir(
+    from: impl AsRef<Utf8Path> + Debug,
+    to: impl AsRef<Utf8Path> + Debug,
+) -> Result<(), Error> {
+    tracing::debug!(from=?from, to=?to, "hardlinking_directory");
+    hardlink_dir_recursive(from.as_ref(), from.as_ref(), to.as_ref())
+}
+
+fn hardlink_dir_recursive(
+    base: &Utf8Path,
+    current: &Utf8Path,
+    dest_base: &Utf8Path,
+) -> Result<(), Error> {
+    let entries = std::fs::read_dir(current).map_err(|err| Error::FileIo {
+        action: FileIoAction::Read,
+        kind: FileKind::Directory,
+        path: current.to_path_buf(),
+        err: Some(err.to_string()),
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|err| Error::FileIo {
+            action: FileIoAction::Read,
+            kind: FileKind::Directory,
+            path: current.to_path_buf(),
+            err: Some(err.to_string()),
+        })?;
+
+        let source_path =
+            Utf8PathBuf::from_path_buf(entry.path()).expect("Non-UTF8 path in hardlink_dir");
+
+        // Skip .git directory
+        if source_path.file_name() == Some(".git") {
+            continue;
+        }
+        let relative = source_path
+            .strip_prefix(base)
+            .expect("Source path should be under base");
+        let dest_path = dest_base.join(relative);
+
+        let file_type = entry.file_type().map_err(|err| Error::FileIo {
+            action: FileIoAction::Read,
+            kind: FileKind::File,
+            path: source_path.clone(),
+            err: Some(err.to_string()),
+        })?;
+
+        // Skip symlinks to prevent path traversal outside the source tree
+        if file_type.is_symlink() {
+            continue;
+        }
+
+        if file_type.is_dir() {
+            mkdir(&dest_path)?;
+            hardlink_dir_recursive(base, &source_path, dest_base)?;
+        } else {
+            hardlink(&source_path, &dest_path)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Check if the given path is inside a git work tree.
 /// This is done by running `git rev-parse --is-inside-work-tree --quiet` in the
 /// given path. If git is not installed then we assume we're not in a git work

--- a/compiler-cli/src/fs/tests.rs
+++ b/compiler-cli/src/fs/tests.rs
@@ -1,4 +1,4 @@
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
 
 #[test]
@@ -186,4 +186,86 @@ HOME_URL=\"https://www.ubuntu.com/\"
         super::extract_distro_id("\nID=\"id first\"\nID=another_id".to_string()),
         "id first"
     );
+}
+
+#[test]
+fn hardlink_dir_copies_files_and_directories() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+    let src = base.join("src");
+    let dest = base.join("dest");
+
+    super::mkdir(&src).unwrap();
+    super::mkdir(&src.join("sub")).unwrap();
+    super::write(&src.join("a.txt"), "hello").unwrap();
+    super::write(&src.join("sub").join("b.txt"), "world").unwrap();
+
+    super::mkdir(&dest).unwrap();
+    super::hardlink_dir(&src, &dest).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(dest.join("a.txt")).unwrap(),
+        "hello"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dest.join("sub").join("b.txt")).unwrap(),
+        "world"
+    );
+}
+
+#[test]
+fn hardlink_dir_skips_git_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+    let src = base.join("src");
+    let dest = base.join("dest");
+
+    super::mkdir(&src).unwrap();
+    super::mkdir(&src.join(".git")).unwrap();
+    super::write(&src.join("a.txt"), "content").unwrap();
+    super::write(&src.join(".git").join("config"), "gitdata").unwrap();
+
+    super::mkdir(&dest).unwrap();
+    super::hardlink_dir(&src, &dest).unwrap();
+
+    assert!(dest.join("a.txt").exists());
+    assert!(!dest.join(".git").exists());
+}
+
+#[test]
+fn hardlink_dir_empty_source() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+    let src = base.join("src");
+    let dest = base.join("dest");
+
+    super::mkdir(&src).unwrap();
+    super::mkdir(&dest).unwrap();
+    super::hardlink_dir(&src, &dest).unwrap();
+
+    assert!(dest.exists());
+    assert_eq!(std::fs::read_dir(&dest).unwrap().count(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn hardlink_dir_skips_symlinks() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+    let src = base.join("src");
+    let dest = base.join("dest");
+    let outside = base.join("outside");
+
+    super::mkdir(&src).unwrap();
+    super::mkdir(&dest).unwrap();
+    super::mkdir(&outside).unwrap();
+    super::write(&src.join("real.txt"), "kept").unwrap();
+    super::write(&outside.join("secret.txt"), "stolen").unwrap();
+
+    std::os::unix::fs::symlink(outside.as_std_path(), src.join("escape").as_std_path()).unwrap();
+
+    super::hardlink_dir(&src, &dest).unwrap();
+
+    assert!(dest.join("real.txt").exists());
+    assert!(!dest.join("escape").exists());
 }

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -25,7 +25,7 @@ bincode = { version = "2", features = ["alloc", "serde"] }
 # cross platform single glob and glob set matching
 globset = { version = "0", features = ["serde1"] }
 # Checksums
-xxhash-rust = { version = "0", features = ["xxh3"] }
+xxhash-rust.workspace = true
 # Pubgrub dependency resolution algorithm
 pubgrub = "0.3"
 # Used for converting absolute path to relative path

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -273,6 +273,13 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
         source_2: String,
     },
 
+    #[error("The path {path} does not exist in the git repository {repo} for package {package}")]
+    GitDependencyPathNotFound {
+        package: String,
+        path: String,
+        repo: String,
+    },
+
     #[error("The package was missing required fields for publishing")]
     MissingHexPublishFields {
         description_missing: bool,
@@ -4568,6 +4575,25 @@ manifest.toml and a version range specified in gleam.toml:
 
                 vec![Diagnostic {
                     title: "Conflicting provided dependencies".into(),
+                    text,
+                    hint: None,
+                    location: None,
+                    level: Level::Error,
+                }]
+            }
+
+            Error::GitDependencyPathNotFound {
+                package,
+                path,
+                repo,
+            } => {
+                let text = format!(
+                    "The path `{path}` does not exist in the git repository `{repo}` \
+for package `{package}`."
+                );
+
+                vec![Diagnostic {
+                    title: "Git dependency path not found".into(),
                     text,
                     hint: None,
                     location: None,

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -85,12 +85,17 @@ impl Manifest {
                     buffer.push_str(&outer_checksum.to_string());
                     buffer.push('"');
                 }
-                ManifestPackageSource::Git { repo, commit } => {
+                ManifestPackageSource::Git { repo, commit, path } => {
                     buffer.push_str(r#", source = "git", repo = ""#);
                     buffer.push_str(repo);
                     buffer.push_str(r#"", commit = ""#);
                     buffer.push_str(commit);
                     buffer.push('"');
+                    if let Some(path) = path {
+                        buffer.push_str(r#", path = ""#);
+                        buffer.push_str(path.as_str());
+                        buffer.push('"');
+                    }
                 }
                 ManifestPackageSource::Local { path } => {
                     buffer.push_str(r#", source = "local", path = ""#);
@@ -226,7 +231,12 @@ pub enum ManifestPackageSource {
     #[serde(rename = "hex")]
     Hex { outer_checksum: Base16Checksum },
     #[serde(rename = "git")]
-    Git { repo: EcoString, commit: EcoString },
+    Git {
+        repo: EcoString,
+        commit: EcoString,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<Utf8PathBuf>,
+    },
     #[serde(rename = "local")]
     Local { path: Utf8PathBuf }, // should be the canonical path
 }
@@ -336,6 +346,7 @@ mod tests {
                     source: ManifestPackageSource::Git {
                         repo: "https://github.com/gleam-lang/gleam.git".into(),
                         commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+                        path: None,
                     },
                 },
                 ManifestPackage {
@@ -446,6 +457,7 @@ zzz = { version = "> 0.0.0" }
                     source: ManifestPackageSource::Git {
                         repo: "https://github.com/gleam-lang/gleam.git".into(),
                         commit: "bd9fe02f72250e6a136967917bcb1bdccaffa3c8".into(),
+                        path: None,
                     },
                 },
                 ManifestPackage {

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -63,6 +63,14 @@ impl ProjectPaths {
         self.build_directory().join("packages")
     }
 
+    pub fn build_git_repos_directory(&self) -> Utf8PathBuf {
+        self.build_directory().join("git_repos")
+    }
+
+    pub fn build_git_repo(&self, name: &str) -> Utf8PathBuf {
+        self.build_git_repos_directory().join(name)
+    }
+
     pub fn build_packages_toml(&self) -> Utf8PathBuf {
         self.build_packages_directory().join("packages.toml")
     }

--- a/compiler-core/src/requirement.rs
+++ b/compiler-core/src/requirement.rs
@@ -27,6 +27,8 @@ pub enum Requirement {
         git: EcoString,
         #[serde(rename = "ref")]
         ref_: EcoString,
+        #[serde(default)]
+        path: Option<Utf8PathBuf>,
     },
 }
 
@@ -48,6 +50,15 @@ impl Requirement {
         Requirement::Git {
             git: url.into(),
             ref_: ref_.into(),
+            path: None,
+        }
+    }
+
+    pub fn git_with_path(url: &str, ref_: &str, path: &str) -> Requirement {
+        Requirement::Git {
+            git: url.into(),
+            ref_: ref_.into(),
+            path: Some(path.into()),
         }
     }
 
@@ -62,9 +73,16 @@ impl Requirement {
                     make_relative(root_path, path).as_str().replace('\\', "/")
                 )
             }
-            Requirement::Git { git: url, ref_ } => {
-                format!(r#"{{ git = "{url}", ref = "{ref_}" }}"#)
-            }
+            Requirement::Git {
+                git: url,
+                ref_,
+                path,
+            } => match path {
+                Some(path) => {
+                    format!(r#"{{ git = "{url}", ref = "{ref_}", path = "{path}" }}"#)
+                }
+                None => format!(r#"{{ git = "{url}", ref = "{ref_}" }}"#),
+            },
         }
     }
 }
@@ -80,9 +98,16 @@ impl Serialize for Requirement {
         match self {
             Requirement::Hex { version: range } => map.serialize_entry("version", range)?,
             Requirement::Path { path } => map.serialize_entry("path", path)?,
-            Requirement::Git { git: url, ref_ } => {
+            Requirement::Git {
+                git: url,
+                ref_,
+                path,
+            } => {
                 map.serialize_entry("git", url)?;
                 map.serialize_entry("ref", ref_)?;
+                if let Some(path) = path {
+                    map.serialize_entry("path", path)?;
+                }
             }
         }
         map.end()

--- a/language-server/src/tests.rs
+++ b/language-server/src/tests.rs
@@ -331,9 +331,11 @@ fn add_package_from_manifest<B>(
             ManifestPackageSource::Git {
                 ref repo,
                 ref commit,
+                ..
             } => Requirement::Git {
                 git: repo.clone(),
                 ref_: commit.clone(),
+                path: None,
             },
         },
     );
@@ -356,9 +358,11 @@ fn add_dev_package_from_manifest<B>(
             ManifestPackageSource::Git {
                 ref repo,
                 ref commit,
+                ..
             } => Requirement::Git {
                 git: repo.clone(),
                 ref_: commit.clone(),
+                path: None,
             },
         },
     );

--- a/test/project_git_deps_path/.gitignore
+++ b/test/project_git_deps_path/.gitignore
@@ -1,0 +1,3 @@
+build
+gleam.toml
+manifest.toml

--- a/test/project_git_deps_path/src/git_deps_path.gleam
+++ b/test/project_git_deps_path/src/git_deps_path.gleam
@@ -1,0 +1,5 @@
+import package_a
+
+pub fn main() {
+  package_a.hello()
+}

--- a/test/project_git_deps_path/test.sh
+++ b/test/project_git_deps_path/test.sh
@@ -47,7 +47,7 @@ GLEAM
 cd "$REPO_DIR"
 git init -q
 git add .
-git commit -q -m "Initial commit"
+git -c user.name="Test" -c user.email="test@example.com" commit -q -m "Initial commit"
 REF=$(git rev-parse HEAD)
 cd "$OLDPWD"
 

--- a/test/project_git_deps_path/test.sh
+++ b/test/project_git_deps_path/test.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+set -eu
+
+GLEAM_COMMAND=${GLEAM_COMMAND:-"cargo run --quiet --"}
+
+g() {
+  echo "Running: $GLEAM_COMMAND $@"
+  $GLEAM_COMMAND "$@"
+}
+
+# Create a monorepo with two sibling packages in a temp directory
+REPO_DIR=$(mktemp -d)
+trap 'rm -rf "$REPO_DIR"' EXIT
+
+mkdir -p "$REPO_DIR/package_a/src" "$REPO_DIR/package_b/src"
+
+cat > "$REPO_DIR/package_b/gleam.toml" << 'TOML'
+name = "package_b"
+version = "0.1.0"
+
+[dependencies]
+TOML
+
+cat > "$REPO_DIR/package_b/src/package_b.gleam" << 'GLEAM'
+pub fn greeting() -> String {
+  "hello from package_b"
+}
+GLEAM
+
+cat > "$REPO_DIR/package_a/gleam.toml" << 'TOML'
+name = "package_a"
+version = "0.1.0"
+
+[dependencies]
+package_b = { path = "../package_b" }
+TOML
+
+cat > "$REPO_DIR/package_a/src/package_a.gleam" << 'GLEAM'
+import package_b
+
+pub fn hello() -> String {
+  package_b.greeting()
+}
+GLEAM
+
+cd "$REPO_DIR"
+git init -q
+git add .
+git commit -q -m "Initial commit"
+REF=$(git rev-parse HEAD)
+cd "$OLDPWD"
+
+echo Resetting the build directory to get to a known state
+rm -fr build
+
+# Write gleam.toml with the local repo URL
+cat > gleam.toml << EOF
+name = "git_deps_path"
+version = "0.1.0"
+
+[dependencies]
+package_a = { git = "file://${REPO_DIR}", ref = "${REF}", path = "package_a" }
+EOF
+
+g update
+g check
+
+echo
+echo Success! 💖
+echo


### PR DESCRIPTION
Allow specifying a subdirectory within a git repository using an optional `path` field.

Closes #4556

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
