### PR TITLE
LSP: don't suggest 'Wrap in anonymous function' with 'use' body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,10 @@
   directly matches one of the branches.
   ([Eyup Can Akman](https://github.com/eyupcanakman))
 
+- Fixed a bug where the "Wrap in anonymous function" code action could be used
+  in the body of a `use` expression
+  ([Giovanni Maria Zanchetta](https://github.com/GioMaz))
+
 ## v1.15.1 - 2026-03-17
 
 ### Bug fixes

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -11537,11 +11537,8 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
             return;
         }
 
-        let is_excluded = if let TypedExpr::Fn { kind, .. } = expression {
-            kind.is_anonymous() || kind.is_capture()
-        } else {
-            false
-        };
+        // Exclude if the expression is already a function literal
+        let is_excluded = matches!(expression, TypedExpr::Fn { .. });
 
         if let Type::Fn { arguments, .. } = &*expression.type_()
             && !is_excluded
@@ -11551,7 +11548,7 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
                 arguments: arguments.clone(),
                 variables_names: VariablesNames::from_expression(expression),
             });
-        };
+        }
 
         ast::visit::visit_typed_expr(self, expression);
     }

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -13605,3 +13605,38 @@ fn op(i: Int) -> Int {
         find_position_of("fn(int)").to_selection()
     );
 }
+
+#[test]
+fn dont_wrap_use_in_anonymous_function() {
+    assert_no_code_actions!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "fn apply(x, k) {
+  k(x)
+}
+
+pub fn main() {
+  use a <- apply(5)
+  a * 1
+}
+",
+        find_position_of("a * 1").to_selection()
+    );
+}
+
+#[test]
+fn dont_wrap_uses_in_anonymous_function() {
+    assert_no_code_actions!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "pub fn main() {
+  use a <- apply(1)
+  use b <- apply(2)
+  use c <- apply(3)
+  a * b * c
+}
+
+fn apply(x, k) {
+  k(x)
+}",
+        find_position_of("a * b * c").to_selection()
+    );
+}


### PR DESCRIPTION
Issue: #5605

This makes it so the `Use` function literal kind is also excluded from the `Wrap in anonymous function` action 

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes