### PR TITLE
Use stdlib v1.0 in new projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Build tool
+
+- New Gleam packages are now generated requiring `>= 1.0.0` of `gleam_stdlib`.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ## v1.16.0-rc2 - 2026-04-14
 
 ### Bug fixes
 
-- `manifest.toml` files with invalid packge names now raise an error
+- `manifest.toml` files with invalid package names now raise an error
   immediately when the file is parsed.
   ([Louis Pilfold](https://github.com/lpil))
 

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -15,7 +15,7 @@ mod tests;
 
 use crate::{NewOptions, fs::get_current_directory};
 
-const GLEAM_STDLIB_REQUIREMENT: &str = ">= 0.70.0 and < 2.0.0";
+const GLEAM_STDLIB_REQUIREMENT: &str = ">= 1.0.0 and < 2.0.0";
 const GLEEUNIT_REQUIREMENT: &str = ">= 1.0.0 and < 2.0.0";
 const ERLANG_OTP_VERSION: &str = "28";
 const REBAR3_VERSION: &str = "3";


### PR DESCRIPTION
Now that `gleam_stdlib` v1 has been released, we should start generating projects requiring v1.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
