### PR TITLE
Todo in constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   analyse the fields that are being provided.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- It is now possible to use the `todo` keyword in constants, this will result in
+  an helpful error message rather than a syntax error.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The `gleam dev` command now accepts the `--no-print-progress` flag. When this

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -90,6 +90,11 @@ pub enum Constant<T, RecordTag> {
         /// states.
         extra_information: Option<InvalidExpression>,
     },
+
+    Todo {
+        location: SrcSpan,
+        type_: T,
+    },
 }
 
 impl TypedConstant {
@@ -105,6 +110,7 @@ impl TypedConstant {
             | Constant::Record { type_, .. }
             | Constant::RecordUpdate { type_, .. }
             | Constant::Var { type_, .. }
+            | Constant::Todo { type_, .. }
             | Constant::Invalid { type_, .. } => type_.clone(),
         }
     }
@@ -117,7 +123,8 @@ impl TypedConstant {
             Constant::Int { .. }
             | Constant::Float { .. }
             | Constant::String { .. }
-            | Constant::Invalid { .. } => Located::Constant(self),
+            | Constant::Invalid { .. }
+            | Constant::Todo { .. } => Located::Constant(self),
             Constant::Var {
                 module: Some((module_alias, location)),
                 constructor: Some(constructor),
@@ -182,6 +189,7 @@ impl TypedConstant {
             | Constant::Tuple { .. }
             | Constant::List { .. }
             | Constant::BitArray { .. }
+            | Constant::Todo { .. }
             | Constant::StringConcatenation { .. }
             | Constant::Invalid { .. } => None,
             Constant::Record {
@@ -203,6 +211,7 @@ impl TypedConstant {
             Constant::Var { name, .. } => im::hashset![name],
 
             Constant::Invalid { .. }
+            | Constant::Todo { .. }
             | Constant::Int { .. }
             | Constant::Float { .. }
             | Constant::String { .. } => im::hashset![],
@@ -245,6 +254,9 @@ impl TypedConstant {
 
     pub(crate) fn syntactically_eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (Constant::Todo { .. }, Constant::Todo { .. }) => true,
+            (Constant::Todo { .. }, _) => false,
+
             (Constant::Int { int_value: n, .. }, Constant::Int { int_value: m, .. }) => n == m,
             (Constant::Int { .. }, _) => false,
 
@@ -416,6 +428,7 @@ impl TypedConstant {
             | Constant::BitArray { .. }
             | Constant::StringConcatenation { .. }
             | Constant::Var { .. }
+            | Constant::Todo { .. }
             | Constant::Invalid { .. } => None,
         }
     }
@@ -440,6 +453,7 @@ impl<A, B> Constant<A, B> {
             | Constant::BitArray { location, .. }
             | Constant::Var { location, .. }
             | Constant::Invalid { location, .. }
+            | Constant::Todo { location, .. }
             | Constant::StringConcatenation { location, .. } => *location,
         }
     }
@@ -450,6 +464,7 @@ impl<A, B> Constant<A, B> {
             Constant::Int { .. }
             | Constant::Float { .. }
             | Constant::String { .. }
+            | Constant::Todo { .. }
             | Constant::Var { .. } => true,
 
             Constant::Tuple { .. }

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -94,6 +94,7 @@ pub enum Constant<T, RecordTag> {
     Todo {
         location: SrcSpan,
         type_: T,
+        message: Option<Box<Self>>,
     },
 }
 
@@ -123,8 +124,13 @@ impl TypedConstant {
             Constant::Int { .. }
             | Constant::Float { .. }
             | Constant::String { .. }
-            | Constant::Invalid { .. }
-            | Constant::Todo { .. } => Located::Constant(self),
+            | Constant::Invalid { .. } => Located::Constant(self),
+
+            Constant::Todo { message, .. } => message
+                .iter()
+                .find_map(|message| message.find_node(byte_index))
+                .unwrap_or(Located::Constant(self)),
+
             Constant::Var {
                 module: Some((module_alias, location)),
                 constructor: Some(constructor),
@@ -211,10 +217,14 @@ impl TypedConstant {
             Constant::Var { name, .. } => im::hashset![name],
 
             Constant::Invalid { .. }
-            | Constant::Todo { .. }
             | Constant::Int { .. }
             | Constant::Float { .. }
             | Constant::String { .. } => im::hashset![],
+
+            Constant::Todo { message, .. } => message
+                .as_ref()
+                .map(|message| message.referenced_variables())
+                .unwrap_or(im::hashset![]),
 
             Constant::List { elements, .. } | Constant::Tuple { elements, .. } => elements
                 .iter()
@@ -254,7 +264,17 @@ impl TypedConstant {
 
     pub(crate) fn syntactically_eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Constant::Todo { .. }, Constant::Todo { .. }) => true,
+            (
+                Constant::Todo { message, .. },
+                Constant::Todo {
+                    message: other_message,
+                    ..
+                },
+            ) => match (message, other_message) {
+                (None, None) => true,
+                (Some(_), None) | (None, Some(_)) => false,
+                (Some(message), Some(other_message)) => message.syntactically_eq(other_message),
+            },
             (Constant::Todo { .. }, _) => false,
 
             (Constant::Int { int_value: n, .. }, Constant::Int { int_value: m, .. }) => n == m,
@@ -464,10 +484,10 @@ impl<A, B> Constant<A, B> {
             Constant::Int { .. }
             | Constant::Float { .. }
             | Constant::String { .. }
-            | Constant::Todo { .. }
             | Constant::Var { .. } => true,
 
             Constant::Tuple { .. }
+            | Constant::Todo { .. }
             | Constant::List { .. }
             | Constant::Record { .. }
             | Constant::RecordUpdate { .. }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -662,6 +662,10 @@ pub trait Visit<'ast> {
         visit_typed_constant(self, constant);
     }
 
+    fn visit_typed_constant_todo(&mut self, location: &'ast SrcSpan, type_: &'ast Arc<Type>) {
+        visit_typed_constant_todo(self, location, type_);
+    }
+
     fn visit_typed_constant_int(
         &mut self,
         location: &'ast SrcSpan,
@@ -919,6 +923,14 @@ fn visit_typed_constant_int<'a, V: Visit<'a> + ?Sized>(
     // No further traversal needed for constant ints
 }
 
+pub fn visit_typed_constant_todo<'a, V: Visit<'a> + ?Sized>(
+    _v: &mut V,
+    _location: &'a SrcSpan,
+    _type_: &'a Arc<Type>,
+) {
+    // No further traversal needed for constant todos
+}
+
 pub fn visit_typed_module<'a, V>(v: &mut V, module: &'a TypedModule)
 where
     V: Visit<'a> + ?Sized,
@@ -1103,6 +1115,7 @@ where
 
 pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a TypedConstant) {
     match constant {
+        super::Constant::Todo { location, type_ } => v.visit_typed_constant_todo(location, type_),
         super::Constant::Int {
             location,
             value,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -662,8 +662,13 @@ pub trait Visit<'ast> {
         visit_typed_constant(self, constant);
     }
 
-    fn visit_typed_constant_todo(&mut self, location: &'ast SrcSpan, type_: &'ast Arc<Type>) {
-        visit_typed_constant_todo(self, location, type_);
+    fn visit_typed_constant_todo(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        message: &'ast Option<Box<TypedConstant>>,
+    ) {
+        visit_typed_constant_todo(self, location, type_, message);
     }
 
     fn visit_typed_constant_int(
@@ -927,6 +932,7 @@ pub fn visit_typed_constant_todo<'a, V: Visit<'a> + ?Sized>(
     _v: &mut V,
     _location: &'a SrcSpan,
     _type_: &'a Arc<Type>,
+    _message: &'a Option<Box<TypedConstant>>,
 ) {
     // No further traversal needed for constant todos
 }
@@ -1115,7 +1121,11 @@ where
 
 pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a TypedConstant) {
     match constant {
-        super::Constant::Todo { location, type_ } => v.visit_typed_constant_todo(location, type_),
+        super::Constant::Todo {
+            location,
+            type_,
+            message,
+        } => v.visit_typed_constant_todo(location, type_, message),
         super::Constant::Int {
             location,
             value,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -953,7 +953,8 @@ pub trait UntypedConstantFolder {
             Constant::Todo {
                 location,
                 type_: (),
-            } => self.fold_constant_todo(location),
+                message,
+            } => self.fold_constant_todo(location, message),
 
             Constant::Int {
                 location,
@@ -1038,10 +1039,15 @@ pub trait UntypedConstantFolder {
         }
     }
 
-    fn fold_constant_todo(&mut self, location: SrcSpan) -> UntypedConstant {
+    fn fold_constant_todo(
+        &mut self,
+        location: SrcSpan,
+        message: Option<Box<UntypedConstant>>,
+    ) -> UntypedConstant {
         Constant::Todo {
             location,
             type_: (),
+            message: message.map(|message| Box::new(self.fold_constant(*message))),
         }
     }
 

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -950,6 +950,11 @@ pub trait UntypedConstantFolder {
     /// You probably don't want to override this method.
     fn update_constant(&mut self, constant: UntypedConstant) -> UntypedConstant {
         match constant {
+            Constant::Todo {
+                location,
+                type_: (),
+            } => self.fold_constant_todo(location),
+
             Constant::Int {
                 location,
                 value,
@@ -1030,6 +1035,13 @@ pub trait UntypedConstantFolder {
                 type_: (),
                 extra_information,
             } => self.fold_constant_invalid(location, extra_information),
+        }
+    }
+
+    fn fold_constant_todo(&mut self, location: SrcSpan) -> UntypedConstant {
+        Constant::Todo {
+            location,
+            type_: (),
         }
     }
 
@@ -1186,7 +1198,8 @@ pub trait UntypedConstantFolder {
             | Constant::Float { .. }
             | Constant::String { .. }
             | Constant::Tuple { .. }
-            | Constant::Invalid { .. } => constant,
+            | Constant::Invalid { .. }
+            | Constant::Todo { .. } => constant,
 
             Constant::List {
                 location,

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -457,6 +457,7 @@ impl<'a> CallGraphBuilder<'a> {
             | Constant::Float { .. }
             | Constant::String { .. }
             | Constant::Invalid { .. }
+            | Constant::Todo { .. }
             | Constant::Var {
                 module: Some(_), ..
             } => (),

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -457,10 +457,15 @@ impl<'a> CallGraphBuilder<'a> {
             | Constant::Float { .. }
             | Constant::String { .. }
             | Constant::Invalid { .. }
-            | Constant::Todo { .. }
             | Constant::Var {
                 module: Some(_), ..
             } => (),
+
+            Constant::Todo { message, .. } => {
+                if let Some(message) = message {
+                    self.constant(message)
+                }
+            }
 
             Constant::List { elements, tail, .. } => {
                 for element in elements {

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -782,6 +782,7 @@ fn const_string_concatenate_argument<'a>(
         | Constant::RecordUpdate { .. }
         | Constant::BitArray { .. }
         | Constant::Var { .. }
+        | Constant::Todo { .. }
         | Constant::Invalid { .. } => const_inline(value, env),
     }
 }
@@ -884,6 +885,7 @@ fn const_segment<'a>(
             | Constant::RecordUpdate { .. }
             | Constant::Var { .. }
             | Constant::StringConcatenation { .. }
+            | Constant::Todo { .. }
             | Constant::Invalid { .. } => const_inline(value, env).surround("(", ")"),
         }
     };
@@ -1812,6 +1814,7 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
         }
 
         Constant::RecordUpdate { .. } => panic!("record updates should not reach code generation"),
+        Constant::Todo { .. } => panic!("todo constants should not reach code generation"),
         Constant::Invalid { .. } => panic!("invalid constants should not reach code generation"),
     }
 }
@@ -2049,6 +2052,7 @@ fn clause_guard_string_concatenate_argument<'a>(
             | Constant::RecordUpdate { .. }
             | Constant::BitArray { .. }
             | Constant::Var { .. }
+            | Constant::Todo { .. }
             | Constant::Invalid { .. } => docvec!["(", const_inline(literal, env), ")/binary"],
         },
 
@@ -3572,6 +3576,7 @@ fn find_referenced_private_functions(
     already_found: &mut im::HashSet<EcoString>,
 ) {
     match constant {
+        Constant::Todo { .. } => panic!("todo constants should not reach code generation"),
         Constant::Invalid { .. } => panic!("invalid constants should not reach code generation"),
         Constant::RecordUpdate { .. } => {
             panic!("record updates should not reach code generation")

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -4870,6 +4870,25 @@ See: https://tour.gleam.run/basics/bools/"
                 extra_labels: vec![],
             }),
         },
+
+        TypeError::TodoConstant { location } => Diagnostic {
+            title: "Constant todo found".to_string(),
+            text: wrap(
+                "This code will crash if it is run. \
+Be sure to finish it before running your program.",
+            ),
+            hint: None,
+            level: Level::Error,
+            location: Some(Location {
+                label: Label {
+                    text: Some("This code is incomplete".into()),
+                    span: *location,
+                },
+                path: path.clone(),
+                src: src.clone(),
+                extra_labels: vec![],
+            }),
+        },
     })
 }
 

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -472,6 +472,8 @@ impl<'comments> Formatter<'comments> {
     fn const_expr<'a, A, B>(&mut self, value: &'a Constant<A, B>) -> Document<'a> {
         let comments = self.pop_comments(value.location().start);
         let document = match value {
+            Constant::Todo { .. } => "todo".to_doc(),
+
             Constant::Int { value, .. } => self.int(value),
 
             Constant::Float { value, .. } => self.float(value),

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -472,7 +472,9 @@ impl<'comments> Formatter<'comments> {
     fn const_expr<'a, A, B>(&mut self, value: &'a Constant<A, B>) -> Document<'a> {
         let comments = self.pop_comments(value.location().start);
         let document = match value {
-            Constant::Todo { .. } => "todo".to_doc(),
+            Constant::Todo { message, .. } => {
+                self.append_as_message_constant("todo".to_doc(), message.as_deref())
+            }
 
             Constant::Int { value, .. } => self.int(value),
 
@@ -496,7 +498,9 @@ impl<'comments> Formatter<'comments> {
             } => {
                 let segment_docs = segments
                     .iter()
-                    .map(|segment| bit_array_segment(segment, |e| self.const_expr(e)))
+                    .map(|segment| {
+                        bit_array_segment(segment, |expression| self.const_expr(expression))
+                    })
                     .collect_vec();
 
                 let packing = self.items_sequence_packing(
@@ -1058,7 +1062,7 @@ impl<'comments> Formatter<'comments> {
             .append(self.assigned_value(value));
 
         commented(
-            self.append_as_message(doc, PrecedingAs::Expression, message),
+            self.append_as_message_expression(doc, PrecedingAs::Expression, message),
             comments,
         )
     }
@@ -1067,13 +1071,17 @@ impl<'comments> Formatter<'comments> {
         let comments = self.pop_comments(expression.start_byte_index());
 
         let document = match expression {
-            UntypedExpr::Panic { message, .. } => {
-                self.append_as_message("panic".to_doc(), PrecedingAs::Keyword, message.as_deref())
-            }
+            UntypedExpr::Panic { message, .. } => self.append_as_message_expression(
+                "panic".to_doc(),
+                PrecedingAs::Keyword,
+                message.as_deref(),
+            ),
 
-            UntypedExpr::Todo { message, .. } => {
-                self.append_as_message("todo".to_doc(), PrecedingAs::Keyword, message.as_deref())
-            }
+            UntypedExpr::Todo { message, .. } => self.append_as_message_expression(
+                "todo".to_doc(),
+                PrecedingAs::Keyword,
+                message.as_deref(),
+            ),
 
             UntypedExpr::Echo {
                 expression,
@@ -2806,8 +2814,11 @@ impl<'comments> Formatter<'comments> {
             self.expr(&assert.value)
         };
 
-        let doc =
-            self.append_as_message(expression, PrecedingAs::Expression, assert.message.as_ref());
+        let doc = self.append_as_message_expression(
+            expression,
+            PrecedingAs::Expression,
+            assert.message.as_ref(),
+        );
         commented(docvec!["assert ", doc], comments)
     }
 
@@ -3101,7 +3112,7 @@ impl<'comments> Formatter<'comments> {
         Some(doc.force_break())
     }
 
-    fn append_as_message<'a>(
+    fn append_as_message_expression<'a>(
         &mut self,
         doc: Document<'a>,
         preceding_as: PrecedingAs,
@@ -3158,13 +3169,47 @@ impl<'comments> Formatter<'comments> {
         doc.group()
     }
 
+    fn append_as_message_constant<'a, A, B>(
+        &mut self,
+        doc: Document<'a>,
+        message: Option<&'a Constant<A, B>>,
+    ) -> Document<'a> {
+        let Some(message) = message else { return doc };
+
+        let comments = self.pop_comments(message.location().start);
+        let comments = printed_comments(comments, false);
+
+        let doc = match comments {
+            // If there's comments between the document and the message we want
+            // the `as` bit to be on the same line as the original document and
+            // go on a new indented line with the message and comments:
+            // ```gleam
+            // todo as
+            //   // comment!
+            //   "wibble"
+            // ```
+            Some(comments) => docvec![
+                doc.group(),
+                " as",
+                docvec![line(), comments, line(), self.const_expr(message).group()].nest(INDENT)
+            ],
+
+            None => {
+                let message = self.const_expr(message).group().nest(INDENT);
+                docvec![doc.group(), " as ", message]
+            }
+        };
+
+        doc.group()
+    }
+
     fn echo<'a>(
         &mut self,
         expression: &'a Option<Box<UntypedExpr>>,
         message: &'a Option<Box<UntypedExpr>>,
     ) -> Document<'a> {
         let Some(expression) = expression else {
-            return self.append_as_message(
+            return self.append_as_message_expression(
                 "echo".to_doc(),
                 PrecedingAs::Keyword,
                 message.as_deref(),
@@ -3192,7 +3237,7 @@ impl<'comments> Formatter<'comments> {
         //
         let doc = self.expr(expression);
         if expression.is_binop() || expression.is_pipeline() {
-            let doc = self.append_as_message(
+            let doc = self.append_as_message_expression(
                 doc.nest(INDENT),
                 PrecedingAs::Expression,
                 message.as_deref(),
@@ -3201,7 +3246,7 @@ impl<'comments> Formatter<'comments> {
         } else {
             docvec![
                 "echo ",
-                self.append_as_message(doc, PrecedingAs::Expression, message.as_deref())
+                self.append_as_message_expression(doc, PrecedingAs::Expression, message.as_deref())
             ]
         }
     }

--- a/compiler-core/src/format/tests/constant.rs
+++ b/compiler-core/src/format/tests/constant.rs
@@ -95,3 +95,21 @@ pub const wobble = [
 "#
     );
 }
+
+#[test]
+fn constant_todo_message() {
+    assert_format!(
+        r#"pub const wibble = todo as "message"
+"#
+    );
+}
+
+#[test]
+fn constant_todo_commented_message() {
+    assert_format!(
+        r#"pub const wibble = todo as
+  // some comment
+  "message"
+"#
+    );
+}

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -2139,7 +2139,9 @@ impl<'module, 'a> Generator<'module, 'a> {
             Constant::RecordUpdate { .. } => {
                 panic!("record updates should not reach code generation")
             }
-
+            Constant::Todo { .. } => {
+                panic!("todo constants should not reach code generation")
+            }
             Constant::Invalid { .. } => {
                 panic!("invalid constants should not reach code generation")
             }
@@ -2490,6 +2492,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             | Constant::String { .. }
             | Constant::RecordUpdate { .. }
             | Constant::StringConcatenation { .. }
+            | Constant::Todo { .. }
             | Constant::Invalid { .. } => self.constant_expression(Context::Guard, expression),
         }
     }

--- a/compiler-core/src/metadata.rs
+++ b/compiler-core/src/metadata.rs
@@ -445,9 +445,14 @@ impl RemapIds {
                 type_: self.type_(type_),
                 extra_information,
             },
-            Constant::Todo { location, type_ } => Constant::Todo {
+            Constant::Todo {
+                location,
+                type_,
+                message,
+            } => Constant::Todo {
                 location,
                 type_: self.type_(type_),
+                message: message.map(|message| Box::new(self.constant(*message))),
             },
         }
     }

--- a/compiler-core/src/metadata.rs
+++ b/compiler-core/src/metadata.rs
@@ -445,6 +445,10 @@ impl RemapIds {
                 type_: self.type_(type_),
                 extra_information,
             },
+            Constant::Todo { location, type_ } => Constant::Todo {
+                location,
+                type_: self.type_(type_),
+            },
         }
     }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1084,6 +1084,26 @@ where
         Ok(message)
     }
 
+    fn maybe_parse_constant_as_message(
+        &mut self,
+    ) -> Result<Option<Box<UntypedConstant>>, ParseError> {
+        let message = if let Some((as_start, as_end)) = self.maybe_one(&Token::As) {
+            match self.parse_const_value_unit()? {
+                Some(constant) => Some(Box::new(constant)),
+                None => {
+                    return Err(ParseError {
+                        error: ParseErrorType::MissingConstantAsMessage,
+                        location: SrcSpan::new(as_start, as_end),
+                    });
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(message)
+    }
+
     // An assignment, with `Let` already consumed
     fn parse_assignment(&mut self, start: u32) -> Result<UntypedStatement, ParseError> {
         let mut kind = match self.tok0 {
@@ -3195,9 +3215,14 @@ where
         match self.tok0.take() {
             Some((start, Token::Todo, end)) => {
                 self.advance();
+                let message = self.maybe_parse_constant_as_message()?;
+                let end = message
+                    .as_ref()
+                    .map_or(end, |message| message.location().end);
                 Ok(Some(Constant::Todo {
                     location: SrcSpan { start, end },
                     type_: (),
+                    message,
                 }))
             }
 

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3193,6 +3193,14 @@ where
 
     fn parse_const_value_unit(&mut self) -> Result<Option<UntypedConstant>, ParseError> {
         match self.tok0.take() {
+            Some((start, Token::Todo, end)) => {
+                self.advance();
+                Ok(Some(Constant::Todo {
+                    location: SrcSpan { start, end },
+                    type_: (),
+                }))
+            }
+
             Some((start, Token::String { value }, end)) => {
                 self.advance();
                 Ok(Some(Constant::String {

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -147,6 +147,8 @@ pub enum ParseErrorType {
         name: EcoString,
         arguments: Vec<EcoString>,
     },
+    // `const x = todo as` with no message after the `as`.
+    MissingConstantAsMessage,
 }
 
 pub(crate) struct ParseErrorDetails {
@@ -714,6 +716,13 @@ See: https://tour.gleam.run/flow-control/case-expressions/"
                 text: "".into(),
                 hint: None,
                 label_text: "A clause guard block cannot be empty".into(),
+                extra_labels: vec![],
+            },
+
+            ParseErrorType::MissingConstantAsMessage => ParseErrorDetails {
+                text: "".into(),
+                hint: None,
+                label_text: "I was expecting to see a constant expression after this `as`".into(),
                 extra_labels: vec![],
             },
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_todo_constant_message.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_todo_constant_message.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: pub const wibble = todo as
+---
+----- SOURCE CODE
+pub const wibble = todo as
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:25
+  │
+1 │ pub const wibble = todo as
+  │                         ^^ I was expecting to see a constant expression after this `as`

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_todo_constant_message_2.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__missing_todo_constant_message_2.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "pub const wibble = todo as\npub fn wibble() {}"
+---
+----- SOURCE CODE
+pub const wibble = todo as
+pub fn wibble() {}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:1:25
+  │
+1 │ pub const wibble = todo as
+  │                         ^^ I was expecting to see a constant expression after this `as`

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -2355,3 +2355,16 @@ fn unicode_fullwidth_caret() {
 fn unicode_fullwidth_colon() {
     assert_module_error!("pub fn wibble(x\u{FF1A} Int) { x }");
 }
+
+#[test]
+fn missing_todo_constant_message() {
+    assert_module_error!("pub const wibble = todo as");
+}
+
+#[test]
+fn missing_todo_constant_message_2() {
+    assert_module_error!(
+        "pub const wibble = todo as
+pub fn wibble() {}"
+    );
+}

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -702,6 +702,12 @@ pub enum Error {
     RecordUpdateVariantWithNoFields {
         location: SrcSpan,
     },
+    /// When a constant contains a todo.
+    /// Unlike todo _expressions_, todo constants are a compile time error: we
+    /// want the developer to take care of them before they can run their code.
+    TodoConstant {
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1374,6 +1380,7 @@ impl Error {
             | Error::ExternalTypeWithConstructors { location, .. }
             | Error::RecordUpdateVariantWithNoFields { location }
             | Error::QualifiedTypeMissingName { location }
+            | Error::TodoConstant { location }
             | Error::LowercaseBoolPattern { location } => location.start,
             Error::UnknownLabels { unknown, .. } => {
                 unknown.iter().map(|(_, s)| s.start).min().unwrap_or(0)

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4325,12 +4325,29 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 }
             }
 
-            Constant::Todo { location, .. } => {
-                // Constant todos always result in a compile time error, this way
-                // the developer has to remember to change them before running their code!
+            Constant::Todo {
+                location, message, ..
+            } => {
                 let type_ = self.new_unbound_var();
+                let message = message.map(|message| {
+                    let message = self.infer_const(&None, *message);
+                    if let Err(error) = unify(string(), message.type_()) {
+                        self.problems
+                            .error(convert_unify_error(error, message.location()))
+                    }
+                    Box::new(message)
+                });
+
+                // Constant todos always result in a compile time error, this
+                // way the developer has to remember to change them before
+                // running their code!
                 self.problems.error(Error::TodoConstant { location });
-                Constant::Todo { location, type_ }
+
+                Constant::Todo {
+                    location,
+                    type_,
+                    message,
+                }
             }
 
             Constant::Invalid { .. } => panic!("invalid constants can not be in an untyped ast"),
@@ -5304,9 +5321,12 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
 
         // Todos should never result in type errors like this one, but just to
         // be safe rather than panicking we replace the type with the new one.
-        Constant::Todo { location, .. } => TypedConstant::Todo {
+        Constant::Todo {
+            location, message, ..
+        } => TypedConstant::Todo {
             location,
             type_: new_type,
+            message,
         },
 
         // In all other cases we don't want to lose information on

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1672,6 +1672,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         }
 
                         Constant::Int { .. }
+                        | Constant::Todo { .. }
                         | Constant::Tuple { .. }
                         | Constant::List { .. }
                         | Constant::Record { .. }
@@ -3861,6 +3862,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     | Constant::BitArray { .. }
                     | Constant::Var { .. }
                     | Constant::StringConcatenation { .. }
+                    | Constant::Todo { .. }
                     | Constant::Invalid { .. } => typed_record,
                 };
 
@@ -4321,6 +4323,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     left: Box::new(left),
                     right: Box::new(right),
                 }
+            }
+
+            Constant::Todo { location, .. } => {
+                // Constant todos always result in a compile time error, this way
+                // the developer has to remember to change them before running their code!
+                let type_ = self.new_unbound_var();
+                self.problems.error(Error::TodoConstant { location });
+                Constant::Todo { location, type_ }
             }
 
             Constant::Invalid { .. } => panic!("invalid constants can not be in an untyped ast"),
@@ -5265,6 +5275,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             | Constant::RecordUpdate { .. }
             | Constant::BitArray { .. }
             | Constant::StringConcatenation { .. }
+            | Constant::Todo { .. }
             | Constant::Invalid { .. } => (),
         }
     }
@@ -5276,7 +5287,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> TypedConstant {
     // In case the types cannot be unified we change the inferred we
     // return a constant where the type matches the annotated one.
-    // This can help minimise fals positive later on!
+    // This can help minimise false positive later on!
     match constant {
         // For simple variants that don't carry their own type we
         // replace them with an invalid constant with the same
@@ -5289,6 +5300,13 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
             location,
             type_: new_type,
             extra_information: None,
+        },
+
+        // Todos should never result in type errors like this one, but just to
+        // be safe rather than panicking we replace the type with the new one.
+        Constant::Todo { location, .. } => TypedConstant::Todo {
+            location,
+            type_: new_type,
         },
 
         // In all other cases we don't want to lose information on

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3594,3 +3594,32 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn todo_in_a_constant_produces_an_error() {
+    assert_module_error!("pub const wibble = todo");
+}
+
+#[test]
+fn todo_constant_does_not_stop_analysis() {
+    assert_module_error!(
+        "pub const wibble = [todo, todo]
+
+pub fn main() -> List(Int) {
+  // This is not an error!!
+  wibble
+}"
+    );
+}
+
+#[test]
+fn todo_constant_does_not_stop_analysis_2() {
+    assert_module_error!(
+        "pub const wibble = [todo, todo]
+
+pub fn main() -> Int {
+  // This is an error!!
+  wibble
+}"
+    );
+}

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3623,3 +3623,28 @@ pub fn main() -> Int {
 }"
     );
 }
+
+#[test]
+fn non_string_in_todo_constant_message() {
+    assert_module_error!("pub const wibble = todo as [1, 2, 3]");
+}
+
+#[test]
+fn string_variable_in_todo_constant_message() {
+    assert_module_error!(
+        r#"
+pub const message = "hello"
+pub const wibble = todo as message
+"#
+    );
+}
+
+#[test]
+fn non_string_variable_in_todo_constant_message() {
+    assert_module_error!(
+        r#"
+pub const message = 1
+pub const wibble = todo as message
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__non_string_in_todo_constant_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__non_string_in_todo_constant_message.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "pub const wibble = todo as [1, 2, 3]"
+---
+----- SOURCE CODE
+pub const wibble = todo as [1, 2, 3]
+
+----- ERROR
+error: Constant todo found
+  ┌─ /src/one/two.gleam:1:20
+  │
+1 │ pub const wibble = todo as [1, 2, 3]
+  │                    ^^^^^^^^^^^^^^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:1:28
+  │
+1 │ pub const wibble = todo as [1, 2, 3]
+  │                            ^^^^^^^^^
+
+Expected type:
+
+    String
+
+Found type:
+
+    List(Int)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__non_string_variable_in_todo_constant_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__non_string_variable_in_todo_constant_message.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub const message = 1\npub const wibble = todo as message\n"
+---
+----- SOURCE CODE
+
+pub const message = 1
+pub const wibble = todo as message
+
+
+----- ERROR
+error: Constant todo found
+  ┌─ /src/one/two.gleam:3:20
+  │
+3 │ pub const wibble = todo as message
+  │                    ^^^^^^^^^^^^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:3:28
+  │
+3 │ pub const wibble = todo as message
+  │                            ^^^^^^^
+
+Expected type:
+
+    String
+
+Found type:
+
+    Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__string_variable_in_todo_constant_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__string_variable_in_todo_constant_message.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub const message = \"hello\"\npub const wibble = todo as message\n"
+---
+----- SOURCE CODE
+
+pub const message = "hello"
+pub const wibble = todo as message
+
+
+----- ERROR
+error: Constant todo found
+  ┌─ /src/one/two.gleam:3:20
+  │
+3 │ pub const wibble = todo as message
+  │                    ^^^^^^^^^^^^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__todo_constant_does_not_stop_analysis.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__todo_constant_does_not_stop_analysis.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "pub const wibble = [todo, todo]\n\npub fn main() -> List(Int) {\n  // This is not an error!!\n  wibble\n}"
+---
+----- SOURCE CODE
+pub const wibble = [todo, todo]
+
+pub fn main() -> List(Int) {
+  // This is not an error!!
+  wibble
+}
+
+----- ERROR
+error: Constant todo found
+  ┌─ /src/one/two.gleam:1:21
+  │
+1 │ pub const wibble = [todo, todo]
+  │                     ^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.
+
+error: Constant todo found
+  ┌─ /src/one/two.gleam:1:27
+  │
+1 │ pub const wibble = [todo, todo]
+  │                           ^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__todo_constant_does_not_stop_analysis_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__todo_constant_does_not_stop_analysis_2.snap
@@ -1,0 +1,47 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "pub const wibble = [todo, todo]\n\npub fn main() -> Int {\n  // This is an error!!\n  wibble\n}"
+---
+----- SOURCE CODE
+pub const wibble = [todo, todo]
+
+pub fn main() -> Int {
+  // This is an error!!
+  wibble
+}
+
+----- ERROR
+error: Constant todo found
+  ┌─ /src/one/two.gleam:1:21
+  │
+1 │ pub const wibble = [todo, todo]
+  │                     ^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.
+
+error: Constant todo found
+  ┌─ /src/one/two.gleam:1:27
+  │
+1 │ pub const wibble = [todo, todo]
+  │                           ^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:3
+  │
+5 │   wibble
+  │   ^^^^^^
+
+The type of this returned value doesn't match the return type
+annotation of this function.
+
+Expected type:
+
+    Int
+
+Found type:
+
+    List(a)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__todo_in_a_constant_produces_an_error.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__todo_in_a_constant_produces_an_error.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: pub const wibble = todo
+---
+----- SOURCE CODE
+pub const wibble = todo
+
+----- ERROR
+error: Constant todo found
+  ┌─ /src/one/two.gleam:1:20
+  │
+1 │ pub const wibble = todo
+  │                    ^^^^ This code is incomplete
+
+This code will crash if it is run. Be sure to finish it before running your
+program.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -4947,3 +4947,13 @@ pub fn run(data) {
         "#
     );
 }
+
+#[test]
+fn constant_used_in_todo_message_counts_as_used() {
+    assert_no_warnings!(
+        "
+const wibble = 1
+pub const wobble = todo as wibble
+"
+    );
+}

--- a/language-server/src/tests/definition.rs
+++ b/language-server/src/tests/definition.rs
@@ -975,3 +975,25 @@ pub fn main() {
         find_position_of("== mod.Wibble").under_char('i')
     );
 }
+
+#[test]
+fn goto_for_invalid_constant_todo_message_still_works() {
+    assert_goto!(
+        "
+const wibble = 1
+const wobble = todo as wibble
+",
+        find_position_of("wibble").nth_occurrence(2)
+    );
+}
+
+#[test]
+fn goto_for_invalid_constant_todo_message_still_works_2() {
+    assert_goto!(
+        "
+const wibble = 1
+const wobble = todo as [wibble]
+",
+        find_position_of("wibble").nth_occurrence(2)
+    );
+}

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -2146,3 +2146,103 @@ pub fn go(wibble: Wibble) {
         find_position_of("Wibble").nth_occurrence(4)
     );
 }
+
+#[test]
+fn hover_on_constant_todo() {
+    assert_hover!(
+        "
+const wibble = todo
+",
+        find_position_of("wibble")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_1() {
+    assert_hover!(
+        "
+const wibble = todo
+",
+        find_position_of("todo")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_in_list() {
+    assert_hover!(
+        "
+const wibble = [todo, 1]
+",
+        find_position_of("wibble")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_in_list_2() {
+    assert_hover!(
+        "
+const wibble = [todo, 1]
+",
+        find_position_of("todo")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_in_bit_array() {
+    assert_hover!(
+        "
+const wibble = <<todo:utf8>>
+",
+        find_position_of("todo")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_in_bit_array_2() {
+    assert_hover!(
+        "
+const wibble = <<todo>>
+",
+        find_position_of("todo")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_in_constructor() {
+    assert_hover!(
+        "
+const wibble = Ok(todo)
+",
+        find_position_of("wibble")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_in_annotated_constructor() {
+    assert_hover!(
+        "
+const wibble: Result(String, Int) = Ok(todo)
+",
+        find_position_of("todo")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_in_constructor_2() {
+    assert_hover!(
+        "
+const wibble = Ok(todo)
+",
+        find_position_of("todo")
+    );
+}
+
+#[test]
+fn hover_on_constant_annotated_todo() {
+    assert_hover!(
+        "
+const wibble: String = todo
+",
+        find_position_of("todo")
+    );
+}

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -2246,3 +2246,24 @@ const wibble: String = todo
         find_position_of("todo")
     );
 }
+
+#[test]
+fn hover_on_constant_todo_message() {
+    assert_hover!(
+        r#"
+const wibble = todo as "wobble"
+"#,
+        find_position_of("wobble")
+    );
+}
+
+#[test]
+fn hover_on_constant_todo_invalid_message_still_works() {
+    assert_hover!(
+        r#"
+const wobble = 1
+const wibble = todo as [wobble]
+"#,
+        find_position_of("wobble").nth_occurrence(2)
+    );
+}

--- a/language-server/src/tests/reference.rs
+++ b/language-server/src/tests/reference.rs
@@ -1095,3 +1095,25 @@ pub fn main() {
         find_position_of("mod.wibble").under_char('w')
     );
 }
+
+#[test]
+fn references_for_invalid_constant_todo_message_still_works() {
+    assert_references!(
+        "
+const wibble = 1
+const wobble = todo as wibble
+",
+        find_position_of("wibble")
+    );
+}
+
+#[test]
+fn references_for_invalid_constant_todo_message_still_works_2() {
+    assert_references!(
+        "
+const wibble = 1
+const wobble = todo as [wibble]
+",
+        find_position_of("wibble")
+    );
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__definition__goto_for_invalid_constant_todo_message_still_works.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__definition__goto_for_invalid_constant_todo_message_still_works.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+const wibble = 1
+const wobble = todo as wibble
+                       ↑     
+
+----- Jumped to `src/app.gleam`
+
+const wibble = 1
+↑▔▔▔▔▔▔▔▔▔▔▔    
+const wobble = todo as wibble

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__definition__goto_for_invalid_constant_todo_message_still_works_2.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__definition__goto_for_invalid_constant_todo_message_still_works_2.snap
@@ -1,0 +1,15 @@
+---
+source: language-server/src/tests/definition.rs
+expression: output
+---
+----- Jumping from `src/app.gleam`
+
+const wibble = 1
+const wobble = todo as [wibble]
+                        ↑      
+
+----- Jumped to `src/app.gleam`
+
+const wibble = 1
+↑▔▔▔▔▔▔▔▔▔▔▔    
+const wobble = todo as [wibble]

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_annotated_todo.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_annotated_todo.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble: String = todo\n"
+---
+
+const wibble: String = todo
+                       ↑▔▔▔
+
+
+----- Hover content (markdown) -----
+```gleam
+String
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = todo\n"
+---
+
+const wibble = todo
+▔▔▔▔▔▔↑▔▔▔▔▔       
+
+
+----- Hover content (markdown) -----
+```gleam
+a
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_1.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_1.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = todo\n"
+---
+
+const wibble = todo
+               ↑▔▔▔
+
+
+----- Hover content (markdown) -----
+```gleam
+a
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_annotated_constructor.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_annotated_constructor.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble: Result(String, Int) = Ok(todo)\n"
+---
+
+const wibble: Result(String, Int) = Ok(todo)
+                                       ↑▔▔▔ 
+
+
+----- Hover content (markdown) -----
+```gleam
+String
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_bit_array.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_bit_array.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = <<todo:utf8>>\n"
+---
+
+const wibble = <<todo:utf8>>
+                 ↑▔▔▔       
+
+
+----- Hover content (markdown) -----
+```gleam
+String
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_bit_array_2.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_bit_array_2.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = <<todo>>\n"
+---
+
+const wibble = <<todo>>
+                 ↑▔▔▔  
+
+
+----- Hover content (markdown) -----
+```gleam
+Int
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_constructor.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_constructor.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = Ok(todo)\n"
+---
+
+const wibble = Ok(todo)
+▔▔▔▔▔▔↑▔▔▔▔▔           
+
+
+----- Hover content (markdown) -----
+```gleam
+Result(a, b)
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_constructor_2.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_constructor_2.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = Ok(todo)\n"
+---
+
+const wibble = Ok(todo)
+                  ↑▔▔▔ 
+
+
+----- Hover content (markdown) -----
+```gleam
+a
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_list.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_list.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = [todo, 1]\n"
+---
+
+const wibble = [todo, 1]
+▔▔▔▔▔▔↑▔▔▔▔▔            
+
+
+----- Hover content (markdown) -----
+```gleam
+List(Int)
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_list_2.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_in_list_2.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = [todo, 1]\n"
+---
+
+const wibble = [todo, 1]
+                ↑▔▔▔    
+
+
+----- Hover content (markdown) -----
+```gleam
+Int
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_invalid_message_still_works.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_invalid_message_still_works.snap
@@ -1,0 +1,14 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wobble = 1\nconst wibble = todo as [wobble]\n"
+---
+
+const wobble = 1
+const wibble = todo as [wobble]
+                        ↑▔▔▔▔▔ 
+
+
+----- Hover content (markdown) -----
+```gleam
+Int
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_message.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_on_constant_todo_message.snap
@@ -1,0 +1,13 @@
+---
+source: language-server/src/tests/hover.rs
+expression: "\nconst wibble = todo as \"wobble\"\n"
+---
+
+const wibble = todo as "wobble"
+                       ▔↑▔▔▔▔▔▔
+
+
+----- Hover content (markdown) -----
+```gleam
+String
+```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_invalid_constant_todo_message_still_works.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_invalid_constant_todo_message_still_works.snap
@@ -1,0 +1,10 @@
+---
+source: language-server/src/tests/reference.rs
+expression: "\nconst wibble = 1\nconst wobble = todo as wibble\n"
+---
+-- app.gleam
+
+const wibble = 1
+      ↑▔▔▔▔▔    
+const wobble = todo as wibble
+                       ▔▔▔▔▔▔

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_invalid_constant_todo_message_still_works_2.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__reference__references_for_invalid_constant_todo_message_still_works_2.snap
@@ -1,0 +1,10 @@
+---
+source: language-server/src/tests/reference.rs
+expression: "\nconst wibble = 1\nconst wobble = todo as [wibble]\n"
+---
+-- app.gleam
+
+const wibble = 1
+      ↑▔▔▔▔▔    
+const wobble = todo as [wibble]
+                        ▔▔▔▔▔▔


### PR DESCRIPTION
This PR closes #5496 
It is now possible to use `todo`s in constants!

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

---

Reminder for me: once this is merged we should update the syntax highlighting grammar to allow this!
