### PR TITLE
Fix typos in code comments

### DIFF
--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -79,7 +79,7 @@ pub fn setup(
     };
 
     // Get the config for the module that is being run to check the target.
-    // Also get the kind of the package the module belongs to: wether the module
+    // Also get the kind of the package the module belongs to: whether the module
     // belongs to a dependency or to the root package.
     let (mod_config, package_kind) = match &module {
         Some(mod_path) => {

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -779,7 +779,7 @@ impl SourceFingerprint {
 ///
 #[derive(Debug)]
 pub enum Outcome<T, E> {
-    /// The operation was totally succesful.
+    /// The operation was totally successful.
     Ok(T),
 
     /// The operation was partially successful but there were problems.

--- a/compiler-core/src/encryption.rs
+++ b/compiler-core/src/encryption.rs
@@ -14,7 +14,7 @@ pub fn encrypt_with_passphrase(
 
 // the function `decrypt_with_passphrase` has two possible failure cases:
 // - when decryption fails
-// - when the data was decrypted succesfully but the result is not UTF-8 valid
+// - when the data was decrypted successfully but the result is not UTF-8 valid
 #[derive(Error, Debug)]
 pub enum DecryptError {
     #[error("unable to decrypt message: {0}")]

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -1420,7 +1420,7 @@ impl BitArrayMatchedValue {
 }
 
 impl BitArrayTest {
-    /// Wether two bit array tests are equivalent, that is they are checking
+    /// Whether two bit array tests are equivalent, that is they are checking
     /// for the same thing.
     ///
     fn equivalent_to(&self, other: &Self) -> bool {

--- a/compiler-core/src/javascript/tests/recursion.rs
+++ b/compiler-core/src/javascript/tests/recursion.rs
@@ -50,7 +50,7 @@ pub fn main(x) {
 // https://github.com/gleam-lang/gleam/issues/2400
 #[test]
 fn shadowing_so_not_recursive() {
-    // This funtion is calling an argument with the same name as itself, so it is not recursive
+    // This function is calling an argument with the same name as itself, so it is not recursive
     assert_js!(
         r#"
 pub fn map(map) {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1008,7 +1008,7 @@ pub struct ModuleInterface {
     pub minimum_required_version: Version,
     pub type_aliases: HashMap<EcoString, TypeAliasConstructor>,
     pub documentation: Vec<EcoString>,
-    /// Wether there's any echo in the module.
+    /// Whether there's any echo in the module.
     pub contains_echo: bool,
     pub references: References,
     /// Functions which can be inlined

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -93,7 +93,7 @@ pub struct Environment<'a> {
     /// IDs and register the original names for them.
     pub deferred_type_variable_aliases: Vec<(u64, Arc<Type>)>,
 
-    /// Wether we ran into an `echo` or not while analysing the current module.
+    /// Whether we ran into an `echo` or not while analysing the current module.
     pub echo_found: bool,
 
     pub references: ReferenceTracker,

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -6535,7 +6535,7 @@ struct VariantToGenerate<'a> {
     end_position: u32,
     arguments_types: Vec<Arc<Type>>,
 
-    /// Wether the type we're adding the variant to is written with braces or
+    /// Whether the type we're adding the variant to is written with braces or
     /// not. We need this information to add braces when missing.
     ///
     type_braces: TypeBraces,

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -354,7 +354,7 @@ impl<'a, IO> Completer<'a, IO> {
     }
 
     // Gets the current range around the cursor to place a completion
-    // and any part of the phrase preceeding a dot if a module is being selected from.
+    // and any part of the phrase preceding a dot if a module is being selected from.
     // A continuous phrase in this case is a name or typename that may have a dot in it.
     // This is used to match the exact location to fill in the completion.
     fn get_phrase_surrounding_completion(&'a self) -> CursorSurroundings {


### PR DESCRIPTION

**Repo:** gleam-lang/gleam (⭐ 17000)
**Type:** docs
**Files changed:** 9
**Lines:** +9/-9

## What
Fixes minor spelling mistakes in code comments across the compiler, language server, and CLI crates: `preceeding` → `preceding`, `funtion` → `function`, `Wether` → `Whether` (4 instances), `succesfully` → `successfully`, `succesful` → `successful`.

## Why
These are pure comment typos that hurt readability when grepping or reading the code. The change is risk-free (comments only), easy to review, and aligns with standard English spelling. No behavior change.

## Testing
Comments only — no runtime or type-system impact. Build and tests unaffected; doc comments parse identically.

## Risk
Low — comment-only changes across 9 files, no code paths modified.
