### PR TITLE
Add `--no-print-progress` option to `gleam dev`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Build tool
 
+- The `gleam dev` command now accepts the `--no-print-progress` flag. When this
+  flag is passed, no progress information is printed.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Language server
 
 ### Formatter

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -154,8 +154,7 @@ enum Command {
         #[arg(short, long, ignore_case = true, help = target_doc())]
         target: Option<Target>,
 
-        /// Don't print progress information
-        #[clap(long)]
+        #[arg(long, help = no_print_progress_doc())]
         no_print_progress: bool,
     },
 
@@ -322,8 +321,7 @@ enum Command {
         #[arg(short, long)]
         module: Option<String>,
 
-        /// Don't print progress information
-        #[clap(long)]
+        #[arg(long, help = no_print_progress_doc())]
         no_print_progress: bool,
 
         arguments: Vec<String>,
@@ -357,6 +355,9 @@ enum Command {
         /// Which runtime to use
         #[arg(long, ignore_case = true, help = runtime_doc())]
         runtime: Option<Runtime>,
+
+        #[arg(long, help = no_print_progress_doc())]
+        no_print_progress: bool,
 
         arguments: Vec<String>,
     },
@@ -434,6 +435,10 @@ fn template_doc() -> &'static str {
 
 fn target_doc() -> &'static str {
     "The platform to target"
+}
+
+fn no_print_progress_doc() -> &'static str {
+    "Don't print progress information"
 }
 
 fn runtime_doc() -> &'static str {
@@ -812,6 +817,7 @@ fn parse_and_run_command() -> Result<(), Error> {
             target,
             arguments,
             runtime,
+            no_print_progress,
         } => {
             let paths = find_project_paths()?;
             run::command(
@@ -821,7 +827,7 @@ fn parse_and_run_command() -> Result<(), Error> {
                 runtime,
                 None,
                 run::Which::Dev,
-                false,
+                no_print_progress,
             )
         }
 


### PR DESCRIPTION
This PR adds the `--no-print-progress` option to `gleam dev` so it is similar to `gleam run`.

- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changes in this PR have been discussed beforehand with Louis
- [x] The changelog has been updated for any user-facing changes
