### PR TITLE
Fix code generation for guards with lists with a tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,7 @@
 - Fixed a bug where the language server would suggest the "wrap in anonymous"
   code action when hovering over a record update.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the compiler would generate invalid code for guards using
+  lists with a tail.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -226,9 +226,15 @@ impl TypedConstant {
                 .map(|message| message.referenced_variables())
                 .unwrap_or(im::hashset![]),
 
-            Constant::List { elements, .. } | Constant::Tuple { elements, .. } => elements
+            Constant::Tuple { elements, .. } => elements
                 .iter()
                 .map(|element| element.referenced_variables())
+                .fold(im::hashset![], im::HashSet::union),
+
+            Constant::List { elements, tail, .. } => elements
+                .iter()
+                .map(|element| element.referenced_variables())
+                .chain(tail.iter().map(|tail| tail.referenced_variables()))
                 .fold(im::hashset![], im::HashSet::union),
 
             Constant::Record { arguments, .. } => arguments
@@ -305,14 +311,23 @@ impl TypedConstant {
             (Constant::Tuple { .. }, _) => false,
 
             (
-                Constant::List { elements, .. },
+                Constant::List { elements, tail, .. },
                 Constant::List {
                     elements: other_elements,
+                    tail: other_tail,
                     ..
                 },
-            ) => pairwise_all(elements, other_elements, |(one, other)| {
-                one.syntactically_eq(other)
-            }),
+            ) => {
+                let tails_are_equal = match (tail, other_tail) {
+                    (None, None) => true,
+                    (None, Some(_)) | (Some(_), None) => false,
+                    (Some(tail), Some(other_tail)) => tail.syntactically_eq(other_tail),
+                };
+                tails_are_equal
+                    && pairwise_all(elements, other_elements, |(one, other)| {
+                        one.syntactically_eq(other)
+                    })
+            }
             (Constant::List { .. }, _) => false,
 
             (
@@ -417,18 +432,27 @@ impl TypedConstant {
         }
     }
 
+    /// If the constant is a list whose elements are known at compile time, this
+    /// returns a vec of all its elements.
+    /// This can happen with:
+    /// - literal lists: `[1, 2]`
+    /// - literal lists whose tail is also known at compile time:
+    ///     - `[1, 2, ..[3, 4]]`
+    ///     - `[1, 2, ..a_known_module_constant]`
+    ///
     pub fn list_elements(&self) -> Option<Vec<&Self>> {
         match self {
-            Constant::List { elements, tail, .. } => Some(
-                elements
-                    .iter()
-                    .chain(
-                        tail.as_deref()
-                            .and_then(|tail| tail.list_elements())
-                            .unwrap_or_default(),
-                    )
-                    .collect(),
-            ),
+            Constant::List { elements, tail, .. } => {
+                if let Some(tail) = tail {
+                    // There's a tail, if it cannot be known at compile time,
+                    // then this entire list cannot be known at compile time!
+                    let tail_elements = tail.list_elements()?;
+                    Some(elements.iter().chain(tail_elements).collect())
+                } else {
+                    // There's no tail, we just return the elements
+                    Some(elements.iter().collect())
+                }
+            }
             Constant::Var {
                 constructor: Some(constructor),
                 ..

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1755,18 +1755,36 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
         }
 
         Constant::List { elements, tail, .. } => {
-            let tail_elements = tail
-                .as_deref()
-                .and_then(|tail| tail.list_elements())
-                .unwrap_or_default();
-
-            join(
-                elements
-                    .iter()
-                    .chain(tail_elements)
-                    .map(|element| const_inline(element, env)),
-                break_(",", ", "),
-            )
+            match tail {
+                // There's no tail in the list, we join all the elements and
+                // call it a day.
+                None => join(
+                    elements.iter().map(|element| const_inline(element, env)),
+                    break_(",", ", "),
+                ),
+                Some(tail) => match tail.list_elements() {
+                    // There's a tail in the list whose elements are all known at
+                    // compile time. In this case we replace the tail with those
+                    // elements and create a single flat list.
+                    Some(tail_elements) => join(
+                        elements
+                            .iter()
+                            .chain(tail_elements)
+                            .map(|element| const_inline(element, env)),
+                        break_(",", ", "),
+                    ),
+                    // There's a tail in the list but we can't really tell what its
+                    // elements are at compile time. This means we have to use
+                    // erlang's syntax to append to a list.
+                    None => {
+                        let elements = join(
+                            elements.iter().map(|element| const_inline(element, env)),
+                            break_(",", ", "),
+                        );
+                        docvec![elements, " | ", const_inline(tail, env)]
+                    }
+                },
+            }
             .nest(INDENT)
             .surround("[", "]")
             .group()
@@ -3606,8 +3624,18 @@ fn find_referenced_private_functions(
             find_referenced_private_functions(right, already_found);
         }
 
-        Constant::Tuple { elements, .. } | Constant::List { elements, .. } => elements
+        Constant::Tuple { elements, .. } => elements
             .iter()
             .for_each(|element| find_referenced_private_functions(element, already_found)),
+
+        Constant::List { elements, tail, .. } => {
+            elements
+                .iter()
+                .for_each(|element| find_referenced_private_functions(element, already_found));
+
+            if let Some(tail) = tail {
+                find_referenced_private_functions(tail, already_found);
+            }
+        }
     }
 }

--- a/compiler-core/src/erlang/tests/case.rs
+++ b/compiler-core/src/erlang/tests/case.rs
@@ -131,3 +131,16 @@ pub fn main(x) {
 "#,
     );
 }
+
+#[test]
+fn list_with_tail_used_in_guard() {
+    assert_erl!(
+        r#"
+pub fn go(x: List(Int), y: List(Int)) {
+  case x {
+    [1, ..x] if [1, 2, ..x] == y -> True
+    _ -> False
+  }
+}"#
+    )
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__list_with_tail_used_in_guard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__case__list_with_tail_used_in_guard.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/erlang/tests/case.rs
+expression: "\npub fn go(x: List(Int), y: List(Int)) {\n  case x {\n    [1, ..x] if [1, 2, ..x] == y -> True\n    _ -> False\n  }\n}"
+---
+----- SOURCE CODE
+
+pub fn go(x: List(Int), y: List(Int)) {
+  case x {
+    [1, ..x] if [1, 2, ..x] == y -> True
+    _ -> False
+  }
+}
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-define(FILEPATH, "project/test/my/mod.gleam").
+-export([go/2]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec go(list(integer()), list(integer())) -> boolean().
+go(X, Y) ->
+    case X of
+        [1 | X@1] when [1, 2 | X@1] =:= Y ->
+            true;
+
+        _ ->
+            false
+    end.

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -2039,19 +2039,41 @@ impl<'module, 'a> Generator<'module, 'a> {
 
             Constant::List { elements, tail, .. } => {
                 self.tracker.list_used = true;
+                let list = match tail {
+                    // There's no tail in the list, we join all the elements and
+                    // call it a day.
+                    None => list(
+                        elements
+                            .iter()
+                            .map(|element| self.constant_expression(context, element)),
+                    ),
 
-                let tail_elements = tail
-                    .as_deref()
-                    .and_then(|tail| tail.list_elements())
-                    .unwrap_or_default();
-
-                let list = list(
-                    elements
-                        .iter()
-                        .chain(tail_elements)
-                        .map(|element| self.constant_expression(context, element)),
-                );
-
+                    Some(tail) => match tail.list_elements() {
+                        // There's a tail in the list whose elements are all
+                        // known at compile time. In this case we replace the
+                        // tail with those elements and create a single flat
+                        // list.
+                        Some(tail_elements) => list(
+                            elements
+                                .iter()
+                                .chain(tail_elements)
+                                .map(|element| self.constant_expression(context, element)),
+                        ),
+                        // There's a tail in the list but we can't really tell
+                        // what its elements are at compile time. This means we
+                        // have to prepend to this list.
+                        None => {
+                            self.tracker.prepend_used = true;
+                            let tail = self.constant_expression(context, tail);
+                            prepend(
+                                elements
+                                    .iter()
+                                    .map(|element| self.constant_expression(context, element)),
+                                tail,
+                            )
+                        }
+                    },
+                };
                 match context {
                     Context::Constant => docvec!["/* @__PURE__ */ ", list],
                     Context::Guard => list,
@@ -2425,14 +2447,6 @@ impl<'module, 'a> Generator<'module, 'a> {
                     .map(|element| self.guard_constant_expression(element)),
             ),
 
-            Constant::List { elements, .. } => {
-                self.tracker.list_used = true;
-                list(
-                    elements
-                        .iter()
-                        .map(|element| self.guard_constant_expression(element)),
-                )
-            }
             Constant::Record { type_, name, .. } if type_.is_bool() && name == "True" => {
                 "true".to_doc()
             }
@@ -2490,6 +2504,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             Constant::Int { .. }
             | Constant::Float { .. }
             | Constant::String { .. }
+            | Constant::List { .. }
             | Constant::RecordUpdate { .. }
             | Constant::StringConcatenation { .. }
             | Constant::Todo { .. }

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -987,3 +987,16 @@ pub fn go() {
 }"#
     )
 }
+
+#[test]
+fn list_with_tail_used_in_guard() {
+    assert_js!(
+        r#"
+pub fn go(x: List(Int), y: List(Int)) {
+  case x {
+    [1, ..x] if [1, 2, ..x] == y -> True
+    _ -> False
+  }
+}"#
+    )
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_tail_used_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_tail_used_in_guard.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go(x: List(Int), y: List(Int)) {\n  case x {\n    [1, ..x] if [1, 2, ..x] == y -> True\n    _ -> False\n  }\n}"
+---
+----- SOURCE CODE
+
+pub fn go(x: List(Int), y: List(Int)) {
+  case x {
+    [1, ..x] if [1, 2, ..x] == y -> True
+    _ -> False
+  }
+}
+
+----- COMPILED JAVASCRIPT
+import { toList, Empty as $Empty, prepend as listPrepend, isEqual } from "../gleam.mjs";
+
+export function go(x, y) {
+  if (x instanceof $Empty) {
+    return false;
+  } else {
+    let $ = x.head;
+    if ($ === 1) {
+      let x$1 = x.tail;
+      if (isEqual(listPrepend(1, listPrepend(2, x$1)), y)) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+}

--- a/test/language/test/language/clause_guard_test.gleam
+++ b/test/language/test/language/clause_guard_test.gleam
@@ -560,3 +560,16 @@ pub fn case_with_guard_does_not_pollute_outer_scope_test() {
   }
   assert a == b
 }
+
+// https://github.com/gleam-lang/gleam/issues/5641
+pub fn tail_of_list_in_clause_guard_is_not_ignored_test() {
+  assert go([2, 3, 4], [1, 2, 3, 4])
+  assert !go([2, 3], [1, 2])
+}
+
+pub fn go(x: List(Int), y: List(Int)) {
+  case x {
+    [_, ..x] if [1, 2, ..x] == y -> True
+    _ -> False
+  }
+}


### PR DESCRIPTION
This PR closes #5641 
Working on constants I noticed that the newly added lists with a tail were not handled properly during code generation, leading to invalid code that could result in ignoring the tail segment. Quite tricky stuff!

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
