### PR TITLE
Fix version tracking for constant list prepending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   or git dependency on Hex when running `gleam update`.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler wouldn't track the minimum required version
+  when using list prepending in constants.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where the language server wouldn't let one extract record
   constructors as variables.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/changelog/v1.16.md
+++ b/changelog/v1.16.md
@@ -161,8 +161,9 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- Compiler can now emit source maps when targeting JavaScript. This can be enabled
-  in the gleam.toml with the `source_maps` setting under the `javascript` section.
+- The compiler can now emit source maps when targeting JavaScript. This can be
+  enabled in the `gleam.toml` with the `source_maps` setting under the
+  `javascript` section.
   ([Ameen Radwan](https://github.com/Acepie))
 
 ### Build tool

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1213,6 +1213,7 @@ pub enum FeatureKind {
     ExternalCustomType,
     ConstantRecordUpdate,
     ExpressionInSegmentSize,
+    ConstantListWithTail,
 }
 
 impl FeatureKind {
@@ -1251,6 +1252,8 @@ impl FeatureKind {
             FeatureKind::ExternalCustomType | FeatureKind::ConstantRecordUpdate => {
                 Version::new(1, 14, 0)
             }
+
+            FeatureKind::ConstantListWithTail => Version::new(1, 16, 0),
         }
     }
 }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4418,6 +4418,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let type_ = list(element_type);
 
         let tail = if let Some(tail) = tail {
+            self.track_feature_usage(FeatureKind::ConstantListWithTail, location);
             let tail = self.infer_const(&None, *tail);
             if let Err(error) = unify(type_.clone(), tail.type_()) {
                 self.problems

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constant_list_prepending_in_guard_requires_v1_16_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constant_list_prepending_in_guard_requires_v1_16_warning.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\nfn go(x) {\n  case x {\n    [1, ..] if [1, ..x] == x -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+fn go(x) {
+  case x {
+    [1, ..] if [1, ..x] == x -> Nil
+    _ -> Nil
+  }
+}
+
+
+----- WARNING
+warning: Unused private function
+  ┌─ /src/warning/wrn.gleam:2:1
+  │
+2 │ fn go(x) {
+  │ ^^^^^^^^ This private function is never used
+
+Hint: You can safely remove it.
+
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:4:16
+  │
+4 │     [1, ..] if [1, ..x] == x -> Nil
+  │                ^^^^^^^^ This requires a Gleam version >= 1.16.0
+
+Prepending to a constant list was introduced in version v1.16.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+
+Hint: Remove the version constraint from your `gleam.toml` or update it to
+be:
+
+    gleam = ">= 1.16.0"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constant_list_prepending_requires_v1_16_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__constant_list_prepending_requires_v1_16_warning.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub const one = []\npub const other = [1, 2, ..one]\n"
+---
+----- SOURCE CODE
+
+pub const one = []
+pub const other = [1, 2, ..one]
+
+
+----- WARNING
+warning: Incompatible gleam version range
+  ┌─ /src/warning/wrn.gleam:3:19
+  │
+3 │ pub const other = [1, 2, ..one]
+  │                   ^^^^^^^^^^^^^ This requires a Gleam version >= 1.16.0
+
+Prepending to a constant list was introduced in version v1.16.0. But the
+Gleam version range specified in your `gleam.toml` would allow this code to
+run on an earlier version like v1.0.0, resulting in compilation errors!
+
+Hint: Remove the version constraint from your `gleam.toml` or update it to
+be:
+
+    gleam = ">= 1.16.0"

--- a/compiler-core/src/type_/tests/version_inference.rs
+++ b/compiler-core/src/type_/tests/version_inference.rs
@@ -411,3 +411,29 @@ pub fn main(x) {
     );
     assert_eq!(version, Version::new(1, 12, 0));
 }
+
+#[test]
+fn constant_list_prepending_requires_v1_16() {
+    let version = infer_version(
+        "
+const one = []
+const other = [1, ..one]
+",
+    );
+    assert_eq!(version, Version::new(1, 16, 0));
+}
+
+#[test]
+fn constant_list_prepending_in_guard_requires_v1_16() {
+    let version = infer_version(
+        "
+pub fn go(x: List(_)) {
+  case x {
+    _ if [1, 2, ..x] == [] -> Nil
+    _ -> Nil
+  }
+}
+",
+    );
+    assert_eq!(version, Version::new(1, 16, 0));
+}

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -4832,6 +4832,32 @@ pub fn main(x) {
 }
 
 #[test]
+fn constant_list_prepending_requires_v1_16_warning() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+pub const one = []
+pub const other = [1, 2, ..one]
+",
+    );
+}
+
+#[test]
+fn constant_list_prepending_in_guard_requires_v1_16_warning() {
+    assert_warnings_with_gleam_version!(
+        Range::higher_than(Version::new(1, 0, 0)),
+        "
+fn go(x) {
+  case x {
+    [1, ..] if [1, ..x] == x -> Nil
+    _ -> Nil
+  }
+}
+",
+    );
+}
+
+#[test]
 fn record_update_with_all_wrong_fields_produces_no_warnings_1() {
     assert_no_warnings!(
         "

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1274,6 +1274,7 @@ See: https://tour.gleam.run/functions/pipelines/",
                         FeatureKind::ConstantRecordUpdate => {
                             "The record update syntax for constants was"
                         }
+                        FeatureKind::ConstantListWithTail => "Prepending to a constant list was",
                     };
 
                     Diagnostic {


### PR DESCRIPTION
I noticed we forgot to update the minimum version tracking for prepending in list constants that was added in 1.16. This fixes it!

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
