### PR TITLE
Completions for list tails and record updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,8 @@
 - Fixed a bug where the language server wouldn't let one extract record
   constructors as variables.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the language server would suggest completions for values
+  from the language's prelude, even though their types were incompatible with
+  the current context.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@
 
 ### Language server
 
+- The language server can now help with completions when typing a list's tail:
+
+  ```gleam
+  pub fn main() {
+    let things_i_like = ["Gleam", "Ice Cream"]
+    ["Dogs", ..t|]
+    //          ^ Can now suggest a completion for `things_i_like`
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- The language server can now help with completions when typing a record update:
+
+  ```gleam
+  pub type User {
+    User(name: String, likes: List(String))
+  }
+
+  pub fn set_name(user: User, name: String) -> User {
+    User(..u|)
+    //      ^ Can now suggest a completion for `user`
+  }
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Compiler
 
+- The inference of record update expressions is now more fault tolerant: if
+  there's an error in the record being updated, the compiler can still able to
+  analyse the fields that are being provided.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The `gleam dev` command now accepts the `--no-print-progress` flag. When this

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -6,7 +6,7 @@ mod untyped;
 mod tests;
 pub mod visit;
 
-pub use self::typed::{InvalidExpression, TypedExpr};
+pub use self::typed::{InvalidExpression, RecordUpdateAssignment, TypedExpr};
 pub use self::untyped::{FunctionLiteralKind, UntypedExpr};
 
 pub use self::constant::{Constant, TypedConstant, UntypedConstant};

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -178,9 +178,11 @@ pub enum TypedExpr {
     RecordUpdate {
         location: SrcSpan,
         type_: Arc<Type>,
-        /// If the record is an expression that is not a variable we will need to assign to a
-        /// variable so it can be referred multiple times.
-        record_assignment: Option<Box<TypedAssignment>>,
+        /// If the record is an expression that is not a variable we will need
+        /// to assign to a variable so it can be referred multiple times.
+        /// If this is `Some` it will contain the record value that has to be
+        /// assigned to a new variable.
+        record_assignment: Option<Box<RecordUpdateAssignment>>,
         constructor: Box<Self>,
         arguments: Vec<CallArg<Self>>,
     },
@@ -205,6 +207,24 @@ pub enum TypedExpr {
         /// states.
         extra_information: Option<InvalidExpression>,
     },
+}
+
+/// If the record is an expression used in an update is not a variable, we will
+/// need to assign it to one so it can be referred multiple times.
+/// For example:
+///
+/// ```gleam
+/// Wibble(..fun_call(1), a:, b:)
+/// //       ^^^^^^^^^^^ This will be `value`
+/// ```
+///
+/// While `name` is the name we pick for the variable that we will assign the
+/// value to.
+///
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordUpdateAssignment {
+    pub name: EcoString,
+    pub value: TypedExpr,
 }
 
 impl TypedExpr {
@@ -429,7 +449,7 @@ impl TypedExpr {
                 .or_else(|| {
                     record_assignment
                         .as_ref()
-                        .and_then(|assignment| assignment.find_node(byte_index))
+                        .and_then(|assignment| assignment.value.find_node(byte_index))
                 })
                 .or_else(|| self.self_if_contains_location(byte_index)),
         }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -43,7 +43,8 @@ use crate::{
     ast::{
         BitArraySize, RecordBeingUpdated, TypeAstConstructorName, TypedBitArraySize,
         TypedConstantBitArraySegment, TypedDefinitions, TypedImport, TypedTailPattern,
-        TypedTypeAlias, typed::InvalidExpression,
+        TypedTypeAlias,
+        typed::{InvalidExpression, RecordUpdateAssignment},
     },
     exhaustiveness::CompiledCase,
     parse::LiteralFloatValue,
@@ -330,7 +331,7 @@ pub trait Visit<'ast> {
         &mut self,
         location: &'ast SrcSpan,
         type_: &'ast Arc<Type>,
-        record: &'ast Option<Box<TypedAssignment>>,
+        record: &'ast Option<Box<RecordUpdateAssignment>>,
         constructor: &'ast TypedExpr,
         arguments: &'ast [TypedCallArg],
     ) {
@@ -1673,7 +1674,7 @@ pub fn visit_typed_expr_record_update<'a, V>(
     v: &mut V,
     _location: &'a SrcSpan,
     _type_: &'a Arc<Type>,
-    record: &'a Option<Box<TypedAssignment>>,
+    record: &'a Option<Box<RecordUpdateAssignment>>,
     constructor: &'a TypedExpr,
     arguments: &'a [TypedCallArg],
 ) where
@@ -1681,7 +1682,7 @@ pub fn visit_typed_expr_record_update<'a, V>(
 {
     v.visit_typed_expr(constructor);
     if let Some(record) = record {
-        v.visit_typed_assignment(record);
+        v.visit_typed_expr(&record.value);
     }
     for argument in arguments {
         v.visit_typed_call_arg(argument);

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1587,6 +1587,16 @@ fn let_assert<'a>(
     ]
 }
 
+/// Generates an the document for assigning to a pattern, for example:
+///
+/// ```erl
+/// {A, B} = Value
+/// Something = fun(atom)
+/// ```
+///
+/// This takes care of the left hand side being any kind of pattern.
+/// If you need to generate an assignment and you know the left hand side to be
+/// a variable name, then you can use the `simple_variable_let` function!
 fn let_<'a>(
     value: &'a TypedExpr,
     pattern: &'a TypedPattern,
@@ -1597,6 +1607,23 @@ fn let_<'a>(
         .print(pattern)
         .append(" = ")
         .append(body)
+}
+
+/// This is used to render a simple variable assignment in Erlang, there's cases
+/// when the left hand side of an assignment is known to be a variable with a
+/// simple name. In that case we don't have to go through `let_` which needs a
+/// whole pattern.
+///
+/// If you need to deal with a complex `let` where the left hand side is a
+/// generic pattern use the `let_` function.
+fn simple_variable_let<'a>(
+    name: &'a EcoString,
+    value: &'a TypedExpr,
+    environment: &mut Env<'a>,
+) -> Document<'a> {
+    let body = maybe_block_expr(value, environment).group();
+    let name = environment.next_local_var_name(name.as_str());
+    docvec![name, " = ", body]
 }
 
 fn float<'a>(value: &str) -> Document<'a> {
@@ -2300,7 +2327,7 @@ fn docs_arguments_call<'a>(
 }
 
 fn record_update<'a>(
-    record: &'a Option<Box<TypedAssignment>>,
+    record: &'a Option<Box<RecordUpdateAssignment>>,
     constructor: &'a TypedExpr,
     arguments: &'a [TypedCallArg],
     env: &mut Env<'a>,
@@ -2309,7 +2336,7 @@ fn record_update<'a>(
 
     let document = match record.as_ref() {
         Some(record) => docvec![
-            assignment(record, env, Position::NotTail),
+            simple_variable_let(&record.name, &record.value, env),
             ",",
             line(),
             call(constructor, arguments, env)

--- a/compiler-core/src/inline.rs
+++ b/compiler-core/src/inline.rs
@@ -125,9 +125,9 @@ use crate::{
     ast::{
         self, ArgNames, Assert, AssignName, Assignment, AssignmentKind, BitArrayOption,
         BitArraySegment, BitArraySize, CallArg, Clause, FunctionLiteralKind, Pattern,
-        PipelineAssignmentKind, Publicity, SrcSpan, Statement, TailPattern, TypedArg, TypedAssert,
-        TypedAssignment, TypedBitArraySize, TypedClause, TypedDefinitions, TypedExpr,
-        TypedExprBitArraySegment, TypedFunction, TypedModule, TypedPattern,
+        PipelineAssignmentKind, Publicity, RecordUpdateAssignment, SrcSpan, Statement, TailPattern,
+        TypedArg, TypedAssert, TypedAssignment, TypedBitArraySize, TypedClause, TypedDefinitions,
+        TypedExpr, TypedExprBitArraySegment, TypedFunction, TypedModule, TypedPattern,
         TypedPipelineAssignment, TypedStatement, TypedUse, visit::Visit,
     },
     exhaustiveness::{Body, CompiledCase, Decision},
@@ -712,8 +712,12 @@ impl Inliner<'_> {
             } => TypedExpr::RecordUpdate {
                 location,
                 type_,
-                record_assignment: record_assignment
-                    .map(|assignment| Box::new(self.assignment(*assignment))),
+                record_assignment: record_assignment.map(|assignment| {
+                    Box::new(RecordUpdateAssignment {
+                        name: assignment.name,
+                        value: self.expression(assignment.value),
+                    })
+                }),
                 constructor: self.boxed_expression(constructor),
                 arguments: self.arguments(arguments),
             },

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -768,7 +768,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                         this.simple_variable_assignment(
                             &assignment.name,
                             &assignment.value,
-                            &assignment.location,
+                            assignment.location,
                         )
                     });
                 documents.push(self.add_statement_level(assignment_document));
@@ -915,7 +915,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         &mut self,
         name: &'a EcoString,
         value: &'a TypedExpr,
-        location: &'a SrcSpan,
+        location: SrcSpan,
     ) -> Document<'a> {
         // Subject must be rendered before the variable for variable numbering
         let subject =
@@ -959,7 +959,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         // generate just a simple assignment instead of using the decision tree
         // for the code generation step.
         if let TypedPattern::Variable { name, .. } = pattern {
-            return self.simple_variable_assignment(name, value, location);
+            return self.simple_variable_assignment(name, value, *location);
         }
 
         docvec![
@@ -1606,16 +1606,21 @@ impl<'module, 'a> Generator<'module, 'a> {
 
     fn record_update(
         &mut self,
-        record: &'a Option<Box<TypedAssignment>>,
+        record: &'a Option<Box<RecordUpdateAssignment>>,
         constructor: &'a TypedExpr,
         arguments: &'a [TypedCallArg],
     ) -> Document<'a> {
         match record.as_ref() {
-            Some(record) => docvec![
-                self.not_in_tail_position(None, |this| this.assignment(record)),
-                line(),
-                self.call(constructor, arguments),
-            ],
+            Some(assignment) => {
+                docvec![
+                    self.not_in_tail_position(None, |this| {
+                        let RecordUpdateAssignment { name, value } = assignment.as_ref();
+                        this.simple_variable_assignment(name, value, value.location())
+                    }),
+                    line(),
+                    self.call(constructor, arguments),
+                ]
+            }
             None => self.call(constructor, arguments),
         }
     }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -6,10 +6,10 @@ use crate::{
         Arg, Assert, Assignment, AssignmentKind, BinOp, BitArrayOption, BitArraySegment,
         CAPTURE_VARIABLE, CallArg, Clause, ClauseGuard, Constant, FunctionLiteralKind, HasLocation,
         ImplicitCallArgOrigin, InvalidExpression, Layer, RECORD_UPDATE_VARIABLE,
-        RecordBeingUpdated, SrcSpan, Statement, TodoKind, TypeAst, TypedArg, TypedAssert,
-        TypedAssignment, TypedClause, TypedClauseGuard, TypedConstant, TypedExpr,
-        TypedMultiPattern, TypedStatement, USE_ASSIGNMENT_VARIABLE, UntypedArg, UntypedAssert,
-        UntypedAssignment, UntypedClause, UntypedClauseGuard, UntypedConstant,
+        RecordBeingUpdated, RecordUpdateAssignment, SrcSpan, Statement, TodoKind, TypeAst,
+        TypedArg, TypedAssert, TypedAssignment, TypedClause, TypedClauseGuard, TypedConstant,
+        TypedExpr, TypedMultiPattern, TypedStatement, USE_ASSIGNMENT_VARIABLE, UntypedArg,
+        UntypedAssert, UntypedAssignment, UntypedClause, UntypedClauseGuard, UntypedConstant,
         UntypedConstantBitArraySegment, UntypedExpr, UntypedExprBitArraySegment,
         UntypedMultiPattern, UntypedStatement, UntypedUse, UntypedUseAssignment, Use,
         UseAssignment,
@@ -3058,17 +3058,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             // We create an Assignment for the old record expression and will
             // use a Var expression to refer back to it while constructing the
             // arguments.
-            let record_assignment = Assignment {
-                location: record_location,
-                pattern: Pattern::Variable {
-                    location: record_location,
-                    name: RECORD_UPDATE_VARIABLE.into(),
-                    type_: record_type.clone(),
-                    origin: VariableOrigin::generated(),
-                },
-                annotation: None,
-                compiled_case: CompiledCase::failure(),
-                kind: AssignmentKind::Generated,
+            let record_assignment = RecordUpdateAssignment {
+                name: RECORD_UPDATE_VARIABLE.into(),
                 value: record,
             };
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -3048,7 +3048,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             .clone();
 
         // infer the record being updated
-        let record = self.infer_or_error(*record.base)?;
+        let record = self.infer(*record.base);
         let record_location = record.location();
         let record_type = record.type_();
 
@@ -3200,8 +3200,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     FieldAccessUsage::RecordUpdate,
                 )?;
 
-                unify(variant.arg_type(index), record_access.type_()).map_err(|e| {
-                    convert_incompatible_fields_error(e, RecordField::Labelled(label.clone()))
+                unify(variant.arg_type(index), record_access.type_()).map_err(|error| {
+                    convert_incompatible_fields_error(error, RecordField::Labelled(label.clone()))
                 })?;
 
                 implicit_arguments.push((
@@ -3248,8 +3248,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             .importable_modules
                             .get(module)
                             .and_then(|module| module.accessors.get(name))
-                            .filter(|a| {
-                                a.publicity.is_importable()
+                            .filter(|accessors_map| {
+                                accessors_map.publicity.is_importable()
                                     || module == &self.environment.current_module
                             })
                             .and_then(|accessors_map| {
@@ -3294,8 +3294,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     type_: type_.clone(),
                 };
 
-                unify(variant.arg_type(index), type_.clone()).map_err(|e| {
-                    convert_incompatible_fields_error(e, RecordField::Unlabelled(index))
+                unify(variant.arg_type(index), type_.clone()).map_err(|error| {
+                    convert_incompatible_fields_error(error, RecordField::Unlabelled(index))
                 })?;
 
                 implicit_arguments.push((
@@ -3372,9 +3372,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             }
         };
 
-        // Check that the record type unifies with the return type of the constructor, and is
-        // not some unrelated other type. This should not affect our returned type, so we
-        // instantiate a new copy of the generic return type for our value constructor.
+        // Check that the record type unifies with the return type of the
+        // constructor, and is not some unrelated other type.
+        // This should not affect our returned type, so we instantiate a new
+        // copy of the generic return type for our value constructor.
         let return_type_copy = match value_constructor.type_.as_ref() {
             Type::Fn { return_, .. } => self.instantiate(return_.clone(), &mut hashmap![]),
             Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
@@ -3397,8 +3398,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             });
         }
 
-        // if we know the record that is being spread, and it does match the one being constructed,
-        // we can safely perform this record update due to variant inference.
+        // if we know the record that is being spread, and it does match the one
+        // being constructed, we can safely perform this record update due to
+        // variant inference.
         if record_index.is_some_and(|index| index == variant_index) {
             self.track_feature_usage(FeatureKind::RecordUpdateVariantInference, record.location());
             return Ok(RecordUpdateVariant {
@@ -3410,8 +3412,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         // We definitely know that we can't do this record update safely.
         //
-        // If we know the variant of the value being spread, and it doesn't match the
-        // one being constructed, we can tell the user that it's always wrong
+        // If we know the variant of the value being spread, and it doesn't
+        // match the one being constructed, we can tell the user that it's
+        // always wrong.
         if record_index.is_some() {
             let Type::Named {
                 module: record_module,
@@ -3436,8 +3439,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             });
         }
 
-        // If we don't have information about the variant being spread, we tell the user
-        // that it's not safe to update it as it could be any variant
+        // If we don't have information about the variant being spread, we tell
+        // the user that it's not safe to update it as it could be any variant.
         Err(Error::UnsafeRecordUpdate {
             location: record.location(),
             reason: UnsafeRecordUpdateReason::UnknownVariant {

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3580,3 +3580,17 @@ pub const wobble = Wibble(..wobble)
 fn qualified_type_with_no_name_results_in_an_error() {
     assert_module_error!("pub fn main() -> wibble. { todo }");
 }
+
+#[test]
+fn can_infer_record_fields_even_if_updated_record_does_not_exist() {
+    assert_module_error!(
+        "
+pub type Wibble { Wibble(a: Int, b: Int) }
+
+pub fn main() {
+  //                       v should see an error here
+  Wibble(..does_not_exist, a: True)
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__can_infer_record_fields_even_if_updated_record_does_not_exist.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__can_infer_record_fields_even_if_updated_record_does_not_exist.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble { Wibble(a: Int, b: Int) }\n\npub fn main() {\n  //                       v should see an error here\n  Wibble(..does_not_exist, a: True)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wibble { Wibble(a: Int, b: Int) }
+
+pub fn main() {
+  //                       v should see an error here
+  Wibble(..does_not_exist, a: True)
+}
+
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:6:12
+  │
+6 │   Wibble(..does_not_exist, a: True)
+  │            ^^^^^^^^^^^^^^
+
+The name `does_not_exist` is not in scope here.
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:6:28
+  │
+6 │   Wibble(..does_not_exist, a: True)
+  │                            ^^^^^^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    Bool

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -301,10 +301,10 @@ impl<'a, IO> Completer<'a, IO> {
         }
     }
 
-    // Gets the current range around the cursor to place a completion
-    // and the phrase surrounding the cursor to use for completion.
-    // This method takes in a helper to determine what qualifies as
-    // a phrase depending on context.
+    /// Gets the current range around the cursor to place a completion
+    /// and the phrase surrounding the cursor to use for completion.
+    /// The `valid_phrase_char` is a function that returns true if a character
+    /// should be included in the phrase surrounding the cursor.
     fn get_phrase_surrounding_for_completion(
         &'a self,
         valid_phrase_char: &impl Fn(char) -> bool,
@@ -315,14 +315,20 @@ impl<'a, IO> Completer<'a, IO> {
         let before = self
             .src
             .get(..cursor as usize)
-            .and_then(|line| line.rsplit_once(valid_phrase_char).map(|r| r.1))
+            .and_then(|line| {
+                line.rsplit_once(|char| !valid_phrase_char(char))
+                    .map(|(_, suffix)| suffix)
+            })
             .unwrap_or("");
 
         // Get part of phrase following cursor
         let after = self
             .src
             .get(cursor as usize..)
-            .and_then(|line| line.split_once(valid_phrase_char).map(|r| r.0))
+            .and_then(|line| {
+                line.split_once(|char| !valid_phrase_char(char))
+                    .map(|(prefix, _)| prefix)
+            })
             .unwrap_or("");
 
         let text_before_cursor_range = Range {
@@ -359,8 +365,9 @@ impl<'a, IO> Completer<'a, IO> {
     // This is used to match the exact location to fill in the completion.
     fn get_phrase_surrounding_completion(&'a self) -> CursorSurroundings {
         self.get_phrase_surrounding_for_completion(&|c: char| {
-            // Checks if a character is not a valid name/upname character or a dot.
-            !c.is_ascii_alphanumeric() && c != '.' && c != '_'
+            // Checks if a character is not a valid name/upname character or a
+            // dot.
+            c.is_ascii_alphanumeric() || c == '.' || c == '_'
         })
     }
 
@@ -371,11 +378,11 @@ impl<'a, IO> Completer<'a, IO> {
         self.get_phrase_surrounding_for_completion(&|c: char| {
             // Checks if a character is not a valid name/upname character or whitespace.
             // The newline character is not included as well.
-            !c.is_ascii_alphanumeric() && c != '_' && c != ' ' && c != '\t'
+            c.is_ascii_alphanumeric() || c == '_' || c == ' ' || c == '\t'
         })
     }
 
-    /// Checks if the line being editted is an import line and provides completions if it is.
+    /// Checks if the line being edited is an import line and provides completions if it is.
     /// If the line includes a dot then it provides unqualified import completions.
     /// Otherwise it provides direct module import completions.
     pub fn import_completions(&'a self) -> Option<Result<Option<Vec<CompletionItem>>>> {
@@ -590,7 +597,7 @@ impl<'a, IO> Completer<'a, IO> {
     // be really hard to understand or use a lot of trait magic.
     // For now I've left it as is but might be worth revisiting.
 
-    /// Provides completions for when the context being editted is a type.
+    /// Provides completions for when the context being edited is a type.
     pub fn completion_types(&'a self) -> Vec<CompletionItem> {
         let cursor_surroundings = self.get_phrase_surrounding_completion();
         let selected_module = cursor_surroundings.selected_module();
@@ -745,7 +752,7 @@ impl<'a, IO> Completer<'a, IO> {
         completions
     }
 
-    /// Provides completions for when the context being editted is a value.
+    /// Provides completions for when the context being edited is a value.
     pub fn completion_values(&'a self) -> Vec<CompletionItem> {
         let cursor_surroundings = self.get_phrase_surrounding_completion();
         let selected_module = cursor_surroundings.selected_module();
@@ -1018,7 +1025,7 @@ impl<'a, IO> Completer<'a, IO> {
         }
     }
 
-    /// Provides completions for field accessors when the context being editted
+    /// Provides completions for field accessors when the context being edited
     /// is a custom type instance
     pub fn completion_field_accessors(&'a self, type_: Arc<Type>) -> Vec<CompletionItem> {
         if let Type::Named {
@@ -1087,7 +1094,7 @@ impl<'a, IO> Completer<'a, IO> {
         }
     }
 
-    /// Provides completions for labels when the context being editted is a call
+    /// Provides completions for labels when the context being edited is a call
     /// that has labelled arguments that can be passed
     pub fn completion_labels(
         &'a self,

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -146,6 +146,7 @@ enum TypeCompletionContext {
 /// wibble.w|ob
 /// //      ^ cursor here
 /// ```
+#[derive(Debug)]
 struct CursorSurroundings {
     /// The text surrounding the cursor. For example:
     ///
@@ -364,11 +365,60 @@ impl<'a, IO> Completer<'a, IO> {
     // A continuous phrase in this case is a name or typename that may have a dot in it.
     // This is used to match the exact location to fill in the completion.
     fn get_phrase_surrounding_completion(&'a self) -> CursorSurroundings {
-        self.get_phrase_surrounding_for_completion(&|c: char| {
+        let cursor_surroundings = self.get_phrase_surrounding_for_completion(&|c: char| {
             // Checks if a character is not a valid name/upname character or a
             // dot.
             c.is_ascii_alphanumeric() || c == '.' || c == '_'
-        })
+        });
+
+        // While a single `.` is ok to be in the cursor sentence, there's a
+        // special case where always accepting `.` is not ok: in list tails and
+        // record updates!
+        // In those case accepting a `.` means we would end up with a phrase
+        // surrounding the cursor that looks like this: `..wibble` and so we
+        // won't be able to show completions for that because it doesn't look
+        // like a module access or a name!
+        //
+        // So we need to do some final massaging of the cursor surroundings if
+        // we realise we have captures a `..` at the beginning of the sentence.
+        // This will allow the language server to provide good completions for
+        // list tails and record updates as well.
+        if cursor_surroundings.text_before_cursor.starts_with("..") {
+            let CursorSurroundings {
+                surrounding_text,
+                surrounding_text_range,
+                text_before_cursor,
+                text_before_cursor_range,
+                text_after_cursor,
+            } = cursor_surroundings;
+            let (_, text_before_cursor) = text_before_cursor.split_at(2);
+            let text_before_cursor_range = Range {
+                start: Position {
+                    character: text_before_cursor_range.start.character + 2,
+                    ..text_before_cursor_range.start
+                },
+                ..text_before_cursor_range
+            };
+
+            let (_, surrounding_text) = surrounding_text.split_at(2);
+            let surrounding_text_range = Range {
+                start: Position {
+                    character: surrounding_text_range.start.character + 2,
+                    ..surrounding_text_range.start
+                },
+                ..surrounding_text_range
+            };
+
+            CursorSurroundings {
+                surrounding_text: EcoString::from(surrounding_text),
+                surrounding_text_range,
+                text_before_cursor: EcoString::from(text_before_cursor),
+                text_before_cursor_range,
+                text_after_cursor,
+            }
+        } else {
+            cursor_surroundings
+        }
     }
 
     // Gets the current range around the cursor to place a completion.

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -792,9 +792,10 @@ impl<'a, IO> Completer<'a, IO> {
         }
 
         // Module and prelude values
-        // Do not complete direct module values if the user has already started typing a module select.
-        // e.x. when the user has typed mymodule.| we know local module and prelude values are no longer
-        // relevant.
+        // Do not complete direct module values if the user has already started
+        // typing a module select.
+        // e.x. when the user has typed mymodule.| we know local module and
+        // prelude values are no longer relevant.
         if selected_module.is_none() {
             // Find the function that the cursor is in and push completions for
             // its arguments and local variables.
@@ -907,8 +908,10 @@ impl<'a, IO> Completer<'a, IO> {
                 }
 
                 if let Some(module) = import.used_name() {
-                    // If the user has already started a module select then don't show irrelevant modules.
-                    // e.x. when the user has typed mymodule.| we should only show items from mymodule.
+                    // If the user has already started a module select then
+                    // don't show irrelevant modules.
+                    // e.x. when the user has typed mymodule.| we should only
+                    // show items from mymodule.
                     if let Some(input_mod_name) = &selected_module
                         && &module != input_mod_name
                     {
@@ -926,8 +929,10 @@ impl<'a, IO> Completer<'a, IO> {
             }
 
             // Unqualified values
-            // Do not complete unqualified values if the user has already started typing a module select.
-            // e.x. when the user has typed mymodule.| we know unqualified module values are no longer relevant.
+            // Do not complete unqualified values if the user has already
+            // started typing a module select.
+            // e.x. when the user has typed mymodule.| we know unqualified
+            // module values are no longer relevant.
             if selected_module.is_none() {
                 for unqualified in &import.unqualified_values {
                     if let Some(value) = module.get_public_value(&unqualified.name) {
@@ -966,8 +971,10 @@ impl<'a, IO> Completer<'a, IO> {
                 .next_back()
                 .unwrap_or(module_full_name);
 
-            // If the user has already started a module select then don't show irrelevant modules.
-            // e.x. when the user has typed mymodule.| we should only show items from mymodule.
+            // If the user has already started a module select then don't show
+            // irrelevant modules.
+            // e.x. when the user has typed mymodule.| we should only show items
+            // from mymodule.
             if let Some(selected_module) = &selected_module
                 && qualifier != selected_module
             {
@@ -1017,9 +1024,11 @@ impl<'a, IO> Completer<'a, IO> {
                 ..
             } => importable_modules
                 .get(module)
-                .and_then(|i| i.accessors.get(name))
-                .filter(|a| a.publicity.is_importable() || module == &self.module.name)
-                .map(|a| a.accessors_for_variant(*inferred_variant)),
+                .and_then(|interface| interface.accessors.get(name))
+                .filter(|accessor| {
+                    accessor.publicity.is_importable() || module == &self.module.name
+                })
+                .map(|accessor| accessor.accessors_for_variant(*inferred_variant)),
 
             Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => None,
         }

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -835,6 +835,11 @@ impl<'a, IO> Completer<'a, IO> {
             }
 
             let mut push_prelude_completion = |label: &str, kind, type_: Arc<Type>| {
+                match match_type(&self.expected_type, &type_) {
+                    TypeMatch::Incompatible => return,
+                    TypeMatch::Matching | TypeMatch::Unknown => (),
+                };
+
                 let label = label.to_string();
                 let sort_text = Some(sort_text(
                     CompletionKind::Prelude,

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -343,6 +343,28 @@ where
                     );
                     Some(completions)
                 }
+
+                // If we're typing inside an expression body (and not being any
+                // more specific than this, meaning we're not editing some
+                // specific value inside it) we don't want to set the expected
+                // type to the type of the entire anonymous function, otherwise
+                // the language server would start recommending the wrong
+                // values:
+                //
+                // ```
+                // fn(x: Int) -> String {
+                //   | // <- Typing here
+                //     //    We don't want the language server to suggest values
+                //     //    of type `fn(Int) -> String`!
+                //   todo
+                // }
+                // ```
+                //
+                Located::Expression {
+                    position: ExpressionPosition::Expression,
+                    expression: TypedExpr::Fn { .. },
+                } => Some(completer.completion_values()),
+
                 Located::Expression { expression, .. } => {
                     completer.expected_type = Some(expression.type_());
                     Some(completer.completion_values())

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -303,6 +303,7 @@ where
                     ..
                 }
                 | Located::Constant(Constant::String { .. }) => None,
+
                 Located::Expression {
                     expression:
                         TypedExpr::Call { fun, arguments, .. }
@@ -318,6 +319,7 @@ where
                     completions.append(&mut completer.completion_labels(fun, arguments));
                     Some(completions)
                 }
+
                 Located::Expression {
                     expression: TypedExpr::RecordAccess { record, type_, .. },
                     ..
@@ -328,6 +330,7 @@ where
                     completions.append(&mut completer.completion_field_accessors(record.type_()));
                     Some(completions)
                 }
+
                 Located::Expression {
                     position:
                         ExpressionPosition::ArgumentOrLabel {
@@ -369,6 +372,7 @@ where
                     completer.expected_type = Some(expression.type_());
                     Some(completer.completion_values())
                 }
+
                 Located::ModuleFunction(_) => Some(completer.completion_types()),
 
                 Located::Statement(_) => Some(completer.completion_values()),

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -269,7 +269,7 @@ where
     ) -> Response<Option<Vec<lsp::CompletionItem>>> {
         self.respond(|this| {
             let module = match this.module_for_uri(&params.text_document.uri) {
-                Some(m) => m,
+                Some(module) => module,
                 None => return Ok(None),
             };
 

--- a/language-server/src/tests/completion.rs
+++ b/language-server/src/tests/completion.rs
@@ -2489,3 +2489,35 @@ pub fn main() {
         Position::new(3, 16)
     );
 }
+
+#[test]
+fn completions_when_typing_list_tail() {
+    assert_completion!(
+        TestProject::for_source(
+            "
+pub fn main() {
+  let wibble = [1, 2]
+  [3, 4, ..w]
+}
+"
+        ),
+        Position::new(3, 12)
+    );
+}
+
+#[test]
+fn completions_when_typing_record_update() {
+    assert_completion!(
+        TestProject::for_source(
+            "
+pub type Wibble { Wibble(a: Int, b: String) }
+
+pub fn main() {
+  let wibble = todo
+  Wibble(..w)
+}
+"
+        ),
+        Position::new(5, 12)
+    );
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__argument_shadowing.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__argument_shadowing.snap
@@ -34,7 +34,7 @@ True
 main
   kind:   Function
   detail: fn(Int) -> fn(Float) -> a
-  sort:   03_main
+  sort:   3_main
   desc:   app
   edits:
     [3:0-3:0]: "main"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_when_typing_list_tail.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_when_typing_list_tail.snap
@@ -1,0 +1,27 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\npub fn main() {\n  let wibble = [1, 2]\n  [3, 4, ..w]\n}\n"
+---
+
+pub fn main() {
+  let wibble = [1, 2]
+  [3, 4, ..w|]
+}
+
+
+----- Completion content -----
+main
+  kind:   Function
+  detail: fn() -> List(Int)
+  sort:   03_main
+  desc:   app
+  edits:
+    [3:11-3:12]: "main"
+wibble
+  kind:   Variable
+  detail: List(Int)
+  sort:   03_wibble
+  desc:   app
+  docs:   "A locally defined variable."
+  edits:
+    [3:11-3:12]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_when_typing_record_update.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_when_typing_record_update.snap
@@ -1,0 +1,36 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\npub type Wibble { Wibble(a: Int, b: String) }\n\npub fn main() {\n  let wibble = todo\n  Wibble(..w)\n}\n"
+---
+
+pub type Wibble { Wibble(a: Int, b: String) }
+
+pub fn main() {
+  let wibble = todo
+  Wibble(..w|)
+}
+
+
+----- Completion content -----
+Wibble
+  kind:   Constructor
+  detail: fn(Int, String) -> Wibble
+  sort:   03_Wibble
+  desc:   app
+  edits:
+    [5:11-5:12]: "Wibble"
+main
+  kind:   Function
+  detail: fn() -> Wibble
+  sort:   03_main
+  desc:   app
+  edits:
+    [5:11-5:12]: "main"
+wibble
+  kind:   Variable
+  detail: a
+  sort:   03_wibble
+  desc:   app
+  docs:   "A locally defined variable."
+  edits:
+    [5:11-5:12]: "wibble"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_anonymous_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_anonymous_function.snap
@@ -10,26 +10,6 @@ pub fn main() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Int

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_args_nested.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_args_nested.snap
@@ -14,26 +14,6 @@ pub fn main() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 add_two
   kind:   Variable
   detail: fn(Int) -> Int

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_returned.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_ignore_anonymous_function_returned.snap
@@ -13,26 +13,6 @@ pub fn main() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 add_two
   kind:   Variable
   detail: fn(Int) -> Int

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_inside_nested_exprs.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_inside_nested_exprs.snap
@@ -14,22 +14,10 @@ fn wibble() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
   sort:   05_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_nested_anonymous_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_nested_anonymous_function.snap
@@ -14,26 +14,6 @@ pub fn main() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Int

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_pipe.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_pipe.snap
@@ -11,26 +11,6 @@ pub fn main() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 add_one
   kind:   Variable
   detail: fn(Int) -> Int

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_case_clause_scope.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_after_case_clause_scope.snap
@@ -13,26 +13,10 @@ pub fn main() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
   sort:   05_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_case_clause.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__no_variable_completions_before_case_clause.snap
@@ -13,26 +13,10 @@ pub fn main() {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
 Nil
   kind:   EnumMember
   detail: gleam
   sort:   05_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 main
   kind:   Function
   detail: fn() -> a

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_generic_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_generic_type.snap
@@ -15,22 +15,10 @@ Error
   kind:   Constructor
   detail: gleam
   sort:   05_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
 Ok
   kind:   Constructor
   detail: gleam
   sort:   05_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 main
   kind:   Function
   detail: fn() -> Result(Int, Nil)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_function_which_returns_expected_type.snap
@@ -13,26 +13,6 @@ fn addf(a, b) { a +. b }
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
-False
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
-True
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_True
 add
   kind:   Function
   detail: fn(Int, Int) -> Int

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_values_matching_expected_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__prefer_values_matching_expected_type.snap
@@ -12,22 +12,10 @@ pub fn main() -> Bool {
 
 
 ----- Completion content -----
-Error
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Error
 False
   kind:   EnumMember
   detail: gleam
   sort:   05_False
-Nil
-  kind:   EnumMember
-  detail: gleam
-  sort:   5_Nil
-Ok
-  kind:   Constructor
-  detail: gleam
-  sort:   5_Ok
 True
   kind:   EnumMember
   detail: gleam


### PR DESCRIPTION
I noticed the language server would not show completions when typing a record update or a list tail:
```gleam
Wibble(..wi|)
//         ^ No help here
[1, 2, ..t|]
//        ^ Nor here
```
I thought it would be an easy fix, but it kind of lead down a rabbit hole and fixing this required a couple of other things to get fixed first. Here's a recap:
- record updates needed to be more fault tolerant so that if the record being updated doesn't exist (e.g. `Wibble(..i_do_not_exist)`) the compiler doesn't entirely give up
- the language server was always suggesting all prelude values despite their type being incompatible with the current context

I've made sure to keep each item of work onto a separate commit and would recommend reviewing this going over each individual one!

---
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
