### PR TITLE
Fix extract variable bug

### DIFF
--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -3507,6 +3507,46 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
         ast::visit::visit_typed_expr_call(self, location, type_, fun, arguments, open_parenthesis);
     }
 
+    fn visit_typed_expr_record_update(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        record: &'ast Option<Box<ast::RecordUpdateAssignment>>,
+        constructor: &'ast TypedExpr,
+        arguments: &'ast [TypedCallArg],
+    ) {
+        // Record updates need some extra care. If we're inspecting a record
+        // update like this one: `Wibble(..wobble, woo)` and the cursor is over
+        // the constructor itself we never want to allow extracting it, or it
+        // would result in the following code:
+        //
+        // ```gleam
+        // Wibble(..wobble, woo)
+        // // ^^ Cursor here
+        //
+        // let wibble = Wibble
+        // wibble(..wobble, woo)
+        // // That's a bit silly!
+        // ```
+        let constructor_range = self.edits.src_span_to_lsp_range(constructor.location());
+        if within(self.params.range, constructor_range)
+            && constructor.is_record_constructor_function()
+        {
+            return;
+        }
+
+        // Otherwise we just keep visiting like usual, no special handling is
+        // required.
+        ast::visit::visit_typed_expr_record_update(
+            self,
+            location,
+            type_,
+            record,
+            constructor,
+            arguments,
+        );
+    }
+
     fn visit_typed_expr(&mut self, expr: &'ast TypedExpr) {
         let expr_location = expr.location();
         let expr_range = self.edits.src_span_to_lsp_range(expr_location);

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -5939,6 +5939,21 @@ fn extract_variable_does_not_extract_echo() {
 }
 
 #[test]
+fn extract_variable_does_not_extract_record_constructor_in_record_update() {
+    assert_no_code_actions!(
+        EXTRACT_VARIABLE,
+        r#"
+pub fn main() {
+  Wibble(..todo, a: 1)
+}
+
+pub type Wibble { Wibble(a: Int, b: Int) }
+"#,
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
 fn extract_variable_does_not_extract_assignment() {
     assert_no_code_actions!(
         EXTRACT_VARIABLE,


### PR DESCRIPTION
I noticed I introduced a little bug with the recent changes to the "extract variable" code action, that would allow extracting a record update like this:
```gleam
Wibble(..wibble, a: 1)
// ^^ Trigger here
let function = Wibble
function(..wibble, a: 1)
// That's a bit silly
```

So I've added a check to make sure it doesn't happen, I haven't updated the changelog since the bug wasn't in any released version

- [X] Tests have been added for new behaviour
