### PR TITLE
Fix wrap in anonymous function code action applied on record updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,7 @@
 - Fixed a bug where the language server would suggest the "wrap in anonymous"
   code action even when not hovering directly over a function.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the language server would suggest the "wrap in anonymous"
+  code action when hovering over a record update.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,7 @@
   from the language's prelude, even though their types were incompatible with
   the current context.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the language server would suggest the "wrap in anonymous"
+  code action even when not hovering directly over a function.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -11522,9 +11522,9 @@ impl<'ast> ast::visit::Visit<'ast> for ReplaceUnderscoreWithType<'ast> {
 /// ```
 pub struct WrapInAnonymousFunction<'a> {
     module: &'a Module,
-    line_numbers: &'a LineNumbers,
     params: &'a CodeActionParams,
     functions: Vec<FunctionToWrap>,
+    edits: TextEdits<'a>,
 }
 
 /// Helper struct, a target for [WrapInAnonymousFunction].
@@ -11542,8 +11542,8 @@ impl<'a> WrapInAnonymousFunction<'a> {
     ) -> Self {
         Self {
             module,
-            line_numbers,
             params,
+            edits: TextEdits::new(line_numbers),
             functions: vec![],
         }
     }
@@ -11558,16 +11558,20 @@ impl<'a> WrapInAnonymousFunction<'a> {
             let arguments = target
                 .arguments
                 .iter()
-                .map(|t| name_generator.generate_name_from_type(t))
+                .map(|type_| name_generator.generate_name_from_type(type_))
                 .join(", ");
 
-            let mut edits = TextEdits::new(self.line_numbers);
-            edits.insert(target.location.start, format!("fn({arguments}) {{ "));
-            edits.insert(target.location.end, format!("({arguments}) }}"));
+            self.edits
+                .insert(target.location.start, format!("fn({arguments}) {{ "));
+            self.edits
+                .insert(target.location.end, format!("({arguments}) }}"));
 
             CodeActionBuilder::new("Wrap in anonymous function")
                 .kind(CodeActionKind::REFACTOR_REWRITE)
-                .changes(self.params.text_document.uri.clone(), edits.edits)
+                .changes(
+                    self.params.text_document.uri.clone(),
+                    self.edits.edits.drain(..).collect(),
+                )
                 .push_to(&mut actions);
         }
         actions
@@ -11576,7 +11580,7 @@ impl<'a> WrapInAnonymousFunction<'a> {
 
 impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
     fn visit_typed_expr(&mut self, expression: &'ast TypedExpr) {
-        let expression_range = src_span_to_lsp_range(expression.location(), self.line_numbers);
+        let expression_range = self.edits.src_span_to_lsp_range(expression.location());
         if !within(self.params.range, expression_range) {
             return;
         }
@@ -11611,7 +11615,7 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
     ) {
         // We only need to do this interception for explicit calls, so if any
         // of our arguments are explicit we re-enter the visitor as usual.
-        if arguments.iter().any(|a| a.is_implicit()) {
+        if arguments.iter().any(|argument| argument.is_implicit()) {
             self.visit_typed_expr(fun);
         } else {
             // We still want to visit other nodes nested in the function being
@@ -11622,6 +11626,41 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
         for argument in arguments {
             self.visit_typed_call_arg(argument);
         }
+    }
+
+    /// We don't want to apply this to record constructors used in a record
+    /// update.
+    fn visit_typed_expr_record_update(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        record: &'ast Option<Box<ast::RecordUpdateAssignment>>,
+        constructor: &'ast TypedExpr,
+        arguments: &'ast [TypedCallArg],
+    ) {
+        // If we're hovering the record constructor of an update and that is a
+        // simple record constructor, we don't want to offer the wrap in
+        // anonymous function code action:
+        //
+        // ```gleam
+        // Wibble(..wibble, a: 1)
+        // // ^^^ Wrap in anonymous function makes no sense on this!
+        // ```
+        let constructor_range = self.edits.src_span_to_lsp_range(constructor.location());
+        if within(self.params.range, constructor_range)
+            && constructor.is_record_constructor_function()
+        {
+            return;
+        }
+
+        ast::visit::visit_typed_expr_record_update(
+            self,
+            location,
+            type_,
+            record,
+            constructor,
+            arguments,
+        );
     }
 }
 

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -11577,7 +11577,7 @@ impl<'a> WrapInAnonymousFunction<'a> {
 impl<'ast> ast::visit::Visit<'ast> for WrapInAnonymousFunction<'ast> {
     fn visit_typed_expr(&mut self, expression: &'ast TypedExpr) {
         let expression_range = src_span_to_lsp_range(expression.location(), self.line_numbers);
-        if !overlaps(self.params.range, expression_range) {
+        if !within(self.params.range, expression_range) {
             return;
         }
 

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -13199,6 +13199,32 @@ fn some_function(i) {
 }
 
 #[test]
+fn wrap_function_in_anonymous_function_does_not_trigger_on_record_update() {
+    assert_no_code_actions!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "pub fn main() {
+  Wibble(..todo, a: 1)
+}
+
+pub type Wibble { Wibble(a: Int, b: Int) }
+",
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
+fn wrap_function_in_anonymous_function_does_not_trigger_on_invalid_record_update() {
+    assert_no_code_actions!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "pub fn main() {
+  Wibble(..todo, a: 1)
+}
+",
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
 fn replace_nested_underscore_with_generic_type() {
     assert_code_action!(
         REPLACE_UNDERSCORE_WITH_TYPE,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -13180,6 +13180,25 @@ fn op(i) {
 }
 
 #[test]
+fn wrap_function_in_anonymous_function_does_not_trigger_if_selection_is_not_within_the_function() {
+    assert_no_code_actions!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "pub fn main() {
+  let a = 1
+  some_function
+  let b = 2
+  Nil
+}
+
+fn some_function(i) {
+  todo
+}
+",
+        find_position_of("1").select_until(find_position_of("2"))
+    );
+}
+
+#[test]
 fn replace_nested_underscore_with_generic_type() {
     assert_code_action!(
         REPLACE_UNDERSCORE_WITH_TYPE,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -13225,6 +13225,32 @@ fn wrap_function_in_anonymous_function_does_not_trigger_on_invalid_record_update
 }
 
 #[test]
+fn wrap_function_in_anonymous_function_does_not_trigger_on_record_call() {
+    assert_no_code_actions!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "pub fn main() {
+  Wibble(1, 2)
+}
+
+pub type Wibble { Wibble(a: Int, b: Int) }
+",
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
+fn wrap_function_in_anonymous_function_does_not_trigger_on_invalid_record_call() {
+    assert_no_code_actions!(
+        WRAP_IN_ANONYMOUS_FUNCTION,
+        "pub fn main() {
+  Wibble(1)
+}
+",
+        find_position_of("Wibble").to_selection()
+    );
+}
+
+#[test]
 fn replace_nested_underscore_with_generic_type() {
     assert_code_action!(
         REPLACE_UNDERSCORE_WITH_TYPE,


### PR DESCRIPTION
I noticed a small bug in the newly added "wrap in anonymous function" code action. The LS would allow to trigger it on record update expressions generating invalid code. This fixes it!

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
