### PR TITLE
generate valid code when matching on the rhs of another let

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
   or git dependency on Hex when running `gleam update`.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the "pattern match on value" code action would generate
+  invalid code when used on a `let` assignment on the right hand side of another
+  `let` assignment.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where the compiler wouldn't track the minimum required version
   when using list prepending in constants.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -5967,7 +5967,18 @@ impl<'ast, IO> ast::visit::Visit<'ast> for PatternMatchOnValue<'ast, IO> {
         }
 
         ast::visit::visit_typed_assignment(self, assignment);
-        if let Some((name, _, ref type_)) = self.pattern_variable_under_cursor {
+        if let Some((name, _, ref type_)) = self.pattern_variable_under_cursor
+            // We must make sure that no other value was selected while visiting
+            // this. If it were `Some` that means that we have found _another_
+            // variable to match on inside the assignmemt itself. For example:
+            // ```gleam
+            // let a = {
+            //   let b = todo
+            //   //  ^ We're matching on this, not the outer one!
+            // }
+            // ```
+            && self.selected_value.is_none()
+        {
             self.selected_value = Some(PatternMatchedValue::LetVariable {
                 variable_name: name,
                 variable_type: type_.clone(),

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -7846,6 +7846,24 @@ fn maybe_wibble() { Ok(Wobble) }
 }
 
 #[test]
+// https://github.com/gleam-lang/gleam/issues/5648
+fn pattern_match_on_variable_defined_inside_anonymous_function() {
+    assert_code_action!(
+        PATTERN_MATCH_ON_VARIABLE,
+        "
+pub fn main() {
+  let outcome = apply(#(Ok(1), Nil), fn(pair) {
+    let #(result, nil) = pair
+  })
+}
+
+fn apply(a, f) { f(a) }
+",
+        find_position_of("result").to_selection()
+    );
+}
+
+#[test]
 fn pattern_match_on_clause_variable_with_label() {
     assert_code_action!(
         PATTERN_MATCH_ON_VARIABLE,

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__pattern_match_on_variable_defined_inside_anonymous_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__pattern_match_on_variable_defined_inside_anonymous_function.snap
@@ -1,0 +1,29 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn main() {\n  let outcome = apply(#(Ok(1), Nil), fn(pair) {\n    let #(result, nil) = pair\n  })\n}\n\nfn apply(a, f) { f(a) }\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  let outcome = apply(#(Ok(1), Nil), fn(pair) {
+    let #(result, nil) = pair
+          ↑                  
+  })
+}
+
+fn apply(a, f) { f(a) }
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  let outcome = apply(#(Ok(1), Nil), fn(pair) {
+    let #(result, nil) = pair
+    case result {
+      Ok(value) -> todo
+      Error(value) -> todo
+    }
+  })
+}
+
+fn apply(a, f) { f(a) }


### PR DESCRIPTION
This PR fixes #5648 

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
