### PR TITLE
fix: switch to gen-lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,12 +339,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -804,7 +798,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "block2",
  "libc",
  "objc2",
@@ -1095,6 +1089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-lsp-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4552cb20fa322e0ebc35c2bbbe3eed8ace907bbcedc92aace7a325c9064b80b"
+dependencies = [
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1160,7 @@ dependencies = [
  "fs_extra",
  "fslock",
  "futures",
+ "gen-lsp-types",
  "gleam-core",
  "gleam-language-server",
  "hexpm",
@@ -1166,7 +1172,6 @@ dependencies = [
  "insta",
  "itertools",
  "lsp-server",
- "lsp-types",
  "opener",
  "pretty_assertions",
  "pubgrub",
@@ -1207,6 +1212,7 @@ dependencies = [
  "ecow",
  "flate2",
  "futures",
+ "gen-lsp-types",
  "globset",
  "hexpm",
  "http",
@@ -1216,7 +1222,6 @@ dependencies = [
  "insta",
  "itertools",
  "lsp-server",
- "lsp-types",
  "num-bigint",
  "num-traits",
  "pathdiff",
@@ -1251,13 +1256,13 @@ dependencies = [
  "camino",
  "debug-ignore",
  "ecow",
+ "gen-lsp-types",
  "gleam-core",
  "hexpm",
  "im",
  "insta",
  "itertools",
  "lsp-server",
- "lsp-types",
  "serde",
  "serde_json",
  "strum",
@@ -1916,7 +1921,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
  "redox_syscall",
 ]
@@ -1966,19 +1971,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "lsp-types"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -2060,7 +2052,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2483,7 +2475,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "memchr",
  "pulldown-cmark-escape",
  "unicase",
@@ -2655,7 +2647,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2847,7 +2839,7 @@ version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3000,7 +2992,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3105,17 +3097,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3710,7 +3691,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -4325,7 +4306,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ members = [
   "test-output",
   "test-package-compiler",
   "test-project-compiler",
-  "language-server",
   "hexpm",
 ]
 
@@ -52,7 +51,7 @@ debug-ignore = "1"
 base16 = "0"
 # Language server protocol server plumbing
 lsp-server = "0"
-lsp-types = "=0.95.1"
+lsp-types = { package = "gen-lsp-types", version = "0.5.0", features = ["url"] }
 # Compact clone-on-write vector & string type
 ecow = "0"
 # Drop in replacement for std::path but with only utf-8

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -30,8 +30,8 @@ use gleam_core::{
 use im::HashMap;
 use itertools::Itertools;
 use lsp_types::{
-    CodeAction, CodeActionKind, CodeActionParams, CreateFile, CreateFileOptions,
-    DocumentChangeOperation, DocumentChanges, Position, Range, ResourceOp, TextEdit, Url,
+    CodeAction, CodeActionKind, CodeActionParams, CreateFile, CreateFileOptions, DocumentChange,
+    Position, Range, TextEdit, Uri as Url,
 };
 use vec1::{Vec1, vec1};
 
@@ -66,6 +66,7 @@ impl CodeActionBuilder {
                 is_preferred: None,
                 disabled: None,
                 data: None,
+                tags: None,
             },
         }
     }
@@ -85,7 +86,7 @@ impl CodeActionBuilder {
         self
     }
 
-    pub fn document_changes(mut self, changes: DocumentChanges) -> Self {
+    pub fn document_changes(mut self, changes: Vec<DocumentChange>) -> Self {
         let mut edit = self.action.edit.take().unwrap_or_default();
 
         edit.document_changes = Some(changes);
@@ -271,7 +272,7 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
 
         let mut actions = vec![];
         CodeActionBuilder::new("Remove redundant tuples")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut actions);
@@ -431,7 +432,7 @@ impl<'ast> ast::visit::Visit<'ast> for LetAssertToCase<'_> {
         let uri = &self.params.text_document.uri;
 
         CodeActionBuilder::new("Convert to case")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(uri.clone(), vec![TextEdit { range, new_text }])
             .preferred(false)
             .push_to(&mut self.actions);
@@ -613,7 +614,7 @@ pub fn code_action_inexhaustive_let_to_case(
         text_edits.replace(*location, new_text);
 
         CodeActionBuilder::new("Convert to case")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(uri.clone(), text_edits.edits)
             .preferred(true)
             .push_to(actions);
@@ -703,7 +704,7 @@ impl<'a> UseLabelShorthandSyntax<'a> {
         }
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Use label shorthand syntax")
-            .kind(CodeActionKind::REFACTOR)
+            .kind(CodeActionKind::Refactor)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -896,7 +897,7 @@ impl<'a> FillInMissingLabelledArgs<'a> {
 
             let mut action = Vec::with_capacity(1);
             CodeActionBuilder::new("Fill labels")
-                .kind(CodeActionKind::QUICKFIX)
+                .kind(CodeActionKind::QuickFix)
                 .changes(self.params.text_document.uri.clone(), self.edits.edits)
                 .preferred(true)
                 .push_to(&mut action);
@@ -1216,7 +1217,7 @@ pub fn code_action_import_module(
             };
 
             CodeActionBuilder::new(title)
-                .kind(CodeActionKind::QUICKFIX)
+                .kind(CodeActionKind::QuickFix)
                 .changes(uri.clone(), edits)
                 .preferred(true)
                 .push_to(actions);
@@ -1367,7 +1368,7 @@ pub fn code_action_add_missing_patterns(
         }
 
         CodeActionBuilder::new("Add missing patterns")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(uri.clone(), edits.edits)
             .preferred(true)
             .push_to(actions);
@@ -1574,7 +1575,7 @@ impl<'a> AddAnnotations<'a> {
         };
 
         CodeActionBuilder::new(title)
-            .kind(CodeActionKind::REFACTOR)
+            .kind(CodeActionKind::Refactor)
             .changes(uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(actions);
@@ -1615,7 +1616,7 @@ impl<'a> AnnotateTopLevelDefinitions<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Annotate all top level definitions")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -2005,7 +2006,7 @@ impl<'a> QualifiedToUnqualifiedImportSecondPass<'a> {
             "Unqualify {}.{}",
             self.qualified_constructor.used_name, self.qualified_constructor.constructor
         ))
-        .kind(CodeActionKind::REFACTOR)
+        .kind(CodeActionKind::Refactor)
         .changes(self.params.text_document.uri.clone(), self.edits.edits)
         .preferred(false)
         .push_to(&mut action);
@@ -2508,7 +2509,7 @@ impl<'a> UnqualifiedToQualifiedImportSecondPass<'a> {
             module_name,
             constructor.name,
         ))
-        .kind(CodeActionKind::REFACTOR)
+        .kind(CodeActionKind::Refactor)
         .changes(self.params.text_document.uri.clone(), self.edits.edits)
         .preferred(false)
         .push_to(&mut action);
@@ -2881,7 +2882,7 @@ impl<'a> ConvertFromUse<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Convert from `use`")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -3031,7 +3032,7 @@ impl<'a> ConvertToUse<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Convert to `use`")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -3318,7 +3319,7 @@ impl<'a> ExtractVariable<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Extract variable")
-            .kind(CodeActionKind::REFACTOR_EXTRACT)
+            .kind(CodeActionKind::RefactorExtract)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -4068,7 +4069,7 @@ impl<'a> ExtractConstant<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Extract constant")
-            .kind(CodeActionKind::REFACTOR_EXTRACT)
+            .kind(CodeActionKind::RefactorExtract)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -4259,7 +4260,7 @@ impl<'a> ExpandFunctionCapture<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Expand function capture")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -4572,7 +4573,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for GenerateDynamicDecoder<'ast, IO> {
         maybe_import(&mut self.edits, self.module, DECODE_MODULE);
 
         CodeActionBuilder::new("Generate dynamic decoder")
-            .kind(CodeActionKind::REFACTOR)
+            .kind(CodeActionKind::Refactor)
             .preferred(false)
             .changes(
                 self.params.text_document.uri.clone(),
@@ -5226,7 +5227,7 @@ fn {name}({record_name}: {type_}) -> {json_type} {{
         maybe_import(&mut self.edits, self.module, JSON_MODULE);
 
         CodeActionBuilder::new("Generate to-JSON function")
-            .kind(CodeActionKind::REFACTOR)
+            .kind(CodeActionKind::Refactor)
             .preferred(false)
             .changes(
                 self.params.text_document.uri.clone(),
@@ -5599,7 +5600,7 @@ impl<'a, IO> PatternMatchOnValue<'a, IO> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new(action_title)
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -6441,7 +6442,7 @@ impl<'a> GenerateFunction<'a> {
         };
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Generate function")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(uri, self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -6774,7 +6775,7 @@ impl<'a, IO> GenerateVariant<'a, IO> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Generate variant")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(variant_module, variant_edits)
             .preferred(true)
             .push_to(&mut action);
@@ -7346,7 +7347,7 @@ impl<'a> ConvertToFunctionCall<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Convert to function call")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -7478,7 +7479,7 @@ impl<'a> InlineVariable<'a> {
         self.edits.delete(location);
 
         CodeActionBuilder::new("Inline variable")
-            .kind(CodeActionKind::REFACTOR_INLINE)
+            .kind(CodeActionKind::RefactorInline)
             .changes(
                 self.params.text_document.uri.clone(),
                 std::mem::take(&mut self.edits.edits),
@@ -7716,7 +7717,7 @@ impl<'a> ConvertToPipe<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Convert to pipe")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -7945,7 +7946,7 @@ impl<'a> InterpolateString<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Interpolate string")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -8170,7 +8171,7 @@ impl<'a> FillUnusedFields<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Fill unused fields")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -8268,7 +8269,7 @@ impl<'a> RemoveEchos<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Remove all `echo`s from this module")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -8529,7 +8530,7 @@ impl<'a> WrapInBlock<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Wrap in block")
-            .kind(CodeActionKind::REFACTOR_EXTRACT)
+            .kind(CodeActionKind::RefactorExtract)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -8638,7 +8639,7 @@ impl<'a> FixBinaryOperation<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new(format!("Use `{}`", replacement.name()))
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -8721,7 +8722,7 @@ impl<'a> FixTruncatedBitArraySegment<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new(format!("Replace with `{replacement}`"))
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -8971,7 +8972,7 @@ impl<'a> RemoveUnusedImports<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Remove unused imports")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -9022,7 +9023,7 @@ impl<'a> RemoveBlock<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Remove block")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -9139,7 +9140,7 @@ impl<'a> RemovePrivateOpaque<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Remove opaque from private type")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -9476,7 +9477,7 @@ impl<'a> CollapseNestedCase<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Collapse nested case")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -9680,7 +9681,7 @@ impl<'a> RemoveUnreachableCaseClauses<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Remove unreachable clauses")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -9782,7 +9783,7 @@ impl<'a> RemoveRedundantRecordUpdate<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Remove redundant record update")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -9848,7 +9849,7 @@ impl<'a> AddOmittedLabels<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Add omitted labels")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -10305,7 +10306,7 @@ impl<'a> ExtractFunction<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Extract function")
-            .kind(CodeActionKind::REFACTOR_EXTRACT)
+            .kind(CodeActionKind::RefactorExtract)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -11326,7 +11327,7 @@ impl<'a> MergeCaseBranches<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Merge case branches")
-            .kind(CodeActionKind::REFACTOR_REWRITE)
+            .kind(CodeActionKind::RefactorRewrite)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(false)
             .push_to(&mut action);
@@ -11562,7 +11563,7 @@ impl<'a> AddMissingTypeParameter<'a> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Add missing type parameter")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -11659,7 +11660,7 @@ impl<'a> ReplaceUnderscoreWithType<'a> {
             .replace(location, format!("{}", printer.print_type(&type_)));
 
         CodeActionBuilder::new("Replace `_` with type")
-            .kind(CodeActionKind::QUICKFIX)
+            .kind(CodeActionKind::QuickFix)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
             .preferred(true)
             .push_to(&mut action);
@@ -11754,7 +11755,7 @@ impl<'a> WrapInAnonymousFunction<'a> {
                 .insert(target.location.end, format!("({arguments}) }}"));
 
             CodeActionBuilder::new("Wrap in anonymous function")
-                .kind(CodeActionKind::REFACTOR_REWRITE)
+                .kind(CodeActionKind::RefactorRewrite)
                 .changes(
                     self.params.text_document.uri.clone(),
                     self.edits.edits.drain(..).collect(),
@@ -11935,7 +11936,7 @@ impl<'a> UnwrapAnonymousFunction<'a> {
             });
 
             CodeActionBuilder::new("Remove anonymous function wrapper")
-                .kind(CodeActionKind::REFACTOR_REWRITE)
+                .kind(CodeActionKind::RefactorRewrite)
                 .changes(self.params.text_document.uri.clone(), edits.edits)
                 .push_to(&mut actions);
         }
@@ -12133,17 +12134,15 @@ impl<'a> CreateUnknownModule<'a> {
                 self.module.origin.folder_name(),
                 unknown_module.name
             ))
-            .kind(CodeActionKind::QUICKFIX)
-            .document_changes(DocumentChanges::Operations(vec![
-                DocumentChangeOperation::Op(ResourceOp::Create(CreateFile {
-                    uri,
-                    options: Some(CreateFileOptions {
-                        overwrite: Some(false),
-                        ignore_if_exists: Some(true),
-                    }),
-                    annotation_id: None,
-                })),
-            ]))
+            .kind(CodeActionKind::QuickFix)
+            .document_changes(vec![DocumentChange::CreateFile(CreateFile {
+                uri,
+                options: Some(CreateFileOptions {
+                    overwrite: Some(false),
+                    ignore_if_exists: Some(true),
+                }),
+                annotation_id: None,
+            })])
             .push_to(&mut actions);
         }
 

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use ecow::{EcoString, eco_format};
 use itertools::Itertools;
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionTextEdit,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionItemTextEdit,
     Documentation, MarkupContent, MarkupKind, Position, Range, TextDocumentPositionParams,
     TextEdit,
 };
@@ -208,7 +208,7 @@ impl CursorSurroundings {
     /// > This could also return `None` as sometimes no further edit is actually
     /// > needed!
     ///
-    fn to_text_edit(&self, new_text: String) -> Option<CompletionTextEdit> {
+    fn to_text_edit(&self, new_text: String) -> Option<CompletionItemTextEdit> {
         // We need to check if the new text we're adding could actually be
         // a simple addition in the middle of something that is already being
         // typed.
@@ -247,14 +247,14 @@ impl CursorSurroundings {
             // This is one of the cases (like the one in the example above) were
             // the label is a more complete version of the text surrounding the
             // cursor. So we replace the entire range.
-            Some(_) => Some(CompletionTextEdit::Edit(TextEdit {
+            Some(_) => Some(CompletionItemTextEdit::TextEdit(TextEdit {
                 range: self.surrounding_text_range,
                 new_text,
             })),
             // In all other cases the completion is never meant to replace text
             // that comes after the cursor.
             // We only replace what comes before it with the new text.
-            None => Some(CompletionTextEdit::Edit(TextEdit {
+            None => Some(CompletionItemTextEdit::TextEdit(TextEdit {
                 range: self.text_before_cursor_range,
                 new_text,
             })),
@@ -634,8 +634,8 @@ impl<'a, IO> Completer<'a, IO> {
             .iter()
             .map(|(name, _)| CompletionItem {
                 label: name.to_string(),
-                kind: Some(CompletionItemKind::MODULE),
-                text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                kind: Some(CompletionItemKind::Module),
+                text_edit: Some(CompletionItemTextEdit::TextEdit(TextEdit {
                     range: Range { start, end },
                     new_text: name.to_string(),
                 })),
@@ -682,7 +682,7 @@ impl<'a, IO> Completer<'a, IO> {
                 completions.push(CompletionItem {
                     label,
                     detail: Some("Type".into()),
-                    kind: Some(CompletionItemKind::CLASS),
+                    kind: Some(CompletionItemKind::Class),
                     sort_text,
                     ..Default::default()
                 });
@@ -920,31 +920,31 @@ impl<'a, IO> Completer<'a, IO> {
                     PreludeType::Bool => {
                         push_prelude_completion(
                             "True",
-                            CompletionItemKind::ENUM_MEMBER,
+                            CompletionItemKind::EnumMember,
                             type_::bool(),
                         );
                         push_prelude_completion(
                             "False",
-                            CompletionItemKind::ENUM_MEMBER,
+                            CompletionItemKind::EnumMember,
                             type_::bool(),
                         );
                     }
                     PreludeType::Nil => {
                         push_prelude_completion(
                             "Nil",
-                            CompletionItemKind::ENUM_MEMBER,
+                            CompletionItemKind::EnumMember,
                             type_::nil(),
                         );
                     }
                     PreludeType::Result => {
                         push_prelude_completion(
                             "Ok",
-                            CompletionItemKind::CONSTRUCTOR,
+                            CompletionItemKind::Constructor,
                             type_::result(type_::unbound_var(0), type_::unbound_var(0)),
                         );
                         push_prelude_completion(
                             "Error",
-                            CompletionItemKind::CONSTRUCTOR,
+                            CompletionItemKind::Constructor,
                             type_::result(type_::unbound_var(0), type_::unbound_var(0)),
                         );
                     }
@@ -1219,7 +1219,7 @@ impl<'a, IO> Completer<'a, IO> {
                 CompletionItem {
                     label,
                     detail,
-                    kind: Some(CompletionItemKind::FIELD),
+                    kind: Some(CompletionItemKind::Field),
                     sort_text,
                     ..Default::default()
                 }
@@ -1266,7 +1266,7 @@ impl<'a, IO> Completer<'a, IO> {
 
         CompletionItem {
             label: label.clone(),
-            kind: Some(CompletionItemKind::KEYWORD),
+            kind: Some(CompletionItemKind::Keyword),
             detail: None,
             label_details: None,
             documentation: None,
@@ -1298,11 +1298,11 @@ impl<'a, IO> Completer<'a, IO> {
         let type_ = Printer::new().pretty_print(&value.type_, 0);
 
         let kind = Some(match value.variant {
-            ValueConstructorVariant::LocalVariable { .. } => CompletionItemKind::VARIABLE,
-            ValueConstructorVariant::ModuleConstant { .. } => CompletionItemKind::CONSTANT,
-            ValueConstructorVariant::ModuleFn { .. } => CompletionItemKind::FUNCTION,
-            ValueConstructorVariant::Record { arity: 0, .. } => CompletionItemKind::ENUM_MEMBER,
-            ValueConstructorVariant::Record { .. } => CompletionItemKind::CONSTRUCTOR,
+            ValueConstructorVariant::LocalVariable { .. } => CompletionItemKind::Variable,
+            ValueConstructorVariant::ModuleConstant { .. } => CompletionItemKind::Constant,
+            ValueConstructorVariant::ModuleFn { .. } => CompletionItemKind::Function,
+            ValueConstructorVariant::Record { arity: 0, .. } => CompletionItemKind::EnumMember,
+            ValueConstructorVariant::Record { .. } => CompletionItemKind::Constructor,
         });
 
         let documentation = value.get_documentation().map(|documentation| {
@@ -1333,7 +1333,7 @@ impl<'a, IO> Completer<'a, IO> {
 
         CompletionItem {
             label: label.into(),
-            kind: Some(CompletionItemKind::FIELD),
+            kind: Some(CompletionItemKind::Field),
             detail: Some(type_),
             sort_text: Some(sort_text(CompletionKind::FieldAccessor, label, type_match)),
             ..Default::default()
@@ -1368,9 +1368,9 @@ fn type_completion(
     };
 
     let kind = Some(if type_.type_.is_variable() {
-        CompletionItemKind::VARIABLE
+        CompletionItemKind::Variable
     } else {
-        CompletionItemKind::CLASS
+        CompletionItemKind::Class
     });
 
     let completion_text = match type_completion_context {
@@ -1496,7 +1496,7 @@ impl<'a> LocalCompletion<'a> {
 
         CompletionItem {
             label: label.clone(),
-            kind: Some(CompletionItemKind::VARIABLE),
+            kind: Some(CompletionItemKind::Variable),
             detail: Some(type_),
             label_details: Some(CompletionItemLabelDetails {
                 detail: None,
@@ -1508,7 +1508,7 @@ impl<'a> LocalCompletion<'a> {
                 &label,
                 type_match,
             )),
-            text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+            text_edit: Some(CompletionItemTextEdit::TextEdit(TextEdit {
                 range: insert_range,
                 new_text: label.clone(),
             })),

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -26,9 +26,9 @@ use itertools::Itertools;
 use lsp::CodeAction;
 use lsp_server::ResponseError;
 use lsp_types::{
-    self as lsp, DocumentSymbol, FoldingRange, FoldingRangeKind, Hover, HoverContents,
-    MarkedString, Position, PrepareRenameResponse, Range, SignatureHelp, SymbolKind, SymbolTag,
-    TextEdit, Url, WorkspaceEdit,
+    self as lsp, Contents, DocumentSymbol, FoldingRange, FoldingRangeKind, Hover, MarkedString,
+    MarkupContent, Position, PrepareRenameResult, Range, SignatureHelp, SymbolKind, SymbolTag,
+    TextEdit, Uri as Url, WorkspaceEdit,
 };
 use std::{collections::HashSet, sync::Arc};
 
@@ -193,7 +193,7 @@ where
 
     pub fn goto_definition(
         &mut self,
-        params: lsp::GotoDefinitionParams,
+        params: lsp::DefinitionParams,
     ) -> Response<Option<lsp::Location>> {
         self.respond(|this| {
             let params = params.text_document_position_params;
@@ -214,7 +214,7 @@ where
 
     pub(crate) fn goto_type_definition(
         &mut self,
-        params: lsp_types::GotoDefinitionParams,
+        params: lsp_types::TypeDefinitionParams,
     ) -> Response<Vec<lsp::Location>> {
         self.respond(|this| {
             let params = params.text_document_position_params;
@@ -571,7 +571,7 @@ where
                             .print_type(&get_function_type(function))
                             .to_string(),
                     ),
-                    kind: SymbolKind::FUNCTION,
+                    kind: SymbolKind::Function,
                     tags: make_deprecated_symbol_tag(&function.deprecation),
                     deprecated: None,
                     range: src_span_to_lsp_range(full_function_span, &line_numbers),
@@ -603,7 +603,7 @@ where
                             .print_type_without_aliases(&alias.type_)
                             .to_string(),
                     ),
-                    kind: SymbolKind::CLASS,
+                    kind: SymbolKind::Class,
                     tags: make_deprecated_symbol_tag(&alias.deprecation),
                     deprecated: None,
                     range: src_span_to_lsp_range(full_alias_span, &line_numbers),
@@ -643,7 +643,7 @@ where
                             .print_type(&constant.type_)
                             .to_string(),
                     ),
-                    kind: SymbolKind::CONSTANT,
+                    kind: SymbolKind::Constant,
                     tags: make_deprecated_symbol_tag(&constant.deprecation),
                     deprecated: None,
                     range: src_span_to_lsp_range(full_constant_span, &line_numbers),
@@ -737,25 +737,28 @@ where
 
     pub fn prepare_rename(
         &mut self,
-        params: lsp::TextDocumentPositionParams,
-    ) -> Response<Option<PrepareRenameResponse>> {
+        params: lsp::PrepareRenameParams,
+    ) -> Response<Option<PrepareRenameResult>> {
         self.respond(|this| {
-            let (lines, found) = match this.node_at_position(&params) {
+            let (lines, found) = match this.node_at_position(&params.text_document_position_params)
+            {
                 Some(value) => value,
                 None => return Ok(None),
             };
 
-            let Some(current_module) = this.module_for_uri(&params.text_document.uri) else {
+            let Some(current_module) =
+                this.module_for_uri(&params.text_document_position_params.text_document.uri)
+            else {
                 return Ok(None);
             };
 
             let success_response = |location| {
-                Some(PrepareRenameResponse::Range(src_span_to_lsp_range(
+                Some(PrepareRenameResult::Range(src_span_to_lsp_range(
                     location, &lines,
                 )))
             };
 
-            let byte_index = lines.byte_index(params.position);
+            let byte_index = lines.byte_index(params.text_document_position_params.position);
 
             let referenced = reference_for_ast_node(found, &current_module.name);
 
@@ -813,7 +816,7 @@ where
         params: lsp::RenameParams,
     ) -> Response<Result<Option<WorkspaceEdit>, ResponseError>> {
         self.respond(|this| {
-            let position = &params.text_document_position;
+            let position = &params.text_document_position_params;
 
             let (lines, found) = match this.node_at_position(position) {
                 Some(value) => value,
@@ -913,7 +916,7 @@ where
         params: lsp::ReferenceParams,
     ) -> Response<Option<Vec<lsp::Location>>> {
         self.respond(|this| {
-            let position = &params.text_document_position;
+            let position = &params.text_document_position_params;
 
             let (lines, found) = match this.node_at_position(position) {
                 Some(value) => value,
@@ -1120,7 +1123,10 @@ Unused labelled fields:
                     };
 
                     Some(Hover {
-                        contents: HoverContents::Scalar(MarkedString::from_markdown(content)),
+                        contents: Contents::MarkupContent(MarkupContent {
+                            value: content,
+                            kind: lsp_types::MarkupKind::Markdown,
+                        }),
                         range,
                     })
                 }
@@ -1343,7 +1349,7 @@ fn custom_type_symbol(
                             .print_type(&argument.type_)
                             .to_string(),
                     ),
-                    kind: SymbolKind::FIELD,
+                    kind: SymbolKind::Field,
                     tags: None,
                     deprecated: None,
                     range: src_span_to_lsp_range(full_arg_span, line_numbers),
@@ -1373,9 +1379,9 @@ fn custom_type_symbol(
                 name: constructor.name.to_string(),
                 detail: None,
                 kind: if constructor.arguments.is_empty() {
-                    SymbolKind::ENUM_MEMBER
+                    SymbolKind::EnumMember
                 } else {
-                    SymbolKind::CONSTRUCTOR
+                    SymbolKind::Constructor
                 },
                 tags: make_deprecated_symbol_tag(&constructor.deprecation),
                 deprecated: None,
@@ -1411,7 +1417,7 @@ fn custom_type_symbol(
     DocumentSymbol {
         name: type_.name.to_string(),
         detail: None,
-        kind: SymbolKind::CLASS,
+        kind: SymbolKind::Class,
         tags: make_deprecated_symbol_tag(&type_.deprecation),
         deprecated: None,
         range: src_span_to_lsp_range(full_type_span, line_numbers),
@@ -1436,7 +1442,7 @@ fn hover_for_pattern(pattern: &TypedPattern, line_numbers: LineNumbers, module: 
 {documentation}"
     );
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(pattern.location(), &line_numbers)),
     }
 }
@@ -1472,7 +1478,7 @@ fn hover_for_function_head(
 {documentation}"
     );
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(fun.location, &line_numbers)),
     }
 }
@@ -1485,7 +1491,7 @@ fn hover_for_function_argument(
     let type_ = Printer::new(&module.ast.names).print_type(&argument.type_);
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(argument.location, &line_numbers)),
     }
 }
@@ -1513,7 +1519,7 @@ fn hover_for_annotation(
 {documentation}"
     );
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(location, &line_numbers)),
     }
 }
@@ -1527,7 +1533,7 @@ fn hover_for_label(
     let type_ = Printer::new(&module.ast.names).print_type(&type_);
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(location, &line_numbers)),
     }
 }
@@ -1546,7 +1552,7 @@ fn hover_for_module_constant(
         .unwrap_or(&empty_str);
     let contents = format!("```gleam\n{type_}\n```\n{documentation}");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(constant.location, &line_numbers)),
     }
 }
@@ -1559,7 +1565,7 @@ fn hover_for_constant(
     let type_ = Printer::new(&module.ast.names).print_type(&constant.type_());
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(constant.location(), &line_numbers)),
     }
 }
@@ -1572,7 +1578,7 @@ fn hover_for_clause_guard(
     let type_ = Printer::new(&module.ast.names).print_type(&guard.type_());
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(guard.location(), &line_numbers)),
     }
 }
@@ -1585,7 +1591,7 @@ fn hover_for_string_prefix_pattern_variable(
     let type_ = Printer::new(&module.ast.names).print_type(&type_::string());
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(location, lines)),
     }
 }
@@ -1613,7 +1619,7 @@ fn hover_for_expression(
 {documentation}{link_section}"
     );
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(expression.location(), &line_numbers)),
     }
 }
@@ -1641,7 +1647,7 @@ fn hover_for_imported_value(
 {documentation}{link_section}"
     );
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(*location, &line_numbers)),
     }
 }
@@ -1669,7 +1675,7 @@ fn hover_for_module(
 {link_section}",
     );
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(location, line_numbers)),
     }
 }
@@ -1684,7 +1690,7 @@ fn hover_for_custom_type(type_: &CustomType<Arc<Type>>, line_numbers: LineNumber
 
     let contents = format!("```gleam\n{name}\n```\n{documentation}");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(type_.full_location(), &line_numbers)),
     }
 }
@@ -1719,7 +1725,7 @@ fn hover_for_constructor(
 
     let contents = format!("```gleam\n{constructor_doc}\n```\n{documentation}");
     Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        contents: Contents::MarkedString(MarkedString::String(contents)),
         range: Some(src_span_to_lsp_range(constructor.location, &line_numbers)),
     }
 }
@@ -1849,7 +1855,7 @@ fn code_action_unused_values(
         };
 
         CodeActionBuilder::new("Assign unused Result value to `_`")
-            .kind(lsp_types::CodeActionKind::QUICKFIX)
+            .kind(lsp_types::CodeActionKind::QuickFix)
             .changes(uri.clone(), vec![edit])
             .preferred(true)
             .push_to(actions);
@@ -1912,7 +1918,7 @@ fn code_action_fix_names(
             };
 
             CodeActionBuilder::new(format!("Rename to {correction}"))
-                .kind(lsp_types::CodeActionKind::QUICKFIX)
+                .kind(lsp_types::CodeActionKind::QuickFix)
                 .changes(uri.clone(), vec![edit])
                 .preferred(true)
                 .push_to(actions);
@@ -2011,5 +2017,5 @@ fn get_doc_marker_position(content_pos: u32) -> u32 {
 fn make_deprecated_symbol_tag(deprecation: &Deprecation) -> Option<Vec<SymbolTag>> {
     deprecation
         .is_deprecated()
-        .then(|| vec![SymbolTag::DEPRECATED])
+        .then(|| vec![SymbolTag::Deprecated])
 }

--- a/language-server/src/lib.rs
+++ b/language-server/src/lib.rs
@@ -75,7 +75,7 @@ use gleam_core::{
     Result, ast::SrcSpan, build::Target, line_numbers::LineNumbers, manifest::Manifest,
     paths::ProjectPaths,
 };
-use lsp_types::{Position, Range, TextEdit, Url};
+use lsp_types::{Position, Range, TextEdit, Uri as Url};
 use std::any::Any;
 
 #[derive(Debug)]

--- a/language-server/src/messages.rs
+++ b/language-server/src/messages.rs
@@ -1,16 +1,11 @@
 use camino::Utf8PathBuf;
-use lsp::{
-    notification::{DidChangeWatchedFiles, DidOpenTextDocument},
-    request::GotoDefinition,
-};
+use lsp::{DefinitionRequest, DidChangeWatchedFilesNotification, DidOpenTextDocumentNotification};
 use lsp_types::{
-    self as lsp,
-    notification::{DidChangeTextDocument, DidCloseTextDocument, DidSaveTextDocument},
-    request::{
-        CodeActionRequest, Completion, DocumentSymbolRequest, FoldingRangeRequest, Formatting,
-        GotoTypeDefinition, HoverRequest, PrepareRenameRequest, References, Rename,
-        SignatureHelpRequest,
-    },
+    self as lsp, CodeActionRequest, CompletionRequest, DidChangeTextDocumentNotification,
+    DidCloseTextDocumentNotification, DidSaveTextDocumentNotification, DocumentFormattingRequest,
+    DocumentSymbolRequest, FoldingRangeRequest, HoverRequest, PrepareRenameRequest,
+    ReferencesRequest, RenameRequest, SignatureHelpRequest, TextDocumentContentChangeEvent,
+    TypeDefinitionRequest,
 };
 use std::time::Duration;
 
@@ -24,14 +19,14 @@ pub enum Message {
 pub enum Request {
     Format(lsp::DocumentFormattingParams),
     Hover(lsp::HoverParams),
-    GoToDefinition(lsp::GotoDefinitionParams),
-    GoToTypeDefinition(lsp::GotoDefinitionParams),
+    GoToDefinition(lsp::DefinitionParams),
+    GoToTypeDefinition(lsp::TypeDefinitionParams),
     Completion(lsp::CompletionParams),
     CodeAction(lsp::CodeActionParams),
     SignatureHelp(lsp::SignatureHelpParams),
     DocumentSymbol(lsp::DocumentSymbolParams),
     FoldingRange(lsp::FoldingRangeParams),
-    PrepareRename(lsp::TextDocumentPositionParams),
+    PrepareRename(lsp::PrepareRenameParams),
     Rename(lsp::RenameParams),
     FindReferences(lsp::ReferenceParams),
 }
@@ -41,7 +36,7 @@ impl Request {
         let id = request.id.clone();
         match request.method.as_str() {
             "textDocument/formatting" => {
-                let params = cast_request::<Formatting>(request);
+                let params = cast_request::<DocumentFormattingRequest>(request);
                 Some(Message::Request(id, Request::Format(params)))
             }
             "textDocument/hover" => {
@@ -49,11 +44,11 @@ impl Request {
                 Some(Message::Request(id, Request::Hover(params)))
             }
             "textDocument/definition" => {
-                let params = cast_request::<GotoDefinition>(request);
+                let params = cast_request::<DefinitionRequest>(request);
                 Some(Message::Request(id, Request::GoToDefinition(params)))
             }
             "textDocument/completion" => {
-                let params = cast_request::<Completion>(request);
+                let params = cast_request::<CompletionRequest>(request);
                 Some(Message::Request(id, Request::Completion(params)))
             }
             "textDocument/codeAction" => {
@@ -73,7 +68,7 @@ impl Request {
                 Some(Message::Request(id, Request::FoldingRange(params)))
             }
             "textDocument/rename" => {
-                let params = cast_request::<Rename>(request);
+                let params = cast_request::<RenameRequest>(request);
                 Some(Message::Request(id, Request::Rename(params)))
             }
             "textDocument/prepareRename" => {
@@ -81,11 +76,11 @@ impl Request {
                 Some(Message::Request(id, Request::PrepareRename(params)))
             }
             "textDocument/typeDefinition" => {
-                let params = cast_request::<GotoTypeDefinition>(request);
+                let params = cast_request::<TypeDefinitionRequest>(request);
                 Some(Message::Request(id, Request::GoToTypeDefinition(params)))
             }
             "textDocument/references" => {
-                let params = cast_request::<References>(request);
+                let params = cast_request::<ReferencesRequest>(request);
                 Some(Message::Request(id, Request::FindReferences(params)))
             }
             _ => None,
@@ -113,7 +108,7 @@ impl Notification {
     fn extract(notification: lsp_server::Notification) -> Option<Message> {
         match notification.method.as_str() {
             "textDocument/didOpen" => {
-                let params = cast_notification::<DidOpenTextDocument>(notification);
+                let params = cast_notification::<DidOpenTextDocumentNotification>(notification);
                 let notification = Notification::SourceFileOpened {
                     path: super::path(&params.text_document.uri),
                     text: params.text_document.text,
@@ -121,29 +116,34 @@ impl Notification {
                 Some(Message::Notification(notification))
             }
             "textDocument/didChange" => {
-                let params = cast_notification::<DidChangeTextDocument>(notification);
+                let params = cast_notification::<DidChangeTextDocumentNotification>(notification);
+                let TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(change) =
+                    params.content_changes.into_iter().next_back()?
+                else {
+                    return None;
+                };
                 let notification = Notification::SourceFileChangedInMemory {
-                    path: super::path(&params.text_document.uri),
-                    text: params.content_changes.into_iter().next_back()?.text,
+                    path: super::path(&params.text_document.text_document_identifier.uri),
+                    text: change.text,
                 };
                 Some(Message::Notification(notification))
             }
             "textDocument/didSave" => {
-                let params = cast_notification::<DidSaveTextDocument>(notification);
+                let params = cast_notification::<DidSaveTextDocumentNotification>(notification);
                 let notification = Notification::SourceFileSaved {
                     path: super::path(&params.text_document.uri),
                 };
                 Some(Message::Notification(notification))
             }
             "textDocument/didClose" => {
-                let params = cast_notification::<DidCloseTextDocument>(notification);
+                let params = cast_notification::<DidCloseTextDocumentNotification>(notification);
                 let notification = Notification::SourceFileClosed {
                     path: super::path(&params.text_document.uri),
                 };
                 Some(Message::Notification(notification))
             }
             "workspace/didChangeWatchedFiles" => {
-                let params = cast_notification::<DidChangeWatchedFiles>(notification);
+                let params = cast_notification::<DidChangeWatchedFilesNotification>(notification);
                 let notification = Notification::ConfigFileChanged {
                     path: super::path(&params.changes.into_iter().next_back()?.uri),
                 };
@@ -263,19 +263,19 @@ impl MessageBuffer {
 
 fn cast_request<R>(request: lsp_server::Request) -> R::Params
 where
-    R: lsp::request::Request,
+    R: lsp::Request,
     R::Params: serde::de::DeserializeOwned,
 {
-    let (_, params) = request.extract(R::METHOD).expect("cast request");
+    let (_, params) = request.extract(R::METHOD.as_str()).expect("cast request");
     params
 }
 
 fn cast_notification<N>(notification: lsp_server::Notification) -> N::Params
 where
-    N: lsp::notification::Notification,
+    N: lsp::Notification,
     N::Params: serde::de::DeserializeOwned,
 {
     notification
-        .extract::<N::Params>(N::METHOD)
+        .extract::<N::Params>(N::METHOD.as_str())
         .expect("cast notification")
 }

--- a/language-server/src/progress.rs
+++ b/language-server/src/progress.rs
@@ -1,7 +1,7 @@
 use debug_ignore::DebugIgnore;
 use lsp_types::{
-    InitializeParams, NumberOrString, ProgressParams, ProgressParamsValue, WorkDoneProgress,
-    WorkDoneProgressBegin, WorkDoneProgressCreateParams, WorkDoneProgressEnd,
+    InitializeParams, LspAny, ProgressParams, ProgressToken, WorkDoneProgressBegin,
+    WorkDoneProgressCreateParams, WorkDoneProgressEnd,
 };
 
 const DOWNLOADING_TOKEN: &str = "downloading-dependencies";
@@ -35,10 +35,10 @@ impl<'a> ConnectionProgressReporter<'a> {
         }
     }
 
-    fn send_notification(&self, token: &str, work_done: WorkDoneProgress) {
+    fn send_notification(&self, token: &str, work_done: LspAny) {
         let params = ProgressParams {
-            token: NumberOrString::String(token.to_string()),
-            value: ProgressParamsValue::WorkDone(work_done),
+            token: ProgressToken::String(token.to_string()),
+            value: work_done,
         };
         let notification = lsp_server::Notification {
             method: "$/progress".into(),
@@ -72,22 +72,24 @@ impl ProgressReporter for ConnectionProgressReporter<'_> {
     }
 }
 
-fn end_message() -> WorkDoneProgress {
-    WorkDoneProgress::End(WorkDoneProgressEnd { message: None })
+fn end_message() -> LspAny {
+    serde_json::to_value(WorkDoneProgressEnd { message: None })
+        .expect("Failed to serialize WorkDoneProgressEnd")
 }
 
-fn begin_message(title: &str) -> WorkDoneProgress {
-    WorkDoneProgress::Begin(WorkDoneProgressBegin {
+fn begin_message(title: &str) -> LspAny {
+    serde_json::to_value(WorkDoneProgressBegin {
         title: title.into(),
         cancellable: Some(false),
         message: None,
         percentage: None,
     })
+    .expect("Failed to serialize WorkDoneProgressBegin")
 }
 
 fn create_token(token: &str, connection: &lsp_server::Connection) {
     let params = WorkDoneProgressCreateParams {
-        token: NumberOrString::String(token.into()),
+        token: ProgressToken::String(token.into()),
     };
     let request = lsp_server::Request {
         id: format!("create-token--{token}").into(),

--- a/language-server/src/rename.rs
+++ b/language-server/src/rename.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use ecow::EcoString;
 use lsp_server::ResponseError;
-use lsp_types::{Range, RenameParams, TextEdit, Url, WorkspaceEdit};
+use lsp_types::{Range, RenameParams, TextEdit, Uri as Url, WorkspaceEdit};
 
 use gleam_core::{
     analyse::name,
@@ -76,7 +76,11 @@ pub fn rename_local_variable(
         return RenameOutcome::InvalidName { name: new_name };
     }
 
-    let uri = params.text_document_position.text_document.uri.clone();
+    let uri = params
+        .text_document_position_params
+        .text_document
+        .uri
+        .clone();
     let mut edits = TextEdits::new(line_numbers);
 
     let references =
@@ -292,7 +296,11 @@ fn alias_references_in_module(
 
     RenameOutcome::Renamed {
         edit: workspace_edit(
-            params.text_document_position.text_document.uri.clone(),
+            params
+                .text_document_position_params
+                .text_document
+                .uri
+                .clone(),
             edits.edits,
         ),
     }
@@ -342,7 +350,11 @@ pub fn rename_module_alias(
         return RenameOutcome::InvalidName { name: new_name };
     }
 
-    let uri = params.text_document_position.text_document.uri.clone();
+    let uri = params
+        .text_document_position_params
+        .text_document
+        .uri
+        .clone();
     let mut edits = TextEdits::new(line_numbers);
 
     let mut finder = reference::FindModuleNameReferences {

--- a/language-server/src/server.rs
+++ b/language-server/src/server.rs
@@ -18,8 +18,8 @@ use gleam_core::{
 };
 use lsp_server::ResponseError;
 use lsp_types::{
-    self as lsp, HoverProviderCapability, InitializeParams, Position, PublishDiagnosticsParams,
-    Range, RenameOptions, TextEdit, Url,
+    self as lsp, InitializeParams, Position, PublishDiagnosticsParams, Range, RenameOptions,
+    TextEdit, Uri as Url,
 };
 use serde_json::Value as Json;
 use std::collections::{HashMap, HashSet};
@@ -224,9 +224,9 @@ where
     fn publish_messages(&self, messages: Vec<Diagnostic>) {
         for message in messages {
             let params = lsp::ShowMessageParams {
-                typ: match message.level {
-                    Level::Error => lsp::MessageType::ERROR,
-                    Level::Warning => lsp::MessageType::WARNING,
+                kind: match message.level {
+                    Level::Error => lsp::MessageType::Error,
+                    Level::Warning => lsp::MessageType::Warning,
                 },
                 message: message.text,
             };
@@ -352,7 +352,7 @@ where
 
     fn goto_definition(
         &mut self,
-        params: lsp::GotoDefinitionParams,
+        params: lsp::DefinitionParams,
     ) -> (Result<Json, ResponseError>, Feedback) {
         let path = super::path(&params.text_document_position_params.text_document.uri);
         self.respond_with_engine(path, |engine| engine.goto_definition(params))
@@ -360,7 +360,7 @@ where
 
     fn goto_type_definition(
         &mut self,
-        params: lsp_types::GotoDefinitionParams,
+        params: lsp_types::TypeDefinitionParams,
     ) -> (Result<Json, ResponseError>, Feedback) {
         let path = super::path(&params.text_document_position_params.text_document.uri);
         self.respond_with_engine(path, |engine| engine.goto_type_definition(params))
@@ -370,14 +370,14 @@ where
         &mut self,
         params: lsp::CompletionParams,
     ) -> (Result<Json, ResponseError>, Feedback) {
-        let path = super::path(&params.text_document_position.text_document.uri);
+        let path = super::path(&params.text_document_position_params.text_document.uri);
 
         let src = match self.io.read(&path) {
             Ok(src) => src.into(),
             Err(error) => return self.path_error_response(path, error),
         };
         self.respond_with_engine(path, |engine| {
-            engine.completion(params.text_document_position, src)
+            engine.completion(params.text_document_position_params, src)
         })
     }
 
@@ -415,14 +415,14 @@ where
 
     fn prepare_rename(
         &mut self,
-        params: lsp::TextDocumentPositionParams,
+        params: lsp::PrepareRenameParams,
     ) -> (Result<Json, ResponseError>, Feedback) {
-        let path = super::path(&params.text_document.uri);
+        let path = super::path(&params.text_document_position_params.text_document.uri);
         self.respond_with_engine(path, |engine| engine.prepare_rename(params))
     }
 
     fn rename(&mut self, params: lsp::RenameParams) -> (Result<Json, ResponseError>, Feedback) {
-        let path = super::path(&params.text_document_position.text_document.uri);
+        let path = super::path(&params.text_document_position_params.text_document.uri);
         self.fallible_respond_with_engine(
             path,
             |engine: &mut LanguageServerEngine<IO, ConnectionProgressReporter<'a>>| {
@@ -435,7 +435,7 @@ where
         &mut self,
         params: lsp_types::ReferenceParams,
     ) -> (Result<Json, ResponseError>, Feedback) {
-        let path = super::path(&params.text_document_position.text_document.uri);
+        let path = super::path(&params.text_document_position_params.text_document.uri);
         self.respond_with_engine(path, |engine| engine.find_references(params))
     }
 
@@ -496,21 +496,23 @@ where
 
 fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializeParams {
     let server_capabilities = lsp::ServerCapabilities {
-        text_document_sync: Some(lsp::TextDocumentSyncCapability::Options(
+        text_document_sync: Some(
             lsp::TextDocumentSyncOptions {
                 open_close: Some(true),
-                change: Some(lsp::TextDocumentSyncKind::FULL),
+                change: Some(lsp::TextDocumentSyncKind::Full),
                 will_save: None,
                 will_save_wait_until: None,
-                save: Some(lsp::TextDocumentSyncSaveOptions::SaveOptions(
+                save: Some(
                     lsp::SaveOptions {
                         include_text: Some(false),
-                    },
-                )),
-            },
-        )),
+                    }
+                    .into(),
+                ),
+            }
+            .into(),
+        ),
         selection_range_provider: None,
-        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        hover_provider: Some(true.into()),
         completion_provider: Some(lsp::CompletionOptions {
             resolve_provider: None,
             trigger_characters: Some(vec![".".into()]),
@@ -527,27 +529,30 @@ fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializePa
                 work_done_progress: None,
             },
         }),
-        definition_provider: Some(lsp::OneOf::Left(true)),
-        type_definition_provider: Some(lsp::TypeDefinitionProviderCapability::Simple(true)),
+        definition_provider: Some(true.into()),
+        type_definition_provider: Some(true.into()),
         implementation_provider: None,
-        references_provider: Some(lsp::OneOf::Left(true)),
+        references_provider: Some(true.into()),
         document_highlight_provider: None,
-        document_symbol_provider: Some(lsp::OneOf::Left(true)),
+        document_symbol_provider: Some(true.into()),
         workspace_symbol_provider: None,
-        code_action_provider: Some(lsp::CodeActionProviderCapability::Simple(true)),
+        code_action_provider: Some(true.into()),
         code_lens_provider: None,
-        document_formatting_provider: Some(lsp::OneOf::Left(true)),
+        document_formatting_provider: Some(true.into()),
         document_range_formatting_provider: None,
         document_on_type_formatting_provider: None,
-        rename_provider: Some(lsp::OneOf::Right(RenameOptions {
-            prepare_provider: Some(true),
-            work_done_progress_options: lsp::WorkDoneProgressOptions {
-                work_done_progress: None,
-            },
-        })),
+        rename_provider: Some(
+            RenameOptions {
+                prepare_provider: Some(true),
+                work_done_progress_options: lsp::WorkDoneProgressOptions {
+                    work_done_progress: None,
+                },
+            }
+            .into(),
+        ),
         document_link_provider: None,
         color_provider: None,
-        folding_range_provider: Some(lsp::FoldingRangeProviderCapability::Simple(true)),
+        folding_range_provider: Some(true.into()),
         declaration_provider: None,
         execute_command_provider: None,
         workspace: None,
@@ -560,6 +565,9 @@ fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializePa
         inline_value_provider: None,
         inlay_hint_provider: None,
         diagnostic_provider: None,
+        type_hierarchy_provider: None,
+        notebook_document_sync: None,
+        inline_completion_provider: None,
     };
     let server_capabilities_json =
         serde_json::to_value(server_capabilities).expect("server_capabilities_serde");
@@ -573,8 +581,8 @@ fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializePa
 
 fn diagnostic_to_lsp(diagnostic: Diagnostic) -> Vec<lsp::Diagnostic> {
     let severity = match diagnostic.level {
-        Level::Error => lsp::DiagnosticSeverity::ERROR,
-        Level::Warning => lsp::DiagnosticSeverity::WARNING,
+        Level::Error => lsp::DiagnosticSeverity::Error,
+        Level::Warning => lsp::DiagnosticSeverity::Warning,
     };
     let hint = diagnostic.hint;
     let mut text = diagnostic.title;
@@ -626,7 +634,7 @@ fn diagnostic_to_lsp(diagnostic: Diagnostic) -> Vec<lsp::Diagnostic> {
     match hint {
         Some(hint) => {
             let hint = lsp::Diagnostic {
-                severity: Some(lsp::DiagnosticSeverity::HINT),
+                severity: Some(lsp::DiagnosticSeverity::Hint),
                 message: hint,
                 // Some editors require this kind of "link" to group diagnostics.
                 // For example, in Zed "go to next diagnostic" would move you from

--- a/language-server/src/signature_help.rs
+++ b/language-server/src/signature_help.rs
@@ -5,8 +5,8 @@ use std::{
 
 use ecow::EcoString;
 use lsp_types::{
-    Documentation, MarkupContent, MarkupKind, ParameterInformation, ParameterLabel, SignatureHelp,
-    SignatureInformation,
+    ActiveParameter, Documentation, MarkupContent, MarkupKind, ParameterInformation,
+    ParameterInformationLabel, SignatureHelp, SignatureInformation,
 };
 
 use gleam_core::{
@@ -142,7 +142,8 @@ fn signature_help(
     let active_parameter = active_parameter_index(arity, supplied_arguments, index_to_label)
         // If we don't want to highlight any arg in the suggestion we have to
         // explicitly provide an out of bound index.
-        .or(Some(arity));
+        .or(Some(arity))
+        .map(ActiveParameter::Int);
 
     Some(SignatureHelp {
         signatures: vec![SignatureInformation {
@@ -266,7 +267,7 @@ fn print_signature_help(
         }
         signature.push_str(&printer.print_type(argument));
         let arg_end = signature.len();
-        let label = ParameterLabel::LabelOffsets([arg_start as u32, arg_end as u32]);
+        let label = ParameterInformationLabel::Tuple((arg_start as u32, arg_end as u32));
 
         parameter_informations.push(ParameterInformation {
             label,

--- a/language-server/src/tests.rs
+++ b/language-server/src/tests.rs
@@ -21,7 +21,7 @@ use hexpm::version::{Range, Version};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
-use lsp_types::{Position, TextDocumentIdentifier, TextDocumentPositionParams, Url};
+use lsp_types::{Position, TextDocumentIdentifier, TextDocumentPositionParams, Uri as Url};
 
 use gleam_core::{
     Result,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use lsp_types::{
-    CodeActionContext, CodeActionParams, DocumentChangeOperation, DocumentChanges,
-    PartialResultParams, Position, ResourceOp, Url, WorkDoneProgressParams,
+    CodeActionContext, CodeActionParams, DocumentChange, PartialResultParams, Position, Uri as Url,
+    WorkDoneProgressParams,
 };
 
 use super::*;
@@ -117,7 +117,7 @@ fn show_code_edits(tester: &TestProject<'_>, changed_files: HashMap<Url, String>
     }
 }
 
-fn format_code_action_file_operations<'a>(actions: &[lsp_types::CodeAction]) -> String {
+fn format_code_action_file_operations(actions: &[lsp_types::CodeAction]) -> String {
     // Display path the same on linux or windows so tests don't fail between targets
     let normalized_path = |uri: &Url| {
         format!(
@@ -137,36 +137,25 @@ fn format_code_action_file_operations<'a>(actions: &[lsp_types::CodeAction]) -> 
     actions
         .iter()
         .filter_map(|action| {
-            if let Some(DocumentChanges::Operations(operations)) = action
+            action
                 .edit
                 .as_ref()
                 .and_then(|edit| edit.document_changes.as_ref())
-            {
-                Some(operations)
-            } else {
-                None
-            }
         })
-        .flat_map(|operations| {
-            operations.into_iter().filter_map(|op| match op {
-                DocumentChangeOperation::Op(op) => Some(op),
-                DocumentChangeOperation::Edit(_) => None,
-            })
-        })
-        .map(|op| match op {
-            ResourceOp::Create(create) => {
-                format!("- Create {}", normalized_path(&create.uri))
+        .flatten()
+        .filter_map(|op| match op {
+            DocumentChange::CreateFile(create) => {
+                Some(format!("- Create {}", normalized_path(&create.uri)))
             }
-            ResourceOp::Rename(rename) => {
-                format!(
-                    "- Rename {} to {}",
-                    normalized_path(&rename.old_uri),
-                    normalized_path(&rename.new_uri)
-                )
+            DocumentChange::RenameFile(rename) => Some(format!(
+                "- Rename {} to {}",
+                normalized_path(&rename.old_uri),
+                normalized_path(&rename.new_uri)
+            )),
+            DocumentChange::DeleteFile(delete) => {
+                Some(format!("- Delete {}", normalized_path(&delete.uri)))
             }
-            ResourceOp::Delete(delete) => {
-                format!("- Delete {}", normalized_path(&delete.uri))
-            }
+            DocumentChange::TextDocumentEdit(_) => None,
         })
         .join("\n")
 }

--- a/language-server/src/tests/completion.rs
+++ b/language-server/src/tests/completion.rs
@@ -29,7 +29,7 @@ fn apply_completion(src: &str, completions: Vec<CompletionItem>, value: &str) ->
         .unwrap_or_else(|| panic!("no completion with value `{value}`"));
 
     let mut edits = vec![];
-    if let Some(lsp_types::CompletionTextEdit::Edit(edit)) = &completion.text_edit {
+    if let Some(lsp_types::CompletionItemTextEdit::TextEdit(edit)) = &completion.text_edit {
         edits.push(edit.clone());
     }
     apply_code_edit(src, edits)
@@ -98,6 +98,7 @@ fn format_completion_results(completions: Vec<CompletionItem>) -> EcoString {
         kind,
         detail,
         documentation,
+        #[allow(deprecated)]
         deprecated,
         preselect,
         sort_text,
@@ -111,6 +112,7 @@ fn format_completion_results(completions: Vec<CompletionItem>) -> EcoString {
         commit_characters,
         data,
         tags,
+        text_edit_text,
     } in completions
     {
         assert!(deprecated.is_none());
@@ -123,6 +125,7 @@ fn format_completion_results(completions: Vec<CompletionItem>) -> EcoString {
         assert!(commit_characters.is_none());
         assert!(data.is_none());
         assert!(tags.is_none());
+        assert!(text_edit_text.is_none());
 
         buffer.push_str(&label);
 
@@ -167,7 +170,7 @@ fn format_completion_results(completions: Vec<CompletionItem>) -> EcoString {
         };
 
         if let Some(text_edit) = text_edit {
-            let lsp_types::CompletionTextEdit::Edit(e) = text_edit else {
+            let lsp_types::CompletionItemTextEdit::TextEdit(e) = text_edit else {
                 panic!("unexpected text edit in test {text_edit:?}");
             };
             buffer.push_str("\n  edits:");

--- a/language-server/src/tests/definition.rs
+++ b/language-server/src/tests/definition.rs
@@ -1,12 +1,10 @@
-use lsp_types::{
-    GotoDefinitionParams, Location, Position, Range, Url, request::GotoTypeDefinitionParams,
-};
+use lsp_types::{DefinitionParams, Location, Position, Range, TypeDefinitionParams, Uri as Url};
 
 use super::*;
 
 fn definition(tester: &TestProject<'_>, position: Position) -> Option<Location> {
     tester.at(position, |engine, param, _| {
-        let params = GotoDefinitionParams {
+        let params = DefinitionParams {
             text_document_position_params: param,
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
@@ -24,7 +22,7 @@ fn pretty_definition(project: TestProject<'_>, position_finder: PositionFinder) 
 
 fn type_definition(tester: &TestProject<'_>, position: Position) -> Vec<Location> {
     tester.at(position, |engine, param, _| {
-        let params = GotoTypeDefinitionParams {
+        let params = TypeDefinitionParams {
             text_document_position_params: param,
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
@@ -430,7 +428,7 @@ fn main() {
         .add_hex_module("example_module", dep)
         .positioned_with_io(Position::new(3, 20));
 
-    let params = GotoDefinitionParams {
+    let params = DefinitionParams {
         text_document_position_params: position_param.clone(),
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
@@ -504,7 +502,7 @@ fn main() {
         .add_dep_module("example_module", dep)
         .positioned_with_io(Position::new(3, 20));
 
-    let params = GotoDefinitionParams {
+    let params = DefinitionParams {
         text_document_position_params: position_param.clone(),
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),

--- a/language-server/src/tests/folding_range.rs
+++ b/language-server/src/tests/folding_range.rs
@@ -15,11 +15,12 @@ fn folding_ranges(tester: TestProject<'_>) -> Vec<FoldingRange> {
     })
 }
 
-fn kind_name(kind: &Option<FoldingRangeKind>) -> &'static str {
+fn kind_name(kind: &Option<FoldingRangeKind>) -> &str {
     match kind {
         Some(FoldingRangeKind::Imports) => "imports",
         Some(FoldingRangeKind::Comment) => "comment",
         Some(FoldingRangeKind::Region) => "region",
+        Some(FoldingRangeKind::Custom(any)) => &any,
         None => "none",
     }
 }

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -1,4 +1,4 @@
-use lsp_types::{Hover, HoverContents, HoverParams, MarkedString, Position, Range};
+use lsp_types::{Contents, Hover, HoverParams, MarkedString, Position, Range};
 
 use super::*;
 
@@ -49,17 +49,17 @@ pub fn show_hover(code: &str, range: Range, position: Position) -> String {
     buffer
 }
 
-fn pretty_hover_contents(contents: HoverContents) -> String {
+fn pretty_hover_contents(contents: Contents) -> String {
     let (kind, content) = match contents {
-        HoverContents::Scalar(marked_string) => ("markdown", pretty_marked_string(marked_string)),
-        HoverContents::Array(marked_strings) => (
+        Contents::MarkedString(marked_string) => ("markdown", pretty_marked_string(marked_string)),
+        Contents::MarkedStringList(marked_strings) => (
             "markdown array",
             marked_strings
                 .into_iter()
                 .map(pretty_marked_string)
                 .join("\n\n"),
         ),
-        HoverContents::Markup(lsp_types::MarkupContent { kind, value }) => match kind {
+        Contents::MarkupContent(lsp_types::MarkupContent { kind, value }) => match kind {
             lsp_types::MarkupKind::PlainText => ("plaintext", value),
             lsp_types::MarkupKind::Markdown => ("markdown", value),
         },
@@ -70,7 +70,11 @@ fn pretty_hover_contents(contents: HoverContents) -> String {
 fn pretty_marked_string(marked_string: MarkedString) -> String {
     match marked_string {
         MarkedString::String(string) => string,
-        MarkedString::LanguageString(lsp_types::LanguageString { language, value }) => {
+        #[allow(deprecated)]
+        MarkedString::MarkedStringWithLanguage(lsp_types::MarkedStringWithLanguage {
+            language,
+            value,
+        }) => {
             format!("```{language}\n{value}\n```")
         }
     }

--- a/language-server/src/tests/reference.rs
+++ b/language-server/src/tests/reference.rs
@@ -13,7 +13,7 @@ fn find_references(
 ) -> Option<HashMap<String, Vec<Range>>> {
     let locations = tester.at(position, |engine, params, _| {
         let params = ReferenceParams {
-            text_document_position: TextDocumentPositionParams {
+            text_document_position_params: TextDocumentPositionParams {
                 text_document: params.text_document,
                 position,
             },

--- a/language-server/src/tests/rename.rs
+++ b/language-server/src/tests/rename.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use lsp_types::{
-    Position, Range, RenameParams, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+    Position, PrepareRenameParams, PrepareRenamePlaceholder, Range, RenameParams,
+    TextDocumentPositionParams, Uri as Url, WorkDoneProgressParams,
 };
 
 use super::{TestProject, find_position_of, hover};
@@ -16,22 +17,29 @@ fn rename(
     position: Position,
 ) -> Result<Option<(Range, lsp_types::WorkspaceEdit)>, String> {
     let prepare_rename_response = tester.at(position, |engine, params, _| {
-        let params = TextDocumentPositionParams {
-            text_document: params.text_document,
-            position,
+        let params = PrepareRenameParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: params.text_document,
+                position,
+            },
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
         };
         engine.prepare_rename(params).result.unwrap()
     });
 
     let range = match prepare_rename_response {
-        Some(lsp_types::PrepareRenameResponse::Range(range)) => range,
-        Some(lsp_types::PrepareRenameResponse::RangeWithPlaceholder { range, .. }) => range,
+        Some(lsp_types::PrepareRenameResult::Range(range)) => range,
+        Some(lsp_types::PrepareRenameResult::PrepareRenamePlaceholder(
+            PrepareRenamePlaceholder { range, .. },
+        )) => range,
         _ => return Ok(None),
     };
 
     let outcome = tester.at(position, |engine, params, _| {
         let params = RenameParams {
-            text_document_position: TextDocumentPositionParams {
+            text_document_position_params: TextDocumentPositionParams {
                 text_document: params.text_document,
                 position,
             },

--- a/language-server/src/tests/signature_help.rs
+++ b/language-server/src/tests/signature_help.rs
@@ -1,6 +1,7 @@
 use super::*;
 use lsp_types::{
-    ParameterInformation, ParameterLabel, SignatureHelp, SignatureHelpParams, SignatureInformation,
+    ActiveParameter, ParameterInformation, ParameterInformationLabel, SignatureHelp,
+    SignatureHelpParams, SignatureInformation,
 };
 
 fn signature_help(tester: TestProject<'_>, position: Position) -> Option<SignatureHelp> {
@@ -42,11 +43,11 @@ fn pretty_signature_help(signature_help: SignatureHelp) -> String {
     };
 
     let label = match active_parameter {
-        None => label.to_string(),
-        Some(i) => match parameters.get(i as usize) {
+        None | Some(ActiveParameter::Null) => label.to_string(),
+        Some(ActiveParameter::Int(i)) => match parameters.get(i as usize) {
             None => label.to_string(),
             Some(ParameterInformation {
-                label: ParameterLabel::LabelOffsets([start, end]),
+                label: ParameterInformationLabel::Tuple((start, end)),
                 ..
             }) => {
                 let spaces = " ".repeat(*start as usize);

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_import_not_from_dev_dependency_in_test.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_import_not_from_dev_dependency_in_test.snap
@@ -9,6 +9,7 @@ expression: completions
         kind: Some(
             Module,
         ),
+        tags: None,
         detail: None,
         documentation: None,
         deprecated: None,
@@ -19,7 +20,7 @@ expression: completions
         insert_text_format: None,
         insert_text_mode: None,
         text_edit: Some(
-            Edit(
+            TextEdit(
                 TextEdit {
                     range: Range {
                         start: Position {
@@ -35,11 +36,11 @@ expression: completions
                 },
             ),
         ),
+        text_edit_text: None,
         additional_text_edits: None,
-        command: None,
         commit_characters: None,
+        command: None,
         data: None,
-        tags: None,
     },
     CompletionItem {
         label: "example_module",
@@ -47,6 +48,7 @@ expression: completions
         kind: Some(
             Module,
         ),
+        tags: None,
         detail: None,
         documentation: None,
         deprecated: None,
@@ -57,7 +59,7 @@ expression: completions
         insert_text_format: None,
         insert_text_mode: None,
         text_edit: Some(
-            Edit(
+            TextEdit(
                 TextEdit {
                     range: Range {
                         start: Position {
@@ -73,11 +75,11 @@ expression: completions
                 },
             ),
         ),
+        text_edit_text: None,
         additional_text_edits: None,
-        command: None,
         commit_characters: None,
+        command: None,
         data: None,
-        tags: None,
     },
     CompletionItem {
         label: "indirect_module",
@@ -85,6 +87,7 @@ expression: completions
         kind: Some(
             Module,
         ),
+        tags: None,
         detail: None,
         documentation: None,
         deprecated: None,
@@ -95,7 +98,7 @@ expression: completions
         insert_text_format: None,
         insert_text_mode: None,
         text_edit: Some(
-            Edit(
+            TextEdit(
                 TextEdit {
                     range: Range {
                         start: Position {
@@ -111,10 +114,10 @@ expression: completions
                 },
             ),
         ),
+        text_edit_text: None,
         additional_text_edits: None,
-        command: None,
         commit_characters: None,
+        command: None,
         data: None,
-        tags: None,
     },
 ]

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_import_while_in_test.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completions_for_an_import_while_in_test.snap
@@ -9,6 +9,7 @@ expression: completions
         kind: Some(
             Module,
         ),
+        tags: None,
         detail: None,
         documentation: None,
         deprecated: None,
@@ -19,7 +20,7 @@ expression: completions
         insert_text_format: None,
         insert_text_mode: None,
         text_edit: Some(
-            Edit(
+            TextEdit(
                 TextEdit {
                     range: Range {
                         start: Position {
@@ -35,11 +36,11 @@ expression: completions
                 },
             ),
         ),
+        text_edit_text: None,
         additional_text_edits: None,
-        command: None,
         commit_characters: None,
+        command: None,
         data: None,
-        tags: None,
     },
     CompletionItem {
         label: "test_helper",
@@ -47,6 +48,7 @@ expression: completions
         kind: Some(
             Module,
         ),
+        tags: None,
         detail: None,
         documentation: None,
         deprecated: None,
@@ -57,7 +59,7 @@ expression: completions
         insert_text_format: None,
         insert_text_mode: None,
         text_edit: Some(
-            Edit(
+            TextEdit(
                 TextEdit {
                     range: Range {
                         start: Position {
@@ -73,10 +75,10 @@ expression: completions
                 },
             ),
         ),
+        text_edit_text: None,
         additional_text_edits: None,
-        command: None,
         commit_characters: None,
+        command: None,
         data: None,
-        tags: None,
     },
 ]


### PR DESCRIPTION
[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) is an alternative to the lsp-types crate, with types generated via codegen from the official LSP Metamodel for correctness and completeness.

lsp-types issues fixed in gen-lsp-types:

- https://github.com/gluon-lang/lsp-types/issues/310
- https://github.com/gluon-lang/lsp-types/issues/308
- https://github.com/gluon-lang/lsp-types/issues/284
- https://github.com/gluon-lang/lsp-types/issues/278
- https://github.com/gluon-lang/lsp-types/issues/277
- https://github.com/gluon-lang/lsp-types/issues/260
- https://github.com/gluon-lang/lsp-types/issues/245
- https://github.com/gluon-lang/lsp-types/issues/93

See: https://github.com/wgsl-analyzer/wgsl-analyzer/pull/1090 and https://github.com/rust-lang/rust-analyzer/pull/22115

Closes #3662

- [x] The changes in this PR have been discussed beforehand in an issue
  - https://github.com/gleam-lang/gleam/discussions/5652
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes (N/A)

