### PR TITLE
Allow removing dependencies without manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@
 
 ### Build tool
 
+- The `gleam remove` command now updates `gleam.toml` when `manifest.toml` is
+  missing rather than reporting a file IO error.
+  ([Arjun Rawal](https://github.com/arjunrawal1))
+
 - The `gleam dev` command now accepts the `--no-print-progress` flag. When this
   flag is passed, no progress information is printed.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -46,7 +46,54 @@ pub fn command(paths: &ProjectPaths, packages: Vec<String>) -> Result<()> {
 
     // Write the updated config
     fs::write(root_config.as_path(), &toml.to_string())?;
+
+    // If there is no manifest, there is no dependency state to clean up.
+    // This can happen in a newly created project or while users are temporarily
+    // recreating their manifest. Removing the entry from gleam.toml is enough.
+    if !paths.manifest().exists() {
+        return Ok(());
+    }
+
     _ = crate::dependencies::cleanup(paths, cli::Reporter::new())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+    use gleam_core::paths::ProjectPaths;
+    use pretty_assertions::assert_eq;
+
+    use super::command;
+
+    #[test]
+    fn remove_dependency_without_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let paths = ProjectPaths::new(root.clone());
+        std::fs::write(
+            root.join("gleam.toml"),
+            r#"name = "app"
+version = "1.0.0"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleeunit = ">= 1.0.0 and < 2.0.0"
+"#,
+        )
+        .unwrap();
+
+        command(&paths, vec!["gleeunit".to_string()]).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("gleam.toml")).unwrap(),
+            r#"name = "app"
+version = "1.0.0"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+"#
+        );
+    }
 }


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

This updates `gleam remove` so that if `manifest.toml` is missing it still removes the dependency from `gleam.toml` and exits successfully instead of trying to run manifest cleanup and reporting a file IO error.

Closes #5654

Testing:
- Added `remove_dependency_without_manifest` regression coverage.
- `git diff --check`
- Could not run `cargo test -p gleam-cli remove::tests::remove_dependency_without_manifest` locally because this machine does not have `cargo`/`rustc` installed.

AI assistance disclosure: I used OpenAI Codex GPT-5.5 to inspect the issue, implement the scoped change, and prepare this PR.
