### PR TITLE
fix(remove): skip cleanup when manifest.toml is missing (#5654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,13 @@
 
 ### Bug fixes
 
+- Fixed a bug where `gleam remove` would fail with a confusing "File IO failure"
+  error reading `manifest.toml` when the manifest didn't exist (e.g. on a fresh
+  project that hadn't yet resolved dependencies, or after manually deleting
+  `manifest.toml`). The dependency entry is now removed from `gleam.toml`
+  without attempting resolution when there is no manifest to clean up.
+  ([Matt Van Horn](https://github.com/mvanhorn))
+
 - Fixed a bug where the build tool would check for new major versions of a local
   or git dependency on Hex when running `gleam update`.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -46,7 +46,16 @@ pub fn command(paths: &ProjectPaths, packages: Vec<String>) -> Result<()> {
 
     // Write the updated config
     fs::write(root_config.as_path(), &toml.to_string())?;
-    _ = crate::dependencies::cleanup(paths, cli::Reporter::new())?;
+
+    // If manifest.toml is missing (fresh `gleam new` project, or one where
+    // the user temporarily deleted manifest.toml while debugging dependency
+    // conflicts), there's nothing to resolve against -- removing the entry
+    // from gleam.toml is the whole job. Running cleanup() would try to read
+    // manifest.toml and error out with a confusing "File IO failure" even
+    // though gleam.toml was already updated correctly. See #5654.
+    if paths.manifest().exists() {
+        _ = crate::dependencies::cleanup(paths, cli::Reporter::new())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Closes #5654.

## What changed

\`compiler-cli/src/remove.rs\` now skips the \`dependencies::cleanup()\` call when \`manifest.toml\` does not exist. The dependency entry is still removed from \`gleam.toml\` exactly as before — that path is unchanged.

## Why this matches the issue

@lpil's comment on #5654:

> I think we could just remove the entry from \`gleam.toml\` without doing resolution when there is no \`manifest.toml\`.

That's what this PR does. \`cleanup()\` calls \`read_manifest_from_disc()\`, which fails with the "File IO failure" / "No such file or directory" error the issue reported. Skipping cleanup when the manifest is absent makes the error go away without changing behavior in the common case (manifest present, full resolution runs).

## Verification

Reproduced the original failure on \`main\`, then on the branch:

\`\`\`
$ cd $(mktemp -d)
$ gleam new app && cd app
$ rm -f manifest.toml          # fresh project; nothing to remove, but matches the issue's setup
$ gleam remove gleam_stdlib
# Before: "error: File IO failure" reading /tmp/.../app/manifest.toml
# After:  silent success
$ grep -A2 dependencies gleam.toml
[dependencies]
\`\`\`

The \`gleam_stdlib\` line is gone from \`[dependencies]\`, the \`[dev_dependencies]\` table is preserved, and there's no error.

\`cargo test -p gleam-cli remove\` passes — the five existing \`dependencies::test_remove_*\` tests are unaffected (they all use a manifest, so they hit the unchanged path).

Added a CHANGELOG entry under "Unreleased → Bug fixes".