### PR TITLE
fix detection of integer segments over the safe js limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,14 @@
   patterns and guards of a case arm.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the compiler would not warn for integers over the safe
+  JavaScript limit in `BitArray` segments with a unit option.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
+- Fixed a bug where the compiler would incorrectly warn for integers over the
+  safe JavaScript limit in `BitArray` byte segments that aren't integers.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,12 +218,12 @@
   patterns and guards of a case arm.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- Fixed a bug where the compiler would not warn for integers over the safe
+- Fixed a bug where the compiler would not warn for ints over the safe
   JavaScript limit in `BitArray` segments with a unit option.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
-- Fixed a bug where the compiler would incorrectly warn for integers over the
-  safe JavaScript limit in `BitArray` byte segments that aren't integers.
+- Fixed a bug where the compiler would incorrectly warn for ints over the
+  safe JavaScript limit in `BitArray` byte segments that aren't ints.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 - Fixed a bug where enabling `javascript.typescript_declarations` or

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -494,7 +494,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             .expect("The function always returns Ok");
 
         self.check_pattern_segment_size_expression(&options);
-        self.check_matched_int_is_in_js_bounds(segment.value.as_ref(), &options);
 
         let segment_type = match bit_array::type_options_for_pattern(
             &options,
@@ -640,12 +639,16 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             | Pattern::Invalid { .. } => {}
         };
 
-        BitArraySegment {
+        let typed_segment = BitArraySegment {
             location: segment.location,
             value: Box::new(typed_value),
             options,
             type_,
-        }
+        };
+
+        self.check_matched_int_is_in_js_bounds(&typed_segment);
+
+        typed_segment
     }
 
     /// When we have an assignment or a case expression we unify the pattern with the
@@ -1532,61 +1535,36 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
     /// That's the maximum size of ints on the JS target, matching on anything
     /// bigger would result in the number being truncated.
     ///
-    fn check_matched_int_is_in_js_bounds(
-        &mut self,
-        pattern: &UntypedPattern,
-        options: &[BitArrayOption<TypedPattern>],
-    ) {
+    fn check_matched_int_is_in_js_bounds(&mut self, segment: &TypedPatternBitArraySegment) {
         // This only makes sense to check on the js target
         // And if the segment actually defines a variable that would end up
-        // being truncated.
-        if self.environment.target != Target::JavaScript {
+        // being truncated and that is an integer!
+        if self.environment.target != Target::JavaScript || !segment.type_.is_int() {
             return;
         }
-        let (Pattern::Assign { .. } | Pattern::Variable { .. }) = pattern else {
-            return;
-        };
-
-        // We need to check if there's an explicit size value for the segment.
-        let Some((location, size_value)) = options.iter().find_map(|option| match option {
-            BitArrayOption::Size {
-                value, location, ..
-            } => Some((location, value)),
-
-            BitArrayOption::Bytes { .. }
-            | BitArrayOption::Int { .. }
-            | BitArrayOption::Float { .. }
-            | BitArrayOption::Bits { .. }
-            | BitArrayOption::Utf8 { .. }
-            | BitArrayOption::Utf16 { .. }
-            | BitArrayOption::Utf32 { .. }
-            | BitArrayOption::Utf8Codepoint { .. }
-            | BitArrayOption::Utf16Codepoint { .. }
-            | BitArrayOption::Utf32Codepoint { .. }
-            | BitArrayOption::Signed { .. }
-            | BitArrayOption::Unsigned { .. }
-            | BitArrayOption::Big { .. }
-            | BitArrayOption::Little { .. }
-            | BitArrayOption::Native { .. }
-            | BitArrayOption::Unit { .. } => None,
-        }) else {
+        let (Pattern::Assign { .. } | Pattern::Variable { .. }) = segment.value.as_ref() else {
             return;
         };
 
         // The size must be a compile time known number, otherwise there's not
         // much we can tell about it.
-        let Pattern::BitArraySize(size) = size_value.as_ref() else {
+        let Some(Pattern::BitArraySize(size)) = segment.size() else {
             return;
         };
+
+        // We need to check if there's an explicit size value for the segment.
         let Some(size) = size.compile_time_number() else {
             return;
         };
 
+        let unit = segment.unit();
+        let bits = size.clone() * unit;
+
         // If the size is above the JS limit we raise a warning.
-        if size > BigInt::from(52) {
+        if bits > BigInt::from(52) {
             self.problems.warning(Warning::JavaScriptBitArrayUnsafeInt {
-                location: *location,
-                size,
+                location: segment.location,
+                size: bits,
             });
         }
     }

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -1531,14 +1531,14 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
     }
 
     /// This raises a warning if we're on the js target and we're matching on
-    /// an integer segment that has an explicit literal size over 52 bits.
+    /// an int segment that has an explicit literal size over 52 bits.
     /// That's the maximum size of ints on the JS target, matching on anything
     /// bigger would result in the number being truncated.
     ///
     fn check_matched_int_is_in_js_bounds(&mut self, segment: &TypedPatternBitArraySegment) {
         // This only makes sense to check on the js target
         // And if the segment actually defines a variable that would end up
-        // being truncated and that is an integer!
+        // being truncated and that is an int!
         if self.environment.target != Target::JavaScript || !segment.type_.is_int() {
             return;
         }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__assert_on_impossible_to_reach_int_segment.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__assert_on_impossible_to_reach_int_segment.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x) {\n  let assert <<1, -1, 2, -3>> = x\n}"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  let assert <<1, -1, 2, -3>> = x
+}
+
+----- WARNING
+warning: Assertion that will always fail
+  ┌─ /src/warning/wrn.gleam:3:14
+  │
+3 │   let assert <<1, -1, 2, -3>> = x
+  │              ^^^^^^^^^^^^^^^^
+  │                   │      │
+  │                   │      A 1 byte unsigned integer will never match this value
+  │                   A 1 byte unsigned integer will never match this value
+
+We can tell from the code above that the value will never match this
+pattern and that this code will always crash.
+
+Either change the pattern or use `panic` to unconditionally fail.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_int_over_js_limit.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_int_over_js_limit.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go(x: BitArray) {\n    let <<number:123>> = x\n    number\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x: BitArray) {
+    let <<number:123>> = x
+    number
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:3:11
+  │
+3 │     let <<number:123>> = x
+  │           ^^^^^^^^^^
+
+This segment is a 123-bit long int, but on the JavaScript target numbers
+have at most 52 bits. It would be truncated to its first 52 bits.
+
+Hint: Did you mean to use the `bytes` segment option?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_int_over_js_limit_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_int_over_js_limit_1.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go(x: BitArray) {\n  case x {\n    <<n:size(53)>> -> n\n    _ -> 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x: BitArray) {
+  case x {
+    <<n:size(53)>> -> n
+    _ -> 1
+  }
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:4:7
+  │
+4 │     <<n:size(53)>> -> n
+  │       ^^^^^^^^^^
+
+This segment is a 53-bit long int, but on the JavaScript target numbers
+have at most 52 bits. It would be truncated to its first 52 bits.
+
+Hint: Did you mean to use the `bytes` segment option?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_int_over_js_limit_with_unit.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_int_over_js_limit_with_unit.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go(x: BitArray) {\n  case x {\n    <<n:2-unit(250)>> -> n\n    _ -> 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x: BitArray) {
+  case x {
+    <<n:2-unit(250)>> -> n
+    _ -> 1
+  }
+}
+
+
+----- WARNING
+warning: Truncated bit array segment
+  ┌─ /src/warning/wrn.gleam:4:7
+  │
+4 │     <<n:2-unit(250)>> -> n
+  │       ^^^^^^^^^^^^^
+
+This segment is a 500-bit long int, but on the JavaScript target numbers
+have at most 52 bits. It would be truncated to its first 52 bits.
+
+Hint: Did you mean to use the `bytes` segment option?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_integer_over_js_limit.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_integer_over_js_limit.snap
@@ -12,10 +12,10 @@ pub fn go(x: BitArray) {
 
 ----- WARNING
 warning: Truncated bit array segment
-  ┌─ /src/warning/wrn.gleam:3:18
+  ┌─ /src/warning/wrn.gleam:3:11
   │
 3 │     let <<number:123>> = x
-  │                  ^^^
+  │           ^^^^^^^^^^
 
 This segment is a 123-bit long int, but on the JavaScript target numbers
 have at most 52 bits. It would be truncated to its first 52 bits.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_integer_over_js_limit_with_unit.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__bit_array_match_on_integer_over_js_limit_with_unit.snap
@@ -1,12 +1,12 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\npub fn go(x: BitArray) {\n  case x {\n    <<n:size(53)>> -> n\n    _ -> 1\n  }\n}\n"
+expression: "\npub fn go(x: BitArray) {\n  case x {\n    <<n:2-unit(250)>> -> n\n    _ -> 1\n  }\n}\n"
 ---
 ----- SOURCE CODE
 
 pub fn go(x: BitArray) {
   case x {
-    <<n:size(53)>> -> n
+    <<n:2-unit(250)>> -> n
     _ -> 1
   }
 }
@@ -16,10 +16,10 @@ pub fn go(x: BitArray) {
 warning: Truncated bit array segment
   ┌─ /src/warning/wrn.gleam:4:7
   │
-4 │     <<n:size(53)>> -> n
-  │       ^^^^^^^^^^
+4 │     <<n:2-unit(250)>> -> n
+  │       ^^^^^^^^^^^^^
 
-This segment is a 53-bit long int, but on the JavaScript target numbers
+This segment is a 500-bit long int, but on the JavaScript target numbers
 have at most 52 bits. It would be truncated to its first 52 bits.
 
 Hint: Did you mean to use the `bytes` segment option?

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_int_literal.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_int_literal.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub fn main() { let _ = --7 }"
+---
+----- SOURCE CODE
+pub fn main() { let _ = --7 }
+
+----- WARNING
+warning: Unnecessary double negation (--) on integer
+  ┌─ /src/warning/wrn.gleam:1:25
+  │
+1 │ pub fn main() { let _ = --7 }
+  │                         ^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_int_variable.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__double_unary_int_variable.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n        pub fn main() {\n            let x = 7\n            let _ = --x\n        }\n        "
+---
+----- SOURCE CODE
+
+        pub fn main() {
+            let x = 7
+            let _ = --x
+        }
+        
+
+----- WARNING
+warning: Unnecessary double negation (--) on integer
+  ┌─ /src/warning/wrn.gleam:4:21
+  │
+4 │             let _ = --x
+  │                     ^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__even_number_of_multiple_int_negations_raise_a_single_warning.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__even_number_of_multiple_int_negations_raise_a_single_warning.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub fn main() { let _ = ----7 }"
+---
+----- SOURCE CODE
+pub fn main() { let _ = ----7 }
+
+----- WARNING
+warning: Unnecessary double negation (--) on integer
+  ┌─ /src/warning/wrn.gleam:1:25
+  │
+1 │ pub fn main() { let _ = ----7 }
+  │                         ^^^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x) {\n  case x {\n    <<9:size(2)>> -> True\n    _ -> False\n  }\n}"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  case x {
+    <<9:size(2)>> -> True
+    _ -> False
+  }
+}
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:4:5
+  │
+4 │     <<9:size(2)>> -> True
+  │     ^^^^^^^^^^^^^
+  │       │
+  │       A 2 bits unsigned integer will never match this value
+
+This pattern cannot be reached as it contains segments that will never
+match.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment_2.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x) {\n  case x {\n    <<-9:unsigned>> -> True\n    _ -> False\n  }\n}"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  case x {
+    <<-9:unsigned>> -> True
+    _ -> False
+  }
+}
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:4:5
+  │
+4 │     <<-9:unsigned>> -> True
+  │     ^^^^^^^^^^^^^^^
+  │       │
+  │       A 1 byte unsigned integer will never match this value
+
+This pattern cannot be reached as it contains segments that will never
+match.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment_3.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x) {\n  case x {\n    <<312>> -> True\n    _ -> False\n  }\n}"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  case x {
+    <<312>> -> True
+    _ -> False
+  }
+}
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:4:5
+  │
+4 │     <<312>> -> True
+  │     ^^^^^^^
+  │       │
+  │       A 1 byte unsigned integer will never match this value
+
+This pattern cannot be reached as it contains segments that will never
+match.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impossible_to_reach_int_segment_4.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x) {\n  case x {\n    <<-1>> -> True\n    _ -> False\n  }\n}"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  case x {
+    <<-1>> -> True
+    _ -> False
+  }
+}
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:4:5
+  │
+4 │     <<-1>> -> True
+  │     ^^^^^^
+  │       │
+  │       A 1 byte unsigned integer will never match this value
+
+This pattern cannot be reached as it contains segments that will never
+match.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__multiple_impossible_to_reach_int_segments.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__multiple_impossible_to_reach_int_segments.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main(x) {\n  case x {\n    <<1, -1, 2, -3>> -> True\n    _ -> False\n  }\n}"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  case x {
+    <<1, -1, 2, -3>> -> True
+    _ -> False
+  }
+}
+
+----- WARNING
+warning: Unreachable pattern
+  ┌─ /src/warning/wrn.gleam:4:5
+  │
+4 │     <<1, -1, 2, -3>> -> True
+  │     ^^^^^^^^^^^^^^^^
+  │          │      │
+  │          │      A 1 byte unsigned integer will never match this value
+  │          A 1 byte unsigned integer will never match this value
+
+This pattern cannot be reached as it contains segments that will never
+match.
+
+Hint: It can be safely removed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__odd_number_of_multiple_int_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__odd_number_of_multiple_int_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "pub fn main() { let _ = -----7 }"
+---
+----- SOURCE CODE
+pub fn main() { let _ = -----7 }
+
+----- WARNING
+warning: Unnecessary double negation (--) on integer
+  ┌─ /src/warning/wrn.gleam:1:25
+  │
+1 │ pub fn main() { let _ = -----7 }
+  │                         ^^^^ You can safely remove this.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -4962,6 +4962,34 @@ pub fn go(x: BitArray) {
     );
 }
 
+#[test]
+fn bit_array_match_on_integer_over_js_limit_with_unit() {
+    assert_js_warning!(
+        "
+pub fn go(x: BitArray) {
+  case x {
+    <<n:2-unit(250)>> -> n
+    _ -> 1
+  }
+}
+"
+    );
+}
+
+#[test]
+fn bit_array_match_on_bytes_does_not_complain_about_integer_size() {
+    assert_js_no_warnings!(
+        "
+pub fn go(x: BitArray) {
+  case x {
+    <<n:150-bytes>> -> n
+    _ -> <<>>
+  }
+}
+"
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/5599
 #[test]
 fn bit_array_size_constant() {

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -491,17 +491,17 @@ pub const make_two = one.Two
 
 // https://github.com/gleam-lang/gleam/issues/2050
 #[test]
-fn double_unary_integer_literal() {
+fn double_unary_int_literal() {
     assert_warning!("pub fn main() { let _ = --7 }");
 }
 
 #[test]
-fn even_number_of_multiple_integer_negations_raise_a_single_warning() {
+fn even_number_of_multiple_int_negations_raise_a_single_warning() {
     assert_warning!("pub fn main() { let _ = ----7 }");
 }
 
 #[test]
-fn odd_number_of_multiple_integer_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones()
+fn odd_number_of_multiple_int_negations_raise_a_single_warning_that_highlights_the_unnecessary_ones()
  {
     assert_warning!("pub fn main() { let _ = -----7 }");
 }
@@ -519,7 +519,7 @@ fn odd_number_of_multiple_bool_negations_raise_a_single_warning_that_highlights_
 
 // https://github.com/gleam-lang/gleam/issues/2050
 #[test]
-fn double_unary_integer_variable() {
+fn double_unary_int_variable() {
     assert_warning!(
         r#"
         pub fn main() {
@@ -4580,7 +4580,7 @@ pub fn main() {
 }
 
 #[test]
-fn impossible_to_reach_integer_segment() {
+fn impossible_to_reach_int_segment() {
     assert_warning!(
         "
 pub fn main(x) {
@@ -4593,7 +4593,7 @@ pub fn main(x) {
 }
 
 #[test]
-fn impossible_to_reach_integer_segment_2() {
+fn impossible_to_reach_int_segment_2() {
     assert_warning!(
         "
 pub fn main(x) {
@@ -4606,7 +4606,7 @@ pub fn main(x) {
 }
 
 #[test]
-fn impossible_to_reach_integer_segment_3() {
+fn impossible_to_reach_int_segment_3() {
     assert_warning!(
         "
 pub fn main(x) {
@@ -4619,7 +4619,7 @@ pub fn main(x) {
 }
 
 #[test]
-fn impossible_to_reach_integer_segment_4() {
+fn impossible_to_reach_int_segment_4() {
     assert_warning!(
         "
 pub fn main(x) {
@@ -4632,7 +4632,7 @@ pub fn main(x) {
 }
 
 #[test]
-fn multiple_impossible_to_reach_integer_segments() {
+fn multiple_impossible_to_reach_int_segments() {
     assert_warning!(
         "
 pub fn main(x) {
@@ -4645,7 +4645,7 @@ pub fn main(x) {
 }
 
 #[test]
-fn assert_on_impossible_to_reach_integer_segment() {
+fn assert_on_impossible_to_reach_int_segment() {
     assert_warning!(
         "
 pub fn main(x) {
@@ -4937,7 +4937,7 @@ pub fn main() {
 }
 
 #[test]
-fn bit_array_match_on_integer_over_js_limit() {
+fn bit_array_match_on_int_over_js_limit() {
     assert_js_warning!(
         "
 pub fn go(x: BitArray) {
@@ -4949,7 +4949,7 @@ pub fn go(x: BitArray) {
 }
 
 #[test]
-fn bit_array_match_on_integer_over_js_limit_1() {
+fn bit_array_match_on_int_over_js_limit_1() {
     assert_js_warning!(
         "
 pub fn go(x: BitArray) {
@@ -4963,7 +4963,7 @@ pub fn go(x: BitArray) {
 }
 
 #[test]
-fn bit_array_match_on_integer_over_js_limit_with_unit() {
+fn bit_array_match_on_int_over_js_limit_with_unit() {
     assert_js_warning!(
         "
 pub fn go(x: BitArray) {
@@ -4977,7 +4977,7 @@ pub fn go(x: BitArray) {
 }
 
 #[test]
-fn bit_array_match_on_bytes_does_not_complain_about_integer_size() {
+fn bit_array_match_on_bytes_does_not_complain_about_int_size() {
     assert_js_no_warnings!(
         "
 pub fn go(x: BitArray) {


### PR DESCRIPTION
This PR fixes #5674 

This PR fixes two bugs with safe integer segment detection on the JS target:
- One where the compiler would incorrectly warn on byte segments (that Hayleigh reported on discord)
- And another one I found by chance where the compiler wouldn't take the unit into account when computing the safe integer limit

---

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
