### PR TITLE
fix(javascript): escape reserved property names in TypeScript declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@
 
 ### Bug fixes
 
+- Fixed a bug where the generated TypeScript declarations for record fields
+  using JavaScript reserved property names (`constructor`, `prototype`,
+  `__proto__`, `then`) did not match the names used in the generated JavaScript
+  classes, leading to incorrect TypeScript declarations and misleading
+  autocompletion.
+  ([Metbcy](https://github.com/Metbcy))
+
 - Fixed a bug where the build tool would check for new major versions of a local
   or git dependency on Hex when running `gleam update`.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -204,6 +204,18 @@ pub fn go() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5613
+#[test]
+fn typescript_record_with_javascript_keyword_labels() {
+    assert_ts_def!(
+        r#"
+pub type Box {
+  Box(constructor: Int, prototype: Int, then: Int, other: Int)
+}
+"#,
+    );
+}
+
 #[test]
 fn long_name_variant_mixed_labels_typescript() {
     assert_ts_def!(

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__typescript_record_with_javascript_keyword_labels.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__typescript_record_with_javascript_keyword_labels.snap
@@ -1,0 +1,48 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Box {\n  Box(constructor: Int, prototype: Int, then: Int, other: Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Box {
+  Box(constructor: Int, prototype: Int, then: Int, other: Int)
+}
+
+
+----- TYPESCRIPT DEFINITIONS
+import type * as _ from "../gleam.d.mts";
+
+export class Box extends _.CustomType {
+  /** @deprecated */
+  constructor(
+    constructor: number,
+    prototype: number,
+    then$: number,
+    other: number
+  );
+  /** @deprecated */
+  constructor$: number;
+  /** @deprecated */
+  prototype$: number;
+  /** @deprecated */
+  then$: number;
+  /** @deprecated */
+  other: number;
+}
+export function Box$Box(
+  constructor: number,
+  prototype: number,
+  then$: number,
+  other: number,
+): Box$;
+export function Box$isBox(value: any): value is Box$;
+export function Box$Box$0(value: Box$): number;
+export function Box$Box$constructor(value: Box$): number;
+export function Box$Box$1(value: Box$): number;
+export function Box$Box$prototype(value: Box$): number;
+export function Box$Box$2(value: Box$): number;
+export function Box$Box$then(value: Box$): number;
+export function Box$Box$3(value: Box$): number;
+export function Box$Box$other(value: Box$): number;
+
+export type Box$ = Box;

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -585,7 +585,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     let name = arg
                         .label
                         .as_ref()
-                        .map(|(_, s)| super::maybe_escape_identifier(s))
+                        .map(|(_, s)| super::maybe_escape_property(s))
                         .unwrap_or_else(|| eco_format!("{i}"))
                         .to_doc();
                     docvec![


### PR DESCRIPTION
Closes #5613.

### Summary

The generated TypeScript declarations for record fields were using `maybe_escape_identifier`, which does not escape JavaScript reserved property names like `constructor`, `prototype`, `__proto__`, and `then`. The corresponding JavaScript class generation uses `maybe_escape_property`, which *does* escape them by appending `$`.

Result: the `.d.ts` advertised fields like `prototype: number` while the runtime actually exposes them as `prototype$`, and produced outright invalid declarations for `constructor`.

### Fix

Switch the field declaration in `compiler-core/src/javascript/typescript.rs` to `maybe_escape_property` so the `.d.ts` output mirrors the actual JS class shape (e.g. `constructor$`, `prototype$`, `then$`).

The constructor parameter list and `Box$Box(...)` factory function still use `maybe_escape_identifier`, matching the unescaped parameter names emitted by the JS code generator.

### Test plan

- New regression test `typescript_record_with_javascript_keyword_labels` in `compiler-core/src/javascript/tests/custom_types.rs` covering `constructor`, `prototype`, `then`, and a control field.
- New insta snapshot showing the corrected `.d.ts` output.
- `cargo test -p gleam-core` — 3816 passed, 0 failed.
