### PR TITLE
Fix code action overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,10 @@
   decoder" code action even when not explicitly hovering a custom type.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "generate json
+  encoder" code action even when not explicitly hovering a custom type.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,10 @@
   action even when not explicitly hovering a qualified value.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "qualify" code
+  action even when not explicitly hovering an unqualified type or constructor.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,10 @@
   encoder" code action even when not explicitly hovering a custom type.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "missing type
+  parameter" code action even when not explicitly hovering a custom type.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,10 @@
   code action even when not explicitly hovering an inexhaustive case expression.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "unqualify" code
+  action even when not explicitly hovering a qualified value.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,10 @@
   action even when not explicitly hovering an unqualified type or constructor.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "generate dynamic
+  decoder" code action even when not explicitly hovering a custom type.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,10 @@
   lists with a tail.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "convert to case" code
+  action even when not explicitly hovering an inexhaustive let assignment.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,10 @@
   parameter" code action even when not explicitly hovering a custom type.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "unwrap anonymous
+  function" code action even when not explicitly hovering a custom type.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,10 @@
   action even when not explicitly hovering an inexhaustive let assignment.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "add missing pattern"
+  code action even when not explicitly hovering an inexhaustive case expression.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -1815,7 +1815,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         arguments_types: Option<Vec<Arc<Type>>>,
     ) {
         let range = src_span_to_lsp_range(*location, self.line_numbers);
-        if overlaps(self.params.range, range)
+        if within(self.params.range, range)
             && let Some(module_alias) = name.module_name()
             && let Some(name) = name.name()
             && let Some(import) = self.get_module_import(module_alias, name, ast::Layer::Type)
@@ -1846,7 +1846,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         //  ↑
         // This allows us to offer a code action when hovering over the module name.
         let range = src_span_to_lsp_range(*location, self.line_numbers);
-        if overlaps(self.params.range, range)
+        if within(self.params.range, range)
             && let ModuleValueConstructor::Record {
                 name: constructor_name,
                 ..
@@ -1885,7 +1885,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         type_: &'ast Arc<Type>,
     ) {
         let range = src_span_to_lsp_range(*location, self.line_numbers);
-        if overlaps(self.params.range, range)
+        if within(self.params.range, range)
             && let Some((module_alias, _)) = module
             && let Inferred::Known(_) = constructor
             && let Some(import) = self.get_module_import(module_alias, name, ast::Layer::Value)
@@ -1922,7 +1922,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         record_constructor: &'ast Option<Box<ValueConstructor>>,
     ) {
         let range = src_span_to_lsp_range(*location, self.line_numbers);
-        if overlaps(self.params.range, range)
+        if within(self.params.range, range)
             && let Some((module_alias, _)) = module
             && let Some(import) = self.get_module_import(module_alias, name, ast::Layer::Value)
         {
@@ -1955,7 +1955,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         type_: &'ast Arc<Type>,
     ) {
         let range = src_span_to_lsp_range(*location, self.line_numbers);
-        if overlaps(self.params.range, range)
+        if within(self.params.range, range)
             && let Some((module_alias, _)) = module
             && let Some(constructor) = constructor
             && let type_::ValueConstructorVariant::Record { .. } = &constructor.variant

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -545,7 +545,7 @@ pub fn code_action_inexhaustive_let_to_case(
         let mut text_edits = TextEdits::new(line_numbers);
 
         let range = text_edits.src_span_to_lsp_range(location);
-        if !overlaps(params.range, range) {
+        if !within(params.range, range) {
             return;
         }
 

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -2318,7 +2318,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
     ) {
         if !name.is_qualified()
             && let Some(name) = name.name()
-            && overlaps(
+            && within(
                 self.params.range,
                 src_span_to_lsp_range(*location, self.line_numbers),
             )
@@ -2336,7 +2336,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
         name: &'ast EcoString,
     ) {
         let range = src_span_to_lsp_range(*location, self.line_numbers);
-        if overlaps(self.params.range, range)
+        if within(self.params.range, range)
             && let Some(module_name) = match &constructor.variant {
                 type_::ValueConstructorVariant::ModuleConstant { module, .. }
                 | type_::ValueConstructorVariant::ModuleFn { module, .. }
@@ -2362,7 +2362,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
         type_: &'ast Arc<Type>,
     ) {
         if module.is_none()
-            && overlaps(
+            && within(
                 self.params.range,
                 src_span_to_lsp_range(*location, self.line_numbers),
             )
@@ -2396,7 +2396,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
         record_constructor: &'ast Option<Box<ValueConstructor>>,
     ) {
         if module.is_none()
-            && overlaps(
+            && within(
                 self.params.range,
                 src_span_to_lsp_range(*location, self.line_numbers),
             )
@@ -2433,7 +2433,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
         type_: &'ast Arc<Type>,
     ) {
         if module.is_none()
-            && overlaps(
+            && within(
                 self.params.range,
                 src_span_to_lsp_range(*location, self.line_numbers),
             )

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -4530,8 +4530,10 @@ impl<'a, IO> GenerateDynamicDecoder<'a, IO> {
 
 impl<'ast, IO> ast::visit::Visit<'ast> for GenerateDynamicDecoder<'ast, IO> {
     fn visit_typed_custom_type(&mut self, custom_type: &'ast ast::TypedCustomType) {
-        let range = self.edits.src_span_to_lsp_range(custom_type.location);
-        if !overlaps(self.params.range, range) {
+        let range = self
+            .edits
+            .src_span_to_lsp_range(custom_type.full_location());
+        if !within(self.params.range, range) {
             return;
         }
 

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -11839,7 +11839,7 @@ impl<'a> UnwrapAnonymousFunction<'a> {
         body: &'a Vec1<TypedStatement>,
     ) {
         let function_range = src_span_to_lsp_range(*location, self.line_numbers);
-        if !overlaps(self.params.range, function_range) {
+        if !within(self.params.range, function_range) {
             return;
         }
 
@@ -11909,7 +11909,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnwrapAnonymousFunction<'ast> {
         return_annotation: &'ast Option<ast::TypeAst>,
     ) {
         let function_range = src_span_to_lsp_range(*location, self.line_numbers);
-        if !overlaps(self.params.range, function_range) {
+        if !within(self.params.range, function_range) {
             return;
         }
 

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -11458,7 +11458,7 @@ impl<'ast> ast::visit::Visit<'ast> for AddMissingTypeParameter<'ast> {
             .src_span_to_lsp_range(custom_type.full_location());
 
         // Only continue, if the action was selected anywhere within the custom type definition.
-        if !overlaps(self.params.range, custom_type_range) {
+        if !within(self.params.range, custom_type_range) {
             return;
         }
 

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -5181,8 +5181,10 @@ fn is_nil_like(type_: &Type) -> bool {
 
 impl<'ast> ast::visit::Visit<'ast> for GenerateJsonEncoder<'ast> {
     fn visit_typed_custom_type(&mut self, custom_type: &'ast ast::TypedCustomType) {
-        let range = self.edits.src_span_to_lsp_range(custom_type.location);
-        if !overlaps(self.params.range, range) {
+        let range = self
+            .edits
+            .src_span_to_lsp_range(custom_type.full_location());
+        if !within(self.params.range, range) {
             return;
         }
 

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -1284,7 +1284,7 @@ pub fn code_action_add_missing_patterns(
     for (location, missing) in missing_patterns {
         let mut edits = TextEdits::new(line_numbers);
         let range = edits.src_span_to_lsp_range(location);
-        if !overlaps(params.range, range) {
+        if !within(params.range, range) {
             return;
         }
 

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -8786,6 +8786,30 @@ pub type Person {
 }
 
 #[test]
+fn generate_json_only_triggers_within_a_type() {
+    let src = "
+pub type Person {
+  Person(name: String, age: Int, height: Float, is_cool: Bool)
+}
+
+pub fn main() {
+  // unrelated
+  todo
+}
+";
+
+    assert_no_code_actions!(
+        GENERATE_TO_JSON_FUNCTION,
+        TestProject::for_source(src).add_package_module(
+            "gleam_json",
+            "gleam/json",
+            "pub type Json"
+        ),
+        find_position_of("type").select_until(find_position_of("todo"))
+    );
+}
+
+#[test]
 fn convert_to_function_call_works_with_argument_in_first_position_2() {
     assert_code_action!(
         CONVERT_TO_FUNCTION_CALL,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -5711,6 +5711,17 @@ fn inexhaustive_let_alias_to_case() {
 }
 
 #[test]
+fn cursor_must_be_within_let_assignment_to_trigger_action() {
+    assert_no_code_actions!(
+        CONVERT_TO_CASE,
+        "pub fn main() {
+  let 10 as ten = 10
+}",
+        find_position_of("pub").select_until(find_position_of("}")),
+    );
+}
+
+#[test]
 fn inexhaustive_let_tuple_to_case() {
     assert_code_action!(
         CONVERT_TO_CASE,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -12881,6 +12881,24 @@ type Wibble {
 }
 
 #[test]
+fn add_missing_type_parameter_can_only_trigger_if_within_type() {
+    assert_no_code_actions!(
+        ADD_MISSING_TYPE_PARAMETER,
+        r#"
+type Wibble {
+  Wibble(field: t)
+}
+
+pub fn main() {
+    // unrelated
+    todo
+}
+"#,
+        find_position_of("type").select_until(find_position_of("todo"))
+    );
+}
+
+#[test]
 fn add_missing_type_parameter_to_exising_parameter() {
     assert_code_action!(
         ADD_MISSING_TYPE_PARAMETER,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -7726,6 +7726,24 @@ pub type Person {
 }
 
 #[test]
+fn generate_dynamic_decoder_only_works_if_withing_a_type() {
+    assert_no_code_actions!(
+        GENERATE_DYNAMIC_DECODER,
+        "
+pub type Person {
+  Person(name: String, age: Int, height: Float, is_cool: Bool, brain: BitArray)
+}
+
+pub fn main() {
+  // unrelated
+  todo
+}
+",
+        find_position_of("pub type").select_until(find_position_of("todo"))
+    );
+}
+
+#[test]
 fn generate_dynamic_decoder_complex_types() {
     let src = "
 import gleam/option

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -13817,6 +13817,24 @@ fn op(i: Int) -> Int {
 }
 
 #[test]
+fn unwrap_anonymous_function_can_only_trigger_if_cursor_is_within_the_function() {
+    assert_no_code_actions!(
+        UNWRAP_ANONYMOUS_FUNCTION,
+        "import gleam/list
+
+pub fn main() {
+  list.map([1, 2, 3], fn(int) { op(int) })
+}
+
+fn op(i: Int) -> Int {
+  todo
+}
+",
+        find_position_of("fn(int)").select_until(find_position_of("todo"))
+    );
+}
+
+#[test]
 fn unwrap_trivial_anonymous_function_with_bad_spacing() {
     assert_code_action!(
         UNWRAP_ANONYMOUS_FUNCTION,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -10114,6 +10114,19 @@ fn wibble() {
     );
 }
 
+#[test]
+fn add_missing_patterns_needs_to_be_within_the_inexhaustive_case_expression() {
+    assert_no_code_actions!(
+        ADD_MISSING_PATTERNS,
+        r#"
+fn wibble() {
+  case True {}
+}
+"#,
+        find_position_of("fn").select_until(find_position_of("}"))
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/4626
 #[test]
 fn add_missing_patterns_opaque_type() {

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -4521,7 +4521,25 @@ pub fn main() {
     assert_code_action!(
         "Qualify map as list.map",
         TestProject::for_source(src).add_hex_module("list", "pub fn map(list, f) { todo }"),
-        find_position_of("map(").select_until(find_position_of("[1, 2, 3]")),
+        find_position_of("map").nth_occurrence(2).to_selection(),
+    );
+}
+
+#[test]
+fn test_unqualified_to_qualified_only_triggers_when_within_an_expression() {
+    let src = r#"
+import list.{map}
+
+pub fn main() {
+    let identity = map([1, 2, 3], fn(x) { x })
+    let double = map([1, 2, 3], fn(x) { x * 2 })
+}
+// end
+"#;
+    assert_no_code_actions!(
+        "Qualify map as list.map",
+        TestProject::for_source(src).add_hex_module("list", "pub fn map(list, f) { todo }"),
+        find_position_of("import").select_until(find_position_of("// end")),
     );
 }
 
@@ -4541,7 +4559,7 @@ pub fn circle_circumference(radius: Float) -> Float {
     assert_code_action!(
         "Qualify pi as mymath.pi",
         TestProject::for_source(src).add_hex_module("mymath", "pub const pi = 3.14159"),
-        find_position_of("pi *.").select_until(find_position_of(" radius")),
+        find_position_of("pi").nth_occurrence(2).to_selection(),
     );
 }
 
@@ -4558,7 +4576,10 @@ pub fn create_user(name: String) -> User {
         "Qualify User as user.User",
         TestProject::for_source(src)
             .add_hex_module("user", "pub type User { User(name: String, id: Int) }"),
-        find_position_of("User(").select_until(find_position_of("name: name")),
+        find_position_of("User")
+            .nth_occurrence(4)
+            .under_char('s')
+            .to_selection(),
     );
 }
 
@@ -4575,7 +4596,7 @@ import user.{type User, User}
         "Qualify User as user.User",
         TestProject::for_source(src)
             .add_hex_module("user", "pub type User { User(name: String, id: Int) }"),
-        find_position_of("User(").select_until(find_position_of("name: name")),
+        find_position_of("User").nth_occurrence(2).to_selection(),
     );
 }
 
@@ -4598,7 +4619,7 @@ pub fn user_list(users: List(User)) -> List(String) {
         "Qualify User as user.User",
         TestProject::for_source(src)
             .add_hex_module("user", "pub type User { User(name: String, id: Int) }"),
-        find_position_of("User(").select_until(find_position_of("name: name")),
+        find_position_of("User").nth_occurrence(2).to_selection(),
     );
 }
 
@@ -4619,7 +4640,7 @@ pub fn process_list(items: List(Int)) -> List(Int) {
             "list",
             "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
         ),
-        find_position_of("|> map").select_until(find_position_of("(fn(x)")),
+        find_position_of("map").nth_occurrence(2).to_selection(),
     );
 }
 
@@ -4639,7 +4660,7 @@ pub fn process_result(res: Result(Int, String)) -> Int {
         "Qualify Ok as result.Ok",
         TestProject::for_source(src)
             .add_hex_module("result", "pub type Result(a, e) { Ok(a) Error(e) }"),
-        find_position_of("Ok(").select_until(find_position_of("value)")),
+        find_position_of("Ok").nth_occurrence(2).to_selection(),
     );
 }
 
@@ -4661,7 +4682,7 @@ pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
             .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
         find_position_of("Opt")
             .nth_occurrence(2)
-            .select_until(find_position_of("ion(")),
+            .select_until(find_position_of("ion").nth_occurrence(3)),
     );
 }
 
@@ -4686,7 +4707,9 @@ pub fn process_names(names: List(List(Int))) -> List(Int) {
 pub fn flatten(lists: List(List(a))) -> List(a) { todo }"
             )
             .add_hex_module("operation", "pub fn double(s: Int) -> Int { todo }"),
-        find_position_of("(dou").select_until(find_position_of("ble)")),
+        find_position_of("dou")
+            .nth_occurrence(2)
+            .select_until(find_position_of("ble").nth_occurrence(2)),
     );
 }
 
@@ -4705,7 +4728,9 @@ pub fn double_list(items: List(Int)) -> List(Int) {
             "list",
             "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
         ),
-        find_position_of("transform(").select_until(find_position_of("items,")),
+        find_position_of("transform")
+            .nth_occurrence(2)
+            .to_selection(),
     );
 }
 
@@ -4724,7 +4749,9 @@ pub fn double_list(items: List(Int)) -> List(Int) {
             "list",
             "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
         ),
-        find_position_of("transform(").select_until(find_position_of("items,")),
+        find_position_of("transform")
+            .nth_occurrence(2)
+            .to_selection(),
     );
 }
 
@@ -4744,7 +4771,9 @@ pub fn double_list(items: List(Int)) -> List(Int) {
             "list",
             "pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) { todo }"
         ),
-        find_position_of("transform(").select_until(find_position_of("items,")),
+        find_position_of("transform")
+            .nth_occurrence(2)
+            .to_selection(),
     );
 }
 
@@ -4766,7 +4795,7 @@ pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
             .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
         find_position_of("Opt")
             .nth_occurrence(2)
-            .select_until(find_position_of("ion(")),
+            .select_until(find_position_of("ion").nth_occurrence(3)),
     );
 }
 
@@ -4788,7 +4817,7 @@ pub fn maybe_increment(x: Maybe(Int)) -> Maybe(Int) {
             .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
         find_position_of("May")
             .nth_occurrence(2)
-            .select_until(find_position_of("be(")),
+            .select_until(find_position_of("be").nth_occurrence(3)),
     );
 }
 
@@ -4810,7 +4839,7 @@ pub fn maybe_increment(x: Option(Int)) -> Option(Int) {
             .add_hex_module("option", "pub type Option(a) { Some(a) None }"),
         find_position_of("Opt")
             .nth_occurrence(2)
-            .select_until(find_position_of("ion(")),
+            .select_until(find_position_of("ion").nth_occurrence(3)),
     );
 }
 
@@ -4828,7 +4857,7 @@ pub fn main() {
         "Qualify Some as option.Some",
         TestProject::for_source(src)
             .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
-        find_position_of("Some(").select_until(find_position_of("1)")),
+        find_position_of("Some(1)").select_until(find_position_of("Some(1)").under_char('e')),
     );
 }
 #[test]
@@ -4853,7 +4882,7 @@ pub fn main() {
         "Qualify Some as option.Some",
         TestProject::for_source(src)
             .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
-        find_position_of("Some(").select_until(find_position_of("1)")),
+        find_position_of("Some(1)").select_until(find_position_of("Some(1)").under_char('e')),
     );
 }
 

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -3847,6 +3847,24 @@ pub fn main(x) -> option.Option(Int) {
 }
 
 #[test]
+fn test_qualified_to_unqualified_only_triggers_within_qualified_value() {
+    let src = r#"
+import option
+
+pub fn main(x) -> option.Option(Int) {
+    option.Some(1)
+}
+// end
+"#;
+    assert_no_code_actions!(
+        "Unqualify option.Option",
+        TestProject::for_source(src)
+            .add_hex_module("option", "pub type Option(v) { Some(v) None }"),
+        find_position_of("import").select_until(find_position_of("// end")),
+    );
+}
+
+#[test]
 fn test_qualified_to_unqualified_import_nested_type_outer() {
     let src = r#"
 import option

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_after_constructor.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_after_constructor.snap
@@ -6,7 +6,7 @@ expression: "\npub fn create_user(name: String) -> User {\n    User(name: name, 
 
 pub fn create_user(name: String) -> User {
     User(name: name, id: 1)
-    ▔▔▔▔▔↑                 
+    ↑                      
 }
 
 import user.{type User, User}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_between_constructors.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_between_constructors.snap
@@ -6,7 +6,7 @@ expression: "\npub fn create_user(name: String) -> User {\n    User(name: name, 
 
 pub fn create_user(name: String) -> User {
     User(name: name, id: 1)
-    ▔▔▔▔▔↑                 
+    ↑                      
 }
 
 import user.{type User, User}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_constant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_constant.snap
@@ -8,7 +8,7 @@ import mymath.{pi}
 
 pub fn circle_area(radius: Float) -> Float {
     pi *. radius *. radius
-    ▔▔▔▔▔↑                
+    ↑                     
 }
 
 pub fn circle_circumference(radius: Float) -> Float {

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_constructor_complex_pattern.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_constructor_complex_pattern.snap
@@ -8,7 +8,7 @@ import option.{None, Some}
 
 pub fn main() {
     case [Some(1), None] {
-          ▔▔▔▔▔↑          
+          ▔▔▔↑            
         [None, ..] -> todo
         [Some(_), ..] -> todo
         _ -> todo

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_function.snap
@@ -8,7 +8,7 @@ import list.{map}
 
 pub fn main() {
     let identity = map([1, 2, 3], fn(x) { x })
-                   ▔▔▔▔↑                      
+                   ↑                          
     let double = map([1, 2, 3], fn(x) { x * 2 })
 }
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_in_list_and_tuple.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_in_list_and_tuple.snap
@@ -8,7 +8,7 @@ import option.{Some}
 
 pub fn main() {
     let list = [Some(1), option.None]
-                ▔▔▔▔▔↑               
+                ▔▔▔↑                 
     let tuple = #(Some(2), option.None)
 }
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_in_pattern_matching.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_in_pattern_matching.snap
@@ -9,7 +9,7 @@ import result.{type Result, Ok, Error}
 pub fn process_result(res: Result(Int, String)) -> Int {
     case res {
         Ok(value) -> value
-        ▔▔▔↑              
+        ↑                 
         Error(_) -> 0
     }
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_multiple_occurrences.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_multiple_occurrences.snap
@@ -9,7 +9,7 @@ import list.{map, filter}
 pub fn process_list(items: List(Int)) -> List(Int) {
     items
     |> map(fn(x) { x + 1 })
-    ▔▔▔▔▔▔↑                
+       ↑                   
     |> map(fn(x) { x * 2 })
 }
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_nested_function_call.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_nested_function_call.snap
@@ -11,7 +11,7 @@ pub fn process_names(names: List(List(Int))) -> List(Int) {
     names
     |> flatten
     |> map(double)
-          ▔▔▔▔↑   
+           ▔▔▔↑   
 }
 
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_record_constructor.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_record_constructor.snap
@@ -8,7 +8,7 @@ import user.{type User, User}
 
 pub fn create_user(name: String) -> User {
     User(name: name, id: 1)
-    ▔▔▔▔▔↑                 
+     ↑                     
 }
 
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_with_alias.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_with_alias.snap
@@ -8,7 +8,7 @@ import list.{map as transform}
 
 pub fn double_list(items: List(Int)) -> List(Int) {
     transform(items, fn(x) { x * 2 })
-    ▔▔▔▔▔▔▔▔▔▔↑                      
+    ↑                                
 }
 
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_with_alias_and_module_alias.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__unqualified_to_qualified_import_with_alias_and_module_alias.snap
@@ -8,7 +8,7 @@ import list.{map as transform} as lst
 
 pub fn double_list(items: List(Int)) -> List(Int) {
     transform(items, fn(x) { x * 2 })
-    ▔▔▔▔▔▔▔▔▔▔↑                      
+    ↑                                
 }
 
 


### PR DESCRIPTION
A language server code action normally triggers when the cursor selection falls within a region of interest. I noticed there's a few code action that do something slightly different (and a bit annoying): they trigger when the cursor selection contains a region of interest. In practice this means that for those code actions, if I have a selection that covers a big chunk of code I'll see a rather confusing list pop up. For example:
 
<img width="667" height="485" alt="Screenshot 2026-05-04 alle 20 49 35" src="https://github.com/user-attachments/assets/4ba1264c-1be2-4b84-808f-5b0cca608113" />

This makes it impossible to know which action we should be triggering, and what portion of code they're going to update. I've updated those actions so that they work the same way as all the other ones.

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
