### PR TITLE
Fix bit arrays with `unit` and `bytes` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,3 +186,7 @@
   build directory was manually deleted. The compiler now automatically rebuilds
   the project when this configuration changes.
   ([daniellionel01](https://github.com/daniellionel01))
+
+- Fixed a bug where using the `bytes` and `unit` options together on a bit array
+  segment could generate incorrect code on the JavaScript target.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -3661,12 +3661,16 @@ impl<Value, Type> BitArraySegment<Value, Type> {
         })
     }
 
+    /// Returns the unit of `size` in the bit array segment. The `unit` option
+    /// overrides the `bytes` option, so if a segment has both, the unit is what
+    /// is specified in `unit`, not 8.
     pub fn unit(&self) -> u8 {
-        self.options
-            .iter()
-            .find_map(|option| match option {
-                BitArrayOption::Unit { value, .. } => Some(*value),
-                BitArrayOption::Bytes { .. } => Some(8),
+        let mut has_bytes_option = false;
+
+        for option in self.options.iter() {
+            match option {
+                BitArrayOption::Unit { value, .. } => return *value,
+                BitArrayOption::Bytes { .. } => has_bytes_option = true,
                 BitArrayOption::Int { .. }
                 | BitArrayOption::Float { .. }
                 | BitArrayOption::Bits { .. }
@@ -3681,9 +3685,11 @@ impl<Value, Type> BitArraySegment<Value, Type> {
                 | BitArrayOption::Big { .. }
                 | BitArrayOption::Little { .. }
                 | BitArrayOption::Native { .. }
-                | BitArrayOption::Size { .. } => None,
-            })
-            .unwrap_or(1)
+                | BitArrayOption::Size { .. } => {}
+            }
+        }
+
+        if has_bytes_option { 8 } else { 1 }
     }
 
     pub(crate) fn has_bits_option(&self) -> bool {

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -526,3 +526,28 @@ pub fn go(wibble: String) {
 "#
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/5208
+#[test]
+fn unit_option_ignores_bytes() {
+    assert_erl!(
+        "
+pub fn main() {
+  let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>
+  x
+}
+"
+    );
+}
+
+#[test]
+fn unit_option_ignores_bytes_regardless_of_order() {
+    assert_erl!(
+        "
+pub fn main() {
+  let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>
+  x
+}
+"
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_option_ignores_bytes.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_option_ignores_bytes.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\npub fn main() {\n  let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>\n  x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>
+  x
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-define(FILEPATH, "project/test/my/mod.gleam").
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec main() -> bitstring().
+main() ->
+    X@1 = case <<1:6>> of
+        <<X:3/binary-unit:2>> -> X;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        file => <<?FILEPATH/utf8>>,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"main"/utf8>>,
+                        line => 3,
+                        value => _assert_fail,
+                        start => 19,
+                        'end' => 67,
+                        pattern_start => 30,
+                        pattern_end => 57})
+    end,
+    X@1.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_option_ignores_bytes_regardless_of_order.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_option_ignores_bytes_regardless_of_order.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\npub fn main() {\n  let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>\n  x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>
+  x
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-define(FILEPATH, "project/test/my/mod.gleam").
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec main() -> bitstring().
+main() ->
+    X@1 = case <<1:6>> of
+        <<X:3/binary-unit:2>> -> X;
+        _assert_fail ->
+            erlang:error(#{gleam_error => let_assert,
+                        message => <<"Pattern match failed, no pattern matched the value."/utf8>>,
+                        file => <<?FILEPATH/utf8>>,
+                        module => <<"my/mod"/utf8>>,
+                        function => <<"main"/utf8>>,
+                        line => 3,
+                        value => _assert_fail,
+                        start => 19,
+                        'end' => 67,
+                        pattern_start => 30,
+                        pattern_end => 57})
+    end,
+    X@1.

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -2819,3 +2819,28 @@ pub fn run(data) {
         "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5208
+#[test]
+fn unit_option_ignores_bytes() {
+    assert_js!(
+        "
+pub fn main() {
+  let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>
+  x
+}
+"
+    );
+}
+
+#[test]
+fn unit_option_ignores_bytes_regardless_of_order() {
+    assert_js!(
+        "
+pub fn main() {
+  let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>
+  x
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__unit_option_ignores_bytes.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__unit_option_ignores_bytes.snap
@@ -1,0 +1,35 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn main() {\n  let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>\n  x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>
+  x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError, toBitArray, bitArraySlice, sizedInt } from "../gleam.mjs";
+
+const FILEPATH = "src/module.gleam";
+
+export function main() {
+  let $ = toBitArray([sizedInt(1, 6, true)]);
+  let x;
+  if ($.bitSize === 6) {
+    x = bitArraySlice($, 0, 6);
+  } else {
+    throw makeError(
+      "let_assert",
+      FILEPATH,
+      "my/mod",
+      3,
+      "main",
+      "Pattern match failed, no pattern matched the value.",
+      { value: $, start: 19, end: 67, pattern_start: 30, pattern_end: 57 }
+    )
+  }
+  return x;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__unit_option_ignores_bytes_regardless_of_order.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__unit_option_ignores_bytes_regardless_of_order.snap
@@ -1,0 +1,35 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn main() {\n  let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>\n  x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>
+  x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { makeError, toBitArray, bitArraySlice, sizedInt } from "../gleam.mjs";
+
+const FILEPATH = "src/module.gleam";
+
+export function main() {
+  let $ = toBitArray([sizedInt(1, 6, true)]);
+  let x;
+  if ($.bitSize === 6) {
+    x = bitArraySlice($, 0, 6);
+  } else {
+    throw makeError(
+      "let_assert",
+      FILEPATH,
+      "my/mod",
+      3,
+      "main",
+      "Pattern match failed, no pattern matched the value.",
+      { value: $, start: 19, end: 67, pattern_start: 30, pattern_end: 57 }
+    )
+  }
+  return x;
+}

--- a/test/language/test/language/bit_array_match_test.gleam
+++ b/test/language/test/language/bit_array_match_test.gleam
@@ -139,3 +139,14 @@ pub fn multiple_variable_segments_test() {
   let assert <<a, b:size(a), c:size(b)>> = <<2, 3:2, 7:3>>
   assert a + b + c == 12
 }
+
+// https://github.com/gleam-lang/gleam/issues/5208
+pub fn unit_ignores_bytes_option() {
+  let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>
+  assert x == <<1:6>>
+}
+
+pub fn unit_ignores_bytes_option_regardless_of_order() {
+  let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>
+  assert x == <<1:6>>
+}


### PR DESCRIPTION
Fixes #5208

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Based on some testing, the correct Erlang behaviour is to have `unit` override `bytes`, so that's what I've made it do.