### PR TITLE
fix suggest extract function code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,11 @@
   function" code action even when not explicitly hovering a custom type.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where the language server would suggest the "extract function"
+  code action even when selecting multiple branches of a case expression, or
+  patterns and guards of a case arm.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where enabling `javascript.typescript_declarations` or
   `javascript.source_maps` wouldn't generate their additional files unless the
   build directory was manually deleted. The compiler now automatically rebuilds

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -11074,6 +11074,58 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
         self.register_referenced_variable(name, type_, *location, *definition_location);
     }
 
+    fn visit_typed_expr_case(
+        &mut self,
+        location: &'ast SrcSpan,
+        type_: &'ast Arc<Type>,
+        subjects: &'ast [TypedExpr],
+        clauses: &'ast [ast::TypedClause],
+        compiled_case: &'ast CompiledCase,
+    ) {
+        let was_extracting_already = self.function.is_some();
+
+        // We first visit as usual...
+        ast::visit::visit_typed_expr_case(self, location, type_, subjects, clauses, compiled_case);
+
+        // But then we need to check we're in a situation where it actually makes
+        // sense to extract: if the cursor is entirely within the case (so it's
+        // not part of a bigger extracted chunk) and it spans over one of the
+        // branches' pattern or guard, then we don't want to allow extracting
+        // anything. Popping up the action would be confusing.
+        // For example:
+        //
+        // ```gleam
+        // case wibble {
+        //   Ok(_) -> todo
+        // //^^^^^^^^^^^^^ If I'm selecting this whole branch it makes no sense
+        //                 to propose extracting it as a function
+        //   _ if wibble -> todo
+        // //        ^^^^^^^^^^^ If I'm selecting this it makes no sense to
+        // //                    propose extracting it as a function
+        // }
+        // ```
+
+        // We were already extracting something, we don't want to render that
+        // choice null, this is just a part of a bigger piece being extracted.
+        if was_extracting_already {
+            return;
+        }
+
+        for clause in clauses {
+            let left_hand_side_location = SrcSpan {
+                start: clause.pattern_location().start,
+                end: clause.then.location().start - 1,
+            };
+            let left_hand_side_range = self.edits.src_span_to_lsp_range(left_hand_side_location);
+            // If there's any overlapping with one of the patterns, then we
+            // don't want to extract anything.
+            if overlaps(self.params.range, left_hand_side_range) {
+                self.function = None;
+                break;
+            }
+        }
+    }
+
     fn visit_typed_bit_array_size_variable(
         &mut self,
         location: &'ast SrcSpan,

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -11906,6 +11906,77 @@ pub fn main() {
 }
 
 #[test]
+fn no_extract_function_selecting_multiple_case_branches() {
+    assert_no_code_actions!(
+        EXTRACT_FUNCTION,
+        r#"
+const pi = 3.14
+
+pub fn main() {
+  let value = 3.15
+
+  let string = case value {
+    0.0 -> "Zero"
+    1.0 -> "One"
+    _ -> "Something else"
+  }
+
+  echo string
+}
+"#,
+        find_position_of("0.0").select_until(find_position_of("else"))
+    );
+}
+
+#[test]
+fn no_extract_function_selecting_case_branch_pattern() {
+    assert_no_code_actions!(
+        EXTRACT_FUNCTION,
+        r#"
+const pi = 3.14
+
+pub fn main() {
+  let value = 3.15
+
+  let string = case value {
+    0.0 -> "Zero"
+    1.0 -> "One"
+    _ -> "Something else"
+  }
+
+  echo string
+}
+"#,
+        find_position_of("0.0").select_until(find_position_of("Zero").under_last_char())
+    );
+}
+
+#[test]
+fn no_extract_function_selecting_case_branch_guard() {
+    assert_no_code_actions!(
+        EXTRACT_FUNCTION,
+        r#"
+const pi = 3.14
+
+pub fn main() {
+  let value = 3.15
+
+  let string = case value {
+    0.0 if True -> "Zero"
+    1.0 -> "One"
+    _ -> "Something else"
+  }
+
+  echo string
+}
+"#,
+        find_position_of("True")
+            .under_char('u')
+            .select_until(find_position_of("Zero").under_last_char())
+    );
+}
+
+#[test]
 fn extract_use_inside_function() {
     assert_code_action!(
         EXTRACT_FUNCTION,


### PR DESCRIPTION
I noticed the language server would suggest the extract function even when selecting multiple branches of a case expression, or pattern/guards of a branch:
<img width="846" height="326" alt="Screenshot 2026-05-04 alle 17 24 20" src="https://github.com/user-attachments/assets/9860f0b8-486c-4462-9c42-a535ecfb0efb" />

This PR fixes it!


- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
