### PR TITLE
#2234 type alias and internal leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,39 @@
   raised in.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler now warns when a public function, constructor, or constant
+  exposes an `@internal` type. For example:
+
+  ```gleam
+  @internal
+  pub type Internal { ... }
+
+  pub fn process(value: Internal) -> Internal {
+    todo
+  }
+  ```
+
+  Will produce:
+
+  ```txt
+  warning: Internal type used in public interface
+    ┌─ /src/wrn.gleam:5:1
+    │
+  5 │ pub fn process(value: Internal) -> Internal {
+    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  The following type is internal, but is being used by this public export.
+
+      Internal
+
+  Internal types should not be used in a public facing function since
+  they are hidden from the package's documentation.
+  ```
+
+  Using `pub type Alias = Internal` is a safe escape hatch: the alias is
+  public, so using it in a public signature does not trigger the warning.
+  ([Daniele Scaratti](https://github.com/lupodevelop))
+
 ### Build tool
 
 - The `gleam dev` command now accepts the `--no-print-progress` flag. When this
@@ -78,6 +111,11 @@
 - The package manager now has a specific error and automatic re-authentication
   flow for when a Hex session has been revoked or has expired.
   ([Sahil Upasane](https://github.com/404salad))
+
+- `gleam publish` now refuses to publish a package whose public API exposes
+  an `@internal` type directly. Use a public type alias to re-export the
+  type, or remove the `@internal` annotation.
+  ([Daniele Scaratti](https://github.com/lupodevelop))
 
 ### Language server
 

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -515,10 +515,19 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
         });
     }
 
-    // TODO: If any of the modules in the package contain a leaked internal type then
-    // refuse to publish as the package is not yet finished.
-    // We need to move aliases in to the type system first.
-    // context: https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
+    let leaking_modules: Vec<_> = built
+        .root_package
+        .modules
+        .iter()
+        .filter(|module| module.ast.type_info.contains_internal_type_leak())
+        .map(|module| module.name.clone())
+        .collect();
+
+    if !leaking_modules.is_empty() {
+        return Err(Error::CannotPublishLeakedInternalType {
+            unfinished: leaking_modules,
+        });
+    }
 
     // Collect all the files we want to include in the tarball
     let generated_files = match target {

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1489,6 +1489,9 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             environment
                 .names
                 .type_in_scope(name.clone(), type_.as_ref(), &parameters);
+            environment
+                .names
+                .alias_in_scope(self.module_name.clone(), name.clone());
 
             // Insert the alias so that it can be used by other code.
             environment.insert_type_constructor(

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -34,6 +34,7 @@ use crate::{
         fields::FieldMapBuilder,
         hydrator::Hydrator,
         prelude::*,
+        printer::Names,
     },
     uid::UniqueIdGenerator,
     warning::TypeWarningEmitter,
@@ -343,7 +344,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
         // Ensure no exported values have private types in their type signature
         for value in env.module_values.values() {
-            self.check_for_type_leaks(value)
+            self.check_for_type_leaks(value, &env.names)
         }
 
         // Resolve deferred type variable aliases now that all unification is
@@ -1673,17 +1674,28 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         );
     }
 
-    fn check_for_type_leaks(&mut self, value: &ValueConstructor) {
+    fn check_for_type_leaks(&mut self, value: &ValueConstructor, names: &Names) {
         // A private value doesn't export anything so it can't leak anything.
         if value.publicity.is_private() {
             return;
         }
 
-        // If a private or internal value references a private type
         if let Some(leaked) = value.type_.find_private_type() {
             self.problems.error(Error::PrivateTypeLeak {
                 location: value.variant.definition_location(),
                 leaked,
+            });
+        }
+
+        // Only warn about internal type leaks for public values: an internal
+        // or private value using an internal type is consistent, not a leak.
+        if value.publicity.is_public()
+            && let Some(leaked) = value.type_.find_internal_type()
+        {
+            self.problems.warning(Warning::InternalTypeLeak {
+                location: value.variant.definition_location(),
+                leaked,
+                names: names.clone(),
             });
         }
     }

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -130,6 +130,20 @@ impl<'context, 'problems> Importer<'context, 'problems> {
         {
             self.problems.error(e);
         }
+
+        // If the imported type is also a public alias in the source module,
+        // mirror it locally so the hydrator wraps references in `Type::Alias`
+        // and the printer can show it without a module prefix. Duplicate
+        // diagnostics are reported by `insert_type_constructor` above.
+        if let Some(alias) = module.type_aliases.get(&import.name) {
+            let alias = alias.clone().with_location(import.location);
+            self.environment
+                .names
+                .alias_in_scope(alias.module.clone(), imported_name.clone());
+            let _ = self
+                .environment
+                .insert_type_alias(imported_name.clone(), alias);
+        }
     }
 
     fn register_unqualified_value(

--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -610,6 +610,9 @@ fn type_to_definition_locations<'a>(
     importable_modules: &'a im::HashMap<EcoString, type_::ModuleInterface>,
 ) -> Vec<DefinitionLocation> {
     match type_.as_ref() {
+        Type::Alias { aliased, .. } => {
+            return type_to_definition_locations(aliased.clone(), importable_modules);
+        }
         // For named types we start with the location of the named type itself
         // followed by the locations of all types they reference in their args.
         //

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -441,6 +441,8 @@ impl Printer<'_> {
 
     fn type_(&mut self, type_: &Type, print_mode: PrintMode) -> Document<'static> {
         match type_ {
+            Type::Alias { aliased, .. } => self.type_(aliased, print_mode),
+
             Type::Named {
                 package,
                 module,
@@ -672,6 +674,9 @@ impl Printer<'_> {
     ///
     fn register_local_type_variable_names(&mut self, type_: &Type) {
         match type_ {
+            Type::Alias { aliased, .. } => {
+                self.register_local_type_variable_names(aliased);
+            }
             Type::Named { arguments, .. } => {
                 for argument in arguments {
                     self.register_local_type_variable_names(argument);

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1693,7 +1693,7 @@ fn var<'a>(name: &'a str, constructor: &'a ValueConstructor, env: &mut Env<'a>) 
                 Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
                     atom_string(to_snake_case(record_name))
                 }
-                Type::Alias { .. } => unreachable!(),
+                Type::Alias { .. } => unreachable!("collapse_links strips Type::Alias"),
             }
         }
 
@@ -1812,7 +1812,7 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
                 Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
                     atom_string(to_snake_case(tag))
                 }
-                Type::Alias { .. } => unreachable!(),
+                Type::Alias { .. } => unreachable!("collapse_links strips Type::Alias"),
             }
         }
 

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -9,7 +9,7 @@ mod tests;
 use crate::build::{Target, module_erlang_name};
 use crate::erlang::pattern::{PatternPrinter, StringPatternAssignment};
 use crate::strings::{convert_string_escape_chars, to_snake_case};
-use crate::type_::is_prelude_module;
+use crate::type_::{collapse_links, is_prelude_module};
 use crate::{
     Result,
     ast::{Function, *},
@@ -1676,22 +1676,26 @@ fn var<'a>(name: &'a str, constructor: &'a ValueConstructor, env: &mut Env<'a>) 
     match &constructor.variant {
         ValueConstructorVariant::Record {
             name: record_name, ..
-        } => match constructor.type_.deref() {
-            Type::Fn { arguments, .. } => {
-                let chars = incrementing_arguments_list(arguments.len());
-                "fun("
-                    .to_doc()
-                    .append(chars.clone())
-                    .append(") -> {")
-                    .append(atom_string(to_snake_case(record_name)))
-                    .append(", ")
-                    .append(chars)
-                    .append("} end")
+        } => {
+            let t = collapse_links(constructor.type_.clone());
+            match t.as_ref() {
+                Type::Fn { arguments, .. } => {
+                    let chars = incrementing_arguments_list(arguments.len());
+                    "fun("
+                        .to_doc()
+                        .append(chars.clone())
+                        .append(") -> {")
+                        .append(atom_string(to_snake_case(record_name)))
+                        .append(", ")
+                        .append(chars)
+                        .append("} end")
+                }
+                Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
+                    atom_string(to_snake_case(record_name))
+                }
+                Type::Alias { .. } => unreachable!(),
             }
-            Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
-                atom_string(to_snake_case(record_name))
-            }
-        },
+        }
 
         ValueConstructorVariant::LocalVariable { .. } => env.local_var_name(name),
 
@@ -1801,12 +1805,16 @@ fn const_inline<'a>(literal: &'a TypedConstant, env: &mut Env<'a>) -> Document<'
             type_,
             arguments,
             ..
-        } if arguments.is_empty() => match type_.deref() {
-            Type::Fn { arguments, .. } => record_constructor_function(tag, arguments.len()),
-            Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
-                atom_string(to_snake_case(tag))
+        } if arguments.is_empty() => {
+            let t = collapse_links(type_.clone());
+            match t.as_ref() {
+                Type::Fn { arguments, .. } => record_constructor_function(tag, arguments.len()),
+                Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
+                    atom_string(to_snake_case(tag))
+                }
+                Type::Alias { .. } => unreachable!(),
             }
-        },
+        }
 
         Constant::Record { tag, arguments, .. } => {
             // Record updates are fully expanded during type checking, so we just handle arguments
@@ -3134,13 +3142,15 @@ fn tuple_index<'a>(tuple: &'a TypedExpr, index: u64, env: &mut Env<'a>) -> Docum
 }
 
 fn module_select_fn<'a>(type_: Arc<Type>, module_name: &'a str, label: &'a str) -> Document<'a> {
-    match crate::type_::collapse_links(type_).as_ref() {
+    match collapse_links(type_).as_ref() {
         Type::Fn { arguments, .. } => function_reference(Some(module_name), label, arguments.len()),
 
-        Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => module_name_atom(module_name)
-            .append(":")
-            .append(atom(label))
-            .append("()"),
+        Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } | Type::Alias { .. } => {
+            module_name_atom(module_name)
+                .append(":")
+                .append(atom(label))
+                .append("()")
+        }
     }
 }
 
@@ -3364,6 +3374,7 @@ fn result_type_var_ids(ids: &mut HashMap<u64, u64>, arg_ok: &Type, arg_err: &Typ
 
 fn type_var_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
     match type_ {
+        Type::Alias { aliased, .. } => type_var_ids(aliased, ids),
         Type::Var { type_ } => match type_.borrow().deref() {
             TypeVar::Generic { id, .. } | TypeVar::Unbound { id, .. } => {
                 let count = ids.entry(*id).or_insert(0);
@@ -3472,6 +3483,7 @@ impl<'a> TypePrinter<'a> {
 
     pub fn print(&self, type_: &Type) -> Document<'static> {
         match type_ {
+            Type::Alias { aliased, .. } => self.print(aliased.as_ref()),
             Type::Var { type_ } => self.print_var(&type_.borrow()),
 
             Type::Named {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1320,13 +1320,12 @@ resulting in compilation errors!"
             }],
 
             Error::CannotPublishLeakedInternalType { unfinished } => vec![Diagnostic {
-                title: "Cannot publish unfinished code".into(),
+                title: "Internal types leaked through public API".into(),
                 text: format!(
-                    "These modules leak internal types in their public API and cannot be published:
+                    "These modules expose `@internal` types in a public function, \
+constructor, or constant and cannot be published:
 
 {}
-
-Please make sure internal types do not appear in public functions and try again.
 ",
                     unfinished
                         .iter()
@@ -1334,7 +1333,11 @@ Please make sure internal types do not appear in public functions and try again.
                         .join("\n")
                 ),
                 level: Level::Error,
-                hint: None,
+                hint: Some(
+                    "Use a public type alias (`pub type Alias = Internal`) to expose \
+a stable name without revealing the internal type, or drop the `@internal` annotation."
+                        .into(),
+                ),
                 location: None,
             }],
 

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -846,7 +846,11 @@ impl BranchMode {
 
 impl Variable {
     fn branch_mode(&self, env: &Environment<'_>) -> BranchMode {
-        match collapse_links(self.type_.clone()).as_ref() {
+        // collapse_links recursively follows every alias and TypeVar::Link in
+        // the chain, so the result is guaranteed to be a non-Alias type.
+        let t = collapse_links(self.type_.clone());
+        match t.as_ref() {
+            Type::Alias { .. } => unreachable!("collapse_links always removes aliases"),
             Type::Fn { .. } | Type::Var { .. } => BranchMode::Infinite,
             Type::Named { module, name, .. }
                 if is_prelude_module(module)
@@ -3185,6 +3189,23 @@ impl ConstructorSpecialiser {
 
     fn specialise_type(&self, type_: &Type) -> Arc<Type> {
         Arc::new(match type_ {
+            Type::Alias {
+                name,
+                module,
+                publicity,
+                aliased,
+                parameters,
+            } => Type::Alias {
+                name: name.clone(),
+                module: module.clone(),
+                publicity: *publicity,
+                aliased: self.specialise_type(aliased.as_ref()),
+                parameters: parameters
+                    .iter()
+                    .map(|argument| self.specialise_type(argument))
+                    .collect(),
+            },
+
             Type::Named {
                 publicity,
                 package,

--- a/compiler-core/src/inline.rs
+++ b/compiler-core/src/inline.rs
@@ -1676,6 +1676,7 @@ impl FunctionToInlinable {
 
     fn type_(&self, type_: &Arc<Type>) -> InlinableType {
         match collapse_links(type_.clone()).as_ref() {
+            Type::Alias { aliased, .. } => self.type_(aliased),
             Type::Fn { arguments, return_ } => InlinableType::Function {
                 arguments: arguments
                     .iter()

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -93,6 +93,7 @@ fn collect_generic_usages<'a>(
 
 fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
     match type_ {
+        Type::Alias { aliased, .. } => generic_ids(aliased.as_ref(), ids),
         Type::Var { type_ } => match type_.borrow().deref() {
             TypeVar::Unbound { id, .. } | TypeVar::Generic { id, .. } => {
                 let count = ids.entry(*id).or_insert(0);
@@ -269,6 +270,9 @@ impl<'a> TypeScriptGenerator<'a> {
     ///
     fn collect_imports_for_type<'b>(&mut self, type_: &'b Type, imports: &mut Imports<'a>) {
         match &type_ {
+            Type::Alias { aliased, .. } => {
+                self.collect_imports_for_type(aliased.as_ref(), imports);
+            }
             Type::Named {
                 package,
                 module,
@@ -893,6 +897,7 @@ impl<'a> TypeScriptGenerator<'a> {
         generic_printing: GenericPrinting<'_>,
     ) -> Document<'static> {
         match type_ {
+            Type::Alias { aliased, .. } => self.do_print(aliased.as_ref(), generic_printing),
             Type::Var { type_ } => self.print_var(&type_.borrow(), generic_printing),
 
             Type::Named {
@@ -923,6 +928,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
     fn do_print_force_generic_param(&mut self, type_: &Type) -> Document<'static> {
         match type_ {
+            Type::Alias { aliased, .. } => self.do_print_force_generic_param(aliased.as_ref()),
             Type::Var { type_ } => self.print_var(&type_.borrow(), GenericPrinting::AlwaysGeneric),
 
             Type::Named {

--- a/compiler-core/src/metadata.rs
+++ b/compiler-core/src/metadata.rs
@@ -639,6 +639,22 @@ impl RemapIds {
                     .map(|element| self.type_(element))
                     .collect(),
             },
+            Type::Alias {
+                name,
+                module,
+                publicity,
+                aliased,
+                parameters,
+            } => Type::Alias {
+                name,
+                module,
+                publicity,
+                aliased: self.type_(aliased),
+                parameters: parameters
+                    .into_iter()
+                    .map(|parameter| self.type_(parameter))
+                    .collect(),
+            },
         };
         Arc::new(type_)
     }

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -17,6 +17,7 @@ use crate::{
         self, Deprecation, ModuleInterface, Opaque, References, Type, TypeAliasConstructor,
         TypeConstructor, TypeValueConstructor, TypeValueConstructorField, TypeVariantConstructors,
         ValueConstructor, ValueConstructorVariant,
+        error::Warning,
         expression::{Implementations, Purity},
         prelude,
     },
@@ -115,6 +116,57 @@ fn empty_module() {
         references: References::default(),
         inline_functions: HashMap::new(),
     };
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
+fn module_with_alias() {
+    let mut module = ModuleInterface {
+        warnings: vec![],
+        is_internal: true,
+        package: "some_package".into(),
+        origin: Origin::Src,
+        name: "one/two".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        values: HashMap::new(),
+        accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
+        minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: Vec::new(),
+        contains_echo: false,
+
+        references: References::default(),
+        inline_functions: HashMap::new(),
+    };
+    let _ = module.type_aliases.insert(
+        "MyAlias".into(),
+        TypeAliasConstructor {
+            publicity: Publicity::Public,
+            module: "thepackage".into(),
+            type_: Arc::new(Type::Alias {
+                name: "MyAlias".into(),
+                module: "thepackage".into(),
+                aliased: Arc::new(Type::Named {
+                    publicity: Publicity::Private,
+                    package: "".into(),
+                    module: "gleam".into(),
+                    name: "Int".into(),
+                    arguments: vec![],
+                    inferred_variant: None,
+                }),
+                parameters: vec![],
+                publicity: Publicity::Public,
+            }),
+            arity: 0,
+            deprecation: Deprecation::NotDeprecated,
+            documentation: None,
+            origin: SrcSpan::default(),
+            parameters: vec![],
+        },
+    );
     assert_eq!(roundtrip(&module), module);
 }
 
@@ -1859,6 +1911,90 @@ fn module_with_type_aliases() {
         documentation: Vec::new(),
         contains_echo: false,
 
+        references: References::default(),
+        inline_functions: HashMap::new(),
+    };
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
+fn module_with_public_alias_of_internal_type() {
+    let module = ModuleInterface {
+        warnings: vec![],
+        is_internal: false,
+        package: "some_package".into(),
+        origin: Origin::Src,
+        name: "some_module".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        values: HashMap::new(),
+        accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
+        minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: [(
+            "InternalAlias".into(),
+            TypeAliasConstructor {
+                publicity: Publicity::Public,
+                module: "some_module".into(),
+                type_: Arc::new(Type::Named {
+                    publicity: Publicity::Internal {
+                        attribute_location: Some(SrcSpan::new(0, 1)),
+                    },
+                    package: "some_package".into(),
+                    module: "some_module".into(),
+                    name: "Internal".into(),
+                    arguments: Vec::new(),
+                    inferred_variant: None,
+                }),
+                arity: 0,
+                deprecation: Deprecation::NotDeprecated,
+                documentation: Some("Some documentation".into()),
+                origin: Default::default(),
+                parameters: vec![],
+            },
+        )]
+        .into(),
+        documentation: Vec::new(),
+        contains_echo: false,
+
+        references: References::default(),
+        inline_functions: HashMap::new(),
+    };
+    assert_eq!(roundtrip(&module), module);
+}
+
+#[test]
+fn module_with_internal_type_leak_warning() {
+    let module = ModuleInterface {
+        warnings: vec![Warning::InternalTypeLeak {
+            location: SrcSpan { start: 10, end: 20 },
+            leaked: Type::Named {
+                publicity: Publicity::Internal {
+                    attribute_location: None,
+                },
+                package: "some_package".into(),
+                module: "some_module".into(),
+                name: "Internal".into(),
+                arguments: vec![],
+                inferred_variant: None,
+            },
+            names: type_::printer::Names::new(),
+        }],
+        is_internal: false,
+        package: "some_package".into(),
+        origin: Origin::Src,
+        name: "some_module".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        values: HashMap::new(),
+        accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
+        minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: vec![],
+        contains_echo: false,
         references: References::default(),
         inline_functions: HashMap::new(),
     };

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -2002,6 +2002,49 @@ fn module_with_internal_type_leak_warning() {
 }
 
 #[test]
+fn contains_internal_type_leak_detects_warning() {
+    let leak = Warning::InternalTypeLeak {
+        location: SrcSpan { start: 0, end: 1 },
+        leaked: Type::Named {
+            publicity: Publicity::Internal {
+                attribute_location: None,
+            },
+            package: "pkg".into(),
+            module: "pkg/internal".into(),
+            name: "Internal".into(),
+            arguments: vec![],
+            inferred_variant: None,
+        },
+        names: type_::printer::Names::new(),
+    };
+
+    let leaking = ModuleInterface {
+        warnings: vec![leak],
+        is_internal: false,
+        package: "pkg".into(),
+        origin: Origin::Src,
+        name: "pkg/main".into(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        values: HashMap::new(),
+        accessors: HashMap::new(),
+        line_numbers: LineNumbers::new(""),
+        src_path: "some_path".into(),
+        minimum_required_version: Version::new(0, 1, 0),
+        type_aliases: HashMap::new(),
+        documentation: vec![],
+        contains_echo: false,
+        references: References::default(),
+        inline_functions: HashMap::new(),
+    };
+    assert!(leaking.contains_internal_type_leak());
+
+    let mut clean = leaking.clone();
+    clean.warnings.clear();
+    assert!(!clean.contains_internal_type_leak());
+}
+
+#[test]
 fn module_with_documentation() {
     let module = ModuleInterface {
         warnings: vec![],

--- a/compiler-core/src/package_interface.rs
+++ b/compiler-core/src/package_interface.rs
@@ -559,6 +559,7 @@ impl TypeInterface {
 /// have the same id will also have the same incremental number in the end).
 fn from_type_helper(type_: &Type, id_map: &mut IdMap) -> TypeInterface {
     match type_ {
+        Type::Alias { aliased, .. } => from_type_helper(aliased.as_ref(), id_map),
         Type::Fn { arguments, return_ } => TypeInterface::Fn {
             parameters: arguments
                 .iter()
@@ -659,6 +660,7 @@ impl IdMap {
     /// be assigned to a new incremental number.
     fn add_type_variable_id(&mut self, type_: &Type) {
         match type_ {
+            Type::Alias { aliased, .. } => self.add_type_variable_id(aliased.as_ref()),
             // These types have no id to add to the map.
             Type::Named { .. } | Type::Fn { .. } | Type::Tuple { .. } => (),
             // If the type is actually a type variable whose id needs to be mapped.

--- a/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__function_with_aliased_function_type.snap
+++ b/compiler-core/src/package_interface/snapshots/gleam_core__package_interface__tests__function_with_aliased_function_type.snap
@@ -1,0 +1,88 @@
+---
+source: compiler-core/src/package_interface/tests.rs
+assertion_line: 231
+expression: "\n\npub type F = fn(Int) -> Int\npub fn foo(x: F) -> Int { x 1 }\n"
+snapshot_kind: text
+---
+{
+  "name": "my_package",
+  "version": "11.10.9-1.wibble+build",
+  "gleam-version-constraint": "1.0.0",
+  "modules": {
+    "my/module": {
+      "documentation": [],
+      "type-aliases": {
+        "F": {
+          "documentation": null,
+          "deprecation": null,
+          "parameters": 0,
+          "alias": {
+            "kind": "fn",
+            "parameters": [
+              {
+                "kind": "named",
+                "name": "Int",
+                "package": "",
+                "module": "gleam",
+                "parameters": []
+              }
+            ],
+            "return": {
+              "kind": "named",
+              "name": "Int",
+              "package": "",
+              "module": "gleam",
+              "parameters": []
+            }
+          }
+        }
+      },
+      "types": {},
+      "constants": {},
+      "functions": {
+        "foo": {
+          "documentation": null,
+          "deprecation": null,
+          "implementations": {
+            "gleam": true,
+            "uses-erlang-externals": false,
+            "uses-javascript-externals": false,
+            "can-run-on-erlang": true,
+            "can-run-on-javascript": true
+          },
+          "parameters": [
+            {
+              "label": null,
+              "type": {
+                "kind": "fn",
+                "parameters": [
+                  {
+                    "kind": "named",
+                    "name": "Int",
+                    "package": "",
+                    "module": "gleam",
+                    "parameters": []
+                  }
+                ],
+                "return": {
+                  "kind": "named",
+                  "name": "Int",
+                  "package": "",
+                  "module": "gleam",
+                  "parameters": []
+                }
+              }
+            }
+          ],
+          "return": {
+            "kind": "named",
+            "name": "Int",
+            "package": "",
+            "module": "gleam",
+            "parameters": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -227,6 +227,16 @@ pub fn type_aliases() {
 }
 
 #[test]
+pub fn function_with_aliased_function_type() {
+    assert_package_interface!(
+        "\n
+pub type F = fn(Int) -> Int
+pub fn foo(x: F) -> Int { x 1 }
+"
+    );
+}
+
+#[test]
 pub fn type_definition() {
     assert_package_interface!(
         "

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__byte_order_mark_module.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__byte_order_mark_module.snap
@@ -105,6 +105,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
@@ -347,6 +347,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
@@ -269,6 +269,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
@@ -254,6 +254,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_with_module.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_with_module.snap
@@ -105,6 +105,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -97,6 +97,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__deprecation_attribute_on_type_variant.snap
@@ -68,6 +68,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__external_attribute_with_custom_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__external_attribute_with_custom_type.snap
@@ -70,6 +70,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__import_type.snap
@@ -70,6 +70,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__private_opaque_type_is_parsed.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__private_opaque_type_is_parsed.snap
@@ -52,6 +52,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_access_no_label.snap
@@ -173,6 +173,7 @@ Parsed {
         ],
         names: Names {
             local_types: {},
+            local_aliases: {},
             imported_modules: {},
             type_variables: {},
             local_value_constructors: {},

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1628,6 +1628,13 @@ pub struct TypeAliasConstructor {
     pub parameters: Vec<Arc<Type>>,
 }
 
+impl TypeAliasConstructor {
+    pub(crate) fn with_location(mut self, location: SrcSpan) -> Self {
+        self.origin = location;
+        self
+    }
+}
+
 impl ValueConstructor {
     pub fn field_map(&self) -> Option<&FieldMap> {
         match &self.variant {

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -51,6 +51,18 @@ pub trait HasType {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Type {
+    /// An explicit type alias declared with `pub type Foo = Bar`.
+    ///
+    /// The alias carries its own publicity so diagnostics can tell "this was an
+    /// alias" instead of accidentally warning about the underlying type.
+    Alias {
+        name: EcoString,
+        module: EcoString,
+        publicity: Publicity,
+        aliased: Arc<Type>,
+        parameters: Vec<Arc<Type>>,
+    },
+
     /// A nominal (named) type such as `Int`, `Float`, or a programmer defined
     /// custom type such as `Person`. The type can take other types as
     /// arguments (aka "generics" or "parametric polymorphism").
@@ -116,6 +128,7 @@ pub enum Type {
 impl Type {
     pub fn is_result_constructor(&self) -> bool {
         match self {
+            Type::Alias { aliased, .. } => aliased.is_result_constructor(),
             Type::Fn { return_, .. } => return_.is_result(),
             Type::Var { type_ } => type_.borrow().is_result_constructor(),
             Type::Named { .. } | Type::Tuple { .. } => false,
@@ -124,6 +137,7 @@ impl Type {
 
     pub fn is_result(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_result(),
             Self::Named { name, module, .. } => "Result" == name && is_prelude_module(module),
             Self::Var { type_ } => type_.borrow().is_result(),
             Self::Fn { .. } | Self::Tuple { .. } => false,
@@ -132,6 +146,7 @@ impl Type {
 
     pub fn is_named(&self) -> bool {
         match self {
+            Self::Alias { .. } => true,
             Self::Named { .. } => true,
             Self::Var { .. } | Self::Fn { .. } | Self::Tuple { .. } => false,
         }
@@ -139,6 +154,7 @@ impl Type {
 
     pub fn result_ok_type(&self) -> Option<Arc<Type>> {
         match self {
+            Self::Alias { aliased, .. } => aliased.result_ok_type(),
             Self::Named {
                 module,
                 name,
@@ -152,6 +168,7 @@ impl Type {
 
     pub fn result_types(&self) -> Option<(Arc<Type>, Arc<Type>)> {
         match self {
+            Self::Alias { aliased, .. } => aliased.result_types(),
             Self::Named {
                 module,
                 name,
@@ -167,6 +184,7 @@ impl Type {
 
     pub fn is_unbound(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_unbound(),
             Self::Var { type_ } => type_.borrow().is_unbound(),
             Self::Named { .. } | Self::Fn { .. } | Self::Tuple { .. } => false,
         }
@@ -174,6 +192,7 @@ impl Type {
 
     pub fn is_variable(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_variable(),
             Self::Var { type_ } => type_.borrow().is_variable(),
             Self::Named { .. } | Self::Fn { .. } | Self::Tuple { .. } => false,
         }
@@ -181,6 +200,7 @@ impl Type {
 
     pub fn return_type(&self) -> Option<Arc<Self>> {
         match self {
+            Self::Alias { aliased, .. } => aliased.return_type(),
             Self::Fn { return_, .. } => Some(return_.clone()),
             Self::Var { type_ } => type_.borrow().return_type(),
             Self::Named { .. } | Self::Tuple { .. } => None,
@@ -189,6 +209,7 @@ impl Type {
 
     pub fn fn_types(&self) -> Option<(Vec<Arc<Self>>, Arc<Self>)> {
         match self {
+            Self::Alias { aliased, .. } => aliased.fn_types(),
             Self::Fn {
                 arguments, return_, ..
             } => Some((arguments.clone(), return_.clone())),
@@ -200,6 +221,7 @@ impl Type {
     /// Gets the types inside of a tuple. Returns `None` if the type is not a tuple.
     pub fn tuple_types(&self) -> Option<Vec<Arc<Self>>> {
         match self {
+            Self::Alias { aliased, .. } => aliased.tuple_types(),
             Self::Tuple { elements } => Some(elements.clone()),
             Self::Var { type_, .. } => type_.borrow().tuple_types(),
             Self::Named { .. } | Self::Fn { .. } => None,
@@ -210,6 +232,7 @@ impl Type {
     /// does not lead to a type constructor.
     pub fn constructor_types(&self) -> Option<Vec<Arc<Self>>> {
         match self {
+            Self::Alias { aliased, .. } => aliased.constructor_types(),
             Self::Named { arguments, .. } => Some(arguments.clone()),
             Self::Var { type_, .. } => type_.borrow().constructor_types(),
             Self::Fn { .. } | Self::Tuple { .. } => None,
@@ -220,6 +243,7 @@ impl Type {
     /// type.
     pub fn list_type(&self) -> Option<Arc<Self>> {
         match self {
+            Self::Alias { aliased, .. } => aliased.list_type(),
             Type::Named {
                 publicity: Publicity::Public,
                 name,
@@ -254,6 +278,7 @@ impl Type {
     #[must_use]
     fn is_fun(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_fun(),
             Self::Fn { .. } => true,
             Self::Var { type_ } => type_.borrow().is_fun(),
             Self::Named { .. } | Self::Tuple { .. } => false,
@@ -262,6 +287,7 @@ impl Type {
 
     pub fn is_nil(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_nil(),
             Self::Named { module, name, .. } if "Nil" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_nil(),
             Self::Named { .. } | Self::Fn { .. } | Self::Tuple { .. } => false,
@@ -270,6 +296,7 @@ impl Type {
 
     pub fn is_bit_array(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_bit_array(),
             Self::Named { module, name, .. } if "BitArray" == name && is_prelude_module(module) => {
                 true
             }
@@ -280,6 +307,7 @@ impl Type {
 
     pub fn is_utf_codepoint(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_utf_codepoint(),
             Self::Named { module, name, .. }
                 if "UtfCodepoint" == name && is_prelude_module(module) =>
             {
@@ -292,6 +320,7 @@ impl Type {
 
     pub fn is_bool(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_bool(),
             Self::Named { module, name, .. } if "Bool" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_bool(),
             Self::Named { .. } | Self::Fn { .. } | Self::Tuple { .. } => false,
@@ -300,6 +329,7 @@ impl Type {
 
     pub fn is_int(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_int(),
             Self::Named { module, name, .. } if "Int" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_int(),
             Self::Named { .. } | Self::Fn { .. } | Self::Tuple { .. } => false,
@@ -308,6 +338,7 @@ impl Type {
 
     pub fn is_float(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_float(),
             Self::Named { module, name, .. } if "Float" == name && is_prelude_module(module) => {
                 true
             }
@@ -318,6 +349,7 @@ impl Type {
 
     pub fn is_string(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_string(),
             Self::Named { module, name, .. } if "String" == name && is_prelude_module(module) => {
                 true
             }
@@ -328,6 +360,7 @@ impl Type {
 
     pub fn is_list(&self) -> bool {
         match self {
+            Self::Alias { aliased, .. } => aliased.is_list(),
             Self::Named { module, name, .. } if "List" == name && is_prelude_module(module) => true,
             Self::Var { type_ } => type_.borrow().is_list(),
             Self::Named { .. } | Self::Fn { .. } | Self::Tuple { .. } => false,
@@ -336,6 +369,7 @@ impl Type {
 
     pub fn named_type_name(&self) -> Option<(EcoString, EcoString)> {
         match self {
+            Self::Alias { aliased, .. } => aliased.named_type_name(),
             Self::Named { module, name, .. } => Some((module.clone(), name.clone())),
             Self::Var { type_ } => type_.borrow().named_type_name(),
             Self::Fn { .. } | Self::Tuple { .. } => None,
@@ -344,6 +378,7 @@ impl Type {
 
     pub fn named_type_information(&self) -> Option<(EcoString, EcoString, Vec<Arc<Self>>)> {
         match self {
+            Self::Alias { aliased, .. } => aliased.named_type_information(),
             Self::Named {
                 module,
                 name,
@@ -357,6 +392,7 @@ impl Type {
 
     pub fn set_custom_type_variant(&mut self, index: u16) {
         match self {
+            Type::Alias { aliased, .. } => Arc::make_mut(aliased).set_custom_type_variant(index),
             Type::Named {
                 inferred_variant, ..
             } => *inferred_variant = Some(index),
@@ -367,6 +403,7 @@ impl Type {
 
     pub fn generalise_custom_type_variant(&mut self) {
         match self {
+            Type::Alias { aliased, .. } => Arc::make_mut(aliased).generalise_custom_type_variant(),
             Type::Named {
                 inferred_variant, ..
             } => *inferred_variant = None,
@@ -387,6 +424,7 @@ impl Type {
 
     pub fn custom_type_inferred_variant(&self) -> Option<u16> {
         match self {
+            Type::Alias { aliased, .. } => aliased.custom_type_inferred_variant(),
             Type::Named {
                 inferred_variant, ..
             } => *inferred_variant,
@@ -411,6 +449,9 @@ impl Type {
         environment: &mut Environment<'_>,
     ) -> Option<Vec<Arc<Self>>> {
         match self {
+            Self::Alias { aliased, .. } => {
+                aliased.named_type_arguments(publicity, package, module, name, arity, environment)
+            }
             Self::Named {
                 module: m,
                 name: n,
@@ -465,6 +506,11 @@ impl Type {
 
     pub fn find_private_type(&self) -> Option<Self> {
         match self {
+            Self::Alias {
+                publicity, aliased, ..
+            } if publicity.is_private() => None,
+            Self::Alias { aliased, .. } => aliased.find_private_type(),
+
             Self::Named {
                 publicity: Publicity::Private,
                 ..
@@ -496,6 +542,13 @@ impl Type {
 
     pub fn find_internal_type(&self) -> Option<Self> {
         match self {
+            // An internal alias is itself the leak. A public alias shields its
+            // inner type (callers see only the alias name). Private aliases are
+            // caught earlier by find_private_type, so return None to avoid
+            // double-reporting.
+            Self::Alias { publicity, .. } if publicity.is_internal() => Some(self.clone()),
+            Self::Alias { .. } => None,
+
             Self::Named { publicity, .. } if publicity.is_internal() => Some(self.clone()),
 
             Self::Named { arguments, .. } => arguments
@@ -523,6 +576,7 @@ impl Type {
 
     pub fn fn_arity(&self) -> Option<usize> {
         match self {
+            Self::Alias { aliased, .. } => aliased.fn_arity(),
             Self::Fn { arguments, .. } => Some(arguments.len()),
             Self::Named { .. } | Self::Var { .. } | Self::Tuple { .. } => None,
         }
@@ -532,6 +586,7 @@ impl Type {
     ///
     pub fn named_type_publicity(&self) -> Option<Publicity> {
         match self {
+            Type::Alias { aliased, .. } => aliased.named_type_publicity(),
             Type::Named { publicity, .. } => Some(*publicity),
             Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => None,
         }
@@ -544,6 +599,33 @@ impl Type {
     ///
     pub fn same_as(&self, other: &Self) -> bool {
         match (self, other) {
+            // name/module are intentionally ignored: same_as tests structural
+            // type equality, not alias identity. Use PartialEq for that.
+            (
+                Type::Alias {
+                    publicity,
+                    aliased,
+                    parameters,
+                    ..
+                },
+                Type::Alias {
+                    publicity: other_publicity,
+                    aliased: other_aliased,
+                    parameters: other_params,
+                    ..
+                },
+            ) => {
+                publicity == other_publicity
+                    && parameters.len() == other_params.len()
+                    && parameters
+                        .iter()
+                        .zip(other_params)
+                        .all(|(a, b)| a.same_as(b))
+                    && aliased.same_as(other_aliased)
+            }
+            (Type::Alias { aliased, .. }, rhs) => aliased.same_as(rhs),
+            (lhs, Type::Alias { aliased, .. }) => lhs.same_as(aliased),
+
             (Type::Named { .. }, Type::Fn { .. } | Type::Tuple { .. }) => false,
             (one @ Type::Named { .. }, Type::Var { type_ }) => {
                 type_.as_ref().borrow().same_as_other_type(one)
@@ -628,6 +710,10 @@ impl TypeVar {
             (TypeVar::Unbound { .. }, _) => true,
             (TypeVar::Link { type_ }, other) => type_.same_as(other),
 
+            (one @ TypeVar::Generic { .. }, Type::Alias { aliased, .. }) => {
+                one.same_as_other_type(aliased)
+            }
+
             (
                 TypeVar::Generic { .. },
                 Type::Named { .. } | Type::Fn { .. } | Type::Tuple { .. },
@@ -658,6 +744,9 @@ impl TypeVar {
 }
 
 pub fn collapse_links(t: Arc<Type>) -> Arc<Type> {
+    if let Type::Alias { aliased, .. } = t.deref() {
+        return collapse_links(aliased.clone());
+    }
     if let Type::Var { type_ } = t.deref()
         && let TypeVar::Link { type_ } = type_.borrow().deref()
     {
@@ -1019,6 +1108,12 @@ impl ModuleInterface {
     pub fn contains_todo(&self) -> bool {
         self.warnings.iter().any(|warning| warning.is_todo())
     }
+
+    pub fn contains_internal_type_leak(&self) -> bool {
+        self.warnings
+            .iter()
+            .any(|warning| warning.is_internal_type_leak())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
@@ -1071,6 +1166,20 @@ impl TypeVariantConstructors {
                     .expect("Type parameter not found in hydrator");
                 let error = "Hydrator must not store non generic types here";
                 match t.type_.as_ref() {
+                    Type::Alias { aliased, .. } => match aliased.as_ref() {
+                        Type::Var { type_ } => match type_.borrow().deref() {
+                            TypeVar::Generic { id } => *id,
+                            TypeVar::Unbound { .. } | TypeVar::Link { .. } => panic!("{}", error),
+                        },
+                        Type::Named { .. } | Type::Fn { .. } | Type::Tuple { .. } => {
+                            panic!("{}", error)
+                        }
+                        // A type parameter must resolve to a generic TypeVar.
+                        // Nested aliases cannot appear here because the hydrator
+                        // only wraps the *return* type in Type::Alias, never a
+                        // bare type parameter variable.
+                        Type::Alias { .. } => unreachable!("nested alias in type parameter"),
+                    },
                     Type::Var { type_ } => match type_.borrow().deref() {
                         TypeVar::Generic { id } => *id,
                         TypeVar::Unbound { .. } | TypeVar::Link { .. } => panic!("{}", error),
@@ -1572,6 +1681,7 @@ fn unify_unbound_type(type_: &Type, own_id: u64) -> Result<(), UnifyError> {
     }
 
     match type_ {
+        Type::Alias { aliased, .. } => unify_unbound_type(aliased, own_id),
         Type::Named { arguments, .. } => {
             for argument in arguments {
                 unify_unbound_type(argument, own_id)?
@@ -1650,6 +1760,27 @@ pub fn generalise(t: Arc<Type>) -> Arc<Type> {
                 type_: type_.clone(),
             }),
         },
+
+        Type::Alias {
+            name,
+            module,
+            publicity,
+            aliased,
+            parameters,
+        } => {
+            let aliased = generalise(aliased.clone());
+            let parameters = parameters
+                .iter()
+                .map(|type_| generalise(type_.clone()))
+                .collect();
+            Arc::new(Type::Alias {
+                name: name.clone(),
+                module: module.clone(),
+                publicity: *publicity,
+                aliased,
+                parameters,
+            })
+        }
 
         Type::Named {
             publicity,

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -290,6 +290,7 @@ impl Environment<'_> {
     /// Follow link chains in a type to find the final unbound or generic var ID.
     fn resolve_type_var_id(type_: &Type) -> Option<u64> {
         match type_ {
+            Type::Alias { aliased, .. } => Self::resolve_type_var_id(aliased.as_ref()),
             Type::Var { type_ } => match type_.borrow().deref() {
                 TypeVar::Unbound { id } | TypeVar::Generic { id } => Some(*id),
                 TypeVar::Link { type_ } => Self::resolve_type_var_id(type_),
@@ -608,6 +609,26 @@ impl Environment<'_> {
         hydrator: &Hydrator,
     ) -> Arc<Type> {
         match t.deref() {
+            Type::Alias {
+                name,
+                module,
+                publicity,
+                aliased,
+                parameters,
+            } => {
+                let aliased = self.instantiate(aliased.clone(), ids, hydrator);
+                let parameters = parameters
+                    .iter()
+                    .map(|type_| self.instantiate(type_.clone(), ids, hydrator))
+                    .collect();
+                Arc::new(Type::Alias {
+                    name: name.clone(),
+                    module: module.clone(),
+                    publicity: *publicity,
+                    aliased,
+                    parameters,
+                })
+            }
             Type::Named {
                 publicity,
                 name,
@@ -981,11 +1002,23 @@ pub enum Imported {
 /// It two types are found to not be the same an error is returned.
 ///
 pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
+    // Aliases should not affect unification, they are merely a naming
+    // convenience.  We collapse them early so callers need not handle
+    // Alias everywhere.
+    let t1 = if let Type::Var { .. } = t1.deref() {
+        // leave `t1` alone; the existing variable-handling logic below will
+        // still deal with any aliases nested inside when necessary
+        t1
+    } else {
+        collapse_links(t1)
+    };
+    let t2 = collapse_links(t2);
+
     if t1 == t2 {
         return Ok(());
     }
 
-    // Collapse right hand side type links. Left hand side will be collapsed in the next block.
+    // Collapse any remaining TypeVar::Link on the right-hand side.
     if let Type::Var { type_ } = t2.deref()
         && let TypeVar::Link { type_ } = type_.borrow().deref()
     {

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -1002,12 +1002,15 @@ pub enum Imported {
 /// It two types are found to not be the same an error is returned.
 ///
 pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
-    // Aliases should not affect unification, they are merely a naming
-    // convenience.  We collapse them early so callers need not handle
-    // Alias everywhere.
+    // Keep the originals so error messages can mention the alias the
+    // user wrote rather than the underlying type.
+    let original_t1 = t1.clone();
+    let original_t2 = t2.clone();
+
+    // Collapse aliases so the rest of unification need not handle them.
+    // `Type::Var` is skipped: its `RefCell` is borrowed further down, and
+    // collapsing through the variable would require resolving it first.
     let t1 = if let Type::Var { .. } = t1.deref() {
-        // leave `t1` alone; the existing variable-handling logic below will
-        // still deal with any aliases nested inside when necessary
         t1
     } else {
         collapse_links(t1)
@@ -1080,8 +1083,8 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
             }
 
             Action::CouldNotUnify => Err(UnifyError::CouldNotUnify {
-                expected: t1.clone(),
-                given: t2,
+                expected: original_t1,
+                given: original_t2,
                 situation: None,
             }),
         };
@@ -1107,7 +1110,11 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
             },
         ) if m1 == m2 && n1 == n2 && arguments1.len() == arguments2.len() => {
             for (a, b) in arguments1.iter().zip(arguments2) {
-                unify_enclosed_type(t1.clone(), t2.clone(), unify(a.clone(), b.clone()))?;
+                unify_enclosed_type(
+                    original_t1.clone(),
+                    original_t2.clone(),
+                    unify(a.clone(), b.clone()),
+                )?;
             }
             Ok(())
         }
@@ -1123,7 +1130,11 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
             },
         ) if elements1.len() == elements2.len() => {
             for (a, b) in elements1.iter().zip(elements2) {
-                unify_enclosed_type(t1.clone(), t2.clone(), unify(a.clone(), b.clone()))?;
+                unify_enclosed_type(
+                    original_t1.clone(),
+                    original_t2.clone(),
+                    unify(a.clone(), b.clone()),
+                )?;
             }
             Ok(())
         }
@@ -1142,25 +1153,25 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
         ) => {
             if arguments1.len() != arguments2.len() {
                 Err(unify_wrong_arity(
-                    &t1,
+                    &original_t1,
                     arguments1.len(),
-                    &t2,
+                    &original_t2,
                     arguments2.len(),
                 ))?
             }
 
             for (i, (a, b)) in arguments1.iter().zip(arguments2).enumerate() {
                 unify(a.clone(), b.clone())
-                    .map_err(|_| unify_wrong_arguments(&t1, a, &t2, b, i))?;
+                    .map_err(|_| unify_wrong_arguments(&original_t1, a, &original_t2, b, i))?;
             }
 
             unify(return1.clone(), return2.clone())
-                .map_err(|_| unify_wrong_returns(&t1, return1, &t2, return2))
+                .map_err(|_| unify_wrong_returns(&original_t1, return1, &original_t2, return2))
         }
 
         _ => Err(UnifyError::CouldNotUnify {
-            expected: t1.clone(),
-            given: t2.clone(),
+            expected: original_t1,
+            given: original_t2,
             situation: None,
         }),
     }

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1018,6 +1018,23 @@ pub enum Warning {
         location: SrcSpan,
     },
 
+    /// When a public function, constructor, or constant exposes an `@internal`
+    /// type as part of its signature. For example:
+    ///
+    /// ```gleam
+    /// @internal type Wibble
+    ///
+    /// pub fn wibble(thing: Wibble) { todo }
+    /// //            ^^^^^^^^^^^^^ There would be no documentation
+    /// //                          explaining what `Wibble` is in the
+    /// //                          package's doc site.
+    /// ```
+    InternalTypeLeak {
+        location: SrcSpan,
+        leaked: Type,
+        names: Names,
+    },
+
     RedundantAssertAssignment {
         location: SrcSpan,
     },
@@ -1412,6 +1429,7 @@ impl Warning {
             | Warning::CaseMatchOnLiteralCollection { location, .. }
             | Warning::CaseMatchOnLiteralValue { location, .. }
             | Warning::OpaqueExternalType { location, .. }
+            | Warning::InternalTypeLeak { location, .. }
             | Warning::RedundantAssertAssignment { location, .. }
             | Warning::AssertAssignmentOnImpossiblePattern { location, .. }
             | Warning::TodoOrPanicUsedAsFunction { location, .. }
@@ -1434,6 +1452,10 @@ impl Warning {
 
     pub(crate) fn is_todo(&self) -> bool {
         matches!(self, Self::Todo { .. })
+    }
+
+    pub(crate) fn is_internal_type_leak(&self) -> bool {
+        matches!(self, Self::InternalTypeLeak { .. })
     }
 }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4859,8 +4859,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         type_: Arc<Type>,
         kind: ArgumentKind,
     ) -> TypedExpr {
-        let type_ = collapse_links(type_);
-        let value = match (&*type_, argument) {
+        // The collapsed view is used for pattern-matching on the expected
+        // shape, but `unify` below receives the original `type_` so any alias
+        // name survives into error messages.
+        let collapsed = collapse_links(type_.clone());
+        let value = match (&*collapsed, argument) {
             // If the argument is expected to be a function and we are passed a
             // function literal with the correct number of arguments then we
             // have special handling of this argument, passing in information

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1550,10 +1550,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location: tuple.location(),
             }),
 
-            Type::Named { .. } | Type::Fn { .. } | Type::Var { .. } => Err(Error::NotATuple {
-                location: tuple.location(),
-                given: tuple.type_(),
-            }),
+            Type::Named { .. } | Type::Fn { .. } | Type::Var { .. } | Type::Alias { .. } => {
+                Err(Error::NotATuple {
+                    location: tuple.location(),
+                    given: tuple.type_(),
+                })
+            }
         }
     }
 
@@ -2538,12 +2540,13 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         location: tuple.location(),
                     }),
 
-                    Type::Named { .. } | Type::Fn { .. } | Type::Var { .. } => {
-                        Err(Error::NotATuple {
-                            location: tuple.location(),
-                            given: tuple.type_(),
-                        })
-                    }
+                    Type::Named { .. }
+                    | Type::Fn { .. }
+                    | Type::Var { .. }
+                    | Type::Alias { .. } => Err(Error::NotATuple {
+                        location: tuple.location(),
+                        given: tuple.type_(),
+                    }),
                 }
             }
 
@@ -2946,7 +2949,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 }),
 
             // Non-named types do not have fields
-            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => {
+            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } | Type::Alias { .. } => {
                 return Err(unknown_field(vec![]));
             }
         }
@@ -3262,7 +3265,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                 ))
                             }),
 
-                        Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => {
+                        Type::Fn { .. }
+                        | Type::Var { .. }
+                        | Type::Tuple { .. }
+                        | Type::Alias { .. } => {
                             panic!("Type has already checked to be valid")
                         }
                     }
@@ -3342,7 +3348,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // The record constructor needs to be a function.
         let (arguments_types, return_type) = match constructor.type_().as_ref() {
             Type::Fn { arguments, return_ } => (arguments.clone(), return_.clone()),
-            Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
+            Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } | Type::Alias { .. } => {
                 return Err(Error::RecordUpdateInvalidConstructor {
                     location: constructor.location(),
                 });
@@ -3380,7 +3386,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // copy of the generic return type for our value constructor.
         let return_type_copy = match value_constructor.type_.as_ref() {
             Type::Fn { return_, .. } => self.instantiate(return_.clone(), &mut hashmap![]),
-            Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
+            Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } | Type::Alias { .. } => {
                 return Err(Error::RecordUpdateInvalidConstructor {
                     location: constructor.location(),
                 });
@@ -3833,7 +3839,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 // Extract field types and return type from the instantiated constructor
                 let (field_types, expected_type) = match instantiated_constructor_type.as_ref() {
                     Type::Fn { arguments, return_ } => (arguments.clone(), return_.clone()),
-                    Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
+                    Type::Named { .. }
+                    | Type::Var { .. }
+                    | Type::Tuple { .. }
+                    | Type::Alias { .. } => {
                         self.problems.error(Error::RecordUpdateInvalidConstructor {
                             location: constructor_location,
                         });

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -248,9 +248,37 @@ impl Hydrator {
                 // Unify argument types with instantiated parameter types so that the correct types
                 // are inserted into the return type
                 for (parameter, (location, argument)) in
-                    parameter_types.into_iter().zip(argument_types)
+                    parameter_types.iter().cloned().zip(argument_types)
                 {
                     unify(parameter, argument).map_err(|e| convert_unify_error(e, location))?;
+                }
+
+                // If this constructor corresponds to a type alias we need to
+                // wrap the result in Type::Alias so callers can tell an alias
+                // was used, rather than seeing the underlying type directly.
+                let maybe_alias = if let Some((module_name, _)) = module {
+                    // imported module alias? look in the module interface
+                    environment
+                        .importable_modules
+                        .get(&module_name)
+                        .and_then(|m| m.type_aliases.get(name))
+                } else {
+                    environment.module_type_aliases.get(name)
+                };
+
+                if let Some(alias_info) = maybe_alias {
+                    let publicity = alias_info.publicity;
+                    let aliased = return_type.clone();
+                    // `parameter_types` were instantiated above; they may have been
+                    // linked during unification and now reflect the final types.
+                    let parameters = parameter_types;
+                    return Ok(Arc::new(Type::Alias {
+                        name: name.clone(),
+                        module: alias_info.module.clone(),
+                        publicity,
+                        aliased,
+                        parameters,
+                    }));
                 }
 
                 Ok(return_type)

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     parse::PatternPosition,
     reference::ReferenceKind,
-    type_::expression::FunctionDefinition,
+    type_::{collapse_links, expression::FunctionDefinition},
 };
 use std::sync::Arc;
 
@@ -899,6 +899,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             },
 
             Pattern::Tuple { elements, location } => match collapse_links(type_.clone()).deref() {
+                Type::Alias { .. } => unreachable!("collapse_links should remove aliases"),
                 Type::Tuple {
                     elements: type_elements,
                 } => {
@@ -1197,7 +1198,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 let instantiated_constructor_type =
                     self.environment
                         .instantiate(constructor_type, &mut hashmap![], self.hydrator);
-                match instantiated_constructor_type.deref() {
+                match collapse_links(instantiated_constructor_type.clone()).deref() {
                     Type::Fn { arguments, return_ } => {
                         self.unify_types(type_.clone(), return_.clone(), location);
 
@@ -1237,7 +1238,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             type_: return_.clone(),
                         }
                     }
-
+                    Type::Alias { .. } => unreachable!("collapse_links should remove aliases"),
                     Type::Named {
                         inferred_variant, ..
                     } => {

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -89,6 +89,8 @@ impl Printer {
             Type::Tuple { elements, .. } => {
                 self.arguments_to_gleam_doc(elements).surround("#(", ")")
             }
+
+            Type::Alias { aliased, .. } => self.print(aliased),
         }
     }
 

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -49,6 +49,11 @@ pub struct Names {
     ///
     local_types: BiMap<(EcoString, EcoString), EcoString>,
 
+    /// Aliases visible without qualification in the current module.
+    /// Kept separately from `local_types` so the alias and its underlying
+    /// type can share the same display name.
+    local_aliases: HashSet<(EcoString, EcoString)>,
+
     /// Mapping of imported modules to their locally used named
     ///
     /// key:   The name of the module
@@ -164,11 +169,16 @@ impl Names {
     pub fn new() -> Self {
         Self {
             local_types: Default::default(),
+            local_aliases: Default::default(),
             imported_modules: Default::default(),
             type_variables: Default::default(),
             local_value_constructors: Default::default(),
             reexport_aliases: Default::default(),
         }
+    }
+
+    pub fn alias_in_scope(&mut self, module: EcoString, name: EcoString) {
+        _ = self.local_aliases.insert((module, name));
     }
 
     /// Record a named type in this module.
@@ -500,27 +510,38 @@ impl<'a> Printer<'a> {
             Type::Alias {
                 name,
                 module,
+                aliased,
                 parameters,
                 ..
             } => {
-                let info = self.names.named_type(module, name, print_mode);
-                match info {
-                    NameContextInformation::Qualified(module, name) => {
-                        buffer.push_str(module);
-                        buffer.push('.');
-                        buffer.push_str(name);
-                    }
-                    NameContextInformation::Unqualified(name) => {
-                        buffer.push_str(name);
-                    }
-                    NameContextInformation::Unimported(module, name) => {
-                        // alias not imported: show the module-qualified name so
-                        // the user knows which type is actually leaking.
-                        if let Some(short) = module.split('/').next_back() {
-                            buffer.push_str(short);
+                if print_mode == PrintMode::ExpandAliases {
+                    self.print(aliased, buffer, print_mode);
+                    return;
+                }
+
+                if self
+                    .names
+                    .local_aliases
+                    .contains(&(module.clone(), name.clone()))
+                {
+                    buffer.push_str(name);
+                } else {
+                    match self.names.named_type(module, name, print_mode) {
+                        NameContextInformation::Qualified(module, name) => {
+                            buffer.push_str(module);
                             buffer.push('.');
+                            buffer.push_str(name);
                         }
-                        buffer.push_str(name);
+                        NameContextInformation::Unqualified(name) => {
+                            buffer.push_str(name);
+                        }
+                        NameContextInformation::Unimported(qualified_module, qualified_name) => {
+                            if let Some(short) = qualified_module.split('/').next_back() {
+                                buffer.push_str(short);
+                                buffer.push('.');
+                            }
+                            buffer.push_str(qualified_name);
+                        }
                     }
                 }
                 if !parameters.is_empty() {

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -1,11 +1,12 @@
 use bimap::BiMap;
 use ecow::{EcoString, eco_format};
 use im::HashMap;
+use std::ops::Deref;
 use std::{collections::HashSet, sync::Arc};
 
 use crate::{
     ast::SrcSpan,
-    type_::{Type, TypeAliasConstructor, TypeVar},
+    type_::{Type, TypeAliasConstructor, TypeVar, collapse_links},
 };
 
 /// This class keeps track of what names are used for modules in the current
@@ -122,9 +123,10 @@ pub struct Names {
     /// other packages. This is a common pattern in Gleam, in order to reexport
     /// an internal type, without exposing its implementation details. Because
     /// of this, we want to be able to properly handle this case, and use the
-    /// public alias rather than the internal underlying type. Since Gleam type
-    /// aliases are not part of the type system, we have to track them manually
-    /// here.
+    /// public alias rather than the internal underlying type. Since internal
+    /// types are not visible to external users, we track their public aliases
+    /// here so that diagnostic output names the public alias rather than the
+    /// unexpanded internal type.
     ///
     /// This is a mapping of internal types to their public aliases that we want
     /// to favour over the internal types.
@@ -189,6 +191,25 @@ impl Names {
         parameters: &[Arc<Type>],
     ) {
         match type_ {
+            Type::Alias {
+                aliased,
+                parameters: alias_params,
+                ..
+            } => {
+                if let Type::Named {
+                    module,
+                    name,
+                    arguments,
+                    ..
+                } = aliased.deref()
+                    && compare_arguments(arguments, parameters)
+                    && compare_arguments(alias_params, parameters)
+                {
+                    self.named_type_in_scope(module.clone(), name.clone(), local_alias);
+                    return;
+                }
+                _ = self.local_types.remove_by_right(&local_alias);
+            }
             Type::Named {
                 module,
                 name,
@@ -230,7 +251,8 @@ impl Names {
         alias_name: &EcoString,
         alias: &TypeAliasConstructor,
     ) {
-        match alias.type_.as_ref() {
+        let target = collapse_links(alias.type_.clone());
+        match target.as_ref() {
             Type::Named {
                 publicity,
                 package: type_package,
@@ -243,7 +265,7 @@ impl Names {
                 // - aliasing a type in the same package
                 // - the type is internal
                 // - the alias exposes the same type parameters as the internal type
-                if type_package == package
+                if *type_package == *package
                     && publicity.is_internal()
                     && compare_arguments(arguments, &alias.parameters)
                 {
@@ -253,7 +275,7 @@ impl Names {
                     );
                 }
             }
-            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => {}
+            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } | Type::Alias { .. } => {}
         }
     }
 
@@ -475,6 +497,39 @@ impl<'a> Printer<'a> {
 
     fn print(&mut self, type_: &Type, buffer: &mut EcoString, print_mode: PrintMode) {
         match type_ {
+            Type::Alias {
+                name,
+                module,
+                parameters,
+                ..
+            } => {
+                let info = self.names.named_type(module, name, print_mode);
+                match info {
+                    NameContextInformation::Qualified(module, name) => {
+                        buffer.push_str(module);
+                        buffer.push('.');
+                        buffer.push_str(name);
+                    }
+                    NameContextInformation::Unqualified(name) => {
+                        buffer.push_str(name);
+                    }
+                    NameContextInformation::Unimported(module, name) => {
+                        // alias not imported: show the module-qualified name so
+                        // the user knows which type is actually leaking.
+                        if let Some(short) = module.split('/').next_back() {
+                            buffer.push_str(short);
+                            buffer.push('.');
+                        }
+                        buffer.push_str(name);
+                    }
+                }
+                if !parameters.is_empty() {
+                    buffer.push('(');
+                    self.print_arguments(parameters, buffer, print_mode);
+                    buffer.push(')');
+                }
+            }
+
             Type::Named {
                 name,
                 arguments,

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -3493,6 +3493,19 @@ pub fn go(wibble: Wibble) {
 }
 
 #[test]
+fn alias_type_mismatch_error_message() {
+    assert_module_error!(
+        "type MyAlias = Int
+
+pub fn expect_alias(x: MyAlias) -> MyAlias { x }
+
+pub fn bad() -> MyAlias {
+  expect_alias(\"hello\")
+}"
+    );
+}
+
+#[test]
 fn record_update_does_not_stop_at_first_invalid_field_2() {
     assert_module_error!(
         "
@@ -3507,6 +3520,18 @@ pub fn go(wibble: Wibble) {
 }
 
 #[test]
+fn alias_with_param_type_mismatch_error_message() {
+    assert_module_error!(
+        "type Pair(a) = #(a, a)
+
+pub fn bad() -> Pair(Int) {
+  #(1, \"hello\")
+}"
+    );
+}
+
+#[test]
+
 fn record_update_does_not_stop_at_first_invalid_field_3() {
     assert_module_error!(
         "
@@ -3646,5 +3671,18 @@ fn non_string_variable_in_todo_constant_message() {
 pub const message = 1
 pub const wibble = todo as message
 "#
+    );
+}
+
+#[test]
+fn cross_module_alias_type_mismatch_error_message() {
+    assert_module_error!(
+        ("wibble", "pub type MyAlias = Int"),
+        "
+import wibble.{type MyAlias}
+
+pub fn bad() -> MyAlias {
+  \"hello\"
+}"
     );
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_type_mismatch_error_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_type_mismatch_error_message.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "type MyAlias = Int\n\npub fn expect_alias(x: MyAlias) -> MyAlias { x }\n\npub fn bad() -> MyAlias {\n  expect_alias(\"hello\")\n}"
+snapshot_kind: text
+---
+----- SOURCE CODE
+type MyAlias = Int
+
+pub fn expect_alias(x: MyAlias) -> MyAlias { x }
+
+pub fn bad() -> MyAlias {
+  expect_alias("hello")
+}
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:6:16
+  │
+6 │   expect_alias("hello")
+  │                ^^^^^^^
+
+Expected type:
+
+    MyAlias
+
+Found type:
+
+    String

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_type_mismatch_error_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_type_mismatch_error_message.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "type MyAlias = Int\n\npub fn expect_alias(x: MyAlias) -> MyAlias { x }\n\npub fn bad() -> MyAlias {\n  expect_alias(\"hello\")\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 type MyAlias = Int

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_with_param_type_mismatch_error_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_with_param_type_mismatch_error_message.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "type Pair(a) = #(a, a)\n\npub fn bad() -> Pair(Int) {\n  #(1, \"hello\")\n}"
+snapshot_kind: text
+---
+----- SOURCE CODE
+type Pair(a) = #(a, a)
+
+pub fn bad() -> Pair(Int) {
+  #(1, "hello")
+}
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   #(1, "hello")
+  │   ^^^^^^^^^^^^^
+
+The type of this returned value doesn't match the return type
+annotation of this function.
+
+Expected type:
+
+    #(Int, Int)
+
+Found type:
+
+    #(Int, String)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_with_param_type_mismatch_error_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__alias_with_param_type_mismatch_error_message.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
 expression: "type Pair(a) = #(a, a)\n\npub fn bad() -> Pair(Int) {\n  #(1, \"hello\")\n}"
-snapshot_kind: text
 ---
 ----- SOURCE CODE
 type Pair(a) = #(a, a)
@@ -22,7 +21,7 @@ annotation of this function.
 
 Expected type:
 
-    #(Int, Int)
+    Pair(Int)
 
 Found type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__cross_module_alias_type_mismatch_error_message.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__cross_module_alias_type_mismatch_error_message.snap
@@ -1,0 +1,34 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport wibble.{type MyAlias}\n\npub fn bad() -> MyAlias {\n  \"hello\"\n}"
+snapshot_kind: text
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type MyAlias = Int
+
+-- main.gleam
+
+import wibble.{type MyAlias}
+
+pub fn bad() -> MyAlias {
+  "hello"
+}
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:5:3
+  │
+5 │   "hello"
+  │   ^^^^^^^
+
+The type of this returned value doesn't match the return type
+annotation of this function.
+
+Expected type:
+
+    MyAlias
+
+Found type:
+
+    String

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_alias_in_public_signature_warns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_alias_in_public_signature_warns.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type InternalAlias = Int\n\npub fn foo() -> InternalAlias { 1 }\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type InternalAlias = Int
+
+pub fn foo() -> InternalAlias { 1 }
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:5:1
+  │
+5 │ pub fn foo() -> InternalAlias { 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    test_module.InternalAlias
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_alias_in_public_signature_warns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_alias_in_public_signature_warns.snap
@@ -19,7 +19,7 @@ warning: Internal type used in public interface
 
 The following internal type is exposed by this public definition:
 
-    test_module.InternalAlias
+    InternalAlias
 
 Internal types are hidden from the package's documentation, so consumers
 cannot tell what they are. Either remove the `@internal` annotation, or

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_parametric_alias_in_public_function_warns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_parametric_alias_in_public_function_warns.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type Alias(a) = List(a)\n\npub fn foo() -> Alias(Int) { [] }\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type Alias(a) = List(a)
+
+pub fn foo() -> Alias(Int) { [] }
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:5:1
+  │
+5 │ pub fn foo() -> Alias(Int) { [] }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    test_module.Alias(Int)
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_parametric_alias_in_public_function_warns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_parametric_alias_in_public_function_warns.snap
@@ -19,7 +19,7 @@ warning: Internal type used in public interface
 
 The following internal type is exposed by this public definition:
 
-    test_module.Alias(Int)
+    Alias(Int)
 
 Internal types are hidden from the package's documentation, so consumers
 cannot tell what they are. Either remove the `@internal` annotation, or

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_parametric_type_in_public_function_warns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_parametric_type_in_public_function_warns.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type InternalBox(a) {\n  InternalBox(value: a)\n}\n\npub fn new(x: Int) -> InternalBox(Int) { InternalBox(x) }\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type InternalBox(a) {
+  InternalBox(value: a)
+}
+
+pub fn new(x: Int) -> InternalBox(Int) { InternalBox(x) }
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:7:1
+  │
+7 │ pub fn new(x: Int) -> InternalBox(Int) { InternalBox(x) }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    InternalBox(Int)
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_generic_position_warns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_generic_position_warns.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type Internal {\n  Internal\n}\n\npub fn foo() -> List(Internal) { [] }\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type Internal {
+  Internal
+}
+
+pub fn foo() -> List(Internal) { [] }
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:7:1
+  │
+7 │ pub fn foo() -> List(Internal) { [] }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Internal
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_constant_warns.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_constant_warns.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type Internal {\n  Internal\n}\n\npub const c: Internal = Internal\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type Internal {
+  Internal
+}
+
+pub const c: Internal = Internal
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:7:1
+  │
+7 │ pub const c: Internal = Internal
+  │ ^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Internal
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_constructor.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type Wibble {\n  Wibble\n}\n\npub type Wobble {\n    Wobble(Wibble)\n}\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type Wibble {
+  Wibble
+}
+
+pub type Wobble {
+    Wobble(Wibble)
+}
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:8:5
+  │
+8 │     Wobble(Wibble)
+  │     ^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Wibble
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_function_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_function_argument.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type Wibble {\n  Wibble\n}\n\npub fn wibble(_wibble: Wibble) -> Int { 1 }\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type Wibble {
+  Wibble
+}
+
+pub fn wibble(_wibble: Wibble) -> Int { 1 }
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:7:1
+  │
+7 │ pub fn wibble(_wibble: Wibble) -> Int { 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Wibble
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_function_return.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__internal_type_in_public_function_return.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@internal\npub type Wibble {\n  Wibble\n}\n\npub fn wibble() -> Wibble { Wibble }\n"
+---
+----- SOURCE CODE
+
+@internal
+pub type Wibble {
+  Wibble
+}
+
+pub fn wibble() -> Wibble { Wibble }
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:7:1
+  │
+7 │ pub fn wibble() -> Wibble { Wibble }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Wibble
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_dependency_in_public_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_dependency_in_public_constructor.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\nimport dep/internal.{type Wibble}\n\npub type Wobble {\n  Wobble(Wibble)\n}"
+---
+----- SOURCE CODE
+-- dep/internal.gleam
+pub type Wibble { Wibble }
+
+-- main.gleam
+
+import dep/internal.{type Wibble}
+
+pub type Wobble {
+  Wobble(Wibble)
+}
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:5:3
+  │
+5 │   Wobble(Wibble)
+  │   ^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Wibble
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_in_public_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_in_public_constructor.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\nimport thepackage/internal.{type Wibble}\n\npub type Wobble {\n  Wobble(Wibble)\n}"
+---
+----- SOURCE CODE
+-- thepackage/internal.gleam
+pub type Wibble { Wibble }
+
+-- main.gleam
+
+import thepackage/internal.{type Wibble}
+
+pub type Wobble {
+  Wobble(Wibble)
+}
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:5:3
+  │
+5 │   Wobble(Wibble)
+  │   ^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Wibble
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_in_public_function_argument.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_in_public_function_argument.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\nimport thepackage/internal.{type Wibble}\n\npub fn wibble(_wibble: Wibble) -> Int {\n  1\n}\n"
+---
+----- SOURCE CODE
+-- thepackage/internal.gleam
+pub type Wibble { Wibble }
+
+-- main.gleam
+
+import thepackage/internal.{type Wibble}
+
+pub fn wibble(_wibble: Wibble) -> Int {
+  1
+}
+
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:4:1
+  │
+4 │ pub fn wibble(_wibble: Wibble) -> Int {
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Wibble
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_in_public_function_return.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__type_from_internal_module_in_public_function_return.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\nimport thepackage/internal.{type Wibble, Wibble}\n\npub fn wibble() -> Wibble {\n  Wibble\n}"
+---
+----- SOURCE CODE
+-- thepackage/internal.gleam
+pub type Wibble { Wibble }
+
+-- main.gleam
+
+import thepackage/internal.{type Wibble, Wibble}
+
+pub fn wibble() -> Wibble {
+  Wibble
+}
+
+----- WARNING
+warning: Internal type used in public interface
+  ┌─ /src/warning/wrn.gleam:4:1
+  │
+4 │ pub fn wibble() -> Wibble {
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following internal type is exposed by this public definition:
+
+    Wibble
+
+Internal types are hidden from the package's documentation, so consumers
+cannot tell what they are. Either remove the `@internal` annotation, or
+re-export the type through a `pub type` alias.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1586,14 +1586,6 @@ pub fn main() {
     );
 }
 
-/*
-
-TODO: These tests are commented out until we figure out a better way to deal
-      with reexports of internal types and reintroduce the warning.
-      As things stand it would break both Lustre and Mist.
-      You can see the thread starting around here for more context:
-      https://discord.com/channels/768594524158427167/768594524158427170/1227250677734969386
-
 #[test]
 fn internal_type_in_public_function_return() {
     assert_warning!(
@@ -1691,7 +1683,212 @@ pub type Wobble {
     );
 }
 
-*/
+// New tests verifying alias behaviour
+#[test]
+fn public_alias_of_internal_type_in_public_signature() {
+    assert_no_warnings!(
+        "
+@internal
+pub type Internal { Internal }
+
+pub type Alias = Internal
+
+pub fn foo() -> Alias { Alias }
+"
+    );
+}
+
+#[test]
+fn public_alias_reexported_from_external_module_does_not_warn() {
+    assert_no_warnings!(
+        (
+            "dep",
+            "dep/types",
+            "pub type Internal { Internal } pub type Alias = Internal"
+        ),
+        "
+import dep/types.{type Alias}
+
+pub fn foo() -> Alias { Alias }
+",
+    );
+}
+
+#[test]
+fn nested_public_alias_of_internal_type_does_not_warn() {
+    assert_no_warnings!(
+        "\n@internal
+pub type Internal { Internal }
+
+pub type Mid = Internal
+pub type Outer = Mid
+
+pub fn foo() -> Outer { Outer }
+"
+    );
+}
+
+#[test]
+fn collapse_links_follows_alias_chain() {
+    use crate::type_::{Publicity, Type, collapse_links};
+    use std::sync::Arc;
+
+    // Build a two-alias chain directly: a → b → Tuple(empty).
+    // Verifies that collapse_links traverses the full chain and returns the
+    // underlying non-alias type.
+    let tuple = Arc::new(Type::Tuple { elements: vec![] });
+    let b = Arc::new(Type::Alias {
+        name: "B".into(),
+        module: "test".into(),
+        publicity: Publicity::Public,
+        aliased: tuple,
+        parameters: vec![],
+    });
+    let a = Arc::new(Type::Alias {
+        name: "A".into(),
+        module: "test".into(),
+        publicity: Publicity::Public,
+        aliased: b,
+        parameters: vec![],
+    });
+
+    let result = collapse_links(a);
+    assert!(matches!(result.as_ref(), Type::Tuple { .. }));
+}
+
+#[test]
+fn collapse_links_idempotent() {
+    use crate::type_::{Publicity, Type, collapse_links};
+    use std::sync::Arc;
+
+    // build a long chain of aliases wrapping a simple named type
+    let mut t: Arc<Type> = Arc::new(Type::Named {
+        publicity: Publicity::Public,
+        package: "".into(),
+        module: "gleam".into(),
+        name: "Int".into(),
+        arguments: vec![],
+        inferred_variant: None,
+    });
+    for _ in 0..100 {
+        t = Arc::new(Type::Alias {
+            name: "Alias".into(),
+            module: "test".into(),
+            publicity: Publicity::Public,
+            aliased: t.clone(),
+            parameters: vec![],
+        });
+    }
+
+    let first = collapse_links(t);
+    let second = collapse_links(first.clone());
+    // collapse_links is idempotent: applying it to its own output is a no-op
+    assert_eq!(first, second);
+}
+
+#[test]
+fn internal_alias_in_public_signature_warns() {
+    assert_warning!(
+        "
+@internal
+pub type InternalAlias = Int
+
+pub fn foo() -> InternalAlias { 1 }
+"
+    );
+}
+
+#[test]
+fn internal_type_in_generic_position_warns() {
+    assert_warning!(
+        "
+@internal
+pub type Internal {
+  Internal
+}
+
+pub fn foo() -> List(Internal) { [] }
+"
+    );
+}
+
+#[test]
+fn internal_type_in_public_constant_warns() {
+    assert_warning!(
+        "
+@internal
+pub type Internal {
+  Internal
+}
+
+pub const c: Internal = Internal
+"
+    );
+}
+
+#[test]
+fn internal_type_used_by_internal_function_does_not_warn() {
+    // An @internal function using an @internal type is consistent: neither is
+    // visible to external users, so no warning should be emitted.
+    assert_no_warnings!(
+        "
+@internal
+pub type Internal {
+  Internal
+}
+
+@internal
+pub fn foo() -> Internal { Internal }
+"
+    );
+}
+
+#[test]
+fn internal_parametric_type_in_public_function_warns() {
+    // A parametric @internal type used in a public function should warn,
+    // even when applied to public type arguments.
+    assert_warning!(
+        "
+@internal
+pub type InternalBox(a) {
+  InternalBox(value: a)
+}
+
+pub fn new(x: Int) -> InternalBox(Int) { InternalBox(x) }
+"
+    );
+}
+
+#[test]
+fn public_parametric_alias_of_internal_type_does_not_warn() {
+    // A public parametric alias shields the underlying internal type.
+    // Using the alias in a public function should produce no warning.
+    assert_no_warnings!(
+        "
+@internal
+pub type InternalBox(a) {
+  InternalBox(value: a)
+}
+
+pub type Box(a) = InternalBox(a)
+
+pub fn new(x: Int) -> Box(Int) { InternalBox(x) }
+"
+    );
+}
+
+#[test]
+fn internal_parametric_alias_in_public_function_warns() {
+    // An @internal parametric alias is itself the leaked type.
+    assert_warning!(
+        "
+@internal
+pub type Alias(a) = List(a)
+
+pub fn foo() -> Alias(Int) { [] }
+"
+    );
+}
 
 #[test]
 fn redundant_let_assert() {

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -5185,3 +5185,83 @@ pub const wobble = todo as wibble
 "
     );
 }
+
+// Same-module variant: a public parametric alias re-exports a parametric
+// `@internal` type and a public function uses it in its signature.
+#[test]
+fn public_parametric_alias_of_internal_type_with_used_param_does_not_warn() {
+    assert_no_warnings!(
+        "
+@internal
+pub type HandlerInternal(message) {
+  HandlerInternal(message)
+}
+
+pub type Handler(message) = HandlerInternal(message)
+
+pub fn with_handler(_h: Handler(Int)) -> Int {
+  0
+}
+"
+    );
+}
+
+// Reproduces the original WebsocketHandler scenario from the issue: the
+// parametric alias and the underlying internal type live in a dependency
+// module and are imported unqualified into the consumer.
+#[test]
+fn public_parametric_alias_of_dependency_internal_type_does_not_warn() {
+    assert_no_warnings!(
+        (
+            "websocket/handler",
+            "@internal pub type HandlerInternal(message) { HandlerInternal(message) }
+pub type Handler(message) = HandlerInternal(message)"
+        ),
+        "
+import websocket/handler.{type Handler}
+
+pub fn with_handler(_h: Handler(Int)) -> Int {
+  0
+}
+",
+    );
+}
+
+// A `pub opaque` type is public but its constructors are not visible outside
+// the module. Exposing it via a public alias must not trigger the @internal
+// leak warning (opacity is unrelated to internality).
+#[test]
+fn public_alias_of_opaque_type_does_not_warn() {
+    assert_no_warnings!(
+        "
+pub opaque type Box {
+  Box(Int)
+}
+
+pub type Wrapped = Box
+
+pub fn make() -> Wrapped { Box(1) }
+"
+    );
+}
+
+// Three-link alias chain pointing at an internal type from another module.
+// As long as every alias along the chain is public, the warning must stay
+// quiet.
+#[test]
+fn multi_link_alias_chain_of_dependency_internal_type_does_not_warn() {
+    assert_no_warnings!(
+        (
+            "dep/internal_module",
+            "@internal pub type Internal { Internal }"
+        ),
+        "
+import dep/internal_module.{type Internal}
+
+pub type Mid = Internal
+pub type Outer = Mid
+
+pub fn use_outer(_x: Outer) -> Int { 0 }
+",
+    );
+}

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1022,6 +1022,38 @@ variable, or delete the expression entirely if it's not needed.",
                     }),
                 },
 
+                type_::Warning::InternalTypeLeak {
+                    location,
+                    leaked,
+                    names,
+                } => {
+                    let leaked_str = format!("    {}", Printer::new(names).print_type(leaked));
+                    let text = wrap_format!(
+                        "The following internal type is exposed by this public definition:
+
+{}
+
+Internal types are hidden from the package's documentation, so consumers \
+cannot tell what they are. Either remove the `@internal` annotation, or \
+re-export the type through a `pub type` alias.",
+                        leaked_str,
+                    );
+                    Diagnostic {
+                        title: "Internal type used in public interface".into(),
+                        text,
+                        hint: None,
+                        level: diagnostic::Level::Warning,
+                        location: Some(Location {
+                            label: diagnostic::Label {
+                                text: None,
+                                span: *location,
+                            },
+                            path: path.clone(),
+                            src: src.clone(),
+                            extra_labels: vec![],
+                        }),
+                    }
+                }
                 type_::Warning::RedundantAssertAssignment { location } => Diagnostic {
                     title: "Redundant assertion".into(),
                     text: wrap(

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -5774,6 +5774,7 @@ impl<'a, IO> PatternMatchOnValue<'a, IO> {
         names: &mut NameGenerator,
     ) -> Option<Vec1<EcoString>> {
         match type_ {
+            Type::Alias { aliased, .. } => self.type_to_destructure_patterns(aliased, names),
             Type::Fn { .. } => None,
             Type::Var { type_ } => self.type_var_to_destructure_patterns(&type_.borrow(), names),
 
@@ -8847,7 +8848,8 @@ impl<'a> RemoveUnusedImports<'a> {
                 | type_::Warning::TopLevelDefinitionShadowsImport { .. }
                 | type_::Warning::RedundantComparison { .. }
                 | type_::Warning::UnusedRecursiveArgument { .. }
-                | type_::Warning::JavaScriptBitArrayUnsafeInt { .. } => None,
+                | type_::Warning::JavaScriptBitArrayUnsafeInt { .. }
+                | type_::Warning::InternalTypeLeak { .. } => None,
             })
             .sorted_by_key(|import| import.location())
             .collect_vec();

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -1090,6 +1090,10 @@ impl<'a, IO> Completer<'a, IO> {
     ) -> Option<&'a HashMap<EcoString, RecordAccessor>> {
         let type_ = collapse_links(type_);
         match type_.as_ref() {
+            Type::Alias { aliased, .. } => {
+                // delegate to underlying type
+                return self.type_accessors_from_modules(importable_modules, aliased.clone());
+            }
             Type::Named {
                 name,
                 module,
@@ -1110,11 +1114,15 @@ impl<'a, IO> Completer<'a, IO> {
     /// Provides completions for field accessors when the context being edited
     /// is a custom type instance
     pub fn completion_field_accessors(&'a self, type_: Arc<Type>) -> Vec<CompletionItem> {
+        let mut check_type = collapse_links(type_.clone());
+        if let Type::Alias { aliased, .. } = check_type.as_ref() {
+            check_type = aliased.clone();
+        }
         if let Type::Named {
             publicity,
             module: type_module,
             ..
-        } = type_.as_ref()
+        } = check_type.as_ref()
             && publicity.is_internal()
             && *type_module != self.module.name
         {

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -1090,10 +1090,6 @@ impl<'a, IO> Completer<'a, IO> {
     ) -> Option<&'a HashMap<EcoString, RecordAccessor>> {
         let type_ = collapse_links(type_);
         match type_.as_ref() {
-            Type::Alias { aliased, .. } => {
-                // delegate to underlying type
-                return self.type_accessors_from_modules(importable_modules, aliased.clone());
-            }
             Type::Named {
                 name,
                 module,
@@ -1107,17 +1103,14 @@ impl<'a, IO> Completer<'a, IO> {
                 })
                 .map(|accessor| accessor.accessors_for_variant(*inferred_variant)),
 
-            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => None,
+            Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } | Type::Alias { .. } => None,
         }
     }
 
     /// Provides completions for field accessors when the context being edited
     /// is a custom type instance
     pub fn completion_field_accessors(&'a self, type_: Arc<Type>) -> Vec<CompletionItem> {
-        let mut check_type = collapse_links(type_.clone());
-        if let Type::Alias { aliased, .. } = check_type.as_ref() {
-            check_type = aliased.clone();
-        }
+        let check_type = collapse_links(type_.clone());
         if let Type::Named {
             publicity,
             module: type_module,

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -1182,7 +1182,7 @@ fn main(wibble: Wubble) {
 }
 
 #[test]
-fn hover_print_underlying_for_alias_with_parameters() {
+fn hover_function_signature_preserves_local_alias() {
     let code = "
 type LocalResult = Result(String, Int)
 

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_annotation_aliased.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_annotation_aliased.snap
@@ -1,7 +1,6 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\nimport wibble/wobble\n\ntype Wubble = wobble.Wibble\n\nfn main(wibble: Wubble) {\n  wibble\n}\n"
-snapshot_kind: text
 ---
 
 import wibble/wobble
@@ -16,5 +15,5 @@ fn main(wibble: Wubble) {
 
 ----- Hover content (markdown) -----
 ```gleam
-app.Wubble
+wobble.Wibble
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_annotation_aliased.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_annotation_aliased.snap
@@ -1,6 +1,7 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\nimport wibble/wobble\n\ntype Wubble = wobble.Wibble\n\nfn main(wibble: Wubble) {\n  wibble\n}\n"
+snapshot_kind: text
 ---
 
 import wibble/wobble
@@ -15,5 +16,5 @@ fn main(wibble: Wubble) {
 
 ----- Hover content (markdown) -----
 ```gleam
-wobble.Wibble
+app.Wubble
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
@@ -1,7 +1,6 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\nimport wibble/wobble\ntype MyInt = Int\nfn func(value: wobble.Wibble) -> MyInt { 1 }\n"
-snapshot_kind: text
 ---
 
 import wibble/wobble
@@ -12,5 +11,5 @@ fn func(value: wobble.Wibble) -> MyInt { 1 }
 
 ----- Hover content (markdown) -----
 ```gleam
-fn(wobble.Wibble) -> app.MyInt
+fn(wobble.Wibble) -> MyInt
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
@@ -1,6 +1,7 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\nimport wibble/wobble\ntype MyInt = Int\nfn func(value: wobble.Wibble) -> MyInt { 1 }\n"
+snapshot_kind: text
 ---
 
 import wibble/wobble
@@ -11,5 +12,5 @@ fn func(value: wobble.Wibble) -> MyInt { 1 }
 
 ----- Hover content (markdown) -----
 ```gleam
-fn(wobble.Wibble) -> MyInt
+fn(wobble.Wibble) -> app.MyInt
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_function_signature_preserves_local_alias.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_function_signature_preserves_local_alias.snap
@@ -1,6 +1,7 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\ntype LocalResult = Result(String, Int)\n\nfn do_thing() -> LocalResult {\n  Error(1)\n}\n"
+snapshot_kind: text
 ---
 
 type LocalResult = Result(String, Int)
@@ -13,5 +14,5 @@ fn do_thing() -> LocalResult {
 
 ----- Hover content (markdown) -----
 ```gleam
-fn() -> Result(String, Int)
+fn() -> app.LocalResult
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_function_signature_preserves_local_alias.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_function_signature_preserves_local_alias.snap
@@ -1,7 +1,6 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\ntype LocalResult = Result(String, Int)\n\nfn do_thing() -> LocalResult {\n  Error(1)\n}\n"
-snapshot_kind: text
 ---
 
 type LocalResult = Result(String, Int)
@@ -14,5 +13,5 @@ fn do_thing() -> LocalResult {
 
 ----- Hover content (markdown) -----
 ```gleam
-fn() -> app.LocalResult
+fn() -> LocalResult
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
@@ -1,7 +1,6 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\ntype MyResult(a, b) = Result(a, b)\n\nfn do_thing() -> MyResult(Int, Int) {\n  Error(1)\n}\n"
-snapshot_kind: text
 ---
 
 type MyResult(a, b) = Result(a, b)
@@ -14,5 +13,5 @@ fn do_thing() -> MyResult(Int, Int) {
 
 ----- Hover content (markdown) -----
 ```gleam
-fn() -> app.MyResult(Int, Int)
+fn() -> MyResult(Int, Int)
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
@@ -1,6 +1,7 @@
 ---
 source: language-server/src/tests/hover.rs
 expression: "\ntype MyResult(a, b) = Result(a, b)\n\nfn do_thing() -> MyResult(Int, Int) {\n  Error(1)\n}\n"
+snapshot_kind: text
 ---
 
 type MyResult(a, b) = Result(a, b)
@@ -13,5 +14,5 @@ fn do_thing() -> MyResult(Int, Int) {
 
 ----- Hover content (markdown) -----
 ```gleam
-fn() -> MyResult(Int, Int)
+fn() -> app.MyResult(Int, Int)
 ```

--- a/test/language/test/importable.gleam
+++ b/test/language/test/importable.gleam
@@ -45,3 +45,16 @@ pub type Movie {
 }
 
 pub const war_games = Movie("WarGames")
+
+/// A simple type alias. Values of type `MovieAlias` are identical at runtime
+/// to `Movie` values; the alias is purely a compile-time name.
+pub type MovieAlias =
+  Movie
+
+/// A parametric type alias. `Pair(a, b)` is interchangeable with `#(a, b)`.
+pub type Pair(a, b) =
+  #(a, b)
+
+pub fn make_pair(a: a, b: b) -> Pair(a, b) {
+  #(a, b)
+}

--- a/test/language/test/language/type_alias_test.gleam
+++ b/test/language/test/language/type_alias_test.gleam
@@ -1,0 +1,33 @@
+import importable.{type MovieAlias, type Pair, Movie, make_pair}
+
+// Type aliases are transparent at runtime: a value created through the
+// underlying type is equal to the same value viewed through its alias.
+
+pub fn alias_is_transparent_test() {
+  let via_alias: MovieAlias = Movie("Gleam")
+  assert via_alias == Movie("Gleam")
+}
+
+pub fn alias_value_equals_underlying_test() {
+  let m = importable.war_games
+  let a: MovieAlias = m
+  assert a == m
+}
+
+pub fn parametric_alias_construction_test() {
+  let p: Pair(Int, String) = make_pair(42, "hello")
+  assert p == #(42, "hello")
+}
+
+pub fn parametric_alias_destructure_test() {
+  let p: Pair(String, Int) = make_pair("gleam", 1)
+  let #(lang, version) = p
+  assert lang == "gleam"
+  assert version == 1
+}
+
+pub fn parametric_alias_equality_test() {
+  let a: Pair(Int, Int) = make_pair(1, 2)
+  let b: Pair(Int, Int) = #(1, 2)
+  assert a == b
+}


### PR DESCRIPTION
  ## Checklist

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes


Hopefully this will close the issue: #2234.

_EDIT: Rewrote the summary to give it some soul. Hopefully it makes sense now._

## Summary

Currently, `@internal` types are hidden from documentation but can still leak into public APIs without any compiler feedback. This PR aims to enforce that boundary and make such leaks visible.

* Emit warnings when a public API exposes an internal type.
* Prevent `gleam publish` if these warnings are present.
* Provide an escape hatch via public aliases:

As said, this is not a full finished proposal, but a concrete starting point.

To support the alias escape hatch, I introduced `Type::Alias` into the type system so that alias information is preserved instead of being immediately expanded.

However, as @lpil pointed out, there’s an issue in the current implementation, likely due to a misunderstanding on my part. It’s nothing that can’t be resolved, but it does affect error reporting: in some cases, the actual structure of types (e.g. tuples) is hidden, which makes debugging harder and goes against Gleam’s focus on clarity.


## Open Question

To improve diagnostics, I’m considering showing both forms in error messages when they differ. For example:

```
Expected: Pair(a) (i.e. #(a, a))
Found: #(a, b)
```

Does this feel like the right direction?

I wanted to check before diving deeper into reworking the diagnostics.


## What’s Implemented

* Internal type leak detection (compiler + LSP warnings)
* `gleam publish` guard
* Initial plumbing for alias tracking in the type system


Given this, I’ll wait for feedback to validate whether the proposed approach (aside from the issue mentioned above) is useful for addressing the problem. I’m of course happy to defer to your judgment on the direction.
Also, apologies for the previous message on the PR, my attempt to over-explain likely made things more complicated than necessary.
