### PR TITLE
Deduplicate bitArraySliceToFloat calls in JS codegen

### DIFF
--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -432,6 +432,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
             let old_names = self.variables.scoped_variable_names.clone();
             let old_segments = self.variables.segment_values.clone();
             let old_segment_names = self.variables.scoped_segment_names.clone();
+            let old_cached_float = self.variables.cached_float_var.clone();
 
             let result = self.decision(fallback);
 
@@ -459,6 +460,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
             self.variables.scoped_variable_names = old_names;
             self.variables.segment_values = old_segments;
             self.variables.scoped_segment_names = old_segment_names;
+            self.variables.cached_float_var = old_cached_float;
             return result;
         }
 
@@ -500,7 +502,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
             // - the assignments we need to bring all the bit array segments
             //   referenced by this check
             let (check_doc, body, mut segment_assignments) = self.inside_new_scope(|this| {
-                let segment_assignments = this.variables.bit_array_segment_assignments(check);
+                let segment_assignments = this.variables.bit_array_segment_assignments(var, check);
 
                 // If the pattern matches on a single character, use the character
                 // code instead of `.startsWith`.
@@ -685,6 +687,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
         let old_names = self.variables.scoped_variable_names.clone();
         let old_segments = self.variables.segment_values.clone();
         let old_segment_names = self.variables.scoped_segment_names.clone();
+        let old_cached_float = self.variables.cached_float_var.clone();
         let output = run(self);
 
         match &self.kind {
@@ -697,6 +700,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
         self.variables.scoped_variable_names = old_names;
         self.variables.segment_values = old_segments;
         self.variables.scoped_segment_names = old_segment_names;
+        self.variables.cached_float_var = old_cached_float;
         output
     }
 
@@ -996,6 +1000,13 @@ struct Variables<'generator, 'module, 'a> {
     /// difference that a segment is identified by its name.
     ///
     scoped_segment_names: HashMap<EcoString, EcoString>,
+
+    /// When a `SegmentIsFiniteFloat` check pre-computes a float read, the
+    /// variable holding the result is stored here so that the subsequent
+    /// body binding for the same float segment can reuse it instead of
+    /// emitting a second `bitArraySliceToFloat` call.
+    ///
+    cached_float_var: Option<EcoString>,
 }
 
 impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
@@ -1010,6 +1021,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             scoped_variable_names: HashMap::new(),
             segment_values: HashMap::new(),
             scoped_segment_names: HashMap::new(),
+            cached_float_var: None,
         }
     }
 
@@ -1253,9 +1265,19 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                         (Some(start), Some(end)) => (start + end).to_doc(),
                         (_, _) => docvec![start_doc.clone(), " + ", self.read_size_to_doc(size)],
                     };
-                    let check = self.bit_array_slice_to_float(value, start_doc, end, endianness);
+                    let float_call =
+                        self.bit_array_slice_to_float(value, start_doc, end, endianness);
 
-                    docvec!["Number.isFinite(", check, ")"]
+                    // If we have a cached variable from
+                    // `bit_array_segment_assignments`, assign the float call
+                    // result to it inside the condition so the body binding
+                    // can reuse it without a second `bitArraySliceToFloat`
+                    // call.
+                    if let Some(var_name) = self.cached_float_var.as_ref() {
+                        docvec!["Number.isFinite(", var_name.clone(), " = ", float_call, ")"]
+                    } else {
+                        docvec!["Number.isFinite(", float_call, ")"]
+                    }
                 }
 
                 // Here we need to make sure that the bit array has a specific
@@ -1406,7 +1428,15 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             ReadType::Int => {
                 self.bit_array_slice_to_int(bit_array, start, end, endianness, *signed)
             }
-            ReadType::Float => self.bit_array_slice_to_float(bit_array, start, end, endianness),
+            ReadType::Float => {
+                // If the float read was already pre-computed by a
+                // `SegmentIsFiniteFloat` check, reuse the cached variable
+                // instead of emitting a duplicate `bitArraySliceToFloat` call.
+                if let Some(var_name) = self.cached_float_var.take() {
+                    return var_name.to_doc();
+                }
+                self.bit_array_slice_to_float(bit_array, start, end, endianness)
+            }
             ReadType::BitArray => self.bit_array_slice_with_end(bit_array, from, end),
             ReadType::String | ReadType::UtfCodepoint => {
                 panic!("invalid slice type made it to code generation: {type_:#?}")
@@ -1804,7 +1834,11 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
     /// the referenced segments into scope, so they're available to use for the
     /// runtime check.
     ///
-    fn bit_array_segment_assignments(&mut self, check: &RuntimeCheck) -> Vec<Document<'a>> {
+    fn bit_array_segment_assignments(
+        &mut self,
+        _variable: &Variable,
+        check: &'a RuntimeCheck,
+    ) -> Vec<Document<'a>> {
         let mut check_assignments = vec![];
         for (segment, _) in check.referenced_segment_patterns() {
             // If the segment was already bound to a variable in this scope we
@@ -1821,6 +1855,22 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             self.bind_segment(variable_name.clone(), segment.clone());
             check_assignments.push(let_doc(variable_name, segment_value))
         }
+
+        // If this is a `SegmentIsFiniteFloat` check, declare a variable to
+        // cache the result of the float read. The variable is declared here
+        // (before the if-condition) but assigned inside the condition via an
+        // assignment expression `$N = bitArraySliceToFloat(...)`. This way
+        // the float is only computed after earlier checks (like size) pass,
+        // and the result can be reused in the body binding.
+        if let RuntimeCheck::BitArray {
+            test: BitArrayTest::SegmentIsFiniteFloat { .. },
+        } = check
+        {
+            let var_name = self.next_local_var(&ASSIGNMENT_VAR.into());
+            self.cached_float_var = Some(var_name.clone());
+            check_assignments.push(docvec!["let ", var_name, ";"]);
+        }
+
         check_assignments
     }
 

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -21,7 +21,7 @@ use crate::{
 use ecow::{EcoString, eco_format};
 use itertools::Itertools;
 use num_bigint::BigInt;
-use std::{collections::HashMap, sync::OnceLock};
+use std::{collections::{HashMap, VecDeque}, sync::OnceLock};
 
 pub static ASSIGNMENT_VAR: &str = "$";
 
@@ -432,7 +432,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
             let old_names = self.variables.scoped_variable_names.clone();
             let old_segments = self.variables.segment_values.clone();
             let old_segment_names = self.variables.scoped_segment_names.clone();
-            let old_cached_float = self.variables.cached_float_var.clone();
+            let old_cached_float = self.variables.cached_float_vars.clone();
 
             let result = self.decision(fallback);
 
@@ -460,7 +460,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
             self.variables.scoped_variable_names = old_names;
             self.variables.segment_values = old_segments;
             self.variables.scoped_segment_names = old_segment_names;
-            self.variables.cached_float_var = old_cached_float;
+            self.variables.cached_float_vars = old_cached_float;
             return result;
         }
 
@@ -687,7 +687,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
         let old_names = self.variables.scoped_variable_names.clone();
         let old_segments = self.variables.segment_values.clone();
         let old_segment_names = self.variables.scoped_segment_names.clone();
-        let old_cached_float = self.variables.cached_float_var.clone();
+        let old_cached_float = self.variables.cached_float_vars.clone();
         let output = run(self);
 
         match &self.kind {
@@ -700,7 +700,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
         self.variables.scoped_variable_names = old_names;
         self.variables.segment_values = old_segments;
         self.variables.scoped_segment_names = old_segment_names;
-        self.variables.cached_float_var = old_cached_float;
+        self.variables.cached_float_vars = old_cached_float;
         output
     }
 
@@ -1001,12 +1001,16 @@ struct Variables<'generator, 'module, 'a> {
     ///
     scoped_segment_names: HashMap<EcoString, EcoString>,
 
-    /// When a `SegmentIsFiniteFloat` check pre-computes a float read, the
-    /// variable holding the result is stored here so that the subsequent
-    /// body binding for the same float segment can reuse it instead of
-    /// emitting a second `bitArraySliceToFloat` call.
+    /// When `SegmentIsFiniteFloat` checks pre-compute float reads, the
+    /// variables holding the results are queued here (FIFO) so that the
+    /// subsequent body bindings for the same float segments can reuse them
+    /// instead of emitting duplicate `bitArraySliceToFloat` calls.
     ///
-    cached_float_var: Option<EcoString>,
+    /// A queue is used because patterns like `<<a:float-32, b:float-32>>`
+    /// produce multiple float checks, and the body bindings consume them
+    /// in the same order they were declared.
+    ///
+    cached_float_vars: VecDeque<EcoString>,
 }
 
 impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
@@ -1021,7 +1025,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             scoped_variable_names: HashMap::new(),
             segment_values: HashMap::new(),
             scoped_segment_names: HashMap::new(),
-            cached_float_var: None,
+            cached_float_vars: VecDeque::new(),
         }
     }
 
@@ -1273,7 +1277,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                     // result to it inside the condition so the body binding
                     // can reuse it without a second `bitArraySliceToFloat`
                     // call.
-                    if let Some(var_name) = self.cached_float_var.as_ref() {
+                    if let Some(var_name) = self.cached_float_vars.back() {
                         docvec!["Number.isFinite(", var_name.clone(), " = ", float_call, ")"]
                     } else {
                         docvec!["Number.isFinite(", float_call, ")"]
@@ -1432,7 +1436,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                 // If the float read was already pre-computed by a
                 // `SegmentIsFiniteFloat` check, reuse the cached variable
                 // instead of emitting a duplicate `bitArraySliceToFloat` call.
-                if let Some(var_name) = self.cached_float_var.take() {
+                if let Some(var_name) = self.cached_float_vars.pop_front() {
                     return var_name.to_doc();
                 }
                 self.bit_array_slice_to_float(bit_array, start, end, endianness)
@@ -1867,7 +1871,7 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
         } = check
         {
             let var_name = self.next_local_var(&ASSIGNMENT_VAR.into());
-            self.cached_float_var = Some(var_name.clone());
+            self.cached_float_vars.push_back(var_name.clone());
             check_assignments.push(docvec!["let ", var_name, ";"]);
         }
 

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -1306,6 +1306,49 @@ pub fn go(x) {
 }
 
 #[test]
+fn case_match_two_floats() {
+    assert_js!(
+        r#"
+pub fn go(x) {
+  case x {
+    <<a:float-32, b:float-32>> -> #(a, b)
+    _ -> #(0.0, 0.0)
+  }
+}
+"#,
+    );
+}
+
+#[test]
+fn case_match_float_two_clauses() {
+    assert_js!(
+        r#"
+pub fn go(x) {
+  case x {
+    <<a:float-32, _:int-16>> -> a
+    <<c:float-32, d:float-32>> -> c +. d
+    _ -> 0.0
+  }
+}
+"#,
+    );
+}
+
+#[test]
+fn case_match_float_discard() {
+    assert_js!(
+        r#"
+pub fn go(x) {
+  case x {
+    <<_:float-32>> -> "float"
+    _ -> "other"
+  }
+}
+"#,
+    );
+}
+
+#[test]
 fn match_float_sized_little_endian() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float.snap
@@ -16,14 +16,18 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (
-    x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
-    x.bitSize === 72
-  ) {
-    let a = bitArraySliceToFloat(x, 0, 64, true);
-    let b = x.byteAt(8);
-    return [a, b];
+  if (x.bitSize >= 64) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true)) &&
+      x.bitSize === 72
+    ) {
+      let a = $;
+      let b = x.byteAt(8);
+      return [a, b];
+    } else {
+      return [1.1, 2];
+    }
   } else {
     return [1.1, 2];
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_16_bit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_16_bit.snap
@@ -16,9 +16,14 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (x.bitSize === 16 && Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))) {
-    let a = bitArraySliceToFloat(x, 0, 16, true);
-    return a;
+  if (x.bitSize === 16) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 16, true))) {
+      let a = $;
+      return a;
+    } else {
+      return 1.1;
+    }
   } else {
     return 1.1;
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_big_endian.snap
@@ -16,14 +16,18 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (
-    x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
-    x.bitSize === 72
-  ) {
-    let a = bitArraySliceToFloat(x, 0, 64, true);
-    let b = x.byteAt(8);
-    return [a, b];
+  if (x.bitSize >= 64) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true)) &&
+      x.bitSize === 72
+    ) {
+      let a = $;
+      let b = x.byteAt(8);
+      return [a, b];
+    } else {
+      return [1.1, 1];
+    }
   } else {
     return [1.1, 1];
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_discard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_discard.snap
@@ -1,0 +1,29 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn go(x) {\n  case x {\n    <<_:float-32>> -> \"float\"\n    _ -> \"other\"\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    <<_:float-32>> -> "float"
+    _ -> "other"
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { bitArraySliceToFloat } from "../gleam.mjs";
+
+export function go(x) {
+  if (x.bitSize === 32) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
+      return "float";
+    } else {
+      return "other";
+    }
+  } else {
+    return "other";
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_little_endian.snap
@@ -16,14 +16,18 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (
-    x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, false)) &&
-    x.bitSize === 72
-  ) {
-    let a = bitArraySliceToFloat(x, 0, 64, false);
-    let b = x.byteAt(8);
-    return [a, b];
+  if (x.bitSize >= 64) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, false)) &&
+      x.bitSize === 72
+    ) {
+      let a = $;
+      let b = x.byteAt(8);
+      return [a, b];
+    } else {
+      return [1.1, 2];
+    }
   } else {
     return [1.1, 2];
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized.snap
@@ -16,14 +16,18 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (
-    x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
-    x.bitSize === 40
-  ) {
-    let a = bitArraySliceToFloat(x, 0, 32, true);
-    let b = x.byteAt(4);
-    return [a, b];
+  if (x.bitSize >= 32) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true)) &&
+      x.bitSize === 40
+    ) {
+      let a = $;
+      let b = x.byteAt(4);
+      return [a, b];
+    } else {
+      return [1.1, 2];
+    }
   } else {
     return [1.1, 2];
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_big_endian.snap
@@ -16,14 +16,18 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (
-    x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
-    x.bitSize === 40
-  ) {
-    let a = bitArraySliceToFloat(x, 0, 32, true);
-    let b = x.byteAt(4);
-    return [a, b];
+  if (x.bitSize >= 32) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true)) &&
+      x.bitSize === 40
+    ) {
+      let a = $;
+      let b = x.byteAt(4);
+      return [a, b];
+    } else {
+      return [1.1, 2];
+    }
   } else {
     return [1.1, 2];
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_little_endian.snap
@@ -16,14 +16,18 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (
-    x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, false)) &&
-    x.bitSize === 40
-  ) {
-    let a = bitArraySliceToFloat(x, 0, 32, false);
-    let b = x.byteAt(4);
-    return [a, b];
+  if (x.bitSize >= 32) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, false)) &&
+      x.bitSize === 40
+    ) {
+      let a = $;
+      let b = x.byteAt(4);
+      return [a, b];
+    } else {
+      return [1.1, 2];
+    }
   } else {
     return [1.1, 2];
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_two_clauses.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_two_clauses.snap
@@ -1,0 +1,44 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn go(x) {\n  case x {\n    <<a:float-32, _:int-16>> -> a\n    <<c:float-32, d:float-32>> -> c +. d\n    _ -> 0.0\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    <<a:float-32, _:int-16>> -> a
+    <<c:float-32, d:float-32>> -> c +. d
+    _ -> 0.0
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { bitArraySliceToFloat } from "../gleam.mjs";
+
+export function go(x) {
+  if (x.bitSize >= 32) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
+      if (x.bitSize === 48) {
+        let a = $;
+        return a;
+      } else if (x.bitSize === 64) {
+        let $1;
+        if (Number.isFinite($1 = bitArraySliceToFloat(x, 32, 64, true))) {
+          let c = $;
+          let d = $1;
+          return c + d;
+        } else {
+          return 0.0;
+        }
+      } else {
+        return 0.0;
+      }
+    } else {
+      return 0.0;
+    }
+  } else {
+    return 0.0;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_two_floats.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_two_floats.snap
@@ -1,0 +1,39 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn go(x) {\n  case x {\n    <<a:float-32, b:float-32>> -> #(a, b)\n    _ -> #(0.0, 0.0)\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    <<a:float-32, b:float-32>> -> #(a, b)
+    _ -> #(0.0, 0.0)
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { bitArraySliceToFloat } from "../gleam.mjs";
+
+export function go(x) {
+  if (x.bitSize >= 32) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true)) &&
+      x.bitSize === 64
+    ) {
+      let $1;
+      if (Number.isFinite($1 = bitArraySliceToFloat(x, 32, 64, true))) {
+        let a = $;
+        let b = $1;
+        return [a, b];
+      } else {
+        return [0.0, 0.0];
+      }
+    } else {
+      return [0.0, 0.0];
+    }
+  } else {
+    return [0.0, 0.0];
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float.snap
@@ -17,13 +17,25 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let a;
   let b;
-  if (
-    x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
-    x.bitSize === 72
-  ) {
-    a = bitArraySliceToFloat(x, 0, 64, true);
-    b = x.byteAt(8);
+  if (x.bitSize >= 64) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true)) &&
+      x.bitSize === 72
+    ) {
+      a = $;
+      b = x.byteAt(8);
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 51, pattern_start: 29, pattern_end: 47 }
+      )
+    }
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit.snap
@@ -16,8 +16,21 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let a;
-  if (x.bitSize === 16 && Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))) {
-    a = bitArraySliceToFloat(x, 0, 16, true);
+  if (x.bitSize === 16) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 16, true))) {
+      a = $;
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 53, pattern_start: 29, pattern_end: 49 }
+      )
+    }
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_big_endian.snap
@@ -17,13 +17,25 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let a;
   let b;
-  if (
-    x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
-    x.bitSize === 72
-  ) {
-    a = bitArraySliceToFloat(x, 0, 64, true);
-    b = x.byteAt(8);
+  if (x.bitSize >= 64) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true)) &&
+      x.bitSize === 72
+    ) {
+      a = $;
+      b = x.byteAt(8);
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 55, pattern_start: 29, pattern_end: 51 }
+      )
+    }
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_little_endian.snap
@@ -17,13 +17,25 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let a;
   let b;
-  if (
-    x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, false)) &&
-    x.bitSize === 72
-  ) {
-    a = bitArraySliceToFloat(x, 0, 64, false);
-    b = x.byteAt(8);
+  if (x.bitSize >= 64) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, false)) &&
+      x.bitSize === 72
+    ) {
+      a = $;
+      b = x.byteAt(8);
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 58, pattern_start: 29, pattern_end: 54 }
+      )
+    }
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized.snap
@@ -17,13 +17,25 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let a;
   let b;
-  if (
-    x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
-    x.bitSize === 40
-  ) {
-    a = bitArraySliceToFloat(x, 0, 32, true);
-    b = x.byteAt(4);
+  if (x.bitSize >= 32) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true)) &&
+      x.bitSize === 40
+    ) {
+      a = $;
+      b = x.byteAt(4);
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 54, pattern_start: 29, pattern_end: 50 }
+      )
+    }
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_big_endian.snap
@@ -17,13 +17,25 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let a;
   let b;
-  if (
-    x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
-    x.bitSize === 40
-  ) {
-    a = bitArraySliceToFloat(x, 0, 32, true);
-    b = x.byteAt(4);
+  if (x.bitSize >= 32) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true)) &&
+      x.bitSize === 40
+    ) {
+      a = $;
+      b = x.byteAt(4);
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 58, pattern_start: 29, pattern_end: 54 }
+      )
+    }
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_little_endian.snap
@@ -17,13 +17,25 @@ const FILEPATH = "src/module.gleam";
 export function go(x) {
   let a;
   let b;
-  if (
-    x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, false)) &&
-    x.bitSize === 40
-  ) {
-    a = bitArraySliceToFloat(x, 0, 32, false);
-    b = x.byteAt(4);
+  if (x.bitSize >= 32) {
+    let $;
+    if (
+      Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, false)) &&
+      x.bitSize === 40
+    ) {
+      a = $;
+      b = x.byteAt(4);
+    } else {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        3,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 18, end: 61, pattern_start: 29, pattern_end: 57 }
+      )
+    }
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable_2.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 && x.byteAt(1) === 128 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable_2.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 && x.byteAt(1) === 192 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable_2.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 && x.byteAt(1) === 128 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_float_is_unreachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_float_is_unreachable.snap
@@ -17,8 +17,13 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (x.bitSize === 64 && Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
-    return "Float";
+  if (x.bitSize === 64) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
+      return "Float";
+    } else {
+      return "Other";
+    }
   } else {
     return "Other";
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_int_is_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_int_is_still_reachable.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else {
       return "Int";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable_2.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable_2.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable_2.snap
@@ -18,7 +18,8 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    let $;
+    if (Number.isFinite($ = bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&


### PR DESCRIPTION
Closes #4658

The JS code generator was calling `bitArraySliceToFloat` twice with the same arguments when matching on float bit array patterns — once for the `Number.isFinite` check and again for the body binding. This caches the result in a variable during the check (`$ = bitArraySliceToFloat(...)`) so the body binding can reuse it.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes