### PR TITLE
Fix gleam publish writing wrong OTP app name in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,3 +240,10 @@
   directly matches branch when existing variables with same exist in outer
   scope.
   ([Andrey Kozhev](https://github.com/ankddev))
+
+- Fixed a bug where `gleam publish` wrote the wrong application name into the
+  published package metadata for dependencies whose Hex package name differs
+  from their internal OTP application name. This caused Mix-based projects to
+  fail to build when they depended on Gleam packages with transitive
+  dependencies.
+  ([Logan Bresnahan](https://github.com/LoganBresnahan))

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -421,6 +421,18 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
         })
         .collect();
 
+    // Build a lookup from hex package name to OTP application name
+    let hex_to_otp_app = manifest
+        .packages
+        .iter()
+        .filter_map(|package| {
+            package
+                .otp_app
+                .as_ref()
+                .map(|otp_app_name| (package.name.clone(), otp_app_name.clone()))
+        })
+        .collect::<HashMap<_, _>>();
+
     // Build the project to check that it is valid
     let built = build::main(
         paths,
@@ -528,7 +540,12 @@ fn do_build_hex_tarball(paths: &ProjectPaths, config: &mut PackageConfig) -> Res
     let src_files = project_files(Utf8Path::new(""))?;
     let contents_tar_gz = contents_tarball(&src_files, &generated_files)?;
     let version = "3";
-    let metadata = metadata_config(&built.root_package.config, &src_files, &generated_files)?;
+    let metadata = metadata_config(
+        &built.root_package.config,
+        &hex_to_otp_app,
+        &src_files,
+        &generated_files,
+    )?;
 
     // Calculate checksum
     let mut hasher = sha2::Sha256::new();
@@ -574,6 +591,7 @@ fn check_config_for_publishing(config: &PackageConfig) -> Result<()> {
 
 fn metadata_config<'a>(
     config: &'a PackageConfig,
+    hex_to_otp_app: &'a HashMap<EcoString, EcoString>,
     source_files: &[Utf8PathBuf],
     generated_files: &[(Utf8PathBuf, String)],
 ) -> Result<String> {
@@ -591,6 +609,10 @@ fn metadata_config<'a>(
         .map(|(name, requirement)| match requirement {
             Requirement::Hex { version } => Ok(ReleaseRequirement {
                 name,
+                otp_app: hex_to_otp_app
+                    .get(name)
+                    .map(EcoString::as_str)
+                    .unwrap_or(name.as_str()),
                 requirement: version,
             }),
             _ => Err(Error::PublishNonHexDependencies {
@@ -810,17 +832,19 @@ struct ReleaseRequirement<'a> {
     requirement: &'a Range,
     // Support alternate repositories at a later date.
     // repository: String,
+    otp_app: &'a str,
 }
 impl ReleaseRequirement<'_> {
     pub fn as_erlang(&self) -> String {
         format!(
             r#"
-  {{<<"{app}"/utf8>>, [
-  {{<<"app">>, <<"{app}"/utf8>>}},
+  {{<<"{name}"/utf8>>, [
+  {{<<"app">>, <<"{otp_app}"/utf8>>}},
     {{<<"optional">>, false}},
     {{<<"requirement">>, <<"{requirement}"/utf8>>}}
   ]}}"#,
-            app = self.name,
+            name = self.name,
+            otp_app = self.otp_app,
             requirement = self.requirement,
         )
     }
@@ -860,10 +884,17 @@ fn release_metadata_as_erlang() {
         requirements: vec![
             ReleaseRequirement {
                 name: "wibble",
+                otp_app: "wibble",
                 requirement: &req1,
             },
             ReleaseRequirement {
                 name: "wobble",
+                otp_app: "wobble",
+                requirement: &req2,
+            },
+            ReleaseRequirement {
+                name: "weeble_erl",
+                otp_app: "weeble",
                 requirement: &req2,
             },
         ],
@@ -891,6 +922,11 @@ fn release_metadata_as_erlang() {
   {<<"app">>, <<"wobble"/utf8>>},
     {<<"optional">>, false},
     {<<"requirement">>, <<"~> 1.2"/utf8>>}
+  ]},
+  {<<"weeble_erl"/utf8>>, [
+  {<<"app">>, <<"weeble"/utf8>>},
+    {<<"optional">>, false},
+    {<<"requirement">>, <<"~> 1.2"/utf8>>}
   ]}
 ]}.
 {<<"files">>, [
@@ -913,7 +949,7 @@ fn prevent_publish_local_dependency() {
         ..Default::default()
     };
     assert_eq!(
-        metadata_config(&config, &[], &[]),
+        metadata_config(&config, &HashMap::new(), &[], &[]),
         Err(Error::PublishNonHexDependencies {
             package: "provided".into()
         })
@@ -931,7 +967,7 @@ fn prevent_publish_git_dependency() {
         ..Default::default()
     };
     assert_eq!(
-        metadata_config(&config, &[], &[]),
+        metadata_config(&config, &HashMap::new(), &[], &[]),
         Err(Error::PublishNonHexDependencies {
             package: "provided".into()
         })


### PR DESCRIPTION
Hex package names can differ from the otp app name (hpack_erl vs hpack). Mix needs the otp app name to start the application  for transitive dependencies. This follows the same pattern rebar3 implements: https://github.com/erlef/rebar3_hex/commit/a512dffbc14b17e69c1b8533534252cc0b80aca3

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
