### PR TITLE
reorder code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,10 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The language server now presents quick fix code actions before refactoring
+  ones.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The language server no longer shows completions for deprecated values from
   dependencies.
   ([Andrey Kozhev](https://github.com/ankddev))

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -432,6 +432,19 @@ where
 
             code_action_unused_values(module, &lines, &params, &mut actions);
             actions.extend(RemoveUnusedImports::new(module, &lines, &params).code_actions());
+            code_action_fix_names(module, &lines, &params, &this.error, &mut actions);
+            code_action_import_module(module, &lines, &params, &this.error, &mut actions);
+            code_action_add_missing_patterns(module, &lines, &params, &this.error, &mut actions);
+            actions
+                .extend(RemoveUnreachableCaseClauses::new(module, &lines, &params).code_actions());
+            actions
+                .extend(RemoveRedundantRecordUpdate::new(module, &lines, &params).code_actions());
+            actions.extend(CollapseNestedCase::new(module, &lines, &params).code_actions());
+            actions.extend(FixBinaryOperation::new(module, &lines, &params).code_actions());
+            actions
+                .extend(FixTruncatedBitArraySegment::new(module, &lines, &params).code_actions());
+            actions.extend(RemovePrivateOpaque::new(module, &lines, &params).code_actions());
+            actions.extend(AddMissingTypeParameter::new(module, &lines, &params).code_actions());
             code_action_convert_qualified_constructor_to_unqualified(
                 module,
                 &this.compiler,
@@ -445,14 +458,6 @@ where
                 &params,
                 &mut actions,
             );
-            code_action_fix_names(module, &lines, &params, &this.error, &mut actions);
-            code_action_import_module(module, &lines, &params, &this.error, &mut actions);
-            code_action_add_missing_patterns(module, &lines, &params, &this.error, &mut actions);
-            actions
-                .extend(RemoveUnreachableCaseClauses::new(module, &lines, &params).code_actions());
-            actions
-                .extend(RemoveRedundantRecordUpdate::new(module, &lines, &params).code_actions());
-            actions.extend(CollapseNestedCase::new(module, &lines, &params).code_actions());
             code_action_inexhaustive_let_to_case(
                 module,
                 &lines,
@@ -461,14 +466,11 @@ where
                 &mut actions,
             );
             actions.extend(MergeCaseBranches::new(module, &lines, &params).code_actions());
-            actions.extend(FixBinaryOperation::new(module, &lines, &params).code_actions());
-            actions
-                .extend(FixTruncatedBitArraySegment::new(module, &lines, &params).code_actions());
             actions.extend(LetAssertToCase::new(module, &lines, &params).code_actions());
             actions
                 .extend(RedundantTupleInCaseSubject::new(module, &lines, &params).code_actions());
-            actions.extend(UseLabelShorthandSyntax::new(module, &lines, &params).code_actions());
             actions.extend(FillInMissingLabelledArgs::new(module, &lines, &params).code_actions());
+            actions.extend(UseLabelShorthandSyntax::new(module, &lines, &params).code_actions());
             actions.extend(ConvertFromUse::new(module, &lines, &params).code_actions());
             actions.extend(RemoveEchos::new(module, &lines, &params).code_actions());
             actions.extend(ConvertToUse::new(module, &lines, &params).code_actions());
@@ -493,7 +495,6 @@ where
             actions.extend(InlineVariable::new(module, &lines, &params).code_actions());
             actions.extend(WrapInBlock::new(module, &lines, &params).code_actions());
             actions.extend(RemoveBlock::new(module, &lines, &params).code_actions());
-            actions.extend(RemovePrivateOpaque::new(module, &lines, &params).code_actions());
             actions.extend(ExtractFunction::new(module, &lines, &params).code_actions());
             GenerateDynamicDecoder::new(module, &lines, &params, &mut actions, &this.compiler)
                 .code_actions();
@@ -510,7 +511,6 @@ where
             AddAnnotations::new(module, &lines, &params).code_action(&mut actions);
             actions
                 .extend(AnnotateTopLevelDefinitions::new(module, &lines, &params).code_actions());
-            actions.extend(AddMissingTypeParameter::new(module, &lines, &params).code_actions());
             actions.extend(ReplaceUnderscoreWithType::new(module, &lines, &params).code_actions());
             actions.extend(
                 CreateUnknownModule::new(module, &lines, &params, &this.paths, &this.error)

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -516,6 +516,27 @@ where
                 CreateUnknownModule::new(module, &lines, &params, &this.paths, &this.error)
                     .code_actions(),
             );
+
+            actions.sort_by_key(|one| {
+                let preferred_key = if one.is_preferred == Some(true) { 0 } else { 1 };
+                let kind_key = match &one.kind {
+                    Some(lsp_types::CodeActionKind::QuickFix) => 1,
+                    Some(lsp_types::CodeActionKind::Refactor) => 2,
+                    Some(lsp_types::CodeActionKind::RefactorExtract) => 2,
+                    Some(lsp_types::CodeActionKind::RefactorInline) => 2,
+                    Some(lsp_types::CodeActionKind::RefactorMove) => 2,
+                    Some(lsp_types::CodeActionKind::RefactorRewrite) => 2,
+                    Some(lsp_types::CodeActionKind::Source) => 3,
+                    Some(lsp_types::CodeActionKind::SourceOrganizeImports) => 3,
+                    Some(lsp_types::CodeActionKind::SourceFixAll) => 3,
+                    Some(lsp_types::CodeActionKind::Custom(_)) => 4,
+                    Some(lsp_types::CodeActionKind::Notebook) => 5,
+                    Some(lsp_types::CodeActionKind::Empty) => 6,
+                    None => 7,
+                };
+                (preferred_key, kind_key)
+            });
+
             Ok(if actions.is_empty() {
                 None
             } else {


### PR DESCRIPTION
I've noticed in some cases the language server ordering of code actions is not ideal, for example:
<img width="790" height="327" alt="missing add labels code action" src="https://github.com/user-attachments/assets/44a9930a-91a7-4ffd-80f6-085db72918ba" />
In this case the quick fix to fill in the missing labels (what I actually wanted was third), with the two other options not being immediately useful.

I've reordered the code actions so that fixes for errors and warnings are always presented first, before "refactoring" code actions: this means that when my cursor is over an error or a warning the language server should now first present the quick fix, then the other less relevant refactorings