### PR TITLE
Improve hex revert missing version error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@
   flow for when a Hex session has been revoked or has expired.
   ([Sahil Upasane](https://github.com/404salad))
 
+- The `gleam hex revert` command now reports the missing package version when
+  the requested release does not exist on Hex.
+  ([fizyxbt](https://github.com/fizyxbt))
+
 - New packages are created requesting Erlang/OTP version 29 on GitHub actions.
   ([Louis Pilfold](https://github.com/lpil))
 

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -111,7 +111,13 @@ pub fn revert(
     )
     .map_err(Error::hex)?;
     let response = runtime.block_on(http.send(request))?;
-    hexpm::api_revert_release_response(response).map_err(Error::hex)?;
+    match hexpm::api_revert_release_response(response) {
+        Ok(()) => (),
+        Err(hexpm::ApiError::NotFound) => {
+            return Err(Error::HexReleaseNotFound { package, version });
+        }
+        Err(error) => return Err(Error::hex(error)),
+    }
 
     // Done!
     println!("{package} {version} has been removed from Hex");

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -204,6 +204,9 @@ pub enum Error {
     #[error("Hex error: {0}")]
     Hex(String),
 
+    #[error("Hex release not found")]
+    HexReleaseNotFound { package: String, version: String },
+
     #[error("{error}")]
     ExpandTar { error: String },
 
@@ -1614,6 +1617,14 @@ This was error from the Hex client library:
                     location: None,
                 }]
             }
+
+            Error::HexReleaseNotFound { package, version } => vec![Diagnostic {
+                title: "Hex API failure".into(),
+                text: format!("There is no version {version} of the package {package}."),
+                hint: None,
+                level: Level::Error,
+                location: None,
+            }],
 
             Error::DuplicateModule {
                 module,

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__hex_release_not_found.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__hex_release_not_found.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: "err[0]"
+---
+Diagnostic {
+    title: "Hex API failure",
+    text: "There is no version 1.234234.2 of the package birdie.",
+    level: Error,
+    location: None,
+    hint: None,
+}

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -44,6 +44,16 @@ fn hex_session_revoked() {
 }
 
 #[test]
+fn hex_release_not_found() {
+    let err = Error::HexReleaseNotFound {
+        package: "birdie".to_string(),
+        version: "1.234234.2".to_string(),
+    }
+    .to_diagnostics();
+    assert_debug_snapshot!(err[0]);
+}
+
+#[test]
 fn hex_error_conversion() {
     assert_eq!(
         Error::hex(hexpm::ApiError::OAuthRefreshTokenRejected),


### PR DESCRIPTION
Closes #5709.

This adds a specific error for `gleam hex revert` when Hex reports that the requested release does not exist, so the command can show the package and version directly instead of the generic Hex client message.

Tests:
- `cargo fmt --all -- --check`
- `cargo check -p gleam-cli`
- `cargo test -p gleam-core hex_release_not_found`
- `cargo test -p gleam-cli hex`