### PR TITLE
improve doc tables on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
   flag is passed, no progress information is printed.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Tables in the generated docs now look better on smaller screens.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The comment in `manifest.toml` now instructs the user to include it in their
   source control repository.
   ([Louis Pilfold](https://github.com/lpil))

--- a/compiler-core/templates/docs-css/index.css
+++ b/compiler-core/templates/docs-css/index.css
@@ -605,12 +605,20 @@ body.drawer-open .label-closed {
 /* Tables */
 
 table {
+  display: block;
+  overflow-inline: auto;
   border-spacing: 0;
   border-collapse: collapse;
 }
 
 table td,
 table th {
+  /* Inside table cells we don't won't to break words anywhere, otherwise in
+  narrow columns or in tables with many columns we'd end up with columns with
+  a single character per line.
+  */
+  word-break: normal;
+  overflow-wrap: normal;
   padding: 6px 13px;
   border: 1px solid var(--table-border);
 }


### PR DESCRIPTION
I noticed tables look a bit cramped on mobile, often with columns that are just a single character wide:
<img width="365" height="660" alt="Screenshot 2026-05-14 alle 15 50 14" src="https://github.com/user-attachments/assets/d3dfccad-79f8-465a-9e15-bae51e4fa712" />

I've changed it so that, like code blocks, tables can be scrolled horizontally rather than getting too narrow. This is what it looks like:
![](https://github.com/user-attachments/assets/53158c41-f8ba-491b-89a8-e7981d5df662)

And there's no changes if the table has enough space:
<img width="809" height="319" alt="Screenshot 2026-05-14 alle 15 49 17" src="https://github.com/user-attachments/assets/57f0262a-bdba-4b3e-b5c0-ac049d6f489f" />

Hope this is good!

- [X] The changelog has been updated for any user-facing changes
