### PR TITLE
remove: don't fail when manifest.toml is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,11 @@
 
 ### Bug fixes
 
+- Fixed a bug where `gleam remove` would fail with a confusing File IO error
+  if `manifest.toml` didn't exist yet (e.g. in a freshly-created project or
+  after the manifest had been deleted).
+  ([Charlie Tonneslan](https://github.com/c-tonneslan))
+
 - Fixed a bug where the build tool would check for new major versions of a local
   or git dependency on Hex when running `gleam update`.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/remove.rs
+++ b/compiler-cli/src/remove.rs
@@ -46,7 +46,13 @@ pub fn command(paths: &ProjectPaths, packages: Vec<String>) -> Result<()> {
 
     // Write the updated config
     fs::write(root_config.as_path(), &toml.to_string())?;
-    _ = crate::dependencies::cleanup(paths, cli::Reporter::new())?;
+
+    // If there's no manifest yet (e.g. the project has never been built) we
+    // don't need to clean it up. `cleanup` reads manifest.toml unconditionally
+    // and that failed with a confusing "File IO failure" before this guard.
+    if paths.manifest().exists() {
+        _ = crate::dependencies::cleanup(paths, cli::Reporter::new())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Ran into this trying to reproduce #5654 locally. In a fresh project (or after temporarily `rm manifest.toml` to untangle dependency versions), `gleam remove` bails with:

```
error: File IO failure

An error occurred while trying to read this file:

    /path/to/manifest.toml

The error message from the file IO library was:

    No such file or directory (os error 2)
```

The remove command updates `gleam.toml` and then calls `dependencies::cleanup` to prune the manifest, but cleanup reads `manifest.toml` unconditionally. If there's no manifest there's also nothing to prune, so just skip the cleanup. Next build will regenerate it.

Repro before the fix:

```
$ gleam new myproj && cd myproj
$ gleam add gleam_stdlib
$ rm manifest.toml
$ gleam remove gleam_stdlib
error: File IO failure
...
```

After: `gleam.toml` gets updated and the command exits cleanly.

Closes #5654.