### PR TITLE
fix: use property escaping in TypeScript declarations for reserved field names

### DIFF
--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -1241,7 +1241,7 @@ fn maybe_escape_identifier(word: &str) -> EcoString {
     }
 }
 
-fn maybe_escape_property(label: &str) -> EcoString {
+pub(super) fn maybe_escape_property(label: &str) -> EcoString {
     if is_usable_js_property(label) {
         EcoString::from(label)
     } else {

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -634,6 +634,39 @@ pub fn main() {
     );
 }
 #[test]
+fn record_with_field_named_constructor_typescript() {
+    assert_ts_def!(
+        r#"
+pub type Box {
+  Box(constructor: Int)
+}
+"#,
+    );
+}
+
+#[test]
+fn record_with_field_named_then_typescript() {
+    assert_ts_def!(
+        r#"
+pub type Box {
+  Box(then: Int)
+}
+"#,
+    );
+}
+
+#[test]
+fn record_with_field_named_prototype_typescript() {
+    assert_ts_def!(
+        r#"
+pub type Box {
+  Box(prototype: Int)
+}
+"#,
+    );
+}
+
+#[test]
 fn record_access_in_guard_with_reserved_field_name() {
     assert_js!(
         r#"

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_constructor_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_constructor_typescript.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Box {\n  Box(constructor: Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Box {
+  Box(constructor: Int)
+}
+
+
+----- TYPESCRIPT DEFINITIONS
+import type * as _ from "../gleam.d.mts";
+
+export class Box extends _.CustomType {
+  /** @deprecated */
+  constructor(constructor$: number);
+  /** @deprecated */
+  constructor$: number;
+}
+export function Box$Box(constructor$: number): Box$;
+export function Box$isBox(value: any): value is Box$;
+export function Box$Box$0(value: Box$): number;
+export function Box$Box$constructor(value: Box$): number;
+
+export type Box$ = Box;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_prototype_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_prototype_typescript.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Box {\n  Box(prototype: Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Box {
+  Box(prototype: Int)
+}
+
+
+----- TYPESCRIPT DEFINITIONS
+import type * as _ from "../gleam.d.mts";
+
+export class Box extends _.CustomType {
+  /** @deprecated */
+  constructor(prototype$: number);
+  /** @deprecated */
+  prototype$: number;
+}
+export function Box$Box(prototype$: number): Box$;
+export function Box$isBox(value: any): value is Box$;
+export function Box$Box$0(value: Box$): number;
+export function Box$Box$prototype(value: Box$): number;
+
+export type Box$ = Box;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_then_typescript.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__record_with_field_named_then_typescript.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Box {\n  Box(then: Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Box {
+  Box(then: Int)
+}
+
+
+----- TYPESCRIPT DEFINITIONS
+import type * as _ from "../gleam.d.mts";
+
+export class Box extends _.CustomType {
+  /** @deprecated */
+  constructor(then$: number);
+  /** @deprecated */
+  then$: number;
+}
+export function Box$Box(then$: number): Box$;
+export function Box$isBox(value: any): value is Box$;
+export function Box$Box$0(value: Box$): number;
+export function Box$Box$then(value: Box$): number;
+
+export type Box$ = Box;

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -567,7 +567,7 @@ impl<'a> TypeScriptGenerator<'a> {
                         let name = argument
                             .label
                             .as_ref()
-                            .map(|(_, s)| super::maybe_escape_identifier(s))
+                            .map(|(_, s)| super::maybe_escape_property(s))
                             .unwrap_or_else(|| eco_format!("argument${i}"))
                             .to_doc();
                         docvec![
@@ -585,7 +585,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     let name = arg
                         .label
                         .as_ref()
-                        .map(|(_, s)| super::maybe_escape_identifier(s))
+                        .map(|(_, s)| super::maybe_escape_property(s))
                         .unwrap_or_else(|| eco_format!("{i}"))
                         .to_doc();
                     docvec![
@@ -616,7 +616,7 @@ impl<'a> TypeScriptGenerator<'a> {
 
         for (index, parameter) in constructor.arguments.iter().enumerate() {
             let name = if let Some((_, label)) = &parameter.label {
-                super::maybe_escape_identifier(label)
+                super::maybe_escape_property(label)
             } else {
                 eco_format!("${index}")
             };


### PR DESCRIPTION
Fixes #5613

## Problem

Fields named `constructor`, `prototype`, `then`, or `__proto__` are renamed with a `$` suffix in the JavaScript output to avoid collisions with built-in JS properties. However, the TypeScript declaration generator was using `maybe_escape_identifier` instead of `maybe_escape_property` for field names, so the `.d.ts` output did not reflect this rename.

This caused two problems:

1. A field named `constructor` produced **invalid TypeScript** — the class ended up with a duplicate `constructor` overload which TypeScript rejects.
2. Fields named `prototype` or `then` produced **valid but wrong TypeScript** — the declared property name didn't match the actual JS property name, so e.g. `box.prototype` was suggested by autocomplete when the real property is `box.prototype$`.

## Fix

Make `maybe_escape_property` pub(super) and use it in the three places in `typescript.rs` that emit field names:
- constructor parameter names in the class definition
- class body field declarations  
- parameters in standalone constructor functions

## Tests

Added three snapshot tests for `constructor`, `then`, and `prototype` field names. The generated `.d.ts` now correctly uses `constructor$`, `then$`, and `prototype$` to match the JavaScript output.