### PR TITLE
Add helpful error message for prefix+suffix string pattern matching

### DIFF
--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1364,6 +1364,18 @@ where
                             Some((_, Token::Concatenate, _)) => {
                                 self.advance();
                                 let (r_start, right, r_end) = self.expect_assign_name()?;
+                                // "prefix" as x <> var <> "suffix" is not supported
+                                if let Some((suffix_start, Token::Concatenate, suffix_end)) =
+                                    self.tok0
+                                {
+                                    return Err(ParseError {
+                                        error: ParseErrorType::ConcatPatternWithSuffix,
+                                        location: SrcSpan {
+                                            start: suffix_start,
+                                            end: suffix_end,
+                                        },
+                                    });
+                                }
                                 Pattern::StringPrefix {
                                     location: SrcSpan { start, end: r_end },
                                     left_location: SrcSpan {
@@ -1398,6 +1410,16 @@ where
                     Some((_, Token::Concatenate, _)) => {
                         self.advance();
                         let (r_start, right, r_end) = self.expect_assign_name()?;
+                        // "prefix" <> var <> "suffix" is not supported
+                        if let Some((suffix_start, Token::Concatenate, suffix_end)) = self.tok0 {
+                            return Err(ParseError {
+                                error: ParseErrorType::ConcatPatternWithSuffix,
+                                location: SrcSpan {
+                                    start: suffix_start,
+                                    end: suffix_end,
+                                },
+                            });
+                        }
                         Pattern::StringPrefix {
                             location: SrcSpan { start, end: r_end },
                             left_location: SrcSpan { start, end },

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -108,6 +108,8 @@ pub enum ParseErrorType {
     UnexpectedFunction, // a function was used called outside of another function
     // A variable was assigned or discarded on the left hand side of a <> pattern
     ConcatPatternVariableLeftHandSide,
+    // A <> suffix was added after a prefix pattern like "prefix" <> var <> "suffix"
+    ConcatPatternWithSuffix,
     ListSpreadWithoutTail,               // let x = [1, ..]
     ExpectedFunctionBody,                // let x = fn()
     RedundantInternalAttribute,          // for a private definition marked as internal
@@ -552,6 +554,19 @@ utf16_codepoint, utf32_codepoint, signed, unsigned, big, little, native, size, u
                 .join("\n"),
                 hint: None,
                 label_text: "This must be a string literal".into(),
+                extra_labels: vec![],
+            },
+
+            ParseErrorType::ConcatPatternWithSuffix => ParseErrorDetails {
+                text: [
+                    "String patterns can only match on a prefix, not both a prefix and a suffix.",
+                    "",
+                    "If you want to match on a suffix consider using `string.ends_with`",
+                    "from the stdlib's `gleam/string` module.",
+                ]
+                .join("\n"),
+                hint: None,
+                label_text: "This is not allowed in a string pattern".into(),
                 extra_labels: vec![],
             },
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__concat_pattern_with_suffix.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__concat_pattern_with_suffix.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\n        case \"\" {\n          \"prefix\" <> rest <> \"suffix\" -> rest\n        }\n        "
+---
+----- SOURCE CODE
+
+        case "" {
+          "prefix" <> rest <> "suffix" -> rest
+        }
+        
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:28
+  │
+3 │           "prefix" <> rest <> "suffix" -> rest
+  │                            ^^ This is not allowed in a string pattern
+
+String patterns can only match on a prefix, not both a prefix and a suffix.
+
+If you want to match on a suffix consider using `string.ends_with`
+from the stdlib's `gleam/string` module.

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__concat_pattern_with_suffix_and_as.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__concat_pattern_with_suffix_and_as.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\n        case \"\" {\n          \"prefix\" as p <> rest <> \"suffix\" -> rest\n        }\n        "
+---
+----- SOURCE CODE
+
+        case "" {
+          "prefix" as p <> rest <> "suffix" -> rest
+        }
+        
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:33
+  │
+3 │           "prefix" as p <> rest <> "suffix" -> rest
+  │                                 ^^ This is not allowed in a string pattern
+
+String patterns can only match on a prefix, not both a prefix and a suffix.
+
+If you want to match on a suffix consider using `string.ends_with`
+from the stdlib's `gleam/string` module.

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -634,6 +634,30 @@ fn assign_left_hand_side_of_concat_pattern() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5695
+#[test]
+fn concat_pattern_with_suffix() {
+    assert_error!(
+        r#"
+        case "" {
+          "prefix" <> rest <> "suffix" -> rest
+        }
+        "#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5695
+#[test]
+fn concat_pattern_with_suffix_and_as() {
+    assert_error!(
+        r#"
+        case "" {
+          "prefix" as p <> rest <> "suffix" -> rest
+        }
+        "#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/1890
 #[test]
 fn valueless_list_spread_expression() {


### PR DESCRIPTION
Fixes #5695

## What

When a user writes a string pattern that attempts to match both a prefix and a suffix:

```gleam
case "my string!" {
  "my " <> object <> "!" -> todo
}
```

Previously this produced a confusing generic error:

```
error: Syntax error
  ┌─ src/main.gleam:3:21
  │
3 │   "my " <> object <> "!" -> todo
  │                   ^^ I was not expecting this

Found `<>`, expected one of:
- `->`

Hint: Did you mean to wrap a multi line clause in curly braces?
```

Now it produces a clear, actionable error:

```
error: Syntax error
  ┌─ src/main.gleam:3:21
  │
3 │   "my " <> object <> "!" -> todo
  │                   ^^ This is not allowed in a string pattern

String patterns can only match on a prefix, not both a prefix and a suffix.

If you want to match on a suffix consider using `string.ends_with`
from the stdlib's `gleam/string` module.
```

## How

Added a `ConcatPatternWithSuffix` parse error variant and a check in the parser: after successfully parsing `"prefix" <> var`, if the next token is another `<>`, emit the new specific error. The check covers both the plain form and the `as`-assignment form (`"prefix" as x <> var <> "suffix"`).

Two snapshot tests added.