### PR TITLE
Improve error message for reverting old release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   `package.hexdocs.pm` rather than `hexdocs.pm/package`.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- More readable error message when trying to revert an old release.
+  ([Moritz Böhme](https://github.com/MoritzBoehme))
+
 ### Language server
 
 - The "pattern match on value" code action can now be used to pattern match on

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -272,6 +272,7 @@ impl PackageFetchError {
             | hexpm::ApiError::IncorrectChecksum
             | hexpm::ApiError::Forbidden
             | hexpm::ApiError::NotReplacing
+            | hexpm::ApiError::LateDeletion
             | hexpm::ApiError::LateModification => Self::ApiError(api_error),
         }
     }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -534,6 +534,7 @@ impl Error {
             | hexpm::ApiError::Forbidden
             | hexpm::ApiError::NotReplacing
             | hexpm::ApiError::LateModification
+            | hexpm::ApiError::LateDeletion
             | hexpm::ApiError::OAuthTimeout
             | hexpm::ApiError::OAuthAccessDenied
             | hexpm::ApiError::ExpiredToken => Self::Hex(error.to_string()),

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -64,6 +64,7 @@ pub async fn publish_package<Http: HttpClient>(
         | ApiError::ExpiredToken
         | ApiError::OAuthRefreshTokenRejected
         | ApiError::IncorrectOneTimePassword
+        | ApiError::LateDeletion
         | ApiError::LateModification => Error::hex(e),
     })
 }

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -591,8 +591,14 @@ pub fn api_revert_release_response(response: http::Response<Vec<u8>>) -> Result<
         StatusCode::TOO_MANY_REQUESTS => Err(ApiError::RateLimited),
         StatusCode::UNAUTHORIZED => Err(unauthorised_response(&parts.headers)),
         StatusCode::FORBIDDEN => Err(ApiError::Forbidden),
+        StatusCode::UNPROCESSABLE_ENTITY if is_late_deletion(&body) => Err(ApiError::LateDeletion),
         status => Err(ApiError::unexpected_response(status, body)),
     }
+}
+
+fn is_late_deletion(body: &[u8]) -> bool {
+    String::from_utf8_lossy(body)
+        .contains("can only delete a release up to one hour after publication")
 }
 
 /// See: https://github.com/hexpm/hex/blob/main/lib/mix/tasks/hex.owner.ex#L47
@@ -761,6 +767,9 @@ pub enum ApiError {
 
     #[error("Can only modify a release up to one hour after publication")]
     LateModification,
+
+    #[error("Can only delete a release up to one hour after publication")]
+    LateDeletion,
 
     #[error("The oauth request wasn't approved in time")]
     OAuthTimeout,

--- a/hexpm/src/tests.rs
+++ b/hexpm/src/tests.rs
@@ -76,6 +76,13 @@ fn revert_release_response_success() {
 }
 
 #[test]
+fn revert_release_response_too_old_error() {
+    let response = make_response(422, r#"{"message":"Validation error(s)","status":422,"errors":{"inserted_at":"can only delete a release up to one hour after publication"}}"#.as_bytes().to_vec());
+    let result = crate::api_revert_release_response(response);
+    assert!(matches!(result, Err(ApiError::LateDeletion)));
+}
+
+#[test]
 fn add_owner_request() {
     let key = WriteActionCredentials::OAuthAccessToken {
         access_token: EcoString::from("my-api-key-here"),


### PR DESCRIPTION
Fixes #5708 

- [ ] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

~~I still have to do some clean-up and refactoring. Not really satisfied with the way I handled formatting. I would like to use space_table, but this is implemented in compiler_cli :/~~
I think this is quite okay now.

Adding a snapshot test for the error formatting might also be nice. Insta is not yet a dependency of hexpm, so I did not do so for now.