### PR TITLE
Fault tolerant guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@
   analyse the fields that are being provided.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The inference of clause guards is now more fault tolerant: if there's an error
+  in a part of the guard expression, the compiler can still able to analyse the
+  rest of the guard rather than stopping at the first error.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - It is now possible to use the `todo` keyword in constants, this will result in
   an helpful error message rather than a syntax error.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -2304,6 +2304,11 @@ pub enum ClauseGuard<Type, RecordTag> {
     },
 
     Constant(Constant<Type, RecordTag>),
+
+    Invalid {
+        location: SrcSpan,
+        type_: Type,
+    },
 }
 
 impl<A, B> ClauseGuard<A, B> {
@@ -2315,6 +2320,7 @@ impl<A, B> ClauseGuard<A, B> {
             | ClauseGuard::Var { location, .. }
             | ClauseGuard::TupleIndex { location, .. }
             | ClauseGuard::ModuleSelect { location, .. }
+            | ClauseGuard::Invalid { location, .. }
             | ClauseGuard::Block { location, .. } => *location,
             ClauseGuard::FieldAccess {
                 label_location,
@@ -2337,6 +2343,7 @@ impl<A, B> ClauseGuard<A, B> {
             ClauseGuard::BinaryOperator { operator, .. } => Some(*operator),
 
             ClauseGuard::Constant(_)
+            | ClauseGuard::Invalid { .. }
             | ClauseGuard::Var { .. }
             | ClauseGuard::Not { .. }
             | ClauseGuard::TupleIndex { .. }
@@ -2356,6 +2363,7 @@ impl TypedClauseGuard {
             ClauseGuard::ModuleSelect { type_, .. } => type_.clone(),
             ClauseGuard::Constant(constant) => constant.type_(),
             ClauseGuard::Block { value, .. } => value.type_(),
+            ClauseGuard::Invalid { type_, .. } => type_.clone(),
 
             ClauseGuard::Not { .. } => type_::bool(),
 
@@ -2426,6 +2434,7 @@ impl TypedClauseGuard {
             | ClauseGuard::Block { value, .. } => value.find_node(byte_index),
             ClauseGuard::Constant(constant) => constant.find_node(byte_index),
             ClauseGuard::Var { .. } => Some(Located::ClauseGuard(self)),
+            ClauseGuard::Invalid { .. } => Some(Located::ClauseGuard(self)),
         }
     }
 
@@ -2439,6 +2448,7 @@ impl TypedClauseGuard {
             ClauseGuard::FieldAccess { container, .. } => container.referenced_variables(),
             ClauseGuard::Constant(constant) => constant.referenced_variables(),
             ClauseGuard::ModuleSelect { .. } => im::HashSet::new(),
+            ClauseGuard::Invalid { .. } => im::HashSet::new(),
 
             ClauseGuard::BinaryOperator { left, right, .. } => left
                 .referenced_variables()
@@ -2523,6 +2533,9 @@ impl TypedClauseGuard {
                 one.syntactically_eq(other)
             }
             (ClauseGuard::Constant(_), _) => false,
+
+            // An invalid guard is never the same as another one
+            (ClauseGuard::Invalid { .. }, _) => false,
         }
     }
 
@@ -2532,6 +2545,7 @@ impl TypedClauseGuard {
             | ClauseGuard::BinaryOperator { .. }
             | ClauseGuard::Not { .. }
             | ClauseGuard::TupleIndex { .. }
+            | ClauseGuard::Invalid { .. }
             | ClauseGuard::FieldAccess { .. } => None,
             ClauseGuard::Constant(constant) => constant.definition_location(),
             ClauseGuard::Var {

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -1864,6 +1864,7 @@ where
             literal,
         ),
         super::ClauseGuard::Constant(constant) => v.visit_typed_constant(constant),
+        super::ClauseGuard::Invalid { .. } => (),
     }
 }
 

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -430,6 +430,8 @@ impl<'a> CallGraphBuilder<'a> {
 
     fn guard(&mut self, guard: &'a UntypedClauseGuard) {
         match guard {
+            ClauseGuard::Invalid { .. } => (),
+
             ClauseGuard::BinaryOperator { left, right, .. } => {
                 self.guard(left);
                 self.guard(right);

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1967,6 +1967,8 @@ fn bare_clause_guard<'a>(
     assignments: &HashMap<EcoString, &StringPatternAssignment<'a>>,
 ) -> Document<'a> {
     match guard {
+        ClauseGuard::Invalid { .. } => unreachable!("invalid guard made it to code generation"),
+
         ClauseGuard::Block { value, .. } => {
             bare_clause_guard(value, env, assignments).surround("(", ")")
         }
@@ -2049,6 +2051,8 @@ fn clause_guard_string_concatenate_argument<'a>(
     assignments: &HashMap<EcoString, &StringPatternAssignment<'a>>,
 ) -> Document<'a> {
     match guard {
+        ClauseGuard::Invalid { .. } => unreachable!("invalid guard made it to code generation"),
+
         ClauseGuard::Constant(Constant::String { value, .. }) => {
             docvec!['"', string_inner(value), "\"/utf8"]
         }
@@ -2119,6 +2123,7 @@ fn clause_guard<'a>(
     assignments: &HashMap<EcoString, &StringPatternAssignment<'a>>,
 ) -> Document<'a> {
     match guard {
+        ClauseGuard::Invalid { .. } => unreachable!("invalid guard made it to code generation"),
         // Binary operators are wrapped in parens
         ClauseGuard::BinaryOperator { .. } => "("
             .to_doc()

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2676,6 +2676,8 @@ impl<'comments> Formatter<'comments> {
 
     fn clause_guard<'a>(&mut self, clause_guard: &'a UntypedClauseGuard) -> Document<'a> {
         match clause_guard {
+            ClauseGuard::Invalid { .. } => unreachable!("invalid guard made it to formatting"),
+
             ClauseGuard::BinaryOperator {
                 operator,
                 left,

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -2310,6 +2310,8 @@ impl<'module, 'a> Generator<'module, 'a> {
 
     pub(crate) fn guard(&mut self, guard: &'a TypedClauseGuard) -> Document<'a> {
         match guard {
+            ClauseGuard::Invalid { .. } => unreachable!("invalid guard made it to code generation"),
+
             ClauseGuard::Block { value, .. } => self.guard(value).surround("(", ")"),
 
             ClauseGuard::BinaryOperator {
@@ -2434,6 +2436,7 @@ impl<'module, 'a> Generator<'module, 'a> {
 
     fn wrapped_guard(&mut self, guard: &'a TypedClauseGuard) -> Document<'a> {
         match guard {
+            ClauseGuard::Invalid { .. } => unreachable!("invalid guard made it to code generation"),
             ClauseGuard::Var { .. }
             | ClauseGuard::TupleIndex { .. }
             | ClauseGuard::Constant(_)

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2427,14 +2427,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             let (typed_pattern, typed_alternatives, error_encountered) =
                 this.infer_clause_pattern(pattern, alternative_patterns, subjects, &location);
 
-            let guard = match this.infer_optional_clause_guard(guard) {
-                Ok(guard) => guard,
-                // If an error occurs inferring guard then assume no guard
-                Err(error) => {
-                    this.problems.error(error);
-                    None
-                }
-            };
+            let guard = this.infer_optional_clause_guard(guard);
             let then = this.infer(then);
             let clause = Clause {
                 location,
@@ -2488,49 +2481,34 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     fn infer_optional_clause_guard(
         &mut self,
         guard: Option<UntypedClauseGuard>,
-    ) -> Result<Option<TypedClauseGuard>, Error> {
-        match guard {
-            // If there is no guard we do nothing
-            None => Ok(None),
-
-            // If there is a guard we assert that it is of type Bool
-            Some(guard) => {
-                let guard = self.infer_clause_guard(guard)?;
-                unify(bool(), guard.type_())
-                    .map_err(|e| convert_unify_error(e, guard.location()))?;
-                Ok(Some(guard))
-            }
+    ) -> Option<TypedClauseGuard> {
+        // If there is a guard we type check it and assert that it is of type
+        // Bool.
+        let guard = self.infer_clause_guard(guard?);
+        if let Err(error) = unify(bool(), guard.type_()) {
+            self.problems
+                .error(convert_unify_error(error, guard.location()));
         }
+        Some(guard)
     }
 
-    fn infer_clause_guard(&mut self, guard: UntypedClauseGuard) -> Result<TypedClauseGuard, Error> {
+    fn infer_clause_guard(&mut self, guard: UntypedClauseGuard) -> TypedClauseGuard {
         match guard {
+            ClauseGuard::Invalid { .. } => {
+                unreachable!("untyped guard should never be invalid")
+            }
+
             ClauseGuard::Var { location, name, .. } => {
-                let constructor =
-                    self.infer_value_constructor(&None, &name, &location, ValueUsage::Other)?;
-
-                // We cannot support all values in guard expressions as the BEAM does not
-                let (definition_location, origin) = match &constructor.variant {
-                    ValueConstructorVariant::LocalVariable {
-                        location, origin, ..
-                    } => (*location, origin.clone()),
-                    ValueConstructorVariant::ModuleFn { .. }
-                    | ValueConstructorVariant::Record { .. } => {
-                        return Err(Error::NonLocalClauseGuardVariable { location, name });
+                match self.infer_clause_guard_variable(name, location) {
+                    Ok(variable) => variable,
+                    Err(error) => {
+                        self.problems.error(error);
+                        ClauseGuard::Invalid {
+                            location,
+                            type_: self.new_unbound_var(),
+                        }
                     }
-
-                    ValueConstructorVariant::ModuleConstant { literal, .. } => {
-                        return Ok(ClauseGuard::Constant(literal.clone()));
-                    }
-                };
-
-                Ok(ClauseGuard::Var {
-                    location,
-                    name,
-                    origin,
-                    type_: constructor.type_,
-                    definition_location,
-                })
+                }
             }
 
             ClauseGuard::TupleIndex {
@@ -2539,35 +2517,44 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 index,
                 ..
             } => {
-                let tuple = self.infer_clause_guard(*tuple)?;
-                match tuple.type_().as_ref() {
-                    Type::Tuple { elements } => {
-                        let type_ = elements
-                            .get(index as usize)
-                            .ok_or(Error::OutOfBoundsTupleIndex {
+                let tuple = self.infer_clause_guard(*tuple);
+                let index_type = match tuple.type_().as_ref() {
+                    Type::Tuple { elements } => match elements.get(index as usize) {
+                        Some(type_) => type_.clone(),
+                        // If the index is outside the tuple range, then we
+                        // report the error and return an unbound type to keep
+                        // going.
+                        None => {
+                            self.problems.error(Error::OutOfBoundsTupleIndex {
                                 location,
                                 index,
                                 size: elements.len(),
-                            })?
-                            .clone();
-                        Ok(ClauseGuard::TupleIndex {
-                            location,
-                            index,
-                            type_,
-                            tuple: Box::new(tuple),
-                        })
-                    }
+                            });
+                            self.new_unbound_var()
+                        }
+                    },
 
-                    type_ if type_.is_unbound() => Err(Error::NotATupleUnbound {
-                        location: tuple.location(),
-                    }),
+                    tuple_type if tuple_type.is_unbound() => {
+                        self.problems.error(Error::NotATupleUnbound {
+                            location: tuple.location(),
+                        });
+                        self.new_unbound_var()
+                    }
 
                     Type::Named { .. } | Type::Fn { .. } | Type::Var { .. } => {
-                        Err(Error::NotATuple {
+                        self.problems.error(Error::NotATuple {
                             location: tuple.location(),
                             given: tuple.type_(),
-                        })
+                        });
+                        self.new_unbound_var()
                     }
+                };
+
+                ClauseGuard::TupleIndex {
+                    location,
+                    index,
+                    type_: index_type,
+                    tuple: Box::new(tuple),
                 }
             }
 
@@ -2577,48 +2564,79 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 container,
                 index: _,
                 type_: (),
-            } => match self.infer_clause_guard(*container.clone()) {
-                Ok(container) => self.infer_guard_record_access(container, label, label_location),
+            } => {
+                let container_location = container.location();
+                let result = if let ClauseGuard::Var { name, location, .. } = *container {
+                    // If the container looks like a regular variable, then this
+                    // could either be a module select, or a record access.
+                    match self.infer_clause_guard_variable(name.clone(), location) {
+                        // If the variable itself cannot be inferred as one, then
+                        // it could really be a module select. We try that one
+                        // as an elternative.
+                        Err(error) => self.infer_guard_module_access(
+                            name,
+                            label,
+                            location,
+                            label_location,
+                            error,
+                        ),
+                        // Otherwise that's a proper variable and not a module name,
+                        // so the whole expression has to be inferred as a regular
+                        // record access.
+                        Ok(variable) => {
+                            self.infer_guard_record_access(variable, label.clone(), label_location)
+                        }
+                    }
+                } else {
+                    // If it doesn't this has to be a regular record access and
+                    // we try and inferr it as such.
+                    let inferred_container = self.infer_clause_guard(*container.clone());
+                    self.infer_guard_record_access(
+                        inferred_container,
+                        label.clone(),
+                        label_location,
+                    )
+                };
 
-                Err(err) => {
-                    if let ClauseGuard::Var { name, location, .. } = *container {
-                        self.infer_guard_module_access(name, label, location, label_location, err)
-                    } else {
-                        Err(Error::RecordAccessUnknownType {
-                            location: label_location,
-                        })
+                match result {
+                    Ok(inferred) => inferred,
+                    Err(error) => {
+                        self.problems.error(error);
+                        ClauseGuard::Invalid {
+                            location: container_location.merge(&label_location),
+                            type_: self.new_unbound_var(),
+                        }
                     }
                 }
-            },
+            }
 
-            ClauseGuard::ModuleSelect { location, .. } => {
-                Err(Error::RecordAccessUnknownType { location })
+            ClauseGuard::ModuleSelect { .. } => {
+                unreachable!("untyped guard should never be module select")
             }
 
             ClauseGuard::Not {
                 location,
                 expression,
             } => {
-                let expression = self.infer_clause_guard(*expression)?;
-                unify(bool(), expression.type_())
-                    .map_err(|e| convert_unify_error(e, expression.location()))?;
-                Ok(ClauseGuard::Not {
+                let expression = self.infer_clause_guard(*expression);
+                if let Err(error) = unify(bool(), expression.type_()) {
+                    self.problems
+                        .error(convert_unify_error(error, expression.location()))
+                };
+                ClauseGuard::Not {
                     location,
                     expression: Box::new(expression),
-                })
+                }
             }
 
             ClauseGuard::Constant(constant) => {
-                Ok(ClauseGuard::Constant(self.infer_const(&None, constant)))
+                ClauseGuard::Constant(self.infer_const(&None, constant))
             }
 
-            ClauseGuard::Block { value, location } => {
-                let value = self.infer_clause_guard(*value)?;
-                Ok(ClauseGuard::Block {
-                    location,
-                    value: Box::new(value),
-                })
-            }
+            ClauseGuard::Block { value, location } => ClauseGuard::Block {
+                location,
+                value: Box::new(self.infer_clause_guard(*value)),
+            },
 
             ClauseGuard::BinaryOperator {
                 location,
@@ -2626,20 +2644,25 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 left,
                 right,
             } => {
-                let left = self.infer_clause_guard(*left)?;
-                let right = self.infer_clause_guard(*right)?;
+                let left = self.infer_clause_guard(*left);
+                let right = self.infer_clause_guard(*right);
 
                 match operator {
                     BinOp::And | BinOp::Or => {
-                        unify(bool(), left.type_())
-                            .map_err(|e| convert_unify_error(e, left.location()))?;
-                        unify(bool(), right.type_())
-                            .map_err(|e| convert_unify_error(e, right.location()))?;
+                        if let Err(error) = unify(bool(), left.type_()) {
+                            self.problems
+                                .error(convert_unify_error(error, left.location()));
+                        }
+                        if let Err(error) = unify(bool(), right.type_()) {
+                            self.problems
+                                .error(convert_unify_error(error, right.location()));
+                        }
                     }
 
                     BinOp::Eq | BinOp::NotEq => {
-                        unify(left.type_(), right.type_())
-                            .map_err(|e| convert_unify_error(e, location))?;
+                        if let Err(error) = unify(left.type_(), right.type_()) {
+                            self.problems.error(convert_unify_error(error, location));
+                        }
                     }
 
                     BinOp::GtInt
@@ -2652,15 +2675,21 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     | BinOp::MultInt
                     | BinOp::RemainderInt => {
                         self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
-
+                        // If both operands are floats, then we use a more specialised
+                        // error.
                         if left.type_().is_float() && right.type_().is_float() {
-                            return Err(Error::IntOperatorOnFloats { operator, location });
+                            self.problems
+                                .error(Error::IntOperatorOnFloats { operator, location });
+                        } else {
+                            if let Err(error) = unify(int(), left.type_()) {
+                                self.problems
+                                    .error(convert_unify_error(error, left.location()));
+                            }
+                            if let Err(error) = unify(int(), right.type_()) {
+                                self.problems
+                                    .error(convert_unify_error(error, right.location()));
+                            }
                         }
-
-                        unify(int(), left.type_())
-                            .map_err(|e| convert_unify_error(e, left.location()))?;
-                        unify(int(), right.type_())
-                            .map_err(|e| convert_unify_error(e, right.location()))?;
                     }
 
                     BinOp::GtFloat
@@ -2673,34 +2702,77 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     | BinOp::MultFloat => {
                         self.track_feature_usage(FeatureKind::ArithmeticInGuards, location);
 
+                        // If both operands are int then we use a more specialised
+                        // error
                         if left.type_().is_int() && right.type_().is_int() {
-                            return Err(Error::FloatOperatorOnInts { operator, location });
+                            self.problems
+                                .error(Error::FloatOperatorOnInts { operator, location });
+                        } else {
+                            if let Err(error) = unify(float(), left.type_()) {
+                                self.problems
+                                    .error(convert_unify_error(error, left.location()));
+                            }
+                            if let Err(error) = unify(float(), right.type_()) {
+                                self.problems
+                                    .error(convert_unify_error(error, right.location()));
+                            }
                         }
-
-                        unify(float(), left.type_())
-                            .map_err(|e| convert_unify_error(e, left.location()))?;
-                        unify(float(), right.type_())
-                            .map_err(|e| convert_unify_error(e, right.location()))?;
                     }
 
                     BinOp::Concatenate => {
                         self.track_feature_usage(FeatureKind::ConcatenateInGuards, location);
 
-                        unify(string(), left.type_())
-                            .map_err(|e| convert_unify_error(e, left.location()))?;
-                        unify(string(), right.type_())
-                            .map_err(|e| convert_unify_error(e, right.location()))?;
+                        if let Err(error) = unify(string(), left.type_()) {
+                            self.problems
+                                .error(convert_unify_error(error, left.location()));
+                        }
+                        if let Err(error) = unify(string(), right.type_()) {
+                            self.problems
+                                .error(convert_unify_error(error, right.location()));
+                        }
                     }
                 }
 
-                Ok(ClauseGuard::BinaryOperator {
+                ClauseGuard::BinaryOperator {
                     location,
                     operator,
                     left: Box::new(left),
                     right: Box::new(right),
-                })
+                }
             }
         }
+    }
+
+    fn infer_clause_guard_variable(
+        &mut self,
+        name: EcoString,
+        location: SrcSpan,
+    ) -> Result<TypedClauseGuard, Error> {
+        let constructor =
+            self.infer_value_constructor(&None, &name, &location, ValueUsage::Other)?;
+
+        // We cannot support all values in guard expressions as the BEAM does not
+        let (definition_location, origin) = match &constructor.variant {
+            ValueConstructorVariant::LocalVariable {
+                location, origin, ..
+            } => (*location, origin.clone()),
+
+            ValueConstructorVariant::ModuleFn { .. } | ValueConstructorVariant::Record { .. } => {
+                return Err(Error::NonLocalClauseGuardVariable { location, name });
+            }
+
+            ValueConstructorVariant::ModuleConstant { literal, .. } => {
+                return Ok(ClauseGuard::Constant(literal.clone()));
+            }
+        };
+
+        Ok(ClauseGuard::Var {
+            location,
+            name,
+            origin,
+            type_: constructor.type_,
+            definition_location,
+        })
     }
 
     fn infer_guard_record_access(
@@ -2742,7 +2814,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     ) -> Result<TypedClauseGuard, Error> {
         let module_access = self
             .infer_module_access(&name, label, &module_location, label_location)
-            .and_then(|ma| {
+            .and_then(|module_select| {
                 if let TypedExpr::ModuleSelect {
                     location,
                     field_start: _,
@@ -2751,7 +2823,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     module_name,
                     module_alias,
                     constructor,
-                } = ma
+                } = module_select
                 {
                     match constructor {
                         ModuleValueConstructor::Constant {

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -2661,7 +2661,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
                     BinOp::Eq | BinOp::NotEq => {
                         if let Err(error) = unify(left.type_(), right.type_()) {
-                            self.problems.error(convert_unify_error(error, location));
+                            self.problems
+                                .error(convert_unify_error(error, right.location()));
                         }
                     }
 

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -4204,3 +4204,75 @@ pub fn main() {
 }"
     );
 }
+
+#[test]
+pub fn clause_guard_is_fault_tolerant() {
+    assert_module_error!(
+        r#"
+pub fn main(x: Int) {
+  case x {
+    _ if x == "" && wibble -> 2
+    _ -> 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+pub fn clause_guard_is_fault_tolerant_with_record_access() {
+    assert_module_error!(
+        r#"
+pub type Wibble { Wibble(field: Int) }
+
+pub fn main(wibble: Wibble) {
+  case wibble {
+    _ if wibble.field == "" && wibble -> 2
+    _ -> 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+pub fn clause_guard_is_fault_tolerant_with_int_binop() {
+    assert_module_error!(
+        r#"
+pub fn main(x: Int) {
+  case x {
+    _ if x + "" -> 2
+    _ -> 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+pub fn clause_guard_is_fault_tolerant_with_not_equals() {
+    assert_module_error!(
+        r#"
+pub fn main(x: Int) {
+  case x {
+    _ if x != "" || False -> 2
+    _ -> 1
+  }
+}
+"#
+    );
+}
+
+#[test]
+pub fn clause_guard_is_fault_tolerant_with_not_equals_and_binop() {
+    assert_module_error!(
+        r#"
+pub fn main(x: Int) {
+  case x {
+    _ if { x != "" } +. 2.0 -> 2
+    _ -> 1
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_guard.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_guard.snap
@@ -7,10 +7,10 @@ case <<1>> { <<a:utf16_codepoint>> if a == "test" -> 1 _ -> 2 }
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:39
+  ┌─ /src/one/two.gleam:1:44
   │
 1 │ case <<1>> { <<a:utf16_codepoint>> if a == "test" -> 1 _ -> 2 }
-  │                                       ^^^^^^^^^^^
+  │                                            ^^^^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case10.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case10.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Int)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3], 1.1 { x, y if x >. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case11.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case11.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 2.22, 1, "three" { x, _, y if x >. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case12.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case12.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Int)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3], 1.1 { x, y if x >=. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case13.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case13.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 2.22, 1, "three" { x, _, y if x >=. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case14.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case14.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Int)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3], 1.1 { x, y if x <. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case15.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case15.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 2.22, 1, "three" { x, _, y if x <. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case16.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case16.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Int)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3], 1.1 { x, y if x <=. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case17.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case17.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 2.22, 1, "three" { x, _, y if x <=. y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case18.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case18.snap
@@ -7,10 +7,10 @@ case 1 { x if x == "x" -> 1 }
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:15
+  ┌─ /src/one/two.gleam:1:20
   │
 1 │ case 1 { x if x == "x" -> 1 }
-  │               ^^^^^^^^
+  │                    ^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case18.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case18.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 1 { x if x == "x" -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case2.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Float)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3.33], 1 { x, y if x > y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case3.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 1, 2.22, "three" { x, _, y if x > y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case4.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Float)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3.33], 1 { x, y if x >= y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case5.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case5.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 1, 2.22, "three" { x, _, y if x >= y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case6.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case6.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Float)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3.33], 1 { x, y if x < y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case7.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case7.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 1, 2.22, "three" { x, _, y if x < y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case8.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case8.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     List(Float)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case [3.33], 1 { x, y if x <= y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case9.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case9.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     String
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 1, 2.22, "three" { x, _, y if x <= y -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _, _, _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_int_tuple_guard.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_int_tuple_guard.snap
@@ -7,10 +7,10 @@ case 1 { x if x == #() -> 1 }
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:15
+  ┌─ /src/one/two.gleam:1:20
   │
 1 │ case 1 { x if x == #() -> 1 }
-  │               ^^^^^^^^
+  │                    ^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_int_tuple_guard.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_int_tuple_guard.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     #()
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case 1 { x if x == #() -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard.snap
@@ -7,10 +7,10 @@ case #(1, 2, 3) { x if x == #(1, 1.0) -> 1 }
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:24
+  ┌─ /src/one/two.gleam:1:29
   │
 1 │ case #(1, 2, 3) { x if x == #(1, 1.0) -> 1 }
-  │                        ^^^^^^^^^^^^^^
+  │                             ^^^^^^^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     #(Int, Float)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case #(1, 2, 3) { x if x == #(1, 1.0) -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard_2.snap
@@ -7,10 +7,10 @@ case #(1, 2) { x if x == #(1, 1.0) -> 1 }
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:21
+  ┌─ /src/one/two.gleam:1:26
   │
 1 │ case #(1, 2) { x if x == #(1, 1.0) -> 1 }
-  │                     ^^^^^^^^^^^^^^
+  │                          ^^^^^^^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__case_tuple_guard_2.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     #(Int, Float)
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:1
+  │
+1 │ case #(1, 2) { x if x == #(1, 1.0) -> 1 }
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main(x: Int) {\n  case x {\n    _ if x == \"\" && wibble -> 2\n    _ -> 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x: Int) {
+  case x {
+    _ if x == "" && wibble -> 2
+    _ -> 1
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:15
+  │
+4 │     _ if x == "" && wibble -> 2
+  │               ^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    String
+
+error: Unknown variable
+  ┌─ /src/one/two.gleam:4:21
+  │
+4 │     _ if x == "" && wibble -> 2
+  │                     ^^^^^^
+
+The name `wibble` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_int_binop.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_int_binop.snap
@@ -1,0 +1,42 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main(x: Int) {\n  case x {\n    _ if x + \"\" -> 2\n    _ -> 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x: Int) {
+  case x {
+    _ if x + "" -> 2
+    _ -> 1
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:10
+  │
+4 │     _ if x + "" -> 2
+  │          ^^^^^^
+
+Expected type:
+
+    Bool
+
+Found type:
+
+    Int
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:14
+  │
+4 │     _ if x + "" -> 2
+  │              ^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    String

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_not_equals.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_not_equals.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main(x: Int) {\n  case x {\n    _ if x != \"\" || False -> 2\n    _ -> 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x: Int) {
+  case x {
+    _ if x != "" || False -> 2
+    _ -> 1
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:15
+  │
+4 │     _ if x != "" || False -> 2
+  │               ^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    String

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_not_equals_and_binop.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_not_equals_and_binop.snap
@@ -1,0 +1,56 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn main(x: Int) {\n  case x {\n    _ if { x != \"\" } +. 2.0 -> 2\n    _ -> 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x: Int) {
+  case x {
+    _ if { x != "" } +. 2.0 -> 2
+    _ -> 1
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:10
+  │
+4 │     _ if { x != "" } +. 2.0 -> 2
+  │          ^^^^^^^^^^^
+
+Expected type:
+
+    Float
+
+Found type:
+
+    Bool
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:10
+  │
+4 │     _ if { x != "" } +. 2.0 -> 2
+  │          ^^^^^^^^^^^^^^^^^^
+
+Expected type:
+
+    Bool
+
+Found type:
+
+    Float
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:4:17
+  │
+4 │     _ if { x != "" } +. 2.0 -> 2
+  │                 ^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    String

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_record_access.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__clause_guard_is_fault_tolerant_with_record_access.snap
@@ -1,0 +1,44 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub type Wibble { Wibble(field: Int) }\n\npub fn main(wibble: Wibble) {\n  case wibble {\n    _ if wibble.field == \"\" && wibble -> 2\n    _ -> 1\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wibble { Wibble(field: Int) }
+
+pub fn main(wibble: Wibble) {
+  case wibble {
+    _ if wibble.field == "" && wibble -> 2
+    _ -> 1
+  }
+}
+
+
+----- ERROR
+error: Type mismatch
+  ┌─ /src/one/two.gleam:6:26
+  │
+6 │     _ if wibble.field == "" && wibble -> 2
+  │                          ^^
+
+Expected type:
+
+    Int
+
+Found type:
+
+    String
+
+error: Type mismatch
+  ┌─ /src/one/two.gleam:6:32
+  │
+6 │     _ if wibble.field == "" && wibble -> 2
+  │                                ^^^^^^
+
+Expected type:
+
+    Bool
+
+Found type:
+
+    Wibble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_float_int_eq_vars.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_float_int_eq_vars.snap
@@ -7,10 +7,10 @@ let x = 1.0 let y = 1 case x { _ if x == y -> 1 }
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:37
+  ┌─ /src/one/two.gleam:1:42
   │
 1 │ let x = 1.0 let y = 1 case x { _ if x == y -> 1 }
-  │                                     ^^^^^^
+  │                                          ^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_float_int_eq_vars.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_float_int_eq_vars.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     Int
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:23
+  │
+1 │ let x = 1.0 let y = 1 case x { _ if x == y -> 1 }
+  │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_if_float.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_if_float.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     Float
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:13
+  │
+1 │ let x = 1.0 case x { _ if x -> 1 }
+  │             ^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_int_float_eq_vars.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_int_float_eq_vars.snap
@@ -19,3 +19,16 @@ Expected type:
 Found type:
 
     Float
+
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:1:23
+  │
+1 │ let x = 1 let y = 1.0 case x { _ if x == y -> 1 }
+  │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_int_float_eq_vars.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__guard_int_float_eq_vars.snap
@@ -7,10 +7,10 @@ let x = 1 let y = 1.0 case x { _ if x == y -> 1 }
 
 ----- ERROR
 error: Type mismatch
-  ┌─ /src/one/two.gleam:1:37
+  ┌─ /src/one/two.gleam:1:42
   │
 1 │ let x = 1 let y = 1.0 case x { _ if x == y -> 1 }
-  │                                     ^^^^^^
+  │                                          ^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_non_local_gaurd_var.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__module_non_local_gaurd_var.snap
@@ -7,6 +7,19 @@ fn one() { 1 }
 fn main() { case 1 { _ if one -> 1 } }
 
 ----- ERROR
+error: Inexhaustive patterns
+  ┌─ /src/one/two.gleam:2:13
+  │
+2 │ fn main() { case 1 { _ if one -> 1 } }
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^
+
+This case expression does not have a pattern for all possible values. If it
+is run on one of the values without a pattern then it will crash.
+
+The missing patterns are:
+
+    _
+
 error: Invalid guard variable
   ┌─ /src/one/two.gleam:2:27
   │


### PR DESCRIPTION
While fixing a language server bug I realized the proper fix needed clause guards to be fault tolerant. That is quite the big change on its own so I'm putting this into its own PR to make it easier to review!

With this clause guards in case expressions are fault tolerant, an error in a part of one is no longer blocking the compiler from analyzing the rest of it, or reporting correct errors for missing patterns

- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
