### PR TITLE
wip: pretty printing on lsp hover

### DIFF
--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -1,4 +1,5 @@
 use super::{Type, TypeVar};
+use super::printer::{NameContextInformation, Names as FullNames, PrintMode};
 use crate::{
     docvec,
     pretty::{nil, *},
@@ -8,6 +9,8 @@ use std::sync::Arc;
 
 #[cfg(test)]
 use super::*;
+#[cfg(test)]
+use crate::ast::SrcSpan;
 #[cfg(test)]
 use std::cell::RefCell;
 
@@ -19,6 +22,7 @@ const INDENT: isize = 2;
 #[derive(Debug, Default)]
 pub struct Printer {
     names: im::HashMap<u64, EcoString>,
+    full_names: Option<FullNames>,
     uid: u64,
     // A mapping of printd type names to the module that they are defined in.
     printed_types: im::HashMap<EcoString, EcoString>,
@@ -31,6 +35,11 @@ impl Printer {
 
     pub fn with_names(&mut self, names: im::HashMap<u64, EcoString>) {
         self.names = names;
+    }
+
+    pub fn add_full_names(mut self, names: &FullNames) -> Self {
+        self.full_names = Some(names.clone());
+        self
     }
 
     /// Render a Type as a well formatted string.
@@ -58,7 +67,27 @@ impl Printer {
                 module,
                 ..
             } => {
-                let doc = if self.name_clashes_if_unqualified(name, module) {
+                let doc = if let Some(full_names) = &self.full_names {
+                    let (module, name) = match full_names.named_type(module, name, PrintMode::Normal)
+                    {
+                        NameContextInformation::Qualified(module, name) => {
+                            (Some(EcoString::from(module)), EcoString::from(name))
+                        }
+                        NameContextInformation::Unqualified(name) => {
+                            (None, EcoString::from(name))
+                        }
+                        NameContextInformation::Unimported(module, name) => (
+                            Some(EcoString::from(
+                                module.split('/').next_back().unwrap_or(module),
+                            )),
+                            EcoString::from(name),
+                        ),
+                    };
+                    match module {
+                        Some(module) => qualify_type_name(&module, &name),
+                        None => name.to_doc(),
+                    }
+                } else if self.name_clashes_if_unqualified(name, module) {
                     qualify_type_name(module, name)
                 } else {
                     let _ = self.printed_types.insert(name.clone(), module.clone());
@@ -463,6 +492,46 @@ fn function_test() {
     #(Float, Float, Float, Float, Float, Float),
     #(Float, Float, Float, Float, Float, Float),
   )"
+    );
+}
+
+#[test]
+fn full_names_qualifies_with_module_alias() {
+    let mut names = FullNames::new();
+    _ = names.imported_module("my/module".into(), "my_alias".into(), SrcSpan::new(0, 0));
+
+    let type_ = Arc::new(Type::Named {
+        module: "my/module".into(),
+        package: "whatever".into(),
+        name: "Thing".into(),
+        publicity: Publicity::Public,
+        arguments: vec![],
+        inferred_variant: None,
+    });
+
+    assert_eq!(
+        Printer::new().add_full_names(&names).pretty_print(&type_, 0),
+        "my_alias.Thing"
+    );
+}
+
+#[test]
+fn full_names_uses_local_type_alias() {
+    let mut names = FullNames::new();
+    names.named_type_in_scope("my/module".into(), "Thing".into(), "LocalThing".into());
+
+    let type_ = Arc::new(Type::Named {
+        module: "my/module".into(),
+        package: "whatever".into(),
+        name: "Thing".into(),
+        publicity: Publicity::Public,
+        arguments: vec![],
+        inferred_variant: None,
+    });
+
+    assert_eq!(
+        Printer::new().add_full_names(&names).pretty_print(&type_, 0),
+        "LocalThing"
     );
 }
 

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -258,7 +258,7 @@ impl Names {
     }
 
     /// Get the name and optional module qualifier for a named type.
-    fn named_type<'a>(
+    pub fn named_type<'a>(
         &'a self,
         module: &'a EcoString,
         name: &'a EcoString,

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -1499,7 +1499,9 @@ fn hover_for_function_head(
         .map(|(_, doc)| doc)
         .unwrap_or(&empty_str);
     let function_type = get_function_type(fun);
-    let formatted_type = PrettyPrinter::new().pretty_print(&function_type, 0);
+    let formatted_type = PrettyPrinter::new()
+        .add_full_names(&module.ast.names)
+        .pretty_print(&function_type, 0);
     let contents = format!(
         "```gleam
 {formatted_type}
@@ -1517,7 +1519,9 @@ fn hover_for_function_argument(
     line_numbers: LineNumbers,
     module: &Module,
 ) -> Hover {
-    let type_ = PrettyPrinter::new().pretty_print(&argument.type_, 0);
+    let type_ = PrettyPrinter::new()
+        .add_full_names(&module.ast.names)
+        .pretty_print(&argument.type_, 0);
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
         contents: Contents::MarkedString(MarkedString::String(contents)),

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -19,6 +19,7 @@ use gleam_core::{
         self, Deprecation, ModuleInterface, Type, TypeConstructor, ValueConstructor,
         ValueConstructorVariant,
         error::{Named, VariableSyntax},
+        pretty::Printer as PrettyPrinter,
         printer::Printer,
     },
 };
@@ -1498,7 +1499,7 @@ fn hover_for_function_head(
         .map(|(_, doc)| doc)
         .unwrap_or(&empty_str);
     let function_type = get_function_type(fun);
-    let formatted_type = Printer::new(&module.ast.names).print_type(&function_type);
+    let formatted_type = PrettyPrinter::new().pretty_print(&function_type, 0);
     let contents = format!(
         "```gleam
 {formatted_type}
@@ -1516,7 +1517,7 @@ fn hover_for_function_argument(
     line_numbers: LineNumbers,
     module: &Module,
 ) -> Hover {
-    let type_ = Printer::new(&module.ast.names).print_type(&argument.type_);
+    let type_ = PrettyPrinter::new().pretty_print(&argument.type_, 0);
     let contents = format!("```gleam\n{type_}\n```");
     Hover {
         contents: Contents::MarkedString(MarkedString::String(contents)),

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_arg.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_arg.snap
@@ -2,7 +2,6 @@
 source: language-server/src/tests/hover.rs
 expression: "\nimport wibble/wobble\n\nfn do_things(wibble: wobble.Wibble) { wibble }\n"
 ---
-
 import wibble/wobble
 
 fn do_things(wibble: wobble.Wibble) { wibble }
@@ -11,5 +10,5 @@ fn do_things(wibble: wobble.Wibble) { wibble }
 
 ----- Hover content (markdown) -----
 ```gleam
-wobble.Wibble
+Wibble
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_arg.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_arg.snap
@@ -10,5 +10,5 @@ fn do_things(wibble: wobble.Wibble) { wibble }
 
 ----- Hover content (markdown) -----
 ```gleam
-Wibble
+wobble.Wibble
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
@@ -2,7 +2,6 @@
 source: language-server/src/tests/hover.rs
 expression: "\nimport wibble/wobble\ntype MyInt = Int\nfn func(value: wobble.Wibble) -> MyInt { 1 }\n"
 ---
-
 import wibble/wobble
 type MyInt = Int
 fn func(value: wobble.Wibble) -> MyInt { 1 }
@@ -11,5 +10,5 @@ fn func(value: wobble.Wibble) -> MyInt { 1 }
 
 ----- Hover content (markdown) -----
 ```gleam
-fn(wobble.Wibble) -> MyInt
+fn(Wibble) -> Int
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_function.snap
@@ -10,5 +10,5 @@ fn func(value: wobble.Wibble) -> MyInt { 1 }
 
 ----- Hover content (markdown) -----
 ```gleam
-fn(Wibble) -> Int
+fn(wobble.Wibble) -> MyInt
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
@@ -12,5 +12,5 @@ fn do_thing() -> MyResult(Int, Int) {
 
 ----- Hover content (markdown) -----
 ```gleam
-fn() -> Result(Int, Int)
+fn() -> MyResult(Int, Int)
 ```

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_print_alias_when_parameters_match.snap
@@ -2,7 +2,6 @@
 source: language-server/src/tests/hover.rs
 expression: "\ntype MyResult(a, b) = Result(a, b)\n\nfn do_thing() -> MyResult(Int, Int) {\n  Error(1)\n}\n"
 ---
-
 type MyResult(a, b) = Result(a, b)
 
 fn do_thing() -> MyResult(Int, Int) {
@@ -13,5 +12,5 @@ fn do_thing() -> MyResult(Int, Int) {
 
 ----- Hover content (markdown) -----
 ```gleam
-fn() -> MyResult(Int, Int)
+fn() -> Result(Int, Int)
 ```


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes

closes #5590

so to continue the discussion (https://github.com/gleam-lang/gleam/issues/5590#issuecomment-4415113687) the pretty printer (`gleam_core::type_::pretty.rs`) is not up to speed with the "normal" printer (`gleam_core::type_::printer.rs`) both in gleam_core -> type_. The pretty printer does not track `names` as precise as the normal printer. This causes the differences in the snap tests but it might be possible to get the pretty printer to also take the full `Names` struct and then track the names correctly? Maybe with a `with_names` with all names? I am trying that out when I find the time. I like the problem 😄.

todos:
- [x] add (all `Names`) names and make the snap test right again
- [ ] add test for hover with more than 80 chars so it gets broken
