### PR TITLE
Allow qualified constants in bit array size segments

### DIFF
--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -2732,6 +2732,7 @@ pub enum BitArraySize<Type> {
     Variable {
         location: SrcSpan,
         name: EcoString,
+        module: Option<(EcoString, SrcSpan)>,
         constructor: Option<Box<ValueConstructor>>,
         type_: Type,
     },
@@ -2809,11 +2810,17 @@ impl<T> BitArraySize<T> {
             (BitArraySize::Int { .. }, _) => false,
 
             (
-                BitArraySize::Variable { name, .. },
+                BitArraySize::Variable { name, module, .. },
                 BitArraySize::Variable {
-                    name: other_name, ..
+                    name: other_name,
+                    module: other_module,
+                    ..
                 },
-            ) => name == other_name,
+            ) => {
+                name == other_name
+                    && module.as_ref().map(|(m, _)| m)
+                        == other_module.as_ref().map(|(m, _)| m)
+            }
             (BitArraySize::Variable { .. }, _) => false,
 
             (

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -501,10 +501,11 @@ pub trait Visit<'ast> {
         &mut self,
         location: &'ast SrcSpan,
         name: &'ast EcoString,
+        module: &'ast Option<(EcoString, SrcSpan)>,
         constructor: &'ast Option<Box<ValueConstructor>>,
         type_: &'ast Arc<Type>,
     ) {
-        visit_typed_bit_array_size_variable(self, location, name, constructor, type_)
+        visit_typed_bit_array_size_variable(self, location, name, module, constructor, type_)
     }
 
     fn visit_typed_pattern_assign(
@@ -2087,9 +2088,10 @@ where
         BitArraySize::Variable {
             location,
             name,
+            module,
             constructor,
             type_,
-        } => v.visit_typed_bit_array_size_variable(location, name, constructor, type_),
+        } => v.visit_typed_bit_array_size_variable(location, name, module, constructor, type_),
         BitArraySize::BinaryOperator { left, right, .. } => {
             v.visit_typed_pattern_bit_array_size(left);
             v.visit_typed_pattern_bit_array_size(right);
@@ -2111,6 +2113,7 @@ pub fn visit_typed_bit_array_size_variable<'a, V>(
     _v: &mut V,
     _location: &'a SrcSpan,
     _name: &'a EcoString,
+    _module: &'a Option<(EcoString, SrcSpan)>,
     _constructor: &'a Option<Box<ValueConstructor>>,
     _type_: &'a Arc<Type>,
 ) where

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -1476,9 +1476,12 @@ pub trait PatternFolder {
                 value,
                 int_value,
             } => self.fold_bit_array_size_int(location, value, int_value),
-            BitArraySize::Variable { location, name, .. } => {
-                self.fold_bit_array_size_variable(location, name)
-            }
+            BitArraySize::Variable {
+                location,
+                name,
+                module,
+                ..
+            } => self.fold_bit_array_size_variable(location, name, module),
             BitArraySize::BinaryOperator {
                 location,
                 operator,
@@ -1514,10 +1517,12 @@ pub trait PatternFolder {
         &mut self,
         location: SrcSpan,
         name: EcoString,
+        module: Option<(EcoString, SrcSpan)>,
     ) -> BitArraySize<()> {
         BitArraySize::Variable {
             location,
             name,
+            module,
             constructor: None,
             type_: (),
         }

--- a/compiler-core/src/format.rs
+++ b/compiler-core/src/format.rs
@@ -2564,7 +2564,12 @@ impl<'comments> Formatter<'comments> {
     fn bit_array_size<'a>(&mut self, size: &'a BitArraySize<()>) -> Document<'a> {
         match size {
             BitArraySize::Int { value, .. } => self.int(value),
-            BitArraySize::Variable { name, .. } => name.to_doc(),
+            BitArraySize::Variable { name, module, .. } => match module {
+                Some((module_alias, _)) => {
+                    docvec![module_alias.to_doc(), ".", name.to_doc()]
+                }
+                None => name.to_doc(),
+            },
             BitArraySize::BinaryOperator {
                 left,
                 right,

--- a/compiler-core/src/inline.rs
+++ b/compiler-core/src/inline.rs
@@ -447,11 +447,13 @@ impl Inliner<'_> {
             BitArraySize::Variable {
                 location,
                 name,
+                module,
                 constructor,
                 type_,
             } => BitArraySize::Variable {
                 location,
                 name: self.variable_name(name),
+                module,
                 constructor,
                 type_,
             },
@@ -1360,6 +1362,7 @@ impl<'ast> Visit<'ast> for FindInlinableParameters {
         &mut self,
         _location: &'ast SrcSpan,
         name: &'ast EcoString,
+        _module: &'ast Option<(EcoString, SrcSpan)>,
         constructor: &'ast Option<Box<ValueConstructor>>,
         _type_: &'ast Arc<Type>,
     ) {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3913,11 +3913,37 @@ where
 
     fn parse_bit_array_size_unit(&mut self) -> Result<BitArraySize<()>, ParseError> {
         match self.tok0.take() {
+            // Qualified name: module.constant
+            Some((start, Token::Name { name: module_alias }, module_end))
+                if self.peek_tok1() == Some(&Token::Dot) =>
+            {
+                self.advance(); // advance past module name
+                self.advance(); // advance past dot
+
+                match self.tok0.take() {
+                    Some((_, Token::Name { name }, end)) => {
+                        self.advance();
+                        Ok(BitArraySize::Variable {
+                            location: SrcSpan { start, end },
+                            name,
+                            module: Some((module_alias, SrcSpan { start, end: module_end })),
+                            constructor: None,
+                            type_: (),
+                        })
+                    }
+                    tok0 => {
+                        self.tok0 = tok0;
+                        self.next_tok_unexpected(vec!["A variable name".into()])
+                    }
+                }
+            }
+
             Some((start, Token::Name { name }, end)) => {
                 self.advance();
                 Ok(BitArraySize::Variable {
                     location: SrcSpan { start, end },
                     name,
+                    module: None,
                     constructor: None,
                     type_: (),
                 })

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__correct_precedence_in_pattern_size.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__correct_precedence_in_pattern_size.snap
@@ -82,6 +82,7 @@ expression: "let assert <<size, payload:size(size + 2 * 8)>> = <<>>"
                                                 end: 36,
                                             },
                                             name: "size",
+                                            module: None,
                                             constructor: None,
                                             type_: (),
                                         },

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__operator_in_pattern_size.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__operator_in_pattern_size.snap
@@ -82,6 +82,7 @@ expression: "let assert <<size, payload:size(size - 1)>> = <<>>"
                                                 end: 36,
                                             },
                                             name: "size",
+                                            module: None,
                                             constructor: None,
                                             type_: (),
                                         },

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -1351,70 +1351,129 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     int_value,
                 }
             }
-            BitArraySize::Variable { name, location, .. } => {
-                let constructor = match self.variables.get_mut(&name) {
-                    // If we've bound a variable in the current bit array pattern,
-                    // we want to use that.
-                    Some(variable) if variable.in_scope() => {
-                        variable.usage = Usage::UsedInPattern;
-                        ValueConstructor::local_variable(
-                            variable.location,
-                            variable.origin.clone(),
-                            variable.type_.clone(),
-                        )
-                    }
-                    // Otherwise, we check the local scope.
-                    Some(_) | None => match self.environment.get_variable(&name) {
-                        Some(constructor) => constructor.clone(),
-                        None => {
-                            return Err(Error::UnknownVariable {
+            BitArraySize::Variable {
+                name,
+                location,
+                module,
+                ..
+            } => {
+                let constructor = if let Some((module_alias, module_location)) = &module {
+                    // Qualified name: module_alias.name — look up in imported modules
+                    let (_, imported_module) = self
+                        .environment
+                        .imported_modules
+                        .get(module_alias)
+                        .ok_or_else(|| Error::UnknownModule {
+                            location: *module_location,
+                            name: module_alias.clone(),
+                            suggestions: self
+                                .environment
+                                .suggest_modules(module_alias, Imported::Value(name.clone())),
+                        })?;
+
+                    let vc =
+                        imported_module
+                            .get_importable_value(&name)
+                            .ok_or_else(|| Error::UnknownModuleValue {
                                 location,
                                 name: name.clone(),
-                                variables: self.environment.local_value_names(),
-                                discarded_location: self
-                                    .environment
-                                    .discarded_names
-                                    .get(&eco_format!("_{name}"))
-                                    .cloned(),
-                                type_with_name_in_scope: self
-                                    .environment
-                                    .module_types
-                                    .keys()
-                                    .any(|type_| type_ == &name),
-                                possible_modules: self
-                                    .environment
-                                    .get_possible_modules_with_value(&name),
-                            });
+                                module_name: imported_module.name.clone(),
+                                value_constructors: imported_module.public_value_names(),
+                                type_with_same_name: imported_module
+                                    .get_importable_type(&name)
+                                    .is_some(),
+                                context: ModuleValueUsageContext::ModuleAccess,
+                            })?
+                            .clone();
+
+                    self.environment
+                        .references
+                        .register_module_reference(module_alias.clone());
+
+                    if let ValueConstructorVariant::ModuleConstant {
+                        name: canonical,
+                        module: mod_name,
+                        ..
+                    } = &vc.variant
+                    {
+                        self.environment.references.register_value_reference(
+                            mod_name.clone(),
+                            canonical.clone(),
+                            &name,
+                            location,
+                            ReferenceKind::Qualified,
+                        );
+                    }
+
+                    vc
+                } else {
+                    // Unqualified name — look up in local scope
+                    match self.variables.get_mut(&name) {
+                        // If we've bound a variable in the current bit array pattern,
+                        // we want to use that.
+                        Some(variable) if variable.in_scope() => {
+                            variable.usage = Usage::UsedInPattern;
+                            ValueConstructor::local_variable(
+                                variable.location,
+                                variable.origin.clone(),
+                                variable.type_.clone(),
+                            )
                         }
-                    },
+                        // Otherwise, we check the local scope.
+                        Some(_) | None => match self.environment.get_variable(&name) {
+                            Some(constructor) => constructor.clone(),
+                            None => {
+                                return Err(Error::UnknownVariable {
+                                    location,
+                                    name: name.clone(),
+                                    variables: self.environment.local_value_names(),
+                                    discarded_location: self
+                                        .environment
+                                        .discarded_names
+                                        .get(&eco_format!("_{name}"))
+                                        .cloned(),
+                                    type_with_name_in_scope: self
+                                        .environment
+                                        .module_types
+                                        .keys()
+                                        .any(|type_| type_ == &name),
+                                    possible_modules: self
+                                        .environment
+                                        .get_possible_modules_with_value(&name),
+                                });
+                            }
+                        },
+                    }
                 };
 
-                match &constructor.variant {
-                    ValueConstructorVariant::LocalVariable { .. } => (),
-                    ValueConstructorVariant::ModuleConstant {
-                        name: canonical,
-                        module,
-                        ..
-                    }
-                    | ValueConstructorVariant::ModuleFn {
-                        name: canonical,
-                        module,
-                        ..
-                    }
-                    | ValueConstructorVariant::Record {
-                        name: canonical,
-                        module,
-                        ..
-                    } => self.environment.references.register_value_reference(
-                        module.clone(),
-                        canonical.clone(),
-                        &name,
-                        location,
-                        ReferenceKind::Unqualified,
-                    ),
-                };
+                if module.is_none() {
+                    match &constructor.variant {
+                        ValueConstructorVariant::LocalVariable { .. } => (),
+                        ValueConstructorVariant::ModuleConstant {
+                            name: canonical,
+                            module: mod_name,
+                            ..
+                        }
+                        | ValueConstructorVariant::ModuleFn {
+                            name: canonical,
+                            module: mod_name,
+                            ..
+                        }
+                        | ValueConstructorVariant::Record {
+                            name: canonical,
+                            module: mod_name,
+                            ..
+                        } => self.environment.references.register_value_reference(
+                            mod_name.clone(),
+                            canonical.clone(),
+                            &name,
+                            location,
+                            ReferenceKind::Unqualified,
+                        ),
+                    };
+                    self.environment.increment_usage(&name);
+                }
 
-                self.environment.increment_usage(&name);
                 let type_ = self.environment.instantiate(
                     constructor.type_.clone(),
                     &mut hashmap![],
@@ -1425,6 +1484,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 BitArraySize::Variable {
                     name,
                     location,
+                    module,
                     constructor: Some(Box::new(constructor)),
                     type_,
                 }

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -4204,3 +4204,36 @@ pub fn main() {
 }"
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5607
+#[test]
+fn bit_array_size_unknown_module() {
+    assert_module_error!(
+        "
+pub fn run(data) {
+  case data {
+    <<x:bytes-size(unknown.chunk_size), _:bits>> -> x
+    _ -> data
+  }
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5607
+#[test]
+fn bit_array_size_unknown_module_value() {
+    assert_module_error!(
+        ("thepackage/sizes", "pub const chunk_size = 8"),
+        "
+import thepackage/sizes
+
+pub fn run(data) {
+  case data {
+    <<x:bytes-size(sizes.unknown_const), _:bits>> -> x
+    _ -> data
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_size_unknown_module.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_size_unknown_module.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn run(data) {\n  case data {\n    <<x:bytes-size(unknown.chunk_size), _:bits>> -> x\n    _ -> data\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn run(data) {
+  case data {
+    <<x:bytes-size(unknown.chunk_size), _:bits>> -> x
+    _ -> data
+  }
+}
+
+
+----- ERROR
+error: Unknown module
+  ┌─ /src/one/two.gleam:4:20
+  │
+4 │     <<x:bytes-size(unknown.chunk_size), _:bits>> -> x
+  │                    ^^^^^^^
+
+No module has been found with the name `unknown`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_size_unknown_module_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__bit_array_size_unknown_module_value.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport thepackage/sizes\n\npub fn run(data) {\n  case data {\n    <<x:bytes-size(sizes.unknown_const), _:bits>> -> x\n    _ -> data\n  }\n}\n"
+---
+----- SOURCE CODE
+-- thepackage/sizes.gleam
+pub const chunk_size = 8
+
+-- main.gleam
+
+import thepackage/sizes
+
+pub fn run(data) {
+  case data {
+    <<x:bytes-size(sizes.unknown_const), _:bits>> -> x
+    _ -> data
+  }
+}
+
+
+----- ERROR
+error: Unknown module value
+  ┌─ /src/one/two.gleam:6:20
+  │
+6 │     <<x:bytes-size(sizes.unknown_const), _:bits>> -> x
+  │                    ^^^^^^^^^^^^^^^^^^^ Did you mean `chunk_size`?
+
+The module `thepackage/sizes` does not have a `unknown_const` value.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -5022,6 +5022,42 @@ pub fn run(data) {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5607
+#[test]
+fn bit_array_size_qualified_constant() {
+    assert_no_warnings!(
+        ("thepackage/sizes", "pub const chunk_size = 8"),
+        r#"
+import thepackage/sizes
+
+pub fn run(data) {
+  case data {
+    <<x:bytes-size(sizes.chunk_size), _:bits>> -> x
+    _ -> data
+  }
+}
+        "#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5607
+#[test]
+fn bit_array_size_qualified_constant_in_expression() {
+    assert_no_warnings!(
+        ("thepackage/sizes", "pub const width = 4\npub const height = 2"),
+        r#"
+import thepackage/sizes
+
+pub fn run(data) {
+  case data {
+    <<x:bytes-size(sizes.width * sizes.height), _:bits>> -> x
+    _ -> data
+  }
+}
+        "#
+    );
+}
+
 #[test]
 fn constant_used_in_todo_message_counts_as_used() {
     assert_no_warnings!(


### PR DESCRIPTION
Fixes #5607

## Problem

Using a qualified constant in a bit array size segment caused a parse error:

```gleam
import mymodule

case data {
  <<x:bytes-size(mymodule.chunk_size), _:bits>> -> x
  _ -> data
}
// Found `.`, expected one of: `)`
```

Binary expressions with qualified constants also failed:
```gleam
<<x:bytes-size(sizes.width * sizes.height), _:bits>> -> x
```

## Solution

Added a `module: Option<(EcoString, SrcSpan)>` field to `BitArraySize::Variable` and:

- **Parser**: `parse_bit_array_size_unit()` now checks for `name.name` token sequences and produces a qualified variable node
- **Type checker**: Resolves qualified names via `imported_modules`, emitting proper `UnknownModule` / `UnknownModuleValue` errors with suggestions
- **Formatter**: Renders `module.constant` when a module qualifier is present
- **Other passes**: `ast_folder`, `ast/visit`, and `inline` updated to carry the new field through

The typed representation reuses the existing `ValueConstructor` mechanism — the Erlang code generator already handles `ModuleConstant` constructors by inlining the literal value, so no changes were needed there.

## Tests

- `bit_array_size_qualified_constant` — happy path with a single qualified constant
- `bit_array_size_qualified_constant_in_expression` — qualified constants in binary expressions
- `bit_array_size_unknown_module` — proper error for unknown module
- `bit_array_size_unknown_module_value` — proper error for unknown value within a valid module (with "Did you mean?" suggestion)