### PR TITLE
Simplify the failed Hex API key decryption error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,11 @@
   improves suggestions to push a tag, if it doesn't exists.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- The error shown when the local Hex API key can't be decrypted no longer
+  prints the raw encryption library error, and now hints to check the
+  password.
+  ([Charlie Tonneslan](https://github.com/c-tonneslan))
+
 ### Language server
 
 - The language server now offers a "Fill labels" code action on constants to

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -229,9 +229,7 @@ It will be used to locally encrypt your Hex API tokens.
             encrypted_credentials.refresh_token.as_bytes(),
             &local_password,
         )
-        .map_err(|e| Error::FailedToDecryptLocalHexApiKey {
-            detail: e.to_string(),
-        })?;
+        .map_err(|_| Error::FailedToDecryptLocalHexApiKey)?;
 
         // Use a refresh token, consuming it to get a new set of tokens.
         let request = hexpm::oauth_refresh_token_request(

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -402,7 +402,7 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
     FailedToEncryptLocalHexApiKey { detail: String },
 
     #[error("Failed to decrypt local Hex API key")]
-    FailedToDecryptLocalHexApiKey { detail: String },
+    FailedToDecryptLocalHexApiKey,
 
     #[error("Cannot add a package with the same name as a dependency")]
     CannotAddSelfAsDependency { name: EcoString },
@@ -1767,21 +1767,15 @@ The error from the encryption library was:
                 }]
             }
 
-            Error::FailedToDecryptLocalHexApiKey { detail } => {
-                let text = wrap_format!(
-                    "Unable to decrypt the local Hex API key with the given password.
-The error from the encryption library was:
-
-    {detail}"
-                );
-                vec![Diagnostic {
-                    title: "Failed to decrypt local Hex API key".into(),
-                    text,
-                    hint: None,
-                    level: Level::Error,
-                    location: None,
-                }]
-            }
+            Error::FailedToDecryptLocalHexApiKey => vec![Diagnostic {
+                title: "Failed to decrypt local Hex API key".into(),
+                text: "Unable to decrypt the local Hex API key with the given password.".into(),
+                hint: Some(
+                    "Check that you entered the correct local password and try again.".into(),
+                ),
+                level: Level::Error,
+                location: None,
+            }],
 
             Error::NonUtf8Path { path } => {
                 let text = format!(

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__failed_to_decrypt_local_hex_api_key.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__failed_to_decrypt_local_hex_api_key.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: "err[0]"
+---
+Diagnostic {
+    title: "Failed to decrypt local Hex API key",
+    text: "Unable to decrypt the local Hex API key with the given password.",
+    level: Error,
+    location: None,
+    hint: Some(
+        "Check that you entered the correct local password and try again.",
+    ),
+}

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -44,6 +44,12 @@ fn hex_session_revoked() {
 }
 
 #[test]
+fn failed_to_decrypt_local_hex_api_key() {
+    let err = Error::FailedToDecryptLocalHexApiKey.to_diagnostics();
+    assert_debug_snapshot!(err[0]);
+}
+
+#[test]
 fn hex_error_conversion() {
     assert_eq!(
         Error::hex(hexpm::ApiError::OAuthRefreshTokenRejected),


### PR DESCRIPTION
Closes #5710.

When you give the wrong password for the local Hex API key, the error currently repeats itself and then dumps the raw error from the encryption library:

```
error: Failed to decrypt local Hex API key

Unable to decrypt the local Hex API key with the given password.
The error from the encryption library was:

    unable to decrypt message: Decryption failed
```

That last bit is always the same generic "Decryption failed" for a bad password, so it's just noise, and "the encryption library" isn't something a user cares about. This drops it and adds a hint instead:

```
error: Failed to decrypt local Hex API key

Unable to decrypt the local Hex API key with the given password.
Hint: Check that you entered the correct local password and try again.
```

Since the `detail` field on the error was only used for that line, I removed it too. Added a snapshot test alongside the existing `hex_session_revoked` one.