### PR TITLE
Show a readable error when reverting a release that's too old

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,6 +330,10 @@
 
 ### Bug fixes
 
+- Fixed a bug where `gleam hex revert` printed a raw JSON error body when a
+  release was too old to be reverted, instead of a readable message.
+  ([Charlie Tonneslan](https://github.com/c-tonneslan))
+
 - Fixed a bug where `gleam remove` would fail with a confusing File IO error
   if `manifest.toml` didn't exist yet (e.g. in a freshly-created project or
   after the manifest had been deleted).

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -592,6 +592,17 @@ pub fn api_revert_release_response(response: http::Response<Vec<u8>>) -> Result<
         StatusCode::TOO_MANY_REQUESTS => Err(ApiError::RateLimited),
         StatusCode::UNAUTHORIZED => Err(unauthorised_response(&parts.headers)),
         StatusCode::FORBIDDEN => Err(ApiError::Forbidden),
+        StatusCode::UNPROCESSABLE_ENTITY => {
+            let body = String::from_utf8_lossy(&body);
+            if body.contains("can only modify a release up to one hour after publication") {
+                Err(ApiError::LateModification)
+            } else {
+                Err(ApiError::UnexpectedResponse(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    body.to_string(),
+                ))
+            }
+        }
         status => Err(ApiError::unexpected_response(status, body)),
     }
 }

--- a/hexpm/src/tests.rs
+++ b/hexpm/src/tests.rs
@@ -76,6 +76,22 @@ fn revert_release_response_success() {
 }
 
 #[test]
+fn revert_release_response_late_modification() {
+    let resp_body = json!({
+        "errors": {"inserted_at": "can only modify a release up to one hour after publication"},
+        "message": "Validation error(s)",
+        "status": 422,
+    });
+    let response = make_json_response(422, resp_body);
+    let result = crate::api_revert_release_response(response);
+
+    match result {
+        Err(ApiError::LateModification) => (),
+        result => panic!("expected Err(ApiError::LateModification), got {result:?}"),
+    }
+}
+
+#[test]
 fn add_owner_request() {
     let key = WriteActionCredentials::OAuthAccessToken {
         access_token: EcoString::from("my-api-key-here"),


### PR DESCRIPTION
Closes #5708.

`gleam hex revert` on a release that's too old to revert (Hex only lets you modify a release within an hour of publishing) printed the raw JSON error body straight from Hex instead of a readable message.

`api_publish_package_response` already handles this: on a 422 it checks the body for "can only modify a release up to one hour after publication" and returns `ApiError::LateModification`, which has a proper message. `api_revert_release_response` just never grew the same arm, so the response fell through to the `unexpected_response` fallback and the JSON leaked out.

This adds the matching 422 handling to the revert path. Reverting a too-old release now surfaces the existing "Can only modify a release up to one hour after publication" error. Test mirrors the existing `modify_package_late` one.