### PR TITLE
Fix duplicate let declarations for a case in a pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   function would throw an Error using the wrong class.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where the JavaScript code generator could produce duplicate `let`
+  declarations for internal variables when a `case` expression was used as a
+  step in a pipeline.
+  ([Eyup Can Akman](https://github.com/eyupcanakman))
+
 ## v1.17.0-rc1 - 2026-05-23
 
 ### Compiler

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -1,6 +1,6 @@
 use super::{
     INDENT, bit_array_segment_int_value_to_bytes,
-    expression::{self, Generator, Ordering, float, float_from_value},
+    expression::{self, Generator, Ordering, Scope, float, float_from_value},
 };
 use crate::{
     ast::{AssignmentKind, Endianness, SrcSpan, TypedClause, TypedExpr, TypedPattern},
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use num_bigint::BigInt;
 use std::{collections::HashMap, sync::OnceLock};
 
-pub static ASSIGNMENT_VAR: &str = "$";
+pub const ASSIGNMENT_VAR: &str = "$";
 
 pub fn case<'a>(
     compiled_case: &'a CompiledCase,
@@ -427,14 +427,20 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
 
             // We can't use `inside_new_scope` here without care: the
             // code we generate goes directly into the enclosing scope
-            // (there's no wrapping if-else block), so the `$` variable
-            // counter must not be reset or later code could redeclare
-            // one of the `$N` variables introduced here.
-            let old_scope = match &self.kind {
+            // (there's no wrapping if-else block). User variables bound
+            // in the branch go out of scope at its end, so their counters
+            // are reset and later references resolve to the outer bindings.
+            // Compiler synthesised variables (the `$` case subjects, `_pipe`,
+            // `_block`, ...) can't be referenced by user code and their
+            // declarations leak into this scope. Restoring only the user-variable
+            // counters leaves the synthesised counters advanced, so later code
+            // can't redeclare one of them.
+            let old_user_variables = match &self.kind {
                 DecisionKind::Case { .. } => self
                     .variables
                     .expression_generator
-                    .current_scope_vars
+                    .current_scope
+                    .user_variables()
                     .clone(),
                 DecisionKind::LetAssert { .. } => Default::default(),
             };
@@ -446,18 +452,12 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
 
             match &self.kind {
                 DecisionKind::Case { .. } => {
-                    let assignment_var: EcoString = ASSIGNMENT_VAR.into();
-                    let counter = self
-                        .variables
-                        .expression_generator
-                        .current_scope_vars
-                        .get(&assignment_var)
-                        .copied();
-                    // Extend with variables from old scope
+                    // Restore the user variables that were in scope before the
+                    // branch. The synthesised counters are left advanced.
                     self.variables
                         .expression_generator
-                        .current_scope_vars
-                        .extend(old_scope.clone());
+                        .current_scope
+                        .restore_user_variables(&old_user_variables);
 
                     // For binded variables inside body we need to check if
                     // there is same-named variable in old scope. In this case
@@ -465,23 +465,15 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
                     // redeclaration occurs.
                     if let Decision::Run { body } = fallback {
                         for (variable, _) in body.bindings.iter() {
-                            if old_scope.get(variable).is_some() {
+                            if old_user_variables.get(variable).is_some() {
                                 let new_variable_name = self.variables.next_local_var(variable);
 
-                                let _ = self
-                                    .variables
+                                self.variables
                                     .expression_generator
-                                    .current_scope_vars
-                                    .insert(new_variable_name, 0);
+                                    .current_scope
+                                    .set_counter(&new_variable_name, 0);
                             }
                         }
-                    }
-                    if let Some(n) = counter {
-                        let _ = self
-                            .variables
-                            .expression_generator
-                            .current_scope_vars
-                            .insert(assignment_var, n);
                     }
                 }
                 DecisionKind::LetAssert { .. } => {}
@@ -705,12 +697,8 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
         // Since we use reassignment for `let assert`, we can't reset the scope
         // as it loses data about the assigned variables.
         let old_scope = match &self.kind {
-            DecisionKind::Case { .. } => self
-                .variables
-                .expression_generator
-                .current_scope_vars
-                .clone(),
-            DecisionKind::LetAssert { .. } => Default::default(),
+            DecisionKind::Case { .. } => self.variables.expression_generator.current_scope.clone(),
+            DecisionKind::LetAssert { .. } => Scope::default(),
         };
 
         let old_names = self.variables.scoped_variable_names.clone();
@@ -720,7 +708,7 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
 
         match &self.kind {
             DecisionKind::Case { .. } => {
-                self.variables.expression_generator.current_scope_vars = old_scope
+                self.variables.expression_generator.current_scope = old_scope
             }
             DecisionKind::LetAssert { .. } => {}
         }

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -129,6 +129,82 @@ impl CurrentFunction {
     }
 }
 
+/// The variables in scope while generating the code for a function.
+///
+/// User variables are tracked in a map keyed by name, so a shadowed name can be
+/// given a unique JavaScript identifier. The compiler synthesised variables
+/// (the `$` case subject, `_pipe`, `_block`, ...) are held in their own fields
+/// instead. They can't be referenced by user code, and a branch that generates
+/// directly into its enclosing scope needs to restore the user variables while
+/// leaving the synthesised counters advanced, so that later code doesn't
+/// redeclare one of them.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Scope {
+    user_variables: im::HashMap<EcoString, usize>,
+    assignment: Option<usize>,
+    pipe: Option<usize>,
+    block: Option<usize>,
+    use_assignment: Option<usize>,
+    record_update: Option<usize>,
+    capture: Option<usize>,
+    assert_subject: Option<usize>,
+    assert_fail: Option<usize>,
+}
+
+impl Scope {
+    fn new(user_variables: im::HashMap<EcoString, usize>) -> Self {
+        Self {
+            user_variables,
+            ..Default::default()
+        }
+    }
+
+    /// The counter for a variable name, whether user or synthesised.
+    fn counter(&self, name: &str) -> Option<usize> {
+        match name {
+            ASSIGNMENT_VAR => self.assignment,
+            PIPE_VARIABLE => self.pipe,
+            BLOCK_VARIABLE => self.block,
+            USE_ASSIGNMENT_VARIABLE => self.use_assignment,
+            RECORD_UPDATE_VARIABLE => self.record_update,
+            CAPTURE_VARIABLE => self.capture,
+            ASSERT_SUBJECT_VARIABLE => self.assert_subject,
+            ASSERT_FAIL_VARIABLE => self.assert_fail,
+            _ => self.user_variables.get(name).copied(),
+        }
+    }
+
+    /// Set the counter for a variable name, whether user or synthesised.
+    pub(crate) fn set_counter(&mut self, name: &EcoString, value: usize) {
+        match name.as_str() {
+            ASSIGNMENT_VAR => self.assignment = Some(value),
+            PIPE_VARIABLE => self.pipe = Some(value),
+            BLOCK_VARIABLE => self.block = Some(value),
+            USE_ASSIGNMENT_VARIABLE => self.use_assignment = Some(value),
+            RECORD_UPDATE_VARIABLE => self.record_update = Some(value),
+            CAPTURE_VARIABLE => self.capture = Some(value),
+            ASSERT_SUBJECT_VARIABLE => self.assert_subject = Some(value),
+            ASSERT_FAIL_VARIABLE => self.assert_fail = Some(value),
+            _ => {
+                let _ = self.user_variables.insert(name.clone(), value);
+            }
+        }
+    }
+
+    /// The user variables currently in scope.
+    pub(crate) fn user_variables(&self) -> &im::HashMap<EcoString, usize> {
+        &self.user_variables
+    }
+
+    /// Restore previously saved user variables, reverting any counters advanced
+    /// during the branch to their earlier values. Variables introduced in the
+    /// branch with no earlier binding are kept, and the synthesised counters are
+    /// left untouched.
+    pub(crate) fn restore_user_variables(&mut self, previous: &im::HashMap<EcoString, usize>) {
+        self.user_variables.extend(previous.clone());
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct Generator<'module, 'ast> {
     module_name: EcoString,
@@ -137,7 +213,7 @@ pub(crate) struct Generator<'module, 'ast> {
     function_name: EcoString,
     function_arguments: Vec<Option<&'module EcoString>>,
     current_function: CurrentFunction,
-    pub current_scope_vars: im::HashMap<EcoString, usize>,
+    pub current_scope: Scope,
     pub function_position: Position,
     pub scope_position: Position,
     // We register whether these features are used within an expression so that
@@ -189,13 +265,14 @@ impl<'module, 'a> Generator<'module, 'a> {
         function_name: EcoString,
         function_arguments: Vec<Option<&'module EcoString>>,
         tracker: &'module mut UsageTracker,
-        mut current_scope_vars: im::HashMap<EcoString, usize>,
+        initial_scope_vars: im::HashMap<EcoString, usize>,
         source_map_builder: Option<Rc<RefCell<DebugIgnore<sourcemap::SourceMapBuilder>>>>,
     ) -> Self {
+        let mut current_scope = Scope::new(initial_scope_vars);
         let mut current_function = CurrentFunction::Module;
         for &name in function_arguments.iter().flatten() {
             // Initialise the function arguments
-            let _ = current_scope_vars.insert(name.clone(), 0);
+            current_scope.set_counter(name, 0);
 
             // If any of the function arguments shadow the current function then
             // recursion is no longer possible.
@@ -211,7 +288,7 @@ impl<'module, 'a> Generator<'module, 'a> {
             function_name,
             function_arguments,
             tail_recursion_used: false,
-            current_scope_vars,
+            current_scope,
             current_function,
             function_position: Position::Tail,
             scope_position: Position::Tail,
@@ -222,9 +299,9 @@ impl<'module, 'a> Generator<'module, 'a> {
     }
 
     pub fn local_var(&mut self, name: &EcoString) -> EcoString {
-        match self.current_scope_vars.get(name) {
+        match self.current_scope.counter(name) {
             None => {
-                let _ = self.current_scope_vars.insert(name.clone(), 0);
+                self.current_scope.set_counter(name, 0);
                 maybe_escape_identifier(name)
             }
             Some(0) => maybe_escape_identifier(name),
@@ -234,8 +311,8 @@ impl<'module, 'a> Generator<'module, 'a> {
     }
 
     pub fn next_local_var(&mut self, name: &EcoString) -> EcoString {
-        let next = self.current_scope_vars.get(name).map_or(0, |i| i + 1);
-        let _ = self.current_scope_vars.insert(name.clone(), next);
+        let next = self.current_scope.counter(name).map_or(0, |i| i + 1);
+        self.current_scope.set_counter(name, next);
         self.local_var(name)
     }
 
@@ -687,7 +764,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         let statement_level = std::mem::take(&mut self.statement_level);
 
         // Set state for in this iife
-        let current_scope_vars = self.current_scope_vars.clone();
+        let current_scope = self.current_scope.clone();
 
         // Generate the expression
         let result = to_doc(self, statements);
@@ -695,7 +772,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         let doc = immediately_invoked_function_expression_document(doc);
 
         // Reset
-        self.current_scope_vars = current_scope_vars;
+        self.current_scope = current_scope;
         self.scope_position = scope_position;
         self.statement_level = statement_level;
 
@@ -855,12 +932,12 @@ impl<'module, 'a> Generator<'module, 'a> {
                 }),
             Position::Expression(Ordering::Loose) => self.wrap_block(|this| {
                 // Save previous scope
-                let current_scope_vars = this.current_scope_vars.clone();
+                let current_scope = this.current_scope.clone();
 
                 let document = this.block_document(statements);
 
                 // Restore previous state
-                this.current_scope_vars = current_scope_vars;
+                this.current_scope = current_scope;
 
                 document
             }),
@@ -1481,7 +1558,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                 if self.function_name == *name
                     && self.current_function.can_recurse()
                     && self.function_position.is_tail()
-                    && self.current_scope_vars.get(name) == Some(&0) =>
+                    && self.current_scope.counter(name) == Some(0) =>
             {
                 let mut docs = Vec::with_capacity(arguments.len() * 4);
                 // Record that tail recursion is happening so that we know to
@@ -1561,9 +1638,9 @@ impl<'module, 'a> Generator<'module, 'a> {
         let scope_position = std::mem::replace(&mut self.scope_position, Position::Tail);
 
         // And there's a new scope
-        let scope = self.current_scope_vars.clone();
+        let scope = self.current_scope.clone();
         for name in arguments.iter().flat_map(Arg::get_variable_name) {
-            let _ = self.current_scope_vars.insert(name.clone(), 0);
+            self.current_scope.set_counter(name, 0);
         }
 
         // This is a new function so track that so that we don't
@@ -1577,7 +1654,7 @@ impl<'module, 'a> Generator<'module, 'a> {
         // Reset function name, scope, and tail position tracking
         self.function_position = function_position;
         self.scope_position = scope_position;
-        self.current_scope_vars = scope;
+        self.current_scope = scope;
         std::mem::swap(&mut self.current_function, &mut current_function);
 
         let mut docs = docvec![];

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -988,6 +988,30 @@ pub fn go() {
     )
 }
 
+// https://github.com/gleam-lang/gleam/issues/5743
+#[test]
+fn no_duplicate_pipe_variable_with_case_in_pipeline() {
+    assert_js!(
+        r#"
+pub fn main() {
+  0
+  |> case True {
+    True -> add_one |> identity
+    False -> add_one
+  }
+  |> add_one
+}
+
+fn identity(x) {
+  x
+}
+
+fn add_one(x) {
+  x + 1
+}"#
+    )
+}
+
 #[test]
 fn list_with_tail_used_in_guard() {
     assert_js!(

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__no_duplicate_pipe_variable_with_case_in_pipeline.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__no_duplicate_pipe_variable_with_case_in_pipeline.snap
@@ -1,0 +1,41 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn main() {\n  0\n  |> case True {\n    True -> add_one |> identity\n    False -> add_one\n  }\n  |> add_one\n}\n\nfn identity(x) {\n  x\n}\n\nfn add_one(x) {\n  x + 1\n}"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  0
+  |> case True {
+    True -> add_one |> identity
+    False -> add_one
+  }
+  |> add_one
+}
+
+fn identity(x) {
+  x
+}
+
+fn add_one(x) {
+  x + 1
+}
+
+----- COMPILED JAVASCRIPT
+function add_one(x) {
+  return x + 1;
+}
+
+function identity(x) {
+  return x;
+}
+
+export function main() {
+  let _pipe = 0;
+  let _block;
+  let $ = true;
+  let _pipe$1 = add_one;
+  _block = identity(_pipe$1);
+  let _pipe$2 = _block(_pipe);
+  return add_one(_pipe$2);
+}

--- a/test/language/test/language/directly_matching_case_subject_test.gleam
+++ b/test/language/test/language/directly_matching_case_subject_test.gleam
@@ -1,3 +1,15 @@
+fn identity(x: a) -> a {
+  x
+}
+
+fn add_one(x: Int) -> Int {
+  x + 1
+}
+
+fn add_two(x: Int) -> Int {
+  x + 2
+}
+
 // github.com/gleam-lang/gleam/issues/5265
 pub fn directly_matching_case_subject_test() {
   let result = {
@@ -45,4 +57,16 @@ pub fn no_duplicate_let_after_case_with_same_named_variable_with_declaration_bef
   }
   let x = x
   assert x == 2
+}
+
+// https://github.com/gleam-lang/gleam/issues/5743
+pub fn no_duplicate_pipe_variable_with_case_in_pipeline_test() {
+  let result =
+    0
+    |> case True {
+      True -> add_one |> identity
+      False -> add_two
+    }
+    |> add_one
+  assert result == 2
 }


### PR DESCRIPTION
When a `case` expression is used as a step in a pipeline, the JavaScript code generator could declare the same `_pipe$N` variable twice in one scope. That is a `SyntaxError`.

A directly matching `case` branch generates its code into the enclosing scope, so the counters for the compiler's internal variables have to survive past it. Before this only the `$` case subject counter was kept. The `_pipe` counter got reset, so the next step in the outer pipeline reused the name.

Fixes #5743.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
