### PR TITLE
Fix inexhaustive let-to-case skipping later cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+## Bug Fixes
+
+- Fixed a bug where the "Convert to case" code action would silently fail for
+  every inexhaustive `let` assignment in a module other than the first one.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.17.0-rc1 - 2026-05-23
 
 ### Compiler

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -546,7 +546,7 @@ pub fn code_action_inexhaustive_let_to_case(
 
         let range = text_edits.src_span_to_lsp_range(location);
         if !within(params.range, range) {
-            return;
+            continue;
         }
 
         let Some(Located::Statement(TypedStatement::Assignment(assignment))) =

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -5980,6 +5980,19 @@ fn outer_inexhaustive_let_to_case() {
 }
 
 #[test]
+fn second_sibling_inexhaustive_let_to_case() {
+    assert_code_action!(
+        CONVERT_TO_CASE,
+        r#"pub fn main(a, b) {
+  let Ok(x) = a
+  let Ok(y) = b
+  #(x, y)
+}"#,
+        find_position_of("let Ok(y)").select_until(find_position_of("= b")),
+    );
+}
+
+#[test]
 fn no_code_action_for_exhaustive_let_to_case() {
     assert_no_code_actions!(
         CONVERT_TO_CASE,

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__second_sibling_inexhaustive_let_to_case.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__second_sibling_inexhaustive_let_to_case.snap
@@ -1,0 +1,22 @@
+---
+source: language-server/src/tests/action.rs
+expression: "pub fn main(a, b) {\n  let Ok(x) = a\n  let Ok(y) = b\n  #(x, y)\n}"
+---
+----- BEFORE ACTION
+pub fn main(a, b) {
+  let Ok(x) = a
+  let Ok(y) = b
+  ▔▔▔▔▔▔▔▔▔▔↑  
+  #(x, y)
+}
+
+
+----- AFTER ACTION
+pub fn main(a, b) {
+  let Ok(x) = a
+  let y = case b {
+    Ok(y) -> y
+    Error(_) -> todo
+  }
+  #(x, y)
+}


### PR DESCRIPTION
This is similar to #5732 in that I encountered it during a refactoring, when I noticed an action wasn't available except on the first instance.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
