### PR TITLE
Use singleton values for fieldless variants on the JavaScript target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   functions, constants, module names, and `as` patterns.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler now generates singleton values for variants with no fields on the
+  JavaScript target, allowing for faster comparison in most cases.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - The build tool now generates Hexdocs URLs using the new format of

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -479,6 +479,7 @@ pub enum Pattern {
     },
     Variant {
         index: usize,
+        used_name: EcoString,
         name: EcoString,
         module: Option<EcoString>,
         fields: Vec<Id<Pattern>>,
@@ -736,6 +737,9 @@ pub enum RuntimeCheckKind {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum VariantMatch {
     ExplicitlyMatchedOn {
+        /// The locally used name, including any alias
+        used_name: EcoString,
+        /// The original name of the variant
         name: EcoString,
         module: Option<EcoString>,
     },
@@ -745,16 +749,23 @@ pub enum VariantMatch {
 }
 
 impl VariantMatch {
-    pub(crate) fn name(&self) -> EcoString {
+    pub(crate) fn used_name(&self) -> EcoString {
         match self {
-            VariantMatch::ExplicitlyMatchedOn { name, module: _ } => name.clone(),
+            VariantMatch::ExplicitlyMatchedOn { used_name, .. } => used_name.clone(),
+            VariantMatch::NeverExplicitlyMatchedOn { name } => name.clone(),
+        }
+    }
+
+    pub(crate) fn variant_name(&self) -> EcoString {
+        match self {
+            VariantMatch::ExplicitlyMatchedOn { name, .. } => name.clone(),
             VariantMatch::NeverExplicitlyMatchedOn { name } => name.clone(),
         }
     }
 
     pub(crate) fn module(&self) -> Option<EcoString> {
         match self {
-            VariantMatch::ExplicitlyMatchedOn { name: _, module } => module.clone(),
+            VariantMatch::ExplicitlyMatchedOn { module, .. } => module.clone(),
             VariantMatch::NeverExplicitlyMatchedOn { name: _ } => None,
         }
     }
@@ -2954,7 +2965,13 @@ impl BranchSplitter {
         // Then we have to update all variant checks with any new name/module
         // we might have discovered from the pattern to make sure we're using
         // the correct qualification to refer to each constructor.
-        if let Pattern::Variant { name, module, .. } = pattern {
+        if let Pattern::Variant {
+            used_name,
+            name,
+            module,
+            ..
+        } = pattern
+        {
             for index in indices_of_overlapping_checks {
                 let (check, _) = self
                     .choices
@@ -2963,6 +2980,7 @@ impl BranchSplitter {
                 if let RuntimeCheck::Variant { match_, .. } = check {
                     *match_ = VariantMatch::ExplicitlyMatchedOn {
                         module: module.clone(),
+                        used_name: used_name.clone(),
                         name: name.clone(),
                     }
                 }
@@ -3412,14 +3430,16 @@ impl CaseToCompile {
                 module,
                 ..
             } => {
-                let index = constructor.expect_ref("must be inferred").constructor_index as usize;
+                let constructor = constructor.expect_ref("must be inferred");
+                let index = constructor.constructor_index as usize;
                 let module = module.as_ref().map(|(module, _)| module.clone());
                 let fields = arguments
                     .iter()
                     .map(|argument| self.register(&argument.value))
                     .collect_vec();
                 self.insert(Pattern::Variant {
-                    name: name.clone(),
+                    used_name: name.clone(),
+                    name: constructor.name.clone(),
                     module,
                     index,
                     fields,

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -520,26 +520,32 @@ impl<'a> Generator<'a> {
     ) -> Document<'a> {
         let class_definition = self.variant_class_definition(constructor, publicity);
 
-        // If the custom type is private or opaque, we don't need to generate API
-        // functions for it.
-        if publicity.is_private() {
-            return class_definition;
-        }
-
+        // Singleton constants are used internally by the compiler, so they aren't
+        // part of the public JS API and need to be generated even for private
+        // types.
         let constructor_singleton = if constructor.arguments.is_empty() {
-            self.variant_constructor_constant(constructor, type_name)
-                .append(line())
+            docvec![
+                line(),
+                self.variant_constructor_constant(constructor, type_name, publicity)
+            ]
         } else {
             nil()
         };
+
+        // If the custom type is private or opaque, we don't need to generate API
+        // functions for it.
+        if publicity.is_private() {
+            return class_definition.append(constructor_singleton);
+        }
+
         let constructor_definition = self.variant_constructor_definition(constructor, type_name);
         let variant_check_definition = self.variant_check_definition(constructor, type_name);
         let fields_definition = self.variant_fields_definition(constructor, type_name);
 
         docvec![
             class_definition,
-            line(),
             constructor_singleton,
+            line(),
             constructor_definition,
             line(),
             variant_check_definition,
@@ -555,10 +561,16 @@ impl<'a> Generator<'a> {
         &self,
         constructor: &'a TypedRecordConstructor,
         type_name: &'a str,
+        publicity: Publicity,
     ) -> Document<'a> {
+        let keyword = if publicity.is_importable() {
+            "export const "
+        } else {
+            "const "
+        };
         docvec![
             self.source_map_tracker(constructor.location.start),
-            "export const ",
+            keyword,
             type_name,
             "$",
             constructor.name.as_str(),

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -6,7 +6,7 @@ mod tests;
 mod typescript;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use debug_ignore::DebugIgnore;
@@ -223,6 +223,14 @@ impl<'a> Generator<'a> {
             self.register_prelude_usage(&mut imports, "Empty", Some("$Empty"));
         };
 
+        if self.tracker.list_empty_const_used {
+            self.register_prelude_usage(
+                &mut imports,
+                "List$Empty$const",
+                Some("$List$Empty$const"),
+            );
+        };
+
         if self.tracker.list_non_empty_class_used || self.tracker.echo_used {
             self.register_prelude_usage(&mut imports, "NonEmpty", Some("$NonEmpty"));
         };
@@ -303,6 +311,54 @@ impl<'a> Generator<'a> {
             self.register_prelude_usage(&mut imports, "sizedFloat", None);
         }
 
+        for (variant, alias) in self.tracker.variant_constants_used.iter() {
+            let path = self.import_path(&variant.package, &variant.module);
+            let member = Member {
+                name: eco_format!("{}${}$const", variant.type_name, variant.name),
+                alias: alias.as_ref().map(|alias| alias.to_doc()),
+            };
+            imports.register_module(path, [], [member]);
+        }
+
+        // If we have some Gleam code that looks something like this:
+        // ```gleam
+        // import option.{None}
+        //
+        // pub fn main() {
+        //   None
+        // }
+        // ```
+        //
+        // Here, the generated JavaScript code for `main` will look something
+        // like this:
+        //
+        // ```javascript
+        // export function main() {
+        //   return Option$None$const;
+        // }
+        // ```
+        //
+        // The `None` variant is technically being imported, but we don't
+        // actually use the generated `None` class in the JavaScript code, so
+        // we don't want to import it.
+        //
+        // However, if we are pattern matching on the `None` variant, there
+        // will be some code that looks like `if (value instanceof None)`, in
+        // which case we still need to import `None`. Therefore we remove all
+        // variants which are used as singleton constants, and that are not used
+        // in pattern matching.
+        //
+        imports.filter_unused_variants(
+            self.tracker
+                .variant_constants_used
+                .keys()
+                .filter(|variant| !self.tracker.variants_used_in_instanceof.contains(variant))
+                .map(|variant| {
+                    let path = self.import_path(&variant.package, &variant.module);
+                    (path, variant.name.clone())
+                }),
+        );
+
         let echo_definition = self.echo_definition(&mut imports);
         let sourcemap_reference = self.sourcemap_reference();
         let type_reference = self.type_reference();
@@ -377,7 +433,7 @@ impl<'a> Generator<'a> {
     ) {
         let path = self.import_path(&self.module.type_info.package, PRELUDE_MODULE_NAME);
         let member = Member {
-            name: name.to_doc(),
+            name: name.into(),
             alias: alias.map(|a| a.to_doc()),
         };
         imports.register_module(path, [], [member]);
@@ -470,6 +526,12 @@ impl<'a> Generator<'a> {
             return class_definition;
         }
 
+        let constructor_singleton = if constructor.arguments.is_empty() {
+            self.variant_constructor_constant(constructor, type_name)
+                .append(line())
+        } else {
+            nil()
+        };
         let constructor_definition = self.variant_constructor_definition(constructor, type_name);
         let variant_check_definition = self.variant_check_definition(constructor, type_name);
         let fields_definition = self.variant_fields_definition(constructor, type_name);
@@ -477,10 +539,34 @@ impl<'a> Generator<'a> {
         docvec![
             class_definition,
             line(),
+            constructor_singleton,
             constructor_definition,
             line(),
             variant_check_definition,
             fields_definition,
+        ]
+    }
+
+    /// Generate a singleton constant for a variant with no fields. This means
+    /// that all values of a particular variant are the same underlying reference,
+    /// allowing them to be compared more efficiently.
+    ///
+    fn variant_constructor_constant(
+        &self,
+        constructor: &'a TypedRecordConstructor,
+        type_name: &'a str,
+    ) -> Document<'a> {
+        docvec![
+            self.source_map_tracker(constructor.location.start),
+            "export const ",
+            type_name,
+            "$",
+            constructor.name.as_str(),
+            "$const",
+            " =",
+            docvec![break_("", " "), "new ", constructor.name.as_str(), "();"]
+                .group()
+                .nest(INDENT)
         ]
     }
 
@@ -489,6 +575,27 @@ impl<'a> Generator<'a> {
         constructor: &'a TypedRecordConstructor,
         type_name: &'a str,
     ) -> Document<'a> {
+        // If the constructor has no fields, return the singleton constant
+        // instead.
+        if constructor.arguments.is_empty() {
+            return docvec![
+                "export const ",
+                type_name,
+                "$",
+                constructor.name.as_str(),
+                " = () =>",
+                docvec![
+                    break_("", " "),
+                    type_name,
+                    "$",
+                    constructor.name.as_str(),
+                    "$const;"
+                ]
+                .group()
+                .nest(INDENT),
+            ];
+        }
+
         let mut arguments = Vec::new();
 
         for (index, parameter) in constructor.arguments.iter().enumerate() {
@@ -754,7 +861,7 @@ impl<'a> Generator<'a> {
         imports
     }
 
-    fn import_path(&self, package: &'a str, module: &'a str) -> EcoString {
+    fn import_path(&self, package: &str, module: &str) -> EcoString {
         // TODO: strip shared prefixed between current module and imported
         // module to avoid descending and climbing back out again
         if package == self.module.type_info.package || package.is_empty() {
@@ -801,7 +908,7 @@ impl<'a> Generator<'a> {
                 self.register_in_scope(n);
                 maybe_escape_identifier(n).to_doc()
             });
-            let name = maybe_escape_identifier(&i.name).to_doc();
+            let name = maybe_escape_identifier(&i.name);
             Member { name, alias }
         });
 
@@ -815,11 +922,11 @@ impl<'a> Generator<'a> {
         publicity: Publicity,
         name: &'a str,
         module: &'a str,
-        fun: &'a str,
+        fun: &EcoString,
     ) {
         let needs_escaping = !is_usable_js_identifier(name);
         let member = Member {
-            name: fun.to_doc(),
+            name: fun.clone(),
             alias: if name == fun && !needs_escaping {
                 None
             } else if needs_escaping {
@@ -1254,6 +1361,7 @@ pub(crate) struct UsageTracker {
     pub ok_used: bool,
     pub list_used: bool,
     pub list_empty_class_used: bool,
+    pub list_empty_const_used: bool,
     pub list_non_empty_class_used: bool,
     pub prepend_used: bool,
     pub error_used: bool,
@@ -1276,6 +1384,24 @@ pub(crate) struct UsageTracker {
     pub codepoint_utf32_bit_array_segment_used: bool,
     pub float_bit_array_segment_used: bool,
     pub echo_used: bool,
+    /// Keeps track of each time a fieldless variant is constructed, so we can
+    /// import the singleton constant. Optionally contains an alias, if the variant
+    /// was imported unqualified and aliased.
+    pub variant_constants_used: HashMap<TypeVariant, Option<EcoString>>,
+    /// Fieldless variants that are used in `instanceof` checks during pattern
+    /// matching or comparison. If we're only using a fieldless variant for
+    /// construction, we don't need to import the variant class itself, just it
+    /// singleton constant. However, if we are using `instanceof`, we still need
+    /// to import it.
+    pub variants_used_in_instanceof: HashSet<TypeVariant>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct TypeVariant {
+    package: EcoString,
+    module: EcoString,
+    type_name: EcoString,
+    name: EcoString,
 }
 
 fn bool(bool: bool) -> Document<'static> {

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     format::break_block,
     javascript::{
+        TypeVariant,
         expression::{eco_string_int, string},
         maybe_escape_property,
     },
@@ -274,7 +275,7 @@ enum BodyExpression<'a> {
 /// Here we will first need to check that the list is not empty:
 ///
 /// ```js
-/// if (value instanceOf $NonEmptyList) {
+/// if (value instanceof $NonEmptyList) {
 ///   // ...
 /// } else {
 ///   return [];
@@ -288,7 +289,7 @@ enum BodyExpression<'a> {
 /// first item of the list, so we need to actually create a variable for it:
 ///
 /// ```js
-/// if (value instanceOf $NonEmptyList) {
+/// if (value instanceof $NonEmptyList) {
 ///   let $ = value.head;
 ///   if ($ === 1) {
 ///     // ...
@@ -1338,13 +1339,18 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
             // Some variants like `Bool` and `Result` are special cased and checked
             // in a different way from all other variants.
             RuntimeCheck::Variant { match_, .. } if variable.type_.is_bool() => {
-                match match_.name().as_str() {
+                match match_.used_name().as_str() {
                     "True" => value.to_doc(),
                     _ => docvec!["!", value],
                 }
             }
 
-            RuntimeCheck::Variant { match_, index, .. } => {
+            RuntimeCheck::Variant {
+                match_,
+                index,
+                fields,
+                ..
+            } => {
                 if variable.type_.is_result() && match_.module().is_none() {
                     if *index == 0 {
                         self.expression_generator.tracker.ok_used = true;
@@ -1358,7 +1364,25 @@ impl<'generator, 'module, 'a> Variables<'generator, 'module, 'a> {
                     .map(|module| eco_format!("${module}."))
                     .unwrap_or_default();
 
-                docvec![value, " instanceof ", qualification, match_.name()]
+                // If this variant has no fields, register it as being used
+                // so that we know to import it.
+                if fields.is_empty()
+                    && let Some((package, module, type_name)) =
+                        variable.type_.named_type_name_and_package()
+                {
+                    _ = self
+                        .expression_generator
+                        .tracker
+                        .variants_used_in_instanceof
+                        .insert(TypeVariant {
+                            package,
+                            module,
+                            type_name,
+                            name: match_.variant_name(),
+                        });
+                }
+
+                docvec![value, " instanceof ", qualification, match_.used_name()]
             }
 
             RuntimeCheck::NonEmptyList { .. } => {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1889,6 +1889,15 @@ impl<'module, 'a> Generator<'module, 'a> {
                 });
                 Some(self.singleton_equal(left_doc, Some(module_alias), name, should_be_equal))
             }
+            // Empty lists are implemented as a variant with no fields, so we can
+            // use `instanceof` for a faster check.
+            TypedExpr::List { elements, .. } if elements.is_empty() => {
+                let left_doc = self.not_in_tail_position(Some(Ordering::Strict), |this| {
+                    this.wrap_expression(left)
+                });
+                self.tracker.list_empty_class_used = true;
+                Some(self.singleton_equal(left_doc, None, "$Empty".into(), should_be_equal))
+            }
             TypedExpr::Int { .. }
             | TypedExpr::Float { .. }
             | TypedExpr::String { .. }
@@ -2409,9 +2418,6 @@ impl<'module, 'a> Generator<'module, 'a> {
                 operator,
                 ..
             } => {
-                let left_document = self.wrapped_guard(left);
-                let right_document = self.wrapped_guard(right);
-
                 let operator = match operator {
                     BinOp::Eq if is_js_scalar(left.type_()) => "===",
                     BinOp::NotEq if is_js_scalar(left.type_()) => "!==",
@@ -2447,9 +2453,10 @@ impl<'module, 'a> Generator<'module, 'a> {
 
                     BinOp::DivFloat => {
                         self.tracker.float_division_used = true;
+
                         return docvec![
                             "divideFloat",
-                            wrap_arguments([left_document, right_document])
+                            wrap_arguments([self.guard(left), self.guard(right)])
                         ];
                     }
 
@@ -2457,7 +2464,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                         self.tracker.int_division_used = true;
                         return docvec![
                             "divideInt",
-                            wrap_arguments([left_document, right_document])
+                            wrap_arguments([self.guard(left), self.guard(right)])
                         ];
                     }
 
@@ -2465,13 +2472,16 @@ impl<'module, 'a> Generator<'module, 'a> {
                         self.tracker.int_remainder_used = true;
                         return docvec![
                             "remainderInt",
-                            wrap_arguments([left_document, right_document])
+                            wrap_arguments([self.guard(left), self.guard(right)])
                         ];
                     }
 
                     BinOp::And => "&&",
                     BinOp::Or => "||",
                 };
+
+                let left_document = self.wrapped_guard(left);
+                let right_document = self.wrapped_guard(right);
 
                 docvec![left_document, " ", operator, " ", right_document]
             }
@@ -2504,23 +2514,32 @@ impl<'module, 'a> Generator<'module, 'a> {
         right: &'a TypedClauseGuard,
         should_be_equal: bool,
     ) -> Option<Document<'a>> {
-        if let ClauseGuard::Constant(Constant::Record {
-            record_constructor: Some(constructor),
-            module,
-            name,
-            ..
-        }) = right
-            && let ValueConstructorVariant::Record { arity: 0, .. } = constructor.variant
-        {
-            let left_doc = self.guard(left);
-            return Some(self.singleton_equal(
-                left_doc,
-                module.as_ref().map(|(module, _)| module.as_str()),
+        match right {
+            ClauseGuard::Constant(Constant::Record {
+                record_constructor: Some(constructor),
+                module,
                 name,
-                should_be_equal,
-            ));
+                ..
+            }) if let ValueConstructorVariant::Record { arity: 0, .. } = constructor.variant => {
+                let left_doc = self.guard(left);
+                Some(self.singleton_equal(
+                    left_doc,
+                    module.as_ref().map(|(module, _)| module.as_str()),
+                    name,
+                    should_be_equal,
+                ))
+            }
+            ClauseGuard::Constant(Constant::List {
+                elements,
+                tail: None,
+                ..
+            }) if elements.is_empty() => {
+                let left_doc = self.guard(left);
+                self.tracker.list_empty_class_used = true;
+                Some(self.singleton_equal(left_doc, None, "$Empty", should_be_equal))
+            }
+            _ => None,
         }
-        None
     }
 
     fn wrapped_guard(&mut self, guard: &'a TypedClauseGuard) -> Document<'a> {

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -389,6 +389,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                             tail,
                         )
                     }
+                    None if elements.is_empty() => this.empty_list(),
                     None => {
                         this.tracker.list_used = true;
                         list(elements.iter().map(|element| this.wrap_expression(element)))
@@ -508,6 +509,13 @@ impl<'module, 'a> Generator<'module, 'a> {
                 self.wrap_return(document)
             ]
         }
+    }
+
+    /// Return the singleton empty list; all empty lists are the same underlying
+    /// reference, which makes comparison faster.
+    fn empty_list(&mut self) -> Document<'static> {
+        self.tracker.list_empty_const_used = true;
+        "$List$Empty$const".to_doc()
     }
 
     fn negate_with(&mut self, with: &'static str, value: &'a TypedExpr) -> Document<'a> {
@@ -811,10 +819,13 @@ impl<'module, 'a> Generator<'module, 'a> {
 
     fn variable(&mut self, name: &'a EcoString, constructor: &'a ValueConstructor) -> Document<'a> {
         match &constructor.variant {
-            ValueConstructorVariant::Record { arity, .. } => {
+            ValueConstructorVariant::Record {
+                arity,
+                name: variant_name,
+                ..
+            } => {
                 let type_ = constructor.type_.clone();
-                let tracker = &mut self.tracker;
-                record_constructor(type_, None, name, *arity, tracker)
+                self.record_constructor(type_, None, variant_name, name, *arity)
             }
             ValueConstructorVariant::ModuleFn { .. }
             | ValueConstructorVariant::ModuleConstant { .. }
@@ -1869,7 +1880,12 @@ impl<'module, 'a> Generator<'module, 'a> {
                 name,
                 constructor:
                     ValueConstructor {
-                        variant: ValueConstructorVariant::Record { arity: 0, .. },
+                        variant:
+                            ValueConstructorVariant::Record {
+                                arity: 0,
+                                name: variant_name,
+                                ..
+                            },
                         ..
                     },
                 ..
@@ -1877,7 +1893,14 @@ impl<'module, 'a> Generator<'module, 'a> {
                 let left_doc = self.not_in_tail_position(Some(Ordering::Strict), |this| {
                     this.wrap_expression(left)
                 });
-                Some(self.singleton_equal(left_doc, None, name, should_be_equal))
+                Some(self.singleton_equal(
+                    left_doc,
+                    None,
+                    name.clone(),
+                    should_be_equal,
+                    variant_name.clone(),
+                    right.type_(),
+                ))
             }
             TypedExpr::ModuleSelect {
                 module_alias,
@@ -1887,7 +1910,14 @@ impl<'module, 'a> Generator<'module, 'a> {
                 let left_doc = self.not_in_tail_position(Some(Ordering::Strict), |this| {
                     this.wrap_expression(left)
                 });
-                Some(self.singleton_equal(left_doc, Some(module_alias), name, should_be_equal))
+                Some(self.singleton_equal(
+                    left_doc,
+                    Some(module_alias),
+                    name.clone(),
+                    should_be_equal,
+                    name.clone(),
+                    right.type_(),
+                ))
             }
             // Empty lists are implemented as a variant with no fields, so we can
             // use `instanceof` for a faster check.
@@ -1896,7 +1926,14 @@ impl<'module, 'a> Generator<'module, 'a> {
                     this.wrap_expression(left)
                 });
                 self.tracker.list_empty_class_used = true;
-                Some(self.singleton_equal(left_doc, None, "$Empty".into(), should_be_equal))
+                Some(self.singleton_equal(
+                    left_doc,
+                    None,
+                    "$Empty".into(),
+                    should_be_equal,
+                    "Empty".into(),
+                    right.type_(),
+                ))
             }
             TypedExpr::Int { .. }
             | TypedExpr::Float { .. }
@@ -1926,12 +1963,30 @@ impl<'module, 'a> Generator<'module, 'a> {
     }
 
     fn singleton_equal(
-        &self,
+        &mut self,
         value: Document<'a>,
         module: Option<&'a str>,
-        name: &'a str,
+        name: EcoString,
         should_be_equal: bool,
+        variant_name: EcoString,
+        type_: Arc<Type>,
     ) -> Document<'a> {
+        // If we're using this variant unqualified, register it as used so that
+        // we know to import it. This `instanceof` check only happens if the
+        // variant has no fields, so we don't need to check that here.
+        if module.is_none()
+            && let Some((package, module, type_name)) = type_.named_type_name_and_package()
+        {
+            _ = self
+                .tracker
+                .variants_used_in_instanceof
+                .insert(TypeVariant {
+                    package,
+                    module,
+                    type_name,
+                    name: variant_name,
+                });
+        }
         let record = if let Some(module) = module {
             docvec!["$", module, ".", name]
         } else {
@@ -2089,7 +2144,7 @@ impl<'module, 'a> Generator<'module, 'a> {
 
             ModuleValueConstructor::Record {
                 name, arity, type_, ..
-            } => record_constructor(type_.clone(), Some(module), name, *arity, self.tracker),
+            } => self.record_constructor(type_.clone(), Some(module), name, name, *arity),
         }
     }
 
@@ -2132,6 +2187,10 @@ impl<'module, 'a> Generator<'module, 'a> {
             ),
 
             Constant::List { elements, tail, .. } => {
+                if tail.is_none() && elements.is_empty() {
+                    return self.empty_list();
+                }
+
                 self.tracker.list_used = true;
                 let list = match tail {
                     // There's no tail in the list, we join all the elements and
@@ -2209,7 +2268,7 @@ impl<'module, 'a> Generator<'module, 'a> {
                     && arity != 0
                 {
                     let arity = arity as u16;
-                    return record_constructor(type_.clone(), None, name, arity, self.tracker);
+                    return self.record_constructor(type_.clone(), None, &tag, name, arity);
                 }
 
                 // Otherwise we're always constructing a record! Even if there's
@@ -2520,13 +2579,20 @@ impl<'module, 'a> Generator<'module, 'a> {
                 module,
                 name,
                 ..
-            }) if let ValueConstructorVariant::Record { arity: 0, .. } = constructor.variant => {
+            }) if let ValueConstructorVariant::Record {
+                arity: 0,
+                name: variant_name,
+                ..
+            } = &constructor.variant =>
+            {
                 let left_doc = self.guard(left);
                 Some(self.singleton_equal(
                     left_doc,
                     module.as_ref().map(|(module, _)| module.as_str()),
-                    name,
+                    name.clone(),
                     should_be_equal,
+                    variant_name.clone(),
+                    right.type_(),
                 ))
             }
             ClauseGuard::Constant(Constant::List {
@@ -2536,9 +2602,24 @@ impl<'module, 'a> Generator<'module, 'a> {
             }) if elements.is_empty() => {
                 let left_doc = self.guard(left);
                 self.tracker.list_empty_class_used = true;
-                Some(self.singleton_equal(left_doc, None, "$Empty", should_be_equal))
+                Some(self.singleton_equal(
+                    left_doc,
+                    None,
+                    "$Empty".into(),
+                    should_be_equal,
+                    "Empty".into(),
+                    right.type_(),
+                ))
             }
-            _ => None,
+            ClauseGuard::Block { .. }
+            | ClauseGuard::BinaryOperator { .. }
+            | ClauseGuard::Not { .. }
+            | ClauseGuard::Var { .. }
+            | ClauseGuard::TupleIndex { .. }
+            | ClauseGuard::FieldAccess { .. }
+            | ClauseGuard::ModuleSelect { .. }
+            | ClauseGuard::Constant(_)
+            | ClauseGuard::Invalid { .. } => None,
         }
     }
 
@@ -2594,6 +2675,76 @@ impl<'module, 'a> Generator<'module, 'a> {
 
     pub fn source_map_tracker(&mut self, start_index: u32) -> Document<'a> {
         create_cursor_position_observer(&self.source_map_builder, self.line_numbers, start_index)
+    }
+
+    pub(crate) fn record_constructor(
+        &mut self,
+        type_: Arc<Type>,
+        qualifier: Option<&'a str>,
+        variant_name: &EcoString,
+        name: &'a EcoString,
+        arity: u16,
+    ) -> Document<'a> {
+        if qualifier.is_none() && type_.is_result_constructor() {
+            if name == "Ok" {
+                self.tracker.ok_used = true;
+            } else if name == "Error" {
+                self.tracker.error_used = true;
+            }
+        }
+        if type_.is_bool() && name == "True" {
+            "true".to_doc()
+        } else if type_.is_bool() {
+            "false".to_doc()
+        } else if type_.is_nil() {
+            "undefined".to_doc()
+        } else if arity == 0
+            && let Some((package, module, type_name)) = type_.named_type_name_and_package()
+        {
+            // If the variant has no fields, return the singleton constant so
+            // that all values of the variant are the same underlying reference,
+            // and are faster to compare.
+            match qualifier {
+                Some(module) => docvec!["$", module, ".", type_name, "$", name, "$const"],
+                None => {
+                    if module != self.module_name {
+                        let alias = if name == variant_name {
+                            None
+                        } else {
+                            Some(eco_format!("{}${}$const", type_name, name))
+                        };
+                        // Since this constant is an implementation detail and not
+                        // present in Gleam code, we need to track it so that we
+                        // import it, as it doesn't appear directly in the `import`s
+                        // in the source code.
+                        _ = self.tracker.variant_constants_used.insert(
+                            TypeVariant {
+                                package,
+                                module,
+                                type_name: type_name.clone(),
+                                name: variant_name.clone(),
+                            },
+                            alias,
+                        );
+                    }
+                    docvec![type_name, "$", name, "$const"]
+                }
+            }
+        } else {
+            let vars = (0..arity).map(|i| eco_format!("var{i}").to_doc());
+            let body = docvec![
+                "return ",
+                construct_record(qualifier, name, vars.clone()),
+                ";"
+            ];
+            docvec![
+                docvec![wrap_arguments(vars), " => {", break_("", " "), body]
+                    .nest(INDENT)
+                    .append(break_("", " "))
+                    .group(),
+                "}",
+            ]
+        }
     }
 }
 
@@ -2947,48 +3098,6 @@ fn immediately_invoked_function_expression_document(document: Document<'_>) -> D
         "})()",
     ]
     .group()
-}
-
-pub(crate) fn record_constructor<'a>(
-    type_: Arc<Type>,
-    qualifier: Option<&'a str>,
-    name: &'a str,
-    arity: u16,
-    tracker: &mut UsageTracker,
-) -> Document<'a> {
-    if qualifier.is_none() && type_.is_result_constructor() {
-        if name == "Ok" {
-            tracker.ok_used = true;
-        } else if name == "Error" {
-            tracker.error_used = true;
-        }
-    }
-    if type_.is_bool() && name == "True" {
-        "true".to_doc()
-    } else if type_.is_bool() {
-        "false".to_doc()
-    } else if type_.is_nil() {
-        "undefined".to_doc()
-    } else if arity == 0 {
-        match qualifier {
-            Some(module) => docvec!["new $", module, ".", name, "()"],
-            None => docvec!["new ", name, "()"],
-        }
-    } else {
-        let vars = (0..arity).map(|i| eco_format!("var{i}").to_doc());
-        let body = docvec![
-            "return ",
-            construct_record(qualifier, name, vars.clone()),
-            ";"
-        ];
-        docvec![
-            docvec![wrap_arguments(vars), " => {", break_("", " "), body]
-                .nest(INDENT)
-                .append(break_("", " "))
-                .group(),
-            "}",
-        ]
-    }
 }
 
 fn u8_slice<'a>(bytes: &[u8]) -> Document<'a> {

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -46,7 +46,7 @@ impl<'a> Imports<'a> {
             self.imports
                 .into_values()
                 .sorted_by(|a, b| a.path.cmp(&b.path))
-                .map(|import| Import::into_doc(import, codegen_target)),
+                .map(|import| import.into_doc(codegen_target)),
         );
 
         if self.exports.is_empty() {
@@ -81,6 +81,25 @@ impl<'a> Imports<'a> {
 
     pub fn is_empty(&self) -> bool {
         self.imports.is_empty() && self.exports.is_empty()
+    }
+
+    /// Remove variants which are imported in Gleam code, but not needed to be
+    /// imported because singleton constants are used instead.
+    ///
+    pub fn filter_unused_variants<I>(&mut self, unused: I)
+    where
+        I: Iterator<Item = (EcoString, EcoString)>,
+    {
+        for (path, name) in unused {
+            if let Some(import_) = self.imports.get_mut(&path)
+                && let Some(index) = import_
+                    .unqualified
+                    .iter()
+                    .position(|member| member.name == name)
+            {
+                _ = import_.unqualified.remove(index);
+            }
+        }
     }
 }
 
@@ -146,14 +165,14 @@ impl<'a> Import<'a> {
 
 #[derive(Debug)]
 pub struct Member<'a> {
-    pub name: Document<'a>,
+    pub name: EcoString,
     pub alias: Option<Document<'a>>,
 }
 
 impl<'a> Member<'a> {
     fn into_doc(self) -> Document<'a> {
         match self.alias {
-            None => self.name,
+            None => self.name.to_doc(),
             Some(alias) => docvec![self.name, " as ", alias],
         }
     }
@@ -173,7 +192,7 @@ fn into_doc() {
         "./multiple/times".into(),
         [],
         [Member {
-            name: "one".to_doc(),
+            name: "one".into(),
             alias: None,
         }],
     );
@@ -183,15 +202,15 @@ fn into_doc() {
         [],
         [
             Member {
-                name: "one".to_doc(),
+                name: "one".into(),
                 alias: None,
             },
             Member {
-                name: "one".to_doc(),
+                name: "one".into(),
                 alias: Some("onee".to_doc()),
             },
             Member {
-                name: "two".to_doc(),
+                name: "two".into(),
                 alias: Some("twoo".to_doc()),
             },
         ],
@@ -202,11 +221,11 @@ fn into_doc() {
         [],
         [
             Member {
-                name: "three".to_doc(),
+                name: "three".into(),
                 alias: None,
             },
             Member {
-                name: "four".to_doc(),
+                name: "four".into(),
                 alias: None,
             },
         ],
@@ -217,11 +236,11 @@ fn into_doc() {
         [],
         [
             Member {
-                name: "one".to_doc(),
+                name: "one".into(),
                 alias: None,
             },
             Member {
-                name: "two".to_doc(),
+                name: "two".into(),
                 alias: None,
             },
         ],

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -173,7 +173,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
             importable_modules: &modules,
             warnings: &TypeWarningEmitter::null(),
             direct_dependencies: &HashMap::new(),
-            dev_dependencies: &std::collections::HashSet::new(),
+            dev_dependencies: &HashSet::new(),
             target_support: TargetSupport::Enforced,
             package_config: &dep_config,
         }
@@ -199,7 +199,7 @@ pub fn compile(src: &str, deps: Vec<(&str, &str, &str)>) -> TypedModule {
         importable_modules: &modules,
         warnings: &TypeWarningEmitter::null(),
         direct_dependencies: &direct_dependencies,
-        dev_dependencies: &std::collections::HashSet::new(),
+        dev_dependencies: &HashSet::new(),
         target_support: TargetSupport::NotEnforced,
         package_config: &config,
     }

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -1168,3 +1168,23 @@ pub fn go(x) {
 "
     );
 }
+
+#[test]
+fn opaque_variant_produces_private_singleton_constants() {
+    assert_js!(
+        "
+pub opaque type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub fn wibble() -> Wibble {
+  Wibble
+}
+
+pub fn wobble(x: Int) -> Wibble {
+  Wobble(x)
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -1070,3 +1070,101 @@ pub type Box {
 "#,
     );
 }
+
+#[test]
+fn singleton_for_two_aliased_variants() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble }"),
+        ("wobble", "pub type Wibble { Wibble }"),
+        "
+import wobble.{Wibble as Wobble}
+import wibble.{Wibble as Wubble}
+
+pub fn main() {
+  #(Wobble, Wubble)
+}
+"
+    );
+}
+
+#[test]
+fn fieldless_variant_still_imported_if_used_in_instanceof_comparison() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble Wobble }"),
+        "
+import wibble.{Wibble}
+
+pub fn main() {
+  let x = Wibble
+  x == Wibble
+}
+"
+    );
+}
+
+#[test]
+fn fieldless_variant_still_imported_if_used_in_instanceof_comparison_in_guard() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble Wobble }"),
+        "
+import wibble.{Wibble}
+
+pub fn main() {
+  let x = Wibble
+  case x {
+    _ if x == Wibble -> 1
+    _ -> 2
+  }
+}
+"
+    );
+}
+
+#[test]
+fn aliased_variant_still_imported_if_used_in_instanceof_comparison() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble Wobble }"),
+        "
+import wibble.{Wibble as Wobble}
+
+pub fn main() {
+  let x = Wobble
+  x == Wobble
+}
+"
+    );
+}
+
+#[test]
+fn aliased_variant_still_imported_if_used_in_instanceof_comparison_in_guard() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble Wobble }"),
+        "
+import wibble.{Wibble as Wobble}
+
+pub fn go(x) {
+  case x {
+    _ if x == Wobble -> Wobble
+    _ -> wibble.Wobble
+  }
+}
+"
+    );
+}
+
+#[test]
+fn aliased_variant_still_imported_if_used_in_pattern_matching() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble Wobble }"),
+        "
+import wibble.{Wibble as Wobble}
+
+pub fn go(x) {
+  case x {
+    Wobble -> wibble.Wobble
+    _ -> Wobble
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/lists.rs
+++ b/compiler-core/src/javascript/tests/lists.rs
@@ -111,3 +111,53 @@ pub fn go(func) {
 "#,
     );
 }
+
+#[test]
+fn comparison_with_empty_list() {
+    assert_js!(
+        "
+pub fn go(x) {
+  x == [] && [] == x
+}
+"
+    );
+}
+
+#[test]
+fn negated_comparison_with_empty_list() {
+    assert_js!(
+        "
+pub fn go(x) {
+  x != [] && [] != x
+}
+"
+    );
+}
+
+#[test]
+fn comparison_with_empty_list_ing_guard() {
+    assert_js!(
+        "
+pub fn go(x) {
+  case x {
+    _ if x == [] && [] == x -> 1
+    _ -> 2
+  }
+}
+"
+    );
+}
+
+#[test]
+fn negated_comparison_with_empty_list_ing_guard() {
+    assert_js!(
+        "
+pub fn go(x) {
+  case x {
+    _ if x != [] && [] != x -> 1
+    _ -> 2
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assert__prova.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assert__prova.snap
@@ -12,7 +12,7 @@ fn id(x) { x }
 
 
 ----- COMPILED JAVASCRIPT
-import { Ok, toList, makeError, isEqual } from "../gleam.mjs";
+import { Ok, List$Empty$const as $List$Empty$const, makeError, isEqual } from "../gleam.mjs";
 
 const FILEPATH = "src/module.gleam";
 
@@ -21,10 +21,10 @@ function id(x) {
 }
 
 export function main() {
-  let $ = new Ok(toList([]));
+  let $ = new Ok($List$Empty$const);
   let $1 = new Ok(
     (() => {
-      let _pipe = toList([]);
+      let _pipe = $List$Empty$const;
       return id(_pipe);
     })(),
   );

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bools__shadowed_bools_and_nil.snap
@@ -18,15 +18,18 @@ import { CustomType as $CustomType, makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export class True extends $CustomType {}
-export const True$True = () => new True();
+export const True$True$const = new True();
+export const True$True = () => True$True$const;
 export const True$isTrue = (value) => value instanceof True;
 
 export class False extends $CustomType {}
-export const True$False = () => new False();
+export const True$False$const = new False();
+export const True$False = () => True$False$const;
 export const True$isFalse = (value) => value instanceof False;
 
 export class Nil extends $CustomType {}
-export const True$Nil = () => new Nil();
+export const True$Nil$const = new Nil();
+export const True$Nil = () => True$Nil$const;
 export const True$isNil = (value) => value instanceof Nil;
 
 export function go(x, y) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_branches_guards_are_wrapped_in_parentheses.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_branches_guards_are_wrapped_in_parentheses.snap
@@ -13,11 +13,11 @@ pub fn anything() -> a {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, Empty as $Empty } from "../gleam.mjs";
+import { Empty as $Empty, List$Empty$const as $List$Empty$const } from "../gleam.mjs";
 
 export function anything() {
   while (true) {
-    let $ = toList([]);
+    let $ = $List$Empty$const;
     if (!($ instanceof $Empty)) {
       let $1 = $.tail;
       if ($1 instanceof $Empty && false || true) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
@@ -12,11 +12,11 @@ pub fn func(x) {
     
 
 ----- COMPILED JAVASCRIPT
-import { Ok, toList, isEqual } from "../gleam.mjs";
+import { Ok, toList, Empty as $Empty } from "../gleam.mjs";
 
 export function func(x) {
   let $ = toList([]);
-  if (isEqual(toList([]), toList([(var0) => { return new Ok(var0); }]))) {
+  if (toList([(var0) => { return new Ok(var0); }]) instanceof $Empty) {
     return true;
   } else {
     return false;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
@@ -12,10 +12,10 @@ pub fn func(x) {
     
 
 ----- COMPILED JAVASCRIPT
-import { Ok, toList, Empty as $Empty } from "../gleam.mjs";
+import { Ok, toList, Empty as $Empty, List$Empty$const as $List$Empty$const } from "../gleam.mjs";
 
 export function func(x) {
-  let $ = toList([]);
+  let $ = $List$Empty$const;
   if (toList([(var0) => { return new Ok(var0); }]) instanceof $Empty) {
     return true;
   } else {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__custom_type_constructor_imported_and_aliased.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__custom_type_constructor_imported_and_aliased.snap
@@ -14,10 +14,10 @@ pub fn func() {
 
 ----- COMPILED JAVASCRIPT
 import * as $other_module from "../../package/other_module.mjs";
-import { A as B } from "../../package/other_module.mjs";
+import { A as B, T$A$const as T$B$const } from "../../package/other_module.mjs";
 
 export function func() {
-  let $ = new B();
+  let $ = T$B$const;
   let x = $;
   if (x instanceof B) {
     return true;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__guard_pattern_does_not_shadow_outer_scope.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__guard_pattern_does_not_shadow_outer_scope.snap
@@ -38,7 +38,8 @@ export const Option$isSome = (value) => value instanceof Some;
 export const Option$Some$0 = (value) => value[0];
 
 export class None extends $CustomType {}
-export const Option$None = () => new None();
+export const Option$None$const = new None();
+export const Option$None = () => Option$None$const;
 export const Option$isNone = (value) => value instanceof None;
 
 export class Container extends $CustomType {
@@ -57,7 +58,7 @@ export function main() {
   let $ = new Some(1);
   let x$1 = $[0];
   if (x$1 < 0) {
-    return new Container(new None());
+    return new Container(Option$None$const);
   } else {
     return new Container(x);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_aliased_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_aliased_ok.snap
@@ -20,7 +20,8 @@ import * as $gleam from "../gleam.mjs";
 import { Ok as Y, CustomType as $CustomType, isEqual } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
-export const X$Ok = () => new Ok();
+export const X$Ok$const = new Ok();
+export const X$Ok = () => X$Ok$const;
 export const X$isOk = (value) => value instanceof Ok;
 
 export function func() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
@@ -20,7 +20,8 @@ import * as $gleam from "../gleam.mjs";
 import { Ok, toList, Empty as $Empty, CustomType as $CustomType } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
-export const X$Ok = () => new Ok();
+export const X$Ok$const = new Ok();
+export const X$Ok = () => X$Ok$const;
 export const X$isOk = (value) => value instanceof Ok;
 
 export function func(x) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
@@ -17,7 +17,7 @@ pub fn func(x) {
 
 ----- COMPILED JAVASCRIPT
 import * as $gleam from "../gleam.mjs";
-import { Ok, toList, CustomType as $CustomType, isEqual } from "../gleam.mjs";
+import { Ok, toList, Empty as $Empty, CustomType as $CustomType } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
 export const X$Ok = () => new Ok();
@@ -25,7 +25,7 @@ export const X$isOk = (value) => value instanceof Ok;
 
 export function func(x) {
   let $ = (var0) => { return new $gleam.Ok(var0); };
-  if (isEqual(toList([]), toList([(var0) => { return new Ok(var0); }]))) {
+  if (toList([(var0) => { return new Ok(var0); }]) instanceof $Empty) {
     return true;
   } else {
     return false;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_constructor_gets_pure_annotation.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_constructor_gets_pure_annotation.snap
@@ -13,7 +13,11 @@ pub const y = X(1, [])
         
 
 ----- COMPILED JAVASCRIPT
-import { toList, CustomType as $CustomType } from "../gleam.mjs";
+import {
+  toList,
+  List$Empty$const as $List$Empty$const,
+  CustomType as $CustomType,
+} from "../gleam.mjs";
 
 export class X extends $CustomType {
   constructor($0, $1) {
@@ -29,4 +33,4 @@ export const X$X$1 = (value) => value[1];
 
 export const x = /* @__PURE__ */ new X(1, /* @__PURE__ */ toList(["1"]));
 
-export const y = /* @__PURE__ */ new X(1, /* @__PURE__ */ toList([]));
+export const y = /* @__PURE__ */ new X(1, $List$Empty$const);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__imported_aliased_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__imported_aliased_ok.snap
@@ -17,7 +17,8 @@ import * as $gleam from "../gleam.mjs";
 import { Ok as Y, CustomType as $CustomType } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
-export const X$Ok = () => new Ok();
+export const X$Ok$const = new Ok();
+export const X$Ok = () => X$Ok$const;
 export const X$isOk = (value) => value instanceof Ok;
 
 export const y = (var0) => { return new Y(var0); };

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__imported_ok.snap
@@ -17,7 +17,8 @@ import * as $gleam from "../gleam.mjs";
 import { Ok, CustomType as $CustomType } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
-export const X$Ok = () => new Ok();
+export const X$Ok$const = new Ok();
+export const X$Ok = () => X$Ok$const;
 export const X$isOk = (value) => value instanceof Ok;
 
 export const y = (var0) => { return new Ok(var0); };

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__aliased_variant_still_imported_if_used_in_instanceof_comparison.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__aliased_variant_still_imported_if_used_in_instanceof_comparison.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wibble.{Wibble as Wobble}\n\npub fn main() {\n  let x = Wobble\n  x == Wobble\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
+
+import wibble.{Wibble as Wobble}
+
+pub fn main() {
+  let x = Wobble
+  x == Wobble
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $wibble from "../wibble.mjs";
+import { Wibble as Wobble, Wibble$Wibble$const as Wibble$Wobble$const } from "../wibble.mjs";
+
+export function main() {
+  let x = Wibble$Wobble$const;
+  return x instanceof Wobble;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__aliased_variant_still_imported_if_used_in_instanceof_comparison_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__aliased_variant_still_imported_if_used_in_instanceof_comparison_in_guard.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wibble.{Wibble as Wobble}\n\npub fn go(x) {\n  case x {\n    _ if x == Wobble -> Wobble\n    _ -> wibble.Wobble\n  }\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
+
+import wibble.{Wibble as Wobble}
+
+pub fn go(x) {
+  case x {
+    _ if x == Wobble -> Wobble
+    _ -> wibble.Wobble
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $wibble from "../wibble.mjs";
+import { Wibble as Wobble, Wibble$Wibble$const as Wibble$Wobble$const } from "../wibble.mjs";
+
+export function go(x) {
+  if (x instanceof Wobble) {
+    return Wibble$Wobble$const;
+  } else {
+    return $wibble.Wibble$Wobble$const;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__aliased_variant_still_imported_if_used_in_pattern_matching.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__aliased_variant_still_imported_if_used_in_pattern_matching.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wibble.{Wibble as Wobble}\n\npub fn go(x) {\n  case x {\n    Wobble -> wibble.Wobble\n    _ -> Wobble\n  }\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
+
+import wibble.{Wibble as Wobble}
+
+pub fn go(x) {
+  case x {
+    Wobble -> wibble.Wobble
+    _ -> Wobble
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $wibble from "../wibble.mjs";
+import { Wibble as Wobble, Wibble$Wibble$const as Wibble$Wobble$const } from "../wibble.mjs";
+
+export function go(x) {
+  if (x instanceof Wobble) {
+    return $wibble.Wibble$Wobble$const;
+  } else {
+    return Wibble$Wobble$const;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__equality_with_non_singleton_variant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__equality_with_non_singleton_variant.snap
@@ -18,7 +18,8 @@ pub fn check_other(x: Thing) -> Bool {
 import { CustomType as $CustomType, isEqual } from "../gleam.mjs";
 
 export class Variant extends $CustomType {}
-export const Thing$Variant = () => new Variant();
+export const Thing$Variant$const = new Variant();
+export const Thing$Variant = () => Thing$Variant$const;
 export const Thing$isVariant = (value) => value instanceof Variant;
 
 export class Other extends $CustomType {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__fieldless_variant_still_imported_if_used_in_instanceof_comparison.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__fieldless_variant_still_imported_if_used_in_instanceof_comparison.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wibble.{Wibble}\n\npub fn main() {\n  let x = Wibble\n  x == Wibble\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
+
+import wibble.{Wibble}
+
+pub fn main() {
+  let x = Wibble
+  x == Wibble
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $wibble from "../wibble.mjs";
+import { Wibble, Wibble$Wibble$const } from "../wibble.mjs";
+
+export function main() {
+  let x = Wibble$Wibble$const;
+  return x instanceof Wibble;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__fieldless_variant_still_imported_if_used_in_instanceof_comparison_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__fieldless_variant_still_imported_if_used_in_instanceof_comparison_in_guard.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wibble.{Wibble}\n\npub fn main() {\n  let x = Wibble\n  case x {\n    _ if x == Wibble -> 1\n    _ -> 2\n  }\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
+
+import wibble.{Wibble}
+
+pub fn main() {
+  let x = Wibble
+  case x {
+    _ if x == Wibble -> 1
+    _ -> 2
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $wibble from "../wibble.mjs";
+import { Wibble, Wibble$Wibble$const } from "../wibble.mjs";
+
+export function main() {
+  let x = Wibble$Wibble$const;
+  if (x instanceof Wibble) {
+    return 1;
+  } else {
+    return 2;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__guard_equality_with_non_singleton_variant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__guard_equality_with_non_singleton_variant.snap
@@ -21,7 +21,8 @@ pub fn process(e: Thing) -> String {
 import { CustomType as $CustomType, isEqual } from "../gleam.mjs";
 
 export class Variant extends $CustomType {}
-export const Thing$Variant = () => new Variant();
+export const Thing$Variant$const = new Variant();
+export const Thing$Variant = () => Thing$Variant$const;
 export const Thing$isVariant = (value) => value instanceof Variant;
 
 export class Other extends $CustomType {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__mixed_singleton_and_non_singleton.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__mixed_singleton_and_non_singleton.snap
@@ -29,7 +29,8 @@ export const Result$Ok$value = (value) => value.value;
 export const Result$Ok$0 = (value) => value.value;
 
 export class Error extends $CustomType {}
-export const Result$Error = () => new Error();
+export const Result$Error$const = new Error();
+export const Result$Error = () => Result$Error$const;
 export const Result$isError = (value) => value instanceof Error;
 
 export function is_error(r) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__multiple_singleton_constructors.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__multiple_singleton_constructors.snap
@@ -23,15 +23,18 @@ pub fn is_success(s: Status) -> Bool {
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class Loading extends $CustomType {}
-export const Status$Loading = () => new Loading();
+export const Status$Loading$const = new Loading();
+export const Status$Loading = () => Status$Loading$const;
 export const Status$isLoading = (value) => value instanceof Loading;
 
 export class Success extends $CustomType {}
-export const Status$Success = () => new Success();
+export const Status$Success$const = new Success();
+export const Status$Success = () => Status$Success$const;
 export const Status$isSuccess = (value) => value instanceof Success;
 
 export class Error extends $CustomType {}
-export const Status$Error = () => new Error();
+export const Status$Error$const = new Error();
+export const Status$Error = () => Status$Error$const;
 export const Status$isError = (value) => value instanceof Error;
 
 export function is_loading(s) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__new_type_import_syntax.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__new_type_import_syntax.snap
@@ -13,8 +13,8 @@ pub fn main() {
 
 ----- COMPILED JAVASCRIPT
 import * as $a from "../../package/a.mjs";
-import { A } from "../../package/a.mjs";
+import { A$A$const } from "../../package/a.mjs";
 
 export function main() {
-  return new A();
+  return A$A$const;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_variant_produces_private_singleton_constants.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__opaque_variant_produces_private_singleton_constants.snap
@@ -1,0 +1,40 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub opaque type Wibble {\n  Wibble\n  Wobble(Int)\n}\n\npub fn wibble() -> Wibble {\n  Wibble\n}\n\npub fn wobble(x: Int) -> Wibble {\n  Wobble(x)\n}\n"
+---
+----- SOURCE CODE
+
+pub opaque type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub fn wibble() -> Wibble {
+  Wibble
+}
+
+pub fn wobble(x: Int) -> Wibble {
+  Wobble(x)
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+class Wibble extends $CustomType {}
+const Wibble$Wibble$const = new Wibble();
+
+class Wobble extends $CustomType {
+  constructor($0) {
+    super();
+    this[0] = $0;
+  }
+}
+
+export function wibble() {
+  return Wibble$Wibble$const;
+}
+
+export function wobble(x) {
+  return new Wobble(x);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__qualified.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__qualified.snap
@@ -18,5 +18,5 @@ pub fn main() {
 import * as $other from "../other.mjs";
 
 export function main() {
-  return new $other.One();
+  return $other.One$One$const;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_for_two_aliased_variants.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_for_two_aliased_variants.snap
@@ -1,0 +1,30 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wobble.{Wibble as Wobble}\nimport wibble.{Wibble as Wubble}\n\npub fn main() {\n  #(Wobble, Wubble)\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble }
+
+-- wobble.gleam
+pub type Wibble { Wibble }
+
+-- main.gleam
+
+import wobble.{Wibble as Wobble}
+import wibble.{Wibble as Wubble}
+
+pub fn main() {
+  #(Wobble, Wubble)
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $wibble from "../wibble.mjs";
+import { Wibble$Wibble$const as Wibble$Wubble$const } from "../wibble.mjs";
+import * as $wobble from "../wobble.mjs";
+import { Wibble$Wibble$const as Wibble$Wobble$const } from "../wobble.mjs";
+
+export function main() {
+  return [Wibble$Wobble$const, Wibble$Wubble$const];
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_in_case_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_in_case_guard.snap
@@ -21,11 +21,13 @@ pub fn process(s: State) -> String {
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class Active extends $CustomType {}
-export const State$Active = () => new Active();
+export const State$Active$const = new Active();
+export const State$Active = () => State$Active$const;
 export const State$isActive = (value) => value instanceof Active;
 
 export class Inactive extends $CustomType {}
-export const State$Inactive = () => new Inactive();
+export const State$Inactive$const = new Inactive();
+export const State$Inactive = () => State$Inactive$const;
 export const State$isInactive = (value) => value instanceof Inactive;
 
 export function process(s) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_record_equality.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_record_equality.snap
@@ -18,11 +18,13 @@ pub fn is_wibble(w: Wibble) -> Bool {
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class Wibble extends $CustomType {}
-export const Wibble$Wibble = () => new Wibble();
+export const Wibble$Wibble$const = new Wibble();
+export const Wibble$Wibble = () => Wibble$Wibble$const;
 export const Wibble$isWibble = (value) => value instanceof Wibble;
 
 export class Wobble extends $CustomType {}
-export const Wibble$Wobble = () => new Wobble();
+export const Wibble$Wobble$const = new Wobble();
+export const Wibble$Wobble = () => Wibble$Wobble$const;
 export const Wibble$isWobble = (value) => value instanceof Wobble;
 
 export function is_wibble(w) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_record_inequality.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_record_inequality.snap
@@ -18,11 +18,13 @@ pub fn is_not_wibble(w: Wibble) -> Bool {
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class Wibble extends $CustomType {}
-export const Wibble$Wibble = () => new Wibble();
+export const Wibble$Wibble$const = new Wibble();
+export const Wibble$Wibble = () => Wibble$Wibble$const;
 export const Wibble$isWibble = (value) => value instanceof Wibble;
 
 export class Wobble extends $CustomType {}
-export const Wibble$Wobble = () => new Wobble();
+export const Wibble$Wobble$const = new Wobble();
+export const Wibble$Wobble = () => Wibble$Wobble$const;
 export const Wibble$isWobble = (value) => value instanceof Wobble;
 
 export function is_not_wibble(w) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_record_reverse_order.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_record_reverse_order.snap
@@ -18,11 +18,13 @@ pub fn is_wibble_reverse(w: Wibble) -> Bool {
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class Wibble extends $CustomType {}
-export const Wibble$Wibble = () => new Wibble();
+export const Wibble$Wibble$const = new Wibble();
+export const Wibble$Wibble = () => Wibble$Wibble$const;
 export const Wibble$isWibble = (value) => value instanceof Wibble;
 
 export class Wobble extends $CustomType {}
-export const Wibble$Wobble = () => new Wobble();
+export const Wibble$Wobble$const = new Wobble();
+export const Wibble$Wobble = () => Wibble$Wobble$const;
 export const Wibble$isWobble = (value) => value instanceof Wobble;
 
 export function is_wibble_reverse(w) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__types_must_be_rendered_before_functions.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__types_must_be_rendered_before_functions.snap
@@ -12,9 +12,10 @@ pub type One { One }
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class One extends $CustomType {}
-export const One$One = () => new One();
+export const One$One$const = new One();
+export const One$One = () => One$One$const;
 export const One$isOne = (value) => value instanceof One;
 
 export function one() {
-  return new One();
+  return One$One$const;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_const.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_const.snap
@@ -17,12 +17,15 @@ pub const that = ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLonge
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class This extends $CustomType {}
-export const Mine$This = () => new This();
+export const Mine$This$const = new This();
+export const Mine$This = () => Mine$This$const;
 export const Mine$isThis = (value) => value instanceof This;
 
 export class ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant extends $CustomType {}
-export const Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant = () =>
+export const Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant$const =
   new ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant();
+export const Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant = () =>
+  Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant$const;
 export const Mine$isThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant = (value) =>
   value instanceof ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant;
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported.snap
@@ -16,5 +16,5 @@ pub fn main() {
 import * as $other from "../other.mjs";
 
 export function main() {
-  return new $other.Two();
+  return $other.One$Two$const;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified.snap
@@ -14,8 +14,8 @@ pub fn main() {
 
 ----- COMPILED JAVASCRIPT
 import * as $other from "../other.mjs";
-import { Two } from "../other.mjs";
+import { One$Two$const } from "../other.mjs";
 
 export function main() {
-  return new Two();
+  return One$Two$const;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_imported_unqualified_aliased.snap
@@ -14,8 +14,8 @@ pub fn main() {
 
 ----- COMPILED JAVASCRIPT
 import * as $other from "../other.mjs";
-import { Two as Three } from "../other.mjs";
+import { One$Two$const as One$Three$const } from "../other.mjs";
 
 export function main() {
-  return new Three();
+  return One$Three$const;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_literal.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_literal.snap
@@ -19,16 +19,19 @@ pub fn go() {
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class This extends $CustomType {}
-export const Mine$This = () => new This();
+export const Mine$This$const = new This();
+export const Mine$This = () => Mine$This$const;
 export const Mine$isThis = (value) => value instanceof This;
 
 export class ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant extends $CustomType {}
-export const Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant = () =>
+export const Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant$const =
   new ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant();
+export const Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant = () =>
+  Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant$const;
 export const Mine$isThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant = (value) =>
   value instanceof ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant;
 
 export function go() {
-  new This();
-  return new ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant();
+  Mine$This$const;
+  return Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant$const;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_type_with_import_alias_and_same_named_local_type.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_type_with_import_alias_and_same_named_local_type.snap
@@ -35,11 +35,13 @@ import * as $wibble from "../wibble.mjs";
 import { Active as WibbleActive } from "../wibble.mjs";
 
 export class Active extends $CustomType {}
-export const WobbleStatus$Active = () => new Active();
+export const WobbleStatus$Active$const = new Active();
+export const WobbleStatus$Active = () => WobbleStatus$Active$const;
 export const WobbleStatus$isActive = (value) => value instanceof Active;
 
 export class Disabled extends $CustomType {}
-export const WobbleStatus$Disabled = () => new Disabled();
+export const WobbleStatus$Disabled$const = new Disabled();
+export const WobbleStatus$Disabled = () => WobbleStatus$Disabled$const;
 export const WobbleStatus$isDisabled = (value) => value instanceof Disabled;
 
 export function is_wibble_active(s) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__labelled_argument_ordering.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__labelled_argument_ordering.snap
@@ -41,12 +41,12 @@ function wibble(a, b, c, d) {
 }
 
 export function main() {
-  wibble(new A(), new B(), new C(), new D());
-  wibble(new A(), new B(), new C(), new D());
-  wibble(new A(), new B(), new C(), new D());
-  wibble(new A(), new B(), new C(), new D());
-  wibble(new A(), new B(), new C(), new D());
-  wibble(new A(), new B(), new C(), new D());
-  wibble(new A(), new B(), new C(), new D());
-  return wibble(new A(), new B(), new C(), new D());
+  wibble(A$A$const, B$B$const, C$C$const, D$D$const);
+  wibble(A$A$const, B$B$const, C$C$const, D$D$const);
+  wibble(A$A$const, B$B$const, C$C$const, D$D$const);
+  wibble(A$A$const, B$B$const, C$C$const, D$D$const);
+  wibble(A$A$const, B$B$const, C$C$const, D$D$const);
+  wibble(A$A$const, B$B$const, C$C$const, D$D$const);
+  wibble(A$A$const, B$B$const, C$C$const, D$D$const);
+  return wibble(A$A$const, B$B$const, C$C$const, D$D$const);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__labelled_argument_ordering.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__labelled_argument_ordering.snap
@@ -29,12 +29,16 @@ pub fn main() {
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 class A extends $CustomType {}
+const A$A$const = new A();
 
 class B extends $CustomType {}
+const B$B$const = new B();
 
 class C extends $CustomType {}
+const C$C$const = new C();
 
 class D extends $CustomType {}
+const D$D$const = new D();
 
 function wibble(a, b, c, d) {
   return undefined;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__comparison_with_empty_list.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__comparison_with_empty_list.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/lists.rs
+expression: "\npub fn go(x) {\n  x == [] && [] == x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  x == [] && [] == x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Empty as $Empty } from "../gleam.mjs";
+
+export function go(x) {
+  return (x instanceof $Empty) && (x instanceof $Empty);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__comparison_with_empty_list_ing_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__comparison_with_empty_list_ing_guard.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/javascript/tests/lists.rs
+expression: "\npub fn go(x) {\n  case x {\n    _ if x == [] && [] == x -> 1\n    _ -> 2\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    _ if x == [] && [] == x -> 1
+    _ -> 2
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Empty as $Empty } from "../gleam.mjs";
+
+export function go(x) {
+  if ((x instanceof $Empty) && (x instanceof $Empty)) {
+    return 1;
+  } else {
+    return 2;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__equality.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__equality.snap
@@ -11,9 +11,9 @@ pub fn go() {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, isEqual } from "../gleam.mjs";
+import { toList, Empty as $Empty } from "../gleam.mjs";
 
 export function go() {
-  isEqual(toList([]), toList([1]));
-  return !isEqual(toList([]), toList([1]));
+  toList([1]) instanceof $Empty;
+  return !(toList([1]) instanceof $Empty);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants.snap
@@ -9,8 +9,8 @@ pub const b = [1, 2, 3]
 
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { toList, List$Empty$const as $List$Empty$const } from "../gleam.mjs";
 
-export const a = /* @__PURE__ */ toList([]);
+export const a = $List$Empty$const;
 
 export const b = /* @__PURE__ */ toList([1, 2, 3]);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
@@ -13,10 +13,10 @@ pub fn go(x) {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, prepend as listPrepend } from "../gleam.mjs";
+import { toList, List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
 export function go(x) {
-  toList([]);
+  $List$Empty$const;
   toList([1]);
   toList([1, 2]);
   return listPrepend(1, listPrepend(2, x));

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__negated_comparison_with_empty_list.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__negated_comparison_with_empty_list.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/lists.rs
+expression: "\npub fn go(x) {\n  x != [] && [] != x\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  x != [] && [] != x
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Empty as $Empty } from "../gleam.mjs";
+
+export function go(x) {
+  return (!(x instanceof $Empty)) && (!(x instanceof $Empty));
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__negated_comparison_with_empty_list_ing_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__negated_comparison_with_empty_list_ing_guard.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/javascript/tests/lists.rs
+expression: "\npub fn go(x) {\n  case x {\n    _ if x != [] && [] != x -> 1\n    _ -> 2\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    _ if x != [] && [] != x -> 1
+    _ -> 2
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Empty as $Empty } from "../gleam.mjs";
+
+export function go(x) {
+  if ((!(x instanceof $Empty)) && (!(x instanceof $Empty))) {
+    return 1;
+  } else {
+    return 2;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__tight_empty_list.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__tight_empty_list.snap
@@ -10,9 +10,9 @@ pub fn go(func) {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const } from "../gleam.mjs";
 
 export function go(func) {
-  let huuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuge_variable = toList([]);
+  let huuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuge_variable = $List$Empty$const;
   return huuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuge_variable;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_custom_type_definition.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_custom_type_definition.snap
@@ -22,35 +22,36 @@ expression: "\n/// my custom type\npub type Wibble {\n  /// Wibble\n  Wibble\n  
 4 | * Wibble
 5 | */
 6 |export class Wibble extends $CustomType {}
-7 |export const Wibble$Wibble = () => new Wibble();
-8 |export const Wibble$isWibble = (value) => value instanceof Wibble;
-9 |
-10 |/**
-11 | * Wobble
-12 | */
-13 |export class Wobble extends $CustomType {
-14 |  constructor(field) {
-15 |    super();
-16 |    this.field = field;
-17 |  }
-18 |}
-19 |export const Wibble$Wobble = (field) => new Wobble(field);
-20 |export const Wibble$isWobble = (value) => value instanceof Wobble;
-21 |export const Wibble$Wobble$field = (value) => value.field;
-22 |export const Wibble$Wobble$0 = (value) => value.field;
-23 |
-24 |/**
-25 | * Wabble
-26 | */
-27 |export class Wabble extends $CustomType {
-28 |  constructor($0) {
-29 |    super();
-30 |    this[0] = $0;
-31 |  }
-32 |}
-33 |export const Wibble$Wabble = ($0) => new Wabble($0);
-34 |export const Wibble$isWabble = (value) => value instanceof Wabble;
-35 |export const Wibble$Wabble$0 = (value) => value[0];
+7 |export const Wibble$Wibble$const = new Wibble();
+8 |export const Wibble$Wibble = () => Wibble$Wibble$const;
+9 |export const Wibble$isWibble = (value) => value instanceof Wibble;
+10 |
+11 |/**
+12 | * Wobble
+13 | */
+14 |export class Wobble extends $CustomType {
+15 |  constructor(field) {
+16 |    super();
+17 |    this.field = field;
+18 |  }
+19 |}
+20 |export const Wibble$Wobble = (field) => new Wobble(field);
+21 |export const Wibble$isWobble = (value) => value instanceof Wobble;
+22 |export const Wibble$Wobble$field = (value) => value.field;
+23 |export const Wibble$Wobble$0 = (value) => value.field;
+24 |
+25 |/**
+26 | * Wabble
+27 | */
+28 |export class Wabble extends $CustomType {
+29 |  constructor($0) {
+30 |    super();
+31 |    this[0] = $0;
+32 |  }
+33 |}
+34 |export const Wibble$Wabble = ($0) => new Wabble($0);
+35 |export const Wibble$isWabble = (value) => value instanceof Wabble;
+36 |export const Wibble$Wabble$0 = (value) => value[0];
 
 ----- SOURCE MAP
 File: my/mod.mjs
@@ -83,7 +84,8 @@ Wibble
   
 ⏷
 export class Wibble extends $CustomType {}
-export const Wibble$Wibble = () => new Wibble();
+export const Wibble$Wibble$const = new Wibble();
+export const Wibble$Wibble = () => Wibble$Wibble$const;
 export const Wibble$isWibble = (value) => value instanceof Wibble;
 
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_custom_type_definition_with_unused.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_custom_type_definition_with_unused.snap
@@ -26,18 +26,19 @@ expression: "\n/// my custom type\npub type Wibble {\n  /// Wibble\n  Wibble\n}\
 4 | * Wibble
 5 | */
 6 |export class Wibble extends $CustomType {}
-7 |export const Wibble$Wibble = () => new Wibble();
-8 |export const Wibble$isWibble = (value) => value instanceof Wibble;
-9 |
-10 |export class Wobble extends $CustomType {
-11 |  constructor($0) {
-12 |    super();
-13 |    this[0] = $0;
-14 |  }
-15 |}
-16 |export const Wobble$Wobble = ($0) => new Wobble($0);
-17 |export const Wobble$isWobble = (value) => value instanceof Wobble;
-18 |export const Wobble$Wobble$0 = (value) => value[0];
+7 |export const Wibble$Wibble$const = new Wibble();
+8 |export const Wibble$Wibble = () => Wibble$Wibble$const;
+9 |export const Wibble$isWibble = (value) => value instanceof Wibble;
+10 |
+11 |export class Wobble extends $CustomType {
+12 |  constructor($0) {
+13 |    super();
+14 |    this[0] = $0;
+15 |  }
+16 |}
+17 |export const Wobble$Wobble = ($0) => new Wobble($0);
+18 |export const Wobble$isWobble = (value) => value instanceof Wobble;
+19 |export const Wobble$Wobble$0 = (value) => value[0];
 
 ----- SOURCE MAP
 File: my/mod.mjs
@@ -70,7 +71,8 @@ Wibble
 }
 ⏷
 export class Wibble extends $CustomType {}
-export const Wibble$Wibble = () => new Wibble();
+export const Wibble$Wibble$const = new Wibble();
+export const Wibble$Wibble = () => Wibble$Wibble$const;
 export const Wibble$isWibble = (value) => value instanceof Wibble;
 ----- 
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -439,7 +439,7 @@ impl<'a> TypeScriptGenerator<'a> {
         let definition = if constructors.is_empty() {
             if let Some((module, external_name, _location)) = external_javascript {
                 let member = Member {
-                    name: external_name.to_doc(),
+                    name: external_name.clone(),
                     alias: Some(eco_format!("{name}$").to_doc()),
                 };
                 imports.register_export(eco_format!("{name}$"));

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -355,6 +355,19 @@ impl Type {
         }
     }
 
+    pub fn named_type_name_and_package(&self) -> Option<(EcoString, EcoString, EcoString)> {
+        match self {
+            Self::Named {
+                package,
+                module,
+                name,
+                ..
+            } => Some((package.clone(), module.clone(), name.clone())),
+            Self::Var { type_ } => type_.borrow().named_type_name_and_package(),
+            Self::Fn { .. } | Self::Tuple { .. } => None,
+        }
+    }
+
     pub fn set_custom_type_variant(&mut self, index: u16) {
         match self {
             Type::Named {
@@ -1416,6 +1429,13 @@ impl TypeVar {
     pub fn named_type_name(&self) -> Option<(EcoString, EcoString)> {
         match self {
             Self::Link { type_ } => type_.named_type_name(),
+            Self::Unbound { .. } | Self::Generic { .. } => None,
+        }
+    }
+
+    pub fn named_type_name_and_package(&self) -> Option<(EcoString, EcoString, EcoString)> {
+        match self {
+            Self::Link { type_ } => type_.named_type_name_and_package(),
             Self::Unbound { .. } | Self::Generic { .. } => None,
         }
     }

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -73,8 +73,9 @@ class ListIterator {
   }
 }
 
-export class Empty extends List {}
-export const List$Empty = () => new Empty();
+export class Empty extends List { }
+export const List$Empty$const = new Empty();
+export const List$Empty = () => List$Empty$const;
 export const List$isEmpty = (value) => value instanceof Empty;
 
 export class NonEmpty extends List {
@@ -575,7 +576,7 @@ export function toBitArray(segments) {
       return new BitArray(segment);
     }
 
-    return new BitArray(new Uint8Array(/** @type {number[]} */ (segments)));
+    return new BitArray(new Uint8Array(/** @type {number[]} */(segments)));
   }
 
   // Count the total number of bits and check if all segments are numbers, i.e.
@@ -597,7 +598,7 @@ export function toBitArray(segments) {
   // If all segments are numbers then pass the segments array directly to the
   // Uint8Array constructor
   if (areAllSegmentsNumbers) {
-    return new BitArray(new Uint8Array(/** @type {number[]} */ (segments)));
+    return new BitArray(new Uint8Array(/** @type {number[]} */(segments)));
   }
 
   // Pack the segments into a Uint8Array
@@ -1458,7 +1459,7 @@ export function isEqual(x, y) {
       try {
         if (a.equals(b)) continue;
         else return false;
-      } catch {}
+      } catch { }
     }
 
     let [keys, get] = getters(a);

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -9,11 +9,7 @@ export class CustomType {
 
 export class List {
   static fromArray(array, tail) {
-    let t = tail || new Empty();
-    for (let i = array.length - 1; i >= 0; --i) {
-      t = new NonEmpty(array[i], t);
-    }
-    return t;
+    return toList(array, tail)
   }
 
   [Symbol.iterator]() {
@@ -52,7 +48,11 @@ export function prepend(element, tail) {
 }
 
 export function toList(elements, tail) {
-  return List.fromArray(elements, tail);
+  let t = tail || List$Empty$const
+  for (let i = elements.length - 1; i >= 0; --i) {
+    t = new NonEmpty(elements[i], t);
+  }
+  return t;
 }
 
 class ListIterator {

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -34,9 +34,10 @@ export function wobble(): Wibble$;
 import { CustomType as $CustomType } from "./gleam.mjs";
 
 export class Woo extends $CustomType {}
-export const Wibble$Woo = () => new Woo();
+export const Wibble$Woo$const = new Woo();
+export const Wibble$Woo = () => Wibble$Woo$const;
 export const Wibble$isWoo = (value) => value instanceof Woo;
 
 export function wobble() {
-  return new Woo();
+  return Wibble$Woo$const;
 }

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -38,7 +38,8 @@ export type A$ = A;
 import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class A extends $CustomType {}
-export const A$A = () => new A();
+export const A$A$const = new A();
+export const A$A = () => A$A$const;
 export const A$isA = (value) => value instanceof A;
 
 

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_sourcemaps.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_sourcemaps.snap
@@ -27,13 +27,14 @@ pub fn wobble() -> Wibble {
 import { CustomType as $CustomType } from "./gleam.mjs";
 
 export class Woo extends $CustomType {}
-export const Wibble$Woo = () => new Woo();
+export const Wibble$Woo$const = new Woo();
+export const Wibble$Woo = () => Wibble$Woo$const;
 export const Wibble$isWoo = (value) => value instanceof Woo;
 
 export function wobble() {
-  return new Woo();
+  return Wibble$Woo$const;
 }
 
 
 //// /out/lib/the_package/hello.mjs.map
-{"version":3,"file":"hello.mjs","sources":["hello.gleam"],"names":[],"mappings":";;;AAAA,AACE;AAAA;AAAA,4DACD;;AAED;EACE;CACD"}
+{"version":3,"file":"hello.mjs","sources":["hello.gleam"],"names":[],"mappings":";;;AAAA,AACE;AAAA;;AAAA,4DACD;;AAED;EACE;CACD"}


### PR DESCRIPTION
Closes #5756

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

I've also made empty lists consistent with other empty variants so that expressions in the form `x == []` will be compiled to `x instanceof $Empty` instead of calling the much slower `isEqual` function.

I wasn't 100% sure about how to rename imported constants for aliased variants; happy to hear suggestions for alternative naming schemes.