### PR TITLE
Warn when adding a retired hex package

### DIFF
--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -111,6 +111,36 @@ pub fn print_retired(package: &str, version: &str) {
     print_colourful_prefix("Retired", &format!("{package} {version}"))
 }
 
+pub fn print_warning_retired_dependency(
+    package: &str,
+    version: &str,
+    reason: &str,
+    message: &str,
+) {
+    let detail = if message.is_empty() {
+        format!("{package} v{version} is retired ({reason})")
+    } else {
+        format!("{package} v{version} is retired ({reason}): {message}")
+    };
+    let buffer_writer = stderr_buffer_writer();
+    let mut buffer = buffer_writer.buffer();
+    buffer
+        .set_color(
+            ColorSpec::new()
+                .set_intense(true)
+                .set_fg(Some(Color::Yellow)),
+        )
+        .expect("print_warning_retired_dependency");
+    write!(buffer, "{: >11}", "Warning").expect("print_warning_retired_dependency");
+    buffer
+        .set_color(&ColorSpec::new())
+        .expect("print_warning_retired_dependency");
+    writeln!(buffer, " {detail}").expect("print_warning_retired_dependency");
+    buffer_writer
+        .print(&buffer)
+        .expect("print_warning_retired_dependency");
+}
+
 pub fn print_unretired(package: &str, version: &str) {
     print_colourful_prefix("Unretired", &format!("{package} {version}"))
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1188,6 +1188,15 @@ async fn lookup_package(
             let config = hexpm::Config::new();
             let release =
                 hex::get_package_release(&name, &version, &config, &HttpClient::new()).await?;
+            // Warn the user if the resolved version is retired.
+            if let Some(status) = &release.retirement_status {
+                cli::print_warning_retired_dependency(
+                    &name,
+                    &version.to_string(),
+                    status.reason.to_str(),
+                    &status.message,
+                );
+            }
             let build_tools = release
                 .meta
                 .build_tools


### PR DESCRIPTION
Closes #4476.

## What this does

When `gleam add` resolves a hex package and the chosen version is retired,
it now prints a yellow **Warning** line to stderr so the user knows to
reconsider:

```
   Warning gleam_retry v0.1.4 is retired (deprecated): use gleam_retry v2
```

If the retirement has no message, the output is just:

```
   Warning gleam_retry v0.1.4 is retired (deprecated)
```

## How it works

The `Release` struct returned by `api_get_package_release_response` already
carries a `retirement_status: Option<RetirementStatus>` field that is
populated from the Hex JSON API — no extra network requests are needed.

The check is added in `lookup_package` in `compiler-cli/src/dependencies.rs`,
which is the single place where a hex release is fetched and converted into a
`ManifestPackage`. After the release is fetched, if `retirement_status` is
`Some`, the new `cli::print_warning_retired_dependency` helper is called.

The warning is only emitted if the **resolved version** is retired, matching
the behaviour discussed in the issue.

## Changes

- `compiler-cli/src/dependencies.rs` — check `release.retirement_status` in
  `lookup_package` and call the warning helper.
- `compiler-cli/src/cli.rs` — add `print_warning_retired_dependency` that
  uses yellow colour to distinguish it from normal prefixed output.