### PR TITLE
JS: fix missing `;` after some expressions in statement position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   every inexhaustive `let` assignment in a module other than the first one.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where the JavaScript code generator would not emit semicolon
+  after some expressions.
+  ([Andrey Kozhev](https://github.com/ankddev))
+
 ## v1.17.0-rc1 - 2026-05-23
 
 ### Compiler

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -296,7 +296,7 @@ impl<'module, 'a> Generator<'module, 'a> {
     }
 
     pub fn expression(&mut self, expression: &'a TypedExpr) -> Document<'a> {
-        let document = match expression {
+        let mut document = match expression {
             TypedExpr::String { value, .. } => string(value),
 
             TypedExpr::Int { value, .. } => int(value),
@@ -415,6 +415,11 @@ impl<'module, 'a> Generator<'module, 'a> {
                 panic!("invalid expressions should not reach code generation")
             }
         };
+        if let Position::Statement = self.scope_position
+            && expression_requires_semicolon(expression)
+        {
+            document = document.append(";");
+        }
         if expression.handles_own_return() {
             docvec![
                 self.source_map_tracker(expression.location().start),
@@ -803,18 +808,6 @@ impl<'module, 'a> Generator<'module, 'a> {
         } else {
             let finally_doc = self.expression(finally);
             documents.push(self.add_statement_level(finally_doc));
-
-            // Add a semicolon if needed, to ensure the pipeline is properly
-            // delimited
-            match &self.scope_position {
-                Position::Statement if expression_requires_semicolon(finally) => {
-                    documents.push(";".to_doc())
-                }
-                Position::Statement
-                | Position::Expression(_)
-                | Position::Tail
-                | Position::Assign(_) => {}
-            }
         }
 
         documents.to_doc().force_break()
@@ -897,9 +890,6 @@ impl<'module, 'a> Generator<'module, 'a> {
                 self.function_position = function_position;
                 self.scope_position = scope_position;
 
-                if requires_semicolon(statement) {
-                    documents.push(";".to_doc());
-                }
                 documents.push(line());
             } else {
                 documents.push(self.statement(statement));
@@ -2822,16 +2812,6 @@ pub fn is_js_scalar(t: Arc<Type>) -> bool {
     t.is_int() || t.is_float() || t.is_bool() || t.is_nil() || t.is_string()
 }
 
-fn requires_semicolon(statement: &TypedStatement) -> bool {
-    match statement {
-        Statement::Expression(expression) => expression_requires_semicolon(expression),
-
-        Statement::Assignment(_) => false,
-        Statement::Use(_) => false,
-        Statement::Assert(_) => false,
-    }
-}
-
 fn expression_requires_semicolon(expression: &TypedExpr) -> bool {
     match expression {
         TypedExpr::Int { .. }
@@ -2850,15 +2830,15 @@ fn expression_requires_semicolon(expression: &TypedExpr) -> bool {
         | TypedExpr::NegateBool { .. }
         | TypedExpr::RecordAccess { .. }
         | TypedExpr::PositionalAccess { .. }
-        | TypedExpr::ModuleSelect { .. }
-        | TypedExpr::Block { .. } => true,
+        | TypedExpr::ModuleSelect { .. } => true,
 
         TypedExpr::Todo { .. }
         | TypedExpr::Case { .. }
         | TypedExpr::Panic { .. }
         | TypedExpr::Pipeline { .. }
         | TypedExpr::RecordUpdate { .. }
-        | TypedExpr::Invalid { .. } => false,
+        | TypedExpr::Invalid { .. }
+        | TypedExpr::Block { .. } => false,
     }
 }
 

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -1033,3 +1033,31 @@ pub fn go() {
 }"#
     )
 }
+
+#[test]
+fn semicolon_exists_with_directly_matching_case() {
+    assert_js!(
+        r#"
+pub fn go() {
+  case #(1, 2) {
+    #(a, _) -> a
+  }
+  {2 + 4} * 2
+}"#
+    )
+}
+
+#[test]
+fn semicolon_exists_with_case() {
+    assert_js!(
+        r#"
+pub fn go() {
+  case #(1, 2) {
+    #(2, b) -> b
+    #(1, 3) -> 2
+    #(a, _) -> a
+  }
+  {2 + 4} * 2
+}"#
+    )
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_discard_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_discard_sized.snap
@@ -19,9 +19,9 @@ pub fn go(x) {
 ----- COMPILED JAVASCRIPT
 export function go(x) {
   if (x.bitSize >= 16 && x.bitSize === 24) {
-    1
+    1;
   } else {
-    2
+    2;
   }
   if (x.bitSize >= 16 && x.bitSize === 24) {
     return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_binary_size.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_binary_size.snap
@@ -23,9 +23,9 @@ import { bitArraySlice } from "../gleam.mjs";
 export function go(x) {
   if (x.bitSize >= 8 && x.bitSize === 24) {
     let a = bitArraySlice(x, 8, 24);
-    a
+    a;
   } else {
-    x
+    x;
   }
   if (x.bitSize >= 8 && x.bitSize === 24) {
     let b = bitArraySlice(x, 8, 24);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_whose_values_are_unused_do_not_generate_assignments.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__blocks_whose_values_are_unused_do_not_generate_assignments.snap
@@ -36,13 +36,13 @@ import {
 export function main() {
   {
     let x = 10;
-    echo(x, undefined, "src/module.gleam", 5)
-  };
+    echo(x, undefined, "src/module.gleam", 5);
+  }
   {
     let a = 1;
     let b = 2;
-    a + b
-  };
+    a + b;
+  }
   return undefined;
 }
 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__blocks__nested_multiexpr_non_ending_blocks.snap
@@ -24,8 +24,8 @@ export function go() {
     1;
     {
       2;
-      3
-    };
+      3;
+    }
     _block = 4;
   }
   let x = _block;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__directly_matching_case_subject.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__directly_matching_case_subject.snap
@@ -24,6 +24,6 @@ export function go() {
   let x = "ABC";
   let $ = true;
   let x$1 = 79;
-  0
+  0;
   return x;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_case.snap
@@ -19,18 +19,18 @@ export function go() {
   let $1 = $[0];
   if ($1 === 2) {
     let b = $[1];
-    b
+    b;
   } else if ($1 === 1) {
     let $2 = $[1];
     if ($2 === 3) {
-      2
+      2;
     } else {
       let a = $1;
-      a
+      a;
     }
   } else {
     let a = $1;
-    a
+    a;
   }
   return (2 + 4) * 2;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_case.snap
@@ -1,0 +1,36 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go() {\n  case #(1, 2) {\n    #(2, b) -> b\n    #(1, 3) -> 2\n    #(a, _) -> a\n  }\n  {2 + 4} * 2\n}"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  case #(1, 2) {
+    #(2, b) -> b
+    #(1, 3) -> 2
+    #(a, _) -> a
+  }
+  {2 + 4} * 2
+}
+
+----- COMPILED JAVASCRIPT
+export function go() {
+  let $ = [1, 2];
+  let $1 = $[0];
+  if ($1 === 2) {
+    let b = $[1];
+    b
+  } else if ($1 === 1) {
+    let $2 = $[1];
+    if ($2 === 3) {
+      2
+    } else {
+      let a = $1;
+      a
+    }
+  } else {
+    let a = $1;
+    a
+  }
+  return (2 + 4) * 2;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_directly_matching_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_directly_matching_case.snap
@@ -15,6 +15,6 @@ pub fn go() {
 export function go() {
   let $ = [1, 2];
   let a = $[0];
-  a
+  a;
   return (2 + 4) * 2;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_directly_matching_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_directly_matching_case.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go() {\n  case #(1, 2) {\n    #(a, _) -> a\n  }\n  {2 + 4} * 2\n}"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  case #(1, 2) {
+    #(a, _) -> a
+  }
+  {2 + 4} * 2
+}
+
+----- COMPILED JAVASCRIPT
+export function go() {
+  let $ = [1, 2];
+  let a = $[0];
+  a
+  return (2 + 4) * 2;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_clause_variables.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_clause_variables.snap
@@ -18,7 +18,7 @@ export function main() {
   let text = "first defined";
   let $ = "defined again";
   let text$1 = $;
-  undefined
+  undefined;
   let text$2 = "a third time";
   return text$2;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_shadowed_variable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_shadowed_variable.snap
@@ -23,7 +23,7 @@ export function main() {
   let b = 20;
   {
     let _inline_a_0 = 7;
-    (a + b) + _inline_a_0
-  };
+    (a + b) + _inline_a_0;
+  }
   return a;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_shadowed_variable_nested.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_shadowed_variable_nested.snap
@@ -25,9 +25,9 @@ export function sum(a, b) {
     let _inline_a_0 = 7;
     {
       let _inline_a_1 = 10;
-      ((a + b) + _inline_a_0) - _inline_a_1
-    };
-    _inline_a_0
-  };
+      ((a + b) + _inline_a_0) - _inline_a_1;
+    }
+    _inline_a_0;
+  }
   return a;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_variable_shadowed_in_case_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_variable_shadowed_in_case_pattern.snap
@@ -26,6 +26,6 @@ export function sum() {
   let $1 = 8;
   let _inline_a_0 = $;
   let _inline_b_1 = $1;
-  (_inline_a_0 + _inline_b_1) + (a + b)
+  (_inline_a_0 + _inline_b_1) + (a + b);
   return a + b;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_variable_shadowing_parameter.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__inlining__inline_variable_shadowing_parameter.snap
@@ -18,7 +18,7 @@ pub fn sum(a, b) {
 export function sum(a, b) {
   {
     let _inline_a_0 = 7;
-    (a + b) + _inline_a_0
-  };
+    (a + b) + _inline_a_0;
+  }
   return a;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_utf16.snap
@@ -33,30 +33,30 @@ export function go(x) {
   let $ = "Θ wibble wobble";
   if ($.charCodeAt(0) === 920) {
     let rest = $.slice(1);
-    rest
+    rest;
   } else {
-    ""
+    "";
   }
   let $1 = "🫥 is neutral dotted";
   if ($1.startsWith("🫥")) {
     let rest = $1.slice(2);
-    rest
+    rest;
   } else {
-    ""
+    "";
   }
   let $2 = "🇺🇸 is a cluster";
   if ($2.startsWith("🇺🇸")) {
     let rest = $2.slice(4);
-    rest
+    rest;
   } else {
-    ""
+    "";
   }
   let $3 = "\" is a an escaped quote";
   if ($3.charCodeAt(0) === 34) {
     let rest = $3.slice(1);
-    rest
+    rest;
   } else {
-    ""
+    "";
   }
   let $4 = "\\ is a an escaped backslash";
   if ($4.charCodeAt(0) === 92) {


### PR DESCRIPTION
* Closes https://github.com/gleam-lang/gleam/issues/5680 (resolves its second part)
***
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
