### PR TITLE
Throw the global JS error instead of the Result subclass Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   after some expressions.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- Fixed a bug where the JavaScript prelude's `BitArray$BitArray$data` FFI
+  function would throw an Error using the wrong class.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.17.0-rc1 - 2026-05-23
 
 ### Compiler

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -299,7 +299,9 @@ export const BitArray$BitArray = (buffer, bitSize, bitOffset) =>
 export const BitArray$isBitArray = (value) => value instanceof BitArray;
 export const BitArray$BitArray$data = (bitArray) => {
   if (bitArray.bitSize % 8 !== 0)
-    throw new Error("BitArray$BitArray$data called on un-aligned bit array");
+    throw new globalThis.Error(
+      "BitArray$BitArray$data called on un-aligned bit array",
+    );
   const array = bitArray.rawBuffer;
   return new DataView(array.buffer, array.byteOffset, bitArray.byteSize);
 };


### PR DESCRIPTION
While looking at #5763, I noticed that this code was throwing the local class `Error` that is defined as a subclass of `Result` instead of the global JS class `Error`. The rest of the code was already using `globalThis.Error`.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
