### PR TITLE
publish: check README existence directly instead of matching OS error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   function would throw an Error using the wrong class.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where publishing a package without a README would show a raw
+  IO error on Windows instead of the friendly "Cannot publish with no README"
+  message, because the check matched on the OS-emitted error string which
+  differs between Unix and Windows.
+  ([Charlie Tonneslan](https://github.com/c-tonneslan))
+
 ## v1.17.0-rc1 - 2026-05-23
 
 ### Compiler

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -149,17 +149,13 @@ fn check_for_invalid_readme(config: &PackageConfig, paths: &ProjectPaths) -> Res
             .replace(" ", "")
     };
 
-    let project_readme = match fs::read(paths.readme()) {
-        Err(Error::FileIo {
-            err: Some(message), ..
-        }) if message.contains("No such file or directory") => {
-            return Err(Error::CannotPublishWithInvalidReadme {
-                reason: InvalidReadmeReason::Missing,
-            });
-        }
-        Err(error) => return Err(error),
-        Ok(project_readme) => project_readme,
-    };
+    let readme_path = paths.readme();
+    if !readme_path.exists() {
+        return Err(Error::CannotPublishWithInvalidReadme {
+            reason: InvalidReadmeReason::Missing,
+        });
+    }
+    let project_readme = fs::read(readme_path)?;
 
     let normalised_project_readme = normalise(project_readme);
     if normalised_project_readme.is_empty() {


### PR DESCRIPTION
Closes #5752.

The check matched the raw IO error string \`"No such file or directory"\` to recognize a missing README, but Windows reports something like \`"The system cannot find the file specified"\`. On Windows the friendly \`Cannot publish with no README\` error never fired and the raw IO error showed up instead, as caught in a CI run on a different PR.

Switched to checking whether the path exists before reading, which is OS-independent and a bit clearer:

\`\`\`rust
let readme_path = paths.readme();
if !readme_path.exists() {
    return Err(Error::CannotPublishWithInvalidReadme {
        reason: InvalidReadmeReason::Missing,
    });
}
let project_readme = fs::read(readme_path)?;
\`\`\`

All 93 existing gleam-cli tests still pass.