### PR TITLE
Fix heading level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## Bug Fixes
+### Bug Fixes
 
 - Fixed a bug where the "Convert to case" code action would silently fail for
   every inexhaustive `let` assignment in a module other than the first one.


### PR DESCRIPTION
I noticed that the "Bug fixes" section of the changelog was an h2 instead of an h3.