### PR TITLE
Use new hexdocs URL format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-### Bug Fixes
-
 ### Compiler
 
 ### Build tool
+
+- The build tool now generates Hexdocs URLs using the new format of
+  `package.hexdocs.pm` rather than `hexdocs.pm/package`.
+  ([Surya Rose](https://github.com/GearsDatapacks))
 
 ### Language server
 

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -176,11 +176,13 @@ jobs:
 }
 
 pub fn default_readme(project_name: &str) -> String {
+    let project_name_with_dashes = project_name.replace('_', "-");
+
     format!(
         r#"# {project_name}
 
 [![Package Version](https://img.shields.io/hexpm/v/{project_name})](https://hex.pm/packages/{project_name})
-[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/{project_name}/)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://{project_name_with_dashes}.hexdocs.pm/)
 
 ```sh
 gleam add {project_name}@1
@@ -193,7 +195,7 @@ pub fn main() -> Nil {{
 }}
 ```
 
-Further documentation can be found at <https://hexdocs.pm/{project_name}>.
+Further documentation can be found at <https://{project_name_with_dashes}.hexdocs.pm/>.
 
 ## Development
 

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -110,8 +110,8 @@ pub fn generate_html<IO: FileSystemReader>(
             path,
         });
 
-    let host = if is_hex_publish == DocContext::HexPublish {
-        "https://hexdocs.pm"
+    let url = if is_hex_publish == DocContext::HexPublish {
+        &format!("https://{}.hexdocs.pm", config.name.replace("_", "-"))
     } else {
         ""
     };
@@ -175,7 +175,7 @@ pub fn generate_html<IO: FileSystemReader>(
             project_version: &config.version.to_string(),
             content: rendered_content,
             rendering_timestamp: &rendering_timestamp,
-            host,
+            url,
             unnest: &unnest,
         };
 
@@ -228,7 +228,7 @@ pub fn generate_html<IO: FileSystemReader>(
 
         let template = ModuleTemplate {
             gleam_version: COMPILER_VERSION,
-            host,
+            url,
             unnest,
             links: &links,
             pages: &pages,
@@ -652,7 +652,7 @@ struct DocsValues<'a> {
 struct PageTemplate<'a> {
     gleam_version: &'a str,
     unnest: &'a str,
-    host: &'a str,
+    url: &'a str,
     page_title: &'a str,
     page_meta_description: &'a str,
     file_path: &'a Utf8PathBuf,
@@ -670,7 +670,7 @@ struct PageTemplate<'a> {
 struct ModuleTemplate<'a> {
     gleam_version: &'a str,
     unnest: String,
-    host: &'a str,
+    url: &'a str,
     page_title: &'a str,
     page_meta_description: &'a str,
     file_path: &'a Utf8PathBuf,

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -648,7 +648,10 @@ impl Printer<'_> {
                 kind: DependencyKind::Hex,
                 version,
             }) => self.link(
-                eco_format!("https://hexdocs.pm/{package}/{version}/{module}.html#{name}"),
+                eco_format!(
+                    "https://{package}.hexdocs.pm/{version}/{module}.html#{name}",
+                    package = package.replace('_', "-")
+                ),
                 qualified_name,
                 Some(title),
             ),

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__canonical_link.snap
@@ -18,7 +18,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/LICENSE.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/LICENSE.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>
@@ -343,7 +343,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>
@@ -710,7 +710,7 @@ expression: "compile_with_markdown_pages(config, modules, pages,\nCompileWithMar
          between multiple versions of the same package. -->
     <script src="../../docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="../../css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/gleam/otp/actor.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/gleam/otp/actor.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__discarded_arguments_are_not_shown.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__docs_of_a_type_constructor_are_not_used_by_the_following_function.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__hello_docs.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__ignored_argument_is_called_arg.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__ignored_argument_is_called_arg.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__internal_definitions_are_not_included.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__link_to_type_in_different_package.snap
@@ -16,4 +16,4 @@ pub fn make_dict() -> dict.Dict(a, b) { todo }
 ---- VALUES
 
 --- make_dict
-<pre><code>pub fn make_dict() -> <a href="https://hexdocs.pm/gleam_stdlib/1.0.0/gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>
+<pre><code>pub fn make_dict() -> <a href="https://gleam-stdlib.hexdocs.pm/1.0.0/gleam/dict.html#Dict" title="gleam/dict.{type Dict}">dict.Dict</a>(a, b)</code></pre>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__long_function_wrapping.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_function_comment_is_trimmed.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_module_comment_is_trimmed.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__markdown_code_from_standalone_pages_is_not_trimmed.snap
@@ -18,7 +18,7 @@ expression: "compile_with_markdown_pages(config, vec![], pages,\nCompileWithMark
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/one.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/one.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__tables.snap
@@ -18,7 +18,7 @@ expression: "compile(config, modules)"
          between multiple versions of the same package. -->
     <script src="./docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="./css/atom-one-light.min.css?v=GLEAM_VERSION_HERE"/>
-    <link rel="canonical" href="https://hexdocs.pm/test_project_name/app.html" />
+    <link rel="canonical" href="https://test-project-name.hexdocs.pm/app.html" />
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/compiler-core/src/docs/snapshots/gleam_core__docs__tests__use_reexport_from_other_package.snap
+++ b/compiler-core/src/docs/snapshots/gleam_core__docs__tests__use_reexport_from_other_package.snap
@@ -24,4 +24,4 @@ pub fn do_thing(value: api.External) {
 ---- VALUES
 
 --- do_thing
-<pre><code>pub fn do_thing(value: <a href="https://hexdocs.pm/some_package/1.0.0/some_package/api.html#External" title="some_package/api.{type External}">api.External</a>) -> <a href="https://hexdocs.pm/some_package/1.0.0/some_package/api.html#External" title="some_package/api.{type External}">api.External</a></code></pre>
+<pre><code>pub fn do_thing(value: <a href="https://some-package.hexdocs.pm/1.0.0/some_package/api.html#External" title="some_package/api.{type External}">api.External</a>) -> <a href="https://some-package.hexdocs.pm/1.0.0/some_package/api.html#External" title="some_package/api.{type External}">api.External</a></code></pre>

--- a/compiler-core/templates/documentation_layout.html
+++ b/compiler-core/templates/documentation_layout.html
@@ -12,7 +12,7 @@
          between multiple versions of the same package. -->
     <script src="{{ unnest }}/docs_config.js"></script>
     <link id="syntax-theme" rel="stylesheet" href="{{ unnest }}/css/atom-one-light.min.css?v={{ gleam_version }}"/>
-    {% if !host.is_empty() && !project_name.is_empty() -%}<link rel="canonical" href="{{ host }}/{{ project_name|safe }}/{{ file_path|safe }}" />{%- endif %}
+    {% if !url.is_empty() -%}<link rel="canonical" href="{{url|safe}}/{{ file_path|safe }}" />{%- endif %}
   </head>
   <body class="prewrap-off theme-light drawer-closed">
     <script>

--- a/hexpm/CONTRIBUTING.md
+++ b/hexpm/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Adding a New API Function
 
 1. Figure out what you want to do
-    - Go to https://hexdocs.pm/hex/Mix.Tasks.Hex.html and find what you want to do
+    - Go to https://hex.hexdocs.pm/Mix.Tasks.Hex.html and find what you want to do
 2. Once you find the page, click on the code icon on the top-right to go to the corresponding source code like so: https://github.com/hexpm/hex/blob/main/lib/mix/tasks/hex.owner.ex#L125
 ```elixir
   defp transfer_owner(organization, package, owner) do

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -2087,9 +2087,10 @@ fn format_hexdocs_link_section(
     module_name: &str,
     name: Option<&str>,
 ) -> String {
+    let package_name = package_name.replace('_', "-");
     let link = match name {
-        Some(name) => format!("https://hexdocs.pm/{package_name}/{module_name}.html#{name}"),
-        None => format!("https://hexdocs.pm/{package_name}/{module_name}.html"),
+        Some(name) => format!("https://{package_name}.hexdocs.pm/{module_name}.html#{name}"),
+        None => format!("https://{package_name}.hexdocs.pm/{module_name}.html"),
     };
     format!("\nView on [HexDocs]({link})")
 }

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -302,7 +302,7 @@ fn main() {
 
 #[test]
 fn hover_external_imported_function_nested_module() {
-    // Example of HexDocs link with nested modules: https://hexdocs.pm/lustre/lustre/element/svg.html
+    // Example of HexDocs link with nested modules: https://lustre.hexdocs.pm/lustre/element/svg.html
     let code = "
 import my/nested/example_module
 fn main() {

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_expression.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_expression.snap
@@ -16,4 +16,4 @@ pub fn main() {
 wobble.Wibble
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/wibble/wobble.html#Wibble)
+View on [HexDocs](https://hex.hexdocs.pm/wibble/wobble.html#Wibble)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_unqualified_import.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_contextual_type_unqualified_import.snap
@@ -12,4 +12,4 @@ import wibble/wobble.{type Wibble as Wobble, Wobble}
 Wobble
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/wibble/wobble.html#Wobble)
+View on [HexDocs](https://hex.hexdocs.pm/wibble/wobble.html#Wobble)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_function_with_another_value_same_name.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_function_with_another_value_same_name.snap
@@ -16,4 +16,4 @@ fn main() {
 Int
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)
+View on [HexDocs](https://hex.hexdocs.pm/b/example_module.html#my_const)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_constants.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_constants.snap
@@ -15,4 +15,4 @@ fn main() {
 Int
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_const)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_ffi_renamed_function.snap
@@ -15,4 +15,4 @@ fn main() {
 fn() -> Nil
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_fn)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_function.snap
@@ -15,4 +15,4 @@ fn main() {
 fn() -> Nil
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_fn)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_function_nested_module.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_function_nested_module.snap
@@ -15,4 +15,4 @@ fn main() {
 fn() -> Nil
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/my/nested/example_module.html#my_fn)
+View on [HexDocs](https://hex.hexdocs.pm/my/nested/example_module.html#my_fn)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_function_renamed_module.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_function_renamed_module.snap
@@ -15,4 +15,4 @@ fn main() {
 fn() -> Nil
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_fn)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_unqualified_constants.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_unqualified_constants.snap
@@ -15,4 +15,4 @@ fn main() {
 Int
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_const)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_const)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_unqualified_function.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_imported_unqualified_function.snap
@@ -15,4 +15,4 @@ fn main() {
 fn() -> Nil
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_fn)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_unqualified_imported_function_renamed_module.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_unqualified_imported_function_renamed_module.snap
@@ -15,4 +15,4 @@ fn main() {
 fn() -> Nil
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_fn)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_fn)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_external_value_with_two_modules_same_name.snap
@@ -16,4 +16,4 @@ fn main() {
 Int
 ```
 
-View on [HexDocs](https://hexdocs.pm/hex/b/example_module.html#my_const)
+View on [HexDocs](https://hex.hexdocs.pm/b/example_module.html#my_const)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_import_unqualified_value_from_hex.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_import_unqualified_value_from_hex.snap
@@ -17,4 +17,4 @@ Int
  Exciting documentation
  Maybe even multiple lines
 
-View on [HexDocs](https://hexdocs.pm/hex/example_module.html#my_num)
+View on [HexDocs](https://hex.hexdocs.pm/example_module.html#my_num)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_imported_module.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_imported_module.snap
@@ -15,4 +15,4 @@ wibble
  Here is some documentation about it.
  This module does stuff
 
-View on [HexDocs](https://hexdocs.pm/hex/wibble.html)
+View on [HexDocs](https://hex.hexdocs.pm/wibble.html)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_module_name.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_module_name.snap
@@ -19,4 +19,4 @@ wibble
  Here is some documentation about it.
  This module does stuff
 
-View on [HexDocs](https://hexdocs.pm/hex/wibble.html)
+View on [HexDocs](https://hex.hexdocs.pm/wibble.html)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_module_name_in_annotation.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_module_name_in_annotation.snap
@@ -19,4 +19,4 @@ wibble
  Here is some documentation about it.
  This module does stuff
 
-View on [HexDocs](https://hexdocs.pm/hex/wibble.html)
+View on [HexDocs](https://hex.hexdocs.pm/wibble.html)

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_module_with_path.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__hover__hover_over_module_with_path.snap
@@ -17,4 +17,4 @@ wibble/wobble
 ```
  The module documentation
 
-View on [HexDocs](https://hexdocs.pm/hex/wibble/wobble.html)
+View on [HexDocs](https://hex.hexdocs.pm/wibble/wobble.html)

--- a/test-community-packages/README.md
+++ b/test-community-packages/README.md
@@ -1,7 +1,7 @@
 # test_community_packages
 
 [![Package Version](https://img.shields.io/hexpm/v/test_community_packages)](https://hex.pm/packages/test_community_packages)
-[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/test_community_packages/)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://test-community-packages.hexdocs.pm/)
 
 ```sh
 gleam add test_community_packages
@@ -14,7 +14,7 @@ pub fn main() {
 }
 ```
 
-Further documentation can be found at <https://hexdocs.pm/test_community_packages>.
+Further documentation can be found at <https://test-community-packages.hexdocs.pm>.
 
 ## Development
 

--- a/test/publishing_default_readme/README.md
+++ b/test/publishing_default_readme/README.md
@@ -1,7 +1,7 @@
 # default_readme
 
 [![Package Version](https://img.shields.io/hexpm/v/default_readme)](https://hex.pm/packages/default_readme)
-[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/default_readme/)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://default-readme.hexdocs.pm/)
 
 ```sh
 gleam add default_readme@1
@@ -14,7 +14,7 @@ pub fn main() -> Nil {
 }
 ```
 
-Further documentation can be found at <https://hexdocs.pm/default_readme>.
+Further documentation can be found at <https://default-readme.hexdocs.pm>.
 
 ## Development
 


### PR DESCRIPTION
- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

This PR updates the build tool to generate code using the new Hexdocs URL format.