### PR TITLE
fix: handle Windows error message for missing README file

### DIFF
--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -152,7 +152,8 @@ fn check_for_invalid_readme(config: &PackageConfig, paths: &ProjectPaths) -> Res
     let project_readme = match fs::read(paths.readme()) {
         Err(Error::FileIo {
             err: Some(message), ..
-        }) if message.contains("No such file or directory") => {
+        }) if message.contains("No such file or directory")
+            || message.contains("The system cannot find the file") => {
             return Err(Error::CannotPublishWithInvalidReadme {
                 reason: InvalidReadmeReason::Missing,
             });


### PR DESCRIPTION
This is an independent contribution and is not associated with any hackathon or competition.

## Summary

The  function matches on the OS error message string to detect when a README file is missing. This string is platform-dependent, causing the match to fail on Windows where the error message uses a different format.

## Root Cause

In `compiler-cli/src/publish.rs`, the pattern match:
```rust
}) if message.contains("No such file or directory") => {
```

This only matches the Unix error message. On Windows, `std::io::Error::to_string()` produces a different message (`"The system cannot find the file specified. (os error 2)"`), so the guard fails and the error falls through to the generic error handler.

## Fix

Added a secondary condition to also match the Windows error message:

```rust
}) if message.contains("No such file or directory")
    || message.contains("The system cannot find the file") => {
```

## Testing

Existing tests should continue to pass. The fix cannot be unit tested without Windows CI, but the change is trivially correct — it adds an additional string match that does not affect the existing Unix path.

Closes #5752