### PR TITLE
Fix stale module cache detection

### DIFF
--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -66,15 +66,18 @@ where
             return read_source(name).map(Input::New);
         }
 
-        // If the timestamp of the source is newer than the cache entry and
-        // the hash of the source differs from the one in the cache entry,
-        // then we need to recompile.
-        if meta.mtime < source_mtime {
+        let lsp_incomplete_module =
+            self.mode == Mode::Lsp && self.incomplete_modules.contains(&name);
+
+        // If the timestamp of the source differs from the timestamp recorded
+        // in the cache then verify the source fingerprint. The mtime can move
+        // backwards, such as after a checkout or timestamp-preserving copy.
+        if meta.mtime != source_mtime || lsp_incomplete_module {
             let source_module = read_source(name.clone())?;
             if meta.fingerprint != SourceFingerprint::new(&source_module.code) {
                 tracing::debug!(?name, "cache_stale");
                 return Ok(Input::New(source_module));
-            } else if self.mode == Mode::Lsp && self.incomplete_modules.contains(&name) {
+            } else if lsp_incomplete_module {
                 // Since the lsp can have valid but incorrect intermediate code states between
                 // successful compilations, we need to invalidate the cache even if the fingerprint matches
                 tracing::debug!(?name, "cache_stale for lsp");

--- a/compiler-core/src/build/module_loader/tests.rs
+++ b/compiler-core/src/build/module_loader/tests.rs
@@ -82,6 +82,25 @@ fn cache_present_and_stale_but_source_is_the_same() {
 }
 
 #[test]
+fn cache_present_and_stale_with_older_mtime() {
+    let name = "package".into();
+    let artefact = Utf8Path::new("/artefact");
+    let fs = InMemoryFileSystem::new();
+    let warnings = WarningEmitter::null();
+    let incomplete_modules = HashSet::new();
+    let loader = make_loader(&warnings, &name, &fs, artefact, &incomplete_modules);
+
+    // The source mtime has moved backwards, but the contents have changed.
+    write_src(&fs, TEST_SOURCE_2, "/src/main.gleam", 0);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
+
+    let file = GleamFile::new("/src".into(), "/src/main.gleam".into());
+    let result = loader.load(file).unwrap();
+
+    assert!(result.is_new());
+}
+
+#[test]
 fn cache_present_and_stale_source_is_the_same_lsp_mode() {
     let name = "package".into();
     let artefact = Utf8Path::new("/artefact");
@@ -114,6 +133,26 @@ fn cache_present_and_stale_source_is_the_same_lsp_mode_and_invalidated() {
 
     // The mtime of the source is newer than that of the cache
     write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 2);
+    write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
+
+    let file = GleamFile::new("/src".into(), "/src/main.gleam".into());
+    let result = loader.load(file).unwrap();
+
+    assert!(result.is_new());
+}
+
+#[test]
+fn cache_present_and_same_mtime_lsp_mode_and_invalidated() {
+    let name = "package".into();
+    let artefact = Utf8Path::new("/artefact");
+    let fs = InMemoryFileSystem::new();
+    let warnings = WarningEmitter::null();
+    let mut incomplete_modules = HashSet::new();
+    let _ = incomplete_modules.insert("main".into());
+    let mut loader = make_loader(&warnings, &name, &fs, artefact, &incomplete_modules);
+    loader.mode = Mode::Lsp;
+
+    write_src(&fs, TEST_SOURCE_1, "/src/main.gleam", 1);
     write_cache(&fs, TEST_SOURCE_1, "/artefact/main.cache_meta", 1, false);
 
     let file = GleamFile::new("/src".into(), "/src/main.gleam".into());


### PR DESCRIPTION
## Summary

Fix module cache invalidation when a source file timestamp differs from the cached timestamp but moves backwards rather than forwards.

## Root cause

The module loader only rechecked the source fingerprint when the source mtime was newer than the cached mtime. If a checkout or timestamp-preserving copy changed file contents while giving the source an older timestamp, Gleam could incorrectly reuse stale cached module metadata.

## Changes

- Recheck the source fingerprint whenever the source mtime differs from the cached mtime.
- Keep the fast cached path for matching mtimes.
- Ensure LSP incomplete modules are invalidated even when mtimes match.
- Add regression tests for backward-mtime source changes and same-mtime LSP invalidation.

## Validation

- `cargo test -p gleam-core build::module_loader::tests --quiet`
- `cargo test -p gleam-core --quiet`
- `cargo fmt --check`
- `cargo test --quiet --workspace --exclude test-output`

Full `cargo test --quiet` was also attempted, but local `test-output` tests require `bun`, which is not installed in this environment.