### PR TITLE
Remove duplicate changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-### Bug Fixes
-
 ### Compiler
 
 ### Build tool


### PR DESCRIPTION
When resetting the changelog, looks like you accidentally left and extra "Bug fixes" heading in there.