### PR TITLE
Fix duplicate let when rebinding after a directly matching case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,3 +243,8 @@
   ```
 
   ([Gavin Morrow](https://github.com/gavinmorrow))
+
+- Fixed a bug where the JavaScript code generator could produce duplicate `let`
+  declarations when a variable was reassigned after being shadowed inside a
+  directly matching `case` branch.
+  ([Eyup Can Akman](https://github.com/eyupcanakman))

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -456,28 +456,13 @@ impl<'a> CasePrinter<'_, '_, 'a, '_> {
             match &self.kind {
                 DecisionKind::Case { .. } => {
                     // Restore the user variables that were in scope before the
-                    // branch. The synthesised counters are left advanced.
+                    // branch. The synthesised counters are left advanced, and
+                    // the high-water marks keep any user variable that leaked
+                    // out of the branch from being redeclared by a later `let`.
                     self.variables
                         .expression_generator
                         .current_scope
                         .restore_user_variables(&old_user_variables);
-
-                    // For binded variables inside body we need to check if
-                    // there is same-named variable in old scope. In this case
-                    // we need to register next available variable, so no
-                    // redeclaration occurs.
-                    if let Decision::Run { body } = fallback {
-                        for (variable, _) in body.bindings.iter() {
-                            if old_user_variables.get(variable).is_some() {
-                                let new_variable_name = self.variables.next_local_var(variable);
-
-                                self.variables
-                                    .expression_generator
-                                    .current_scope
-                                    .set_counter(&new_variable_name, 0);
-                            }
-                        }
-                    }
                 }
                 DecisionKind::LetAssert { .. } => {}
             }

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -144,6 +144,10 @@ impl CurrentFunction {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Scope {
     user_variables: im::HashMap<EcoString, usize>,
+    /// The highest suffix handed out for each user variable still declared in
+    /// the current JS scope, kept across a directly matching `case` branch so a
+    /// variable that leaked out of it is not redeclared by a later `let`.
+    high_water: im::HashMap<EcoString, usize>,
     assignment: Option<usize>,
     pipe: Option<usize>,
     block: Option<usize>,
@@ -191,6 +195,21 @@ impl Scope {
             _ => {
                 let _ = self.user_variables.insert(name.clone(), value);
             }
+        }
+    }
+
+    /// Advance the counter for a name to its next suffix, skipping any suffix
+    /// already handed out for it in the current scope so a name that leaked out
+    /// of a directly matching branch can't be redeclared.
+    fn advance_counter(&mut self, name: &EcoString) {
+        let in_scope = self.counter(name).map_or(0, |i| i + 1);
+        let high_water = self.high_water.get(name).map_or(0, |i| i + 1);
+        let next = in_scope.max(high_water);
+        self.set_counter(name, next);
+        // Only user variables leak out of a directly matching branch; the
+        // synthesised counters survive the restore on their own.
+        if self.user_variables.contains_key(name) {
+            let _ = self.high_water.insert(name.clone(), next);
         }
     }
 
@@ -314,8 +333,7 @@ impl<'module, 'a> Generator<'module, 'a> {
     }
 
     pub fn next_local_var(&mut self, name: &EcoString) -> EcoString {
-        let next = self.current_scope.counter(name).map_or(0, |i| i + 1);
-        self.current_scope.set_counter(name, next);
+        self.current_scope.advance_counter(name);
         self.local_var(name)
     }
 

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -1061,6 +1061,26 @@ pub fn go() {
     )
 }
 
+// https://github.com/gleam-lang/gleam/issues/5748
+#[test]
+fn no_duplicate_let_when_rebinding_variable_after_directly_matching_case() {
+    assert_js!(
+        r#"
+pub fn go() {
+  let n = 1
+  case True {
+    True -> {
+      let n = 99
+      n
+    }
+    False -> 0
+  }
+  let n = n + 5
+  n
+}"#
+    )
+}
+
 #[test]
 fn semicolon_exists_with_directly_matching_case() {
     assert_js!(

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__no_duplicate_let_when_rebinding_variable_after_directly_matching_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__no_duplicate_let_when_rebinding_variable_after_directly_matching_case.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go() {\n  let n = 1\n  case True {\n    True -> {\n      let n = 99\n      n\n    }\n    False -> 0\n  }\n  let n = n + 5\n  n\n}"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  let n = 1
+  case True {
+    True -> {
+      let n = 99
+      n
+    }
+    False -> 0
+  }
+  let n = n + 5
+  n
+}
+
+----- COMPILED JAVASCRIPT
+export function go() {
+  let n = 1;
+  let $ = true;
+  let n$1 = 99;
+  n$1;
+  let n$2 = n + 5;
+  return n$2;
+}

--- a/test/language/test/language/directly_matching_case_subject_test.gleam
+++ b/test/language/test/language/directly_matching_case_subject_test.gleam
@@ -73,3 +73,20 @@ pub fn no_duplicate_pipe_variable_with_case_in_pipeline_test() {
     |> add_one
   assert result == 2
 }
+
+// https://github.com/gleam-lang/gleam/issues/5748
+pub fn no_duplicate_let_when_rebinding_variable_after_directly_matching_case_test() {
+  let result = {
+    let n = 1
+    case True {
+      True -> {
+        let n = 99
+        n
+      }
+      False -> 0
+    }
+    let n = n + 5
+    n
+  }
+  assert result == 6
+}


### PR DESCRIPTION
When a variable is shadowed inside a directly matching `case` branch and then rebound after the case, the JavaScript code generator could declare the same `let` variable twice in one scope. That is a `SyntaxError`.

A directly matching branch generates its code into the enclosing scope, so a `let` inside it leaks out. The user variable counter is reset on branch exit so later references resolve to the outer binding, but a later `let` then declared the leaked name again. The generator now keeps the highest counter used for a name and does not go below it, which removes the extra check added in #5493.

Fixes #5748.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
