### PR TITLE
fix completions for types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,8 @@
 
   ([Gavin Morrow](https://github.com/gavinmorrow))
 
-- Fixed a bug where the language server would insert the wrong text when
-  triggering a completion on types that are halfway complete.
+- Work around an ambiguity of the language server protocol that resulted in
+  editors like Zed inserting the wrong text when accepting type completions.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
 - Fixed a bug where the compiler would raise a warning for truncated int

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@
 
   ([Gavin Morrow](https://github.com/gavinmorrow))
 
+- Fixed a bug where the language server would insert the wrong text when
+  triggering a completion on types that are halfway complete.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where the compiler would raise a warning for truncated int
   segments when compiling a function with a JavaScript external.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -237,16 +237,11 @@ impl CursorSurroundings {
         let remaining_label = new_text
             .strip_prefix(self.text_before_cursor.as_str())
             .and_then(|rest| rest.strip_suffix(self.text_after_cursor.as_str()));
-
         match remaining_label {
-            // The entire existing text is already the same as the new text we
-            // might want to add.
-            // In that case there's no need to perform any edit at all!
-            Some("") => None,
-
-            // This is one of the cases (like the one in the example above) were
-            // the label is a more complete version of the text surrounding the
-            // cursor. So we replace the entire range.
+            // The entire existing label is already the same as the text we want
+            // to add or (like in the example above) a more complete version of
+            // the text surrounding the cursor.
+            // So we replace the entire range with the new suggestion.
             Some(_) => Some(CompletionItemTextEdit::TextEdit(TextEdit {
                 range: self.surrounding_text_range,
                 new_text,

--- a/language-server/src/tests/completion.rs
+++ b/language-server/src/tests/completion.rs
@@ -2693,3 +2693,21 @@ pub type Wibble {
         Position::new(3, 20)
     );
 }
+
+#[test]
+fn _completions_for_deprecated_types_in_dep() {
+    let code = "
+import wibble
+
+pub fn wobble() -> wibble.Wobble {
+  todo
+}
+";
+    let dep = "pub type Wobble";
+
+    assert_apply_completion!(
+        TestProject::for_source(code).add_module("wibble", dep),
+        "wibble.Wobble",
+        Position::new(3, 25)
+    );
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion___completions_for_deprecated_types_in_dep.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion___completions_for_deprecated_types_in_dep.snap
@@ -1,0 +1,19 @@
+---
+source: language-server/src/tests/completion.rs
+expression: "\nimport wibble\n\npub fn wobble() -> wibble.Wobble {\n  todo\n}\n"
+---
+
+import wibble
+
+pub fn wobble() -> wibble|.Wobble {
+  todo
+}
+
+
+----- After applying completion -----
+
+import wibble
+
+pub fn wobble() -> wibble.Wobble {
+  todo
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completion_for_type.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__completion_for_type.snap
@@ -10,4 +10,6 @@ wibble.Wibble
   kind:   Class
   detail: Type
   sort:   6_wibble.Wibble
+  edits:
+    [0:16-0:29]: "wibble.Wibble"
     [0:0-0:0]: "import wibble\n\n"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot.snap
@@ -16,3 +16,5 @@ dep.Zoo
   kind:   Class
   detail: Type
   sort:   4_dep.Zoo
+  edits:
+    [3:5-3:12]: "dep.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_matching_modules.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_matching_modules.snap
@@ -17,3 +17,5 @@ dep.Zoo
   kind:   Class
   detail: Type
   sort:   4_dep.Zoo
+  edits:
+    [4:5-4:12]: "dep.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_modules.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_after_dot_other_modules.snap
@@ -16,3 +16,5 @@ dep.Zoo
   kind:   Class
   detail: Type
   sort:   4_dep.Zoo
+  edits:
+    [3:5-3:12]: "dep.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_mid_phrase_other_modules.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__imported_type_cursor_mid_phrase_other_modules.snap
@@ -16,3 +16,5 @@ dep.Zoo
   kind:   Class
   detail: Type
   sort:   4_dep.Zoo
+  edits:
+    [3:5-3:12]: "dep.Zoo"

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_case_expression.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_case_expression.snap
@@ -42,6 +42,8 @@ main
 todo
   kind:   Keyword
   sort:   00_todo
+  edits:
+    [3:24-3:28]: "todo"
 wibble
   kind:   Variable
   detail: Bool

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_inside_nested_exprs.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__local_variable_inside_nested_exprs.snap
@@ -42,3 +42,5 @@ wibble
   detail: fn() -> a
   sort:   3_wibble
   desc:   app
+  edits:
+    [5:4-5:10]: "wibble"


### PR DESCRIPTION
I noticed that completions were a bit messed up when accepting a completion for a type after having it written in full: `set.|Set` would turn out to be `set.set.Set`. This PR fixes it!

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
