### PR TITLE
make sure the int in js bound warning is raised for js functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   Matching on a literal suffix is not possible, because `infix` would have an
   unknown size.
   ```
+
   ([Gavin Morrow](https://github.com/gavinmorrow))
 
 - Improved the error message shown when using an invalid discard name for
@@ -68,6 +69,6 @@
 
   ([Gavin Morrow](https://github.com/gavinmorrow))
 
-- Fixed a bug where the compiler would raise a warning for truncated integer
-  segments when compiling a function with a JavaScript external.
+- Fixed a bug where the compiler would raise a warning for truncated int
+segments when compiling a function with a JavaScript external.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
   Matching on a literal suffix is not possible, because `infix` would have an
   unknown size.
   ```
-
   ([Gavin Morrow](https://github.com/gavinmorrow))
 
 - Improved the error message shown when using an invalid discard name for
@@ -68,3 +67,7 @@
   ```
 
   ([Gavin Morrow](https://github.com/gavinmorrow))
+
+- Fixed a bug where the compiler would raise a warning for truncated integer
+  segments when compiling a function with a JavaScript external.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -1539,10 +1539,17 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
     /// bigger would result in the number being truncated.
     ///
     fn check_matched_int_is_in_js_bounds(&mut self, segment: &TypedPatternBitArraySegment) {
-        // This only makes sense to check on the js target
+        // This only makes sense to check on the js target.
+        if self.environment.target != Target::JavaScript {
+            return;
+        }
+        // And if the current function doesn't have a JavaScript external.
+        if self.current_function.has_javascript_external {
+            return;
+        }
         // And if the segment actually defines a variable that would end up
         // being truncated and that is an int!
-        if self.environment.target != Target::JavaScript || !segment.type_.is_int() {
+        if !segment.type_.is_int() {
             return;
         }
         let (Pattern::Assign { .. } | Pattern::Variable { .. }) = segment.value.as_ref() else {

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -5005,6 +5005,24 @@ pub fn go(x: BitArray) {
     );
 }
 
+#[test]
+fn bit_array_match_on_bytes_for_erlang_does_not_complain_about_int_size() {
+    assert_js_no_warnings!(
+        r#"
+pub fn main() -> Nil {
+  echo wibble(<<1, 2, 3, 4, 5, 6, 7, 8>>)
+  Nil
+}
+
+@external(javascript, "./ffi.mjs", "wibble")
+fn wibble(bits: BitArray) -> Int {
+  let assert <<x:64>> = bits
+  x
+}
+"#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/5599
 #[test]
 fn bit_array_size_constant() {


### PR DESCRIPTION
Fixes #5674 
- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
