### PR TITLE
add tests for unreachable use statement after panic

### DIFF
--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_fn_statement_after_panic.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_fn_statement_after_panic.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() -> Nil {\n  panic\n  use <- fn(_) { Nil }\n  1\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() -> Nil {
+  panic
+  use <- fn(_) { Nil }
+  1
+}
+
+
+----- WARNING
+warning: Unreachable code
+  ┌─ /src/warning/wrn.gleam:4:3
+  │  
+4 │ ╭   use <- fn(_) { Nil }
+5 │ │   1
+  │ ╰───^
+
+This code is unreachable because it comes after a `panic`.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_statement_after_panic.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_statement_after_panic.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  panic\n  use <- wibble\n  1\n}\n\nfn wibble(f) { f() }\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  panic
+  use <- wibble
+  1
+}
+
+fn wibble(f) { f() }
+
+
+----- WARNING
+warning: Unreachable code
+  ┌─ /src/warning/wrn.gleam:4:3
+  │  
+4 │ ╭   use <- wibble
+5 │ │   1
+  │ ╰───^
+
+This code is unreachable because it comes after a `panic`.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1809,6 +1809,35 @@ fn unreachable_warning_if_all_branches_panic() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5683
+#[test]
+fn unreachable_use_statement_after_panic() {
+    assert_warning!(
+        "
+pub fn main() {
+  panic
+  use <- wibble
+  1
+}
+
+fn wibble(f) { f() }
+"
+    );
+}
+
+#[test]
+fn unreachable_use_fn_statement_after_panic() {
+    assert_warning!(
+        "
+pub fn main() -> Nil {
+  panic
+  use <- fn(_) { Nil }
+  1
+}
+"
+    );
+}
+
 #[test]
 fn unreachable_warning_if_all_branches_panic_2() {
     assert_warning!(


### PR DESCRIPTION
This PR fixes #5683 
Actually I can't seem to replicate the bad error message, it seems like something has changed after the issue was created. The warning seems to look good to me highlighting the use block. So I've just added some tests to make sure it remains like this!

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
