### PR TITLE
Fix duplicate use callback deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Compiler
 
+- The compiler no longer emits duplicate deprecation warnings for calls inside
+  `use` callbacks.
+  ([Puneet Dixit](https://github.com/puneetdixit200))
+
 - The compiler now issues a friendlier error when attempting to pattern match
   on both the prefix and suffix of a string:
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4744,6 +4744,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         return_annotation: Option<TypeAst>,
         location: SrcSpan,
     ) -> TypedExpr {
+        let previous_warnings = self.problems.take_warnings();
+
         let typed_call_arguments: Vec<Arc<Type>> = call_arguments
             .iter()
             .map(|argument| {
@@ -4754,6 +4756,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .type_()
             })
             .collect_vec();
+
+        // These expressions are inferred again by the call inference, so ignore
+        // warnings emitted by this contextual pass to avoid reporting them twice.
+        drop(self.problems.take_warnings());
+        for warning in previous_warnings {
+            self.problems.warning(warning);
+        }
+
         self.infer_fn(
             arguments,
             &typed_call_arguments,

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -1017,6 +1017,30 @@ pub fn a() {
 }
 
 #[test]
+fn use_callback_deprecation_warning_once() {
+    // https://github.com/gleam-lang/gleam/issues/3899
+    let warnings = get_warnings(
+        r#"
+@deprecated("Don't use this!")
+pub fn old() {
+  Nil
+}
+
+pub fn main() {
+  use <- fn(f) { f() }
+
+  old()
+}
+"#,
+        vec![],
+        Target::Erlang,
+        None,
+    );
+
+    assert_eq!(warnings.len(), 1, "{warnings:#?}");
+}
+
+#[test]
 fn deprecated_imported_unqualified_function() {
     assert_warning!(
         (


### PR DESCRIPTION
## Summary
- Discard warnings emitted by the contextual call-argument inference pass for `use` callbacks, since those expressions are inferred again by the normal call path.
- Add regression coverage for deprecation warnings inside a `use` callback.
- Update the changelog.

Fixes #3899

## Tests
- `cargo test -p gleam-core use_callback_deprecation_warning_once`
- `cargo test -p gleam-core type_::tests::warnings::`
- `cargo fmt --check`