### PR TITLE
make sure fields named constructor are escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,10 @@
   formatted incorrectly.
   ([Louis Pilfold](https://github.com/lpil))
 
+- Fixed a bug where the compiler would generate invalid TypeScript type
+  definitions for records with a field named `constructor`.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - Fixed a bug where the compiler would raise a warning for truncated int
   segments when compiling a function with a JavaScript external.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -1047,3 +1047,26 @@ pub fn is_wobble_active(s: WobbleStatus) -> Bool {
 "#,
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/5613
+#[test]
+pub fn type_with_constructor_as_field_is_properly_escaped() {
+    assert_js!(
+        "
+pub type Box {
+  Box(constructor: Int)
+}
+"
+    )
+}
+
+#[test]
+fn type_with_constructor_as_field_is_properly_escaped_in_ts_def() {
+    assert_ts_def!(
+        r#"
+pub type Box {
+  Box(constructor: Int)
+}
+"#,
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__type_with_constructor_as_field_is_properly_escaped.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__type_with_constructor_as_field_is_properly_escaped.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Box {\n  Box(constructor: Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Box {
+  Box(constructor: Int)
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+export class Box extends $CustomType {
+  constructor(constructor) {
+    super();
+    this.constructor$ = constructor;
+  }
+}
+export const Box$Box = (constructor) => new Box(constructor);
+export const Box$isBox = (value) => value instanceof Box;
+export const Box$Box$constructor = (value) => value.constructor$;
+export const Box$Box$0 = (value) => value.constructor$;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__type_with_constructor_as_field_is_properly_escaped_in_ts_def.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__type_with_constructor_as_field_is_properly_escaped_in_ts_def.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub type Box {\n  Box(constructor: Int)\n}\n"
+---
+----- SOURCE CODE
+
+pub type Box {
+  Box(constructor: Int)
+}
+
+
+----- TYPESCRIPT DEFINITIONS
+import type * as _ from "../gleam.d.mts";
+
+export class Box extends _.CustomType {
+  /** @deprecated */
+  constructor(constructor: number);
+  /** @deprecated */
+  constructor$: number;
+}
+export function Box$Box(constructor: number): Box$;
+export function Box$isBox(value: any): value is Box$;
+export function Box$Box$0(value: Box$): number;
+export function Box$Box$constructor(value: Box$): number;
+
+export type Box$ = Box;

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -585,7 +585,7 @@ impl<'a> TypeScriptGenerator<'a> {
                     let name = arg
                         .label
                         .as_ref()
-                        .map(|(_, s)| super::maybe_escape_identifier(s))
+                        .map(|(_, s)| super::maybe_escape_property(s))
                         .unwrap_or_else(|| eco_format!("{i}"))
                         .to_doc();
                     docvec![

--- a/test/language/test/language/record_with_field_named_constructor.gleam
+++ b/test/language/test/language/record_with_field_named_constructor.gleam
@@ -1,0 +1,9 @@
+pub type Box {
+  Box(constructor: Int)
+}
+
+pub fn record_with_constructor_as_field_can_be_built_on_js_with_no_crash_test() {
+  let one = Box(1)
+  let other = Box(1)
+  assert one == other
+}


### PR DESCRIPTION
This PR fixes #5613 

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
