### PR TITLE
Improve the error message when a Hex release is too large to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   `package.hexdocs.pm` rather than `hexdocs.pm/package`.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The build tool now shows a clearer error message when publishing to Hex
+  fails because the release tarball is too large.
+  ([kyo5uke](https://github.com/kyo5uke))
+
 ### Language server
 
 - The "pattern match on value" code action can now be used to pattern match on

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -272,7 +272,8 @@ impl PackageFetchError {
             | hexpm::ApiError::IncorrectChecksum
             | hexpm::ApiError::Forbidden
             | hexpm::ApiError::NotReplacing
-            | hexpm::ApiError::LateModification => Self::ApiError(api_error),
+            | hexpm::ApiError::LateModification
+            | hexpm::ApiError::ReleaseTooLarge => Self::ApiError(api_error),
         }
     }
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -534,6 +534,7 @@ impl Error {
             | hexpm::ApiError::Forbidden
             | hexpm::ApiError::NotReplacing
             | hexpm::ApiError::LateModification
+            | hexpm::ApiError::ReleaseTooLarge
             | hexpm::ApiError::OAuthTimeout
             | hexpm::ApiError::OAuthAccessDenied
             | hexpm::ApiError::ExpiredToken => Self::Hex(error.to_string()),

--- a/compiler-core/src/hex.rs
+++ b/compiler-core/src/hex.rs
@@ -64,7 +64,8 @@ pub async fn publish_package<Http: HttpClient>(
         | ApiError::ExpiredToken
         | ApiError::OAuthRefreshTokenRejected
         | ApiError::IncorrectOneTimePassword
-        | ApiError::LateModification => Error::hex(e),
+        | ApiError::LateModification
+        | ApiError::ReleaseTooLarge => Error::hex(e),
     })
 }
 

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -552,6 +552,8 @@ pub fn api_publish_package_response(response: http::Response<Vec<u8>>) -> Result
                 Err(ApiError::NotReplacing)
             } else if body.contains("can only modify a release up to one hour after publication") {
                 Err(ApiError::LateModification)
+            } else if body.contains("too big") {
+                Err(ApiError::ReleaseTooLarge)
             } else {
                 Err(ApiError::UnexpectedResponse(
                     StatusCode::UNPROCESSABLE_ENTITY,
@@ -761,6 +763,9 @@ pub enum ApiError {
 
     #[error("Can only modify a release up to one hour after publication")]
     LateModification,
+
+    #[error("The release tarball is too large to be published to Hex. Try reducing its size.")]
+    ReleaseTooLarge,
 
     #[error("The oauth request wasn't approved in time")]
     OAuthTimeout,

--- a/hexpm/src/tests.rs
+++ b/hexpm/src/tests.rs
@@ -825,9 +825,25 @@ fn not_replacing() {
 }
 
 #[test]
+fn publish_package_response_too_large() {
+    let resp_body = json!({
+        "errors": {"tar": "too big"},
+        "message": "Validation error(s)",
+        "status": 422,
+    });
+    let response = make_json_response(422, resp_body);
+    let result = crate::api_publish_package_response(response);
+
+    match result {
+        Err(ApiError::ReleaseTooLarge) => (),
+        result => panic!("expected Err(ApiError::ReleaseTooLarge), got {result:?}"),
+    }
+}
+
+#[test]
 fn unknown_error_422() {
     let resp_body = json!({
-        "errors": {"tar": "file too big: metadata.config"},
+        "errors": {"name": "has already been taken"},
         "message": "Validation error(s)",
         "status": 422,
     });
@@ -838,8 +854,8 @@ fn unknown_error_422() {
         Err(ApiError::UnexpectedResponse(status, body)) => {
             assert_eq!(status, http::StatusCode::UNPROCESSABLE_ENTITY);
             assert!(
-                body.contains("file too big: metadata.config"),
-                "expected file too big string copied from hexpm error, got: {body}"
+                body.contains("has already been taken"),
+                "expected validation error string copied from hexpm error, got: {body}"
             );
         }
         result => panic!("expected Err(ApiError::UnexpectedResponse), got {result:?}"),


### PR DESCRIPTION
This improves the error shown by `gleam publish` when a release fails to upload
to Hex because the tarball is too large. Previously the build tool fell through
to the generic "unexpected response" handling and printed the raw `422` JSON
body; now it reports a clear message that the release tarball is too large to be
published.

Hex returns a `422 Unprocessable Entity` validation error in this case (the
`@tarball_max_size` limit). `api_publish_package_response` already inspects the
`422` body for the `--replace` and late-modification cases, so this follows the
same style and adds one more arm: a `"too big"` substring maps to a new
`ApiError::ReleaseTooLarge` variant. The substring matches both the server's
`{"errors": {"tar": "too big"}, ...}` form and the `"file too big: <name>"`
form, and is only checked inside the `422` branch after the existing `--replace`
and modify checks, so the collision risk is low.

The pre-existing `unknown_error_422` test used a `"file too big: ..."` body to
exercise the fall-through `UnexpectedResponse` path. Since that body is now
recognised as a too-large error, its body has been changed to a different,
still-unhandled `422` validation error so it keeps testing the fall-through.

A possible follow-up (left out to keep this focused) would be a dedicated
diagnostic that mentions the size limit, modelled on `HexPublishReplaceRequired`,
rather than reusing the generic "Hex API failure" diagnostic.

Verified locally with `cargo test -p hexpm` and `cargo test -p gleam-core`,
`cargo clippy --workspace` (with `-D warnings`), and `cargo fmt --check`, all
passing.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Closes #5744
