### PR TITLE
Singular phrasing for 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@
   now points to the attribute itself and explains that it is incomplete.
   ([Asish Kumar](https://github.com/officialasishkumar))
 
+- The "did you mean one of these:" hint is now phrased in singular when there
+  is only one suggestion, additionally multiple suggestions are listed
+  in a consistent alphabetical order.
+  ([Zbyněk Juřica](https://github.com/zbyju))
+
 ### Build tool
 
 - The build tool now generates Hexdocs URLs using the new format of

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -3528,7 +3528,12 @@ but no type in scope with that name."
                     // If there are some suggestions about public values in imported
                     // modules put a "did you mean" text after the main message
                     if !possible_modules.is_empty() {
-                        text.push_str("\nDid you mean one of these:\n\n");
+                        let message = if possible_modules.len() == 1 {
+                            "\nDid you mean:\n\n"
+                        } else {
+                            "\nDid you mean one of these:\n\n"
+                        };
+                        text.push_str(message);
                         for module_name in possible_modules {
                             text.push_str(&format!("  - {module_name}.{name}\n"))
                         }

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -583,6 +583,7 @@ impl Environment<'_> {
                 }
             })
             .cloned()
+            .sorted()
             .collect_vec()
     }
 
@@ -606,6 +607,7 @@ impl Environment<'_> {
                 }
             })
             .cloned()
+            .sorted()
             .collect_vec()
     }
 

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -4209,6 +4209,72 @@ pub fn main() {
 }
 
 #[test]
+fn unknown_variable_suggest_two_modules() {
+    assert_module_error!(
+        (
+            "wibble",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        (
+            "wobble",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// When multiple modules export a matching value the suggestion should be
+// pluralised.
+
+import wibble
+import wobble
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
+fn unknown_variable_suggest_three_modules() {
+    assert_module_error!(
+        (
+            "wibble",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        (
+            "wobble",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        (
+            "wabble",
+            "
+pub fn add(x: Int, y: Int) {
+    x + y
+}"
+        ),
+        "
+// When multiple modules export a matching value the suggestion should be
+// pluralised.
+
+import wibble
+import wobble
+import wabble
+pub fn main() {
+    add(1, 1)
+}"
+    );
+}
+
+#[test]
 pub fn clause_guard_is_fault_tolerant() {
     assert_module_error!(
         r#"

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -7,14 +7,14 @@ expression: "\n        import gleam/wibble.{wobble}\n        import gleam/wibble
 
             pub fn wobble() { 1 }
             pub fn zoo() { 1 }
-            
+
 
 -- main.gleam
 
         import gleam/wibble.{wobble}
         import gleam/wibble.{zoo}
         pub fn go() { wobble() + zoo() }
-        
+
 
 ----- ERROR
 error: Duplicate import
@@ -35,6 +35,6 @@ error: Unknown variable
   │                                  ^^^
 
 The name `zoo` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - wibble.zoo

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__same_imports_multiple_times.snap
@@ -7,14 +7,14 @@ expression: "\n        import gleam/wibble.{wobble}\n        import gleam/wibble
 
             pub fn wobble() { 1 }
             pub fn zoo() { 1 }
-
+            
 
 -- main.gleam
 
         import gleam/wibble.{wobble}
         import gleam/wibble.{zoo}
         pub fn go() { wobble() + zoo() }
-
+        
 
 ----- ERROR
 error: Duplicate import

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_function.snap
@@ -28,6 +28,6 @@ error: Unknown variable
   │     ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_record_constructor.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_record_constructor.snap
@@ -28,6 +28,6 @@ error: Unknown variable
   │     ^^^^^^^^
 
 The custom type variant constructor `MyRecord` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.MyRecord

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_type.snap
@@ -28,6 +28,6 @@ error: Unknown variable
   │     ^^^
 
 The custom type variant constructor `One` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.One

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_value.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_from_the_same_package_with_internal_value.snap
@@ -25,6 +25,6 @@ error: Unknown variable
   │     ^^^
 
 The name `one` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.one

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_imported_using_an_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_imported_using_an_alias.snap
@@ -27,6 +27,6 @@ error: Unknown variable
   │     ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - wibble.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_multiple_segments.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_multiple_segments.snap
@@ -27,6 +27,6 @@ error: Unknown variable
   │     ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_1.snap
@@ -26,6 +26,6 @@ error: Unknown variable
   │     ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_2.snap
@@ -26,6 +26,6 @@ error: Unknown variable
   │          ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_3.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_3.snap
@@ -26,6 +26,6 @@ error: Unknown variable
   │          ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_4.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_4.snap
@@ -27,6 +27,6 @@ error: Unknown variable
   │            ^^^^^^
 
 The name `wibble` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.wibble

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_even_if_arguments_type_mismatch.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_function_with_correct_arity_even_if_arguments_type_mismatch.snap
@@ -26,6 +26,6 @@ error: Unknown variable
   │     ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_record_constructor_with_correct_arity.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_record_constructor_with_correct_arity.snap
@@ -34,6 +34,6 @@ error: Unknown variable
   │     ^^^^^^^^
 
 The custom type variant constructor `MyRecord` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - moduletwo.MyRecord

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_type.snap
@@ -27,6 +27,6 @@ error: Unknown variable
   │     ^^^
 
 The custom type variant constructor `One` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.One

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_1.snap
@@ -24,6 +24,6 @@ error: Unknown variable
   │     ^^^
 
 The name `one` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.one

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_modules_with_public_value_2.snap
@@ -27,6 +27,6 @@ error: Unknown variable
   │     ^^^
 
 The name `add` is not in scope here.
-Did you mean one of these:
+Did you mean:
 
   - module.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_three_modules.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_three_modules.snap
@@ -1,0 +1,48 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// When multiple modules export a matching value the suggestion should be\n// pluralised.\n\nimport wibble\nimport wobble\nimport wabble\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- wibble.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- wobble.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- wabble.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// When multiple modules export a matching value the suggestion should be
+// pluralised.
+
+import wibble
+import wobble
+import wabble
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:9:5
+  │
+9 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - wabble.add
+  - wibble.add
+  - wobble.add

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_two_modules.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_variable_suggest_two_modules.snap
@@ -1,0 +1,40 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// When multiple modules export a matching value the suggestion should be\n// pluralised.\n\nimport wibble\nimport wobble\npub fn main() {\n    add(1, 1)\n}"
+---
+----- SOURCE CODE
+-- wibble.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- wobble.gleam
+
+pub fn add(x: Int, y: Int) {
+    x + y
+}
+
+-- main.gleam
+
+// When multiple modules export a matching value the suggestion should be
+// pluralised.
+
+import wibble
+import wobble
+pub fn main() {
+    add(1, 1)
+}
+
+----- ERROR
+error: Unknown variable
+  ┌─ /src/one/two.gleam:8:5
+  │
+8 │     add(1, 1)
+  │     ^^^
+
+The name `add` is not in scope here.
+Did you mean one of these:
+
+  - wibble.add
+  - wobble.add


### PR DESCRIPTION
- [ ] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked: https://github.com/gleam-lang/gleam/issues/5821
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Changes:
- Phrasing from "Did you mean one of these:" to "Did you mean:" if there is only 1 option to choose from
  - Changed all existing tests to the singular version
  - Added 2 new test cases for 2 and 3 possible modules
- Possible options are now alphabetically sorted (when collecting from the HashSet)
  - This wasn't strictly necessary, however, the tests for multiple options would be flaky as the order of these options was nondeterministic

AI: used AI to generate tests
