### PR TITLE
Register new advisory & create deadline system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "tar",
  "termcolor",
  "thiserror 2.0.18",
+ "time",
  "toml 0.9.11+spec-1.1.0",
  "tracing",
  "unicode-segmentation",

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -80,6 +80,8 @@ pretty_assertions.workspace = true
 insta.workspace = true
 # Random value generation
 rand = "0.9"
+# Time types
+time = "0.3"
 
 [build-dependencies]
 # Data (de)serialisation

--- a/compiler-core/src/tests.rs
+++ b/compiler-core/src/tests.rs
@@ -3,25 +3,32 @@ use std::path::PathBuf;
 use itertools::Itertools;
 use serde::Deserialize;
 
+#[derive(Deserialize)]
+struct CargoDenyConfig {
+    advisories: CargoDenyAdvisoriesConfig,
+    licenses: CargoDenyLicensesConfig,
+}
+
+#[derive(Deserialize)]
+struct CargoDenyLicensesConfig {
+    allow: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct CargoDenyAdvisoriesConfig {
+    ignore: Vec<CargoDenyIgnoreConfig>,
+}
+
+#[derive(Deserialize)]
+struct CargoDenyIgnoreConfig {
+    id: String,
+    reason: String,
+}
+
 #[test]
 fn licence_files_exist_in_repo() {
-    #[derive(Deserialize)]
-    struct CargoDenoConfig {
-        licenses: CargoDenoLicensesConfig,
-    }
-
-    #[derive(Deserialize)]
-    struct CargoDenoLicensesConfig {
-        allow: Vec<String>,
-    }
-
     // deny.toml specified which licences dependencies are permitted to have.
-    let toml = std::fs::read_to_string("../deny.toml").unwrap();
-    let CargoDenoConfig {
-        licenses: CargoDenoLicensesConfig {
-            allow: dependency_licences,
-        },
-    } = toml::from_str(&toml).unwrap();
+    let dependency_licences = load_cargo_deny_config().licenses.allow;
 
     // Each licence must exist in the licences directory.
     let licences_directory = PathBuf::from("../licences");
@@ -41,4 +48,43 @@ These licences are missing their file:
 
 {licences_missing_licence_file:?}"
     );
+}
+
+fn load_cargo_deny_config() -> CargoDenyConfig {
+    let toml = std::fs::read_to_string("../deny.toml").unwrap();
+    let config = toml::from_str(&toml).unwrap();
+    config
+}
+
+#[test]
+fn rust_advisories_ignore_deadlines() {
+    let today = time::OffsetDateTime::now_utc().date();
+    let regex = regex::Regex::new(r"(?m)^FIX-DEADLINE:\s*(\d{4})-(\d{2})-(\d{2})$").unwrap();
+
+    for ignored in load_cargo_deny_config().advisories.ignore {
+        let id = ignored.id;
+        let Some(deadline) = regex.captures(&ignored.reason).and_then(|caps| {
+            let year = caps[1].parse::<i32>().ok()?;
+            let month = caps[2].parse::<u8>().ok()?;
+            let day = caps[3].parse::<u8>().ok()?;
+            time::Date::from_calendar_date(year, month.try_into().ok()?, day).ok()
+        }) else {
+            panic!(
+                "
+deny.toml advisory missing deadline!
+Add a line to the `reason` property for {id} with this format:
+
+    FIX-DEADLINE: 2026-01-05
+"
+            )
+        };
+
+        assert!(
+            today <= deadline,
+            "
+The deadline for fixing advisory {id} has passed.
+Fix it now, or bump the deadline in deny.toml.
+"
+        )
+    }
 }

--- a/compiler-core/src/tests.rs
+++ b/compiler-core/src/tests.rs
@@ -59,25 +59,29 @@ fn load_cargo_deny_config() -> CargoDenyConfig {
 #[test]
 fn rust_advisories_ignore_deadlines() {
     let today = time::OffsetDateTime::now_utc().date();
-    let regex = regex::Regex::new(r"(?m)^FIX-DEADLINE:\s*(\d{4})-(\d{2})-(\d{2})$").unwrap();
+    let regex = regex::Regex::new(r"(?m)FIX-DEADLINE: (\d{4})-(\d{2})-(\d{2})").unwrap();
 
     for ignored in load_cargo_deny_config().advisories.ignore {
         let id = ignored.id;
-        let Some(deadline) = regex.captures(&ignored.reason).and_then(|caps| {
-            let year = caps[1].parse::<i32>().ok()?;
-            let month = caps[2].parse::<u8>().ok()?;
-            let day = caps[3].parse::<u8>().ok()?;
-            time::Date::from_calendar_date(year, month.try_into().ok()?, day).ok()
-        }) else {
+        let reason = ignored.reason;
+        let Some(captures) = regex.captures(&reason) else {
             panic!(
                 "
 deny.toml advisory missing deadline!
 Add a line to the `reason` property for {id} with this format:
 
     FIX-DEADLINE: 2026-01-05
+
+{reason:?}
 "
             )
         };
+
+        let year = captures[1].parse::<i32>().expect("parse year");
+        let month = captures[2].parse::<u8>().expect("parse month int");
+        let month = month.try_into().expect("parse month");
+        let day = captures[3].parse::<u8>().expect("parse day");
+        let deadline = time::Date::from_calendar_date(year, month, day).expect("construct date");
 
         assert!(
             today <= deadline,

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 [[advisories.ignore]]
 id = "RUSTSEC-2026-0173"
 reason = """
-proc-macro-error is currently unmaintained.
+proc-macro-error2 is currently unmaintained.
 https://rustsec.org/advisories/RUSTSEC-2024-0370
 
 At time of writing, it is used by a single transitive dependency.
@@ -20,6 +20,8 @@ At time of writing, it is used by a single transitive dependency.
    └── i18n-embed-fl v0.9.2
        └── age v0.11.3
            └── gleam-core
+
+https://github.com/gleam-lang/gleam/issues/5829
 
 FIX-DEADLINE: 2026-10-08
 """

--- a/deny.toml
+++ b/deny.toml
@@ -2,9 +2,39 @@
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = [
-    "RUSTSEC-2025-0141"
-]
+
+# The `FIX-DEADLINE` lines are used by the test suite, and once the date
+# they specify has passed they will cause a deadline check test to fail. This
+# is to ensure that we do not forget to fix these.
+#
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0173"
+reason = """
+proc-macro-error is currently unmaintained.
+https://rustsec.org/advisories/RUSTSEC-2024-0370
+
+At time of writing, it is used by a single transitive dependency.
+
+   $ cargo tree -i proc-macro-error2
+   proc-macro-error2 v2.0.1
+   └── i18n-embed-fl v0.9.2
+       └── age v0.11.3
+           └── gleam-core
+
+FIX-DEADLINE: 2026-10-08
+"""
+
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0141"
+reason = """
+Bincode is currently unmaintained.
+https://rustsec.org/advisories/RUSTSEC-2025-0141.html
+
+We need to migrate to some other package.
+https://github.com/gleam-lang/gleam/issues/5827
+
+FIX-DEADLINE: 2026-10-08
+"""
 
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]


### PR DESCRIPTION
The deadline test fails if the deadlines for an advisory has failed, to prevent us from forgetting to fix it.