### PR TITLE
Keep existing spaces when autocompleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,26 @@
 
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Accepting an autocomplete inside the brackets of an import previously
+  removed spaces following the previous import. For example:
+
+  ```gleam
+  import my_package/my_file.{MyFirstImport, MySecondImp|}
+  //                                                   ^ cursor
+
+  // Accepting the autocompletion produced:
+  import my_package/my_file.{MyFirstImport,MySecondImport}
+  ```
+
+  That has been fixed to produce:
+
+  ```gleam
+  import my_package/my_file.{MyFirstImport, MySecondImport}
+
+  ```
+
+  ([Bruno Parga](https://github.com/brunoparga))
+
 ### Formatter
 
 ### Bug fixes

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -423,11 +423,58 @@ impl<'a, IO> Completer<'a, IO> {
     // For unqualified imports we special case the word being completed to allow for whitespace but not dots.
     // This is to allow `type MyType` to be treated as 1 "phrase" for the sake of completion.
     fn get_phrase_surrounding_completion_for_import(&'a self) -> CursorSurroundings {
-        self.get_phrase_surrounding_for_completion(&|c: char| {
+        let cursor_surroundings = self.get_phrase_surrounding_for_completion(&|c: char| {
             // Checks if a character is not a valid name/upname character or whitespace.
             // The newline character is not included as well.
             c.is_ascii_alphanumeric() || c == '_' || c == ' ' || c == '\t'
-        })
+        });
+
+        // The text before the cursor might start with whitespace — for example,
+        // in `{wibble, wo|}` it is captured as " wo". We strip the blank space
+        // here so that later the completion won't affect it.
+        let leading_whitespace = cursor_surroundings.text_before_cursor.len()
+            - cursor_surroundings
+                .text_before_cursor
+                .trim_start_matches(|c: char| c == ' ' || c == '\t')
+                .len();
+
+        if leading_whitespace == 0 {
+            return cursor_surroundings;
+        }
+
+        let CursorSurroundings {
+            surrounding_text,
+            surrounding_text_range,
+            text_before_cursor,
+            text_before_cursor_range,
+            text_after_cursor,
+        } = cursor_surroundings;
+
+        let (_, text_before_cursor) = text_before_cursor.split_at(leading_whitespace);
+        let text_before_cursor_range = Range {
+            start: Position {
+                character: text_before_cursor_range.start.character + leading_whitespace as u32,
+                ..text_before_cursor_range.start
+            },
+            ..text_before_cursor_range
+        };
+
+        let (_, surrounding_text) = surrounding_text.split_at(leading_whitespace);
+        let surrounding_text_range = Range {
+            start: Position {
+                character: surrounding_text_range.start.character + leading_whitespace as u32,
+                ..surrounding_text_range.start
+            },
+            ..surrounding_text_range
+        };
+
+        CursorSurroundings {
+            surrounding_text: EcoString::from(surrounding_text),
+            surrounding_text_range,
+            text_before_cursor: EcoString::from(text_before_cursor),
+            text_before_cursor_range,
+            text_after_cursor,
+        }
     }
 
     /// Checks if the line being edited is an import line and provides completions if it is.

--- a/language-server/src/tests/completion.rs
+++ b/language-server/src/tests/completion.rs
@@ -1579,6 +1579,25 @@ pub type Wibble = String
 }
 
 #[test]
+fn unqualified_import_completion_preserves_space_after_comma() {
+    let code = "
+import dep.{wibble, wo}
+
+pub fn main() {
+  0
+}";
+    let dep = "pub const wibble = \"wibble\"
+pub const wobble = \"wobble\"
+";
+
+    assert_apply_completion!(
+        TestProject::for_source(code).add_module("dep", dep),
+        "wobble",
+        Position::new(1, 22)
+    );
+}
+
+#[test]
 fn completions_for_a_function_arg_annotation() {
     let code = "
 pub fn wibble(

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__unqualified_import_completion_preserves_space_after_comma.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__unqualified_import_completion_preserves_space_after_comma.snap
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/completion.rs
+assertion_line: 1596
+expression: "\nimport dep.{wibble, wo}\n\npub fn main() {\n  0\n}"
+---
+
+import dep.{wibble, wo|}
+
+pub fn main() {
+  0
+}
+
+
+----- After applying completion -----
+
+import dep.{wibble, wobble}
+
+pub fn main() {
+  0
+}

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__completion__unqualified_import_completion_preserves_space_after_comma.snap.new
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__completion__unqualified_import_completion_preserves_space_after_comma.snap.new
@@ -1,0 +1,20 @@
+---
+source: language-server/src/tests/completion.rs
+assertion_line: 1596
+expression: "\nimport dep.{wibble, wo}\n\npub fn main() {\n  0\n}"
+---
+
+import dep.{wibble, wo|}
+
+pub fn main() {
+  0
+}
+
+
+----- After applying completion -----
+
+import dep.{wibble, wobble}
+
+pub fn main() {
+  0
+}


### PR DESCRIPTION
Currently, when completing unqualified imports, the completion clobbers the whitespace before it. This commit preserves it.

Issue: https://github.com/gleam-lang/gleam/issues/5848

- [ ] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
