### PR TITLE
Ignore generated files on Windows

### DIFF
--- a/test-commands/cases/escript_ok/.gitignore
+++ b/test-commands/cases/escript_ok/.gitignore
@@ -3,3 +3,4 @@
 /build
 erl_crash.dump
 escript_ok
+escript_ok.cmd

--- a/test-commands/cases/escript_with_dependency/.gitignore
+++ b/test-commands/cases/escript_with_dependency/.gitignore
@@ -3,3 +3,4 @@
 /build
 erl_crash.dump
 escript_with_dependency
+escript_with_dependency.cmd


### PR DESCRIPTION
I noticed while testing a branch on Windows that `cargo test` leaves files behind so a second `cargo test` would fail because `all_files_have_copyright_notice` would pick them up and fail.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes
