### PR TITLE
Don't rename record fields from other packages

### DIFF
--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -878,11 +878,16 @@ where
                 // spans the whole `label:`, so we trim it down to just the
                 // label.
                 Some(Referenced::Label {
-                    location, label, ..
-                }) => success_response(SrcSpan {
-                    start: location.start,
-                    end: location.start + label.len() as u32,
-                }),
+                    location,
+                    label,
+                    type_module,
+                    ..
+                }) if this.is_same_package(current_module, &type_module) => {
+                    success_response(SrcSpan {
+                        start: location.start,
+                        end: location.start + label.len() as u32,
+                    })
+                }
 
                 _ => None,
             })

--- a/language-server/src/tests/rename.rs
+++ b/language-server/src/tests/rename.rs
@@ -2934,6 +2934,25 @@ pub fn main() {
 }
 
 #[test]
+fn no_rename_record_field_from_other_package() {
+    let src = "
+import wibble
+
+pub fn main() {
+  let value = wibble.Wibble(wibble: 1)
+  value.wibble
+}
+";
+
+    assert_no_rename!(
+        &TestProject::for_source(src)
+            .add_hex_module("wibble", "pub type Wibble {\n  Wibble(wibble: Int)\n}"),
+        "wobble",
+        find_position_of("value.wibble").under_char('i')
+    );
+}
+
+#[test]
 fn rename_record_field_in_module_not_importing_the_type_module() {
     assert_rename!(
         TestProject::for_source(


### PR DESCRIPTION
While trying out the great new features from #5533, I noticed that I was able to rename a record field defined in a dependency. This worked because the downloaded source in `build/` was edited along with my code. However it obviously breaks after a clean build.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes
