### PR TITLE
Fix bug where singleton constants are not used in Gleam constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,3 +362,7 @@
 - Fixed a bug where the language server would produce wrong code when triggering
   rename of types and values with import aliases.
   ([Andrey Kozhev](https://github.com/ankddev))
+
+- Fixed a bug where referencing qualified constructors in constant where a value
+  of the same name exists in scope would cause invalid code to be generated.
+  ([Surya Rose](https://github.com/GearsDatapacks))

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -2281,26 +2281,25 @@ impl<'module, 'a> Generator<'module, 'a> {
                     }
                 }
 
-                // If there's no arguments and the type is a function that takes
-                // arguments then this is the constructor being referenced, not the
-                // function being called.
-                if let Some(arity) = type_.fn_arity()
-                    && arguments.is_none()
-                    && arity != 0
-                {
-                    let arity = arity as u16;
-                    return self.record_constructor(type_.clone(), None, &tag, name, arity);
+                // If there's no arguments, then this is either a constructor
+                // which takes arguments being referenced rather than called,
+                // or a variant with no fields at all.
+                if arguments.is_none() {
+                    // If the constructor is not a function that takes arguments,
+                    // it effectively has zero arity.
+                    let arity = type_.fn_arity().unwrap_or(0) as u16;
+                    return self.record_constructor(
+                        type_.clone(),
+                        module.as_ref().map(|(name, _)| name.as_str()),
+                        &tag,
+                        name,
+                        arity,
+                    );
                 }
 
-                // Otherwise we're always constructing a record! Even if there's
-                // no argument list:
-                // ```gleam
-                // pub type Wibble { Wibble }
-                // pub const wibble = Wibble // <- here we're constructing the record!
-                // ```
-                //
-                // Record updates are fully expanded during type checking, so we
-                // just handle arguments
+                // Otherwise we're always constructing a record! Record updates
+                // are fully expanded during type checking, so we just need to
+                // handle the arguments here.
                 let field_values = arguments
                     .iter()
                     .flatten()

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -1191,3 +1191,68 @@ pub fn wobble(x: Int) -> Wibble {
 "
     );
 }
+
+#[test]
+fn singleton_constant_used_in_const() {
+    assert_js!(
+        "
+pub opaque type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub const wibble = Wibble
+"
+    );
+}
+
+#[test]
+fn singleton_constant_from_other_module_used_in_const() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble Wobble }"),
+        "
+import wibble.{Wobble}
+
+pub const wibble = wibble.Wibble
+
+pub const wobble = Wobble
+"
+    );
+}
+
+#[test]
+fn singleton_constant_used_in_guard() {
+    assert_js!(
+        "
+pub opaque type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub fn go(x) {
+  case x {
+    _ if x == #(Wibble) -> True
+    _ -> False
+  }
+}
+"
+    );
+}
+
+#[test]
+fn singleton_constant_from_other_module_used_in_guard() {
+    assert_js!(
+        ("wibble", "pub type Wibble { Wibble Wobble }"),
+        "
+import wibble.{Wobble}
+
+pub fn go(x) {
+  case x {
+    _ if x == #(wibble.Wibble) -> 1
+    _ if x == #(Wobble) -> 2
+    _ -> 3
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
@@ -17,7 +17,7 @@ pub fn func(x) {
 
 ----- COMPILED JAVASCRIPT
 import * as $gleam from "../gleam.mjs";
-import { Ok, toList, Empty as $Empty, CustomType as $CustomType } from "../gleam.mjs";
+import { toList, Empty as $Empty, CustomType as $CustomType } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
 export const X$Ok$const = new Ok();
@@ -26,7 +26,7 @@ export const X$isOk = (value) => value instanceof Ok;
 
 export function func(x) {
   let $ = (var0) => { return new $gleam.Ok(var0); };
-  if (toList([(var0) => { return new Ok(var0); }]) instanceof $Empty) {
+  if (toList([(var0) => { return new $gleam.Ok(var0); }]) instanceof $Empty) {
     return true;
   } else {
     return false;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__custom_type_constructor_imported_and_aliased.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__custom_type_constructor_imported_and_aliased.snap
@@ -10,6 +10,6 @@ pub const local = B
 
 ----- COMPILED JAVASCRIPT
 import * as $other_module from "../../package/other_module.mjs";
-import { A as B } from "../../package/other_module.mjs";
+import { T$A$const as T$B$const } from "../../package/other_module.mjs";
 
-export const local = /* @__PURE__ */ new B();
+export const local = T$B$const;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__imported_ok.snap
@@ -14,11 +14,11 @@ pub const y = gleam.Ok
 
 ----- COMPILED JAVASCRIPT
 import * as $gleam from "../gleam.mjs";
-import { Ok, CustomType as $CustomType } from "../gleam.mjs";
+import { CustomType as $CustomType } from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
 export const X$Ok$const = new Ok();
 export const X$Ok = () => X$Ok$const;
 export const X$isOk = (value) => value instanceof Ok;
 
-export const y = (var0) => { return new Ok(var0); };
+export const y = (var0) => { return new $gleam.Ok(var0); };

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported.snap
@@ -14,4 +14,4 @@ pub const x = other.Two
 ----- COMPILED JAVASCRIPT
 import * as $other from "../other.mjs";
 
-export const x = /* @__PURE__ */ new $other.Two();
+export const x = $other.One$Two$const;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported_unqualified.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__const_zero_arity_imported_unqualified.snap
@@ -13,6 +13,6 @@ pub const a = Two
 
 ----- COMPILED JAVASCRIPT
 import * as $other from "../other.mjs";
-import { Two } from "../other.mjs";
+import { One$Two$const } from "../other.mjs";
 
-export const a = /* @__PURE__ */ new Two();
+export const a = One$Two$const;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_from_other_module_used_in_const.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_from_other_module_used_in_const.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wibble.{Wobble}\n\npub const wibble = wibble.Wibble\n\npub const wobble = Wobble\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
+
+import wibble.{Wobble}
+
+pub const wibble = wibble.Wibble
+
+pub const wobble = Wobble
+
+
+----- COMPILED JAVASCRIPT
+import * as $wibble from "../wibble.mjs";
+import { Wibble$Wobble$const } from "../wibble.mjs";
+
+export const wibble = $wibble.Wibble$Wibble$const;
+
+export const wobble = Wibble$Wobble$const;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_from_other_module_used_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_from_other_module_used_in_guard.snap
@@ -1,0 +1,35 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport wibble.{Wobble}\n\npub fn go(x) {\n  case x {\n    _ if x == #(wibble.Wibble) -> 1\n    _ if x == #(Wobble) -> 2\n    _ -> 3\n  }\n}\n"
+---
+----- SOURCE CODE
+-- wibble.gleam
+pub type Wibble { Wibble Wobble }
+
+-- main.gleam
+
+import wibble.{Wobble}
+
+pub fn go(x) {
+  case x {
+    _ if x == #(wibble.Wibble) -> 1
+    _ if x == #(Wobble) -> 2
+    _ -> 3
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { isEqual } from "../gleam.mjs";
+import * as $wibble from "../wibble.mjs";
+import { Wibble$Wobble$const } from "../wibble.mjs";
+
+export function go(x) {
+  if (isEqual(x, [$wibble.Wibble$Wibble$const])) {
+    return 1;
+  } else if (isEqual(x, [Wibble$Wobble$const])) {
+    return 2;
+  } else {
+    return 3;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_used_in_const.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_used_in_const.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub opaque type Wibble {\n  Wibble\n  Wobble(Int)\n}\n\npub const wibble = Wibble\n"
+---
+----- SOURCE CODE
+
+pub opaque type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub const wibble = Wibble
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+class Wibble extends $CustomType {}
+const Wibble$Wibble$const = new Wibble();
+
+class Wobble extends $CustomType {
+  constructor($0) {
+    super();
+    this[0] = $0;
+  }
+}
+
+export const wibble = Wibble$Wibble$const;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_used_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singleton_constant_used_in_guard.snap
@@ -1,0 +1,39 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\npub opaque type Wibble {\n  Wibble\n  Wobble(Int)\n}\n\npub fn go(x) {\n  case x {\n    _ if x == #(Wibble) -> True\n    _ -> False\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub opaque type Wibble {
+  Wibble
+  Wobble(Int)
+}
+
+pub fn go(x) {
+  case x {
+    _ if x == #(Wibble) -> True
+    _ -> False
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType, isEqual } from "../gleam.mjs";
+
+class Wibble extends $CustomType {}
+const Wibble$Wibble$const = new Wibble();
+
+class Wobble extends $CustomType {
+  constructor($0) {
+    super();
+    this[0] = $0;
+  }
+}
+
+export function go(x) {
+  if (isEqual(x, [Wibble$Wibble$const])) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_const.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__zero_arity_const.snap
@@ -29,6 +29,6 @@ export const Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLong
 export const Mine$isThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant = (value) =>
   value instanceof ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant;
 
-export const this$ = /* @__PURE__ */ new This();
+export const this$ = Mine$This$const;
 
-export const that = /* @__PURE__ */ new ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant();
+export const that = Mine$ThatOneIsAMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchMuchLongerVariant$const;

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -53,4 +53,4 @@ export const x: $two.A$;
 /// <reference types="./two.d.mts" />
 import * as $two from "./one/two.mjs";
 
-export const x = /* @__PURE__ */ new $two.A();
+export const x = $two.A$A$const;


### PR DESCRIPTION
Fixes #5871

I also found a somewhat related bug that I've fixed here to avoid having to make a separate issue and PR, where constants referencing variants would ignore the qualifier, which could sometimes lead to incorrect code being generated (e.g. in [this snapshot](https://github.com/gleam-lang/gleam/blob/28e51ca0cf733fd62f3aea3d00844709f049f2c6/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__imported_ok.snap#L24), where the constant is incorrectly referencing the local `Ok` instead of `gleam.Ok`).

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
