### PR TITLE
change inefficient regex usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   JavaScript target, allowing for faster comparison in most cases.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- `gleam build` is now up to 15% faster recompiling a project with no changes.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The build tool now generates Hexdocs URLs using the new format of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,6 @@
   JavaScript target, allowing for faster comparison in most cases.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
-- `gleam build` is now up to 15% faster recompiling a project with no changes.
-  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
-
 ### Build tool
 
 - The build tool now generates Hexdocs URLs using the new format of
@@ -369,3 +366,7 @@
 - Fixed a bug where referencing qualified constructors in constant where a value
   of the same name exists in scope would cause invalid code to be generated.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug that would result in `gleam build` being slower than necessary
+  when compiling a project with no changes.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -14,6 +14,7 @@ use gleam_core::{
     warning::WarningEmitterIO,
 };
 use gleam_language_server::{DownloadDependencies, Locker, MakeLocker};
+use regex::Regex;
 use std::{
     collections::HashSet,
     fmt::Debug,
@@ -422,24 +423,23 @@ pub fn write_to_open_file(
     })
 }
 
+static IS_GLEAM_PATH_PATTERN: OnceLock<Regex> = OnceLock::new();
+
 fn is_gleam_path(path: &Utf8Path, dir: impl AsRef<Utf8Path>) -> bool {
-    use regex::Regex;
-
-    static RE: OnceLock<Regex> = OnceLock::new();
-
-    RE.get_or_init(|| {
-        Regex::new(&format!(
-            "^({module}{slash})*{module}\\.gleam$",
-            module = "[a-z][_a-z0-9]*",
-            slash = "(/|\\\\)",
-        ))
-        .expect("is_gleam_path() RE regex")
-    })
-    .is_match(
-        path.strip_prefix(dir.as_ref())
-            .expect("is_gleam_path(): strip_prefix")
-            .as_str(),
-    )
+    IS_GLEAM_PATH_PATTERN
+        .get_or_init(|| {
+            Regex::new(&format!(
+                "^({module}{slash})*{module}\\.gleam$",
+                module = "[a-z][_a-z0-9]*",
+                slash = "(/|\\\\)",
+            ))
+            .expect("is_gleam_path() RE regex")
+        })
+        .is_match(
+            path.strip_prefix(dir.as_ref())
+                .expect("is_gleam_path(): strip_prefix")
+                .as_str(),
+        )
 }
 
 fn is_gleam_build_dir(e: &ignore::DirEntry) -> bool {

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -15,6 +15,7 @@ use gleam_core::{
     type_::ModuleFunction,
     version::COMPILER_VERSION,
 };
+use regex::Regex;
 
 use crate::{config::PackageKind, fs::ProjectIO};
 
@@ -358,20 +359,20 @@ fn add_deno_flag(args: &mut Vec<String>, flag: &str, flags: &DenoFlag) {
     }
 }
 
+static IS_GLEAM_MODULE_PATTERN: OnceLock<Regex> = OnceLock::new();
+
 /// Check if a module name is a valid gleam module name.
 fn is_gleam_module(module: &str) -> bool {
-    use regex::Regex;
-    static RE: OnceLock<Regex> = OnceLock::new();
-
-    RE.get_or_init(|| {
-        Regex::new(&format!(
-            "^({module}{slash})*{module}$",
-            module = "[a-z][_a-z0-9]*",
-            slash = "/",
-        ))
-        .expect("is_gleam_module() RE regex")
-    })
-    .is_match(module)
+    IS_GLEAM_MODULE_PATTERN
+        .get_or_init(|| {
+            Regex::new(&format!(
+                "^({module}{slash})*{module}$",
+                module = "[a-z][_a-z0-9]*",
+                slash = "/",
+            ))
+            .expect("is_gleam_module() RE regex")
+        })
+        .is_match(module)
 }
 
 /// If provided module is not executable, suggest a possible valid module.

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -46,6 +46,7 @@ use ecow::{EcoString, eco_format};
 use hexpm::version::Version;
 use itertools::Itertools;
 use name::{check_argument_names, check_name_case};
+use regex::Regex;
 use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
@@ -54,6 +55,9 @@ use std::{
 use vec1::Vec1;
 
 use self::imports::Importer;
+
+static EXTERNAL_MODULE_PATTERN: OnceLock<Regex> = OnceLock::new();
+static EXTERNAL_FUNCTION_PATTERN: OnceLock<Regex> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum Inferred<T> {
@@ -850,14 +854,11 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
     ) {
         use regex::Regex;
 
-        static MODULE: OnceLock<Regex> = OnceLock::new();
-        static FUNCTION: OnceLock<Regex> = OnceLock::new();
-
         let (module, function) = match external_javascript {
             None => return,
             Some((module, function, _location)) => (module, function),
         };
-        if !MODULE
+        if !EXTERNAL_MODULE_PATTERN
             .get_or_init(|| Regex::new("^[@a-zA-Z0-9\\./:_-]+$").expect("regex"))
             .is_match(module)
         {
@@ -867,7 +868,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 name: function_name.clone(),
             });
         }
-        if !FUNCTION
+        if !EXTERNAL_FUNCTION_PATTERN
             .get_or_init(|| Regex::new("^[a-zA-Z_][a-zA-Z0-9_]*$").expect("regex"))
             .is_match(function)
         {

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -16,6 +16,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use ecow::EcoString;
 use itertools::Itertools;
+use regex::Regex;
 use vec1::Vec1;
 
 use crate::{
@@ -1731,6 +1732,8 @@ pub struct GleamFile {
     pub module_name: EcoString,
 }
 
+static IS_GLEAM_PATH_PATTERN: OnceLock<Regex> = OnceLock::new();
+
 impl GleamFile {
     pub fn new(dir: &Utf8Path, path: Utf8PathBuf) -> Self {
         Self {
@@ -1782,22 +1785,20 @@ impl GleamFile {
     }
 
     fn is_gleam_path(path: &Utf8Path, dir: &Utf8Path) -> bool {
-        use regex::Regex;
-        static RE: OnceLock<Regex> = OnceLock::new();
-
-        RE.get_or_init(|| {
-            Regex::new(&format!(
-                "^({module}{slash})*{module}\\.gleam$",
-                module = "[a-z][_a-z0-9]*",
-                slash = "(/|\\\\)",
-            ))
-            .expect("is_gleam_path() RE regex")
-        })
-        .is_match(
-            path.strip_prefix(dir)
-                .expect("is_gleam_path(): strip_prefix")
-                .as_str(),
-        )
+        IS_GLEAM_PATH_PATTERN
+            .get_or_init(|| {
+                Regex::new(&format!(
+                    "^({module}{slash})*{module}\\.gleam$",
+                    module = "[a-z][_a-z0-9]*",
+                    slash = "(/|\\\\)",
+                ))
+                .expect("is_gleam_path() RE regex")
+            })
+            .is_match(
+                path.strip_prefix(dir)
+                    .expect("is_gleam_path(): strip_prefix")
+                    .as_str(),
+            )
     }
 }
 

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -6,6 +6,7 @@ mod tests;
 
 use std::{
     collections::{HashMap, HashSet},
+    sync::OnceLock,
     time::{Duration, SystemTime},
 };
 
@@ -1782,8 +1783,7 @@ impl GleamFile {
 
     fn is_gleam_path(path: &Utf8Path, dir: &Utf8Path) -> bool {
         use regex::Regex;
-        use std::cell::OnceCell;
-        const RE: OnceCell<Regex> = OnceCell::new();
+        static RE: OnceLock<Regex> = OnceLock::new();
 
         RE.get_or_init(|| {
             Regex::new(&format!(

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -14,11 +14,13 @@ use ecow::EcoString;
 use globset::{Glob, GlobSetBuilder};
 use hexpm::version::{self, LowestVersion, Version};
 use http::Uri;
+use regex::Regex;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{self};
 use std::marker::PhantomData;
+use std::sync::OnceLock;
 
 #[cfg(test)]
 use crate::manifest::ManifestPackage;
@@ -1228,10 +1230,9 @@ pub mod map_with_package_name_keys {
     }
 }
 
+static PACKAGE_NAME_PATTERN: OnceLock<Regex> = OnceLock::new();
+
 fn is_valid_package_name(name: &str) -> bool {
-    use regex::Regex;
-    use std::sync::OnceLock;
-    static PACKAGE_NAME_PATTERN: OnceLock<Regex> = OnceLock::new();
     PACKAGE_NAME_PATTERN
         .get_or_init(|| Regex::new("^[a-z][a-z0-9_]*$").expect("Package name regex"))
         .is_match(name)

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2860,8 +2860,9 @@ fn atom_string(value: EcoString) -> Document<'static> {
     escape_atom_string(value).to_doc()
 }
 
+static ATOM_PATTERN: OnceLock<Regex> = OnceLock::new();
+
 fn atom_pattern() -> &'static Regex {
-    static ATOM_PATTERN: OnceLock<Regex> = OnceLock::new();
     ATOM_PATTERN.get_or_init(|| Regex::new(r"^[a-z][a-z0-9_@]*$").expect("atom RE regex"))
 }
 
@@ -2890,8 +2891,9 @@ pub fn escape_atom_string(value: EcoString) -> EcoString {
     }
 }
 
+static PATTERN: OnceLock<Regex> = OnceLock::new();
+
 fn unicode_escape_sequence_pattern() -> &'static Regex {
-    static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
         Regex::new(r#"(\\+)(u)"#).expect("Unicode escape sequence regex cannot be constructed")
     })

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -991,10 +991,10 @@ pub struct Dependency {
 
 static USER_AGENT: &str = concat!("Gleam v", env!("CARGO_PKG_VERSION"));
 
-fn validate_package_and_version(package: &str, version: &str) -> Result<(), ApiError> {
-    static PACKAGE_PATTERN: OnceLock<Regex> = OnceLock::new();
-    static VERSION_PATTERN: OnceLock<Regex> = OnceLock::new();
+static PACKAGE_PATTERN: OnceLock<Regex> = OnceLock::new();
+static VERSION_PATTERN: OnceLock<Regex> = OnceLock::new();
 
+fn validate_package_and_version(package: &str, version: &str) -> Result<(), ApiError> {
     let package_pattern = PACKAGE_PATTERN.get_or_init(|| Regex::new(r"^[a-z]\w*$").unwrap());
     let version_pattern =
         VERSION_PATTERN.get_or_init(|| Regex::new(r"^[a-zA-Z-0-9\._-]+$").unwrap());


### PR DESCRIPTION
Profiling the compiler on `gleam build -tjs` I noticed that `is_gleam_path` was taking an unusual big percentage of time constantly rebuilding the regex. Turns out it should have been `static` and not just a `const`!