### PR TITLE
formatter: remove import alias if the aliased name is the same as the original

### DIFF
--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -414,6 +414,7 @@ impl<'a, 'doc> Formatter<'a> {
             arena,
             match &unqualified_import.as_name {
                 None => EMPTY_DOCUMENT,
+                Some(s) if s == &unqualified_import.name => EMPTY_DOCUMENT,
                 Some(s) => " as ".to_doc(arena).append(arena, s.as_str()),
             },
         )

--- a/format/src/tests/imports.rs
+++ b/format/src/tests/imports.rs
@@ -28,6 +28,18 @@ fn discarded_import_with_unqualified() {
 }
 
 #[test]
+fn redundant_unqualified_as_name_is_removed() {
+    assert_format_rewrite!(
+        "import wibble.{Wibble as Wibble}",
+        "import wibble.{Wibble}\n"
+    );
+    assert_format_rewrite!(
+        "import wibble.{type Wibble as Wibble}",
+        "import wibble.{type Wibble}\n"
+    );
+}
+
+#[test]
 fn redundant_as_name_is_removed() {
     assert_format_rewrite!("import wibble/wobble as wobble", "import wibble/wobble\n");
     assert_format_rewrite!("import wibble as wibble", "import wibble\n");


### PR DESCRIPTION
The formatter now strips redundant unqualified import aliases. For example:

```gleam
import wibble.{Wibble as Wibble}
```

is formatted to:

```gleam
import wibble.{Wibble}
```

Fixes #5869

---Payment info---
PayPal: n6085530@gmail.com
