### PR TITLE
Preserve return type when extracting statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,35 @@
   hovered call and not only the final one.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- When using the "Extract function" code action on statements whose values are
+  unused, the extracted function will return the last statement. For example:
+
+  ```gleam
+  fn main() {
+  //↓ start selection here
+    echo "line 2"
+    echo "line 3"
+  //            ↑ end selection here
+    echo "line 4"
+  }
+  ```
+
+  will be turned into
+
+  ```gleam
+  fn main() {
+    function()
+    echo "line 4"
+  }
+
+  fn function() -> String {
+    echo "line 2"
+    echo "line 3"
+  }
+  ```
+
+  ([Gavin Morrow](https://github.com/gavinmorrow))
+
 ### Formatter
 
 - Performance of the formatter has been improved.

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -10724,17 +10724,6 @@ enum StatementPosition {
     NotTail,
 }
 
-#[derive(Clone, Debug)]
-enum ReturnValue {
-    /// The function is called for its side effects, and the return value is
-    /// not used.
-    Unbound(Arc<Type>),
-    /// A list of values which need to be returned from the extracted function.
-    /// These are the variables defined in the extracted code which are used
-    /// outside of the extracted section.
-    Bound(Vec<(EcoString, Arc<Type>)>),
-}
-
 impl<'a> ExtractFunction<'a> {
     pub fn new(
         module: &'a Module,
@@ -10820,11 +10809,11 @@ impl<'a> ExtractFunction<'a> {
                     .location()
                     .merge(&statements.last().location());
 
-                self.extract_code_in_tail_position(
+                self.extract_unbound_statements(
                     *full_location,
                     location,
-                    statements.last().type_(),
                     extracted.parameters,
+                    statements.last().type_(),
                     end,
                 )
             }
@@ -10877,11 +10866,11 @@ impl<'a> ExtractFunction<'a> {
                 } else {
                     expression.type_()
                 };
-                self.extract_code_in_tail_position(
+                self.extract_unbound_statements(
                     expression.location(),
                     expression.location(),
-                    expression_type,
                     extracted.parameters,
+                    expression_type,
                     end,
                 )
             }
@@ -10890,12 +10879,22 @@ impl<'a> ExtractFunction<'a> {
                 position: StatementPosition::NotTail,
                 type_,
             } => {
-                let return_value = if extracted.returned_variables.is_empty() {
-                    ReturnValue::Unbound(type_)
+                if extracted.returned_variables.is_empty() {
+                    self.extract_unbound_statements(
+                        location,
+                        location,
+                        extracted.parameters,
+                        type_,
+                        end,
+                    );
                 } else {
-                    ReturnValue::Bound(extracted.returned_variables)
+                    self.extract_bound_statements(
+                        location,
+                        extracted.parameters,
+                        extracted.returned_variables,
+                        end,
+                    )
                 };
-                self.extract_statements(location, extracted.parameters, return_value, end)
             }
 
             ExtractedValue::Use {
@@ -10907,11 +10906,11 @@ impl<'a> ExtractFunction<'a> {
                 location,
                 position: StatementPosition::Tail,
                 type_,
-            } => self.extract_code_in_tail_position(
+            } => self.extract_unbound_statements(
                 location,
                 location,
-                type_,
                 extracted.parameters,
+                type_,
                 end,
             ),
             ExtractedValue::PipelineSteps {
@@ -11142,14 +11141,28 @@ impl<'a> ExtractFunction<'a> {
         self.edits.insert(function_end, function);
     }
 
-    /// Extracts code from the end of a function or block. This could either be
-    /// a single expression, or multiple statements followed by a final expression.
-    fn extract_code_in_tail_position(
+    /// Extracts a function whose return value does not get bound to a variable
+    /// in the calling function.
+    ///
+    /// There are two cases:
+    /// 1. The function is in tail position, and its return value is used as the
+    ///    return value of the calling function.
+    /// 2. The function's return value is unused in the calling function, and so
+    ///    does not get bound to a variable.
+    ///
+    /// # Parameters
+    ///
+    /// In most cases, `location` and `code_location` are the same. They differ
+    /// only when the code being extracted is a single block expression. In
+    /// that case, the code being replaced in the calling function (`location`)
+    /// includes the braces around the block, while the code being put into the
+    /// body of the extracted function (`code_location`) does not.
+    fn extract_unbound_statements(
         &mut self,
         location: SrcSpan,
         code_location: SrcSpan,
-        type_: Arc<Type>,
         parameters: Vec<(EcoString, Arc<Type>)>,
+        return_type: Arc<Type>,
         function_end: u32,
     ) {
         let expression_code = code_at(self.module, code_location);
@@ -11170,7 +11183,7 @@ impl<'a> ExtractFunction<'a> {
             .iter()
             .map(|(name, type_)| eco_format!("{name}: {}", printer.print_type(type_)))
             .join(", ");
-        let return_type = printer.print_type(&type_);
+        let return_type = printer.print_type(&return_type);
 
         let function = format!(
             "\n\nfn {name}({parameters}) -> {return_type} {{
@@ -11181,99 +11194,77 @@ impl<'a> ExtractFunction<'a> {
         self.edits.insert(function_end, function);
     }
 
-    fn extract_statements(
+    /// Extracts a function that does get bound to one or more variables in the
+    /// calling function.
+    ///
+    /// For example, in the code
+    ///
+    /// ```gleam
+    /// pub fn main() {
+    ///   let a = 10
+    /// //^ Select from here
+    ///   let b = 20
+    ///   let c = a + b
+    ///   //          ^ Until here
+    ///
+    ///   echo a
+    ///   echo b
+    ///   echo c
+    /// }
+    /// ```
+    ///
+    /// multiple values defined in the extracted block are used in the calling
+    /// function. So, the extracted function must return multiple values that
+    /// are bound to variables: `let #(a, b, c) = function()`.
+    ///
+    /// There is a special case when there is only one value being bound, as it
+    /// is unnecessary to create a single-element tuple. For example:
+    ///
+    /// ```gleam
+    /// pub fn main() {
+    ///   let a = 10
+    /// //^ Select from here
+    ///   let b = 20
+    ///   let c = a + b
+    ///   //          ^ Until here
+    ///
+    ///   echo c
+    /// }
+    /// ```
+    ///
+    /// Here, the return value of the extracted function will be bound to a
+    /// single variable in the calling function: `let c = function()`.
+    fn extract_bound_statements(
         &mut self,
         location: SrcSpan,
         parameters: Vec<(EcoString, Arc<Type>)>,
-        return_value: ReturnValue,
+        returned_variables: Vec<(EcoString, Arc<Type>)>,
         function_end: u32,
     ) {
         let code = code_at(self.module, location);
 
+        let (return_type, return_value) = match returned_variables.as_slice() {
+            [(returned_name, type_)] => (type_.clone(), returned_name.clone()),
+            _ => {
+                let returned_names = returned_variables
+                    .iter()
+                    .map(|(name, _type)| name)
+                    .join(", ");
+                let return_value = eco_format!("#({returned_names})");
+
+                let returned_types = returned_variables
+                    .into_iter()
+                    .map(|(_name, type_)| type_)
+                    .collect();
+                let type_ = type_::tuple(returned_types);
+
+                (type_, return_value)
+            }
+        };
+
         let name = self.function_name();
         let arguments = parameters.iter().map(|(name, _)| name).join(", ");
-
-        // Here, we decide what value to return from the function. There are
-        // three cases:
-        // The first is when the extracted code is purely for side-effects, and
-        // does not produce any values which are needed outside of the extracted
-        // code. For example:
-        //
-        // ```gleam
-        // pub fn main() {
-        //   let message = "Something important"
-        // //^ Select from here
-        //   io.println("Something important")
-        //   io.println("Something else which is repeated")
-        //   //                                           ^ Until here
-        //
-        //   do_final_thing()
-        // }
-        // ```
-        //
-        // In this case, the extracted function can return its last statement
-        // (here of type `Nil`) but the value won't be assigned to in the
-        // original function.
-        //
-        // The next is when we need just a single value defined in the extracted
-        // function, such as in this piece of code:
-        //
-        // ```gleam
-        // pub fn main() {
-        //   let a = 10
-        // //^ Select from here
-        //   let b = 20
-        //   let c = a + b
-        //   //          ^ Until here
-        //
-        //   echo c
-        // }
-        // ```
-        //
-        // Here, we can just return the single value, `c`.
-        //
-        // The last situation is when we need multiple defined values, such as
-        // in the following code:
-        //
-        // ```gleam
-        // pub fn main() {
-        //   let a = 10
-        // //^ Select from here
-        //   let b = 20
-        //   let c = a + b
-        //   //          ^ Until here
-        //
-        //   echo a
-        //   echo b
-        //   echo c
-        // }
-        // ```
-        //
-        // In this case, we must return a tuple containing `a`, `b` and `c` in
-        // order for the calling function to have access to the correct values.
-        let (return_type, returned_variables, call) = match return_value {
-            ReturnValue::Unbound(type_) => (type_, None, format!("{name}({arguments})")),
-            ReturnValue::Bound(return_values) => match return_values.as_slice() {
-                [(returned_name, type_)] => (
-                    type_.clone(),
-                    Some(returned_name.clone()),
-                    format!("let {returned_name} = {name}({arguments})"),
-                ),
-                _ => {
-                    let returned_names = return_values.iter().map(|(name, _type)| name).join(", ");
-                    let returned_variables = eco_format!("#({returned_names})");
-                    let call = format!("let {returned_variables} = {name}({arguments})");
-
-                    let returned_types = return_values
-                        .into_iter()
-                        .map(|(_name, type_)| type_)
-                        .collect();
-                    let type_ = type_::tuple(returned_types);
-
-                    (type_, Some(returned_variables), call)
-                }
-            },
-        };
+        let call = format!("let {return_value} = {name}({arguments})");
 
         self.edits.replace(location, call);
 
@@ -11283,16 +11274,12 @@ impl<'a> ExtractFunction<'a> {
             .iter()
             .map(|(name, type_)| eco_format!("{name}: {}", printer.print_type(type_)))
             .join(", ");
-
         let return_type = printer.print_type(&return_type);
-        let return_value = match returned_variables {
-            Some(returned_variables) => format!("\n  {returned_variables}"),
-            None => "".to_string(),
-        };
 
         let function = format!(
             "\n\nfn {name}({parameters}) -> {return_type} {{
-  {code}{return_value}
+  {code}
+  {return_value}
 }}"
         );
 
@@ -11665,7 +11652,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                             ..
                         },
                     parameters,
-                    returned_variables: return_value,
+                    returned_variables,
                 }) if location.contains_span(statement_location) => {
                     let use_line_range = self.edits.src_span_to_lsp_range(*use_line_location);
 
@@ -11682,7 +11669,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                                 type_: statement.type_(),
                             },
                             parameters: parameters.to_vec(),
-                            returned_variables: return_value.clone(),
+                            returned_variables: returned_variables.to_vec(),
                         });
                     }
                 }

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -10675,6 +10675,8 @@ enum ExtractedValue<'a> {
     Statements {
         location: SrcSpan,
         position: StatementPosition,
+        /// The type of the final statement.
+        type_: Arc<Type>,
     },
     /// We're extracting a single use statement. We need this special case to
     /// properly handle the statements inside of them.
@@ -10716,51 +10718,21 @@ impl ExtractedValue<'_> {
     }
 }
 
-/// When we are extracting multiple statements, there are two possible cases:
-/// The first is if we are extracting statements in the middle of a function.
-/// In this case, we will need to return some number of arguments, or `Nil`.
-/// For example:
-///
-/// ```gleam
-/// pub fn main() {
-///   let message = "Hello!"
-///   let log_message = "[INFO] " <> message
-/// //^ Select from here
-///   io.println(log_message)
-///   //                    ^ Until here
-///
-///   do_some_more_things()
-/// }
-/// ```
-///
-/// Here, the extracted function doesn't bind any variables which we need
-/// afterwards, it purely performs side effects. In this case we can just return
-/// `Nil` from the new function.
-///
-/// However, consider the following:
-///
-/// ```gleam
-/// pub fn main() {
-///   let a = 1
-///   let b = 2
-/// //^ Select from here
-///   a + b
-///   //  ^ Until here
-/// }
-/// ```
-///
-/// Here, despite us not needing any variables from the extracted code, there
-/// is one key difference: the `a + b` expression is at the end of the function,
-/// and so its value is returned from the entire function. This is known as the
-/// "tail" position. In that case, we can't return `Nil` as that would make the
-/// `main` function return `Nil` instead of the result of the addition. If we
-/// extract the tail-position statement, we need to return that last value rather
-/// than `Nil`.
-///
 #[derive(Debug)]
 enum StatementPosition {
-    Tail { type_: Arc<Type> },
+    Tail,
     NotTail,
+}
+
+#[derive(Clone, Debug)]
+enum ReturnValue {
+    /// The function is called for its side effects, and the return value is
+    /// not used.
+    Unbound(Arc<Type>),
+    /// A list of values which need to be returned from the extracted function.
+    /// These are the variables defined in the extracted code which are used
+    /// outside of the extracted section.
+    Bound(Vec<(EcoString, Arc<Type>)>),
 }
 
 impl<'a> ExtractFunction<'a> {
@@ -10916,12 +10888,15 @@ impl<'a> ExtractFunction<'a> {
             ExtractedValue::Statements {
                 location,
                 position: StatementPosition::NotTail,
-            } => self.extract_statements(
-                location,
-                extracted.parameters,
-                extracted.returned_variables,
-                end,
-            ),
+                type_,
+            } => {
+                let return_value = if extracted.returned_variables.is_empty() {
+                    ReturnValue::Unbound(type_)
+                } else {
+                    ReturnValue::Bound(extracted.returned_variables)
+                };
+                self.extract_statements(location, extracted.parameters, return_value, end)
+            }
 
             ExtractedValue::Use {
                 location,
@@ -10930,7 +10905,8 @@ impl<'a> ExtractFunction<'a> {
             }
             | ExtractedValue::Statements {
                 location,
-                position: StatementPosition::Tail { type_ },
+                position: StatementPosition::Tail,
+                type_,
             } => self.extract_code_in_tail_position(
                 location,
                 location,
@@ -11209,12 +11185,13 @@ impl<'a> ExtractFunction<'a> {
         &mut self,
         location: SrcSpan,
         parameters: Vec<(EcoString, Arc<Type>)>,
-        returned_variables: Vec<(EcoString, Arc<Type>)>,
+        return_value: ReturnValue,
         function_end: u32,
     ) {
         let code = code_at(self.module, location);
 
-        let returns_anything = !returned_variables.is_empty();
+        let name = self.function_name();
+        let arguments = parameters.iter().map(|(name, _)| name).join(", ");
 
         // Here, we decide what value to return from the function. There are
         // three cases:
@@ -11234,9 +11211,9 @@ impl<'a> ExtractFunction<'a> {
         // }
         // ```
         //
-        // It doesn't make sense to return any values from this function, since
-        // no values from the extract code are used afterwards, so we simply
-        // return `Nil`.
+        // In this case, the extracted function can return its last statement
+        // (here of type `Nil`) but the value won't be assigned to in the
+        // original function.
         //
         // The next is when we need just a single value defined in the extracted
         // function, such as in this piece of code:
@@ -11274,32 +11251,30 @@ impl<'a> ExtractFunction<'a> {
         //
         // In this case, we must return a tuple containing `a`, `b` and `c` in
         // order for the calling function to have access to the correct values.
-        let (return_type, return_value) = match returned_variables.as_slice() {
-            [] => (type_::nil(), "Nil".into()),
-            [(name, type_)] => (type_.clone(), name.clone()),
-            _ => {
-                let values = returned_variables.iter().map(|(name, _)| name).join(", ");
-                let type_ = type_::tuple(
-                    returned_variables
+        let (return_type, returned_variables, call) = match return_value {
+            ReturnValue::Unbound(type_) => (type_, None, format!("{name}({arguments})")),
+            ReturnValue::Bound(return_values) => match return_values.as_slice() {
+                [(returned_name, type_)] => (
+                    type_.clone(),
+                    Some(returned_name.clone()),
+                    format!("let {returned_name} = {name}({arguments})"),
+                ),
+                _ => {
+                    let returned_names = return_values.iter().map(|(name, _type)| name).join(", ");
+                    let returned_variables = eco_format!("#({returned_names})");
+                    let call = format!("let {returned_variables} = {name}({arguments})");
+
+                    let returned_types = return_values
                         .into_iter()
-                        .map(|(_, type_)| type_)
-                        .collect(),
-                );
+                        .map(|(_name, type_)| type_)
+                        .collect();
+                    let type_ = type_::tuple(returned_types);
 
-                (type_, eco_format!("#({values})"))
-            }
+                    (type_, Some(returned_variables), call)
+                }
+            },
         };
 
-        let name = self.function_name();
-        let arguments = parameters.iter().map(|(name, _)| name).join(", ");
-
-        // If any values are returned from the extracted function, we need to
-        // bind them so that they are accessible in the current scope.
-        let call = if returns_anything {
-            format!("let {return_value} = {name}({arguments})")
-        } else {
-            format!("{name}({arguments})")
-        };
         self.edits.replace(location, call);
 
         let mut printer = Printer::new(&self.module.ast.names);
@@ -11310,11 +11285,14 @@ impl<'a> ExtractFunction<'a> {
             .join(", ");
 
         let return_type = printer.print_type(&return_type);
+        let return_value = match returned_variables {
+            Some(returned_variables) => format!("\n  {returned_variables}"),
+            None => "".to_string(),
+        };
 
         let function = format!(
             "\n\nfn {name}({parameters}) -> {return_type} {{
-  {code}
-  {return_value}
+  {code}{return_value}
 }}"
         );
 
@@ -11648,9 +11626,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
             // it will be in tail position there and the extracted function should
             // return its returned value.
             let position = if statement.is_use() || is_in_tail_position {
-                StatementPosition::Tail {
-                    type_: statement.type_(),
-                }
+                StatementPosition::Tail
             } else {
                 StatementPosition::NotTail
             };
@@ -11665,6 +11641,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                             Some(ExtractedFunction::new(ExtractedValue::Statements {
                                 location: statement_location,
                                 position,
+                                type_: statement.type_(),
                             }))
                         }
                         TypedStatement::Use(use_) => {
@@ -11688,7 +11665,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                             ..
                         },
                     parameters,
-                    returned_variables,
+                    returned_variables: return_value,
                 }) if location.contains_span(statement_location) => {
                     let use_line_range = self.edits.src_span_to_lsp_range(*use_line_location);
 
@@ -11702,9 +11679,10 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                             value: ExtractedValue::Statements {
                                 location: statement_location,
                                 position,
+                                type_: statement.type_(),
                             },
                             parameters: parameters.to_vec(),
-                            returned_variables: returned_variables.to_vec(),
+                            returned_variables: return_value.clone(),
                         });
                     }
                 }
@@ -11718,6 +11696,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                     *value = ExtractedValue::Statements {
                         location: value.location().merge(&statement_location),
                         position,
+                        type_: statement.type_(),
                     };
                 }
 
@@ -11736,11 +11715,13 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                         ExtractedValue::Statements {
                             location,
                             position: extracted_position,
+                            type_: extracted_type,
                         },
                     ..
                 }) => {
                     *location = location.merge(&statement_location);
                     *extracted_position = position;
+                    *extracted_type = statement.type_();
                 }
                 Some(ExtractedFunction {
                     value: value @ ExtractedValue::PipelineSteps { .. },
@@ -11752,6 +11733,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                     *value = ExtractedValue::Statements {
                         location: value.location(),
                         position,
+                        type_: statement.type_(),
                     }
                 }
             }

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -12465,11 +12465,11 @@ fn extract_function_first_few_statements_inside_of_use() {
         EXTRACT_FUNCTION,
         r#"
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    echo wobble as "2"
-    echo wobble as "3"
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  echo wobble as "2"
+  echo wobble as "3"
+  echo wobble as "4"
 }
 "#,
         find_position_of("echo").select_until(find_position_of("2\""))
@@ -12482,11 +12482,11 @@ fn extract_function_middle_few_statements_inside_of_use() {
         EXTRACT_FUNCTION,
         r#"
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    echo wobble as "2"
-    echo wobble as "3"
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  echo wobble as "2"
+  echo wobble as "3"
+  echo wobble as "4"
 }
 "#,
         find_position_of("echo")
@@ -12501,11 +12501,11 @@ fn extract_function_last_few_statements_inside_of_use() {
         EXTRACT_FUNCTION,
         r#"
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    echo wobble as "2"
-    echo wobble as "3"
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  echo wobble as "2"
+  echo wobble as "3"
+  echo wobble as "4"
 }
 "#,
         find_position_of("echo")
@@ -12520,11 +12520,11 @@ fn extract_function_all_statements_inside_of_use() {
         EXTRACT_FUNCTION,
         r#"
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    echo wobble as "2"
-    echo wobble as "3"
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  echo wobble as "2"
+  echo wobble as "3"
+  echo wobble as "4"
 }
 "#,
         find_position_of("echo").select_until(find_position_of("4\""))

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_all_statements_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_all_statements_inside_of_use.snap
@@ -1,32 +1,32 @@
 ---
 source: language-server/src/tests/action.rs
-expression: "\npub fn wibble() {\n    use wobble <- result.map(todo)\n    echo wobble as \"1\"\n    echo wobble as \"2\"\n    echo wobble as \"3\"\n    echo wobble as \"4\"\n}\n"
+expression: "\npub fn wibble() {\n  use wobble <- result.map(todo)\n  echo wobble as \"1\"\n  echo wobble as \"2\"\n  echo wobble as \"3\"\n  echo wobble as \"4\"\n}\n"
 ---
 ----- BEFORE ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
-    echo wobble as "2"
-▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
-    echo wobble as "3"
-▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
-    echo wobble as "4"
-▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  echo wobble as "2"
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  echo wobble as "3"
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  echo wobble as "4"
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
 }
 
 
 ----- AFTER ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    function(wobble)
+  use wobble <- result.map(todo)
+  function(wobble)
 }
 
 fn function(wobble: a) -> a {
   echo wobble as "1"
-    echo wobble as "2"
-    echo wobble as "3"
-    echo wobble as "4"
+  echo wobble as "2"
+  echo wobble as "3"
+  echo wobble as "4"
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_first_few_statements_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_first_few_statements_inside_of_use.snap
@@ -1,30 +1,30 @@
 ---
 source: language-server/src/tests/action.rs
-expression: "\npub fn wibble() {\n    use wobble <- result.map(todo)\n    echo wobble as \"1\"\n    echo wobble as \"2\"\n    echo wobble as \"3\"\n    echo wobble as \"4\"\n}\n"
+expression: "\npub fn wibble() {\n  use wobble <- result.map(todo)\n  echo wobble as \"1\"\n  echo wobble as \"2\"\n  echo wobble as \"3\"\n  echo wobble as \"4\"\n}\n"
 ---
 ----- BEFORE ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
-    echo wobble as "2"
-▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
-    echo wobble as "3"
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  echo wobble as "2"
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
+  echo wobble as "3"
+  echo wobble as "4"
 }
 
 
 ----- AFTER ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    function(wobble)
-    echo wobble as "3"
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  function(wobble)
+  echo wobble as "3"
+  echo wobble as "4"
 }
 
 fn function(wobble: a) -> a {
   echo wobble as "1"
-    echo wobble as "2"
+  echo wobble as "2"
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_first_few_statements_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_first_few_statements_inside_of_use.snap
@@ -24,8 +24,7 @@ pub fn wibble() {
     echo wobble as "4"
 }
 
-fn function(wobble: a) -> Nil {
+fn function(wobble: a) -> a {
   echo wobble as "1"
     echo wobble as "2"
-  Nil
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_first_statement_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_first_statement_inside_of_use.snap
@@ -24,7 +24,6 @@ pub fn wibble() {
     echo wobble as "4"
 }
 
-fn function(wobble: a) -> Nil {
+fn function(wobble: a) -> a {
   echo wobble as "1"
-  Nil
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_last_few_statements_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_last_few_statements_inside_of_use.snap
@@ -1,30 +1,30 @@
 ---
 source: language-server/src/tests/action.rs
-expression: "\npub fn wibble() {\n    use wobble <- result.map(todo)\n    echo wobble as \"1\"\n    echo wobble as \"2\"\n    echo wobble as \"3\"\n    echo wobble as \"4\"\n}\n"
+expression: "\npub fn wibble() {\n  use wobble <- result.map(todo)\n  echo wobble as \"1\"\n  echo wobble as \"2\"\n  echo wobble as \"3\"\n  echo wobble as \"4\"\n}\n"
 ---
 ----- BEFORE ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    echo wobble as "2"
-    echo wobble as "3"
-    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
-    echo wobble as "4"
-▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  echo wobble as "2"
+  echo wobble as "3"
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  echo wobble as "4"
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
 }
 
 
 ----- AFTER ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    echo wobble as "2"
-    function(wobble)
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  echo wobble as "2"
+  function(wobble)
 }
 
 fn function(wobble: a) -> a {
   echo wobble as "3"
-    echo wobble as "4"
+  echo wobble as "4"
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_middle_few_statements_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_middle_few_statements_inside_of_use.snap
@@ -1,30 +1,30 @@
 ---
 source: language-server/src/tests/action.rs
-expression: "\npub fn wibble() {\n    use wobble <- result.map(todo)\n    echo wobble as \"1\"\n    echo wobble as \"2\"\n    echo wobble as \"3\"\n    echo wobble as \"4\"\n}\n"
+expression: "\npub fn wibble() {\n  use wobble <- result.map(todo)\n  echo wobble as \"1\"\n  echo wobble as \"2\"\n  echo wobble as \"3\"\n  echo wobble as \"4\"\n}\n"
 ---
 ----- BEFORE ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    echo wobble as "2"
-    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
-    echo wobble as "3"
-▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  echo wobble as "2"
+  ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+  echo wobble as "3"
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔↑ 
+  echo wobble as "4"
 }
 
 
 ----- AFTER ACTION
 
 pub fn wibble() {
-    use wobble <- result.map(todo)
-    echo wobble as "1"
-    function(wobble)
-    echo wobble as "4"
+  use wobble <- result.map(todo)
+  echo wobble as "1"
+  function(wobble)
+  echo wobble as "4"
 }
 
 fn function(wobble: a) -> a {
   echo wobble as "2"
-    echo wobble as "3"
+  echo wobble as "3"
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_middle_few_statements_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_middle_few_statements_inside_of_use.snap
@@ -24,8 +24,7 @@ pub fn wibble() {
     echo wobble as "4"
 }
 
-fn function(wobble: a) -> Nil {
+fn function(wobble: a) -> a {
   echo wobble as "2"
     echo wobble as "3"
-  Nil
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_second_statement_inside_of_use.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_second_statement_inside_of_use.snap
@@ -24,7 +24,6 @@ pub fn wibble() {
     echo wobble as "4"
 }
 
-fn function(wobble: a) -> Nil {
+fn function(wobble: a) -> a {
   echo wobble as "2"
-  Nil
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_which_uses_no_extracted_variables.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__extract_function_which_uses_no_extracted_variables.snap
@@ -20,8 +20,7 @@ pub fn do_things(a, b) {
   a
 }
 
-fn function(a: Int, b: Int) -> Nil {
+fn function(a: Int, b: Int) -> Int {
   let x = a + b
   echo x
-  Nil
 }


### PR DESCRIPTION
Fixes #5826.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes