### PR TITLE
remove usages of `Default::default()`

### DIFF
--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -96,7 +96,7 @@ pub struct ProjectIO {
 impl ProjectIO {
     pub fn new() -> Self {
         Self {
-            beam_compiler: Default::default(),
+            beam_compiler: Arc::new(Mutex::new(None)),
         }
     }
 

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -23,6 +23,7 @@
     clippy::option_option,
     clippy::verbose_file_reads,
     clippy::unnested_or_patterns,
+    clippy::default_trait_access,
     rust_2018_idioms,
     missing_debug_implementations,
     missing_copy_implementations,

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -987,7 +987,7 @@ fn release_metadata_as_erlang() {
 fn prevent_publish_local_dependency() {
     let config = PackageConfig {
         dependencies: [("provided".into(), Requirement::path("./path/to/package"))].into(),
-        ..Default::default()
+        ..PackageConfig::default()
     };
     assert_eq!(
         metadata_config(&config, &HashMap::new(), &[], &[]),
@@ -1005,7 +1005,7 @@ fn prevent_publish_git_dependency() {
             Requirement::git("https://github.com/gleam-lang/gleam.git", "da6e917"),
         )]
         .into(),
-        ..Default::default()
+        ..PackageConfig::default()
     };
     assert_eq!(
         metadata_config(&config, &HashMap::new(), &[], &[]),

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -11,6 +11,7 @@ use crate::error::{DefinedModuleOrigin, FailedModule, SkipReason, SkippedModule}
 use crate::io::files_with_extension;
 use crate::line_numbers::{self, LineNumbers};
 use crate::type_::PRELUDE_MODULE_NAME;
+use crate::type_::printer::Names;
 use crate::{
     Error, Result, Warning,
     ast::{SrcSpan, TypedModule, UntypedModule},
@@ -720,7 +721,7 @@ fn analyse(
                 let _ = failed_modules.insert(
                     name.clone(),
                     FailedModule {
-                        names: Default::default(),
+                        names: Box::new(Names::new()),
                         path: path.clone(),
                         src: code.clone(),
                         errors,

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -1685,7 +1685,7 @@ impl<'a> Inputs<'a> {
     ) -> Self {
         Self {
             package,
-            collection: Default::default(),
+            collection: HashMap::new(),
             already_defined_modules,
         }
     }

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -11,6 +11,7 @@ use crate::{
     io::{FileSystemWriter, memory::InMemoryFileSystem},
     line_numbers,
     parse::extra::ModuleExtra,
+    type_::References,
     warning::NullWarningEmitterIO,
 };
 
@@ -57,20 +58,20 @@ fn write_cache(
         name: name.into(),
         origin: Origin::Src,
         package: "my_package".into(),
-        types: Default::default(),
-        types_value_constructors: Default::default(),
-        values: Default::default(),
-        accessors: Default::default(),
+        types: HashMap::new(),
+        types_value_constructors: HashMap::new(),
+        values: HashMap::new(),
+        accessors: HashMap::new(),
         line_numbers: line_numbers.clone(),
         is_internal: false,
         src_path: Utf8PathBuf::from(format!("/src/{}.gleam", name)),
         warnings: vec![],
         minimum_required_version: Version::new(0, 1, 0),
-        type_aliases: Default::default(),
-        documentation: Default::default(),
+        type_aliases: HashMap::new(),
+        documentation: vec![],
         contains_echo: false,
-        references: Default::default(),
-        inline_functions: Default::default(),
+        references: References::default(),
+        inline_functions: HashMap::new(),
     };
     let path = Utf8Path::new("/artefact").join(format!("{artefact_name}.cache"));
     fs.write_bytes(&path, &metadata::encode(&cache).unwrap())

--- a/compiler-core/src/call_graph/into_dependency_order_tests.rs
+++ b/compiler-core/src/call_graph/into_dependency_order_tests.rs
@@ -27,9 +27,9 @@ fn parse_and_order(
                 .map(|name| Arg {
                     names: crate::ast::ArgNames::Named {
                         name: EcoString::from(*name),
-                        location: Default::default(),
+                        location: SrcSpan::default(),
                     },
-                    location: Default::default(),
+                    location: SrcSpan::default(),
                     annotation: None,
                     type_: (),
                 })
@@ -37,7 +37,7 @@ fn parse_and_order(
             body: crate::parse::parse_statement_sequence(src)
                 .expect("syntax error")
                 .to_vec(),
-            location: Default::default(),
+            location: SrcSpan::default(),
             body_start: None,
             return_annotation: None,
             publicity: Publicity::Public,
@@ -63,7 +63,7 @@ fn parse_and_order(
             let const_value = crate::parse::parse_const_value(value).expect("syntax error");
             ModuleConstant {
                 documentation: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 publicity: Publicity::Public,
                 name: EcoString::from(*name),
                 name_location: SrcSpan::default(),

--- a/compiler-core/src/config.rs
+++ b/compiler-core/src/config.rs
@@ -722,19 +722,19 @@ fn locked_version(name: &'static str, version: &'static str) -> (EcoString, Vers
 impl Default for PackageConfig {
     fn default() -> Self {
         Self {
-            name: Default::default(),
+            name: EcoString::new(),
             version: default_version(),
-            gleam_version: Default::default(),
-            description: Default::default(),
-            documentation: Default::default(),
-            dependencies: Default::default(),
-            erlang: Default::default(),
-            javascript: Default::default(),
-            repository: Default::default(),
-            dev_dependencies: Default::default(),
-            licences: Default::default(),
-            links: Default::default(),
-            internal_modules: Default::default(),
+            gleam_version: None,
+            description: EcoString::new(),
+            documentation: Docs::default(),
+            dependencies: HashMap::new(),
+            erlang: ErlangConfig::default(),
+            javascript: JavaScriptConfig::default(),
+            repository: None,
+            dev_dependencies: HashMap::new(),
+            licences: vec![],
+            links: vec![],
+            internal_modules: None,
             target: Target::Erlang,
         }
     }

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -312,7 +312,7 @@ where
             locked,
             remote,
             exact_only,
-            optional_dependencies: RefCell::new(Default::default()),
+            optional_dependencies: RefCell::new(HashMap::new()),
         }
     }
 
@@ -384,7 +384,7 @@ where
             )));
         }
 
-        let mut deps: Map<PackageName, PubgrubRange> = Default::default();
+        let mut deps: Map<PackageName, PubgrubRange> = Map::default();
         for (name, dependency) in &release.requirements {
             let mut range = dependency.requirement.to_pubgrub().clone();
             let mut opt_deps = self.optional_dependencies.borrow_mut();

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -20,6 +20,7 @@ use crate::{
     config::{DocsPage, PackageConfig, Repository},
     docs::{DocContext, search_item_for_module, search_item_for_type, search_item_for_value},
     io::{FileSystemWriter, memory::InMemoryFileSystem},
+    parse::extra::ModuleExtra,
     paths::ProjectPaths,
     type_,
     uid::UniqueIdGenerator,
@@ -164,8 +165,8 @@ fn compile_documentation(
         input_path: "/".into(),
         origin: Origin::Src,
         ast: module,
-        extra: Default::default(),
-        dependencies: Default::default(),
+        extra: ModuleExtra::new(),
+        dependencies: vec![],
     };
 
     let source_links = SourceLinker::new(&paths, &config, &build_module);
@@ -1297,8 +1298,8 @@ fn generate_search_data(module_name: &str, module_src: &str) -> EcoString {
         input_path: "/".into(),
         origin: Origin::Src,
         ast: module,
-        extra: Default::default(),
-        dependencies: Default::default(),
+        extra: ModuleExtra::new(),
+        dependencies: vec![],
     };
 
     let source_links = SourceLinker::new(&paths, &config, &build_module);

--- a/compiler-core/src/io/memory.rs
+++ b/compiler-core/src/io/memory.rs
@@ -381,7 +381,7 @@ impl InMemoryFile {
     pub fn directory() -> Self {
         Self {
             node: InMemoryFileNode::Directory,
-            ..Default::default()
+            ..Self::default()
         }
     }
 
@@ -418,7 +418,7 @@ impl InMemoryFile {
 impl Default for InMemoryFile {
     fn default() -> Self {
         Self {
-            node: InMemoryFileNode::File(Default::default()),
+            node: InMemoryFileNode::File(Rc::new(RefCell::new(vec![]))),
             // We use a fixed time here so that the tests are deterministic. In
             // future we may want to inject this in some fashion.
             modification_time: SystemTime::UNIX_EPOCH + Duration::from_secs(663112800),

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -138,7 +138,7 @@ impl<'a, 'doc> Generator<'a> {
             module,
             src_path,
             tracker: UsageTracker::default(),
-            module_scope: Default::default(),
+            module_scope: im::HashMap::new(),
             typescript,
             source_map_builder: if source_map {
                 let module_name = module.name.clone();

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -461,7 +461,7 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
                     .current_scope
                     .user_variables()
                     .clone(),
-                DecisionKind::LetAssert { .. } => Default::default(),
+                DecisionKind::LetAssert { .. } => im::HashMap::new(),
             };
             let old_names = self.variables.scoped_variable_names.clone();
             let old_segments = self.variables.segment_values.clone();

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -162,7 +162,7 @@ impl Scope {
     fn new(user_variables: im::HashMap<EcoString, usize>) -> Self {
         Self {
             user_variables,
-            ..Default::default()
+            ..Self::default()
         }
     }
 

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -124,8 +124,8 @@ impl<'a, 'doc> Import<'a, 'doc> {
     fn new(path: EcoString) -> Self {
         Self {
             path,
-            aliases: Default::default(),
-            unqualified: Default::default(),
+            aliases: HashSet::new(),
+            unqualified: vec![],
         }
     }
 

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -24,6 +24,7 @@
     clippy::option_option,
     clippy::verbose_file_reads,
     clippy::unnested_or_patterns,
+    clippy::default_trait_access,
     rust_2018_idioms,
     missing_debug_implementations,
     missing_copy_implementations,

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -223,10 +223,10 @@ impl ManifestPackage {
 impl Default for ManifestPackage {
     fn default() -> Self {
         Self {
-            name: Default::default(),
-            build_tools: Default::default(),
-            otp_app: Default::default(),
-            requirements: Default::default(),
+            name: EcoString::new(),
+            build_tools: vec![],
+            otp_app: None,
+            requirements: vec![],
             version: Version::new(1, 0, 0),
             source: ManifestPackageSource::Hex {
                 outer_checksum: Base16Checksum(vec![]),

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -82,11 +82,11 @@ fn constant_module(constant: TypedConstant) -> ModuleInterface {
 
 fn bit_array_segment_option_module(option: TypedConstantBitArraySegmentOption) -> ModuleInterface {
     constant_module(Constant::BitArray {
-        location: Default::default(),
+        location: SrcSpan::default(),
         segments: vec![BitArraySegment {
-            location: Default::default(),
+            location: SrcSpan::default(),
             value: Box::new(Constant::Int {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: "1".into(),
                 int_value: 1.into(),
             }),
@@ -163,7 +163,7 @@ fn module_with_private_type() {
             TypeConstructor {
                 type_: type_::list(type_::int()),
                 publicity: Publicity::Private,
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
@@ -200,7 +200,7 @@ fn module_with_app_type() {
             TypeConstructor {
                 type_: type_::list(type_::int()),
                 publicity: Publicity::Public,
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
@@ -237,7 +237,7 @@ fn module_with_fn_type() {
             TypeConstructor {
                 type_: type_::fn_(vec![type_::nil(), type_::float()], type_::int()),
                 publicity: Publicity::Public,
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
@@ -274,7 +274,7 @@ fn module_with_tuple_type() {
             TypeConstructor {
                 type_: type_::tuple(vec![type_::nil(), type_::float(), type_::int()]),
                 publicity: Publicity::Public,
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
@@ -317,7 +317,7 @@ fn module_with_generic_type() {
                 TypeConstructor {
                     type_: type_::tuple(vec![t1.clone(), t1.clone(), t2.clone()]),
                     publicity: Publicity::Public,
-                    origin: Default::default(),
+                    origin: SrcSpan::default(),
                     module: "the/module".into(),
                     parameters: vec![t1, t2],
                     deprecation: Deprecation::NotDeprecated,
@@ -359,7 +359,7 @@ fn module_with_type_links() {
                 TypeConstructor {
                     type_,
                     publicity: Publicity::Public,
-                    origin: Default::default(),
+                    origin: SrcSpan::default(),
                     module: "a".into(),
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
@@ -401,7 +401,7 @@ fn module_with_type_constructor_documentation() {
                 TypeConstructor {
                     type_,
                     publicity: Publicity::Public,
-                    origin: Default::default(),
+                    origin: SrcSpan::default(),
                     module: "a".into(),
                     parameters: vec![],
                     deprecation: Deprecation::NotDeprecated,
@@ -1050,7 +1050,7 @@ fn private_accessors() {
 #[test]
 fn constant_int() {
     let module = constant_module(Constant::Int {
-        location: Default::default(),
+        location: SrcSpan::default(),
         value: "100".into(),
         int_value: 100.into(),
     });
@@ -1061,7 +1061,7 @@ fn constant_int() {
 #[test]
 fn constant_float() {
     let module = constant_module(Constant::Float {
-        location: Default::default(),
+        location: SrcSpan::default(),
         value: "1.0".into(),
         float_value: LiteralFloatValue::ONE,
     });
@@ -1072,7 +1072,7 @@ fn constant_float() {
 #[test]
 fn constant_string() {
     let module = constant_module(Constant::String {
-        location: Default::default(),
+        location: SrcSpan::default(),
         value: "hello".into(),
     });
 
@@ -1083,7 +1083,7 @@ fn constant_string() {
 fn constant_tuple() {
     let int_float_tuple_type = type_::tuple(vec![type_::int(), type_::float()]);
     let module = constant_module(Constant::Tuple {
-        location: Default::default(),
+        location: SrcSpan::default(),
         type_: type_::tuple(vec![
             type_::int(),
             type_::float(),
@@ -1091,26 +1091,26 @@ fn constant_tuple() {
         ]),
         elements: vec![
             Constant::Int {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: "1".into(),
                 int_value: 1.into(),
             },
             Constant::Float {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: "1.0".into(),
                 float_value: LiteralFloatValue::ONE,
             },
             Constant::Tuple {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 type_: int_float_tuple_type,
                 elements: vec![
                     Constant::Int {
-                        location: Default::default(),
+                        location: SrcSpan::default(),
                         value: "1".into(),
                         int_value: 1.into(),
                     },
                     Constant::Float {
-                        location: Default::default(),
+                        location: SrcSpan::default(),
                         value: "1.0".into(),
                         float_value: LiteralFloatValue::ONE,
                     },
@@ -1125,36 +1125,36 @@ fn constant_tuple() {
 #[test]
 fn constant_list() {
     let module = constant_module(Constant::List {
-        location: Default::default(),
+        location: SrcSpan::default(),
         type_: type_::int(),
         elements: vec![
             Constant::Int {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: "1".into(),
                 int_value: 1.into(),
             },
             Constant::Int {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: "2".into(),
                 int_value: 2.into(),
             },
             Constant::Int {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: "3".into(),
                 int_value: 3.into(),
             },
         ],
         tail: Some(Box::new(Constant::List {
-            location: Default::default(),
+            location: SrcSpan::default(),
             type_: type_::list(type_::int()),
             elements: vec![
                 Constant::Int {
-                    location: Default::default(),
+                    location: SrcSpan::default(),
                     value: "4".into(),
                     int_value: 4.into(),
                 },
                 Constant::Int {
-                    location: Default::default(),
+                    location: SrcSpan::default(),
                     value: "5".into(),
                     int_value: 5.into(),
                 },
@@ -1169,16 +1169,16 @@ fn constant_list() {
 #[test]
 fn constant_record() {
     let module = constant_module(Constant::Record {
-        location: Default::default(),
+        location: SrcSpan::default(),
         module: None,
         name: "".into(),
         arguments: Some(vec![
             CallArg {
                 implicit: None,
                 label: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: Constant::Float {
-                    location: Default::default(),
+                    location: SrcSpan::default(),
                     value: "0.0".into(),
                     float_value: LiteralFloatValue::ZERO,
                 },
@@ -1186,9 +1186,9 @@ fn constant_record() {
             CallArg {
                 implicit: None,
                 label: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: Constant::Int {
-                    location: Default::default(),
+                    location: SrcSpan::default(),
                     value: "1".into(),
                     int_value: 1.into(),
                 },
@@ -1205,13 +1205,13 @@ fn constant_record() {
 #[test]
 fn constant_var() {
     let one_original = Constant::Int {
-        location: Default::default(),
+        location: SrcSpan::default(),
         value: "1".into(),
         int_value: 1.into(),
     };
 
     let one = Constant::Var {
-        location: Default::default(),
+        location: SrcSpan::default(),
         module: None,
         name: "one_original".into(),
         type_: type_::int(),
@@ -1309,7 +1309,7 @@ fn constant_var() {
 #[test]
 fn constant_bit_array() {
     let module = constant_module(Constant::BitArray {
-        location: Default::default(),
+        location: SrcSpan::default(),
         segments: vec![],
     });
     assert_eq!(roundtrip(&module), module);
@@ -1318,7 +1318,7 @@ fn constant_bit_array() {
 #[test]
 fn constant_bit_array_unit() {
     let module = bit_array_segment_option_module(BitArrayOption::Unit {
-        location: Default::default(),
+        location: SrcSpan::default(),
         value: 234,
     });
     assert_eq!(roundtrip(&module), module);
@@ -1327,7 +1327,7 @@ fn constant_bit_array_unit() {
 #[test]
 fn constant_bit_array_float() {
     let module = bit_array_segment_option_module(BitArrayOption::Float {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1335,7 +1335,7 @@ fn constant_bit_array_float() {
 #[test]
 fn constant_bit_array_int() {
     let module = bit_array_segment_option_module(BitArrayOption::Int {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1343,9 +1343,9 @@ fn constant_bit_array_int() {
 #[test]
 fn constant_bit_array_size() {
     let module = bit_array_segment_option_module(BitArrayOption::Size {
-        location: Default::default(),
+        location: SrcSpan::default(),
         value: Box::new(Constant::Int {
-            location: Default::default(),
+            location: SrcSpan::default(),
             value: "1".into(),
             int_value: 1.into(),
         }),
@@ -1357,9 +1357,9 @@ fn constant_bit_array_size() {
 #[test]
 fn constant_bit_array_size_short_form() {
     let module = bit_array_segment_option_module(BitArrayOption::Size {
-        location: Default::default(),
+        location: SrcSpan::default(),
         value: Box::new(Constant::Int {
-            location: Default::default(),
+            location: SrcSpan::default(),
             value: "1".into(),
             int_value: 1.into(),
         }),
@@ -1371,7 +1371,7 @@ fn constant_bit_array_size_short_form() {
 #[test]
 fn constant_bit_array_bit_arry() {
     let module = bit_array_segment_option_module(BitArrayOption::Bits {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1379,7 +1379,7 @@ fn constant_bit_array_bit_arry() {
 #[test]
 fn constant_bit_array_utf8() {
     let module = bit_array_segment_option_module(BitArrayOption::Utf8 {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1387,7 +1387,7 @@ fn constant_bit_array_utf8() {
 #[test]
 fn constant_bit_array_utf16() {
     let module = bit_array_segment_option_module(BitArrayOption::Utf16 {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1395,7 +1395,7 @@ fn constant_bit_array_utf16() {
 #[test]
 fn constant_bit_array_utf32() {
     let module = bit_array_segment_option_module(BitArrayOption::Utf32 {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1403,7 +1403,7 @@ fn constant_bit_array_utf32() {
 #[test]
 fn constant_bit_array_utf8codepoint() {
     let module = bit_array_segment_option_module(BitArrayOption::Utf8Codepoint {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1411,7 +1411,7 @@ fn constant_bit_array_utf8codepoint() {
 #[test]
 fn constant_bit_array_utf16codepoint() {
     let module = bit_array_segment_option_module(BitArrayOption::Utf16Codepoint {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1419,7 +1419,7 @@ fn constant_bit_array_utf16codepoint() {
 #[test]
 fn constant_bit_array_utf32codepoint() {
     let module = bit_array_segment_option_module(BitArrayOption::Utf32Codepoint {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1427,7 +1427,7 @@ fn constant_bit_array_utf32codepoint() {
 #[test]
 fn constant_bit_array_signed() {
     let module = bit_array_segment_option_module(BitArrayOption::Signed {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1435,7 +1435,7 @@ fn constant_bit_array_signed() {
 #[test]
 fn constant_bit_array_unsigned() {
     let module = bit_array_segment_option_module(BitArrayOption::Unsigned {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1443,7 +1443,7 @@ fn constant_bit_array_unsigned() {
 #[test]
 fn constant_bit_array_big() {
     let module = bit_array_segment_option_module(BitArrayOption::Big {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1451,7 +1451,7 @@ fn constant_bit_array_big() {
 #[test]
 fn constant_bit_array_little() {
     let module = bit_array_segment_option_module(BitArrayOption::Little {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1459,7 +1459,7 @@ fn constant_bit_array_little() {
 #[test]
 fn constant_bit_array_native() {
     let module = bit_array_segment_option_module(BitArrayOption::Native {
-        location: Default::default(),
+        location: SrcSpan::default(),
     });
     assert_eq!(roundtrip(&module), module);
 }
@@ -1477,7 +1477,7 @@ fn deprecated_type() {
             TypeConstructor {
                 type_: type_::list(type_::int()),
                 publicity: Publicity::Public,
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::Deprecated {
@@ -1807,7 +1807,7 @@ fn type_with_inferred_variant() {
                 publicity: Publicity::Internal {
                     attribute_location: Some(SrcSpan::new(0, 10)),
                 },
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 module: "the/module".into(),
                 parameters: vec![],
                 deprecation: Deprecation::NotDeprecated,
@@ -1853,7 +1853,7 @@ fn module_with_type_aliases() {
                 arity: 1,
                 deprecation: Deprecation::NotDeprecated,
                 documentation: Some("Some documentation".into()),
-                origin: Default::default(),
+                origin: SrcSpan::default(),
                 parameters: vec![type_::generic_var(0)],
             },
         )]

--- a/compiler-core/src/package_interface/tests.rs
+++ b/compiler-core/src/package_interface/tests.rs
@@ -142,7 +142,7 @@ pub fn compile_package(
     let package: Package = package_from_module(module);
     serde_json::to_string_pretty(&PackageInterface::from_package(
         &package,
-        &Default::default(),
+        &im::HashMap::new(),
     ))
     .expect("to json")
 }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -79,6 +79,7 @@ use crate::parse::extra::ModuleExtra;
 use crate::type_::Deprecation;
 use crate::type_::error::{VariableDeclaration, VariableOrigin, VariableSyntax};
 use crate::type_::expression::{Implementations, Purity};
+use crate::type_::printer::Names;
 use crate::warning::{DeprecatedSyntaxWarning, WarningEmitter};
 use camino::Utf8PathBuf;
 use ecow::EcoString;
@@ -87,7 +88,7 @@ use lexer::{LexResult, Spanned};
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 pub use token::Token;
@@ -261,12 +262,12 @@ where
             documentation: vec![],
             type_info: (),
             definitions,
-            names: Default::default(),
-            unused_definition_positions: Default::default(),
+            names: Names::new(),
+            unused_definition_positions: HashSet::new(),
         };
         Ok(Parsed {
             module,
-            extra: Default::default(),
+            extra: ModuleExtra::new(),
         })
     }
 

--- a/compiler-core/src/parse/extra.rs
+++ b/compiler-core/src/parse/extra.rs
@@ -19,7 +19,7 @@ pub struct ModuleExtra {
 
 impl ModuleExtra {
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// Detects if a byte index is in a comment context

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -30,7 +30,7 @@ pub struct Problems {
 
 impl Problems {
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// Sort the warnings and errors by their location.

--- a/compiler-core/src/type_/prelude.rs
+++ b/compiler-core/src/type_/prelude.rs
@@ -256,7 +256,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
         match t {
             PreludeType::BitArray => {
                 let v = TypeConstructor {
-                    origin: Default::default(),
+                    origin: SrcSpan::default(),
                     parameters: vec![],
                     type_: bit_array(),
                     module: PRELUDE_MODULE_NAME.into(),
@@ -322,7 +322,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let _ = prelude.types.insert(
                     BOOL.into(),
                     TypeConstructor {
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         parameters: vec![],
                         type_: bool(),
                         module: PRELUDE_MODULE_NAME.into(),
@@ -337,7 +337,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let _ = prelude.types.insert(
                     FLOAT.into(),
                     TypeConstructor {
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         parameters: vec![],
                         type_: float(),
                         module: PRELUDE_MODULE_NAME.into(),
@@ -354,7 +354,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                     TypeConstructor {
                         parameters: vec![],
                         type_: int(),
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         module: PRELUDE_MODULE_NAME.into(),
                         publicity: Publicity::Public,
                         deprecation: NotDeprecated,
@@ -368,7 +368,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let _ = prelude.types.insert(
                     LIST.into(),
                     TypeConstructor {
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         parameters: vec![list_parameter.clone()],
                         type_: list(list_parameter),
                         module: PRELUDE_MODULE_NAME.into(),
@@ -399,7 +399,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let _ = prelude.types.insert(
                     NIL.into(),
                     TypeConstructor {
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         parameters: vec![],
                         type_: nil(),
                         module: PRELUDE_MODULE_NAME.into(),
@@ -430,7 +430,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let _ = prelude.types.insert(
                     RESULT.into(),
                     TypeConstructor {
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         parameters: vec![result_value.clone(), result_error.clone()],
                         type_: result(result_value.clone(), result_error.clone()),
                         module: PRELUDE_MODULE_NAME.into(),
@@ -508,7 +508,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let _ = prelude.types.insert(
                     STRING.into(),
                     TypeConstructor {
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         parameters: vec![],
                         type_: string(),
                         module: PRELUDE_MODULE_NAME.into(),
@@ -523,7 +523,7 @@ pub fn build_prelude(ids: &UniqueIdGenerator) -> ModuleInterface {
                 let _ = prelude.types.insert(
                     UTF_CODEPOINT.into(),
                     TypeConstructor {
-                        origin: Default::default(),
+                        origin: SrcSpan::default(),
                         parameters: vec![],
                         type_: utf_codepoint(),
                         module: PRELUDE_MODULE_NAME.into(),

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -29,7 +29,7 @@ pub struct Printer {
 
 impl Printer {
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     pub fn with_names(&mut self, names: im::HashMap<u64, EcoString>) {

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024 The Gleam contributors
 
-use bimap::BiMap;
+use bimap::{BiHashMap, BiMap};
 use ecow::{EcoString, eco_format};
 use im::HashMap;
 use std::{collections::HashSet, sync::Arc};
@@ -164,11 +164,11 @@ fn compare_arguments(arguments: &[Arc<Type>], parameters: &[Arc<Type>]) -> bool 
 impl Names {
     pub fn new() -> Self {
         Self {
-            local_types: Default::default(),
-            imported_modules: Default::default(),
-            type_variables: Default::default(),
-            local_value_constructors: Default::default(),
-            reexport_aliases: Default::default(),
+            local_types: BiHashMap::new(),
+            imported_modules: HashMap::new(),
+            type_variables: HashMap::new(),
+            local_value_constructors: BiHashMap::new(),
+            reexport_aliases: HashMap::new(),
         }
     }
 
@@ -408,8 +408,8 @@ impl<'a> Printer<'a> {
     pub fn new(names: &'a Names) -> Self {
         Printer {
             names,
-            uid: Default::default(),
-            printed_type_variables: Default::default(),
+            uid: 0,
+            printed_type_variables: HashMap::new(),
             printed_type_variable_names: names.type_variables.values().cloned().collect(),
         }
     }
@@ -435,9 +435,9 @@ impl<'a> Printer<'a> {
     pub fn new_without_type_variables(names: &'a Names) -> Self {
         Printer {
             names,
-            uid: Default::default(),
-            printed_type_variables: Default::default(),
-            printed_type_variable_names: Default::default(),
+            uid: 0,
+            printed_type_variables: HashMap::new(),
+            printed_type_variable_names: HashSet::new(),
         }
     }
 

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -571,7 +571,7 @@ pub fn module_error_with_target(
     let (error, names) = match outcome {
         Outcome::Ok(_) => panic!("should infer an error"),
         Outcome::PartialFailure(ast, errors) => (errors.into(), ast.names),
-        Outcome::TotalFailure(errors) => (errors.into(), Default::default()),
+        Outcome::TotalFailure(errors) => (errors.into(), Names::new()),
     };
 
     let error = Error::Type {
@@ -611,7 +611,7 @@ pub fn internal_module_error_with_target(
     let (error, names) = match outcome {
         Outcome::Ok(_) => panic!("should infer an error"),
         Outcome::PartialFailure(ast, errors) => (errors.into(), ast.names),
-        Outcome::TotalFailure(errors) => (errors.into(), Default::default()),
+        Outcome::TotalFailure(errors) => (errors.into(), Names::new()),
     };
 
     let error = Error::Type {
@@ -688,19 +688,19 @@ fn field_map_reorder_test() {
         arguments: vec![
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("1"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("2"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("3"),
             },
@@ -709,19 +709,19 @@ fn field_map_reorder_test() {
         expected_arguments: vec![
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("1"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("2"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("3"),
             },
@@ -735,19 +735,19 @@ fn field_map_reorder_test() {
         arguments: vec![
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("1"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("2"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: Some("last".into()),
                 value: int("3"),
             },
@@ -756,19 +756,19 @@ fn field_map_reorder_test() {
         expected_arguments: vec![
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("1"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: None,
                 value: int("2"),
             },
             CallArg {
                 implicit: None,
-                location: Default::default(),
+                location: SrcSpan::default(),
                 label: Some("last".into()),
                 value: int("3"),
             },
@@ -784,8 +784,8 @@ fn infer_module_type_retention_test() {
         name: "ok".into(),
         definitions: vec![],
         type_info: (),
-        names: Default::default(),
-        unused_definition_positions: Default::default(),
+        names: Names::new(),
+        unused_definition_positions: HashSet::new(),
     };
     let direct_dependencies = HashMap::from_iter(vec![]);
     let ids = UniqueIdGenerator::new();
@@ -2942,10 +2942,10 @@ fn assert_suitable_main_function_not_module_function() {
         type_: fn_(vec![], int()),
         variant: ValueConstructorVariant::ModuleConstant {
             documentation: None,
-            location: Default::default(),
+            location: SrcSpan::default(),
             module: "module".into(),
             literal: Constant::Int {
-                location: Default::default(),
+                location: SrcSpan::default(),
                 value: "1".into(),
                 int_value: 1.into(),
             },
@@ -2976,7 +2976,7 @@ fn assert_suitable_main_function_wrong_arity() {
             field_map: None,
             arity: 1,
             documentation: None,
-            location: Default::default(),
+            location: SrcSpan::default(),
             module: "module".into(),
             external_erlang: None,
             external_javascript: None,
@@ -3007,7 +3007,7 @@ fn assert_suitable_main_function_ok() {
             field_map: None,
             arity: 0,
             documentation: None,
-            location: Default::default(),
+            location: SrcSpan::default(),
             module: "module".into(),
             external_erlang: None,
             external_javascript: None,
@@ -3038,7 +3038,7 @@ fn assert_suitable_main_function_erlang_not_supported() {
             field_map: None,
             arity: 0,
             documentation: None,
-            location: Default::default(),
+            location: SrcSpan::default(),
             module: "module".into(),
             external_erlang: Some(("wibble".into(), "wobble".into())),
             external_javascript: Some(("wobble".into(), "wibble".into())),
@@ -3069,7 +3069,7 @@ fn assert_suitable_main_function_javascript_not_supported() {
             field_map: None,
             arity: 0,
             documentation: None,
-            location: Default::default(),
+            location: SrcSpan::default(),
             module: "module".into(),
             external_erlang: Some(("wibble".into(), "wobble".into())),
             external_javascript: Some(("wobble".into(), "wibble".into())),

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -177,7 +177,7 @@ fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {
         name: "library".into(),
         version: Version::new(1, 0, 0),
         target,
-        ..Default::default()
+        ..PackageConfig::default()
     };
 
     let target = match target {

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -637,7 +637,7 @@ impl<'a, IO> Completer<'a, IO> {
                     range: Range { start, end },
                     new_text: name.to_string(),
                 })),
-                ..Default::default()
+                ..CompletionItem::default()
             })
             .collect()
     }
@@ -682,7 +682,7 @@ impl<'a, IO> Completer<'a, IO> {
                     detail: Some("Type".into()),
                     kind: Some(CompletionItemKind::Class),
                     sort_text,
-                    ..Default::default()
+                    ..CompletionItem::default()
                 });
             }
         }
@@ -909,7 +909,7 @@ impl<'a, IO> Completer<'a, IO> {
                     detail: Some(PRELUDE_MODULE_NAME.into()),
                     kind: Some(kind),
                     sort_text,
-                    ..Default::default()
+                    ..CompletionItem::default()
                 });
             };
 
@@ -1219,7 +1219,7 @@ impl<'a, IO> Completer<'a, IO> {
                     detail,
                     kind: Some(CompletionItemKind::Field),
                     sort_text,
-                    ..Default::default()
+                    ..CompletionItem::default()
                 }
             })
             .collect()
@@ -1274,7 +1274,7 @@ impl<'a, IO> Completer<'a, IO> {
                 TypeMatch::Matching,
             )),
             text_edit: cursor_surrounding.to_text_edit(label),
-            ..Default::default()
+            ..CompletionItem::default()
         }
     }
 
@@ -1321,7 +1321,7 @@ impl<'a, IO> Completer<'a, IO> {
             documentation,
             sort_text: Some(sort_text(priority, &label, type_match)),
             text_edit: cursor_surrounding.to_text_edit(label),
-            ..Default::default()
+            ..CompletionItem::default()
         }
     }
 
@@ -1334,7 +1334,7 @@ impl<'a, IO> Completer<'a, IO> {
             kind: Some(CompletionItemKind::Field),
             detail: Some(type_),
             sort_text: Some(sort_text(CompletionKind::FieldAccessor, label, type_match)),
-            ..Default::default()
+            ..CompletionItem::default()
         }
     }
 }
@@ -1385,7 +1385,7 @@ fn type_completion(
         detail: Some("Type".into()),
         sort_text: Some(sort_text(priority, &label, TypeMatch::Unknown)),
         text_edit: cursor_surrounding.to_text_edit(completion_text),
-        ..Default::default()
+        ..CompletionItem::default()
     }
 }
 
@@ -1510,7 +1510,7 @@ impl<'a> LocalCompletion<'a> {
                 range: insert_range,
                 new_text: label.clone(),
             })),
-            ..Default::default()
+            ..CompletionItem::default()
         }
     }
 }

--- a/language-server/src/feedback.rs
+++ b/language-server/src/feedback.rs
@@ -28,7 +28,7 @@ impl Feedback {
     /// No feedback at all.
     ///
     pub fn none() -> Feedback {
-        Default::default()
+        Feedback::default()
     }
 
     /// Add all the content of another feedback to this feedback.

--- a/language-server/src/lib.rs
+++ b/language-server/src/lib.rs
@@ -22,6 +22,7 @@
     clippy::option_option,
     clippy::verbose_file_reads,
     clippy::unnested_or_patterns,
+    clippy::default_trait_access,
     rust_2018_idioms,
     missing_debug_implementations,
     missing_copy_implementations,

--- a/language-server/src/rename.rs
+++ b/language-server/src/rename.rs
@@ -75,7 +75,7 @@ pub fn rename_local_variable(
     kind: VariableReferenceKind,
 ) -> RenameOutcome {
     let new_name = EcoString::from(&params.new_name);
-    if name::check_name_case(Default::default(), &new_name, Named::Variable).is_err() {
+    if name::check_name_case(SrcSpan::default(), &new_name, Named::Variable).is_err() {
         return RenameOutcome::InvalidName { name: new_name };
     }
 
@@ -518,7 +518,7 @@ pub fn rename_type_variable(
     name: EcoString,
 ) -> RenameOutcome {
     let new_name = EcoString::from(&params.new_name);
-    if name::check_name_case(Default::default(), &new_name, Named::TypeVariable).is_err() {
+    if name::check_name_case(SrcSpan::default(), &new_name, Named::TypeVariable).is_err() {
         return RenameOutcome::InvalidName { name: new_name };
     }
 

--- a/language-server/src/tests.rs
+++ b/language-server/src/tests.rs
@@ -69,10 +69,10 @@ struct LanguageServerTestIO {
 
 fn default_manifest_package() -> ManifestPackage {
     ManifestPackage {
-        name: Default::default(),
-        build_tools: Default::default(),
-        otp_app: Default::default(),
-        requirements: Default::default(),
+        name: EcoString::new(),
+        build_tools: vec![],
+        otp_app: None,
+        requirements: vec![],
         version: Version::new(1, 0, 0),
         source: ManifestPackageSource::Hex {
             outer_checksum: Base16Checksum(vec![]),
@@ -83,8 +83,8 @@ fn default_manifest_package() -> ManifestPackage {
 impl LanguageServerTestIO {
     fn new() -> Self {
         Self {
-            io: Default::default(),
-            actions: Default::default(),
+            io: InMemoryFileSystem::default(),
+            actions: Arc::new(Mutex::new(vec![])),
             paths: ProjectPaths::at_filesystem_root(),
             manifest: Manifest {
                 requirements: HashMap::new(),

--- a/language-server/src/tests/definition.rs
+++ b/language-server/src/tests/definition.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024 The Gleam contributors
 
-use lsp_types::{DefinitionParams, Location, Position, Range, TypeDefinitionParams, Uri as Url};
+use lsp_types::{
+    DefinitionParams, Location, PartialResultParams, Position, Range, TypeDefinitionParams,
+    Uri as Url, WorkDoneProgressParams,
+};
 
 use super::*;
 
@@ -9,8 +12,8 @@ fn definition(tester: &TestProject<'_>, position: Position) -> Option<Location> 
     tester.at(position, |engine, param, _| {
         let params = DefinitionParams {
             text_document_position_params: param,
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
         };
         let response = engine.goto_definition(params);
         response.result.unwrap()
@@ -27,8 +30,8 @@ fn type_definition(tester: &TestProject<'_>, position: Position) -> Vec<Location
     tester.at(position, |engine, param, _| {
         let params = TypeDefinitionParams {
             text_document_position_params: param,
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
         };
         let response = engine.goto_type_definition(params);
 
@@ -447,8 +450,8 @@ fn main() {
 
     let params = DefinitionParams {
         text_document_position_params: position_param.clone(),
-        work_done_progress_params: Default::default(),
-        partial_result_params: Default::default(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
     };
     let response = engine.goto_definition(params.clone());
     let response = response.result.unwrap();
@@ -521,8 +524,8 @@ fn main() {
 
     let params = DefinitionParams {
         text_document_position_params: position_param.clone(),
-        work_done_progress_params: Default::default(),
-        partial_result_params: Default::default(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
     };
 
     let response = engine.goto_definition(params.clone());

--- a/language-server/src/tests/document_symbols.rs
+++ b/language-server/src/tests/document_symbols.rs
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2024 The Gleam contributors
 
 use insta::assert_debug_snapshot;
-use lsp_types::{DocumentSymbol, DocumentSymbolParams};
+use lsp_types::{
+    DocumentSymbol, DocumentSymbolParams, PartialResultParams, WorkDoneProgressParams,
+};
 
 use super::*;
 
@@ -10,8 +12,8 @@ fn doc_symbols(tester: TestProject<'_>) -> Vec<DocumentSymbol> {
     tester.at(Position::default(), |engine, param, _| {
         let params = DocumentSymbolParams {
             text_document: param.text_document,
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
         };
         let response = engine.document_symbol(params);
 

--- a/language-server/src/tests/folding_range.rs
+++ b/language-server/src/tests/folding_range.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Gleam contributors
 
-use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams};
+use lsp_types::{
+    FoldingRange, FoldingRangeKind, FoldingRangeParams, PartialResultParams, WorkDoneProgressParams,
+};
 
 use super::*;
 
@@ -9,8 +11,8 @@ fn folding_ranges(tester: TestProject<'_>) -> Vec<FoldingRange> {
     tester.at(Position::default(), |engine, param, _| {
         let params = FoldingRangeParams {
             text_document: param.text_document,
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
         };
         let response = engine.folding_range(params);
 

--- a/language-server/src/tests/hover.rs
+++ b/language-server/src/tests/hover.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 The Gleam contributors
 
-use lsp_types::{Contents, Hover, HoverParams, MarkedString, Position, Range};
+use lsp_types::{
+    Contents, Hover, HoverParams, MarkedString, Position, Range, WorkDoneProgressParams,
+};
 
 use super::*;
 
@@ -9,7 +11,7 @@ fn hover(tester: TestProject<'_>, position: Position) -> Option<Hover> {
     tester.at(position, |engine, param, _| {
         let params = HoverParams {
             text_document_position_params: param,
-            work_done_progress_params: Default::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
         };
         let response = engine.hover(params);
 

--- a/language-server/src/tests/signature_help.rs
+++ b/language-server/src/tests/signature_help.rs
@@ -4,7 +4,7 @@
 use super::*;
 use lsp_types::{
     ActiveParameter, ParameterInformation, ParameterInformationLabel, SignatureHelp,
-    SignatureHelpParams, SignatureInformation,
+    SignatureHelpParams, SignatureInformation, WorkDoneProgressParams,
 };
 
 fn signature_help(tester: TestProject<'_>, position: Position) -> Option<SignatureHelp> {
@@ -12,7 +12,7 @@ fn signature_help(tester: TestProject<'_>, position: Position) -> Option<Signatu
         let params = SignatureHelpParams {
             context: None,
             text_document_position_params: param,
-            work_done_progress_params: Default::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
         };
         let response = engine.signature_help(params);
 


### PR DESCRIPTION
This PR removes all usages of `Default::default()` and adds a clippy lint to make sure we don't use it again. This way the code is more explicit!
