### PR TITLE
format: fix indent on trailing comments inside multi-line lists/tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,3 +434,7 @@
 
 - The build tool will no longer panic when unable to lock the build directory.
   ([Louis Pilfold](https://github.com/lpil))
+
+- The formatter now properly indents multiline trailing comments inside of
+  multiline lists and tuples.
+  ([0xda157](https://github.com/0xda157))

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -758,7 +758,7 @@ impl<'a, 'doc> Formatter<'a> {
                 // ^ See how here we're adding the missing indentation to the
                 //   final break so that the final comment is as indented as the
                 //   list's items.
-                .append(arena, comment)
+                .append(arena, comment.nest(arena, INDENT))
                 .append(arena, LINE_DOCUMENT)
                 .append(arena, CLOSE_SQUARE_DOCUMENT)
                 .force_break(arena),
@@ -815,7 +815,7 @@ impl<'a, 'doc> Formatter<'a> {
                 .group(arena),
             Some(comments) => tuple_doc
                 .append(arena, TRAILING_COMMA_BREAK_DOCUMENT.nest(arena, INDENT))
-                .append(arena, comments)
+                .append(arena, comments.nest(arena, INDENT))
                 .append(arena, LINE_DOCUMENT)
                 .append(arena, CLOSE_PAREN_DOCUMENT)
                 .force_break(arena),

--- a/format/src/tests/lists.rs
+++ b/format/src/tests/lists.rs
@@ -366,3 +366,18 @@ fn const_lists_with_empty_lines_are_always_broken() {
 "
     );
 }
+
+#[test]
+fn const_list_trailing_comment_indent() {
+    assert_format!(
+        "const list = [
+  1,
+  2,
+  3,
+  // 4,
+  // 5,
+  // 6,
+]
+"
+    );
+}

--- a/format/src/tests/tuple.rs
+++ b/format/src/tests/tuple.rs
@@ -114,3 +114,18 @@ fn nested_literal_tuple_with_needless_block_is_not_changed() {
 "#
     );
 }
+
+#[test]
+fn multi_line_tuple_trailing_comment() {
+    assert_format!(
+        "const tuple = #(
+  1,
+  2,
+  3,
+  // 4,
+  // 5,
+  // 6,
+)
+"
+    );
+}


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Resolves https://github.com/gleam-lang/gleam/issues/5896