### PR TITLE
Deprecate ambiguous pipe syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,10 @@
 
   ([Gavin Morrow](https://github.com/gavinmorrow))
 
+- The language server now offers a code action to fix the new deprecated pipeline
+  syntax.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Formatter
 
 - Performance of the formatter has been improved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
   JavaScript target, allowing for faster comparison in most cases.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- The use of pipes to turn the Gleam code `a |> b(c)` into `b(c)(a)` has been
+  deprecated.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - The build tool now generates Hexdocs URLs using the new format of

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1190,6 +1190,10 @@ pub enum Warning {
         location: SrcSpan,
         size: BigInt,
     },
+
+    PipeIntoCallWhichReturnsFunction {
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -1461,7 +1465,8 @@ impl Warning {
             }
             | Warning::RedundantComparison { location, .. }
             | Warning::JavaScriptBitArrayUnsafeInt { location, .. }
-            | Warning::UnusedRecursiveArgument { location, .. } => *location,
+            | Warning::UnusedRecursiveArgument { location, .. }
+            | Warning::PipeIntoCallWhichReturnsFunction { location } => *location,
         }
     }
 

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -144,6 +144,12 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                             // Without lifting purity tracking into the type system,
                             // we have no idea whether it's pure or not!
                             self.expr_typer.purity = self.expr_typer.purity.merge(Purity::Unknown);
+
+                            // This syntax is deprecated.
+                            self.expr_typer
+                                .problems
+                                .warning(Warning::PipeIntoCallWhichReturnsFunction { location });
+
                             (
                                 PipelineAssignmentKind::FunctionCall,
                                 self.infer_apply_to_call_pipe(fun, arguments, location),

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__piping_into_call_which_returns_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__piping_into_call_which_returns_function.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  1 |> wibble(2)\n}\n\nfn wibble(a) {\n  fn(b) { #(a, b) }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  1 |> wibble(2)
+}
+
+fn wibble(a) {
+  fn(b) { #(a, b) }
+}
+
+
+----- WARNING
+warning: Deprecated pipe use
+  ┌─ /src/warning/wrn.gleam:3:8
+  │
+3 │   1 |> wibble(2)
+  │        ^^^^^^^^^ This should have an extra set of parentheses
+
+This use of pipelines is deprecated, as it creates ambiguity in pipe
+syntax. Currently `a |> b(c)` can desugar to either `b(a, c)` or `b(a)(c)`
+depending on the type of `b`. The latter syntax is deprecated, and should
+not be used.
+
+Hint: Add an extra set of parentheses after the call, like `a |> b(c)()`

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -3949,7 +3949,7 @@ fn make_panic() {
 }
 
 fn impure(x) {
-  x |> make_panic()
+  x |> make_panic()()
 }
 
 pub fn main() {
@@ -5078,6 +5078,36 @@ fn constant_used_in_todo_message_counts_as_used() {
         "
 const wibble = 1
 pub const wobble = todo as wibble
+"
+    );
+}
+
+#[test]
+fn piping_into_call_which_returns_function() {
+    assert_warning!(
+        "
+pub fn main() {
+  1 |> wibble(2)
+}
+
+fn wibble(a) {
+  fn(b) { #(a, b) }
+}
+"
+    );
+}
+
+#[test]
+fn no_warning_when_extra_brackets_are_added_to_call_returning_function() {
+    assert_no_warnings!(
+        "
+pub fn main() {
+  1 |> wibble(2)()
+}
+
+fn wibble(a) {
+  fn(b) { #(a, b) }
+}
 "
     );
 }

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1490,6 +1490,29 @@ The imported value could not be used in this module anyway."
                         extra_labels: vec![],
                     }),
                 },
+
+                type_::Warning::PipeIntoCallWhichReturnsFunction { location } => Diagnostic {
+                    title: "Deprecated pipe use".into(),
+                    text: wrap(
+                        "This use of pipelines is deprecated, as it creates \
+ambiguity in pipe syntax. Currently `a |> b(c)` can desugar to either `b(a, c)` or \
+`b(a)(c)` depending on the type of `b`. The latter syntax is deprecated, and should \
+not be used.",
+                    ),
+                    hint: Some(
+                        "Add an extra set of parentheses after the call, like `a |> b(c)()`".into(),
+                    ),
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        label: diagnostic::Label {
+                            text: Some("This should have an extra set of parentheses".into()),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
             },
 
             Warning::EmptyModule { path: _, name } => Diagnostic {

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -47,3 +47,16 @@ compiler allows this: `case wibble { big if -> True }`
 
 - [x] Emits warning when used.
 - [x] Formatter rewrites it to desired syntax.
+
+## Piping into a call that returns a function
+
+In Gleam v1, the syntax `a |> b(c)` is ambiguous; it can either mean `b(a, c)`
+or `b(a)(c)`. This makes code harder to reason about as it means that you cannot
+determine the meaning of pipe expressions without knowing the type of the called
+function.
+
+In Gleam v2, we want to remove the second option, so `a |> b(c)` always desugars
+to `b(a, c)`, regardless of the types.
+
+- [x] Emits warning when used.
+- [ ] Code action to rewrite to desired syntax

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -59,4 +59,4 @@ In Gleam v2, we want to remove the second option, so `a |> b(c)` always desugars
 to `b(a, c)`, regardless of the types.
 
 - [x] Emits warning when used.
-- [ ] Code action to rewrite to desired syntax
+- [x] Code action to rewrite to desired syntax

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -12913,3 +12913,52 @@ impl<'a> DiscardUnusedVariable<'a> {
         action
     }
 }
+
+pub fn code_action_fix_deprecated_pipe(
+    module: &Module,
+    line_numbers: &LineNumbers,
+    params: &CodeActionParams,
+    actions: &mut Vec<CodeAction>,
+) {
+    let uri = &params.text_document.uri;
+    let mut deprecated_pipes: Vec<&SrcSpan> = module
+        .ast
+        .type_info
+        .warnings
+        .iter()
+        .filter_map(|warning| {
+            if let type_::Warning::PipeIntoCallWhichReturnsFunction { location } = warning {
+                Some(location)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if deprecated_pipes.is_empty() {
+        return;
+    }
+
+    // Sort spans by start position, with longer spans coming first
+    deprecated_pipes.sort_by_key(|span| (span.start, -(span.len() as i64)));
+
+    for location in deprecated_pipes {
+        let range = src_span_to_lsp_range(*location, line_numbers);
+
+        // Check if the cursor is within this span
+        if !within(params.range, range) {
+            continue;
+        }
+
+        let edit = TextEdit {
+            range: Range::new(range.end, range.end),
+            new_text: "()".into(),
+        };
+
+        CodeActionBuilder::new("Add extra parentheses")
+            .kind(CodeActionKind::QuickFix)
+            .changes(uri.clone(), vec![edit])
+            .preferred(true)
+            .push_to(actions);
+    }
+}

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -9413,7 +9413,8 @@ impl<'a> RemoveUnusedImports<'a> {
                 | type_::Warning::TopLevelDefinitionShadowsImport { .. }
                 | type_::Warning::RedundantComparison { .. }
                 | type_::Warning::UnusedRecursiveArgument { .. }
-                | type_::Warning::JavaScriptBitArrayUnsafeInt { .. } => None,
+                | type_::Warning::JavaScriptBitArrayUnsafeInt { .. }
+                | type_::Warning::PipeIntoCallWhichReturnsFunction { .. } => None,
             })
             .sorted_by_key(|import| import.location())
             .collect_vec();

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -41,7 +41,7 @@ use std::{
 use crate::{
     code_action::{
         DiscardUnusedVariable, RemoveRedundantRecordUpdate, ReplaceUnderscoreWithType,
-        type_errors_for_module,
+        code_action_fix_deprecated_pipe, type_errors_for_module,
     },
     reference::find_module_references_in_module,
     rename::{rename_module_alias, rename_module_occurrences, rename_type_variable},
@@ -554,6 +554,7 @@ where
                 .code_actions(),
             );
             actions.extend(DiscardUnusedVariable::new(module, &lines, &params).code_actions());
+            code_action_fix_deprecated_pipe(module, &lines, &params, &mut actions);
 
             actions.sort_by_key(|one| {
                 let preferred_key = if one.is_preferred == Some(true) { 0 } else { 1 };

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -207,6 +207,7 @@ const WRAP_IN_ANONYMOUS_FUNCTION: &str = "Wrap in anonymous function";
 const UNWRAP_ANONYMOUS_FUNCTION: &str = "Remove anonymous function wrapper";
 const REMOVE_REDUNDANT_RECORD_UPDATE: &str = "Remove redundant record update";
 const DISCARD_UNUSED_VARIABLE: &str = "Discard unused variable";
+const ADD_EXTRA_PARENTHESES: &str = "Add extra parentheses";
 
 macro_rules! assert_code_action {
     ($title:expr, $code:literal, $range_selector:expr $(,)?) => {
@@ -15398,5 +15399,24 @@ fn convert_to_function_call_on_last_step_single_line() {
   [1, 2, 3] |> echo |> wibble |> wobble
 }",
         find_position_of("wobble").to_selection()
+    );
+}
+
+#[test]
+fn fix_deprecated_pipe_syntax() {
+    assert_code_action!(
+        ADD_EXTRA_PARENTHESES,
+        "
+pub fn main() {
+  1 |> wibble(2)
+}
+
+pub fn wibble(a) {
+  fn(b) {
+    #(a, b)
+  }
+}
+",
+        find_position_of("wibble").under_char('i').to_selection()
     );
 }

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__action__fix_deprecated_pipe_syntax.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__action__fix_deprecated_pipe_syntax.snap
@@ -1,0 +1,29 @@
+---
+source: language-server/src/tests/action.rs
+expression: "\npub fn main() {\n  1 |> wibble(2)\n}\n\npub fn wibble(a) {\n  fn(b) {\n    #(a, b)\n  }\n}\n"
+---
+----- BEFORE ACTION
+
+pub fn main() {
+  1 |> wibble(2)
+        ↑       
+}
+
+pub fn wibble(a) {
+  fn(b) {
+    #(a, b)
+  }
+}
+
+
+----- AFTER ACTION
+
+pub fn main() {
+  1 |> wibble(2)()
+}
+
+pub fn wibble(a) {
+  fn(b) {
+    #(a, b)
+  }
+}


### PR DESCRIPTION
- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

This PR deprecates the pipe syntax where `a |> b(c)` gets rewritten as `b(c)(a)` rather than `b(a, c)`, which will be eventually changed in Gleam 2.0 to remove ambiguity.

I'm still not really sure on the error message, so any thoughts would be good