### PR TITLE
Fix conflict for git path dep to repo root

### DIFF
--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1524,13 +1524,23 @@ fn provide_package(
                 } => {
                     let (child_path, child_repo_path) =
                         resolve_git_path_package(&name, &path, repo, &package_path, repo_root)?;
+                    // A path dependency resolving to the repository root has an
+                    // empty repo-relative path. Normalise it to `None` so it
+                    // matches a package declared directly as a git dependency
+                    // with no path.
+                    let child_repo_path = if child_repo_path.as_str().is_empty() {
+                        None
+                    } else {
+                        Some(child_repo_path)
+                    };
+
                     provide_package(
                         name.clone(),
                         child_path,
                         SourceContext::Git {
                             repo: repo.clone(),
                             commit: commit.clone(),
-                            path: Some(child_repo_path),
+                            path: child_repo_path,
                             repo_root,
                         },
                         project_paths,

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -891,6 +891,66 @@ version = "0.2.0"
 }
 
 #[test]
+fn provided_git_path_package_to_repo_root_has_no_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+    let repo = base.join("repo");
+    fs::mkdir(&repo.join("backends").join("package_a")).unwrap();
+    fs::write(
+        &repo.join("gleam.toml"),
+        r#"
+name = "package_b"
+version = "0.2.0"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        &repo.join("backends").join("package_a").join("gleam.toml"),
+        r#"
+name = "package_a"
+version = "0.1.0"
+
+[dependencies]
+package_b = { path = "../.." }
+"#,
+    )
+    .unwrap();
+
+    let mut provided = HashMap::new();
+    let project_paths = crate::project_paths_at_current_directory_without_toml();
+    let repo_root = fs::canonicalise(&repo).unwrap();
+    let result = provide_package(
+        "package_a".into(),
+        fs::canonicalise(&repo.join("backends").join("package_a")).unwrap(),
+        SourceContext::Git {
+            repo: "https://github.com/gleam-lang/wibble.git".into(),
+            commit: "95cd2c2f45907e5571e9b5fcdfb27ff35cdcdd29".into(),
+            path: Some("backends/package_a".into()),
+            repo_root: &repo_root,
+        },
+        &project_paths,
+        &mut provided,
+        &mut vec!["root".into()],
+    );
+    assert_eq!(
+        result,
+        Ok(hexpm::version::Range::new("== 0.1.0".into()).unwrap())
+    );
+    // A path dependency resolving to the repository root must match how the
+    // same package is provided when declared directly as a git dependency
+    // with no path (`None`), otherwise it is reported as a conflict.
+    let package = provided.get("package_b").unwrap();
+    assert_eq!(
+        package.source,
+        ProvidedPackageSource::Git {
+            repo: "https://github.com/gleam-lang/wibble.git".into(),
+            commit: "95cd2c2f45907e5571e9b5fcdfb27ff35cdcdd29".into(),
+            path: None,
+        }
+    );
+}
+
+#[test]
 fn provided_git_path_package_rejects_missing_directory() {
     let tmp = tempfile::tempdir().unwrap();
     let base = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();


### PR DESCRIPTION
@renatillas spotted a bug with git deps with paths where if you have deps declared as:

```
wobble = {git = "git@github.com:jtdowney/wibble.git", ref="main", path="packages/wobble"}
wibble = {git = "git@github.com:jtdowney/wibble.git", ref="main"}
```

And wobble has a `"../.."` path dep back to wibble, then you will get a conflict error:

```
The package `wibble` is provided as both `{ repo: "git@github.com:jtdowney/wibble.git", commit: "84bfce09b213cba5fce09e65b192ecf593e15241" }` and `{ repo: "git@github.com:jtdowney/wibble.git", commit: "84bfce09b213cba5fce09e65b192ecf593e15241", path: "" }`.
```

The fix is to normalize a git dep with a path at the root of the repo (`""`) back to a git dep with no path at all.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes
