### PR TITLE
Fix duplicate diagnostics in calls to fn literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,3 +475,7 @@
 - Fixed a bug where the language server would not show autocomplete for record
   fields of internal types within the same package.
   ([Surya Rose](https://github.com/GearsDatapacks))
+
+- Fixed a bug where warnings and errors in the arguments of a call to a
+  function literal would be reported multiple times.
+  ([John Downey](https://github.com/jtdowney))

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4818,6 +4818,20 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         return_annotation: Option<TypeAst>,
         location: SrcSpan,
     ) -> TypedExpr {
+        // The pass below speculatively infers the call arguments to discover
+        // their types, which are used to type any unannotated parameters of
+        // the function literal being called. The arguments are then inferred
+        // in `do_infer_call_with_known_fun`, so any diagnostics recorded here
+        // would be reported twice, compounding to 2^N copies for N nested
+        // `use`s. To prevent that we discard any problems this pass records
+        // and restore the inference state, so the real pass behaves as if this
+        // one never ran.
+        // https://github.com/gleam-lang/gleam/issues/3899
+        let problems_before_speculation = std::mem::take(self.problems);
+        let previous_panics = self.previous_panics;
+        let already_warned_for_unreachable_code = self.already_warned_for_unreachable_code;
+        let purity = self.purity;
+
         let typed_call_arguments: Vec<Arc<Type>> = call_arguments
             .iter()
             .map(|argument| {
@@ -4828,6 +4842,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .type_()
             })
             .collect_vec();
+
+        *self.problems = problems_before_speculation;
+        self.previous_panics = previous_panics;
+        self.already_warned_for_unreachable_code = already_warned_for_unreachable_code;
+        self.purity = purity;
+
         self.infer_fn(
             arguments,
             &typed_call_arguments,

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_nested_use_with_fn_literal_rhs_warns_once.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_nested_use_with_fn_literal_rhs_warns_once.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@deprecated(\"Don't use this!\")\npub fn wibble() {\n  Nil\n}\n\npub fn main() {\n  use <- fn(f) { f() }\n  use <- fn(f) { f() }\n  wibble()\n}\n"
+---
+----- SOURCE CODE
+
+@deprecated("Don't use this!")
+pub fn wibble() {
+  Nil
+}
+
+pub fn main() {
+  use <- fn(f) { f() }
+  use <- fn(f) { f() }
+  wibble()
+}
+
+
+----- WARNING
+warning: Deprecated value used
+   ┌─ /src/warning/wrn.gleam:10:3
+   │
+10 │   wibble()
+   │   ^^^^^^ This value has been deprecated
+
+It was deprecated with this message: Don't use this!

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_use_with_fn_literal_rhs_warns_once.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_use_with_fn_literal_rhs_warns_once.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n@deprecated(\"Don't use this!\")\npub fn wibble() {\n  Nil\n}\n\npub fn main() {\n  use <- fn(f) { f() }\n  wibble()\n}\n"
+---
+----- SOURCE CODE
+
+@deprecated("Don't use this!")
+pub fn wibble() {
+  Nil
+}
+
+pub fn main() {
+  use <- fn(f) { f() }
+  wibble()
+}
+
+
+----- WARNING
+warning: Deprecated value used
+  ┌─ /src/warning/wrn.gleam:9:3
+  │
+9 │   wibble()
+  │   ^^^^^^ This value has been deprecated
+
+It was deprecated with this message: Don't use this!

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_code_in_use_with_fn_literal_rhs_warns_once.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_code_in_use_with_fn_literal_rhs_warns_once.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn wibble() {\n  Nil\n}\n\npub fn main() {\n  use <- fn(f) { f() }\n  panic\n  wibble()\n}\n"
+---
+----- SOURCE CODE
+
+pub fn wibble() {
+  Nil
+}
+
+pub fn main() {
+  use <- fn(f) { f() }
+  panic
+  wibble()
+}
+
+
+----- WARNING
+warning: Unreachable code
+  ┌─ /src/warning/wrn.gleam:9:3
+  │
+9 │   wibble()
+  │   ^^^^^^^^
+
+This code is unreachable because it comes after a `panic`.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -5111,3 +5111,58 @@ fn wibble(a) {
 "
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/3899
+#[test]
+fn deprecated_value_in_use_with_fn_literal_rhs_warns_once() {
+    assert_warning!(
+        r#"
+@deprecated("Don't use this!")
+pub fn wibble() {
+  Nil
+}
+
+pub fn main() {
+  use <- fn(f) { f() }
+  wibble()
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/3899
+#[test]
+fn deprecated_value_in_nested_use_with_fn_literal_rhs_warns_once() {
+    assert_warning!(
+        r#"
+@deprecated("Don't use this!")
+pub fn wibble() {
+  Nil
+}
+
+pub fn main() {
+  use <- fn(f) { f() }
+  use <- fn(f) { f() }
+  wibble()
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/3899
+#[test]
+fn unreachable_code_in_use_with_fn_literal_rhs_warns_once() {
+    assert_warning!(
+        "
+pub fn wibble() {
+  Nil
+}
+
+pub fn main() {
+  use <- fn(f) { f() }
+  panic
+  wibble()
+}
+"
+    );
+}


### PR DESCRIPTION
I originally had what I thought was a clever way to fix this, but it turned out not to be a complete solution. The simplest route to me seemed to be just to save/restore the state after doing the speculative inference pass.

Fixes #3899

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
