### PR TITLE
Use configured target as default when deleting docs build directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,3 +483,7 @@
 - Fixed a bug where pattern matching on overlapping string prefixes with guards
   could generate incorrect JavaScript.
   ([John Downey](https://github.com/jtdowney))
+
+- Fixed a bug where running `gleam docs build` on non-Erlang target projects
+  with a warm cache would not produce the module pages.
+  ([Matt Champagne](https://github.com/han-tyumi))

--- a/compiler-cli/src/docs.rs
+++ b/compiler-cli/src/docs.rs
@@ -61,7 +61,7 @@ pub fn build(paths: &ProjectPaths, options: BuildOptions) -> Result<()> {
     // documentation for our package.
     crate::fs::delete_directory(&paths.build_directory_for_package(
         Mode::Prod,
-        options.target.unwrap_or(Target::Erlang),
+        options.target.unwrap_or(config.target),
         &config.name,
     ))?;
 


### PR DESCRIPTION
Fixes #5941

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
