### PR TITLE
Keep cached modules in the generated Erlang .app file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,11 @@
 
 ### Bug fixes
 
+- Fixed a bug where the generated Erlang `.app` file's `modules` list would only
+  contain the modules recompiled by the latest build, becoming empty on a warm
+  rebuild where nothing changed.
+  ([Charlie Tonneslan](https://github.com/c-tonneslan))
+
 - When using the language server to extract a function from within an anonymous
   function, the return value of the extracted function is respected.
 

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -239,7 +239,7 @@ where
         //     modules
         // };
 
-        if let Err(error) = self.perform_codegen(&modules) {
+        if let Err(error) = self.perform_codegen(&modules, &cached_module_names) {
             return error.into();
         }
 
@@ -352,7 +352,11 @@ where
         Ok(())
     }
 
-    fn perform_codegen(&mut self, modules: &[Module]) -> Result<()> {
+    fn perform_codegen(
+        &mut self,
+        modules: &[Module],
+        cached_module_names: &[EcoString],
+    ) -> Result<()> {
         if !self.perform_codegen {
             tracing::debug!("skipping_codegen");
             return Ok(());
@@ -370,7 +374,7 @@ where
                 prelude_location,
             ),
             TargetCodegenConfiguration::Erlang { app_file } => {
-                self.perform_erlang_codegen(modules, app_file.as_ref())
+                self.perform_erlang_codegen(modules, cached_module_names, app_file.as_ref())
             }
         }
     }
@@ -378,6 +382,7 @@ where
     fn perform_erlang_codegen(
         &mut self,
         modules: &[Module],
+        cached_module_names: &[EcoString],
         app_file_config: Option<&ErlangAppCodegenConfiguration>,
     ) -> Result<(), Error> {
         let mut written = HashSet::new();
@@ -418,6 +423,7 @@ where
                 io,
                 &self.config,
                 modules,
+                cached_module_names,
                 native_modules,
             )?;
         }

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -335,7 +335,6 @@ mod tests {
         let app = fs
             .read(Utf8Path::new("/ebin/my_app.app"))
             .expect("read .app");
-        assert!(app.contains("my_app@one"), "{app}");
-        assert!(app.contains("my_app@two"), "{app}");
+        insta::assert_snapshot!(app);
     }
 }

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -99,6 +99,7 @@ impl<'a> ErlangApp<'a> {
         writer: Writer,
         config: &PackageConfig,
         modules: &[Module],
+        cached_module_names: &[EcoString],
         native_modules: Vec<EcoString>,
     ) -> Result<()> {
         fn tuple(key: &str, value: &str) -> String {
@@ -119,9 +120,12 @@ impl<'a> ErlangApp<'a> {
             }
         };
 
+        // Include the cached modules that were not recompiled this build, so a
+        // warm rebuild doesn't shrink the `modules` list (see #5834).
         let modules = modules
             .iter()
             .map(|m| m.erlang_name())
+            .chain(cached_module_names.iter().map(module_erlang_name))
             .chain(native_modules)
             .unique()
             .sorted()
@@ -296,5 +300,42 @@ impl<'a> JavaScript<'a> {
             writer.write(&source_map_path, &content)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::{FileSystemReader, memory::InMemoryFileSystem};
+    use std::collections::HashMap;
+
+    #[test]
+    fn app_file_includes_cached_modules() {
+        // A warm rebuild recompiles nothing, so every module arrives as a cached
+        // name rather than in `modules`; they must still be listed in the .app
+        // (https://github.com/gleam-lang/gleam/issues/5834).
+        let fs = InMemoryFileSystem::new();
+        let mut config = PackageConfig::default();
+        config.name = "my_app".into();
+        let codegen_config = ErlangAppCodegenConfiguration {
+            include_dev_deps: false,
+            package_name_overrides: HashMap::new(),
+        };
+
+        ErlangApp::new(Utf8Path::new("/ebin"), &codegen_config)
+            .render(
+                fs.clone(),
+                &config,
+                &[],
+                &["my_app/one".into(), "my_app/two".into()],
+                vec![],
+            )
+            .expect("render .app");
+
+        let app = fs
+            .read(Utf8Path::new("/ebin/my_app.app"))
+            .expect("read .app");
+        assert!(app.contains("my_app@one"), "{app}");
+        assert!(app.contains("my_app@two"), "{app}");
     }
 }

--- a/compiler-core/src/snapshots/gleam_core__codegen__tests__app_file_includes_cached_modules.snap
+++ b/compiler-core/src/snapshots/gleam_core__codegen__tests__app_file_includes_cached_modules.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/codegen.rs
+expression: app
+---
+{application, my_app, [
+    {vsn, "0.1.0"},
+    {applications, []},
+    {description, ""},
+    {modules, [my_app@one,
+               my_app@two]},
+    {registered, []}
+]}.


### PR DESCRIPTION
Fixes #5834.

The Erlang `.app` `modules` list was populated only from the modules recompiled by the current build. On a warm rebuild where nothing changed, that list came out empty — a problem for any tool that boots the release in embedded mode (as noted in the issue, and confirmed by @lpil).

`perform_codegen` already receives `cached_module_names` (the modules loaded from cache rather than recompiled); this threads them through to `ErlangApp::render` and chains them into the `modules` list alongside the freshly compiled ones. The existing `.unique().sorted()` keeps the output stable and deduplicated.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes