### PR TITLE
Clippy

### DIFF
--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -89,7 +89,7 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
                     gleam_toml["dependencies"] = toml_edit::table();
                 }
                 gleam_toml["dependencies"][&added_package] = toml_edit::value(range.clone());
-            };
+            }
             manifest_toml["requirements"][&added_package]["version"] = range.into();
         }
     }

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -114,11 +114,12 @@ fn read_toml_edit(name: &Utf8Path) -> Result<toml_edit::DocumentMut, Error> {
 
 fn version_to_string(version: &Version) -> String {
     let mut text = String::new();
-    let _ = write!(
+    write!(
         text,
         "{}.{}.{}",
         version.major, version.minor, version.patch
-    );
+    )
+    .expect("write to a string");
 
     if !version.pre.is_empty() {
         text.push('-');
@@ -133,7 +134,8 @@ fn version_to_string(version: &Version) -> String {
         }
     }
     if let Some(build) = version.build.as_ref() {
-        let _ = write!(text, "+{build}");
+        text.push('+');
+        text.push_str(build);
     }
     text
 }

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2021 The Gleam contributors
 
 use camino::{Utf8Path, Utf8PathBuf};
+use std::fmt::Write as _;
 
 use gleam_core::{
     Error, Result,
@@ -113,10 +114,12 @@ fn read_toml_edit(name: &Utf8Path) -> Result<toml_edit::DocumentMut, Error> {
 
 fn version_to_string(version: &Version) -> String {
     let mut text = String::new();
-    text.push_str(&format!(
+    let _ = write!(
+        text,
         "{}.{}.{}",
         version.major, version.minor, version.patch
-    ));
+    );
+
     if !version.pre.is_empty() {
         text.push('-');
         for (i, identifier) in version.pre.iter().enumerate() {
@@ -130,7 +133,7 @@ fn version_to_string(version: &Version) -> String {
         }
     }
     if let Some(build) = version.build.as_ref() {
-        text.push_str(&format!("+{build}"));
+        let _ = write!(text, "+{build}");
     }
     text
 }

--- a/compiler-cli/src/beam_compiler.rs
+++ b/compiler-cli/src/beam_compiler.rs
@@ -90,7 +90,7 @@ impl BeamCompilerInstance {
                 },
             }
 
-            buf.clear()
+            buf.clear();
         }
 
         // if we get here, stdout got closed before we got an "ok" or "err".

--- a/compiler-cli/src/build.rs
+++ b/compiler-cli/src/build.rs
@@ -75,7 +75,7 @@ pub(crate) fn main_with_warnings(
     match perform_codegen {
         Codegen::All | Codegen::DepsOnly => telemetry.compiled_package(start.elapsed()),
         Codegen::None => telemetry.checked_package(start.elapsed()),
-    };
+    }
 
     Ok(result)
 }

--- a/compiler-cli/src/build_lock.rs
+++ b/compiler-cli/src/build_lock.rs
@@ -69,7 +69,7 @@ impl BuildLock {
 
         if !file.try_lock_with_pid().map_err(lock_error)? {
             telemetry.waiting_for_build_directory_lock();
-            file.lock_with_pid().map_err(lock_error)?
+            file.lock_with_pid().map_err(lock_error)?;
         }
 
         Ok(Guard(file))

--- a/compiler-cli/src/cli.rs
+++ b/compiler-cli/src/cli.rs
@@ -42,15 +42,15 @@ impl Telemetry for Reporter {
     }
 
     fn downloading_package(&self, name: &str) {
-        print_downloading(name)
+        print_downloading(name);
     }
 
     fn packages_downloaded(&self, start: Instant, count: usize) {
-        print_packages_downloaded(start, count)
+        print_packages_downloaded(start, count);
     }
 
     fn resolving_package_versions(&self) {
-        print_resolving_versions()
+        print_resolving_versions();
     }
 
     fn running(&self, name: &str) {
@@ -58,11 +58,11 @@ impl Telemetry for Reporter {
     }
 
     fn waiting_for_build_directory_lock(&self) {
-        print_waiting_for_build_directory_lock()
+        print_waiting_for_build_directory_lock();
     }
 
     fn resolved_package_versions(&self, changes: &PackageChanges) {
-        print_package_changes(changes)
+        print_package_changes(changes);
     }
 }
 
@@ -103,19 +103,19 @@ pub fn ask_password(question: &str) -> Result<EcoString, Error> {
 }
 
 pub fn print_publishing(name: &str, version: &Version) {
-    print_colourful_prefix("Publishing", &format!("{name} v{version}"))
+    print_colourful_prefix("Publishing", &format!("{name} v{version}"));
 }
 
 pub fn print_published(detail: &str) {
-    print_colourful_prefix("Published", detail)
+    print_colourful_prefix("Published", detail);
 }
 
 pub fn print_retired(package: &str, version: &str) {
-    print_colourful_prefix("Retired", &format!("{package} {version}"))
+    print_colourful_prefix("Retired", &format!("{package} {version}"));
 }
 
 pub fn print_unretired(package: &str, version: &str) {
-    print_colourful_prefix("Unretired", &format!("{package} {version}"))
+    print_colourful_prefix("Unretired", &format!("{package} {version}"));
 }
 
 pub fn print_publishing_documentation() {
@@ -123,39 +123,39 @@ pub fn print_publishing_documentation() {
 }
 
 fn print_downloading(text: &str) {
-    print_colourful_prefix("Downloading", text)
+    print_colourful_prefix("Downloading", text);
 }
 
 fn print_waiting_for_build_directory_lock() {
-    print_colourful_prefix("Waiting", "for build directory lock")
+    print_colourful_prefix("Waiting", "for build directory lock");
 }
 
 fn print_resolving_versions() {
-    print_colourful_prefix("Resolving", "versions")
+    print_colourful_prefix("Resolving", "versions");
 }
 
 fn print_compiling(text: &str) {
-    print_colourful_prefix("Compiling", text)
+    print_colourful_prefix("Compiling", text);
 }
 
 pub(crate) fn print_exported(text: &str) {
-    print_colourful_prefix("Exported", text)
+    print_colourful_prefix("Exported", text);
 }
 
 pub(crate) fn print_checking(text: &str) {
-    print_colourful_prefix("Checking", text)
+    print_colourful_prefix("Checking", text);
 }
 
 pub(crate) fn print_compiled(duration: Duration) {
-    print_colourful_prefix("Compiled", &format!("in {}", seconds(duration)))
+    print_colourful_prefix("Compiled", &format!("in {}", seconds(duration)));
 }
 
 pub(crate) fn print_checked(duration: Duration) {
-    print_colourful_prefix("Checked", &format!("in {}", seconds(duration)))
+    print_colourful_prefix("Checked", &format!("in {}", seconds(duration)));
 }
 
 pub(crate) fn print_running(text: &str) {
-    print_colourful_prefix("Running", text)
+    print_colourful_prefix("Running", text);
 }
 
 pub(crate) fn print_package_changes(changes: &PackageChanges) {
@@ -179,19 +179,19 @@ pub(crate) fn print_package_changes(changes: &PackageChanges) {
 }
 
 fn print_added(text: &str) {
-    print_colourful_prefix("Added", text)
+    print_colourful_prefix("Added", text);
 }
 
 fn print_changed(text: &str) {
-    print_colourful_prefix("Changed", text)
+    print_colourful_prefix("Changed", text);
 }
 
 fn print_removed(text: &str) {
-    print_colourful_prefix("Removed", text)
+    print_colourful_prefix("Removed", text);
 }
 
 pub(crate) fn print_generating_documentation() {
-    print_colourful_prefix("Generating", "documentation")
+    print_colourful_prefix("Generating", "documentation");
 }
 
 pub(crate) fn print_transferring_ownership() {
@@ -216,7 +216,7 @@ fn print_packages_downloaded(start: Instant, count: usize) {
         1 => format!("1 package in {elapsed}"),
         _ => format!("{count} packages in {elapsed}"),
     };
-    print_colourful_prefix("Downloaded", &msg)
+    print_colourful_prefix("Downloaded", &msg);
 }
 
 pub fn seconds(duration: Duration) -> String {

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -831,7 +831,7 @@ fn path_dependency_configs_unchanged(
             if config_time <= fingerprint_time {
                 continue;
             }
-        };
+        }
 
         let config_text = fs::read(&config_path)?;
         let current_fingerprint = SourceFingerprint::new(&config_text).to_numerical_string();
@@ -1512,7 +1512,7 @@ fn provide_package(
             path: package_path.to_path_buf(),
             found: config.name.into(),
         });
-    };
+    }
     // Walk the requirements of the package
     let mut requirements = HashMap::new();
     parents.push(package_name);

--- a/compiler-cli/src/dependencies/dependency_manager.rs
+++ b/compiler-cli/src/dependencies/dependency_manager.rs
@@ -177,7 +177,7 @@ where
                     _ = config.dev_dependencies.insert(package, requirement);
                 } else {
                     _ = config.dependencies.insert(package, requirement);
-                };
+                }
             }
         }
 

--- a/compiler-cli/src/hex/auth.rs
+++ b/compiler-cli/src/hex/auth.rs
@@ -160,7 +160,7 @@ It will be used to locally encrypt your Hex API tokens.
         loop {
             let password = cli::ask_password(LOCAL_PASS_PROMPT)?;
             if password.chars().count() < required_length {
-                println!("\nPlease use a password at least {required_length} characters long.\n")
+                println!("\nPlease use a password at least {required_length} characters long.\n");
             } else {
                 self.local_password = Some(password);
                 return Ok(());

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -24,6 +24,7 @@
     clippy::verbose_file_reads,
     clippy::unnested_or_patterns,
     clippy::default_trait_access,
+    clippy::format_push_string,
     rust_2018_idioms,
     missing_debug_implementations,
     missing_copy_implementations,

--- a/compiler-cli/src/panic.rs
+++ b/compiler-cli/src/panic.rs
@@ -6,7 +6,7 @@ use std::panic::PanicHookInfo;
 
 pub fn add_handler() {
     std::panic::set_hook(Box::new(move |info: &PanicHookInfo<'_>| {
-        print_compiler_bug_message(info)
+        print_compiler_bug_message(info);
     }));
 }
 

--- a/compiler-cli/src/publish.rs
+++ b/compiler-cli/src/publish.rs
@@ -136,7 +136,7 @@ HTML documentation will work:
     git tag {tag_name}
     git push origin {tag_name}
 "
-            )
+            );
         }
     }
     Ok(())

--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -66,7 +66,7 @@ pub fn setup(
         return Err(Error::InvalidModuleName {
             module: mod_path.to_owned(),
         });
-    };
+    }
 
     let telemetry: &'static dyn Telemetry = if no_print_progress {
         &NullTelemetry
@@ -280,7 +280,7 @@ fn run_javascript_deno_command(
 
     // Enable unstable features and APIs
     if config.javascript.deno.unstable {
-        args.push("--unstable".into())
+        args.push("--unstable".into());
     }
 
     // Enable location API
@@ -291,19 +291,19 @@ fn run_javascript_deno_command(
     // Set deno permissions
     if config.javascript.deno.allow_all {
         // Allow all
-        args.push("--allow-all".into())
+        args.push("--allow-all".into());
     } else {
         // Allow env
         add_deno_flag(&mut args, "--allow-env", &config.javascript.deno.allow_env);
 
         // Allow sys
         if config.javascript.deno.allow_sys {
-            args.push("--allow-sys".into())
+            args.push("--allow-sys".into());
         }
 
         // Allow hrtime
         if config.javascript.deno.allow_hrtime {
-            args.push("--allow-hrtime".into())
+            args.push("--allow-hrtime".into());
         }
 
         // Allow net
@@ -311,7 +311,7 @@ fn run_javascript_deno_command(
 
         // Allow ffi
         if config.javascript.deno.allow_ffi {
-            args.push("--allow-ffi".into())
+            args.push("--allow-ffi".into());
         }
 
         // Allow read

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -305,12 +305,12 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
             for definition in group {
                 match definition {
                     CallGraphNode::Function(function) => {
-                        working_functions.push(self.infer_function(function, &mut env))
+                        working_functions.push(self.infer_function(function, &mut env));
                     }
                     CallGraphNode::ModuleConstant(constant) => {
-                        working_constants.push(self.infer_module_constant(constant, &mut env))
+                        working_constants.push(self.infer_module_constant(constant, &mut env));
                     }
-                };
+                }
             }
 
             // Now that the entire group has been inferred, generalise their types.
@@ -319,7 +319,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                     inferred_constant,
                     &mut env,
                     &self.module_name,
-                ))
+                ));
             }
             for inferred_function in working_functions.drain(..) {
                 typed_functions.push(generalise_function(
@@ -350,7 +350,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
         // Ensure no exported values have private types in their type signature
         for value in env.module_values.values() {
-            self.check_for_type_leaks(value)
+            self.check_for_type_leaks(value);
         }
 
         // Resolve deferred type variable aliases now that all unification is
@@ -753,7 +753,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         if let Some((module, _, location)) = &external_javascript
             && module.contains('@')
         {
-            self.track_feature_usage(FeatureKind::AtInJavascriptModules, *location)
+            self.track_feature_usage(FeatureKind::AtInJavascriptModules, *location);
         }
 
         // Assert that the inferred type matches the type of any recursive call
@@ -953,7 +953,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 location,
                 module: module_info.name.clone(),
                 package: module_info.package.clone(),
-            })
+            });
         }
 
         Some(Import {
@@ -1729,7 +1729,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                         feature_kind,
                         minimum_required_version: minimum_required_version.clone(),
                         wrongfully_allowed_version: lowest_allowed_version,
-                    })
+                    });
             }
         }
 
@@ -1757,7 +1757,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 fn validate_module_name(name: &EcoString) -> Result<(), Error> {
     if is_prelude_module(name) {
         return Err(Error::ReservedModuleName { name: name.clone() });
-    };
+    }
     for segment in name.split('/') {
         if crate::parse::lexer::string_to_keyword(segment).is_some() {
             return Err(Error::KeywordInModuleName {
@@ -2151,7 +2151,7 @@ fn get_compatible_record_fields(constructors: &[TypeValueConstructor]) -> Vec<Re
             label: first_label.clone(),
             type_: first_parameter.type_.clone(),
             documentation,
-        })
+        });
     }
 
     compatible
@@ -2180,20 +2180,20 @@ fn get_type_dependencies(type_: &TypeAst) -> Vec<EcoString> {
             });
 
             for arg in arguments {
-                deps.extend(get_type_dependencies(arg))
+                deps.extend(get_type_dependencies(arg));
             }
         }
         TypeAst::Fn(TypeAstFn {
             arguments, return_, ..
         }) => {
             for arg in arguments {
-                deps.extend(get_type_dependencies(arg))
+                deps.extend(get_type_dependencies(arg));
             }
-            deps.extend(get_type_dependencies(return_))
+            deps.extend(get_type_dependencies(return_));
         }
         TypeAst::Tuple(TypeAstTuple { elements, .. }) => {
             for element in elements {
-                deps.extend(get_type_dependencies(element))
+                deps.extend(get_type_dependencies(element));
             }
         }
     }
@@ -2205,7 +2205,7 @@ fn sorted_type_aliases(aliases: &Vec<UntypedTypeAlias>) -> Result<Vec<&UntypedTy
     let mut deps: Vec<(EcoString, Vec<EcoString>)> = Vec::with_capacity(aliases.len());
 
     for alias in aliases {
-        deps.push((alias.alias.clone(), get_type_dependencies(&alias.type_ast)))
+        deps.push((alias.alias.clone(), get_type_dependencies(&alias.type_ast)));
     }
 
     let sorted_deps = dep_tree::toposort_deps(deps).map_err(|err| {

--- a/compiler-core/src/analyse/imports.rs
+++ b/compiler-core/src/analyse/imports.rs
@@ -43,7 +43,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
     ) -> Environment<'context> {
         let mut importer = Self::new(origin, env, problems);
         for import in imports {
-            importer.register_import(import)
+            importer.register_import(import);
         }
         importer.environment
     }
@@ -161,7 +161,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                     self.problems.error(Error::UnsupportedExpressionTarget {
                         target: self.environment.target,
                         location,
-                    })
+                    });
                 }
 
                 self.environment.insert_variable(
@@ -240,7 +240,7 @@ impl<'context, 'problems> Importer<'context, 'problems> {
                 );
             }
             ValueConstructorVariant::LocalVariable { .. } => {}
-        };
+        }
 
         // Check if value already was imported
         if let Some(previous) = self.environment.unqualified_imported_names.get(used_name) {

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -659,7 +659,7 @@ impl TypeAst {
                         buffer.push_str(", ");
                     }
                 }
-                buffer.push(')')
+                buffer.push(')');
             }
             TypeAst::Fn(func) => {
                 buffer.push_str("fn(");
@@ -683,7 +683,7 @@ impl TypeAst {
                             buffer.push_str(name);
                         }
                     }
-                };
+                }
 
                 if !constructor.arguments.is_empty() {
                     buffer.push('(');
@@ -905,7 +905,7 @@ impl TypedFunction {
             .find_map(|arg| arg.find_node(byte_index))
         {
             return Some(found_arg);
-        };
+        }
 
         if let Some(found_statement) = self
             .body
@@ -913,7 +913,7 @@ impl TypedFunction {
             .find(|statement| statement.location().contains(byte_index))
         {
             return Some(Located::Statement(found_statement));
-        };
+        }
 
         // Check if location is within the return annotation.
         if let Some(located) = self
@@ -922,7 +922,7 @@ impl TypedFunction {
             .find_map(|annotation| annotation.find_node(byte_index, self.return_type.clone()))
         {
             return Some(located);
-        };
+        }
 
         // Note that the fn `.location` covers the function head, not
         // the entire statement.
@@ -3643,8 +3643,8 @@ impl TypedPattern {
                         },
                         location,
                         type_: type_.clone(),
-                    })
-                };
+                    });
+                }
             }
             Pattern::Constructor { arguments, .. } => {
                 for argument in arguments {
@@ -3653,7 +3653,7 @@ impl TypedPattern {
                             name: BoundVariableName::ShorthandLabel { name: name.clone() },
                             location: argument.location,
                             type_: argument.value.type_(),
-                        })
+                        });
                     } else {
                         argument.value.collect_bound_variables(variables);
                     }
@@ -4402,7 +4402,7 @@ impl GroupedDefinitions {
         let mut this = Self::default();
 
         for definition in definitions {
-            this.add(definition)
+            this.add(definition);
         }
 
         this

--- a/compiler-core/src/ast/typed.rs
+++ b/compiler-core/src/ast/typed.rs
@@ -1810,7 +1810,7 @@ impl TypedExpr {
             let Some(label) = argument.label.as_ref() else {
                 continue;
             };
-            unchanged_arguments.push((label.clone(), argument.value.type_()))
+            unchanged_arguments.push((label.clone(), argument.value.type_()));
         }
         Some(unchanged_arguments)
     }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -89,11 +89,11 @@ pub trait Visit<'ast> {
     }
 
     fn visit_typed_type_alias(&mut self, type_alias: &'ast TypedTypeAlias) {
-        visit_typed_type_alias(self, type_alias)
+        visit_typed_type_alias(self, type_alias);
     }
 
     fn visit_typed_import(&mut self, import: &'ast TypedImport) {
-        visit_typed_import(self, import)
+        visit_typed_import(self, import);
     }
 
     fn visit_typed_expr(&mut self, expr: &'ast TypedExpr) {
@@ -357,7 +357,7 @@ pub trait Visit<'ast> {
     }
 
     fn visit_typed_expr_negate_int(&mut self, location: &'ast SrcSpan, value: &'ast TypedExpr) {
-        visit_typed_expr_negate_int(self, location, value)
+        visit_typed_expr_negate_int(self, location, value);
     }
 
     fn visit_typed_expr_invalid(
@@ -430,7 +430,7 @@ pub trait Visit<'ast> {
         type_: &'ast Arc<Type>,
         tuple: &'ast TypedClauseGuard,
     ) {
-        visit_typed_clause_guard_tuple_index(self, location, index, type_, tuple)
+        visit_typed_clause_guard_tuple_index(self, location, index, type_, tuple);
     }
 
     fn visit_typed_clause_guard_field_access(
@@ -441,7 +441,7 @@ pub trait Visit<'ast> {
         type_: &'ast Arc<Type>,
         container: &'ast TypedClauseGuard,
     ) {
-        visit_typed_clause_guard_field_access(self, label_location, index, label, type_, container)
+        visit_typed_clause_guard_field_access(self, label_location, index, label, type_, container);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -466,7 +466,7 @@ pub trait Visit<'ast> {
             module_name,
             module_alias,
             literal,
-        )
+        );
     }
 
     fn visit_typed_expr_bit_array_segment(&mut self, segment: &'ast TypedExprBitArraySegment) {
@@ -508,7 +508,7 @@ pub trait Visit<'ast> {
     }
 
     fn visit_typed_bit_array_size_int(&mut self, location: &'ast SrcSpan, value: &'ast EcoString) {
-        visit_typed_bit_array_size_int(self, location, value)
+        visit_typed_bit_array_size_int(self, location, value);
     }
 
     fn visit_typed_bit_array_size_variable(
@@ -518,7 +518,7 @@ pub trait Visit<'ast> {
         constructor: &'ast Option<Box<ValueConstructor>>,
         type_: &'ast Arc<Type>,
     ) {
-        visit_typed_bit_array_size_variable(self, location, name, constructor, type_)
+        visit_typed_bit_array_size_variable(self, location, name, constructor, type_);
     }
 
     fn visit_typed_pattern_assign(
@@ -536,7 +536,7 @@ pub trait Visit<'ast> {
         name: &'ast EcoString,
         type_: &'ast Arc<Type>,
     ) {
-        visit_typed_pattern_discard(self, location, name, type_)
+        visit_typed_pattern_discard(self, location, name, type_);
     }
 
     fn visit_typed_pattern_list(
@@ -757,7 +757,7 @@ pub trait Visit<'ast> {
             type_,
             field_map,
             record_constructor,
-        )
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -782,7 +782,7 @@ pub trait Visit<'ast> {
             arguments,
             type_,
             field_map,
-        )
+        );
     }
 
     fn visit_typed_constant_bit_array(
@@ -873,7 +873,7 @@ pub fn visit_typed_constant_record<'a, V: Visit<'a> + ?Sized>(
     _record_constructor: &'a Option<Box<ValueConstructor>>,
 ) {
     for argument in arguments.iter().flatten() {
-        v.visit_typed_constant(&argument.value)
+        v.visit_typed_constant(&argument.value);
     }
 }
 
@@ -903,7 +903,7 @@ fn visit_typed_constant_list<'a, V: Visit<'a> + ?Sized>(
     tail: &'a Option<Box<TypedConstant>>,
 ) {
     for element in elements {
-        v.visit_typed_constant(element)
+        v.visit_typed_constant(element);
     }
     if let Some(tail) = tail {
         v.visit_typed_constant(tail);
@@ -917,7 +917,7 @@ fn visit_typed_constant_tuple<'a, V: Visit<'a> + ?Sized>(
     _type_: &'a Arc<Type>,
 ) {
     for element in elements {
-        v.visit_typed_constant(element)
+        v.visit_typed_constant(element);
     }
 }
 
@@ -1156,7 +1156,7 @@ pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a 
             float_value,
         } => v.visit_typed_constant_float(location, value, float_value),
         super::Constant::String { location, value } => {
-            v.visit_typed_constant_string(location, value)
+            v.visit_typed_constant_string(location, value);
         }
         super::Constant::Tuple {
             location,
@@ -1206,7 +1206,7 @@ pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a 
             field_map,
         ),
         super::Constant::BitArray { location, segments } => {
-            v.visit_typed_constant_bit_array(location, segments)
+            v.visit_typed_constant_bit_array(location, segments);
         }
         super::Constant::Var {
             location,
@@ -1406,7 +1406,7 @@ where
             arguments,
         ),
         TypedExpr::NegateBool { location, value } => {
-            v.visit_typed_expr_negate_bool(location, value)
+            v.visit_typed_expr_negate_bool(location, value);
         }
         TypedExpr::NegateInt { location, value } => v.visit_typed_expr_negate_int(location, value),
         TypedExpr::Invalid {
@@ -1676,10 +1676,10 @@ pub fn visit_typed_expr_echo<'a, V>(
     V: Visit<'a> + ?Sized,
 {
     if let Some(expression) = expression {
-        v.visit_typed_expr(expression)
+        v.visit_typed_expr(expression);
     }
     if let Some(message) = message {
-        v.visit_typed_expr(message)
+        v.visit_typed_expr(message);
     }
 }
 
@@ -1846,7 +1846,7 @@ where
             type_,
             container,
         } => {
-            v.visit_typed_clause_guard_field_access(label_location, index, label, type_, container)
+            v.visit_typed_clause_guard_field_access(label_location, index, label, type_, container);
         }
         super::ClauseGuard::ModuleSelect {
             location,
@@ -2043,7 +2043,7 @@ where
         ),
         Pattern::Tuple { location, elements } => v.visit_typed_pattern_tuple(location, elements),
         Pattern::BitArray { location, segments } => {
-            v.visit_typed_pattern_bit_array(location, segments)
+            v.visit_typed_pattern_bit_array(location, segments);
         }
         Pattern::StringPrefix {
             location,
@@ -2198,7 +2198,7 @@ pub fn visit_typed_pattern_call_arg<'a, V>(v: &mut V, argument: &'a CallArg<Type
 where
     V: Visit<'a> + ?Sized,
 {
-    v.visit_typed_pattern(&argument.value)
+    v.visit_typed_pattern(&argument.value);
 }
 
 pub fn visit_typed_pattern_tuple<'a, V>(

--- a/compiler-core/src/bit_array.rs
+++ b/compiler-core/src/bit_array.rs
@@ -193,7 +193,7 @@ where
                     categories.unit = Some(option);
                 }
             }
-        };
+        }
     }
 
     // Some options are not allowed in value mode

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -173,10 +173,10 @@ impl<'a> CallGraphBuilder<'a> {
             Statement::Assert(assert) => {
                 self.expression(&assert.value);
                 if let Some(message) = &assert.message {
-                    self.expression(message)
+                    self.expression(message);
                 }
             }
-        };
+        }
     }
 
     fn expression(&mut self, expression: &'a UntypedExpr) {
@@ -185,13 +185,13 @@ impl<'a> CallGraphBuilder<'a> {
 
             UntypedExpr::Todo { message, .. } => {
                 if let Some(msg_expr) = message {
-                    self.expression(msg_expr)
+                    self.expression(msg_expr);
                 }
             }
 
             UntypedExpr::Panic { message, .. } => {
                 if let Some(msg_expr) = message {
-                    self.expression(msg_expr)
+                    self.expression(msg_expr);
                 }
             }
 
@@ -295,7 +295,7 @@ impl<'a> CallGraphBuilder<'a> {
                 let names = self.names.clone();
                 for argument in arguments {
                     if let Some(name) = argument.names.get_variable_name() {
-                        self.define(name)
+                        self.define(name);
                     }
                 }
                 self.statements(body);
@@ -468,7 +468,7 @@ impl<'a> CallGraphBuilder<'a> {
 
             Constant::Todo { message, .. } => {
                 if let Some(message) = message {
-                    self.constant(message)
+                    self.constant(message);
                 }
             }
 

--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -213,7 +213,7 @@ impl<'a> JavaScript<'a> {
             if self.typescript == TypeScriptDeclarations::Emit {
                 self.ts_declaration(writer, module, &js_name)?;
             }
-            self.js_module(writer, module, &js_name, stdlib_package)?
+            self.js_module(writer, module, &js_name, stdlib_package)?;
         }
         self.write_prelude(writer)?;
         Ok(())

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -229,7 +229,7 @@ but it is locked to {locked_version}, which is incompatible.",
                     });
                 }
             }
-        };
+        }
     }
 
     Ok(requirements)

--- a/compiler-core/src/derivation_tree.rs
+++ b/compiler-core/src/derivation_tree.rs
@@ -13,7 +13,6 @@ use petgraph::prelude::StableGraph;
 use pubgrub::External;
 use pubgrub::{DerivationTree, Derived, Ranges};
 use std::collections::HashMap;
-use std::fmt::Write as _;
 use std::hash::RandomState;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::sync::Arc;
@@ -172,11 +171,13 @@ impl DerivationTreePrinter {
                 .ranges_between(previous, next)
                 .expect("path edge is in the graph");
 
-            let _ = write!(
-                message,
-                "\n    - {previous_name} requires {next_name} {}",
-                pretty_range(next_range)
-            );
+            message.push_str("\n    - ");
+            message.push_str(previous_name);
+            message.push_str(" requires ");
+            message.push_str(next_name);
+            message.push(' ');
+            message.push_str(&pretty_range(next_range));
+
             previous = next;
         }
         message

--- a/compiler-core/src/derivation_tree.rs
+++ b/compiler-core/src/derivation_tree.rs
@@ -13,6 +13,7 @@ use petgraph::prelude::StableGraph;
 use pubgrub::External;
 use pubgrub::{DerivationTree, Derived, Ranges};
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::hash::RandomState;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::sync::Arc;
@@ -171,10 +172,11 @@ impl DerivationTreePrinter {
                 .ranges_between(previous, next)
                 .expect("path edge is in the graph");
 
-            message.push_str(&format!(
+            let _ = write!(
+                message,
                 "\n    - {previous_name} requires {next_name} {}",
                 pretty_range(next_range)
-            ));
+            );
             previous = next;
         }
         message

--- a/compiler-core/src/derivation_tree.rs
+++ b/compiler-core/src/derivation_tree.rs
@@ -338,7 +338,7 @@ fn simplify_derivation_tree_outer(
                         package_range.union(other_package_range),
                         required_package.clone(),
                         required_package_range.union(other_required_package_range),
-                    ))
+                    ));
                 }
 
                 _ => {}

--- a/compiler-core/src/diagnostic.rs
+++ b/compiler-core/src/diagnostic.rs
@@ -68,7 +68,7 @@ impl Diagnostic {
         match &self.location {
             Some(location) => self.write_span(location, buffer),
             None => self.write_title(buffer),
-        };
+        }
 
         if !self.text.is_empty() {
             writeln!(buffer, "{}", self.text).expect("write text");

--- a/compiler-core/src/docs.rs
+++ b/compiler-core/src/docs.rs
@@ -191,7 +191,7 @@ pub fn generate_html<IO: FileSystemReader>(
             &config.name,
             page.path.as_str(),
             content,
-        ))
+        ));
     }
 
     // Generate module documentation pages

--- a/compiler-core/src/docs/printer.rs
+++ b/compiler-core/src/docs/printer.rs
@@ -154,7 +154,7 @@ impl<'a, 'doc> Printer<'a> {
                 },
                 source_url: source_links.url(*location),
                 opaque: *opaque,
-            })
+            });
         }
 
         for TypeAlias {
@@ -190,7 +190,7 @@ impl<'a, 'doc> Printer<'a> {
                     Deprecation::Deprecated { message } => message.to_string(),
                 },
                 opaque: false,
-            })
+            });
         }
 
         type_definitions.sort();
@@ -256,7 +256,7 @@ impl<'a, 'doc> Printer<'a> {
                     Deprecation::NotDeprecated => "".to_string(),
                     Deprecation::Deprecated { message } => message.to_string(),
                 },
-            })
+            });
         }
 
         for TypedModuleConstant {
@@ -284,7 +284,7 @@ impl<'a, 'doc> Printer<'a> {
                     Deprecation::NotDeprecated => "".to_string(),
                     Deprecation::Deprecated { message } => message.to_string(),
                 },
-            })
+            });
         }
 
         value_definitions.sort();
@@ -627,7 +627,7 @@ impl<'a, 'doc> Printer<'a> {
             if rest == 0 {
                 break;
             }
-            rest -= 1
+            rest -= 1;
         }
 
         self.next_type_variable_id += 1;

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fmt::Write as _,
     time::SystemTime,
 };
 
@@ -200,7 +201,7 @@ fn compile_documentation(
 
     output.push_str("---- SOURCE CODE\n");
     for (_package, name, src) in modules {
-        output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+        let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
     }
     output.push_str("-- ");
     output.push_str(module_name);

--- a/compiler-core/src/docs/tests.rs
+++ b/compiler-core/src/docs/tests.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fmt::Write as _,
     time::SystemTime,
 };
 
@@ -201,7 +200,11 @@ fn compile_documentation(
 
     output.push_str("---- SOURCE CODE\n");
     for (_package, name, src) in modules {
-        let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
+        output.push_str("-- ");
+        output.push_str(name);
+        output.push_str(".gleam\n");
+        output.push_str(src);
+        output.push_str("\n\n");
     }
     output.push_str("-- ");
     output.push_str(module_name);

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -273,7 +273,7 @@ impl<'a> Generator<'a> {
             let documentation = &self.module.documentation.iter().join("\n");
             builder.string(documentation);
             builder.end_doc_attribute(doc);
-        };
+        }
     }
 
     fn type_definition<Output>(
@@ -672,7 +672,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         let spec = builder.start_function_spec(function_name, function.arguments.len());
         let function_type = builder.start_function_type();
         for argument in &function.arguments {
-            generator.type_(builder, &argument.type_)
+            generator.type_(builder, &argument.type_);
         }
         let function_type = builder.end_function_type_arguments(function_type);
         generator.type_(builder, &function.return_type);
@@ -769,7 +769,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 Statement::Assert(assert) => self.assert(builder, assert),
                 Statement::Assignment(assignment) => match &assignment.kind {
                     AssignmentKind::Let | AssignmentKind::Generated => {
-                        self.let_(builder, &assignment.value, &assignment.pattern)
+                        self.let_(builder, &assignment.value, &assignment.pattern);
                     }
                     // Let asserts are slightly different from everything else:
                     // A let assert is compiled to a case expression where we
@@ -838,7 +838,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 } else {
                     let block = builder.start_block();
                     self.statement_sequence(builder, statements);
-                    builder.end_block(block)
+                    builder.end_block(block);
                 }
             }
 
@@ -847,11 +847,11 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             //
             TypedExpr::NegateBool { value, .. } => {
                 builder.unary_operator("not");
-                self.maybe_block_expr(builder, value)
+                self.maybe_block_expr(builder, value);
             }
             TypedExpr::NegateInt { value, .. } => {
                 builder.unary_operator("-");
-                self.maybe_block_expr(builder, value)
+                self.maybe_block_expr(builder, value);
             }
             TypedExpr::BinOp {
                 operator,
@@ -889,7 +889,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 for element in elements {
                     self.maybe_block_expr(builder, element);
                 }
-                builder.end_tuple(tuple)
+                builder.end_tuple(tuple);
             }
 
             //
@@ -899,7 +899,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             TypedExpr::TupleIndex { tuple, index, .. } => self.tuple_index(builder, tuple, *index),
             TypedExpr::RecordAccess { record, index, .. }
             | TypedExpr::PositionalAccess { record, index, .. } => {
-                self.tuple_index(builder, record, index + 1)
+                self.tuple_index(builder, record, index + 1);
             }
 
             //
@@ -926,7 +926,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                     self.maybe_block_expr(builder, updated_record);
                 }
                 // Then a record update is simply a call!
-                self.call(builder, constructor, arguments)
+                self.call(builder, constructor, arguments);
             }
 
             //
@@ -1066,7 +1066,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         if let Some(message) = message {
             self.maybe_block_expr(builder, message);
         } else {
-            builder.atom("nil")
+            builder.atom("nil");
         }
 
         // ...the filepath of this module...
@@ -1115,7 +1115,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         if let Some(message) = message {
             self.maybe_block_expr(builder, message);
         } else {
-            builder.string(error_kind.default_error_message())
+            builder.string(error_kind.default_error_message());
         }
 
         builder.map_field();
@@ -1177,7 +1177,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
     ) {
         builder.match_operator();
         PatternGenerator::new(self).pattern(builder, pattern);
-        self.maybe_block_expr(builder, value)
+        self.maybe_block_expr(builder, value);
     }
 
     fn let_assert<Output>(
@@ -1328,11 +1328,11 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                             .to_owned()
                             .expect("echo with no previous step in a pipe"),
                     },
-                )
+                );
             } else {
                 self.maybe_block_expr(builder, &assignment.value);
                 previous_step_variable_name = Some(name);
-            };
+            }
         }
 
         // We also need to do the same thing for the final step of the pipeline.
@@ -1353,9 +1353,9 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                     name: previous_step_variable_name
                         .expect("echo with no previous step in a pipe"),
                 },
-            )
+            );
         } else {
-            self.expression(builder, finally)
+            self.expression(builder, finally);
         }
     }
 
@@ -1893,7 +1893,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             AssertedExpressionRuntimeValue::KnownBool(false) => builder.atom("false"),
             AssertedExpressionRuntimeValue::Variable(name) => builder.variable(name),
             AssertedExpressionRuntimeValue::Expression(expr) => {
-                self.maybe_block_expr(builder, expr)
+                self.maybe_block_expr(builder, expr);
             }
         }
     }
@@ -1938,19 +1938,19 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 // }
                 // ```
                 Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
-                    builder.atom(&to_snake_case(record_name))
+                    builder.atom(&to_snake_case(record_name));
                 }
                 Type::Fn { arguments, .. } => {
-                    self.record_builder_anonymous_function(builder, record_name, arguments.len())
+                    self.record_builder_anonymous_function(builder, record_name, arguments.len());
                 }
             },
 
             ValueConstructorVariant::LocalVariable { location, .. } => {
-                builder.variable(&self.local_var_name(location))
+                builder.variable(&self.local_var_name(location));
             }
 
             ValueConstructorVariant::ModuleConstant { literal, .. } => {
-                self.inlined_constant(builder, literal)
+                self.inlined_constant(builder, literal);
             }
 
             ValueConstructorVariant::ModuleFn {
@@ -1960,16 +1960,16 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             } => {
                 let name = escape_erlang_existing_name(name);
                 if *module == self.module_generator.module.name {
-                    builder.function_reference(None, name, *arity)
+                    builder.function_reference(None, name, *arity);
                 } else {
-                    builder.function_reference(Some(ErlangModuleName::new(module)), name, *arity)
+                    builder.function_reference(Some(ErlangModuleName::new(module)), name, *arity);
                 }
             }
 
             ValueConstructorVariant::ModuleFn { arity, module, .. }
                 if *module == self.module_generator.module.name =>
             {
-                builder.function_reference(None, escape_erlang_existing_name(name), *arity)
+                builder.function_reference(None, escape_erlang_existing_name(name), *arity);
             }
 
             ValueConstructorVariant::ModuleFn {
@@ -2012,7 +2012,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 for argument in arguments {
                     self.maybe_block_expr(builder, &argument.value);
                 }
-                builder.end_call(call)
+                builder.end_call(call);
             }
             // If we're calling anything else (like an anonymous function, or
             // the result of another function call) we generate its code and
@@ -2067,7 +2067,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 for argument in arguments {
                     self.runtime_value(builder, argument);
                 }
-                builder.end_call(call)
+                builder.end_call(call);
             }
 
             // If we're calling anything else (like an anonymous function, or
@@ -2098,14 +2098,14 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         arguments: &'a [TypedCallArg],
     ) {
         if arguments.is_empty() {
-            builder.atom(&to_snake_case(record_name))
+            builder.atom(&to_snake_case(record_name));
         } else {
             let tuple = builder.start_tuple();
             builder.atom(&to_snake_case(record_name));
             for argument in arguments {
                 self.maybe_block_expr(builder, &argument.value);
             }
-            builder.end_tuple(tuple)
+            builder.end_tuple(tuple);
         }
     }
 
@@ -2195,7 +2195,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 }
                 builder.end_tuple_pattern(tuple);
             }
-        };
+        }
 
         let variables_to_add_later = pattern_generator.variables_to_add_later;
 
@@ -2245,7 +2245,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             Constant::Tuple { elements, .. } => {
                 let tuple = builder.start_tuple();
                 for element in elements {
-                    self.inlined_constant(builder, element)
+                    self.inlined_constant(builder, element);
                 }
                 builder.end_tuple(tuple);
             }
@@ -2253,7 +2253,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             Constant::List { elements, tail, .. } => {
                 for element in elements {
                     builder.cons_list();
-                    self.inlined_constant(builder, element)
+                    self.inlined_constant(builder, element);
                 }
                 match tail {
                     // If there's no tail we simply add an empty list cell to
@@ -2319,17 +2319,17 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                     // ```
                     None => match type_::collapse_links(type_.clone()).deref() {
                         Type::Named { .. } | Type::Var { .. } | Type::Tuple { .. } => {
-                            builder.atom(&to_snake_case(&tag))
+                            builder.atom(&to_snake_case(&tag));
                         }
                         Type::Fn { arguments, .. } => {
-                            self.record_builder_anonymous_function(builder, &tag, arguments.len())
+                            self.record_builder_anonymous_function(builder, &tag, arguments.len());
                         }
                     },
                 }
             }
 
             Constant::StringConcatenation { left, right, .. } => {
-                self.constant_string_concatenate(builder, left, right)
+                self.constant_string_concatenate(builder, left, right);
             }
 
             Constant::RecordUpdate { .. } => {
@@ -2351,11 +2351,11 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         self.inlined_constant(builder, &segment.value);
         match segment.size() {
             Some(TypedConstant::Int { int_value, .. }) if int_value.is_negative() => {
-                builder.int(BigInt::ZERO)
+                builder.int(BigInt::ZERO);
             }
             Some(size) => self.inlined_constant(builder, size),
             None => builder.atom("default"),
-        };
+        }
         self.bit_array_segment_specifiers(builder, segment);
     }
 
@@ -2809,7 +2809,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         // negative value must be turned to zero instead:
         if let TypedExpr::Int { int_value, .. } = &size {
             if int_value.is_negative() {
-                builder.int(BigInt::ZERO)
+                builder.int(BigInt::ZERO);
             } else {
                 builder.int(int_value.clone());
             }
@@ -2836,7 +2836,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             ClauseGuard::Block { value, .. } => self.clause_guard(builder, value, assignments),
 
             ClauseGuard::TupleIndex { tuple, index, .. } => {
-                self.clause_guard_tuple_index(builder, tuple, *index)
+                self.clause_guard_tuple_index(builder, tuple, *index);
             }
 
             ClauseGuard::FieldAccess {
@@ -2994,14 +2994,14 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         let function = builder.start_anonymous_function(&arguments);
 
         if arguments.is_empty() {
-            builder.atom(&to_snake_case(record_name))
+            builder.atom(&to_snake_case(record_name));
         } else {
             let tuple = builder.start_tuple();
             builder.atom(&to_snake_case(record_name));
             for argument in arguments {
                 builder.variable(&argument);
             }
-            builder.end_tuple(tuple)
+            builder.end_tuple(tuple);
         }
 
         builder.end_function(function);
@@ -3761,23 +3761,23 @@ fn type_var_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
             ..
         } => match arguments[..] {
             [ref arg_ok, ref arg_err] if is_prelude_module(module) && name == "Result" => {
-                result_type_var_ids(ids, arg_ok, arg_err)
+                result_type_var_ids(ids, arg_ok, arg_err);
             }
             _ => {
                 for argument in arguments {
-                    type_var_ids(argument, ids)
+                    type_var_ids(argument, ids);
                 }
             }
         },
         Type::Fn { arguments, return_ } => {
             for argument in arguments {
-                type_var_ids(argument, ids)
+                type_var_ids(argument, ids);
             }
             type_var_ids(return_, ids);
         }
         Type::Tuple { elements } => {
             for element in elements {
-                type_var_ids(element, ids)
+                type_var_ids(element, ids);
             }
         }
     }
@@ -3908,7 +3908,7 @@ impl<'a> TypeGenerator<'a> {
             Type::Tuple { elements } => {
                 let tuple = builder.start_tuple_type();
                 for element in elements {
-                    self.type_(builder, element)
+                    self.type_(builder, element);
                 }
                 builder.end_tuple_type(tuple);
             }
@@ -3923,7 +3923,7 @@ impl<'a> TypeGenerator<'a> {
                     let any = builder.start_named_type("any");
                     builder.end_named_type(any);
                 } else {
-                    builder.type_variable(&id_to_type_var_str(*id))
+                    builder.type_variable(&id_to_type_var_str(*id));
                 }
             }
         }
@@ -4017,7 +4017,7 @@ impl<'a> TypeGenerator<'a> {
         };
 
         for argument in arguments {
-            self.type_(builder, argument)
+            self.type_(builder, argument);
         }
 
         builder.end_named_type(type_);
@@ -4031,7 +4031,7 @@ fn find_private_functions_referenced_in_importable_constants(
 
     for constant in &module.definitions.constants {
         if constant.publicity.is_importable() {
-            find_referenced_private_functions(&constant.value, &mut overridden_publicity)
+            find_referenced_private_functions(&constant.value, &mut overridden_publicity);
         }
     }
     overridden_publicity

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -138,7 +138,7 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
             Pattern::Int { int_value, .. } => builder.int_pattern(int_value.clone()),
             Pattern::String { value, .. } => builder.string_pattern(value),
             Pattern::Variable { name, location, .. } => {
-                builder.variable_pattern(&self.generator.new_erlang_variable(name, *location))
+                builder.variable_pattern(&self.generator.new_erlang_variable(name, *location));
             }
 
             Pattern::Assign {
@@ -272,10 +272,10 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
                     let constructor = constructor.as_ref().expect("variable with no constructor");
                     match &constructor.variant {
                         ValueConstructorVariant::ModuleConstant { literal, .. } => {
-                            self.generator.inlined_constant(builder, literal)
+                            self.generator.inlined_constant(builder, literal);
                         }
                         ValueConstructorVariant::LocalVariable { location, .. } => {
-                            builder.variable(&self.generator.local_var_name(location))
+                            builder.variable(&self.generator.local_var_name(location));
                         }
                         ValueConstructorVariant::ModuleFn { .. }
                         | ValueConstructorVariant::Record { .. } => panic!("invalid segment"),

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -7,6 +7,7 @@ use crate::bit_array::UnsupportedOption;
 use crate::build::{Origin, Outcome, Runtime, Target};
 use crate::dependency::{PackageFetcher, ResolutionError};
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
+use std::fmt::Write as _;
 
 use crate::derivation_tree::DerivationTreePrinter;
 use crate::parse::error::ParseErrorDetails;
@@ -3535,7 +3536,7 @@ but no type in scope with that name."
                         };
                         text.push_str(message);
                         for module_name in possible_modules {
-                            text.push_str(&format!("  - {module_name}.{name}\n"))
+                            let _ = writeln!(text, "  - {module_name}.{name}");
                         }
                     }
 
@@ -4648,10 +4649,11 @@ here takes {expected_string}.\n"
 the `use` callback function.\n",
                     )
                 } else {
-                    text.push_str(&format!(
+                    let _ = writeln!(
+                        text,
                         "You supplied {supplied_arguments_string} \
-and the final one is the `use` callback function.\n"
-                    ));
+and the final one is the `use` callback function."
+                    );
                 }
             } else {
                 text.push_str(

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1485,7 +1485,7 @@ your app.src file \"{app_ver}\"."
                         }
                         match program.as_str() {
                             "erl" | "erlc" | "escript" => {
-                                text.push_str(&brew_install("Erlang", "erlang"))
+                                text.push_str(&brew_install("Erlang", "erlang"));
                             }
                             "rebar3" => text.push_str(&brew_install("Rebar3", "rebar3")),
                             "deno" => text.push_str(&brew_install("Deno", "deno")),
@@ -3460,7 +3460,7 @@ but no type in scope with that name."
                     text.push_str(hint.as_str());
                 }
                 UnknownTypeHint::AlternativeTypes(_) => {}
-            };
+            }
 
             Diagnostic {
                 title: "Unknown type".into(),
@@ -4647,7 +4647,7 @@ here takes {expected_string}.\n"
                     text.push_str(
                         "The only argument that was supplied is \
 the `use` callback function.\n",
-                    )
+                    );
                 } else {
                     let _ = writeln!(
                         text,
@@ -4659,8 +4659,8 @@ and the final one is the `use` callback function."
                 text.push_str(
                     "All the arguments have already been supplied, \
 so it cannot take the `use` callback function as a final argument.\n",
-                )
-            };
+                );
+            }
 
             text.push_str("\nSee: https://tour.gleam.run/advanced-features/use/");
 
@@ -5250,7 +5250,7 @@ fn wrap_text(text: &str, width: usize) -> Vec<Cow<'_, str>> {
                 let mut new_lines = break_line(line, width);
                 lines.append(&mut new_lines);
             }
-        };
+        }
     }
 
     lines

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -7,7 +7,6 @@ use crate::bit_array::UnsupportedOption;
 use crate::build::{Origin, Outcome, Runtime, Target};
 use crate::dependency::{PackageFetcher, ResolutionError};
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
-use std::fmt::Write as _;
 
 use crate::derivation_tree::DerivationTreePrinter;
 use crate::parse::error::ParseErrorDetails;
@@ -3536,7 +3535,11 @@ but no type in scope with that name."
                         };
                         text.push_str(message);
                         for module_name in possible_modules {
-                            let _ = writeln!(text, "  - {module_name}.{name}");
+                            text.push_str("  - ");
+                            text.push_str(module_name);
+                            text.push('.');
+                            text.push_str(name);
+                            text.push('\n');
                         }
                     }
 
@@ -4649,11 +4652,9 @@ here takes {expected_string}.\n"
 the `use` callback function.\n",
                     );
                 } else {
-                    let _ = writeln!(
-                        text,
-                        "You supplied {supplied_arguments_string} \
-and the final one is the `use` callback function."
-                    );
+                    text.push_str("You supplied ");
+                    text.push_str(&supplied_arguments_string);
+                    text.push_str(" and the final one is the `use` callback function.\n");
                 }
             } else {
                 text.push_str(

--- a/compiler-core/src/exhaustiveness.rs
+++ b/compiler-core/src/exhaustiveness.rs
@@ -461,7 +461,7 @@ impl Body {
                 bit_array,
                 read_action: value,
             },
-        ))
+        ));
     }
 
     fn assign_segment_constant_value(&mut self, name: EcoString, value: &BitArrayMatchedValue) {
@@ -478,7 +478,7 @@ impl Body {
             }
         };
 
-        self.bindings.push((name, value))
+        self.bindings.push((name, value));
     }
 }
 
@@ -1269,14 +1269,14 @@ impl MatchTest {
         let offset_other = other.read_action.from.constant_bits()?.to_usize()?;
         if offset_one > offset_other {
             return None;
-        };
+        }
 
         // The second requirement is that: `o1 + s1 > o2`
         let size_one = self.read_action.size.constant_bits()?.to_usize()?;
         let size_other = other.read_action.size.constant_bits()?.to_usize()?;
         if offset_one + size_one <= offset_other {
             return None;
-        };
+        }
 
         // At this point we know that both are interfering, so we compare the
         // overlapping slice of bits they're matching against.
@@ -1998,7 +1998,7 @@ impl ReadSize {
             }
 
             ReadSize::ConstantBits(..) | ReadSize::RemainingBits | ReadSize::RemainingBytes => (),
-        };
+        }
     }
 
     fn can_be_negative(&self) -> bool {
@@ -2564,9 +2564,9 @@ impl<'a> Compiler<'a> {
                 let mut remaining_choices = vec![];
                 for choice in choices.into_iter() {
                     if choice.0.is_ignored() {
-                        ignored_checks.push(choice.0)
+                        ignored_checks.push(choice.0);
                     } else {
-                        remaining_choices.push(choice)
+                        remaining_choices.push(choice);
                     }
                 }
 
@@ -3011,7 +3011,7 @@ impl BranchSplitter {
         if let Pattern::BitArray { tests } = pattern {
             self.add_checked_bit_array_branch(pattern_check, tests, branch, compiler);
             return;
-        };
+        }
 
         let kind = pattern
             .to_runtime_check_kind()
@@ -3367,7 +3367,7 @@ impl ConstructorSpecialiser {
             // it the same as an external type.
             Opaque::Opaque if current_module != type_module => return Vec::new(),
             Opaque::Opaque | Opaque::NotOpaque => {}
-        };
+        }
 
         let specialiser = Self::new(constructors.type_parameters_ids.as_slice(), type_arguments);
         constructors
@@ -3523,7 +3523,7 @@ impl CaseToCompile {
                     .subject_variables
                     .get(i)
                     .expect("wrong number of subjects");
-                checks.push(var.is(pattern))
+                checks.push(var.is(pattern));
             }
 
             let guard = branch.guard.as_ref().map(|guard| {
@@ -3763,7 +3763,7 @@ impl CaseToCompile {
                     };
                     tests.push_back(BitArrayTest::Size(SizeTest { operator, size }));
                 }
-            };
+            }
 
             let type_ = match &segment.type_ {
                 type_ if type_.is_int() => ReadType::Int,
@@ -4098,7 +4098,7 @@ fn representable_with_bits(value: &BigInt, bits: u32, signed: bool) -> bool {
     // No number is representable in 0 bits.
     if bits == 0 {
         return false;
-    };
+    }
 
     let required_bits = match (value.sign(), signed) {
         // Zero always needs one bit.

--- a/compiler-core/src/exhaustiveness/missing_patterns.rs
+++ b/compiler-core/src/exhaustiveness/missing_patterns.rs
@@ -132,14 +132,14 @@ impl<'a, 'env> MissingPatternsGenerator<'a, 'env> {
                         self.add_missing_patterns(fallback);
                     }
                     FallbackCheck::RuntimeCheck { check } => {
-                        self.add_missing_patterns_after_check(var, check, fallback)
+                        self.add_missing_patterns_after_check(var, check, fallback);
                     }
                     FallbackCheck::CatchAll { ignored_checks } => {
                         for check in ignored_checks {
                             self.add_missing_patterns_after_check(var, check, fallback);
                         }
                     }
-                };
+                }
             }
         }
     }

--- a/compiler-core/src/exhaustiveness/printer.rs
+++ b/compiler-core/src/exhaustiveness/printer.rs
@@ -192,7 +192,7 @@ impl<'a> Printer<'a> {
                         terms,
                         mapping,
                         buffer,
-                    )
+                    );
                 } else {
                     buffer.push('_');
                 }
@@ -207,7 +207,7 @@ impl<'a> Printer<'a> {
                         | Term::Infinite { .. }
                         | Term::List { .. } => {
                             buffer.push_str(", ");
-                            self.print_list(term, terms, mapping, buffer)
+                            self.print_list(term, terms, mapping, buffer);
                         }
                     }
                 } else {

--- a/compiler-core/src/io.rs
+++ b/compiler-core/src/io.rs
@@ -273,7 +273,7 @@ impl DirWalker {
                     });
                 };
 
-                self.walk_queue.push_back(entry.into_path())
+                self.walk_queue.push_back(entry.into_path());
             }
         }
 

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -222,19 +222,19 @@ impl<'a, 'doc> Generator<'a> {
 
         if self.tracker.ok_used {
             self.register_prelude_usage(arena, &mut imports, "Ok", None);
-        };
+        }
 
         if self.tracker.error_used {
             self.register_prelude_usage(arena, &mut imports, "Error", None);
-        };
+        }
 
         if self.tracker.list_used {
             self.register_prelude_usage(arena, &mut imports, "toList", None);
-        };
+        }
 
         if self.tracker.list_empty_class_used || self.tracker.echo_used {
             self.register_prelude_usage(arena, &mut imports, "Empty", Some("$Empty"));
-        };
+        }
 
         if self.tracker.list_empty_const_used {
             self.register_prelude_usage(
@@ -243,39 +243,39 @@ impl<'a, 'doc> Generator<'a> {
                 "List$Empty$const",
                 Some("$List$Empty$const"),
             );
-        };
+        }
 
         if self.tracker.list_non_empty_class_used || self.tracker.echo_used {
             self.register_prelude_usage(arena, &mut imports, "NonEmpty", Some("$NonEmpty"));
-        };
+        }
 
         if self.tracker.prepend_used {
             self.register_prelude_usage(arena, &mut imports, "prepend", Some("listPrepend"));
-        };
+        }
 
         if self.tracker.custom_type_used || self.tracker.echo_used {
             self.register_prelude_usage(arena, &mut imports, "CustomType", Some("$CustomType"));
-        };
+        }
 
         if self.tracker.make_error_used {
             self.register_prelude_usage(arena, &mut imports, "makeError", None);
-        };
+        }
 
         if self.tracker.int_remainder_used {
             self.register_prelude_usage(arena, &mut imports, "remainderInt", None);
-        };
+        }
 
         if self.tracker.float_division_used {
             self.register_prelude_usage(arena, &mut imports, "divideFloat", None);
-        };
+        }
 
         if self.tracker.int_division_used {
             self.register_prelude_usage(arena, &mut imports, "divideInt", None);
-        };
+        }
 
         if self.tracker.object_equality_used {
             self.register_prelude_usage(arena, &mut imports, "isEqual", None);
-        };
+        }
 
         if self.tracker.bit_array_literal_used {
             self.register_prelude_usage(arena, &mut imports, "toBitArray", None);
@@ -780,7 +780,7 @@ impl<'a, 'doc> Generator<'a> {
                     index,
                     CLOSE_SQUARE_SEMICOLON_DOCUMENT
                 ]
-                .group(arena)
+                .group(arena);
             }
 
             functions.push(docvec![
@@ -873,7 +873,7 @@ impl<'a, 'doc> Generator<'a> {
 
         if constructor.arguments.is_empty() {
             return docvec![arena, doc, head, CLOSE_CURLY_DOCUMENT];
-        };
+        }
 
         let parameters = arena.join(
             constructor
@@ -938,19 +938,19 @@ impl<'a, 'doc> Generator<'a> {
 
         for custom_type in &self.module.definitions.custom_types {
             if let Some(mut new_definitions) = self.custom_type_definition(arena, custom_type) {
-                definitions.append(&mut new_definitions)
+                definitions.append(&mut new_definitions);
             }
         }
 
         for constant in &self.module.definitions.constants {
             if let Some(definition) = self.module_constant(arena, constant) {
-                definitions.push(definition)
+                definitions.push(definition);
             }
         }
 
         for function in &self.module.definitions.functions {
             if let Some(definition) = self.module_function(arena, function) {
-                definitions.push(definition)
+                definitions.push(definition);
             }
         }
 
@@ -989,7 +989,7 @@ impl<'a, 'doc> Generator<'a> {
                     name,
                     module,
                     external_function,
-                )
+                );
             }
         }
 
@@ -1073,7 +1073,7 @@ impl<'a, 'doc> Generator<'a> {
             },
         };
         if publicity.is_importable() {
-            imports.register_export(maybe_escape_identifier_string(name))
+            imports.register_export(maybe_escape_identifier_string(name));
         }
         imports.register_module(EcoString::from(module), [], [member]);
     }
@@ -1249,7 +1249,7 @@ impl<'a, 'doc> Generator<'a> {
 
     fn register_module_definitions_in_scope(&mut self) {
         for constant in &self.module.definitions.constants {
-            self.register_in_scope(&constant.name)
+            self.register_in_scope(&constant.name);
         }
 
         for function in &self.module.definitions.functions {
@@ -1260,7 +1260,7 @@ impl<'a, 'doc> Generator<'a> {
 
         for import in &self.module.definitions.imports {
             for unqualified_value in &import.unqualified_values {
-                self.register_in_scope(unqualified_value.used_name())
+                self.register_in_scope(unqualified_value.used_name());
             }
         }
     }

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -500,8 +500,8 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
             let name = self.variables.next_local_var(&ASSIGNMENT_VAR.into());
             let value = self.variables.get_value(var);
             self.variables.bind(name.clone(), var);
-            assignments.push(let_doc(arena, name, value.to_doc(arena)))
-        };
+            assignments.push(let_doc(arena, name, value.to_doc(arena)));
+        }
 
         // Variable storing the character code for the first character of a string.
         // This is only declared if multiple patterns match on just the first
@@ -734,7 +734,7 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
 
         match &self.kind {
             DecisionKind::Case { .. } => {
-                self.variables.expression_generator.current_scope = old_scope
+                self.variables.expression_generator.current_scope = old_scope;
             }
             DecisionKind::LetAssert { .. } => {}
         }
@@ -1652,9 +1652,9 @@ impl<'generator, 'module, 'a, 'doc> Variables<'generator, 'module, 'a, 'doc> {
             if *times != 1 {
                 variable = variable
                     .append(arena, SPACE_TIMES_SPACE_DOCUMENT)
-                    .append(arena, *times)
+                    .append(arena, *times);
             }
-            pieces.push(variable.to_doc(arena))
+            pieces.push(variable.to_doc(arena));
         }
 
         for calculation in offset.calculations.iter() {
@@ -1670,9 +1670,9 @@ impl<'generator, 'module, 'a, 'doc> Variables<'generator, 'module, 'a, 'doc> {
             );
 
             if parenthesise {
-                pieces.push(calculation.surround(arena, OPEN_PAREN_DOCUMENT, CLOSE_PAREN_DOCUMENT))
+                pieces.push(calculation.surround(arena, OPEN_PAREN_DOCUMENT, CLOSE_PAREN_DOCUMENT));
             } else {
-                pieces.push(calculation)
+                pieces.push(calculation);
             }
         }
 
@@ -2081,7 +2081,7 @@ impl<'generator, 'module, 'a, 'doc> Variables<'generator, 'module, 'a, 'doc> {
 
             RuntimeCheck::BitArray { test } => {
                 for (segment_name, read_action) in test.referenced_segment_patterns() {
-                    self.set_segment_value(arena, variable, segment_name.clone(), read_action)
+                    self.set_segment_value(arena, variable, segment_name.clone(), read_action);
                 }
             }
 
@@ -2138,7 +2138,7 @@ impl<'generator, 'module, 'a, 'doc> Variables<'generator, 'module, 'a, 'doc> {
                 .get_segment_value(arena, segment)
                 .expect("segment referenced in a check before being created");
             self.bind_segment(variable_name.clone(), segment.clone());
-            check_assignments.push(let_doc(arena, variable_name, segment_value))
+            check_assignments.push(let_doc(arena, variable_name, segment_value));
         }
         check_assignments
     }

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1921,7 +1921,7 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                                     LOOP_DOLLAR_DOCUMENT,
                                     name.to_doc(arena),
                                     SPACE_EQUAL_SPACE_DOCUMENT
-                                ]
+                                ];
                             }
                             // Render the value given to the function. Even if it is not
                             // assigned we still render it because the expression may
@@ -3494,7 +3494,7 @@ pub fn eco_string_int<'a, 'doc>(
         out.push('-');
     } else if value.starts_with('+') {
         out.push('+');
-    };
+    }
     let value = value.trim_start_matches(['+', '-'].as_ref());
 
     let value = if value.starts_with("0x") {
@@ -3527,7 +3527,7 @@ pub fn float<'a, 'doc>(arena: &'doc DocumentArena<'a, 'doc>, value: &'a str) -> 
         out.push('-');
     } else if value.starts_with('+') {
         out.push('+');
-    };
+    }
     let value = value.trim_start_matches(['+', '-'].as_ref());
 
     let value = value.trim_start_matches(['0', '_']);

--- a/compiler-core/src/javascript/import.rs
+++ b/compiler-core/src/javascript/import.rs
@@ -38,7 +38,7 @@ impl<'a, 'doc> Imports<'a, 'doc> {
             .entry(path.clone())
             .or_insert_with(|| Import::new(path.clone()));
         import.aliases.extend(aliases);
-        import.unqualified.extend(unqualified_imports)
+        import.unqualified.extend(unqualified_imports);
     }
 
     pub fn into_doc(

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -47,13 +47,14 @@ pub static CURRENT_PACKAGE: &str = "thepackage";
 #[macro_export]
 macro_rules! assert_js {
     ($(($name:literal, $module_src:literal)),+, $src:literal $(,)?) => {
+        use std::fmt::Write as _;
         let compiled =
             $crate::javascript::tests::compile_js($src, vec![$(($crate::javascript::tests::CURRENT_PACKAGE, $name, $module_src)),*]);
             let mut output = String::from("----- SOURCE CODE\n");
             for (name, src) in [$(($name, $module_src)),*] {
-                output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+                let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
             }
-            output.push_str(&format!("-- main.gleam\n{}\n\n----- COMPILED JAVASCRIPT\n{compiled}", $src));
+            let _ = write!(output, "-- main.gleam\n{}\n\n----- COMPILED JAVASCRIPT\n{compiled}", $src);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 
@@ -332,13 +333,11 @@ pub fn source_map_to_string(src: &str, compiled: &str, source_map: SourceMap) ->
             src_line_numbers.byte_index(Position::new(*next_src_line, *next_src_col)) as usize;
         let next_compiled_index =
             compiled_line_numbers.byte_index(Position::new(*next_dst_line, *next_dst_col)) as usize;
-        output.push_str(&format!("{}\n", &src[src_index..next_src_index]));
-        output.push_str("⏷\n");
-        output.push_str(&format!(
-            "{}\n",
-            &compiled[compiled_index..next_compiled_index]
-        ));
-        output.push_str("----- \n");
+
+        output.push_str(&src[src_index..next_src_index]);
+        output.push_str("\n⏷\n");
+        output.push_str(&compiled[compiled_index..next_compiled_index]);
+        output.push_str("\n----- \n");
         prev_compiled_index = next_compiled_index;
     }
     // Print the last mapping. this needs to be done separately because the last mapping
@@ -353,15 +352,17 @@ pub fn source_map_to_string(src: &str, compiled: &str, source_map: SourceMap) ->
             let next_src_index = src_line_numbers
                 .byte_index(Position::new(next_src_token.0, next_src_token.1))
                 as usize;
-            output.push_str(&format!("{}\n", &src[src_index..next_src_index]));
+            output.push_str(&src[src_index..next_src_index]);
+            output.push('\n');
         }
         None => {
             // If there is no next src token, print the rest of the source and compiled code
-            output.push_str(&format!("{}\n", &src[src_index..]));
+            output.push_str(&src[src_index..]);
+            output.push('\n');
         }
     }
     output.push_str("⏷\n");
-    output.push_str(&format!("{}\n", &compiled[prev_compiled_index..]));
-    output.push_str("----- \n");
+    output.push_str(&compiled[prev_compiled_index..]);
+    output.push_str("\n----- \n");
     output
 }

--- a/compiler-core/src/javascript/tests.rs
+++ b/compiler-core/src/javascript/tests.rs
@@ -47,14 +47,21 @@ pub static CURRENT_PACKAGE: &str = "thepackage";
 #[macro_export]
 macro_rules! assert_js {
     ($(($name:literal, $module_src:literal)),+, $src:literal $(,)?) => {
-        use std::fmt::Write as _;
         let compiled =
             $crate::javascript::tests::compile_js($src, vec![$(($crate::javascript::tests::CURRENT_PACKAGE, $name, $module_src)),*]);
             let mut output = String::from("----- SOURCE CODE\n");
             for (name, src) in [$(($name, $module_src)),*] {
-                let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
+                output.push_str("-- ");
+                output.push_str(name);
+                output.push_str(".gleam\n");
+                output.push_str(src);
+                output.push_str("\n\n");
             }
-            let _ = write!(output, "-- main.gleam\n{}\n\n----- COMPILED JAVASCRIPT\n{compiled}", $src);
+            output.push_str("-- main.gleam\n");
+            output.push_str($src);
+            output.push_str("\n\n----- COMPILED JAVASCRIPT\n");
+            output.push_str(&compiled);
+
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -106,18 +106,18 @@ fn generic_ids(type_: &Type, ids: &mut HashMap<u64, u64>) {
         },
         Type::Named { arguments, .. } => {
             for argument in arguments {
-                generic_ids(argument, ids)
+                generic_ids(argument, ids);
             }
         }
         Type::Fn { arguments, return_ } => {
             for argument in arguments {
-                generic_ids(argument, ids)
+                generic_ids(argument, ids);
             }
             generic_ids(return_, ids);
         }
         Type::Tuple { elements } => {
             for element in elements {
-                generic_ids(element, ids)
+                generic_ids(element, ids);
             }
         }
     }
@@ -595,7 +595,7 @@ impl<'a, 'doc> TypeScriptGenerator<'a> {
 
         if constructor.arguments.is_empty() {
             return head.append(arena, CLOSE_CURLY_DOCUMENT);
-        };
+        }
 
         let class_body = docvec![
             arena,
@@ -676,7 +676,7 @@ impl<'a, 'doc> TypeScriptGenerator<'a> {
                 name,
                 COLON_SPACE_DOCUMENT,
                 self.do_print_force_generic_param(arena, &parameter.type_)
-            ])
+            ]);
         }
 
         let function_name = eco_format!(
@@ -743,7 +743,7 @@ impl<'a, 'doc> TypeScriptGenerator<'a> {
                 }
             }
             document = document.append(arena, GT_INT_DOCUMENT);
-        };
+        }
         document = document.append(arena, SEMICOLON_DOCUMENT);
         document.group(arena)
     }
@@ -1227,7 +1227,7 @@ impl<'a, 'doc> TypeScriptGenerator<'a> {
     /// Allows an outside module to mark the Gleam prelude as "used"
     ///
     pub fn set_prelude_used(&mut self) {
-        self.tracker.prelude_used = true
+        self.tracker.prelude_used = true;
     }
 
     /// Returns if the Gleam prelude has been used at all during the process

--- a/compiler-core/src/lib.rs
+++ b/compiler-core/src/lib.rs
@@ -25,6 +25,7 @@
     clippy::verbose_file_reads,
     clippy::unnested_or_patterns,
     clippy::default_trait_access,
+    clippy::format_push_string,
     rust_2018_idioms,
     missing_debug_implementations,
     missing_copy_implementations,

--- a/compiler-core/src/manifest.rs
+++ b/compiler-core/src/manifest.rs
@@ -113,7 +113,7 @@ impl Manifest {
                     buffer.push_str(&make_relative(root_path, path).as_str().replace('\\', "/"));
                     buffer.push('"');
                 }
-            };
+            }
 
             buffer.push_str(" },\n");
         }
@@ -713,7 +713,7 @@ impl PackageChanges {
                             name: new.name.clone(),
                             old_hash: old_hash.clone(),
                             new_hash: new_hash.clone(),
-                        })
+                        });
                     }
                     (
                         ManifestPackageSource::Hex { .. }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -441,7 +441,7 @@ where
             match self.parse_expression_unit(expression_unit_context)? {
                 Some(unit) => {
                     self.post_process_expression_unit(&unit, is_let_binding)?;
-                    estack.push(unit)
+                    estack.push(unit);
                 }
                 _ if estack.is_empty() => return Ok(None),
                 _ => {
@@ -649,8 +649,8 @@ where
                             Ok(elements) => {
                                 elements_after_tail = Some(elements);
                             }
-                        };
-                    };
+                        }
+                    }
 
                     if tail.is_some() {
                         if !elements_end_with_comma {
@@ -1549,8 +1549,8 @@ where
                                 Ok(elements) => {
                                     elements_after_tail = Some(elements);
                                 }
-                            };
-                        };
+                            }
+                        }
                         Some(tail)
                     }
                     _ => None,
@@ -1604,7 +1604,7 @@ where
                                 start,
                                 end: closing_square_bracket_end,
                             },
-                        })
+                        });
                 }
 
                 Pattern::List {
@@ -2057,7 +2057,7 @@ where
                     self.warnings
                         .push(DeprecatedSyntaxWarning::DeprecatedRecordSpreadPattern {
                             location: spread_location,
-                        })
+                        });
                 }
             }
             let (_, end) = self.expect_one(&Token::RightParen)?;
@@ -2222,7 +2222,7 @@ where
                     end: colon_end,
                 },
             });
-        };
+        }
 
         let return_annotation = self.parse_type_annotation(&Token::RArrow)?;
 
@@ -3138,7 +3138,7 @@ where
                     },
                     location: SrcSpan::new(dot_start, dot_end),
                 });
-            };
+            }
 
             let parsed = self.parse_unqualified_imports()?;
             unqualified_types = parsed.types;
@@ -3201,7 +3201,7 @@ where
                         import.as_name = Some(as_name);
                         import.location.end = end;
                     }
-                    imports.values.push(import)
+                    imports.values.push(import);
                 }
 
                 Some((start, Token::UpName { name }, end)) => {
@@ -3218,7 +3218,7 @@ where
                         import.as_name = Some(as_name);
                         import.location.end = end;
                     }
-                    imports.values.push(import)
+                    imports.values.push(import);
                 }
 
                 Some((start, Token::Type, _)) => {
@@ -3236,7 +3236,7 @@ where
                         import.as_name = Some(as_name);
                         import.location.end = end;
                     }
-                    imports.types.push(import)
+                    imports.types.push(import);
                 }
 
                 t0 => {
@@ -3413,8 +3413,8 @@ where
                             Ok(elements) => {
                                 elements_after_tail = Some(elements);
                             }
-                        };
-                    };
+                        }
+                    }
 
                     if tail.is_some() {
                         // Give a better error when there are two lists being
@@ -4443,8 +4443,8 @@ functions are declared separately from types.";
         // If the sequence ends with a trailing comma we want to keep track of
         // its position.
         if let (Some(Token::Comma), Some((_, end))) = (sep, final_separator) {
-            self.extra.trailing_commas.push(end)
-        };
+            self.extra.trailing_commas.push(end);
+        }
 
         Ok((results, final_separator.is_some()))
     }
@@ -4810,7 +4810,7 @@ fn handle_op<A>(
 fn precedence(t: &Token) -> Option<u8> {
     if t == &Token::Pipe {
         return Some(6);
-    };
+    }
     tok_to_binop(t).map(|op| op.precedence())
 }
 
@@ -5327,7 +5327,7 @@ impl PartialOrd for LiteralFloatValue {
 
 impl Hash for LiteralFloatValue {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_bits().hash(state)
+        self.0.to_bits().hash(state);
     }
 }
 

--- a/compiler-core/src/parse/lexer.rs
+++ b/compiler-core/src/parse/lexer.rs
@@ -103,10 +103,10 @@ where
                 // Transform windows EOL into \n
                 let _ = self.shift();
                 // using the position from the \r
-                self.chr0 = Some((i, '\n'))
+                self.chr0 = Some((i, '\n'));
             } else {
                 // Transform MAC EOL into \n
-                self.chr0 = Some((i, '\n'))
+                self.chr0 = Some((i, '\n'));
             }
         }
 
@@ -156,7 +156,7 @@ where
             let mut check_for_minus = false;
             if self.is_upname_start(c) {
                 let name = self.lex_upname()?;
-                self.emit(name)
+                self.emit(name);
             } else if self.is_name_start(c) {
                 check_for_minus = true;
                 let name = self.lex_name()?;
@@ -207,7 +207,7 @@ where
                                     end: tok_end + 1,
                                 },
                             });
-                        };
+                        }
                         self.emit((tok_start, Token::EqualEqual, tok_end));
                     }
                     _ => {
@@ -844,7 +844,7 @@ where
         let start_pos = self.get_pos();
 
         while self.is_name_continuation() {
-            name.push(self.next_char().expect("lex_name continue"))
+            name.push(self.next_char().expect("lex_name continue"));
         }
 
         let end_pos = self.get_pos();

--- a/compiler-core/src/paths.rs
+++ b/compiler-core/src/paths.rs
@@ -188,7 +188,7 @@ pub fn default_global_gleam_cache() -> Utf8PathBuf {
 pub fn unnest(within: &Utf8Path) -> Utf8PathBuf {
     let mut path = Utf8PathBuf::new();
     for _ in within {
-        path = path.join("..")
+        path = path.join("..");
     }
     path
 }

--- a/compiler-core/src/reference.rs
+++ b/compiler-core/src/reference.rs
@@ -577,7 +577,7 @@ impl ReferenceTracker {
             EntityKind::ImportedConstructor { module }
             | EntityKind::ImportedType { module }
             | EntityKind::ImportedValue { module } => {
-                self.register_module_reference(module.clone())
+                self.register_module_reference(module.clone());
             }
         }
     }
@@ -639,7 +639,7 @@ impl ReferenceTracker {
             }
             ReferenceKind::Import(_) | ReferenceKind::Definition => {}
             ReferenceKind::Alias | ReferenceKind::Unqualified => {
-                self.register_type_reference_in_call_graph(referenced_name.clone())
+                self.register_type_reference_in_call_graph(referenced_name.clone());
             }
         }
 

--- a/compiler-core/src/strings.rs
+++ b/compiler-core/src/strings.rs
@@ -158,7 +158,7 @@ pub fn length_utf16(string: &str) -> usize {
     let mut length = 0;
 
     for char in string.chars() {
-        length += char.len_utf16()
+        length += char.len_utf16();
     }
 
     length

--- a/compiler-core/src/type_.rs
+++ b/compiler-core/src/type_.rs
@@ -1662,7 +1662,7 @@ fn unify_unbound_type(type_: &Type, own_id: u64) -> Result<(), UnifyError> {
     match type_ {
         Type::Named { arguments, .. } => {
             for argument in arguments {
-                unify_unbound_type(argument, own_id)?
+                unify_unbound_type(argument, own_id)?;
             }
             Ok(())
         }
@@ -1676,7 +1676,7 @@ fn unify_unbound_type(type_: &Type, own_id: u64) -> Result<(), UnifyError> {
 
         Type::Tuple { elements, .. } => {
             for element in elements {
-                unify_unbound_type(element, own_id)?
+                unify_unbound_type(element, own_id)?;
             }
             Ok(())
         }

--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -1159,7 +1159,7 @@ pub fn unify(t1: Arc<Type>, t2: Arc<Type>) -> Result<(), UnifyError> {
                     arguments1.len(),
                     &t2,
                     arguments2.len(),
-                ))?
+                ))?;
             }
 
             for (i, (a, b)) in arguments1.iter().zip(arguments2).enumerate() {

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -43,13 +43,13 @@ impl Problems {
     /// Register an error.
     ///
     pub fn error(&mut self, error: Error) {
-        self.errors.push(error)
+        self.errors.push(error);
     }
 
     /// Register a warning.
     ///
     pub fn warning(&mut self, warning: Warning) {
-        self.warnings.push(warning)
+        self.warnings.push(warning);
     }
 
     /// Take all the errors, leaving an empty vector in its place.

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -658,7 +658,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             self.problems.warning(Warning::UnreachableCodeAfterPanic {
                 location,
                 panic_position,
-            })
+            });
         }
     }
 
@@ -708,7 +708,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         } else if discarded.is_pure_value_constructor() {
             self.problems.warning(Warning::UnusedValue {
                 location: discarded.location(),
-            })
+            });
         }
     }
 
@@ -1252,8 +1252,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 self.problems.error(convert_unify_error(
                     error.list_element_mismatch(),
                     element.location(),
-                ))
-            };
+                ));
+            }
             inferred_elements.push(element);
         }
 
@@ -1267,7 +1267,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     self.problems.error(convert_unify_error(
                         error.list_tail_mismatch(),
                         tail.location(),
-                    ))
+                    ));
                 }
                 Some(Box::new(tail))
             }
@@ -1443,7 +1443,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             &constructor.variant,
                             *location,
                             ReferenceKind::Unqualified,
-                        )
+                        );
                     }
                 }
                 record_access
@@ -1631,7 +1631,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             );
                             segment.options.push(BitArrayOption::Float {
                                 location: SrcSpan::default(),
-                            })
+                            });
                         }
 
                         UntypedExpr::Int { .. }
@@ -1668,7 +1668,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     // check if it's `size` option uses any feature that has to
                     // be tracked!
                     self.check_segment_size_expression(&segment.options);
-                };
+                }
 
                 segment
             })
@@ -1712,7 +1712,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                             );
                             segment.options.push(BitArrayOption::Float {
                                 location: SrcSpan::default(),
-                            })
+                            });
                         }
 
                         Constant::Int { .. }
@@ -1863,7 +1863,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let expression = self.infer(expression);
         if let Err(error) = unify(type_, expression.type_()) {
             self.problems
-                .error(convert_unify_error(error, expression.location()))
+                .error(convert_unify_error(error, expression.location()));
         }
         expression
     }
@@ -1942,18 +1942,18 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             self.problems.error(Error::FloatOperatorOnInts {
                 operator,
                 location: SrcSpan::new(operator_start, operator_start + operator.size()),
-            })
+            });
         } else if operator.is_int_operator() && left.type_().is_float() && right.type_().is_float()
         {
             self.problems.error(Error::IntOperatorOnFloats {
                 operator,
                 location: SrcSpan::new(operator_start, operator_start + operator.size()),
-            })
+            });
         } else if operator == BinOp::AddInt && left.type_().is_string() && right.type_().is_string()
         {
             self.problems.error(Error::StringConcatenationWithAddInt {
                 location: SrcSpan::new(operator_start, operator_start + operator.size()),
-            })
+            });
         } else {
             // In all other cases we just report an error for each of the operands.
             if let Err(error) = unify_left {
@@ -2249,7 +2249,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     | Reachability::Unreachable(UnreachablePatternReason::DuplicatePattern) => {}
                 }
             }
-        };
+        }
 
         Assignment {
             location,
@@ -2378,7 +2378,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             self.previous_panics = false;
             let (typed_clause, error_typing_patterns) = self.infer_clause(clause, &typed_subjects);
             if error_typing_patterns {
-                patterns_typechecked_successfully = false
+                patterns_typechecked_successfully = false;
             }
             all_clauses_panic = all_clauses_panic && self.previous_panics;
 
@@ -2639,8 +2639,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 let expression = self.infer_clause_guard(*expression);
                 if let Err(error) = unify(bool(), expression.type_()) {
                     self.problems
-                        .error(convert_unify_error(error, expression.location()))
-                };
+                        .error(convert_unify_error(error, expression.location()));
+                }
                 ClauseGuard::Not {
                     location,
                     expression: Box::new(expression),
@@ -2949,7 +2949,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     location: select_location,
                     message: message.clone(),
                     layer: Layer::Value,
-                })
+                });
             }
 
             self.environment
@@ -3272,7 +3272,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 // We still want to accumulate errors for all field to come!
                 if let Err(error) = unify(variant.arg_type(index), value.type_()) {
                     self.problems.error(convert_unify_error(error, *location));
-                };
+                }
 
                 if let Some(type_name) = return_type.named_type_name() {
                     self.environment.references.register_label_reference(
@@ -3291,14 +3291,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         value,
                         implicit: None,
                     },
-                ))
+                ));
             } else if variant.has_field(label) {
                 // The variant has this field but it was already removed in a
                 // previous iteration. This means we've found a duplicate field!
                 self.problems.error(Error::DuplicateArgument {
                     location: *location,
                     label: label.clone(),
-                })
+                });
             } else {
                 // Otherwise, it's just an unknown field!
                 self.problems.error(self.unknown_field_error(
@@ -3307,8 +3307,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     *location,
                     label.clone(),
                     FieldAccessUsage::RecordUpdate,
-                ))
-            };
+                ));
+            }
         }
 
         // Generate the remaining copied arguments, making sure they unify with
@@ -3363,7 +3363,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         value: record_access,
                         implicit: Some(ImplicitCallArgOrigin::RecordUpdate),
                     },
-                ))
+                ));
             } else {
                 let (accessor_type, positional_fields) =
                     match collapse_links(record.type_()).as_ref() {
@@ -3457,7 +3457,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         value: record_access,
                         implicit: Some(ImplicitCallArgOrigin::RecordUpdate),
                     },
-                ))
+                ));
             }
         }
 
@@ -3733,7 +3733,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location: *location,
                 message: message.clone(),
                 layer: Layer::Value,
-            })
+            });
         }
 
         self.narrow_implementations(*location, &variant)?;
@@ -3830,7 +3830,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     referenced_name,
                     location,
                     ReferenceKind::Alias,
-                )
+                );
             }
             ValueConstructorVariant::ModuleFn { name, module, .. }
             | ValueConstructorVariant::Record { name, module, .. }
@@ -3841,10 +3841,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     referenced_name,
                     location,
                     kind,
-                )
+                );
             }
             ValueConstructorVariant::LocalVariable { .. } => {
-                self.environment.increment_usage(referenced_name)
+                self.environment.increment_usage(referenced_name);
             }
         }
     }
@@ -4295,8 +4295,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         error
                             .operator_situation(BinOp::Concatenate)
                             .into_error(left.location()),
-                    )
-                };
+                    );
+                }
 
                 let right = self.infer_const(&None, *right);
                 if let Err(error) = unify(string(), right.type_()) {
@@ -4304,8 +4304,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         error
                             .operator_situation(BinOp::Concatenate)
                             .into_error(right.location()),
-                    )
-                };
+                    );
+                }
 
                 Constant::StringConcatenation {
                     location,
@@ -4322,7 +4322,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     let message = self.infer_const(&None, *message);
                     if let Err(error) = unify(string(), message.type_()) {
                         self.problems
-                            .error(convert_unify_error(error, message.location()))
+                            .error(convert_unify_error(error, message.location()));
                     }
                     Box::new(message)
                 });
@@ -4476,7 +4476,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 let value = self.infer_const(&None, value);
                 if let Err(error) = unify(type_.clone(), value.type_()) {
                     self.problems
-                        .error(convert_unify_error(error, value.location()))
+                        .error(convert_unify_error(error, value.location()));
                 }
                 CallArg {
                     label,
@@ -4546,7 +4546,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 },
                 implicit,
                 location,
-            })
+            });
         }
 
         Constant::Record {
@@ -4652,7 +4652,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             let tail = self.infer_const(&None, *tail);
             if let Err(error) = unify(type_.clone(), tail.type_()) {
                 self.problems
-                    .error(convert_unify_error(error, tail.location()))
+                    .error(convert_unify_error(error, tail.location()));
             }
             Some(Box::new(tail))
         } else {
@@ -4954,7 +4954,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 });
             }
             arguments.push(last);
-        };
+        }
 
         // Ensure that the given args have the correct types
         let arguments_count = arguments_types.len();
@@ -4997,7 +4997,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     self.warn_for_unreachable_code(
                         value.location(),
                         PanicPosition::PreviousFunctionArgument,
-                    )
+                    );
                 }
 
                 let value = self.infer_call_argument(
@@ -5078,7 +5078,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 },
                 implicit,
                 location,
-            })
+            });
         }
 
         // We don't want to emit a warning for unreachable function call if the
@@ -5294,7 +5294,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         }
                     }
                     ArgNames::Discard { .. } | ArgNames::LabelledDiscard { .. } => (),
-                };
+                }
             }
 
             if let Ok(body) = Vec1::try_from_vec(body) {
@@ -5324,8 +5324,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         },
                         type_: body_typer.new_unbound_var(),
                         extra_information: None,
-                    }))
-                };
+                    }));
+                }
 
                 Ok((arguments, body.to_vec()))
             } else {
@@ -5407,7 +5407,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         let location = SrcSpan::new(first.location().start, last.location().end);
 
                         self.problems
-                            .warning(Warning::UnreachableCasePattern { location, reason })
+                            .warning(Warning::UnreachableCasePattern { location, reason });
                     }
                 }
             }
@@ -5435,7 +5435,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         feature_kind,
                         minimum_required_version: minimum_required_version.clone(),
                         wrongfully_allowed_version: lowest_allowed_version,
-                    })
+                    });
             }
         }
 
@@ -5476,7 +5476,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             // Blocks and binops were added in Gleam 1.12.0!
             TypedExpr::Block { location, .. } | TypedExpr::BinOp { location, .. } => {
-                self.track_feature_usage(FeatureKind::ExpressionInSegmentSize, *location)
+                self.track_feature_usage(FeatureKind::ExpressionInSegmentSize, *location);
             }
 
             // None of these are currently supported... for now!
@@ -6095,7 +6095,7 @@ impl UseAssignments {
                     };
                     assignments
                         .body_assignments
-                        .push(Statement::Assignment(Box::new(assignment)))
+                        .push(Statement::Assignment(Box::new(assignment)));
                 }
             }
         }
@@ -6248,7 +6248,7 @@ fn static_compare(one: &TypedExpr, other: &TypedExpr) -> StaticComparison {
                 },
                 (None, Some(_)) | (Some(_), None) => return StaticComparison::CantTell,
                 (None, None) => (),
-            };
+            }
 
             // If we can tell the two lists have a different number of items
             // then we know it's never going to match.

--- a/compiler-core/src/type_/fields.rs
+++ b/compiler-core/src/type_/fields.rs
@@ -239,7 +239,7 @@ impl FieldMapBuilder {
                 label: label.clone(),
                 location,
             });
-        };
+        }
         self.any_labels = true;
         Ok(())
     }

--- a/compiler-core/src/type_/hydrator.rs
+++ b/compiler-core/src/type_/hydrator.rs
@@ -79,11 +79,11 @@ impl Hydrator {
     }
 
     pub fn disallow_new_type_variables(&mut self) {
-        self.permit_new_type_variables = false
+        self.permit_new_type_variables = false;
     }
 
     pub fn permit_holes(&mut self, flag: bool) {
-        self.permit_holes = flag
+        self.permit_holes = flag;
     }
 
     /// A rigid type is a generic type that was specified as being generic in
@@ -211,7 +211,7 @@ impl Hydrator {
                             location: *location,
                             message,
                             layer: Layer::Type,
-                        })
+                        });
                     }
                 }
 

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -179,7 +179,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                 self.problems.error(convert_unify_error(error, location));
                                 self.error_encountered = true;
                             }
-                        };
+                        }
                         unify_constructor_variants(Arc::make_mut(&mut initial.type_), &type_);
                     }
 
@@ -435,7 +435,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
 
         if let Some(s) = last_segment {
             let typed_last_segment = self.infer_pattern_segment(s, true);
-            typed_segments.push(typed_last_segment)
+            typed_segments.push(typed_last_segment);
         }
 
         TypedPattern::BitArray {
@@ -466,7 +466,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     self.track_feature_usage(FeatureKind::UnannotatedFloatSegment, *location);
                     segment.options.push(BitArrayOption::Float {
                         location: SrcSpan::default(),
-                    })
+                    });
                 }
 
                 Pattern::Int { .. }
@@ -640,7 +640,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             | Pattern::BitArray { .. }
             | Pattern::StringPrefix { .. }
             | Pattern::Invalid { .. } => {}
-        };
+        }
 
         let typed_segment = BitArraySegment {
             location: segment.location,
@@ -772,7 +772,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             .insert(right.clone(), right_location);
                         self.check_name_case(right_location, right, Named::Discard);
                     }
-                };
+                }
 
                 Pattern::StringPrefix {
                     location,
@@ -1141,7 +1141,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                     implicit: Some(ImplicitCallArgOrigin::PatternFieldSpread),
                                 });
                             }
-                        };
+                        }
                     }
                 }
 
@@ -1190,7 +1190,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             location,
                             message,
                             layer: Layer::Value,
-                        })
+                        });
                     }
                 }
 
@@ -1328,7 +1328,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         && let Some(label) = &arg.label
                         && let Some(field) = field_map.fields.get(label)
                     {
-                        index = *field as usize
+                        index = *field as usize;
                     }
                 }
 
@@ -1441,7 +1441,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         location,
                         ReferenceKind::Unqualified,
                     ),
-                };
+                }
 
                 self.environment.increment_usage(&name);
                 let type_ = self.environment.instantiate(
@@ -1515,7 +1515,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         feature_kind,
                         minimum_required_version: minimum_required_version.clone(),
                         wrongfully_allowed_version: lowest_allowed_version,
-                    })
+                    });
             }
         }
 
@@ -1557,7 +1557,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
             BitArraySize::Int { .. } | BitArraySize::Variable { .. } => (),
             BitArraySize::BinaryOperator { location, .. }
             | BitArraySize::Block { location, .. } => {
-                self.track_feature_usage(FeatureKind::ExpressionInSegmentSize, *location)
+                self.track_feature_usage(FeatureKind::ExpressionInSegmentSize, *location);
             }
         }
     }

--- a/compiler-core/src/type_/pipe.rs
+++ b/compiler-core/src/type_/pipe.rs
@@ -390,7 +390,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
                 };
                 self.expr_typer.problems.error(error);
             }
-        };
+        }
 
         TypedExpr::Call {
             location: function_location,

--- a/compiler-core/src/type_/pretty.rs
+++ b/compiler-core/src/type_/pretty.rs
@@ -151,7 +151,7 @@ impl<'a, 'doc> Printer {
             if rest == 0 {
                 break;
             }
-            rest -= 1
+            rest -= 1;
         }
 
         self.uid += 1;

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -270,7 +270,7 @@ impl Names {
         if print_mode == PrintMode::ExpandAliases {
             if let Some((module, _)) = self.imported_modules.get(module) {
                 return NameContextInformation::Qualified(module, name.as_str());
-            };
+            }
 
             return NameContextInformation::Unimported(module, name);
         }
@@ -294,7 +294,7 @@ impl Names {
         // This type is from a module that has been imported
         if let Some((module, _)) = self.imported_modules.get(module) {
             return NameContextInformation::Qualified(module, name.as_str());
-        };
+        }
 
         NameContextInformation::Unimported(module, name)
     }
@@ -328,7 +328,7 @@ impl Names {
         // This value is from a module that has been imported
         if let Some((module, _)) = self.imported_modules.get(module) {
             return NameContextInformation::Qualified(module, name.as_str());
-        };
+        }
 
         NameContextInformation::Unimported(module, name)
     }
@@ -517,7 +517,7 @@ impl<'a> Printer<'a> {
             Type::Var { type_, .. } => match *type_.borrow() {
                 TypeVar::Link { ref type_, .. } => self.print(type_, buffer, print_mode),
                 TypeVar::Unbound { id, .. } | TypeVar::Generic { id, .. } => {
-                    buffer.push_str(&self.type_variable(id))
+                    buffer.push_str(&self.type_variable(id));
                 }
             },
 
@@ -593,7 +593,7 @@ impl<'a> Printer<'a> {
             if rest == 0 {
                 break;
             }
-            rest -= 1
+            rest -= 1;
         }
 
         self.uid += 1;

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -90,8 +90,6 @@ macro_rules! assert_module_error {
     };
 
     ($(($name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
-        use std::fmt::Write as _;
-
         let error = $crate::type_::tests::module_error(
             $src,
             vec![
@@ -101,15 +99,20 @@ macro_rules! assert_module_error {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
+            output.push_str("-- ");
+            output.push_str(name);
+            output.push_str(".gleam\n");
+            output.push_str(src);
+            output.push_str("\n\n");
         }
-        let _ = write!(output, "-- main.gleam\n{}\n\n----- ERROR\n{error}", $src);
+        output.push_str("-- main.gleam\n");
+        output.push_str($src);
+        output.push_str("\n\n----- ERROR\n");
+        output.push_str(&error);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 
     ($(($package:literal, $name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
-        use std::fmt::Write as _;
-
         let error = $crate::type_::tests::module_error(
             $src,
             vec![
@@ -119,9 +122,16 @@ macro_rules! assert_module_error {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
+            output.push_str("-- ");
+            output.push_str(name);
+            output.push_str(".gleam\n");
+            output.push_str(src);
+            output.push_str("\n\n");
         }
-        let _ = write!(output, "-- main.gleam\n{}\n\n----- ERROR\n{error}", $src);
+        output.push_str("-- main.gleam\n");
+        output.push_str($src);
+        output.push_str("\n\n----- ERROR\n");
+        output.push_str(&error);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }
@@ -235,8 +245,6 @@ macro_rules! assert_warning {
     };
 
     ($(($name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
-        use std::fmt::Write as _;
-
         let warning = $crate::type_::tests::get_printed_warnings(
             $src,
             vec![
@@ -249,15 +257,21 @@ macro_rules! assert_warning {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
+            output.push_str("-- ");
+            output.push_str(name);
+            output.push_str(".gleam\n");
+            output.push_str(src);
+            output.push_str("\n\n");
         }
-        let _ = write!(output, "-- main.gleam\n{}\n\n----- WARNING\n{warning}", $src);
+
+        output.push_str("-- main.gleam\n");
+        output.push_str($src);
+        output.push_str("\n\n----- WARNING\n");
+        output.push_str(&warning);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 
     ($(($package:expr, $name:expr, $module_src:literal)),+, $src:expr) => {
-        use std::fmt::Write as _;
-
         let warning = $crate::type_::tests::get_printed_warnings(
             $src,
             vec![$(($package, $name, $module_src)),*],
@@ -268,9 +282,17 @@ macro_rules! assert_warning {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
+            output.push_str("-- ");
+            output.push_str(name);
+            output.push_str(".gleam\n");
+            output.push_str(src);
+            output.push_str("\n\n");
         }
-        let _ = write!(output, "-- main.gleam\n{}\n\n----- WARNING\n{warning}", $src);
+
+        output.push_str("-- main.gleam\n");
+        output.push_str($src);
+        output.push_str("\n\n----- WARNING\n");
+        output.push_str(&warning);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }

--- a/compiler-core/src/type_/tests.rs
+++ b/compiler-core/src/type_/tests.rs
@@ -90,6 +90,8 @@ macro_rules! assert_module_error {
     };
 
     ($(($name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
+        use std::fmt::Write as _;
+
         let error = $crate::type_::tests::module_error(
             $src,
             vec![
@@ -99,13 +101,15 @@ macro_rules! assert_module_error {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
         }
-        output.push_str(&format!("-- main.gleam\n{}\n\n----- ERROR\n{error}", $src));
+        let _ = write!(output, "-- main.gleam\n{}\n\n----- ERROR\n{error}", $src);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 
     ($(($package:literal, $name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
+        use std::fmt::Write as _;
+
         let error = $crate::type_::tests::module_error(
             $src,
             vec![
@@ -115,9 +119,9 @@ macro_rules! assert_module_error {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
         }
-        output.push_str(&format!("-- main.gleam\n{}\n\n----- ERROR\n{error}", $src));
+        let _ = write!(output, "-- main.gleam\n{}\n\n----- ERROR\n{error}", $src);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }
@@ -231,6 +235,8 @@ macro_rules! assert_warning {
     };
 
     ($(($name:expr, $module_src:literal)),+, $src:literal $(,)?) => {
+        use std::fmt::Write as _;
+
         let warning = $crate::type_::tests::get_printed_warnings(
             $src,
             vec![
@@ -243,13 +249,15 @@ macro_rules! assert_warning {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
         }
-        output.push_str(&format!("-- main.gleam\n{}\n\n----- WARNING\n{warning}", $src));
+        let _ = write!(output, "-- main.gleam\n{}\n\n----- WARNING\n{warning}", $src);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 
     ($(($package:expr, $name:expr, $module_src:literal)),+, $src:expr) => {
+        use std::fmt::Write as _;
+
         let warning = $crate::type_::tests::get_printed_warnings(
             $src,
             vec![$(($package, $name, $module_src)),*],
@@ -260,9 +268,9 @@ macro_rules! assert_warning {
 
         let mut output = String::from("----- SOURCE CODE\n");
         for (name, src) in [$(($name, $module_src)),*] {
-            output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+            let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
         }
-        output.push_str(&format!("-- main.gleam\n{}\n\n----- WARNING\n{warning}", $src));
+        let _ = write!(output, "-- main.gleam\n{}\n\n----- WARNING\n{warning}", $src);
         insta::assert_snapshot!(insta::internals::AutoName, output, $src);
     };
 }

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -22,6 +22,7 @@ use debug_ignore::DebugIgnore;
 use ecow::EcoString;
 use itertools::Itertools;
 use std::{
+    fmt::Write as _,
     io::Write,
     sync::{Arc, atomic::Ordering},
 };
@@ -1100,9 +1101,12 @@ Either change the pattern or use `panic` to unconditionally fail.",
                     };
                     let mut text = format!("`{name}` is not a function");
                     match arguments {
-                        0 => text.push_str(&format!(
-                            ", you can just write `{name}` instead of `{name}()`."
-                        )),
+                        0 => {
+                            let _ = write!(
+                                text,
+                                ", you can just write `{name}` instead of `{name}()`."
+                            );
+                        }
                         1 => text.push_str(
                             " and will crash before it can do anything with this argument.",
                         ),

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1113,7 +1113,7 @@ Either change the pattern or use `panic` to unconditionally fail.",
                         _ => text.push_str(
                             " and will crash before it can do anything with these arguments.",
                         ),
-                    };
+                    }
 
                     let hint = match arguments {
                         0 => None,

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -22,7 +22,6 @@ use debug_ignore::DebugIgnore;
 use ecow::EcoString;
 use itertools::Itertools;
 use std::{
-    fmt::Write as _,
     io::Write,
     sync::{Arc, atomic::Ordering},
 };
@@ -1102,10 +1101,11 @@ Either change the pattern or use `panic` to unconditionally fail.",
                     let mut text = format!("`{name}` is not a function");
                     match arguments {
                         0 => {
-                            let _ = write!(
-                                text,
-                                ", you can just write `{name}` instead of `{name}()`."
-                            );
+                            text.push_str(", you can just write `");
+                            text.push_str(name);
+                            text.push_str("` instead of `");
+                            text.push_str(name);
+                            text.push_str("()`.");
                         }
                         1 => text.push_str(
                             " and will crash before it can do anything with this argument.",

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -235,7 +235,7 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
                         elements.last().map(|element| element.location()),
                     ),
                     Some(Pattern::Discard { location, .. }) => {
-                        self.discard_tuple_items(*location, elements.len())
+                        self.discard_tuple_items(*location, elements.len());
                     }
                     _ => panic!("safe: we've just checked all patterns must be discards/tuples"),
                 }
@@ -244,7 +244,7 @@ impl<'ast> ast::visit::Visit<'ast> for RedundantTupleInCaseSubject<'_> {
             self.hovered = self.hovered || overlaps(self.params.range, range);
         }
 
-        ast::visit::visit_typed_expr_case(self, location, type_, subjects, clauses, compiled_case)
+        ast::visit::visit_typed_expr_case(self, location, type_, subjects, clauses, compiled_case);
     }
 }
 
@@ -339,7 +339,7 @@ impl<'a> RedundantTupleInCaseSubject<'a> {
         self.edits.replace(
             discard_location,
             itertools::intersperse(iter::repeat_n("_", tuple_items), ", ").collect(),
-        )
+        );
     }
 }
 
@@ -725,12 +725,12 @@ impl<'ast> ast::visit::Visit<'ast> for UseLabelShorthandSyntax<'_> {
                 value: TypedExpr::Var { name, location, .. },
                 ..
             } if is_selected && !arg.uses_label_shorthand() && label == name => {
-                self.edits.delete(*location)
+                self.edits.delete(*location);
             }
             _ => (),
         }
 
-        ast::visit::visit_typed_call_arg(self, arg)
+        ast::visit::visit_typed_call_arg(self, arg);
     }
 
     fn visit_typed_pattern_call_arg(&mut self, arg: &'ast CallArg<TypedPattern>) {
@@ -743,12 +743,12 @@ impl<'ast> ast::visit::Visit<'ast> for UseLabelShorthandSyntax<'_> {
                 value: TypedPattern::Variable { name, location, .. },
                 ..
             } if is_selected && !arg.uses_label_shorthand() && label == name => {
-                self.edits.delete(*location)
+                self.edits.delete(*location);
             }
             _ => (),
         }
 
-        ast::visit::visit_typed_pattern_call_arg(self, arg)
+        ast::visit::visit_typed_pattern_call_arg(self, arg);
     }
 }
 
@@ -996,7 +996,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
                     .as_ref()
                     .map(|constructor| constructor.type_.clone()),
                 enclosing_function: None,
-            })
+            });
         }
 
         // We only want to take into account the innermost function call
@@ -1037,7 +1037,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
                 kind: SelectedCallKind::Value,
                 fun_type: Some(fun.type_()),
                 enclosing_function: self.current_function,
-            })
+            });
         }
 
         // We only want to take into account the innermost function call
@@ -1074,7 +1074,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
                 kind: SelectedCallKind::Pattern,
                 fun_type: None,
                 enclosing_function: self.current_function,
-            })
+            });
         }
 
         ast::visit::visit_typed_pattern_constructor(
@@ -1265,8 +1265,8 @@ pub fn code_action_import_module(
                     import_location,
                     import,
                     &after_import_newlines,
-                ))
-            };
+                ));
+            }
 
             let title = match &suggestion.import {
                 Some(import) => &format!("Import `{import}`"),
@@ -1765,7 +1765,7 @@ impl<'a> AnnotateTopLevelDefinitions<'a> {
         // which is lacking some annotations in the module
         if !self.is_hovering_definition_requiring_annotations {
             return vec![];
-        };
+        }
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new("Annotate all top level definitions")
@@ -2024,7 +2024,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
             module_name,
             module_alias,
             constructor,
-        )
+        );
     }
 
     fn visit_typed_pattern_constructor(
@@ -2168,7 +2168,7 @@ impl<'a> QualifiedToUnqualifiedImportSecondPass<'a> {
         self.edits.delete(SrcSpan {
             start: location.start,
             end: location.start + self.qualified_constructor.used_name.len() as u32 + 1, // plus .
-        })
+        });
     }
 
     fn edit_import(&mut self) {
@@ -2258,7 +2258,7 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
             module_name,
             module_alias,
             constructor,
-        )
+        );
     }
 
     fn visit_typed_pattern_constructor(
@@ -2431,7 +2431,7 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
                             layer: ast::Layer::Value,
                         })
                     })
-            })
+            });
     }
 
     fn get_module_import_from_type_constructor(&mut self, constructor_name: &EcoString) {
@@ -2454,7 +2454,7 @@ impl<'a> UnqualifiedToQualifiedImportFirstPass<'a> {
                         });
                     }
                     None
-                })
+                });
     }
 }
 
@@ -2992,7 +2992,7 @@ impl<'a> ConvertFromUse<'a> {
                 } else {
                     callback_start
                 },
-            )
+            );
         } else {
             // On the other hand, if the function on the right hand side doesn't
             // end with a closed parenthese then we have to manually add it.
@@ -3001,8 +3001,8 @@ impl<'a> ConvertFromUse<'a> {
             //                  ^ No parentheses
             //
             self.edits
-                .insert(use_line_end, format!("(fn({assignments}) {{"))
-        };
+                .insert(use_line_end, format!("(fn({assignments}) {{"));
+        }
 
         // Then we have to increase indentation for all the lines of the use
         // body.
@@ -3016,7 +3016,7 @@ impl<'a> ConvertFromUse<'a> {
                     end: Position { line, character: 0 },
                 },
                 new_text: "  ".to_string(),
-            })
+            });
         }
 
         let final_line_indentation = " ".repeat(use_body_range.start.character as usize);
@@ -3158,7 +3158,7 @@ impl<'a> ConvertToUse<'a> {
                 SrcSpan::new(arg_before_callback.end, callback_body_span.start),
                 format!(")\n{indentation}"),
             ),
-        };
+        }
 
         // Then we have to remove two spaces of indentation from each line of
         // the callback function's body.
@@ -3167,7 +3167,7 @@ impl<'a> ConvertToUse<'a> {
             self.edits.delete_range(Range::new(
                 Position { line, character: 0 },
                 Position { line, character: 2 },
-            ))
+            ));
         }
 
         // Then we have to remove the anonymous fn closing `}` and the call's
@@ -3199,7 +3199,7 @@ impl<'ast> ast::visit::Visit<'ast> for ConvertToUse<'ast> {
             self.selected_call = Some(call_data);
         }
 
-        ast::visit::visit_typed_function(self, fun)
+        ast::visit::visit_typed_function(self, fun);
     }
 
     fn visit_typed_expr_fn(
@@ -3246,7 +3246,7 @@ impl<'ast> ast::visit::Visit<'ast> for ConvertToUse<'ast> {
         if within(self.params.range, statement_range) {
             // Only the last statement of a block can be turned into a use!
             if let Some(selected_call) = turn_statement_into_use(last_statement) {
-                self.selected_call = Some(selected_call)
+                self.selected_call = Some(selected_call);
             }
         }
 
@@ -3454,7 +3454,7 @@ impl<'a> ExtractVariable<'a> {
             self.edits.insert(*line_end, format!("{indent}}}\n"));
             indent += "  ";
             insertion = format!("{{\n{indent}{insertion}");
-        };
+        }
 
         self.edits
             .insert(insert_location.start, format!("{insertion}\n{indent}"));
@@ -3567,8 +3567,8 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
 
     fn visit_typed_assignment(&mut self, assignment: &'ast TypedAssignment) {
         if let Pattern::Variable { name, .. } = &assignment.pattern {
-            self.name_generator.add_used_name(name.clone())
-        };
+            self.name_generator.add_used_name(name.clone());
+        }
         ast::visit::visit_typed_assignment(self, assignment);
     }
 
@@ -3591,7 +3591,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
                 finally_kind,
             );
             return;
-        };
+        }
 
         // Visiting a pipeline requires a bit of care, we don't want to extract
         // intermediate steps as variables (those are function calls)!
@@ -3632,7 +3632,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
         }
 
         self.at_position(ExtractVariablePosition::PipelineCall, |this| {
-            this.visit_typed_expr(finally)
+            this.visit_typed_expr(finally);
         });
     }
 
@@ -3801,7 +3801,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractVariable<'ast> {
                     // variable inside the parenthesis where the call argument is located.
                 } else {
                     self.statement_before_selected_expression = self.latest_statement;
-                };
+                }
                 self.selected_expression = Some(ExtractedToVariable::Expression {
                     location: *location,
                     name: self.generate_candidate_name(expr.type_()),
@@ -4451,7 +4451,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExpandFunctionCapture<'ast> {
             arguments,
             body,
             return_annotation,
-        )
+        );
     }
 }
 
@@ -4973,7 +4973,7 @@ impl<'a, 'b, IO> DecoderPrinter<'a, 'b, IO> {
             } else {
                 return Some(eco_format!("#({})", field_zeroes.iter().join(", ")));
             }
-        };
+        }
 
         let (module, name, _) = type_.named_type_information()?;
         match (module.as_str(), name.as_str()) {
@@ -5022,7 +5022,7 @@ impl<'a, 'b, IO> DecoderPrinter<'a, 'b, IO> {
 
         if already_seen_type {
             return None;
-        };
+        }
 
         let type_is_inside_current_module = &self.type_module == custom_type_module;
 
@@ -5112,7 +5112,7 @@ impl<'a, 'b, IO> DecoderPrinter<'a, 'b, IO> {
         // Only proceed if we were able to construct every field successfully
         if zero_params.len() < zero_constructor.parameters.len() {
             return None;
-        };
+        }
 
         let zero_constructor = if !type_is_inside_current_module {
             // Type constructors from other modules need to be qualified appropriately,
@@ -5931,7 +5931,7 @@ impl<'a, IO> PatternMatchOnValue<'a, IO> {
             self.edits.insert(
                 statement_location.end,
                 format!(" {{\n{patterns}\n{nesting}}}"),
-            )
+            );
         }
     }
 
@@ -6223,7 +6223,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for PatternMatchOnValue<'ast, IO> {
                 self.selected_value = Some(PatternMatchedValue::Statement {
                     location: statement.location(),
                     type_: type_.clone(),
-                })
+                });
             }
 
             ast::Statement::Expression(_)
@@ -6476,7 +6476,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for PatternMatchOnValue<'ast, IO> {
         let location = PatternLocation::ListTail {
             location: tail_location,
         };
-        self.pattern_variable_under_cursor = Some((name, location, tail_type.clone()))
+        self.pattern_variable_under_cursor = Some((name, location, tail_type.clone()));
     }
 }
 
@@ -6742,7 +6742,7 @@ impl<'a> GenerateFunction<'a> {
                     return_type,
                     previous_definition_end: self.last_visited_definition_end,
                     module: None,
-                })
+                });
             }
         }
     }
@@ -6764,7 +6764,7 @@ impl<'a> GenerateFunction<'a> {
                 return_type,
                 previous_definition_end: self.last_visited_definition_end,
                 module: Some(module),
-            })
+            });
         }
     }
 }
@@ -6790,10 +6790,10 @@ impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
         if within(self.params.range, invalid_range) {
             match extra_information {
                 Some(InvalidExpression::ModuleSelect { module_name, label }) => {
-                    self.try_save_function_from_other_module(module_name, label, type_, None)
+                    self.try_save_function_from_other_module(module_name, label, type_, None);
                 }
                 Some(InvalidExpression::UnknownVariable { name }) => {
-                    self.try_save_function_to_generate(name, type_, None)
+                    self.try_save_function_to_generate(name, type_, None);
                 }
                 None => {}
             }
@@ -6814,10 +6814,10 @@ impl<'ast> ast::visit::Visit<'ast> for GenerateFunction<'ast> {
         {
             match extra_information {
                 InvalidExpression::ModuleSelect { module_name, label } => {
-                    self.try_save_function_from_other_module(module_name, label, type_, None)
+                    self.try_save_function_from_other_module(module_name, label, type_, None);
                 }
                 InvalidExpression::UnknownVariable { name } => {
-                    self.try_save_function_to_generate(name, type_, None)
+                    self.try_save_function_to_generate(name, type_, None);
                 }
             }
         }
@@ -7137,7 +7137,7 @@ impl<'a, IO> GenerateVariant<'a, IO> {
                 builder = builder.changes(
                     self.params.text_document.uri.clone(),
                     current_module_edits.edits,
-                )
+                );
             }
             GenerateVariantEdits::GenerateInDifferentModule {
                 current_module_edits,
@@ -7155,9 +7155,9 @@ impl<'a, IO> GenerateVariant<'a, IO> {
                     );
                 }
 
-                builder = builder.changes(variant_module_path, variant_module_edits.edits)
+                builder = builder.changes(variant_module_path, variant_module_edits.edits);
             }
-        };
+        }
 
         let mut action = Vec::with_capacity(1);
         builder.push_to(&mut action);
@@ -7371,7 +7371,7 @@ impl<'a, IO> GenerateVariant<'a, IO> {
             current_module_edits.insert(insert_positions, new_text);
         } else {
             // We need to qualify the variant that triggered the code action!
-            current_module_edits.insert(variant_start, format!("{variant_module_name}."))
+            current_module_edits.insert(variant_start, format!("{variant_module_name}."));
         }
     }
 }
@@ -7787,7 +7787,7 @@ impl<'a> ConvertToFunctionCall<'a> {
             // missing parentheses:
             // `[1, 2] |> length` becomes `length([1, 2])`
             PipelineAssignmentKind::FunctionCall => {
-                self.edits.insert(call.end, format!("({first_value_text})"))
+                self.edits.insert(call.end, format!("({first_value_text})"));
             }
 
             // When the piped value is inserted as the first argument there's two
@@ -7808,7 +7808,7 @@ impl<'a> ConvertToFunctionCall<'a> {
             // have to insert the value after the `echo` with no parentheses:
             // `a |> echo` is rewritten as `echo a`.
             PipelineAssignmentKind::Echo => {
-                self.edits.insert(call.end, format!(" {first_value_text}"))
+                self.edits.insert(call.end, format!(" {first_value_text}"));
             }
         }
 
@@ -8205,7 +8205,7 @@ impl<'a> ConvertToPipe<'a> {
             // In all other cases we're piping something that is not the first
             // argument so we just replace it with an `_`.
             _ => self.edits.replace(arg.location, "_".into()),
-        };
+        }
 
         // Finally we can add the argument that was removed as the first step
         // of the newly defined pipeline.
@@ -8434,7 +8434,7 @@ impl<'a> InterpolateString<'a> {
             }
 
             StringInterpolation::SplitString { .. } => return vec![],
-        };
+        }
 
         if self.string_literal_position == StringLiteralPosition::FirstPipelineStep {
             self.edits.insert(string_location.end, " }".into());
@@ -8608,7 +8608,7 @@ impl<'a> FillUnusedFields<'a> {
         // Do not suggest this code action if there's no ignored fields at all.
         if positional.is_empty() && labelled.is_empty() {
             return vec![];
-        };
+        }
 
         // We add all the missing positional arguments before the first
         // labelled one (and so after all the already existing positional ones).
@@ -8659,10 +8659,10 @@ impl<'a> FillUnusedFields<'a> {
             // This way we also get rid of any comma separating the last argument
             // and the spread to be removed.
             self.edits
-                .delete(SrcSpan::new(delete_start, spread_location.end))
+                .delete(SrcSpan::new(delete_start, spread_location.end));
         } else {
             // Otherwise we just delete the spread.
-            self.edits.delete(spread_location)
+            self.edits.delete(spread_location);
         }
 
         let mut action = Vec::with_capacity(1);
@@ -8713,7 +8713,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillUnusedFields<'ast> {
                 last_argument_end,
                 spread_location: *spread_location,
             });
-        };
+        }
 
         ast::visit::visit_typed_pattern(self, pattern);
     }
@@ -8757,7 +8757,7 @@ impl<'a> RemoveEchos<'a> {
         // the module
         if !self.is_hovering_echo {
             return vec![];
-        };
+        }
 
         for span in self.echo_spans_to_delete {
             self.edits.delete(span);
@@ -9072,7 +9072,7 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInBlock<'ast> {
             | TypedExpr::Invalid { .. } => {
                 self.selected_expression = Some(assignment.value.location());
             }
-        };
+        }
         ast::visit::visit_typed_assignment(self, assignment);
     }
 
@@ -9089,7 +9089,7 @@ impl<'ast> ast::visit::Visit<'ast> for WrapInBlock<'ast> {
         // To avoid wrapping the same expression in multiple, nested blocks.
         if !matches!(clause.then, TypedExpr::Block { .. }) {
             self.selected_expression = Some(clause.then.location());
-        };
+        }
 
         ast::visit::visit_typed_clause(self, clause);
     }
@@ -9157,9 +9157,9 @@ impl<'a> FixBinaryOperation<'a> {
         } else if operator.is_float_operator() && left.is_int() && right.is_int() {
             self.fix = operator
                 .int_equivalent()
-                .map(|fix| (operator_location, fix))
+                .map(|fix| (operator_location, fix));
         } else if operator == ast::BinOp::AddInt && left.is_string() && right.is_string() {
-            self.fix = Some((operator_location, ast::BinOp::Concatenate))
+            self.fix = Some((operator_location, ast::BinOp::Concatenate));
         }
     }
 }
@@ -9442,9 +9442,9 @@ impl<'a> RemoveUnusedImports<'a> {
                         self.edits.delete(SrcSpan {
                             start: location.start,
                             end: location.end + 1,
-                        })
+                        });
                     } else {
-                        self.edits.delete(*location)
+                        self.edits.delete(*location);
                     }
                 }
 
@@ -9500,7 +9500,7 @@ impl<'a> RemoveUnusedImports<'a> {
                             self.edits.delete(SrcSpan {
                                 start: previous_value.end,
                                 end: location.end,
-                            })
+                            });
                         }
 
                         // In all other cases it means that this is the only
@@ -9613,7 +9613,7 @@ impl<'ast> ast::visit::Visit<'ast> for RemoveBlock<'ast> {
                 ast::Statement::Use(_)
                 | ast::Statement::Assert(_)
                 | ast::Statement::Assignment(_) => {
-                    ast::visit::visit_typed_expr_block(self, location, statements)
+                    ast::visit::visit_typed_expr_block(self, location, statements);
                 }
 
                 ast::Statement::Expression(expr) => match expr {
@@ -9707,7 +9707,7 @@ impl<'ast> ast::visit::Visit<'ast> for RemovePrivateOpaque<'ast> {
             self.opaque_span = Some(SrcSpan {
                 start: custom_type.location.start,
                 end: custom_type.location.start + 7,
-            })
+            });
         }
     }
 }
@@ -9925,8 +9925,8 @@ impl<'a> CollapseNestedCase<'a> {
                             // When it's a list literal, we remove the surrounding brackets.
                             let len = trimmed_contents.len();
                             if let Some(slice) = new_content.trim().get(1..(len - 1)) {
-                                new_content = slice.to_string()
-                            };
+                                new_content = slice.to_string();
+                            }
 
                             *tail_location
                         }
@@ -9984,7 +9984,7 @@ impl<'a> CollapseNestedCase<'a> {
                     let mut pattern_code = code_at(self.module, pattern_location).to_string();
                     if !references_to_matched_variable.is_empty() {
                         pattern_code = format!("{pattern_code} as {}", matched_variable.name());
-                    };
+                    }
                     pattern_with_variable(pattern_code)
                 })
                 .join(" | ");
@@ -9995,10 +9995,10 @@ impl<'a> CollapseNestedCase<'a> {
                     let mut outer_code = code_at(self.module, outer.location()).to_string();
                     let mut inner_code = code_at(self.module, inner.location()).to_string();
                     if ast::BinOp::And.precedence() > outer.precedence() {
-                        outer_code = format!("{{ {outer_code} }}")
+                        outer_code = format!("{{ {outer_code} }}");
                     }
                     if ast::BinOp::And.precedence() > inner.precedence() {
-                        inner_code = format!("{{ {inner_code} }}")
+                        inner_code = format!("{{ {inner_code} }}");
                     }
                     format!(" if {outer_code} && {inner_code}")
                 }
@@ -10123,7 +10123,7 @@ impl<'ast> ast::visit::Visit<'ast> for CollapseNestedCase<'ast> {
             // We're done, there's no need to keep exploring as we know the
             // cursor is over this pattern and it can't be over any other one!
             return;
-        };
+        }
 
         ast::visit::visit_typed_clause(self, clause);
     }
@@ -10328,7 +10328,7 @@ impl<'ast> ast::visit::Visit<'ast> for RemoveUnreachableCaseClauses<'ast> {
                 // // we want the entire branch to be deleted!
                 // }
                 // ```
-                self.clauses_to_delete.push(clause.location())
+                self.clauses_to_delete.push(clause.location());
             } else {
                 // If only some of the variants are unreachable but not all
                 // we want to delete just those.
@@ -10476,7 +10476,7 @@ impl<'a> AddOmittedLabels<'a> {
                 self.edits.insert(call_argument.location.end, ":".into());
             } else {
                 self.edits
-                    .insert(call_argument.location.start, format!("{label}: "))
+                    .insert(call_argument.location.start, format!("{label}: "));
             }
         }
 
@@ -10559,7 +10559,7 @@ impl<'ast> ast::visit::Visit<'ast> for AddOmittedLabels<'ast> {
                 location: argument.location,
                 omitted_label: label,
                 can_use_shorthand_syntax,
-            })
+            });
         }
         self.arguments_and_omitted_labels = Some(omitted_labels);
     }
@@ -10816,7 +10816,7 @@ impl<'a> ExtractFunction<'a> {
                     extracted.parameters,
                     statements.last().type_(),
                     end,
-                )
+                );
             }
             ExtractedValue::Expression(TypedExpr::Fn {
                 type_,
@@ -10836,7 +10836,7 @@ impl<'a> ExtractFunction<'a> {
                         arguments,
                         return_type,
                         end,
-                    )
+                    );
                 } else if arguments.len() == 1 {
                     self.extract_anonymous_function_with_capture_hole(
                         *full_location,
@@ -10845,7 +10845,7 @@ impl<'a> ExtractFunction<'a> {
                         extracted.parameters,
                         return_type,
                         end,
-                    )
+                    );
                 } else {
                     self.extract_anonymous_function_body(
                         location,
@@ -10853,7 +10853,7 @@ impl<'a> ExtractFunction<'a> {
                         extracted.parameters,
                         return_type,
                         end,
-                    )
+                    );
                 }
             }
             ExtractedValue::Expression(expression) => {
@@ -10873,7 +10873,7 @@ impl<'a> ExtractFunction<'a> {
                     extracted.parameters,
                     expression_type,
                     end,
-                )
+                );
             }
             ExtractedValue::Statements {
                 location,
@@ -10894,8 +10894,8 @@ impl<'a> ExtractFunction<'a> {
                         extracted.parameters,
                         extracted.returned_variables,
                         end,
-                    )
-                };
+                    );
+                }
             }
 
             ExtractedValue::Use {
@@ -11753,7 +11753,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
             && position_within(self.params.range.end, final_step_range)
         {
             extracted_function.try_add_pipeline_step(finally.type_(), finally.location());
-        };
+        }
 
         self.visit_typed_expr(finally);
         self.previous_pipeline_assignment_type = None;
@@ -11776,7 +11776,7 @@ impl<'ast> ast::visit::Visit<'ast> for ExtractFunction<'ast> {
                 }));
             }
             Some(extracted_function) => {
-                extracted_function.try_add_pipeline_step(assignment.type_(), assignment.location)
+                extracted_function.try_add_pipeline_step(assignment.type_(), assignment.location);
             }
         }
         ast::visit::visit_typed_pipeline_assignment(self, assignment);
@@ -12141,7 +12141,7 @@ impl<'ast> ast::visit::Visit<'ast> for MergeCaseBranches<'ast> {
         }
 
         if let result @ Some(_) = self.select_mergeable_branches(clauses) {
-            self.patterns_to_merge = result
+            self.patterns_to_merge = result;
         }
 
         // We still need to visit the case expression in case we want to apply
@@ -12359,7 +12359,7 @@ impl<'ast> ast::visit::Visit<'ast> for ReplaceUnderscoreWithType<'ast> {
             self.hovered_hole = Some(HoveredHole {
                 type_,
                 location: *location,
-            })
+            });
         }
     }
 }
@@ -12689,7 +12689,7 @@ impl<'a> UnwrapAnonymousFunction<'a> {
             outer_function_body_start: outer_body.start,
             inner_function: *call_location,
             inner_function_arguments_start: *arguments_start,
-        })
+        });
     }
 }
 
@@ -12718,7 +12718,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnwrapAnonymousFunction<'ast> {
             arguments,
             body,
             return_annotation,
-        )
+        );
     }
 }
 

--- a/language-server/src/completer.rs
+++ b/language-server/src/completer.rs
@@ -580,7 +580,7 @@ impl<'a, IO> Completer<'a, IO> {
                     .config
                     .dev_dependencies
                     .keys(),
-            )
+            );
         }
 
         let already_imported: std::collections::HashSet<EcoString> =
@@ -742,7 +742,7 @@ impl<'a, IO> Completer<'a, IO> {
                             &cursor_surroundings,
                             TypeCompletionContext::UnqualifiedType,
                             CompletionKind::ImportedModule,
-                        ))
+                        ));
                     }
                 }
             }
@@ -844,7 +844,7 @@ impl<'a, IO> Completer<'a, IO> {
         if !cursor_surroundings.surrounding_text.is_empty() {
             for keyword in ["panic", "todo", "echo"] {
                 if keyword.starts_with(cursor_surroundings.surrounding_text.as_str()) {
-                    completions.push(self.keyword_completion(keyword, &cursor_surroundings))
+                    completions.push(self.keyword_completion(keyword, &cursor_surroundings));
                 }
             }
         }
@@ -896,7 +896,7 @@ impl<'a, IO> Completer<'a, IO> {
                 match match_type(&self.expected_type, &type_) {
                     TypeMatch::Incompatible => return,
                     TypeMatch::Matching | TypeMatch::Unknown => (),
-                };
+                }
 
                 let label = label.to_string();
                 let sort_text = Some(sort_text(
@@ -1011,7 +1011,7 @@ impl<'a, IO> Completer<'a, IO> {
                             value,
                             &cursor_surroundings,
                             CompletionKind::ImportedModule,
-                        ))
+                        ));
                     }
                 }
             }

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -1124,7 +1124,7 @@ where
                         reference_locations.push(lsp::Location {
                             uri: uri.clone(),
                             range: src_span_to_lsp_range(reference.location, &lines),
-                        })
+                        });
                     }
 
                     Some(reference_locations)

--- a/language-server/src/lib.rs
+++ b/language-server/src/lib.rs
@@ -144,22 +144,22 @@ impl<'a> TextEdits<'a> {
         self.edits.push(TextEdit {
             range: src_span_to_lsp_range(location, self.line_numbers),
             new_text,
-        })
+        });
     }
 
     pub fn insert(&mut self, at: u32, new_text: String) {
-        self.replace(SrcSpan { start: at, end: at }, new_text)
+        self.replace(SrcSpan { start: at, end: at }, new_text);
     }
 
     pub fn delete(&mut self, location: SrcSpan) {
-        self.replace(location, "".to_string())
+        self.replace(location, "".to_string());
     }
 
     fn delete_range(&mut self, range: Range) {
         self.edits.push(TextEdit {
             range,
             new_text: "".into(),
-        })
+        });
     }
 }
 

--- a/language-server/src/lib.rs
+++ b/language-server/src/lib.rs
@@ -23,6 +23,7 @@
     clippy::verbose_file_reads,
     clippy::unnested_or_patterns,
     clippy::default_trait_access,
+    clippy::format_push_string,
     rust_2018_idioms,
     missing_debug_implementations,
     missing_copy_implementations,

--- a/language-server/src/progress.rs
+++ b/language-server/src/progress.rs
@@ -50,7 +50,7 @@ impl<'a> ConnectionProgressReporter<'a> {
         self.connection
             .sender
             .send(lsp_server::Message::Notification(notification))
-            .expect("send_work_done_notification send")
+            .expect("send_work_done_notification send");
     }
 }
 

--- a/language-server/src/reference.rs
+++ b/language-server/src/reference.rs
@@ -771,7 +771,7 @@ impl FindVariableReferences {
             }
 
             DefinitionLocation::Regular { .. } | DefinitionLocation::Alternative { .. } => (),
-        };
+        }
     }
 
     pub fn find_in_module(mut self, module: &TypedModule) -> HashSet<VariableReference> {
@@ -979,7 +979,7 @@ impl<'ast> Visit<'ast> for FindVariableReferences {
         // Handle the suffix in alternative pattern: "prefix" <> name | "other_prefix" <> name
         match right_side_assignment {
             AssignName::Variable(name) => {
-                self.register_alternative_definition(name, right_location)
+                self.register_alternative_definition(name, right_location);
             }
             AssignName::Discard(_) => {}
         }
@@ -1029,7 +1029,7 @@ impl<'ast> Visit<'ast> for FindTypeVariableReferences<'_> {
         if custom_type.full_location().contains_span(self.location) {
             for (location, name) in custom_type.parameters.iter() {
                 if name == self.name {
-                    self.references.push(*location)
+                    self.references.push(*location);
                 }
             }
             ast::visit::visit_typed_custom_type(self, custom_type);
@@ -1046,7 +1046,7 @@ impl<'ast> Visit<'ast> for FindTypeVariableReferences<'_> {
         if type_alias.location.contains_span(self.location) {
             for (location, name) in type_alias.parameters.iter() {
                 if name == self.name {
-                    self.references.push(*location)
+                    self.references.push(*location);
                 }
             }
             ast::visit::visit_typed_type_alias(self, type_alias);

--- a/language-server/src/rename.rs
+++ b/language-server/src/rename.rs
@@ -91,20 +91,20 @@ pub fn rename_local_variable(
 
     match kind {
         VariableReferenceKind::Variable => {
-            edits.replace(definition_location, params.new_name.clone())
+            edits.replace(definition_location, params.new_name.clone());
         }
         VariableReferenceKind::LabelShorthand => {
-            edits.insert(definition_location.end, format!(" {}", params.new_name))
+            edits.insert(definition_location.end, format!(" {}", params.new_name));
         }
     }
 
     for reference in references {
         match reference.kind {
             VariableReferenceKind::Variable => {
-                edits.replace(reference.location, params.new_name.clone())
+                edits.replace(reference.location, params.new_name.clone());
             }
             VariableReferenceKind::LabelShorthand => {
-                edits.insert(reference.location.end, format!(" {}", params.new_name))
+                edits.insert(reference.location.end, format!(" {}", params.new_name));
             }
         }
     }
@@ -327,7 +327,7 @@ fn rename_label_references_in_module(
             // would break that, so we expand the shorthand and keep the original
             // name as the value: `wibble:` becomes `new_name: wibble`.
             LabelSyntax::Shorthand => {
-                edits.replace(reference.location, format!("{new_name}: {label}"))
+                edits.replace(reference.location, format!("{new_name}: {label}"));
             }
             LabelSyntax::Longhand => edits.replace(reference.location, new_name.to_string()),
         }
@@ -365,7 +365,7 @@ fn alias_references_in_module(
         match reference.kind {
             ReferenceKind::Qualified { .. } => {}
             ReferenceKind::Unqualified | ReferenceKind::Alias => {
-                edits.replace(reference.location, params.new_name.clone())
+                edits.replace(reference.location, params.new_name.clone());
             }
             ReferenceKind::Import(alias_location) => {
                 // If old name is equal to original name, we can just remove
@@ -495,7 +495,7 @@ pub fn rename_module_alias(
                 if params.new_name == original_module_name {
                     edits.delete(SrcSpan::new(alias_location.start - 1, alias_location.end));
                 } else {
-                    edits.replace(*alias_location, format!("as {}", params.new_name))
+                    edits.replace(*alias_location, format!("as {}", params.new_name));
                 }
             }
             ModuleNameReference::ModuleSelect(location)
@@ -532,7 +532,7 @@ pub fn rename_type_variable(
     let references = FindTypeVariableReferences::find_in_module(&module.ast, location, &name);
 
     for reference in references {
-        edits.replace(reference, params.new_name.clone())
+        edits.replace(reference, params.new_name.clone());
     }
 
     RenameOutcome::Renamed {
@@ -604,7 +604,7 @@ pub fn rename_module_occurrences(
                 // to change.
                 ModuleNameReference::AliasedModuleSelect(_) => {}
                 ModuleNameReference::ModuleSelect(location) => {
-                    edits.replace(*location, last_component_of_new_name.clone())
+                    edits.replace(*location, last_component_of_new_name.clone());
                 }
             }
         }

--- a/language-server/src/server.rs
+++ b/language-server/src/server.rs
@@ -137,7 +137,7 @@ where
         self.connection
             .sender
             .send(lsp_server::Message::Response(response))
-            .expect("channel send LSP response")
+            .expect("channel send LSP response");
     }
 
     fn handle_notification(&mut self, notification: Notification) {
@@ -521,7 +521,7 @@ where
         let mut feedback = self.cache_file_in_memory(path.clone(), text);
         if let Ok(Some(project)) = self.router.project_for_path(path.clone()) {
             feedback.append_feedback(project.feedback.open_file(path));
-        };
+        }
         feedback
     }
 
@@ -529,7 +529,7 @@ where
         let mut feedback = self.discard_in_memory_cache(path.clone());
         if let Ok(Some(project)) = self.router.project_for_path(path.clone()) {
             feedback.append_feedback(project.feedback.close_file(&path));
-        };
+        }
         feedback
     }
 }

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -6,7 +6,6 @@ use lsp_types::{
     CodeActionContext, CodeActionParams, DocumentChange, PartialResultParams, Position, Uri as Url,
     WorkDoneProgressParams,
 };
-use std::fmt::Write as _;
 
 use super::*;
 use crate::path;
@@ -249,7 +248,8 @@ macro_rules! assert_code_action {
         );
 
         if !file_operations.is_empty() {
-            let _ = write!(output, "\n----- FILE OPERATIONS -----\n{file_operations}");
+            output.push_str("\n----- FILE OPERATIONS -----\n");
+            output.push_str(&file_operations);
         }
 
         insta::assert_snapshot!(insta::internals::AutoName, output, src);

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -6,6 +6,7 @@ use lsp_types::{
     CodeActionContext, CodeActionParams, DocumentChange, PartialResultParams, Position, Uri as Url,
     WorkDoneProgressParams,
 };
+use std::fmt::Write as _;
 
 use super::*;
 use crate::path;
@@ -248,7 +249,7 @@ macro_rules! assert_code_action {
         );
 
         if !file_operations.is_empty() {
-            output.push_str(&format!("\n----- FILE OPERATIONS -----\n{file_operations}"));
+            let _ = write!(output, "\n----- FILE OPERATIONS -----\n{file_operations}");
         }
 
         insta::assert_snapshot!(insta::internals::AutoName, output, src);

--- a/language-server/src/tests/document_highlight.rs
+++ b/language-server/src/tests/document_highlight.rs
@@ -86,8 +86,6 @@ macro_rules! assert_highlights {
     };
 
     ($project:expr, $position:expr $(,)?) => {
-        use std::fmt::Write as _;
-
         let project = $project;
         let src = project.src;
         let position = $position.find_position(src);
@@ -101,22 +99,24 @@ macro_rules! assert_highlights {
             } else {
                 &Vec::new()
             };
-            let _ = write!(
-                output,
-                "-- {name}.gleam\n{}\n\n",
-                show_highlights(src, None, highlights_in_module)
-            );
+
+            output.push_str("-- ");
+            output.push_str(name);
+            output.push_str(".gleam\n");
+            output.push_str(&show_highlights(src, None, highlights_in_module));
+            output.push_str("\n\n");
         }
         let highlights_in_app_module = if module_name == "app" {
             &result
         } else {
             &Vec::new()
         };
-        let _ = write!(
-            output,
-            "-- app.gleam\n{}",
-            show_highlights(src, Some(position), highlights_in_app_module)
-        );
+        output.push_str("-- app.gleam\n");
+        output.push_str(&show_highlights(
+            src,
+            Some(position),
+            highlights_in_app_module,
+        ));
 
         insta::assert_snapshot!(insta::internals::AutoName, output, src);
     };

--- a/language-server/src/tests/document_highlight.rs
+++ b/language-server/src/tests/document_highlight.rs
@@ -86,6 +86,8 @@ macro_rules! assert_highlights {
     };
 
     ($project:expr, $position:expr $(,)?) => {
+        use std::fmt::Write as _;
+
         let project = $project;
         let src = project.src;
         let position = $position.find_position(src);
@@ -99,20 +101,22 @@ macro_rules! assert_highlights {
             } else {
                 &Vec::new()
             };
-            output.push_str(&format!(
+            let _ = write!(
+                output,
                 "-- {name}.gleam\n{}\n\n",
                 show_highlights(src, None, highlights_in_module)
-            ));
+            );
         }
         let highlights_in_app_module = if module_name == "app" {
             &result
         } else {
             &Vec::new()
         };
-        output.push_str(&format!(
+        let _ = write!(
+            output,
             "-- app.gleam\n{}",
             show_highlights(src, Some(position), highlights_in_app_module)
-        ));
+        );
 
         insta::assert_snapshot!(insta::internals::AutoName, output, src);
     };

--- a/language-server/src/tests/reference.rs
+++ b/language-server/src/tests/reference.rs
@@ -94,8 +94,6 @@ macro_rules! assert_references {
     };
 
     ($project:expr, $position:expr $(,)?) => {
-        use std::fmt::Write as _;
-
         let project = $project;
         let src = project.src;
         let position = $position.find_position(src);
@@ -103,21 +101,22 @@ macro_rules! assert_references {
 
         let mut output = String::new();
         for (name, src) in project.root_package_modules.iter() {
-            let _ = write!(
-                output,
-                "-- {name}.gleam\n{}\n\n",
-                show_references(src, None, result.get(*name).unwrap_or(&Vec::new()))
-            );
-        }
-        let _ = write!(
-            output,
-            "-- app.gleam\n{}",
-            show_references(
+            output.push_str("-- ");
+            output.push_str(name);
+            output.push_str(".gleam\n");
+            output.push_str(&show_references(
                 src,
-                Some(position),
-                result.get("app").unwrap_or(&Vec::new())
-            )
-        );
+                None,
+                result.get(*name).unwrap_or(&Vec::new()),
+            ));
+            output.push_str("\n\n");
+        }
+        output.push_str("-- app.gleam\n");
+        output.push_str(&show_references(
+            src,
+            Some(position),
+            result.get("app").unwrap_or(&Vec::new()),
+        ));
 
         insta::assert_snapshot!(insta::internals::AutoName, output, src);
     };

--- a/language-server/src/tests/reference.rs
+++ b/language-server/src/tests/reference.rs
@@ -94,6 +94,8 @@ macro_rules! assert_references {
     };
 
     ($project:expr, $position:expr $(,)?) => {
+        use std::fmt::Write as _;
+
         let project = $project;
         let src = project.src;
         let position = $position.find_position(src);
@@ -101,19 +103,21 @@ macro_rules! assert_references {
 
         let mut output = String::new();
         for (name, src) in project.root_package_modules.iter() {
-            output.push_str(&format!(
+            let _ = write!(
+                output,
                 "-- {name}.gleam\n{}\n\n",
                 show_references(src, None, result.get(*name).unwrap_or(&Vec::new()))
-            ));
+            );
         }
-        output.push_str(&format!(
+        let _ = write!(
+            output,
             "-- app.gleam\n{}",
             show_references(
                 src,
                 Some(position),
                 result.get("app").unwrap_or(&Vec::new())
             )
-        ));
+        );
 
         insta::assert_snapshot!(insta::internals::AutoName, output, src);
     };

--- a/language-server/src/tests/rename.rs
+++ b/language-server/src/tests/rename.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 The Gleam contributors
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 use lsp_types::{
     Position, PrepareRenameParams, PrepareRenamePlaceholder, Range, RenameParams,
@@ -119,7 +120,7 @@ fn display_result(
 ) -> String {
     let mut output = String::from("----- BEFORE RENAME\n");
     for (name, src) in project.root_package_modules.iter() {
-        output.push_str(&format!("-- {name}.gleam\n{src}\n\n"));
+        let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
     }
 
     let src = project.src;
@@ -128,9 +129,10 @@ fn display_result(
     } else {
         src.to_string()
     };
-    output.push_str(&format!(
+    let _ = write!(
+        output,
         "-- app.gleam\n{app_src_before}\n\n----- AFTER RENAME\n",
-    ));
+    );
 
     for &(name, src) in project.root_package_modules.iter() {
         let used_name = if let Some(new_name) = renamed_modules.get(name) {
@@ -138,21 +140,23 @@ fn display_result(
         } else {
             name
         };
-        output.push_str(&format!(
+        let _ = write!(
+            output,
             "-- {used_name}.gleam\n{}\n\n",
             modules
                 .get(name)
                 .map(|string| string.as_str())
                 .unwrap_or(src)
-        ));
+        );
     }
-    output.push_str(&format!(
+    let _ = write!(
+        output,
         "-- app.gleam\n{}",
         modules
             .get("app")
             .map(|string| string.as_str())
             .unwrap_or(src)
-    ));
+    );
     output
 }
 

--- a/language-server/src/tests/rename.rs
+++ b/language-server/src/tests/rename.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2025 The Gleam contributors
 
 use std::collections::HashMap;
-use std::fmt::Write as _;
 
 use lsp_types::{
     Position, PrepareRenameParams, PrepareRenamePlaceholder, Range, RenameParams,
@@ -120,7 +119,11 @@ fn display_result(
 ) -> String {
     let mut output = String::from("----- BEFORE RENAME\n");
     for (name, src) in project.root_package_modules.iter() {
-        let _ = write!(output, "-- {name}.gleam\n{src}\n\n");
+        output.push_str("-- ");
+        output.push_str(name);
+        output.push_str(".gleam\n");
+        output.push_str(src);
+        output.push_str("\n\n");
     }
 
     let src = project.src;
@@ -129,10 +132,9 @@ fn display_result(
     } else {
         src.to_string()
     };
-    let _ = write!(
-        output,
-        "-- app.gleam\n{app_src_before}\n\n----- AFTER RENAME\n",
-    );
+    output.push_str("-- app.gleam\n");
+    output.push_str(&app_src_before);
+    output.push_str("\n\n----- AFTER RENAME\n");
 
     for &(name, src) in project.root_package_modules.iter() {
         let used_name = if let Some(new_name) = renamed_modules.get(name) {
@@ -140,22 +142,24 @@ fn display_result(
         } else {
             name
         };
-        let _ = write!(
-            output,
-            "-- {used_name}.gleam\n{}\n\n",
+
+        output.push_str("-- ");
+        output.push_str(used_name);
+        output.push_str(".gleam\n");
+        output.push_str(
             modules
                 .get(name)
                 .map(|string| string.as_str())
-                .unwrap_or(src)
+                .unwrap_or(src),
         );
+        output.push_str("\n\n");
     }
-    let _ = write!(
-        output,
-        "-- app.gleam\n{}",
+    output.push_str("-- app.gleam\n");
+    output.push_str(
         modules
             .get("app")
             .map(|string| string.as_str())
-            .unwrap_or(src)
+            .unwrap_or(src),
     );
     output
 }

--- a/test-package-compiler/build.rs
+++ b/test-package-compiler/build.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Gleam contributors
 
-use std::fmt::Write as _;
 use std::path::PathBuf;
 
 pub fn main() {
@@ -26,20 +25,33 @@ pub fn main() {
     for name in names {
         let path = cases.join(&name);
         let path = path.to_str().unwrap().replace('\\', "/");
-        let _ = write!(
-            module,
-            r#"
+        module.push_str(
+            "
 #[rustfmt::skip]
 #[test]
-fn {name}() {{
-    let output = crate::prepare("{path}");
+fn ",
+        );
+        module.push_str(&name);
+        module.push_str("() {\n");
+        module.push_str("    let output = crate::prepare(\"");
+        module.push_str(&path);
+        module.push_str(
+            "\");
     insta::assert_snapshot!(
-        "{name}",
+        \"",
+        );
+        module.push_str(&name);
+        module.push_str(
+            "\",
         output,
-        "{path}",
+        \"",
+        );
+        module.push_str(&path);
+        module.push_str(
+            "\",
     );
-}}
-"#
+}
+",
         );
     }
 

--- a/test-package-compiler/build.rs
+++ b/test-package-compiler/build.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2022 The Gleam contributors
 
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 pub fn main() {
@@ -25,7 +26,8 @@ pub fn main() {
     for name in names {
         let path = cases.join(&name);
         let path = path.to_str().unwrap().replace('\\', "/");
-        module.push_str(&format!(
+        let _ = write!(
+            module,
             r#"
 #[rustfmt::skip]
 #[test]
@@ -38,7 +40,7 @@ fn {name}() {{
     );
 }}
 "#
-        ));
+        );
     }
 
     let out = PathBuf::from("./src/generated_tests.rs");


### PR DESCRIPTION
- This PR enables the clippy lint that warns for `.push_str(&format(...))`, as suggested `write!(...)` is used instead to save an allocation
- I've also had clippy reformat the code so that `;` usage is consistent: expressions returning nothing end with a `;` but blocks like `if {} else {}` do not. That's already what we're doing in most of the codebase
- Though I've not enabled the lint to warn about that, it would be quite annoying to have CI fail because of that and have to wait loads, I think this is fine as a one-of