### PR TITLE
fix generated erlang code for externals with discarded arguments

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -739,13 +739,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 name,
                 name_location: location,
                 ..
-            } if is_external => {
-                if name.chars().all(|char| char == '_') {
-                    self.new_generated_variable()
-                } else {
-                    self.new_erlang_variable(name, *location)
-                }
-            }
+            } if is_external => self.new_generated_variable(),
             ArgNames::Discard { .. } | ArgNames::LabelledDiscard { .. } => EcoString::from("_"),
             ArgNames::Named { name, location }
             | ArgNames::NamedLabelled {

--- a/compiler-core/src/erlang/tests/external_fn.rs
+++ b/compiler-core/src/erlang/tests/external_fn.rs
@@ -423,3 +423,14 @@ pub fn woo(__: a, _two: b) -> Nil
 "#
     );
 }
+
+#[test]
+// https://github.com/gleam-lang/gleam/issues/5970
+fn discarded_argument_called_value_does_not_have_the_same_name_as_discarded_one() {
+    assert_erl!(
+        r#"
+@external(erlang, "wibble", "wobble")
+pub fn woo(_: a, _value: b) -> Nil
+"#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__discarded_argument_called_value_does_not_have_the_same_name_as_discarded_one.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__discarded_argument_called_value_does_not_have_the_same_name_as_discarded_one.snap
@@ -1,19 +1,19 @@
 ---
 source: compiler-core/src/erlang/tests/external_fn.rs
-expression: "\n@external(erlang, \"wibble\", \"wobble\")\npub fn woo(_a: a) -> Nil\n"
+expression: "\n@external(erlang, \"wibble\", \"wobble\")\npub fn woo(_: a, _value: b) -> Nil\n"
 ---
 ----- SOURCE CODE
 
 @external(erlang, "wibble", "wobble")
-pub fn woo(_a: a) -> Nil
+pub fn woo(_: a, _value: b) -> Nil
 
 
 ----- COMPILED ERLANG
 -module(my@mod).
 -compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
--export([woo/1]).
+-export([woo/2]).
 
 -file("project/test/my/mod.gleam", 3).
--spec woo(any()) -> nil.
-woo(_value) ->
-    wibble:wobble(_value).
+-spec woo(any(), any()) -> nil.
+woo(_value, _value@1) ->
+    wibble:wobble(_value, _value@1).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__multiple_discarded_args_in_external_are_passed_correctly_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__external_fn__multiple_discarded_args_in_external_are_passed_correctly_2.snap
@@ -15,5 +15,5 @@ pub fn woo(__: a, _two: b) -> Nil
 
 -file("project/test/my/mod.gleam", 3).
 -spec woo(any(), any()) -> nil.
-woo(_value, _two) ->
-    wibble:wobble(_value, _two).
+woo(_value, _value@1) ->
+    wibble:wobble(_value, _value@1).


### PR DESCRIPTION
This PR closes #5970 
Since the names are discarded already I think it's fine we just use a generated variable for all of them.

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour

