### PR TITLE
Fix formatting of commented guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,6 +520,9 @@
   writing a constructor with a lowercase name.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where guards with comments wouldn't be formatted properly.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - A `gleam@@compile.erl` is no longer left in the build output of
   `gleam compile-package`.
   ([Louis Pilfold](https://github.com/lpil))

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -3093,14 +3093,17 @@ impl<'a, 'doc> Formatter<'a> {
         left: &'a UntypedClauseGuard,
         right: &'a UntypedClauseGuard,
     ) -> Document<'a, 'doc> {
-        self.clause_guard_bin_op_side(arena, name, left, left.precedence())
-            .append(arena, BREAKABLE_SPACE_DOCUMENT)
-            .append(arena, binop(*name))
-            .append(arena, SPACE_DOCUMENT)
-            .append(
-                arena,
-                self.clause_guard_bin_op_side(arena, name, right, right.precedence() - 1),
-            )
+        let left_comments = self.pop_comments(left.location().start);
+        let left = self.clause_guard_bin_op_side(arena, name, left, left.precedence());
+        let left = commented(arena, left, left_comments);
+
+        let right_comments = self.pop_comments(right.location().start);
+        let right = self.clause_guard_bin_op_side(arena, name, right, right.precedence() - 1);
+        let right = docvec![arena, binop(*name), SPACE_DOCUMENT, right];
+        let right = commented(arena, right, right_comments);
+
+        left.append(arena, BREAKABLE_SPACE_DOCUMENT)
+            .append(arena, right)
     }
 
     fn clause_guard_bin_op_side(

--- a/format/src/tests/guards.rs
+++ b/format/src/tests/guards.rs
@@ -52,6 +52,31 @@ fn operators_in_guard() {
 }
 
 #[test]
+fn commented_operators_in_guard() {
+    assert_format!(
+        r#"pub fn main() {
+  case list.map(codepoints, string.utf_codepoint_to_int) {
+    [drive, colon, slash]
+      if { slash == 47 || slash == 92 }
+      && colon == 58
+      // Hello
+      && drive >= 65
+      && drive <= 90
+      // This is a comment
+      || drive >= 97
+      // And another one
+      && drive <= 122
+    -> {
+      1
+      |> 2
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
 fn a_comment_before_a_guard_doesnt_force_it_to_break() {
     assert_format!(
         r#"pub fn main() {


### PR DESCRIPTION
As Hayleigh pointed out guards with comments were not formatted properly. This fixes it!