### PR TITLE
editorconfig: do not trim whitespace in snapshot files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,7 @@ indent_size = 4
 [Makefile]
 indent_style = tab
 indent_size = 4
+
+# snapshot files contain trailing whitespace which shouldn't be removed
+[*.snap]
+trim_trailing_whitespace = false


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Resolves #5977