### PR TITLE
Fix grammar in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   nothing.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug in `gleam new` where the incorrect verb form would be used when
+  single or multiple conflicting files existed in the target directory.
+  ([Spenser Black](https://github.com/spenserblack))
+
 ## v1.18.0-rc2 - 2026-07-25
 
 ### Bug fixes
@@ -678,7 +682,3 @@
 - Fixed a bug where the compiler would report a module import as unused when
   its local name matched another imported module's full name.
   ([John Downey](https://github.com/jtdowney))
-
-- Fixed a bug in `gleam new` where the incorrect verb form would be used when
-  single or multiple conflicting files existed in the target directory.
-  ([Spenser Black](https://github.com/spenserblack))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -678,3 +678,7 @@
 - Fixed a bug where the compiler would report a module import as unused when
   its local name matched another imported module's full name.
   ([John Downey](https://github.com/jtdowney))
+
+- Fixed a bug in `gleam new` where the incorrect verb form would be used when
+  single or multiple conflicting files existed in the target directory.
+  ([Spenser Black](https://github.com/spenserblack))

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1285,29 +1285,29 @@ target, so it cannot be run.",
                 location: None,
             }],
 
-            Error::OutputFilesAlreadyExist { file_names } => vec![Diagnostic {
-                title: format!(
-                    "{} already exist{} in target directory",
-                    if file_names.len() == 1 {
-                        "File"
-                    } else {
-                        "Files"
-                    },
-                    if file_names.len() == 1 { "" } else { "s" }
-                ),
-                text: format!(
-                    "{}
-If you want to overwrite these files, delete them and run the command again.
-",
-                    file_names
-                        .iter()
-                        .map(|name| format!("  - {}", name.as_str()))
-                        .join("\n")
-                ),
-                level: Level::Error,
-                hint: None,
-                location: None,
-            }],
+            Error::OutputFilesAlreadyExist { file_names } => {
+                let (plural, conjugation, text_files, text_pronoun) = if file_names.len() == 1 {
+                    ("", "s", "this file", "it")
+                } else {
+                    ("s", "", "these files", "them")
+                };
+                let file_list = file_names
+                    .iter()
+                    .map(|name| format!("  - {}", name.as_str()))
+                    .join("\n");
+                vec![Diagnostic {
+                    title: format!("File{plural} already exist{conjugation} in target directory"),
+                    text: format!(
+                        "{file_list}
+
+If you want to overwrite {text_files}, delete {text_pronoun} and run the command again.
+"
+                    ),
+                    level: Level::Error,
+                    hint: None,
+                    location: None,
+                }]
+            }
 
             Error::RemovedPackagesNotExist { packages } => vec![Diagnostic {
                 title: "Package not found".into(),

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__output_files_already_exist_multiple.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__output_files_already_exist_multiple.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: err.pretty_string()
+---
+error: Files already exist in target directory
+
+  - wibble
+  - wobble
+
+If you want to overwrite these files, delete them and run the command again.

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__output_files_already_exist_singular.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__output_files_already_exist_singular.snap
@@ -1,0 +1,9 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: err.pretty_string()
+---
+error: File already exists in target directory
+
+  - wibble
+
+If you want to overwrite this file, delete it and run the command again.

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -54,6 +54,24 @@ fn hex_error_conversion() {
     );
 }
 
+#[test]
+fn test_output_files_already_exist() {
+    let file_names = vec![
+        ("singular", vec![Utf8PathBuf::from("wibble")]),
+        (
+            "multiple",
+            vec![Utf8PathBuf::from("wibble"), Utf8PathBuf::from("wobble")],
+        ),
+    ];
+    for (group, file_names) in file_names {
+        let err = Error::OutputFilesAlreadyExist { file_names };
+        assert_snapshot!(
+            format!("output_files_already_exist_{group}"),
+            err.pretty_string(),
+        );
+    }
+}
+
 // There are 2 separate tests for Windows and for Unix, because on Windows note
 // about inability to create symlinks without Developer Mode is shown, so
 // snapshots differ.


### PR DESCRIPTION
When one or more files already exist in the target directory for `gleam new`, the error message would be one of the below:

- File already exist...
- Files already exists...

This reverses the verb forms to be one of the below:

- File already exists...
- Files already exist...

As an English-speaker (en-US) this just naturally felt incorrect to me, but I've Googled and provided a source just in case: https://www.yourdictionary.com/articles/singular-plural-verb-chart

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
