### PR TITLE
Fix panic wrapping multibyte char at width boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fixed a bug where the compiler would crash when wrapping an error message
+  whose line broke in the middle of a multi-byte UTF-8 character.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.0-rc1 - 2026-07-21
 
 ### Compiler

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -5307,8 +5307,8 @@ fn break_line(line: &str, width: usize) -> Vec<Cow<'_, str>> {
 // breaks word into n lines based on width. Returns list of new lines and remainder
 fn break_word(word: &str, width: usize) -> (Vec<Cow<'_, str>>, &str) {
     let mut new_lines: Vec<Cow<'_, str>> = Vec::new();
-    // split on a char boundary so a multi-byte UTF-8 char straddling `width`
-    // can't panic.
+    // Split on a char boundary so a multi-byte UTF-8 char straddling `width`
+    // doesn't cause a panic.
     let (first, mut remainder) = word.split_at(word.floor_char_boundary(width));
     new_lines.push(Cow::from(first));
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -5307,12 +5307,14 @@ fn break_line(line: &str, width: usize) -> Vec<Cow<'_, str>> {
 // breaks word into n lines based on width. Returns list of new lines and remainder
 fn break_word(word: &str, width: usize) -> (Vec<Cow<'_, str>>, &str) {
     let mut new_lines: Vec<Cow<'_, str>> = Vec::new();
-    let (first, mut remainder) = word.split_at(width);
+    // split on a char boundary so a multi-byte UTF-8 char straddling `width`
+    // can't panic.
+    let (first, mut remainder) = word.split_at(word.floor_char_boundary(width));
     new_lines.push(Cow::from(first));
 
     // split remainder until it's small enough
     while remainder.len() > width {
-        let (first, second) = remainder.split_at(width);
+        let (first, second) = remainder.split_at(remainder.floor_char_boundary(width));
         new_lines.push(Cow::from(first));
         remainder = second;
     }

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -215,3 +215,10 @@ fn io_read_metadata_of_file_error() {
     .pretty_string();
     assert_snapshot!(error);
 }
+
+#[test]
+fn wrap_with_multibyte_char_at_width_boundary() {
+    let input = format!("{}é", "a".repeat(74));
+    let wrapped = wrap(&input);
+    assert_eq!(wrapped.replace('\n', ""), input);
+}


### PR DESCRIPTION
Currently, this program crashes the compiler:

```gleam
@deprecated("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaé")
pub fn old() -> Int {
  1
}

pub fn main() -> Int {
  old()
}
```

This is because it attempts to split the message for wrapping in the middle of the é.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
