### PR TITLE
Fix invalid BEAM code for bits + unit bit-array segments

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -472,6 +472,33 @@ fn type_parameter_name(type_: &Type) -> EcoString {
     }
 }
 
+fn fold_bits_unit_value<Value>(options: &[BitArrayOption<Value>]) -> Option<u8> {
+    let mut has_bits = false;
+    let mut unit_value = None;
+    for option in options {
+        match option {
+            BitArrayOption::Bits { .. } => has_bits = true,
+            BitArrayOption::Unit { value, .. } => unit_value = Some(value),
+            BitArrayOption::Bytes { .. }
+            | BitArrayOption::Int { .. }
+            | BitArrayOption::Float { .. }
+            | BitArrayOption::Utf8 { .. }
+            | BitArrayOption::Utf16 { .. }
+            | BitArrayOption::Utf32 { .. }
+            | BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. }
+            | BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. }
+            | BitArrayOption::Size { .. } => {}
+        }
+    }
+    if has_bits { unit_value.copied() } else { None }
+}
+
 impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
     pub fn new(
         function: &'a TypedFunction,
@@ -2349,17 +2376,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a TypedConstantBitArraySegment,
     ) {
-        // Fold unit for constant bits segments
-        let mut has_bits = false;
-        let mut bits_unit_value = None;
-        for option in &segment.options {
-            match option {
-                BitArrayOption::Bits { .. } => has_bits = true,
-                BitArrayOption::Unit { value, .. } => bits_unit_value = Some(*value),
-                _ => {}
-            }
-        }
-        let bits_unit_value = if has_bits { bits_unit_value } else { None };
+        let bits_unit_value = fold_bits_unit_value(&segment.options);
 
         builder.bit_array_segment();
         self.inlined_constant(builder, &segment.value);
@@ -2806,16 +2823,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         } else {
             // If the bit array segment doesn't need any special handling we use the
             // regular printing functions to format its value and options.
-            let mut has_bits = false;
-            let mut bits_unit_value = None;
-            for option in &segment.options {
-                match option {
-                    BitArrayOption::Bits { .. } => has_bits = true,
-                    BitArrayOption::Unit { value, .. } => bits_unit_value = Some(*value),
-                    _ => {}
-                }
-            }
-            let bits_unit_value = if has_bits { bits_unit_value } else { None };
+            let bits_unit_value = fold_bits_unit_value(&segment.options);
             builder.bit_array_segment();
 
             // Fold unit into size for bits segments with unit
@@ -2845,9 +2853,10 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         // results in a runtime error. We can't do that in Gleam! So any
         // negative value must be turned to zero instead.
         //
-        // When `bits_unit_value` is set the unit has been folded into
-        // the size so the unit specifier can be omitted. For example,
-        // size=8 with unit=8 produces 64, emitting <<X:64/bitstring>>
+        // And when `bits_unit_value` is set the unit has been folded into
+        // the size so the unit specifier can be omitted.
+        //
+        // For example, size=8 with unit=8 produces 64, emitting <<X:64/bitstring>>
         // instead of <<X:8/bitstring-unit:8>>.
         if let Some(unit) = bits_unit_value {
             // Multiply the size by the unit

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2341,22 +2341,38 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a TypedConstantBitArraySegment,
     ) {
+        // fold unit for constant bits segments
+        let unit_fold = segment
+            .has_bits_option()
+            .then(|| segment.options.iter().find_map(|o| match o {
+                BitArrayOption::Unit { value, .. } => Some(*value),
+                _ => None,
+            }))
+            .flatten();
+
         builder.bit_array_segment();
         self.inlined_constant(builder, &segment.value);
-        match segment.size() {
-            Some(TypedConstant::Int { int_value, .. }) if int_value.is_negative() => {
+        match (segment.size(), unit_fold) {
+            (Some(TypedConstant::Int { int_value, .. }), _) if int_value.is_negative() => {
                 builder.int(BigInt::ZERO);
             }
-            Some(size) => self.inlined_constant(builder, size),
-            None => builder.atom("default"),
+            (Some(TypedConstant::Int { int_value, .. }), Some(unit)) => {
+                builder.int(int_value * unit);
+            }
+            (Some(size), _) => self.inlined_constant(builder, size),
+            (None, _) => builder.atom("default"),
         }
-        self.bit_array_segment_specifiers(builder, segment);
+        self.bit_array_segment_specifiers(builder, segment, unit_fold.is_some());
     }
 
+    // When fold_unit is true, the unit was already multiplied into the
+    // size (e.g. size=8, unit=8 became 64), so skip emitting the unit
+    // specifier. BEAM rejects unit with the bitstring type.
     fn bit_array_segment_specifiers<Output, Expr>(
         &self,
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a BitArraySegment<Expr, Arc<Type>>,
+        fold_unit: bool,
     ) {
         let options = segment.options.iter();
         builder.bit_array_segment_specifiers(options.filter_map(|option| match option {
@@ -2378,6 +2394,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             BitArrayOption::Big { .. } => Some(BitArraySegmentSpecifier::Big),
             BitArrayOption::Little { .. } => Some(BitArraySegmentSpecifier::Little),
             BitArrayOption::Native { .. } => Some(BitArraySegmentSpecifier::Native),
+            BitArrayOption::Unit { .. } if fold_unit => None,
             BitArrayOption::Unit { value, .. } => Some(BitArraySegmentSpecifier::Unit(*value)),
             BitArrayOption::Size { .. } => None,
         }));
@@ -2776,10 +2793,19 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         } else {
             // If the bit array segment doesn't need any special handling we use the
             // regular printing functions to format its value and options.
+            let unit_fold = segment
+                .has_bits_option()
+                .then(|| segment.options.iter().find_map(|o| match o {
+                    BitArrayOption::Unit { value, .. } => Some(*value),
+                    _ => None,
+                }))
+                .flatten();
             builder.bit_array_segment();
+
+            // Folds unit for expression bits segments
             self.maybe_block_expr(builder, &segment.value);
-            self.bit_array_expression_segment_size(builder, segment);
-            self.bit_array_segment_specifiers(builder, segment);
+            self.bit_array_expression_segment_size(builder, segment, unit_fold);
+            self.bit_array_segment_specifiers(builder, segment, unit_fold.is_some());
         }
     }
 
@@ -2792,6 +2818,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         &mut self,
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a TypedExprBitArraySegment,
+        unit_fold: Option<u8>,
     ) {
         let Some(size) = segment.size() else {
             builder.atom("default");
@@ -2800,8 +2827,27 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
 
         // Sizes need some care: in Erlang, having a negative segment size
         // results in a runtime error. We can't do that in Gleam! So any
-        // negative value must be turned to zero instead:
-        if let TypedExpr::Int { int_value, .. } = &size {
+        // negative value must be turned to zero instead.
+        //
+        // Also see the `unit_fold` parameter above: when set,
+        // we fold the unit into the size here.
+        if let Some(unit) = unit_fold {
+            // size * unit
+            if let TypedExpr::Int { int_value, .. } = &size {
+                if int_value.is_negative() {
+                    builder.int(BigInt::ZERO);
+                } else {
+                    builder.int(int_value.clone() * unit);
+                }
+            } else {
+                let call = builder.start_remote_call(ErlangModuleName::erlang(), "max");
+                builder.int(BigInt::ZERO);
+                builder.binary_operator("*");
+                self.maybe_block_expr(builder, size);
+                builder.int(unit.into());
+                builder.end_call(call);
+            }
+        } else if let TypedExpr::Int { int_value, .. } = &size {
             if int_value.is_negative() {
                 builder.int(BigInt::ZERO);
             } else {

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -472,31 +472,24 @@ fn type_parameter_name(type_: &Type) -> EcoString {
     }
 }
 
-fn fold_bits_unit_value<Value>(options: &[BitArrayOption<Value>]) -> Option<u8> {
+/// Extract Bits, Unit and Size options from a bit array segment in a
+/// Returns a tuple of (has_bits, unit_value, size_value).
+fn collect_bit_array_options<Value>(
+    options: &[BitArrayOption<Value>],
+) -> (bool, Option<u8>, Option<&Box<Value>>) {
     let mut has_bits = false;
     let mut unit_value = None;
+    let mut size_value = None;
+    #[allow(clippy::wildcard_enum_match_arm)]
     for option in options {
         match option {
             BitArrayOption::Bits { .. } => has_bits = true,
-            BitArrayOption::Unit { value, .. } => unit_value = Some(value),
-            BitArrayOption::Bytes { .. }
-            | BitArrayOption::Int { .. }
-            | BitArrayOption::Float { .. }
-            | BitArrayOption::Utf8 { .. }
-            | BitArrayOption::Utf16 { .. }
-            | BitArrayOption::Utf32 { .. }
-            | BitArrayOption::Utf8Codepoint { .. }
-            | BitArrayOption::Utf16Codepoint { .. }
-            | BitArrayOption::Utf32Codepoint { .. }
-            | BitArrayOption::Signed { .. }
-            | BitArrayOption::Unsigned { .. }
-            | BitArrayOption::Big { .. }
-            | BitArrayOption::Little { .. }
-            | BitArrayOption::Native { .. }
-            | BitArrayOption::Size { .. } => {}
+            BitArrayOption::Unit { value, .. } => unit_value = Some(*value),
+            BitArrayOption::Size { value, .. } => size_value = Some(value),
+            _ => {}
         }
     }
-    if has_bits { unit_value.copied() } else { None }
+    (has_bits, unit_value, size_value)
 }
 
 impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
@@ -2376,11 +2369,13 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a TypedConstantBitArraySegment,
     ) {
-        let bits_unit_value = fold_bits_unit_value(&segment.options);
+        let (has_bits, unit_value, size_value) = collect_bit_array_options(&segment.options);
+        let bits_unit_value = if has_bits { unit_value } else { None };
+        let size = size_value.map(|v| v.as_ref());
 
         builder.bit_array_segment();
         self.inlined_constant(builder, &segment.value);
-        match (segment.size(), bits_unit_value) {
+        match (size, bits_unit_value) {
             (Some(TypedConstant::Int { int_value, .. }), _) if int_value.is_negative() => {
                 builder.int(BigInt::ZERO);
             }
@@ -2823,12 +2818,14 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         } else {
             // If the bit array segment doesn't need any special handling we use the
             // regular printing functions to format its value and options.
-            let bits_unit_value = fold_bits_unit_value(&segment.options);
+            let (has_bits, unit_value, size_value) = collect_bit_array_options(&segment.options);
+            let bits_unit_value = if has_bits { unit_value } else { None };
+            let size = size_value.map(|v| v.as_ref());
             builder.bit_array_segment();
 
             // Fold unit into size for bits segments with unit
             self.maybe_block_expr(builder, &segment.value);
-            self.bit_array_expression_segment_size(builder, segment, bits_unit_value);
+            self.bit_array_expression_segment_size(builder, size, bits_unit_value);
             self.bit_array_segment_specifiers(builder, segment, bits_unit_value.is_some());
         }
     }
@@ -2841,10 +2838,10 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
     fn bit_array_expression_segment_size<Output>(
         &mut self,
         builder: &mut impl ErlangBuilder<Output>,
-        segment: &'a TypedExprBitArraySegment,
+        size: Option<&'a TypedExpr>,
         bits_unit_value: Option<u8>,
     ) {
-        let Some(size) = segment.size() else {
+        let Some(size) = size else {
             builder.bit_array_segment_default_size();
             return;
         };

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -472,24 +472,38 @@ fn type_parameter_name(type_: &Type) -> EcoString {
     }
 }
 
-/// Extract Bits, Unit and Size options from a bit array segment in a
-/// Returns a tuple of (has_bits, unit_value, size_value).
+/// Extract bits, unit and size options from a bit array segment in a
+/// single pass. Returns the unit value (only when the segment has a
+/// Bits option) and the Size option value.
 fn collect_bit_array_options<Value>(
     options: &[BitArrayOption<Value>],
-) -> (bool, Option<u8>, Option<&Box<Value>>) {
+) -> (Option<u8>, Option<&Value>) {
     let mut has_bits = false;
     let mut unit_value = None;
     let mut size_value = None;
-    #[allow(clippy::wildcard_enum_match_arm)]
     for option in options {
         match option {
             BitArrayOption::Bits { .. } => has_bits = true,
             BitArrayOption::Unit { value, .. } => unit_value = Some(*value),
-            BitArrayOption::Size { value, .. } => size_value = Some(value),
-            _ => {}
+            BitArrayOption::Size { value, .. } => size_value = Some(value.as_ref()),
+            BitArrayOption::Bytes { .. }
+            | BitArrayOption::Int { .. }
+            | BitArrayOption::Float { .. }
+            | BitArrayOption::Utf8 { .. }
+            | BitArrayOption::Utf16 { .. }
+            | BitArrayOption::Utf32 { .. }
+            | BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. }
+            | BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. } => {}
         }
     }
-    (has_bits, unit_value, size_value)
+    let unit_value = if has_bits { unit_value } else { None };
+    (unit_value, size_value)
 }
 
 impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
@@ -2369,13 +2383,11 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a TypedConstantBitArraySegment,
     ) {
-        let (has_bits, unit_value, size_value) = collect_bit_array_options(&segment.options);
-        let bits_unit_value = if has_bits { unit_value } else { None };
-        let size = size_value.map(|v| v.as_ref());
+        let (bits_unit_value, size_value) = collect_bit_array_options(&segment.options);
 
         builder.bit_array_segment();
         self.inlined_constant(builder, &segment.value);
-        match (size, bits_unit_value) {
+        match (size_value, bits_unit_value) {
             (Some(TypedConstant::Int { int_value, .. }), _) if int_value.is_negative() => {
                 builder.int(BigInt::ZERO);
             }
@@ -2818,14 +2830,14 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         } else {
             // If the bit array segment doesn't need any special handling we use the
             // regular printing functions to format its value and options.
-            let (has_bits, unit_value, size_value) = collect_bit_array_options(&segment.options);
-            let bits_unit_value = if has_bits { unit_value } else { None };
-            let size = size_value.map(|v| v.as_ref());
+            let (bits_unit_value, size_value) = collect_bit_array_options(&segment.options);
             builder.bit_array_segment();
 
-            // Fold unit into size for bits segments with unit
+            // Multiply the unit into the size for bits segments so the
+            // unit specifier can be dropped from the Erlang output.
+            // The BEAM rejects unit with the bitstring type.
             self.maybe_block_expr(builder, &segment.value);
-            self.bit_array_expression_segment_size(builder, size, bits_unit_value);
+            self.bit_array_expression_segment_size(builder, size_value, bits_unit_value);
             self.bit_array_segment_specifiers(builder, segment, bits_unit_value.is_some());
         }
     }
@@ -2850,8 +2862,8 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         // results in a runtime error. We can't do that in Gleam! So any
         // negative value must be turned to zero instead.
         //
-        // And when `bits_unit_value` is set the unit has been folded into
-        // the size so the unit specifier can be omitted.
+        // And when `bits_unit_value` is set the unit has been multiplied
+        // into the size so the unit specifier can be omitted.
         //
         // For example, size=8 with unit=8 produces 64, emitting <<X:64/bitstring>>
         // instead of <<X:8/bitstring-unit:8>>.

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2833,9 +2833,6 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             let (bits_unit_value, size_value) = collect_bit_array_options(&segment.options);
             builder.bit_array_segment();
 
-            // Multiply the unit into the size for bits segments so the
-            // unit specifier can be dropped from the Erlang output.
-            // The BEAM rejects unit with the bitstring type.
             self.maybe_block_expr(builder, &segment.value);
             self.bit_array_expression_segment_size(builder, size_value, bits_unit_value);
             self.bit_array_segment_specifiers(builder, segment, bits_unit_value.is_some());

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -485,6 +485,40 @@ fn type_parameter_name(type_: &Type) -> EcoString {
     }
 }
 
+/// Extract bits, unit and size options from a bit array segment in a
+/// single pass. Returns the unit value (only when the segment has a
+/// Bits option) and the Size option value.
+fn collect_bit_array_options<Value>(
+    options: &[BitArrayOption<Value>],
+) -> (Option<u8>, Option<&Value>) {
+    let mut has_bits = false;
+    let mut unit_value = None;
+    let mut size_value = None;
+    for option in options {
+        match option {
+            BitArrayOption::Bits { .. } => has_bits = true,
+            BitArrayOption::Unit { value, .. } => unit_value = Some(*value),
+            BitArrayOption::Size { value, .. } => size_value = Some(value.as_ref()),
+            BitArrayOption::Bytes { .. }
+            | BitArrayOption::Int { .. }
+            | BitArrayOption::Float { .. }
+            | BitArrayOption::Utf8 { .. }
+            | BitArrayOption::Utf16 { .. }
+            | BitArrayOption::Utf32 { .. }
+            | BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. }
+            | BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. } => {}
+        }
+    }
+    let unit_value = if has_bits { unit_value } else { None };
+    (unit_value, size_value)
+}
+
 impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
     pub fn new(
         function: &'a TypedFunction,
@@ -2588,26 +2622,45 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a TypedConstantBitArraySegment,
     ) {
+        let (bits_unit_value, size_value) = collect_bit_array_options(&segment.options);
+
         builder.bit_array_segment(segment.location);
         self.inlined_constant(builder, &segment.value);
-        match segment.size() {
-            Some(TypedConstant::Int {
-                int_value,
-                location,
-                ..
-            }) if int_value.is_negative() => {
+        match (size_value, bits_unit_value) {
+            (
+                Some(TypedConstant::Int {
+                    int_value,
+                    location,
+                    ..
+                }),
+                _,
+            ) if int_value.is_negative() => {
                 builder.int_expression(*location, BigInt::ZERO);
             }
-            Some(size) => self.inlined_constant(builder, size),
-            None => builder.bit_array_segment_default_size(),
+            (
+                Some(TypedConstant::Int {
+                    int_value,
+                    location,
+                    ..
+                }),
+                Some(unit),
+            ) => {
+                builder.int_expression(*location, int_value * unit);
+            }
+            (Some(size), _) => self.inlined_constant(builder, size),
+            (None, _) => builder.bit_array_segment_default_size(),
         }
-        self.bit_array_segment_specifiers(builder, segment);
+        self.bit_array_segment_specifiers(builder, segment, bits_unit_value.is_some());
     }
 
+    // When `omit_unit_specifier` is true, the unit was already multiplied
+    // into the size (e.g. size=8, unit=8 became 64), so we skip emitting
+    // the unit specifier. The BEAM rejects unit with the bitstring type.
     fn bit_array_segment_specifiers<Output, Expr>(
         &self,
         builder: &mut impl ErlangBuilder<Output>,
         segment: &'a BitArraySegment<Expr, Arc<Type>>,
+        omit_unit_specifier: bool,
     ) {
         let options = segment.options.iter();
         builder.bit_array_segment_specifiers(options.filter_map(|option| match option {
@@ -2629,6 +2682,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             BitArrayOption::Big { .. } => Some(BitArraySegmentSpecifier::Big),
             BitArrayOption::Little { .. } => Some(BitArraySegmentSpecifier::Little),
             BitArrayOption::Native { .. } => Some(BitArraySegmentSpecifier::Native),
+            BitArrayOption::Unit { .. } if omit_unit_specifier => None,
             BitArrayOption::Unit { value, .. } => Some(BitArraySegmentSpecifier::Unit(*value)),
             BitArrayOption::Size { .. } => None,
         }));
@@ -3051,10 +3105,11 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         } else {
             // If the bit array segment doesn't need any special handling we use the
             // regular printing functions to format its value and options.
+            let (bits_unit_value, size_value) = collect_bit_array_options(&segment.options);
             builder.bit_array_segment(segment.location);
             self.maybe_block_expr(builder, &segment.value);
-            self.bit_array_expression_segment_size(builder, segment);
-            self.bit_array_segment_specifiers(builder, segment);
+            self.bit_array_expression_segment_size(builder, size_value, bits_unit_value);
+            self.bit_array_segment_specifiers(builder, segment, bits_unit_value.is_some());
         }
     }
 
@@ -3066,26 +3121,45 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
     fn bit_array_expression_segment_size<Output>(
         &mut self,
         builder: &mut impl ErlangBuilder<Output>,
-        segment: &'a TypedExprBitArraySegment,
+        size: Option<&'a TypedExpr>,
+        bits_unit_value: Option<u8>,
     ) {
-        let Some(size) = segment.size() else {
+        let Some(size) = size else {
             builder.bit_array_segment_default_size();
             return;
         };
 
         // Sizes need some care: in Erlang, having a negative segment size
         // results in a runtime error. We can't do that in Gleam! So any
-        // negative value must be turned to zero instead:
-        if let TypedExpr::Int {
-            int_value,
-            location: size_location,
-            ..
-        } = &size
-        {
-            if int_value.is_negative() {
-                builder.int_expression(*size_location, BigInt::ZERO);
+        // negative value must be turned to zero instead.
+        //
+        // And when `bits_unit_value` is set the unit has been multiplied
+        // into the size so the unit specifier can be omitted.
+        //
+        // For example, size=8 with unit=8 produces 64, emitting <<X:64/bitstring>>
+        // instead of <<X:8/bitstring-unit:8>>.
+        if let Some(unit) = bits_unit_value {
+            // Multiply the size by the unit
+            if let TypedExpr::Int { int_value, .. } = &size {
+                if int_value.is_negative() {
+                    builder.int_expression(size.location(), BigInt::ZERO);
+                } else {
+                    builder.int_expression(size.location(), int_value.clone() * unit);
+                }
             } else {
-                builder.int_expression(*size_location, int_value.clone());
+                let call =
+                    builder.start_remote_call(size.location(), ErlangModuleName::erlang(), "max");
+                builder.int_expression(size.location(), BigInt::ZERO);
+                builder.binary_operator(size.location(), "*");
+                self.maybe_block_expr(builder, size);
+                builder.int_expression(size.location(), unit.into());
+                builder.end_call(call);
+            }
+        } else if let TypedExpr::Int { int_value, .. } = &size {
+            if int_value.is_negative() {
+                builder.int_expression(size.location(), BigInt::ZERO);
+            } else {
+                builder.int_expression(size.location(), int_value.clone());
             }
         } else {
             let call =

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -239,22 +239,12 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
                 for segment in segments {
                     // Only fold unit into size for literal integer sizes,
                     // patterns cannot use binary operators at runtime.
-                    let mut has_bits = false;
-                    let mut bits_unit_value = None;
                     let is_literal_size = matches!(
                         segment.size(),
                         Some(Pattern::BitArraySize(BitArraySize::Int { .. }))
                     );
-                    for option in &segment.options {
-                        match option {
-                            BitArrayOption::Bits { .. } => has_bits = true,
-                            BitArrayOption::Unit { value, .. } if is_literal_size => {
-                                bits_unit_value = Some(*value)
-                            }
-                            _ => {}
-                        }
-                    }
-                    let bits_unit_value = if has_bits { bits_unit_value } else { None };
+                    let bits_unit_value = fold_bits_unit_value(&segment.options)
+                        .filter(|_| is_literal_size);
 
                     builder.bit_array_segment();
                     self.bit_array_pattern_segment_value(builder, segment);
@@ -263,8 +253,11 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
                     } else {
                         self.bit_array_pattern_segment_size(builder, segment);
                     }
-                    self.generator
-                        .bit_array_segment_specifiers(builder, segment, bits_unit_value.is_some());
+                    self.generator.bit_array_segment_specifiers(
+                        builder,
+                        segment,
+                        bits_unit_value.is_some(),
+                    );
                 }
                 builder.end_bit_array_pattern(bit_array);
             }

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -237,11 +237,31 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
             Pattern::BitArray { segments, .. } => {
                 let bit_array = builder.start_bit_array_pattern();
                 for segment in segments {
+                    // Only fold literal ints, patterns don't have runtime ops
+                    let unit_fold = segment.has_bits_option().then(|| {
+                        segment.options.iter().find_map(|o| match o {
+                            BitArrayOption::Unit { value, .. } => {
+                                let is_literal_size = matches!(
+                                    segment.size(),
+                                    Some(Pattern::BitArraySize(
+                                        BitArraySize::Int { .. }
+                                    ))
+                                );
+                                if is_literal_size { Some(*value) } else { None }
+                            }
+                            _ => None,
+                        })
+                    }).flatten();
+
                     builder.bit_array_segment();
                     self.bit_array_pattern_segment_value(builder, segment);
-                    self.bit_array_pattern_segment_size(builder, segment);
+                    if let Some(unit) = unit_fold {
+                        self.bit_array_pattern_segment_size_with_unit(builder, segment, unit);
+                    } else {
+                        self.bit_array_pattern_segment_size(builder, segment);
+                    }
                     self.generator
-                        .bit_array_segment_specifiers(builder, segment);
+                        .bit_array_segment_specifiers(builder, segment, unit_fold.is_some());
                 }
                 builder.end_bit_array_pattern(bit_array);
             }
@@ -390,6 +410,31 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
             panic!("invalid size in pattern size segment")
         };
         self.bit_array_size(builder, size);
+    }
+
+    /// For bits segments with unit+literal int size,
+    /// multiply size by unit so we can drop the unit specifier.
+    fn bit_array_pattern_segment_size_with_unit<Output>(
+        &mut self,
+        builder: &mut impl ErlangBuilder<Output>,
+        segment: &'a TypedPatternBitArraySegment,
+        unit: u8,
+    ) {
+        let Some(size) = segment.size() else {
+            builder.atom("default");
+            return;
+        };
+        let TypedPattern::BitArraySize(size) = size else {
+            panic!("invalid size in pattern size segment")
+        };
+        match size {
+            BitArraySize::Int { int_value, .. } => {
+                builder.int(int_value * unit);
+            }
+            BitArraySize::Block { .. }
+            | BitArraySize::Variable { .. }
+            | BitArraySize::BinaryOperator { .. } => self.bit_array_size(builder, size),
+        }
     }
 
     fn bit_array_size_divide<Output>(

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -237,19 +237,34 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
             Pattern::BitArray { segments, .. } => {
                 let bit_array = builder.start_bit_array_pattern();
                 for segment in segments {
-                    // Only fold unit into size for literal integer sizes,
-                    // patterns cannot use binary operators at runtime.
-                    let is_literal_size = matches!(
-                        segment.size(),
-                        Some(Pattern::BitArraySize(BitArraySize::Int { .. }))
-                    );
-                    let bits_unit_value = fold_bits_unit_value(&segment.options)
-                        .filter(|_| is_literal_size);
+                    // When a bits segment has both size and unit as literal
+                    // ints, multiply them so the unit specifier can be
+                    // dropped. The BEAM rejects unit with bitstring.
+                    let int_value = match segment.size() {
+                        Some(Pattern::BitArraySize(BitArraySize::Int { int_value, .. })) => {
+                            Some(int_value)
+                        }
+                        _ => None,
+                    };
+                    let mut has_bits = false;
+                    let mut bits_unit_value = None;
+                    for option in &segment.options {
+                        match option {
+                            BitArrayOption::Bits { .. } => has_bits = true,
+                            BitArrayOption::Unit { value, .. } => bits_unit_value = Some(*value),
+                            _ => {}
+                        }
+                    }
+                    let bits_unit_value = if has_bits && int_value.is_some() {
+                        bits_unit_value
+                    } else {
+                        None
+                    };
 
                     builder.bit_array_segment();
                     self.bit_array_pattern_segment_value(builder, segment);
-                    if let Some(unit) = bits_unit_value {
-                        self.bit_array_pattern_segment_size_with_unit(builder, segment, unit);
+                    if let (Some(int_value), Some(unit)) = (int_value, bits_unit_value) {
+                        self.bit_array_pattern_segment_size_with_unit(builder, int_value, unit);
                     } else {
                         self.bit_array_pattern_segment_size(builder, segment);
                     }
@@ -408,29 +423,13 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
         self.bit_array_size(builder, size);
     }
 
-    /// For bits segments with a unit option and a literal integer size,
-    /// multiply the size by the unit so we can drop the unit specifier.
     fn bit_array_pattern_segment_size_with_unit<Output>(
         &mut self,
         builder: &mut impl ErlangBuilder<Output>,
-        segment: &'a TypedPatternBitArraySegment,
+        int_value: &BigInt,
         unit: u8,
     ) {
-        let Some(size) = segment.size() else {
-            builder.atom("default");
-            return;
-        };
-        let TypedPattern::BitArraySize(size) = size else {
-            panic!("invalid size in pattern size segment")
-        };
-        match size {
-            BitArraySize::Int { int_value, .. } => {
-                builder.int(int_value * unit);
-            }
-            BitArraySize::Block { .. }
-            | BitArraySize::Variable { .. }
-            | BitArraySize::BinaryOperator { .. } => self.bit_array_size(builder, size),
-        }
+        builder.int(int_value * unit);
     }
 
     fn bit_array_size_divide<Output>(

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -240,18 +240,23 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
                     // When a bits segment has both size and unit as literal
                     // ints, multiply them so the unit specifier can be
                     // dropped. The BEAM rejects unit with bitstring.
-                    let int_value = match segment.size() {
-                        Some(Pattern::BitArraySize(BitArraySize::Int { int_value, .. })) => {
-                            Some(int_value)
-                        }
-                        _ => None,
-                    };
                     let mut has_bits = false;
                     let mut bits_unit_value = None;
+                    let mut int_value = None;
                     for option in &segment.options {
+                        #[allow(clippy::wildcard_enum_match_arm)]
                         match option {
                             BitArrayOption::Bits { .. } => has_bits = true,
                             BitArrayOption::Unit { value, .. } => bits_unit_value = Some(*value),
+                            BitArrayOption::Size { value, .. } => {
+                                if let Pattern::BitArraySize(BitArraySize::Int {
+                                    int_value: iv,
+                                    ..
+                                }) = value.as_ref()
+                                {
+                                    int_value = Some(iv);
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -264,7 +269,7 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
                     builder.bit_array_segment();
                     self.bit_array_pattern_segment_value(builder, segment);
                     if let (Some(int_value), Some(unit)) = (int_value, bits_unit_value) {
-                        self.bit_array_pattern_segment_size_with_unit(builder, int_value, unit);
+                        builder.int(int_value * unit);
                     } else {
                         self.bit_array_pattern_segment_size(builder, segment);
                     }
@@ -421,15 +426,6 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
             panic!("invalid size in pattern size segment")
         };
         self.bit_array_size(builder, size);
-    }
-
-    fn bit_array_pattern_segment_size_with_unit<Output>(
-        &mut self,
-        builder: &mut impl ErlangBuilder<Output>,
-        int_value: &BigInt,
-        unit: u8,
-    ) {
-        builder.int(int_value * unit);
     }
 
     fn bit_array_size_divide<Output>(

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -275,11 +275,45 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
             } => {
                 let bit_array = builder.start_bit_array_pattern(*location);
                 for segment in segments {
+                    // When a bits segment has both size and unit as literal
+                    // ints, multiply them so the unit specifier can be
+                    // dropped. The BEAM rejects unit with bitstring.
+                    let (bits_unit_value, size_value) = collect_bit_array_options(&segment.options);
+                    let int_value = size_value.and_then(|v| match v {
+                        Pattern::BitArraySize(BitArraySize::Int { int_value, .. }) => {
+                            Some(int_value)
+                        }
+                        Pattern::Int { .. }
+                        | Pattern::Float { .. }
+                        | Pattern::String { .. }
+                        | Pattern::Variable { .. }
+                        | Pattern::BitArraySize(_)
+                        | Pattern::Assign { .. }
+                        | Pattern::Discard { .. }
+                        | Pattern::List { .. }
+                        | Pattern::Constructor { .. }
+                        | Pattern::Tuple { .. }
+                        | Pattern::BitArray { .. }
+                        | Pattern::StringPrefix { .. }
+                        | Pattern::Invalid { .. } => None,
+                    });
+                    let bits_unit_value = match (bits_unit_value, int_value) {
+                        (Some(unit), Some(_)) => Some(unit),
+                        _ => None,
+                    };
+
                     builder.bit_array_segment(segment.location);
                     self.bit_array_pattern_segment_value(builder, segment);
-                    self.bit_array_pattern_segment_size(builder, segment);
-                    self.generator
-                        .bit_array_segment_specifiers(builder, segment);
+                    if let (Some(int_value), Some(unit)) = (int_value, bits_unit_value) {
+                        builder.int_expression(segment.location, int_value * unit);
+                    } else {
+                        self.bit_array_pattern_segment_size(builder, segment);
+                    }
+                    self.generator.bit_array_segment_specifiers(
+                        builder,
+                        segment,
+                        bits_unit_value.is_some(),
+                    );
                 }
                 builder.end_bit_array_pattern(bit_array);
             }

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -247,7 +247,10 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
                         }
                         _ => None,
                     });
-                    let bits_unit_value = bits_unit_value.filter(|_| int_value.is_some());
+                    let bits_unit_value = match (bits_unit_value, int_value) {
+                        (Some(unit), Some(_)) => Some(unit),
+                        _ => None,
+                    };
 
                     builder.bit_array_segment();
                     self.bit_array_pattern_segment_value(builder, segment);

--- a/compiler-core/src/erlang/pattern.rs
+++ b/compiler-core/src/erlang/pattern.rs
@@ -240,31 +240,14 @@ impl<'a, 'generator, 'module> PatternGenerator<'a, 'generator, 'module> {
                     // When a bits segment has both size and unit as literal
                     // ints, multiply them so the unit specifier can be
                     // dropped. The BEAM rejects unit with bitstring.
-                    let mut has_bits = false;
-                    let mut bits_unit_value = None;
-                    let mut int_value = None;
-                    for option in &segment.options {
-                        #[allow(clippy::wildcard_enum_match_arm)]
-                        match option {
-                            BitArrayOption::Bits { .. } => has_bits = true,
-                            BitArrayOption::Unit { value, .. } => bits_unit_value = Some(*value),
-                            BitArrayOption::Size { value, .. } => {
-                                if let Pattern::BitArraySize(BitArraySize::Int {
-                                    int_value: iv,
-                                    ..
-                                }) = value.as_ref()
-                                {
-                                    int_value = Some(iv);
-                                }
-                            }
-                            _ => {}
+                    let (bits_unit_value, size_value) = collect_bit_array_options(&segment.options);
+                    let int_value = size_value.and_then(|v| match v {
+                        Pattern::BitArraySize(BitArraySize::Int { int_value, .. }) => {
+                            Some(int_value)
                         }
-                    }
-                    let bits_unit_value = if has_bits && int_value.is_some() {
-                        bits_unit_value
-                    } else {
-                        None
-                    };
+                        _ => None,
+                    });
+                    let bits_unit_value = bits_unit_value.filter(|_| int_value.is_some());
 
                     builder.bit_array_segment();
                     self.bit_array_pattern_segment_value(builder, segment);

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -532,6 +532,29 @@ pub fn go(wibble: String) {
 
 // https://github.com/gleam-lang/gleam/issues/5208
 #[test]
+fn unit_with_bits_option() {
+    assert_erl!(
+        "
+pub fn go(x) {
+  <<x:bits-size(8)-unit(8)>>
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
+fn unit_with_bits_option_constant() {
+    assert_erl!(
+        "
+pub const bits = <<1, 2, 3>>
+pub const more_bits = <<bits:bits-size(3)-unit(8)>>
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
 fn unit_option_ignores_bytes() {
     assert_erl!(
         "

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -573,6 +573,19 @@ pub fn main(x) {
 
 // https://github.com/gleam-lang/gleam/issues/5984
 #[test]
+fn unit_with_bits_option_variable_size() {
+    assert_erl!(
+        "
+pub fn main(x) {
+  let size = 8
+  <<x:bits-size(size)-unit(8)>>
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
 fn unit_option_ignores_bytes() {
     assert_erl!(
         "

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -576,9 +576,21 @@ pub fn main(x) {
 fn unit_with_bits_option_variable_size() {
     assert_erl!(
         "
-pub fn main(x) {
-  let size = 8
+pub fn main(x, size) {
   <<x:bits-size(size)-unit(8)>>
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
+fn unit_with_bits_option_variable_size_pattern() {
+    assert_erl!(
+        "
+pub fn main(x, size) {
+  let assert <<a:size(size)-unit(8)-bits, _:bits>> = x
+  a
 }
 "
     );

--- a/compiler-core/src/erlang/tests/bit_arrays.rs
+++ b/compiler-core/src/erlang/tests/bit_arrays.rs
@@ -532,6 +532,58 @@ pub fn go(wibble: String) {
 
 // https://github.com/gleam-lang/gleam/issues/5208
 #[test]
+fn unit_with_bits_option() {
+    assert_erl!(
+        "
+pub fn go(x) {
+  <<x:bits-size(8)-unit(8)>>
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
+fn unit_with_bits_option_constant() {
+    assert_erl!(
+        "
+pub const bits = <<1, 2, 3>>
+pub const more_bits = <<bits:bits-size(3)-unit(8)>>
+
+pub fn main() {
+  more_bits
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
+fn unit_with_bits_option_variable_size() {
+    assert_erl!(
+        "
+pub fn main(x, size) {
+  <<x:bits-size(size)-unit(8)>>
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
+fn unit_with_bits_option_variable_size_pattern() {
+    assert_erl!(
+        "
+pub fn main(x, size) {
+  let assert <<a:size(size)-unit(8)-bits, _:bits>> = x
+  a
+}
+"
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/5984
+#[test]
 fn unit_option_ignores_bytes() {
     assert_erl!(
         "

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+assertion_line: 535
+expression: "\npub fn go(x) {\n  <<x:bits-size(8)-unit(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  <<x:bits-size(8)-unit(8)>>
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([go/1]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec go(bitstring()) -> bitstring().
+go(X) ->
+    <<X:64/bitstring>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+assertion_line: 536
+expression: "\npub fn go(x) {\n  <<x:bits-size(8)-unit(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  <<x:bits-size(8)-unit(8)>>
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([go/1]).
+
+-spec go(bitstring()) -> bitstring().
+go(X) ->
+    <<X:64/bitstring>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_constant.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+assertion_line: 546
+expression: "\npub const bits = <<1, 2, 3>>\npub const more_bits = <<bits:bits-size(3)-unit(8)>>\n"
+---
+----- SOURCE CODE
+
+pub const bits = <<1, 2, 3>>
+pub const more_bits = <<bits:bits-size(3)-unit(8)>>
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_constant.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\npub const bits = <<1, 2, 3>>\npub const more_bits = <<bits:bits-size(3)-unit(8)>>\n\npub fn main() {\n  more_bits\n}\n"
+---
+----- SOURCE CODE
+
+pub const bits = <<1, 2, 3>>
+pub const more_bits = <<bits:bits-size(3)-unit(8)>>
+
+pub fn main() {
+  more_bits
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-spec main() -> bitstring().
+main() ->
+    <<<<1, 2, 3>>:24/bitstring>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+assertion_line: 563
+expression: "\npub fn main(x, size) {\n  <<x:bits-size(size)-unit(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, size) {
+  <<x:bits-size(size)-unit(8)>>
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/2]).
+
+-spec main(bitstring(), integer()) -> bitstring().
+main(X, Size) ->
+    <<X:(erlang:max(0, Size * 8))/bitstring>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size.snap
@@ -1,11 +1,10 @@
 ---
 source: compiler-core/src/erlang/tests/bit_arrays.rs
-expression: "\npub fn main(x) {\n  let size = 8\n  <<x:bits-size(size)-unit(8)>>\n}\n"
+expression: "\npub fn main(x, size) {\n  <<x:bits-size(size)-unit(8)>>\n}\n"
 ---
 ----- SOURCE CODE
 
-pub fn main(x) {
-  let size = 8
+pub fn main(x, size) {
   <<x:bits-size(size)-unit(8)>>
 }
 
@@ -13,10 +12,9 @@ pub fn main(x) {
 ----- COMPILED ERLANG
 -module(my@mod).
 -compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
--export([main/1]).
+-export([main/2]).
 
 -file("project/test/my/mod.gleam", 2).
--spec main(bitstring()) -> bitstring().
-main(X) ->
-    Size = 8,
+-spec main(bitstring(), integer()) -> bitstring().
+main(X, Size) ->
     <<X:(erlang:max(0, Size * 8))/bitstring>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\npub fn main(x) {\n  let size = 8\n  <<x:bits-size(size)-unit(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  let size = 8
+  <<x:bits-size(size)-unit(8)>>
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/1]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec main(bitstring()) -> bitstring().
+main(X) ->
+    Size = 8,
+    <<X:(erlang:max(0, Size * 8))/bitstring>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size_pattern.snap
@@ -1,0 +1,39 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+expression: "\npub fn main(x, size) {\n  let assert <<a:size(size)-unit(8)-bits, _:bits>> = x\n  a\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, size) {
+  let assert <<a:size(size)-unit(8)-bits, _:bits>> = x
+  a
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/2]).
+
+-file("project/test/my/mod.gleam", 2).
+-spec main(bitstring(), integer()) -> bitstring().
+main(X, Size) ->
+    case X of
+        <<A:Size/bitstring-unit:8, _/bitstring>> ->
+            A;
+
+        _value ->
+            erlang:error(#{
+                gleam_error => let_assert,
+                message => ~"Pattern match failed, no pattern matched the value.",
+                file => ~"project/test/my/mod.gleam",
+                module => ~"my/mod",
+                function => ~"main",
+                line => 3,
+                value => _value,
+                start => 26,
+                'end' => 78,
+                pattern_start => 37,
+                pattern_end => 74
+            })
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size_pattern.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__bit_arrays__unit_with_bits_option_variable_size_pattern.snap
@@ -1,0 +1,39 @@
+---
+source: compiler-core/src/erlang/tests/bit_arrays.rs
+assertion_line: 575
+expression: "\npub fn main(x, size) {\n  let assert <<a:size(size)-unit(8)-bits, _:bits>> = x\n  a\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, size) {
+  let assert <<a:size(size)-unit(8)-bits, _:bits>> = x
+  a
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/2]).
+
+-spec main(bitstring(), integer()) -> bitstring().
+main(X, Size) ->
+    case X of
+        <<A:Size/bitstring-unit:8, _/bitstring>> ->
+            A;
+
+        _value ->
+            erlang:error(#{
+                gleam_error => let_assert,
+                message => ~"Pattern match failed, no pattern matched the value.",
+                file => ~"project/test/my/mod.gleam",
+                module => ~"my/mod",
+                function => ~"main",
+                line => 3,
+                value => _value,
+                start => 26,
+                'end' => 78,
+                pattern_start => 37,
+                pattern_end => 74
+            })
+    end.

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -2515,6 +2515,10 @@ fn unit_with_bits_option_constant() {
         "
 pub const bits = <<1, 2, 3>>
 pub const more_bits = <<bits:bits-size(3)-unit(8)>>
+
+pub fn main() {
+  more_bits
+}
 "
     );
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__unit_with_bits_option_constant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__unit_with_bits_option_constant.snap
@@ -1,11 +1,15 @@
 ---
 source: compiler-core/src/javascript/tests/bit_arrays.rs
-expression: "\npub const bits = <<1, 2, 3>>\npub const more_bits = <<bits:bits-size(3)-unit(8)>>\n"
+expression: "\npub const bits = <<1, 2, 3>>\npub const more_bits = <<bits:bits-size(3)-unit(8)>>\n\npub fn main() {\n  more_bits\n}\n"
 ---
 ----- SOURCE CODE
 
 pub const bits = <<1, 2, 3>>
 pub const more_bits = <<bits:bits-size(3)-unit(8)>>
+
+pub fn main() {
+  more_bits
+}
 
 
 ----- COMPILED JAVASCRIPT
@@ -14,3 +18,7 @@ import { toBitArray, bitArraySlice } from "../gleam.mjs";
 export const bits = /* @__PURE__ */ toBitArray([1, 2, 3]);
 
 export const more_bits = /* @__PURE__ */ toBitArray([bitArraySlice(bits, 0, 24)]);
+
+export function main() {
+  return more_bits;
+}

--- a/test/language/test/language/bit_array_test.gleam
+++ b/test/language/test/language/bit_array_test.gleam
@@ -192,3 +192,23 @@ pub fn sliced_bit_array_data_view_byte_length_test() {
   let assert Ok(sliced) = bit_array.slice(data, 1, 2)
   assert sliced == <<0xBB, 0xCC>>
 }
+
+pub fn bits_with_unit_literal_size_test() {
+  let data = <<1, 2>>
+  let result = <<data:bits-size(8)-unit(8)>>
+  assert result == <<1, 2>>
+}
+
+pub fn bits_with_unit_variable_size_test() {
+  let data = <<1, 2>>
+  let size = 16
+  let result = <<data:bits-size(size)-unit(8)>>
+  assert result == <<1, 2>>
+}
+
+pub fn bits_with_unit_pattern_test() {
+  let data = <<1, 2>>
+  let assert <<a:size(8)-unit(8)-bits, b:size(8)-unit(8)-bits>> = data
+  assert a == 1
+  assert b == 2
+}

--- a/test/language/test/language/bit_array_test.gleam
+++ b/test/language/test/language/bit_array_test.gleam
@@ -220,3 +220,23 @@ pub fn zero_size_int_segment_test() {
   assert <<0:size(0), 1:size(8)>> == <<1>>
   assert bit_array.bit_size(<<0:size(0)>>) == 0
 }
+
+pub fn bits_with_unit_literal_size_test() {
+  let data = <<1, 2>>
+  let result = <<data:bits-size(2)-unit(8)>>
+  assert result == <<1, 2>>
+}
+
+pub fn bits_with_unit_variable_size_test() {
+  let data = <<1, 2>>
+  let size = 2
+  let result = <<data:bits-size(size)-unit(8)>>
+  assert result == <<1, 2>>
+}
+
+pub fn bits_with_unit_pattern_test() {
+  let data = <<1, 2>>
+  let assert <<a:size(1)-unit(8)-bits, b:size(1)-unit(8)-bits>> = data
+  assert a == <<1>>
+  assert b == <<2>>
+}


### PR DESCRIPTION
Fixes #5984

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
