### PR TITLE
Remove references to "foobar" in codebase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,13 @@
     "Telem",
     "Unretire",
     "Untar",
-    "walkdir"
+    "walkdir",
+    // Alternatives to "foo bar"
+    "!foo",
+    "!foobar",
+    "wibble",
+    "wobble",
+    "warble"
   ],
   "cSpell.language": "en,uk,en-GB,en-US"
 }

--- a/compiler-cli/src/beam_compiler.rs
+++ b/compiler-cli/src/beam_compiler.rs
@@ -160,16 +160,16 @@ mod tests {
     #[test]
     fn escape_path_plain() {
         assert_eq!(
-            escape_path("/build/packages/foo/src/bar.erl"),
-            "/build/packages/foo/src/bar.erl"
+            escape_path("/build/packages/wibble/src/bar.erl"),
+            "/build/packages/wibble/src/bar.erl"
         );
     }
 
     #[test]
     fn escape_path_backslash() {
         assert_eq!(
-            escape_path("C:\\Users\\foo\\bar.erl"),
-            "C:\\\\Users\\\\foo\\\\bar.erl"
+            escape_path("C:\\Users\\wibble\\bar.erl"),
+            "C:\\\\Users\\\\wibble\\\\bar.erl"
         );
     }
 

--- a/hexpm/src/version/lexer.rs
+++ b/hexpm/src/version/lexer.rs
@@ -294,12 +294,12 @@ mod tests {
     #[test]
     pub fn whitespace() {
         assert_eq!(
-            lex("  foo \t\n\rbar"),
+            lex("  wibble \t\n\rwobble"),
             vec![
                 Whitespace(0, 2),
-                AlphaNumeric("foo"),
-                Whitespace(5, 9),
-                AlphaNumeric("bar"),
+                AlphaNumeric("wibble"),
+                Whitespace(8, 12),
+                AlphaNumeric("wobble"),
             ]
         );
     }

--- a/hexpm/src/version/parser.rs
+++ b/hexpm/src/version/parser.rs
@@ -146,7 +146,7 @@ impl<'input> Parser<'input> {
 
     /// Parse an string identifier.
     ///
-    /// Like, `foo`, or `bar`, or `beta-1`.
+    /// Like, `wibble`, or `wobble`, or `beta-1`.
     pub fn identifier(&mut self) -> Result<Identifier, Error> {
         let identifier = match self.pop()? {
             Token::AlphaNumeric(identifier) => {

--- a/hexpm/src/version/tests.rs
+++ b/hexpm/src/version/tests.rs
@@ -132,7 +132,7 @@ version_parse_test!(
     Some("ignore".to_string())
 );
 
-version_parse_fail_test!(just_a_word, "foobar");
+version_parse_fail_test!(just_a_word, "wibble");
 
 version_parse_fail_test!(just_major, "2");
 
@@ -359,7 +359,7 @@ parse_range_fail_test!(range_just_major, "1");
 parse_range_fail_test!(range_just_major_minor, "1.1");
 parse_range_fail_test!(alpha_component, "1.1.a");
 
-parse_range_fail_test!(range_word, "foobar");
+parse_range_fail_test!(range_word, "wibble");
 parse_range_fail_test!(range_major_dot, "2.");
 parse_range_fail_test!(range_major_minor_dot, "2.3.");
 parse_range_fail_test!(range_triplet_dash, "2.3.0-");


### PR DESCRIPTION
- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes

Based on conversation in https://github.com/gleam-lang/gleam/pull/5997, I figured this could be helpful. This:

- Forbids `foo` and `foobar` in the cspell config and allows alternatives, which should help some contributors catch this mistake before making a PR.
- Removes references to `foo` (and the following `bar`) and `foobar` that I found with `git grep '\bfoo\b'` and `git grep '\bfoobar\b'`.

Forbidding `bar` seemed too extreme since it has way more uses than just as a placeholder word. I think that forbidding the first word in the "foo bar baz etc." sequence is enough to encourage developers to use an alternative sequence.