### PR TITLE
Improve error message when reverting a non-existent Hex release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@
   when building large projects.
   ([John Downey](https://github.com/jtdowney))
 
+- `gleam hex revert` now shows a clearer error when the specified package
+  version does not exist on Hex, including the package name and version in the
+  message rather than the generic "Resource was not found".
+  ([KevesDev](https://github.com/KevesDev))
+
 ### Language server
 
 - The language server now supports go-to-definition, find-references and rename

--- a/compiler-cli/src/hex.rs
+++ b/compiler-cli/src/hex.rs
@@ -114,7 +114,13 @@ pub fn revert(
     )
     .map_err(Error::hex)?;
     let response = runtime.block_on(http.send(request))?;
-    hexpm::api_revert_release_response(response).map_err(Error::hex)?;
+    match hexpm::api_revert_release_response(response) {
+        Ok(()) => (),
+        Err(hexpm::ApiError::NotFound) => {
+            return Err(Error::HexReleaseNotFound { package, version });
+        }
+        Err(error) => return Err(Error::hex(error)),
+    }
 
     // Done!
     println!("{package} {version} has been removed from Hex");

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -430,6 +430,9 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
     #[error("Incorrect Hex one-time-password")]
     IncorrectHexOneTimePassword,
 
+    #[error("Hex release not found")]
+    HexReleaseNotFound { package: String, version: String },
+
     #[error("{path} could not be added to the tarball as it is outside the project root")]
     TarPathOutsideOfProjectRoot { path: Utf8PathBuf },
 
@@ -2521,6 +2524,18 @@ add `gleam add {name}` in this project."
                 level: Level::Error,
                 location: None,
                 hint: None,
+            }],
+
+            Error::HexReleaseNotFound { package, version } => vec![Diagnostic {
+                title: "Release not found".into(),
+                text: wrap_format!(
+                    "There is no version {version} of the package {package} on Hex."
+                ),
+                level: Level::Error,
+                location: None,
+                hint: Some(
+                    "Check that the package name and version are correct.".into(),
+                ),
             }],
         }
     }

--- a/hexpm/src/tests.rs
+++ b/hexpm/src/tests.rs
@@ -86,6 +86,13 @@ fn revert_release_response_too_old_error() {
 }
 
 #[test]
+fn revert_release_response_not_found() {
+    let response = make_response(404, vec![]);
+    let result = crate::api_revert_release_response(response);
+    assert!(matches!(result, Err(ApiError::NotFound)));
+}
+
+#[test]
 fn add_owner_request() {
     let key = WriteActionCredentials::OAuthAccessToken {
         access_token: EcoString::from("my-api-key-here"),


### PR DESCRIPTION
When running gleam hex revert with an invalid version, the error message only reports Resource was not found, which doesn't provide any context about whether the package or version was missing.

To improve this, I added a new error variant in compiler-core/src/error.rs that includes the package name and version. In compiler-cli/src/hex.rs, the NotFound case from the hexpm crate is now caught and converted into this more specific error instead of returning the generic one.

I followed the existing pattern used by HexPublishAccessDenied and HexPublishReplaceRequired. The CLI layer already has the package and version information available, while the hexpm crate does not, so this context belongs at the caller level.

While investigating this, I looked into api_revert_release_response() in the hexpm crate and found that it discards the 404 response body entirely. This means there is no way to distinguish between a missing package and a missing version, which was the question raised in PR #5717. Because of this limitation, the error message reports that "version X of package Y" was not found rather than attempting to make a more specific distinction.

Closes #5709