### PR TITLE
Fix bug with bit array float slice and `Number` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   whose line broke in the middle of a multi-byte UTF-8 character.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where invalid JavaScript would be generated for code which used a
+  bit array pattern to extract a `Float` and had a constructor called `Number`.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
+
 ## v1.18.0-rc1 - 2026-07-21
 
 ### Compiler

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -1414,7 +1414,7 @@ impl<'generator, 'module, 'a, 'doc> Variables<'generator, 'module, 'a, 'doc> {
 
                     docvec![
                         arena,
-                        NUMBER_DOT_IS_FINITE_OPEN_PAREN_DOCUMENT,
+                        GLOBAL_THIS_DOT_NUMBER_DOT_IS_FINITE_OPEN_PAREN_DOCUMENT,
                         check,
                         CLOSE_PAREN_DOCUMENT
                     ]

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -1108,3 +1108,22 @@ pub fn go() {
 }"#
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/6029
+#[test]
+fn bit_array_slice_float_with_number_constructor() {
+    assert_js!(
+        "
+pub type Number {
+  Number(Int)
+}
+
+pub fn go(bit_array) {
+  case bit_array {
+    <<f:float>> -> f
+    _ -> 0.0
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 export function go(x) {
   if (
     x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
     x.bitSize === 72
   ) {
     let a = bitArraySliceToFloat(x, 0, 64, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_16_bit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_16_bit.snap
@@ -16,7 +16,10 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (x.bitSize === 16 && Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))) {
+  if (
+    x.bitSize === 16 &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))
+  ) {
     let a = bitArraySliceToFloat(x, 0, 16, true);
     return a;
   } else {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_big_endian.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 export function go(x) {
   if (
     x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
     x.bitSize === 72
   ) {
     let a = bitArraySliceToFloat(x, 0, 64, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_little_endian.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 export function go(x) {
   if (
     x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, false)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, false)) &&
     x.bitSize === 72
   ) {
     let a = bitArraySliceToFloat(x, 0, 64, false);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 export function go(x) {
   if (
     x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
     x.bitSize === 40
   ) {
     let a = bitArraySliceToFloat(x, 0, 32, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_big_endian.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 export function go(x) {
   if (
     x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
     x.bitSize === 40
   ) {
     let a = bitArraySliceToFloat(x, 0, 32, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__case_match_float_sized_little_endian.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 export function go(x) {
   if (
     x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, false)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, false)) &&
     x.bitSize === 40
   ) {
     let a = bitArraySliceToFloat(x, 0, 32, false);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float.snap
@@ -19,7 +19,7 @@ export function go(x) {
   let b;
   if (
     x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
     x.bitSize === 72
   ) {
     a = bitArraySliceToFloat(x, 0, 64, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_16_bit.snap
@@ -16,7 +16,10 @@ const FILEPATH = "src/module.gleam";
 
 export function go(x) {
   let a;
-  if (x.bitSize === 16 && Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))) {
+  if (
+    x.bitSize === 16 &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 16, true))
+  ) {
     a = bitArraySliceToFloat(x, 0, 16, true);
   } else {
     throw makeError(

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_big_endian.snap
@@ -19,7 +19,7 @@ export function go(x) {
   let b;
   if (
     x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true)) &&
     x.bitSize === 72
   ) {
     a = bitArraySliceToFloat(x, 0, 64, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_little_endian.snap
@@ -19,7 +19,7 @@ export function go(x) {
   let b;
   if (
     x.bitSize >= 64 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 64, false)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, false)) &&
     x.bitSize === 72
   ) {
     a = bitArraySliceToFloat(x, 0, 64, false);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized.snap
@@ -19,7 +19,7 @@ export function go(x) {
   let b;
   if (
     x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
     x.bitSize === 40
   ) {
     a = bitArraySliceToFloat(x, 0, 32, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_big_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_big_endian.snap
@@ -19,7 +19,7 @@ export function go(x) {
   let b;
   if (
     x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true)) &&
     x.bitSize === 40
   ) {
     a = bitArraySliceToFloat(x, 0, 32, true);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_little_endian.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__match_float_sized_little_endian.snap
@@ -19,7 +19,7 @@ export function go(x) {
   let b;
   if (
     x.bitSize >= 32 &&
-    Number.isFinite(bitArraySliceToFloat(x, 0, 32, false)) &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, false)) &&
     x.bitSize === 40
   ) {
     a = bitArraySliceToFloat(x, 0, 32, false);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_minus_infinity_still_reachable_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 && x.byteAt(1) === 128 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_nan_still_reachable_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 && x.byteAt(1) === 192 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_32_float_plus_infinity_still_reachable_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 32) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 32, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 && x.byteAt(1) === 128 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_float_is_unreachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_float_is_unreachable.snap
@@ -17,7 +17,10 @@ pub fn go(x) {
 import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
-  if (x.bitSize === 64 && Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+  if (
+    x.bitSize === 64 &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))
+  ) {
     return "Float";
   } else {
     return "Other";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_int_is_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_int_is_still_reachable.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else {
       return "Int";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_minus_infinity_still_reachable_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 255 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_nan_still_reachable_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__pattern_matching_on_64_float_plus_infinity_still_reachable_2.snap
@@ -18,7 +18,7 @@ import { bitArraySliceToFloat } from "../gleam.mjs";
 
 export function go(x) {
   if (x.bitSize === 64) {
-    if (Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
+    if (globalThis.Number.isFinite(bitArraySliceToFloat(x, 0, 64, true))) {
       return "Float";
     } else if (
       x.byteAt(0) === 127 &&

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__bit_array_slice_float_with_number_constructor.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__bit_array_slice_float_with_number_constructor.snap
@@ -1,0 +1,42 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub type Number {\n  Number(Int)\n}\n\npub fn go(bit_array) {\n  case bit_array {\n    <<f:float>> -> f\n    _ -> 0.0\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub type Number {
+  Number(Int)
+}
+
+pub fn go(bit_array) {
+  case bit_array {
+    <<f:float>> -> f
+    _ -> 0.0
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType, bitArraySliceToFloat } from "../gleam.mjs";
+
+export class Number extends $CustomType {
+  constructor($0) {
+    super();
+    this[0] = $0;
+  }
+}
+export const Number$Number = ($0) => new Number($0);
+export const Number$isNumber = (value) => value instanceof Number;
+export const Number$Number$0 = (value) => value[0];
+
+export function go(bit_array) {
+  if (
+    bit_array.bitSize === 64 &&
+    globalThis.Number.isFinite(bitArraySliceToFloat(bit_array, 0, 64, true))
+  ) {
+    let f = bitArraySliceToFloat(bit_array, 0, 64, true);
+    return f;
+  } else {
+    return 0.0;
+  }
+}

--- a/pretty-arena/src/lib.rs
+++ b/pretty-arena/src/lib.rs
@@ -839,9 +839,9 @@ const_str!(CLOSE_PAREN_MODULO_8_DOCUMENT, ") % 8", 5);
 const_str!(SPACE_GT_EQ_ZERO_DOCUMENT, " >= 0", 5);
 const_str!(SPACE_GT_EQ_SPACE_DOCUMENT, " >= ", 4);
 const_str!(
-    NUMBER_DOT_IS_FINITE_OPEN_PAREN_DOCUMENT,
-    "Number.isFinite(",
-    16
+    GLOBAL_THIS_DOT_NUMBER_DOT_IS_FINITE_OPEN_PAREN_DOCUMENT,
+    "globalThis.Number.isFinite(",
+    27
 );
 const_str!(SPACE_INSTANCE_OF_SPACE_DOCUMENT, " instanceof ", 12);
 const_str!(


### PR DESCRIPTION
Fixes #6029

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
