### PR TITLE
Fix ignored type annotations on discarded variables in `use` bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   compiles.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where type annotations on discarded variables in `use` bindings
+  were ignored.
+  ([Francesco Cappetti](https://github.com/frakappa))
+
 ## v1.18.0-rc1 - 2026-07-21
 
 ### Compiler

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -6049,7 +6049,7 @@ impl UseAssignments {
                 Pattern::Discard { name, .. } => assignments.function_arguments.push(Arg {
                     location,
                     names: ArgNames::Discard { name, location },
-                    annotation: None,
+                    annotation,
                     type_: (),
                 }),
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___discard_pattern_type_annotation_is_checked.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___discard_pattern_type_annotation_is_checked.snap
@@ -1,37 +1,30 @@
 ---
 source: compiler-core/src/type_/tests/use_.rs
-expression: "\npub type Woo(a) {\n  Woo\n}\n\npub fn wibble(_f: fn(Woo(a)) -> Nil) -> Woo(a) {\n  Woo\n}\n\npub fn main() -> Woo(Int) {\n  use _: Woo(String) <- wibble()\n  Nil\n}\n"
+expression: "\nfn wibble(f: fn(Int, String) -> Nil) -> Nil {\n  f(1, \"\")\n}\n\npub fn main() {\n  use _a: Int, _b: Float <- wibble()\n  Nil\n}\n"
 ---
 ----- SOURCE CODE
 
-pub type Woo(a) {
-  Woo
+fn wibble(f: fn(Int, String) -> Nil) -> Nil {
+  f(1, "")
 }
 
-pub fn wibble(_f: fn(Woo(a)) -> Nil) -> Woo(a) {
-  Woo
-}
-
-pub fn main() -> Woo(Int) {
-  use _: Woo(String) <- wibble()
+pub fn main() {
+  use _a: Int, _b: Float <- wibble()
   Nil
 }
 
 
 ----- ERROR
 error: Type mismatch
-   ┌─ /src/one/two.gleam:11:3
-   │
-11 │   use _: Woo(String) <- wibble()
-   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The type of this returned value doesn't match the return type
-annotation of this function.
+  ┌─ /src/one/two.gleam:7:16
+  │
+7 │   use _a: Int, _b: Float <- wibble()
+  │                ^^^^^^^^^
 
 Expected type:
 
-    Woo(Int)
+    String
 
 Found type:
 
-    Woo(String)
+    Float

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___discard_pattern_type_annotation_is_checked.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__use___discard_pattern_type_annotation_is_checked.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/type_/tests/use_.rs
+expression: "\npub type Woo(a) {\n  Woo\n}\n\npub fn wibble(_f: fn(Woo(a)) -> Nil) -> Woo(a) {\n  Woo\n}\n\npub fn main() -> Woo(Int) {\n  use _: Woo(String) <- wibble()\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+pub type Woo(a) {
+  Woo
+}
+
+pub fn wibble(_f: fn(Woo(a)) -> Nil) -> Woo(a) {
+  Woo
+}
+
+pub fn main() -> Woo(Int) {
+  use _: Woo(String) <- wibble()
+  Nil
+}
+
+
+----- ERROR
+error: Type mismatch
+   ┌─ /src/one/two.gleam:11:3
+   │
+11 │   use _: Woo(String) <- wibble()
+   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The type of this returned value doesn't match the return type
+annotation of this function.
+
+Expected type:
+
+    Woo(Int)
+
+Found type:
+
+    Woo(String)

--- a/compiler-core/src/type_/tests/use_.rs
+++ b/compiler-core/src/type_/tests/use_.rs
@@ -501,16 +501,12 @@ use <- x()
 fn discard_pattern_type_annotation_is_checked() {
     assert_module_error!(
         r#"
-pub type Woo(a) {
-  Woo
+fn wibble(f: fn(Int, String) -> Nil) -> Nil {
+  f(1, "")
 }
 
-pub fn wibble(_f: fn(Woo(a)) -> Nil) -> Woo(a) {
-  Woo
-}
-
-pub fn main() -> Woo(Int) {
-  use _: Woo(String) <- wibble()
+pub fn main() {
+  use _a: Int, _b: Float <- wibble()
   Nil
 }
 "#

--- a/compiler-core/src/type_/tests/use_.rs
+++ b/compiler-core/src/type_/tests/use_.rs
@@ -496,3 +496,23 @@ use <- x()
 "#
     );
 }
+
+#[test]
+fn discard_pattern_type_annotation_is_checked() {
+    assert_module_error!(
+        r#"
+pub type Woo(a) {
+  Woo
+}
+
+pub fn wibble(_f: fn(Woo(a)) -> Nil) -> Woo(a) {
+  Woo
+}
+
+pub fn main() -> Woo(Int) {
+  use _: Woo(String) <- wibble()
+  Nil
+}
+"#
+    );
+}


### PR DESCRIPTION
- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes

Closes #6031 .