### PR TITLE
Fix formatting of negative alternate base numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   segments on the JavaScript target.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where the formatter would insert underscores into negative
+  hexadecimal, octal, and binary literals, producing code that no longer
+  compiles.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.0-rc1 - 2026-07-21
 
 ### Compiler

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1460,7 +1460,8 @@ impl<'a, 'doc> Formatter<'a> {
     }
 
     fn int(&self, arena: &'doc DocumentArena<'a, 'doc>, value: &'a str) -> Document<'a, 'doc> {
-        if value.starts_with("0x") || value.starts_with("0b") || value.starts_with("0o") {
+        let digits = value.trim_start_matches('-');
+        if digits.starts_with("0x") || digits.starts_with("0b") || digits.starts_with("0o") {
             return value.to_doc(arena);
         }
 

--- a/format/src/tests.rs
+++ b/format/src/tests.rs
@@ -1358,6 +1358,9 @@ fn expr_int() {
     assert_format!("fn o() {\n  0o1234567\n}\n");
     assert_format!("fn o() {\n  0o1_234_567\n}\n");
     assert_format!("fn o() {\n  0o_123_456_7\n}\n");
+    assert_format!("fn h() {\n  -0xFFFFF\n}\n");
+    assert_format!("fn b() {\n  -0b10100001\n}\n");
+    assert_format!("fn o() {\n  -0o1234567\n}\n");
 }
 
 #[test]


### PR DESCRIPTION
- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
