### PR TITLE
Fix 16-bit encoding for -0.0 on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   bit array pattern to extract a `Float` and had a constructor called `Number`.
   ([Surya Rose](https://github.com/GearsDatapacks))
 
+- Fixed a bug where `-0.0` would be encoded incorrectly in 16-bit bit array
+  segments on the JavaScript target.
+  ([Surya Rose](https://github.com/GearsDatapacks))
 
 ## v1.18.0-rc1 - 2026-07-21
 

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -1255,7 +1255,11 @@ function numberToFp16Uint(value, isBigEndian) {
   } else if (value === -Infinity) {
     buffer[1] = 0xfc;
   } else if (value === 0) {
-    // Both values are already zero
+    // 0 === -0, so we need to do an additional check here
+    if (isNegativeZero(value)) {
+      buffer[1] = 128;
+    }
+    // Otherwise, both values are already zero
   } else {
     const sign = value < 0 ? 1 : 0;
     value = Math.abs(value);
@@ -1287,6 +1291,19 @@ function numberToFp16Uint(value, isBigEndian) {
   }
 
   return buffer;
+}
+
+/**
+ * Returns whether or not a value is `-0`, since this cannot be checked using
+ * equality.
+ *
+ * @param {number} value
+ * @returns {boolean}
+ */
+function isNegativeZero(value) {
+  // One of the few differences between 0 and -0 is that division by -0 returns
+  // -Infinity rather than Infinity.
+  return 1 / value === -Infinity;
 }
 
 /**

--- a/test/language/test/language/bit_array_test.gleam
+++ b/test/language/test/language/bit_array_test.gleam
@@ -192,3 +192,9 @@ pub fn sliced_bit_array_data_view_byte_length_test() {
   let assert Ok(sliced) = bit_array.slice(data, 1, 2)
   assert sliced == <<0xBB, 0xCC>>
 }
+
+// https://github.com/gleam-lang/gleam/issues/6036
+pub fn negative_zero_16_bits_test() {
+  let data = <<-0.0:16>>
+  assert data == <<0x8000:16>>
+}


### PR DESCRIPTION
Fixes #6036 

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
