### PR TITLE
fix: renaming a record constructor deletes its arguments in constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   single or multiple conflicting files existed in the target directory.
   ([Spenser Black](https://github.com/spenserblack))
 
+- Fixed a bug where renaming constructors referenced in constants
+  results in incorrect code.
+  ([Khalid Belkassmi E.H.](https://github.com/khalidbelk))
+
 ## v1.18.0-rc2 - 2026-07-25
 
 ### Bug fixes

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -42,7 +42,7 @@ pub enum Constant<T> {
 
     Record {
         location: SrcSpan,
-        constructor_location: SrcSpan,
+        arguments_start_position: u32,
         module: Option<(EcoString, SrcSpan)>,
         name: EcoString,
         /// These are the arguments used when calling the record.

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -42,6 +42,7 @@ pub enum Constant<T> {
 
     Record {
         location: SrcSpan,
+        constructor_location: SrcSpan,
         module: Option<(EcoString, SrcSpan)>,
         name: EcoString,
         /// These are the arguments used when calling the record.

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -742,6 +742,7 @@ pub trait Visit<'ast> {
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
+        constructor_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<TypedConstant>>>,
@@ -752,6 +753,7 @@ pub trait Visit<'ast> {
         visit_typed_constant_record(
             self,
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -866,6 +868,7 @@ fn visit_typed_constant_bit_array<'a, V: Visit<'a> + ?Sized>(
 pub fn visit_typed_constant_record<'a, V: Visit<'a> + ?Sized>(
     v: &mut V,
     _location: &'a SrcSpan,
+    _constructor_location: &'a SrcSpan,
     _module: &'a Option<(EcoString, SrcSpan)>,
     _name: &'a EcoString,
     arguments: &'a Option<Vec<CallArg<TypedConstant>>>,
@@ -1172,6 +1175,7 @@ pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a 
         } => v.visit_typed_constant_list(location, elements, type_, tail),
         super::Constant::Record {
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -1180,6 +1184,7 @@ pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a 
             record_constructor,
         } => v.visit_typed_constant_record(
             location,
+            constructor_location,
             module,
             name,
             arguments,

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -742,7 +742,7 @@ pub trait Visit<'ast> {
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
-        constructor_location: &'ast SrcSpan,
+        arguments_start_position: &'ast u32,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<TypedConstant>>>,
@@ -753,7 +753,7 @@ pub trait Visit<'ast> {
         visit_typed_constant_record(
             self,
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -868,7 +868,7 @@ fn visit_typed_constant_bit_array<'a, V: Visit<'a> + ?Sized>(
 pub fn visit_typed_constant_record<'a, V: Visit<'a> + ?Sized>(
     v: &mut V,
     _location: &'a SrcSpan,
-    _constructor_location: &'a SrcSpan,
+    _arguments_start_position: &'a u32,
     _module: &'a Option<(EcoString, SrcSpan)>,
     _name: &'a EcoString,
     arguments: &'a Option<Vec<CallArg<TypedConstant>>>,
@@ -1175,7 +1175,7 @@ pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a 
         } => v.visit_typed_constant_list(location, elements, type_, tail),
         super::Constant::Record {
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -1184,7 +1184,7 @@ pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a 
             record_constructor,
         } => v.visit_typed_constant_record(
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -993,14 +993,14 @@ pub trait UntypedConstantFolder {
 
             Constant::Record {
                 location,
-                constructor_location,
+                arguments_start_position,
                 module,
                 name,
                 arguments,
                 type_: (),
                 field_map: _,
                 record_constructor: _,
-            } => self.fold_constant_record(location, constructor_location, module, name, arguments),
+            } => self.fold_constant_record(location, arguments_start_position, module, name, arguments),
 
             Constant::RecordUpdate {
                 location,
@@ -1117,14 +1117,14 @@ pub trait UntypedConstantFolder {
     fn fold_constant_record(
         &mut self,
         location: SrcSpan,
-        constructor_location: SrcSpan,
+        arguments_start_position: u32,
         module: Option<(EcoString, SrcSpan)>,
         name: EcoString,
         arguments: Option<Vec<CallArg<UntypedConstant>>>,
     ) -> UntypedConstant {
         Constant::Record {
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -1235,7 +1235,7 @@ pub trait UntypedConstantFolder {
 
             Constant::Record {
                 location,
-                constructor_location,
+                arguments_start_position,
                 module,
                 name,
                 arguments,
@@ -1254,7 +1254,7 @@ pub trait UntypedConstantFolder {
                 });
                 Constant::Record {
                     location,
-                    constructor_location,
+                    arguments_start_position,
                     module,
                     name,
                     arguments,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -1000,7 +1000,13 @@ pub trait UntypedConstantFolder {
                 type_: (),
                 field_map: _,
                 record_constructor: _,
-            } => self.fold_constant_record(location, arguments_start_position, module, name, arguments),
+            } => self.fold_constant_record(
+                location,
+                arguments_start_position,
+                module,
+                name,
+                arguments,
+            ),
 
             Constant::RecordUpdate {
                 location,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -993,13 +993,14 @@ pub trait UntypedConstantFolder {
 
             Constant::Record {
                 location,
+                constructor_location,
                 module,
                 name,
                 arguments,
                 type_: (),
                 field_map: _,
                 record_constructor: _,
-            } => self.fold_constant_record(location, module, name, arguments),
+            } => self.fold_constant_record(location, constructor_location, module, name, arguments),
 
             Constant::RecordUpdate {
                 location,
@@ -1116,12 +1117,14 @@ pub trait UntypedConstantFolder {
     fn fold_constant_record(
         &mut self,
         location: SrcSpan,
+        constructor_location: SrcSpan,
         module: Option<(EcoString, SrcSpan)>,
         name: EcoString,
         arguments: Option<Vec<CallArg<UntypedConstant>>>,
     ) -> UntypedConstant {
         Constant::Record {
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -1232,6 +1235,7 @@ pub trait UntypedConstantFolder {
 
             Constant::Record {
                 location,
+                constructor_location,
                 module,
                 name,
                 arguments,
@@ -1250,6 +1254,7 @@ pub trait UntypedConstantFolder {
                 });
                 Constant::Record {
                     location,
+                    constructor_location,
                     module,
                     name,
                     arguments,

--- a/compiler-core/src/metadata.rs
+++ b/compiler-core/src/metadata.rs
@@ -335,6 +335,7 @@ impl RemapIds {
             },
             Constant::Record {
                 location,
+                constructor_location,
                 module,
                 name,
                 arguments,
@@ -343,6 +344,7 @@ impl RemapIds {
                 record_constructor,
             } => Constant::Record {
                 location,
+                constructor_location,
                 module,
                 name,
                 arguments: arguments.map(|arguments| {

--- a/compiler-core/src/metadata.rs
+++ b/compiler-core/src/metadata.rs
@@ -335,7 +335,7 @@ impl RemapIds {
             },
             Constant::Record {
                 location,
-                constructor_location,
+                arguments_start_position,
                 module,
                 name,
                 arguments,
@@ -344,7 +344,7 @@ impl RemapIds {
                 record_constructor,
             } => Constant::Record {
                 location,
-                constructor_location,
+                arguments_start_position,
                 module,
                 name,
                 arguments: arguments.map(|arguments| {

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -1170,6 +1170,7 @@ fn constant_list() {
 fn constant_record() {
     let module = constant_module(Constant::Record {
         location: SrcSpan::default(),
+        constructor_location: SrcSpan::default(),
         module: None,
         name: "".into(),
         arguments: Some(vec![

--- a/compiler-core/src/metadata/tests.rs
+++ b/compiler-core/src/metadata/tests.rs
@@ -1170,7 +1170,7 @@ fn constant_list() {
 fn constant_record() {
     let module = constant_module(Constant::Record {
         location: SrcSpan::default(),
-        constructor_location: SrcSpan::default(),
+        arguments_start_position: 0,
         module: None,
         name: "".into(),
         arguments: Some(vec![

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3688,7 +3688,7 @@ where
 
                     Ok(Some(Constant::Record {
                         location: SrcSpan { start, end: par_e },
-                        constructor_location: SrcSpan { start, end },
+                        arguments_start_position: end,
                         module,
                         name,
                         arguments: Some(arguments),
@@ -3700,7 +3700,7 @@ where
             }
             _ => Ok(Some(Constant::Record {
                 location: SrcSpan { start, end },
-                constructor_location: SrcSpan { start, end },
+                arguments_start_position: end,
                 module,
                 name,
                 arguments: None,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3688,6 +3688,7 @@ where
 
                     Ok(Some(Constant::Record {
                         location: SrcSpan { start, end: par_e },
+                        constructor_location: SrcSpan { start, end },
                         module,
                         name,
                         arguments: Some(arguments),
@@ -3699,6 +3700,7 @@ where
             }
             _ => Ok(Some(Constant::Record {
                 location: SrcSpan { start, end },
+                constructor_location: SrcSpan { start, end },
                 module,
                 name,
                 arguments: None,

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
@@ -172,6 +172,10 @@ Parsed {
                                 start: 78,
                                 end: 107,
                             },
+                            constructor_location: SrcSpan {
+                                start: 78,
+                                end: 84,
+                            },
                             module: None,
                             name: "Person",
                             arguments: Some(

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_all_fields.snap
@@ -172,10 +172,7 @@ Parsed {
                                 start: 78,
                                 end: 107,
                             },
-                            constructor_location: SrcSpan {
-                                start: 78,
-                                end: 84,
-                            },
+                            arguments_start_position: 84,
                             module: None,
                             name: "Person",
                             arguments: Some(

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
@@ -138,6 +138,10 @@ Parsed {
                                 start: 65,
                                 end: 84,
                             },
+                            constructor_location: SrcSpan {
+                                start: 65,
+                                end: 71,
+                            },
                             module: None,
                             name: "Person",
                             arguments: Some(

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_basic.snap
@@ -138,10 +138,7 @@ Parsed {
                                 start: 65,
                                 end: 84,
                             },
-                            constructor_location: SrcSpan {
-                                start: 65,
-                                end: 71,
-                            },
+                            arguments_start_position: 71,
                             module: None,
                             name: "Person",
                             arguments: Some(

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
@@ -138,6 +138,10 @@ Parsed {
                                 start: 65,
                                 end: 84,
                             },
+                            constructor_location: SrcSpan {
+                                start: 65,
+                                end: 71,
+                            },
                             module: None,
                             name: "Person",
                             arguments: Some(

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_record_update_only.snap
@@ -138,10 +138,7 @@ Parsed {
                                 start: 65,
                                 end: 84,
                             },
-                            constructor_location: SrcSpan {
-                                start: 65,
-                                end: 71,
-                            },
+                            arguments_start_position: 71,
                             module: None,
                             name: "Person",
                             arguments: Some(

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__constant_record_with_empty_arguments_is_record.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__constant_record_with_empty_arguments_is_record.snap
@@ -28,10 +28,7 @@ Parsed {
                                 start: 19,
                                 end: 27,
                             },
-                            constructor_location: SrcSpan {
-                                start: 19,
-                                end: 25,
-                            },
+                            arguments_start_position: 25,
                             module: None,
                             name: "Wibble",
                             arguments: Some(

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__constant_record_with_empty_arguments_is_record.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__constant_record_with_empty_arguments_is_record.snap
@@ -28,6 +28,10 @@ Parsed {
                                 start: 19,
                                 end: 27,
                             },
+                            constructor_location: SrcSpan {
+                                start: 19,
+                                end: 25,
+                            },
                             module: None,
                             name: "Wibble",
                             arguments: Some(

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4236,7 +4236,13 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 name,
                 arguments,
                 ..
-            } => self.infer_constant_record(module, location, arguments_start_position, name, arguments),
+            } => self.infer_constant_record(
+                module,
+                location,
+                arguments_start_position,
+                name,
+                arguments,
+            ),
 
             Constant::Var {
                 location,
@@ -4367,14 +4373,18 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 arity: arguments.len(),
             });
 
-        let constructor_location = SrcSpan { start: location.start, end: arguments_start_position };
-        let constructor = match self.infer_value_constructor(&module, &name, &constructor_location, usage) {
-            Ok(constructor) => constructor,
-            Err(error) => {
-                self.problems.error(error);
-                return self.new_invalid_constant(location);
-            }
+        let constructor_location = SrcSpan {
+            start: location.start,
+            end: arguments_start_position,
         };
+        let constructor =
+            match self.infer_value_constructor(&module, &name, &constructor_location, usage) {
+                Ok(constructor) => constructor,
+                Err(error) => {
+                    self.problems.error(error);
+                    return self.new_invalid_constant(location);
+                }
+            };
 
         let field_map = match &constructor.variant {
             ValueConstructorVariant::Record { field_map, .. } => field_map.clone(),

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4220,6 +4220,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 Constant::Record {
                     module,
                     location,
+                    constructor_location,
                     name,
                     arguments: Some(final_arguments),
                     type_: expected_type,
@@ -4231,10 +4232,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             Constant::Record {
                 module,
                 location,
+                constructor_location,
                 name,
                 arguments,
                 ..
-            } => self.infer_constant_record(module, location, name, arguments),
+            } => self.infer_constant_record(module, location, constructor_location, name, arguments),
 
             Constant::Var {
                 location,
@@ -4347,6 +4349,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         module: Option<(EcoString, SrcSpan)>,
         location: SrcSpan,
+        constructor_location: SrcSpan,
         name: EcoString,
         arguments: Option<Vec<CallArg<UntypedConstant>>>,
     ) -> Constant<Arc<Type>> {
@@ -4364,7 +4367,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 arity: arguments.len(),
             });
 
-        let constructor = match self.infer_value_constructor(&module, &name, &location, usage) {
+        let constructor = match self.infer_value_constructor(&module, &name, &constructor_location, usage) {
             Ok(constructor) => constructor,
             Err(error) => {
                 self.problems.error(error);
@@ -4394,6 +4397,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             return Constant::Record {
                 module,
                 location,
+                constructor_location,
                 name,
                 arguments: None,
                 type_: constructor.type_.clone(),
@@ -4552,6 +4556,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Constant::Record {
             module,
             location,
+            constructor_location,
             name,
             arguments: Some(typed_arguments),
             type_: expected_return,
@@ -5746,6 +5751,7 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
 
         Constant::Record {
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -5754,6 +5760,7 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
             record_constructor,
         } => Constant::Record {
             location,
+            constructor_location,
             module,
             name,
             arguments,

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4220,7 +4220,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 Constant::Record {
                     module,
                     location,
-                    constructor_location,
+                    arguments_start_position: constructor_location.end,
                     name,
                     arguments: Some(final_arguments),
                     type_: expected_type,
@@ -4232,11 +4232,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             Constant::Record {
                 module,
                 location,
-                constructor_location,
+                arguments_start_position,
                 name,
                 arguments,
                 ..
-            } => self.infer_constant_record(module, location, constructor_location, name, arguments),
+            } => self.infer_constant_record(module, location, arguments_start_position, name, arguments),
 
             Constant::Var {
                 location,
@@ -4349,7 +4349,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         module: Option<(EcoString, SrcSpan)>,
         location: SrcSpan,
-        constructor_location: SrcSpan,
+        arguments_start_position: u32,
         name: EcoString,
         arguments: Option<Vec<CallArg<UntypedConstant>>>,
     ) -> Constant<Arc<Type>> {
@@ -4367,6 +4367,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 arity: arguments.len(),
             });
 
+        let constructor_location = SrcSpan { start: location.start, end: arguments_start_position };
         let constructor = match self.infer_value_constructor(&module, &name, &constructor_location, usage) {
             Ok(constructor) => constructor,
             Err(error) => {
@@ -4397,7 +4398,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             return Constant::Record {
                 module,
                 location,
-                constructor_location,
+                arguments_start_position,
                 name,
                 arguments: None,
                 type_: constructor.type_.clone(),
@@ -4556,7 +4557,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         Constant::Record {
             module,
             location,
-            constructor_location,
+            arguments_start_position,
             name,
             arguments: Some(typed_arguments),
             type_: expected_return,
@@ -5751,7 +5752,7 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
 
         Constant::Record {
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -5760,7 +5761,7 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
             record_constructor,
         } => Constant::Record {
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -973,6 +973,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
+        constructor_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -1007,6 +1008,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
         ast::visit::visit_typed_constant_record(
             self,
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -2068,6 +2070,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
+        constructor_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2090,6 +2093,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         ast::visit::visit_typed_constant_record(
             self,
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -2303,6 +2307,7 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
+        constructor_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2325,6 +2330,7 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
         ast::visit::visit_typed_constant_record(
             self,
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -2538,6 +2544,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
+        constructor_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2564,6 +2571,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
         ast::visit::visit_typed_constant_record(
             self,
             location,
+            constructor_location,
             module,
             name,
             arguments,
@@ -2771,6 +2779,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
+        constructor_location: &'ast SrcSpan,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2791,6 +2800,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
         ast::visit::visit_typed_constant_record(
             self,
             location,
+            constructor_location,
             module,
             name,
             arguments,

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -973,7 +973,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
-        constructor_location: &'ast SrcSpan,
+        arguments_start_position: &'ast u32,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -1008,7 +1008,7 @@ impl<'ast> ast::visit::Visit<'ast> for FillInMissingLabelledArgs<'ast> {
         ast::visit::visit_typed_constant_record(
             self,
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -2070,7 +2070,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
-        constructor_location: &'ast SrcSpan,
+        arguments_start_position: &'ast u32,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2093,7 +2093,7 @@ impl<'ast, IO> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportFirstPass
         ast::visit::visit_typed_constant_record(
             self,
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -2307,7 +2307,7 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
-        constructor_location: &'ast SrcSpan,
+        arguments_start_position: &'ast u32,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2330,7 +2330,7 @@ impl<'ast> ast::visit::Visit<'ast> for QualifiedToUnqualifiedImportSecondPass<'a
         ast::visit::visit_typed_constant_record(
             self,
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -2544,7 +2544,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
-        constructor_location: &'ast SrcSpan,
+        arguments_start_position: &'ast u32,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2571,7 +2571,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportFirstPass<'as
         ast::visit::visit_typed_constant_record(
             self,
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,
@@ -2779,7 +2779,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
     fn visit_typed_constant_record(
         &mut self,
         location: &'ast SrcSpan,
-        constructor_location: &'ast SrcSpan,
+        arguments_start_position: &'ast u32,
         module: &'ast Option<(EcoString, SrcSpan)>,
         name: &'ast EcoString,
         arguments: &'ast Option<Vec<CallArg<ast::TypedConstant>>>,
@@ -2800,7 +2800,7 @@ impl<'ast> ast::visit::Visit<'ast> for UnqualifiedToQualifiedImportSecondPass<'a
         ast::visit::visit_typed_constant_record(
             self,
             location,
-            constructor_location,
+            arguments_start_position,
             module,
             name,
             arguments,

--- a/language-server/src/tests/rename.rs
+++ b/language-server/src/tests/rename.rs
@@ -3358,6 +3358,21 @@ pub fn main() {
 }
 
 #[test]
+fn rename_record_constructor_in_constant() {
+    assert_rename!(
+        "
+type Wibble {
+  Wibble(wibble: Int)
+}
+
+pub const zero = Wibble(0)
+",
+        "Wobble",
+        find_position_of("Wibble(wibble: Int)").under_char('W')
+    );
+}
+
+#[test]
 fn rename_record_field_renames_labelled_arguments_of_call_with_incorrect_arity() {
     assert_rename!(
         "

--- a/language-server/src/tests/snapshots/gleam_language_server__tests__rename__rename_record_constructor_in_constant.snap
+++ b/language-server/src/tests/snapshots/gleam_language_server__tests__rename__rename_record_constructor_in_constant.snap
@@ -1,0 +1,23 @@
+---
+source: language-server/src/tests/rename.rs
+expression: "\ntype Wibble {\n  Wibble(wibble: Int)\n}\n\npub const zero = Wibble(0)\n"
+---
+----- BEFORE RENAME
+-- app.gleam
+
+type Wibble {
+  Wibble(wibble: Int)
+  ↑▔▔▔▔▔             
+}
+
+pub const zero = Wibble(0)
+
+
+----- AFTER RENAME
+-- app.gleam
+
+type Wibble {
+  Wobble(wibble: Int)
+}
+
+pub const zero = Wobble(0)


### PR DESCRIPTION
Hey : ) ! This PR fixes issue #5884 

When renaming the `Wibble` constructor to `Wobble`, now it behaves as expected like this : 

Before renaming
```
pub type Wibble {
  Wibble(Int) // or even Wibble(wibble: Int)
}

pub const zero = Wibble(0)
```

After:
```
pub type Wibble {
  Wobble(Int)
}

pub const zero = Wobble(0)
```
whereas before it would incorrectly produce `pub const zero = Wobble`

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes