### PR TITLE
feat: add git dep support to gleam add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
   making the cache files noticeably smaller.
   ([Andrey Kozhev](httos://github.com/ankddev))
 
+- Added support for installing Git dependencies via `gleam add`.
+  ([Hari Mohan](https://github.com/seafoamteal))
+
 ### Language server
 
 - The "Generate dynamic decoder" code action is now only offered when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,13 @@
   making the cache files noticeably smaller.
   ([Andrey Kozhev](httos://github.com/ankddev))
 
-- Added support for installing Git dependencies via `gleam add`.
+- The `gleam add` command now supports a `--git` flag that allows the user to
+  add Git dependencies without manually editing `gleam.toml`. Optional `--ref`
+  and `--path` flags can be provided; these behave the same as `path` and `ref`
+  in the `gleam.toml` Git dependency syntax. When `--ref` is omitted,
+  `gleam add` pins the dependency to the commit at the tip of the default
+  branch; the user may opt in to tracking a branch instead by explicitly
+  providing `--ref <branch_name>`.
   ([Hari Mohan](https://github.com/seafoamteal))
 
 ### Language server

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2021 The Gleam contributors
 
 use camino::{Utf8Path, Utf8PathBuf};
+use ecow::EcoString;
 use std::fmt::Write as _;
 
 use gleam_core::{
@@ -18,60 +19,20 @@ use crate::{
     fs,
 };
 
-pub enum PackagesToAdd {
-    Hex(Vec<String>),
-    Git {
-        repository: String,
-        ref_: Option<String>,
-        path: Option<Utf8PathBuf>,
-    },
-}
-
-pub fn command(paths: &ProjectPaths, packages_to_add: PackagesToAdd, dev: bool) -> Result<()> {
+pub fn hex_dependencies(
+    paths: &ProjectPaths,
+    packages_to_add: Vec<String>,
+    dev: bool,
+) -> Result<()> {
     let config = crate::config::root_config(paths)?;
+    if packages_to_add.iter().any(|name| name == &config.name) {
+        return Err(Error::CannotAddSelfAsDependency { name: config.name });
+    }
 
-    let new_package_requirements = match &packages_to_add {
-        PackagesToAdd::Hex(packages_to_add) => {
-            if packages_to_add.iter().any(|name| name == &config.name) {
-                return Err(Error::CannotAddSelfAsDependency { name: config.name });
-            }
-
-            let mut new_package_requirements = Vec::with_capacity(packages_to_add.len());
-            for specifier in packages_to_add {
-                new_package_requirements.push(parse_gleam_add_specifier(specifier)?);
-            }
-
-            new_package_requirements
-        }
-        PackagesToAdd::Git {
-            repository,
-            ref_,
-            path,
-        } => {
-            // When a user adds a git dependency, we do NOT know its name! The rest
-            // of this dependency resolution code path needs to know the names of the
-            // packages it's working with, and we don't want to maintain a second,
-            // near-identical copy. Instead, we fetch the repo and resolve the name
-            // of the package upfront, letting us continue as usual from here.
-            //
-            // When we get to the bit where we actually download and provide the package,
-            // we can simply reuse the clone from here. A second small request will be made
-            // to fetch the refs, but since they (almost certainly) haven't changed, no more
-            // deltas will be downloaded.
-            let (package_to_add, requirement) = dependencies::resolve_git_requirement(
-                repository,
-                ref_.as_deref(),
-                path.as_deref(),
-                paths,
-            )?;
-
-            if package_to_add == config.name {
-                return Err(Error::CannotAddSelfAsDependency { name: config.name });
-            }
-
-            vec![(package_to_add, requirement)]
-        }
-    };
+    let mut new_package_requirements = Vec::with_capacity(packages_to_add.len());
+    for specifier in packages_to_add {
+        new_package_requirements.push(parse_gleam_add_specifier(&specifier)?);
+    }
 
     // Insert the new packages into the manifest and perform dependency
     // resolution to determine suitable versions
@@ -90,9 +51,7 @@ pub fn command(paths: &ProjectPaths, packages_to_add: PackagesToAdd, dev: bool) 
     let mut gleam_toml = read_toml_edit(&paths.root_config())?;
 
     // Insert the new deps
-    for (added_package, requirement) in new_package_requirements {
-        let added_package = added_package.to_string();
-
+    for (added_package, _) in new_package_requirements {
         // Pull the selected version out of the new manifest so we know what it is
         let version = &manifest
             .packages
@@ -103,94 +62,155 @@ pub fn command(paths: &ProjectPaths, packages_to_add: PackagesToAdd, dev: bool) 
 
         tracing::info!(version=%version, "new_package_version_resolved");
 
+        // Produce a version requirement locked to the major version.
+        // i.e. if 1.2.3 is selected we want >= 1.2.3 and < 2.0.0
+        let range = toml_edit::value(format!(
+            ">= {} and < {}.0.0",
+            version_to_string(version),
+            version.major + 1
+        ));
+
         // The manifest.toml file has already been updated on disk by
         // `resolve_and_download`; we just have to update `gleam.toml` now.
-        let specifier: toml_edit::Item = match &requirement {
-            Requirement::Hex { .. } => {
-                // Produce a version requirement locked to the major version.
-                // i.e. if 1.2.3 is selected we want >= 1.2.3 and < 2.0.0
-                toml_edit::value(format!(
-                    ">= {} and < {}.0.0",
-                    version_to_string(version),
-                    version.major + 1
-                ))
-            }
-
-            Requirement::Git {
-                git,
-                path,
-                ref_: commit_hash,
-            } => {
-                // The manifest's ref will always be a fully resolved commit-SHA, even if the
-                // user provides a branch as the ref. This will pin the dep to the tip of the
-                // branch at the moment the command was run, which is not the user's intent:
-                // they most likely want to TRACK the branch.
-                //
-                // At this point, we know that their ref resolved correctly and the dep has
-                // been added, so we can safely use the value they explicitly provided via --ref
-                // as the ref to insert into gleam.toml.
-                let PackagesToAdd::Git {
-                    ref_: ref explicit_arg_ref,
-                    ..
-                } = packages_to_add
-                else {
-                    unreachable!(
-                        "new_package_requirements can only contain a Git requirement if packages_to_add is Git"
-                    )
-                };
-
-                let ref_: String = if let Some(ref_) = explicit_arg_ref {
-                    ref_.into()
-                } else {
-                    commit_hash.into()
-                };
-
-                let mut git_specifier = toml_edit::InlineTable::new();
-                let _ = git_specifier.insert("git", git.to_string().into());
-                let _ = git_specifier.insert("ref", ref_.into());
-
-                if let Some(path) = path {
-                    let _ = git_specifier.insert("path", path.to_string().into());
-                }
-
-                git_specifier.into()
-            }
-
-            Requirement::Path { .. } => {
-                unreachable!("Adding path deps via gleam add is not supported yet")
-            }
-        };
-
-        // False positive. This package doesn't use the indexing API correctly.
-        #[allow(clippy::indexing_slicing)]
-        {
-            if dev {
-                let canonical_name = "dev_dependencies";
-                let deprecated_name = "dev-dependencies";
-                let has_canonical = gleam_toml.as_table().contains_key(canonical_name);
-                let has_deprecated = gleam_toml.as_table().contains_key(deprecated_name);
-                if !has_canonical && !has_deprecated {
-                    gleam_toml["dev_dependencies"] = toml_edit::table();
-                }
-                let name = if has_deprecated {
-                    deprecated_name
-                } else {
-                    canonical_name
-                };
-                gleam_toml[name][&added_package] = specifier.clone();
-            } else {
-                if !gleam_toml.as_table().contains_key("dependencies") {
-                    gleam_toml["dependencies"] = toml_edit::table();
-                }
-                gleam_toml["dependencies"][&added_package] = specifier.clone();
-            }
-        }
+        add_dependency_to_gleam_toml(added_package, &mut gleam_toml, range, dev);
     }
 
     // Write the updated config
     fs::write(&paths.root_config(), &gleam_toml.to_string())?;
 
     Ok(())
+}
+
+pub fn git_dependency(
+    paths: &ProjectPaths,
+    repository: String,
+    ref_: Option<String>,
+    path: Option<Utf8PathBuf>,
+    dev: bool,
+) -> Result<()> {
+    let config = crate::config::root_config(paths)?;
+    // When a user adds a git dependency, we do NOT know its name! The rest
+    // of this dependency resolution code path needs to know the names of the
+    // packages it's working with, and we don't want to maintain a second,
+    // near-identical copy. Instead, we fetch the repo and resolve the name
+    // of the package upfront, letting us continue as usual from here.
+    //
+    // When we get to the bit where we actually download and provide the package,
+    // we can simply reuse the clone from here. A second small request will be made
+    // to fetch the refs, but since they (almost certainly) haven't changed, no more
+    // deltas will be downloaded.
+    let (package_to_add, requirement) = dependencies::resolve_git_requirement(
+        &repository,
+        ref_.as_deref(),
+        path.as_deref(),
+        paths,
+    )?;
+
+    if package_to_add == config.name {
+        return Err(Error::CannotAddSelfAsDependency { name: config.name });
+    }
+
+    let new_package_requirements = vec![(package_to_add.clone(), requirement.clone())];
+    // Insert the new packages into the manifest and perform dependency
+    // resolution to determine suitable versions
+    let manifest = dependencies::resolve_and_download(
+        paths,
+        cli::Reporter::new(),
+        Some((new_package_requirements, dev)),
+        Vec::new(),
+        dependencies::DependencyManagerConfig {
+            use_manifest: dependencies::UseManifest::Yes,
+            check_major_versions: dependencies::CheckMajorVersions::No,
+        },
+    )?;
+
+    // Read gleam.toml and manifest.toml so we can insert new deps into it
+    let mut gleam_toml = read_toml_edit(&paths.root_config())?;
+
+    // Pull the selected version out of the new manifest so we know what it is
+    let version = &manifest
+        .packages
+        .iter()
+        .find(|package| package.name == package_to_add)
+        .expect("Added package not found in resolved manifest")
+        .version;
+
+    tracing::info!(version=%version, "new_package_version_resolved");
+
+    let specifier: toml_edit::Item = match &requirement {
+        Requirement::Git {
+            git,
+            path,
+            ref_: commit_hash,
+        } => {
+            // The manifest's ref will always be a fully resolved commit-SHA, even if the
+            // user provides a branch as the ref. This will pin the dep to the tip of the
+            // branch at the moment the command was run, which is not the user's intent:
+            // they most likely want to TRACK the branch.
+            //
+            // At this point, we know that their ref resolved correctly and the dep has
+            // been added, so we can safely use the value they explicitly provided via --ref
+            // as the ref to insert into gleam.toml.
+            let ref_: EcoString = if let Some(user_ref) = &ref_ {
+                user_ref.into()
+            } else {
+                commit_hash.into()
+            };
+
+            let mut git_specifier = toml_edit::InlineTable::new();
+            let _ = git_specifier.insert("git", git.to_string().into());
+            let _ = git_specifier.insert("ref", ref_.to_string().into());
+
+            if let Some(path) = path {
+                let _ = git_specifier.insert("path", path.to_string().into());
+            }
+
+            git_specifier.into()
+        }
+
+        _ => {
+            unreachable!("dependencies::resolve_git_requirement must return Requirement::Git")
+        }
+    };
+
+    // The manifest.toml file has already been updated on disk by
+    // `resolve_and_download`; we just have to update `gleam.toml` now.
+    add_dependency_to_gleam_toml(package_to_add, &mut gleam_toml, specifier, dev);
+
+    // Write the updated config
+    fs::write(&paths.root_config(), &gleam_toml.to_string())?;
+
+    Ok(())
+}
+
+fn add_dependency_to_gleam_toml(
+    package_to_add: EcoString,
+    gleam_toml: &mut toml_edit::DocumentMut,
+    specifier: toml_edit::Item,
+    dev: bool,
+) {
+    // False positive. This package doesn't use the indexing API correctly.
+    #[allow(clippy::indexing_slicing)]
+    if dev {
+        let canonical_name = "dev_dependencies";
+        let deprecated_name = "dev-dependencies";
+        let has_canonical = gleam_toml.as_table().contains_key(canonical_name);
+        let has_deprecated = gleam_toml.as_table().contains_key(deprecated_name);
+        if !has_canonical && !has_deprecated {
+            gleam_toml["dev_dependencies"] = toml_edit::table();
+        }
+        let name = if has_deprecated {
+            deprecated_name
+        } else {
+            canonical_name
+        };
+        gleam_toml[name][&package_to_add.to_string()] = specifier;
+    } else {
+        if !gleam_toml.as_table().contains_key("dependencies") {
+            gleam_toml["dependencies"] = toml_edit::table();
+        }
+        gleam_toml["dependencies"][&package_to_add.to_string()] = specifier;
+    }
 }
 
 fn read_toml_edit(name: &Utf8Path) -> Result<toml_edit::DocumentMut, Error> {

--- a/compiler-cli/src/add.rs
+++ b/compiler-cli/src/add.rs
@@ -8,6 +8,7 @@ use gleam_core::{
     Error, Result,
     error::{FileIoAction, FileKind},
     paths::ProjectPaths,
+    requirement::Requirement,
 };
 use hexpm::version::{Identifier, Version};
 
@@ -17,16 +18,60 @@ use crate::{
     fs,
 };
 
-pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) -> Result<()> {
-    let config = crate::config::root_config(paths)?;
-    if packages_to_add.iter().any(|name| name == &config.name) {
-        return Err(Error::CannotAddSelfAsDependency { name: config.name });
-    }
+pub enum PackagesToAdd {
+    Hex(Vec<String>),
+    Git {
+        repository: String,
+        ref_: Option<String>,
+        path: Option<Utf8PathBuf>,
+    },
+}
 
-    let mut new_package_requirements = Vec::with_capacity(packages_to_add.len());
-    for specifier in packages_to_add {
-        new_package_requirements.push(parse_gleam_add_specifier(&specifier)?);
-    }
+pub fn command(paths: &ProjectPaths, packages_to_add: PackagesToAdd, dev: bool) -> Result<()> {
+    let config = crate::config::root_config(paths)?;
+
+    let new_package_requirements = match &packages_to_add {
+        PackagesToAdd::Hex(packages_to_add) => {
+            if packages_to_add.iter().any(|name| name == &config.name) {
+                return Err(Error::CannotAddSelfAsDependency { name: config.name });
+            }
+
+            let mut new_package_requirements = Vec::with_capacity(packages_to_add.len());
+            for specifier in packages_to_add {
+                new_package_requirements.push(parse_gleam_add_specifier(specifier)?);
+            }
+
+            new_package_requirements
+        }
+        PackagesToAdd::Git {
+            repository,
+            ref_,
+            path,
+        } => {
+            // When a user adds a git dependency, we do NOT know its name! The rest
+            // of this dependency resolution code path needs to know the names of the
+            // packages it's working with, and we don't want to maintain a second,
+            // near-identical copy. Instead, we fetch the repo and resolve the name
+            // of the package upfront, letting us continue as usual from here.
+            //
+            // When we get to the bit where we actually download and provide the package,
+            // we can simply reuse the clone from here. A second small request will be made
+            // to fetch the refs, but since they (almost certainly) haven't changed, no more
+            // deltas will be downloaded.
+            let (package_to_add, requirement) = dependencies::resolve_git_requirement(
+                repository,
+                ref_.as_deref(),
+                path.as_deref(),
+                paths,
+            )?;
+
+            if package_to_add == config.name {
+                return Err(Error::CannotAddSelfAsDependency { name: config.name });
+            }
+
+            vec![(package_to_add, requirement)]
+        }
+    };
 
     // Insert the new packages into the manifest and perform dependency
     // resolution to determine suitable versions
@@ -43,10 +88,9 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
 
     // Read gleam.toml and manifest.toml so we can insert new deps into it
     let mut gleam_toml = read_toml_edit(&paths.root_config())?;
-    let mut manifest_toml = read_toml_edit(&paths.manifest())?;
 
     // Insert the new deps
-    for (added_package, _) in new_package_requirements {
+    for (added_package, requirement) in new_package_requirements {
         let added_package = added_package.to_string();
 
         // Pull the selected version out of the new manifest so we know what it is
@@ -59,13 +103,63 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
 
         tracing::info!(version=%version, "new_package_version_resolved");
 
-        // Produce a version requirement locked to the major version.
-        // i.e. if 1.2.3 is selected we want >= 1.2.3 and < 2.0.0
-        let range = format!(
-            ">= {} and < {}.0.0",
-            version_to_string(version),
-            version.major + 1
-        );
+        // The manifest.toml file has already been updated on disk by
+        // `resolve_and_download`; we just have to update `gleam.toml` now.
+        let specifier: toml_edit::Item = match &requirement {
+            Requirement::Hex { .. } => {
+                // Produce a version requirement locked to the major version.
+                // i.e. if 1.2.3 is selected we want >= 1.2.3 and < 2.0.0
+                toml_edit::value(format!(
+                    ">= {} and < {}.0.0",
+                    version_to_string(version),
+                    version.major + 1
+                ))
+            }
+
+            Requirement::Git {
+                git,
+                path,
+                ref_: commit_hash,
+            } => {
+                // The manifest's ref will always be a fully resolved commit-SHA, even if the
+                // user provides a branch as the ref. This will pin the dep to the tip of the
+                // branch at the moment the command was run, which is not the user's intent:
+                // they most likely want to TRACK the branch.
+                //
+                // At this point, we know that their ref resolved correctly and the dep has
+                // been added, so we can safely use the value they explicitly provided via --ref
+                // as the ref to insert into gleam.toml.
+                let PackagesToAdd::Git {
+                    ref_: ref explicit_arg_ref,
+                    ..
+                } = packages_to_add
+                else {
+                    unreachable!(
+                        "new_package_requirements can only contain a Git requirement if packages_to_add is Git"
+                    )
+                };
+
+                let ref_: String = if let Some(ref_) = explicit_arg_ref {
+                    ref_.into()
+                } else {
+                    commit_hash.into()
+                };
+
+                let mut git_specifier = toml_edit::InlineTable::new();
+                let _ = git_specifier.insert("git", git.to_string().into());
+                let _ = git_specifier.insert("ref", ref_.into());
+
+                if let Some(path) = path {
+                    let _ = git_specifier.insert("path", path.to_string().into());
+                }
+
+                git_specifier.into()
+            }
+
+            Requirement::Path { .. } => {
+                unreachable!("Adding path deps via gleam add is not supported yet")
+            }
+        };
 
         // False positive. This package doesn't use the indexing API correctly.
         #[allow(clippy::indexing_slicing)]
@@ -83,20 +177,18 @@ pub fn command(paths: &ProjectPaths, packages_to_add: Vec<String>, dev: bool) ->
                 } else {
                     canonical_name
                 };
-                gleam_toml[name][&added_package] = toml_edit::value(range.clone());
+                gleam_toml[name][&added_package] = specifier.clone();
             } else {
                 if !gleam_toml.as_table().contains_key("dependencies") {
                     gleam_toml["dependencies"] = toml_edit::table();
                 }
-                gleam_toml["dependencies"][&added_package] = toml_edit::value(range.clone());
+                gleam_toml["dependencies"][&added_package] = specifier.clone();
             }
-            manifest_toml["requirements"][&added_package]["version"] = range.into();
         }
     }
 
     // Write the updated config
     fs::write(&paths.root_config(), &gleam_toml.to_string())?;
-    fs::write(&paths.manifest(), &manifest_toml.to_string())?;
 
     Ok(())
 }

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -1048,7 +1048,6 @@ fn provide_local_package(
 /// Resolve a path dependency of a git package to its canonical filesystem
 /// location and its repository-relative path.
 fn resolve_git_path_package(
-    package_name: &EcoString,
     path: &Utf8Path,
     repo: &EcoString,
     parent_path: &Utf8Path,
@@ -1057,7 +1056,6 @@ fn resolve_git_path_package(
     let location = parent_path.join(path);
     if !location.is_dir() {
         return Err(Error::GitDependencyPathNotFound {
-            package: package_name.to_string(),
             path: path.to_string(),
             repo: repo.to_string(),
         });
@@ -1070,7 +1068,6 @@ fn resolve_git_path_package(
     let repo_path = package_path
         .strip_prefix(repo_root)
         .map_err(|_| Error::GitDependencyPathNotFound {
-            package: package_name.to_string(),
             path: path.to_string(),
             repo: repo.to_string(),
         })?
@@ -1145,23 +1142,22 @@ fn git_staging_path(project_paths: &ProjectPaths, repo: &str, package_name: &str
     ))
 }
 
-enum GitCheckout {
-    InPlace {
-        commit: EcoString,
-    },
-    Staged {
-        commit: EcoString,
-        staging_path: Utf8PathBuf,
-    },
+/// A temporary directory used to resolve the package name for a git dependency
+/// being added via `gleam add`
+fn git_name_resolution_path(project_paths: &ProjectPaths, repo: &str) -> Utf8PathBuf {
+    project_paths.build_git_repo(&format!("{}-name_resolution", git_repo_dir_name(repo)))
+}
+
+struct GitCheckout {
+    commit: EcoString,
+    staging_path: Utf8PathBuf,
 }
 
 impl GitCheckout {
     fn cleanup(self) -> Result<()> {
         // The clones dangling worktree registration is left for the next
         // download to prune before it re-adds the staging worktree.
-        if let Self::Staged { staging_path, .. } = self {
-            fs::delete_directory(&staging_path)?;
-        }
+        fs::delete_directory(&self.staging_path)?;
         Ok(())
     }
 }
@@ -1214,49 +1210,23 @@ impl GitCheckout {
 /// In the future we can optimise this more, for example first checking if we
 /// are already checked out to the commit stored in the manifest, or by only
 /// fetching the history without the objects to resolve partial commit hashes.
-/// For now though this is good enough until it become an actual performance
+/// For now though this is good enough until it becomes an actual performance
 /// problem.
 ///
 fn download_git_package(
     package_name: &str,
     repo: &str,
     ref_: &str,
-    path: Option<&Utf8Path>,
+    subdir: Option<&Utf8Path>,
     project_paths: &ProjectPaths,
-) -> Result<GitCheckout> {
-    match path {
-        None => download_git_package_in_place(package_name, repo, ref_, project_paths),
-        Some(subdir) => {
-            download_git_package_to_staged_path(package_name, repo, ref_, project_paths, subdir)
-        }
-    }
-}
-
-fn download_git_package_in_place(
-    package_name: &str,
-    repo: &str,
-    ref_: &str,
-    project_paths: &ProjectPaths,
-) -> Result<GitCheckout, Error> {
-    let clone_path = project_paths.build_packages_package(package_name);
-    prepare_git_clone(&clone_path, repo, CloneFormat::WorkTree)?;
-    let _ = execute_command(git_command(&clone_path).arg("checkout").arg(ref_))?;
-    let output = execute_command(git_command(&clone_path).arg("rev-parse").arg("HEAD"))?;
-    let commit = git_stdout(output);
-
-    Ok(GitCheckout::InPlace { commit })
-}
-
-fn download_git_package_to_staged_path(
-    package_name: &str,
-    repo: &str,
-    ref_: &str,
-    project_paths: &ProjectPaths,
-    subdir: &Utf8Path,
 ) -> Result<GitCheckout, Error> {
     let clone_path = project_paths.build_git_repo(&git_repo_dir_name(repo));
-    prepare_git_clone(&clone_path, repo, CloneFormat::Bare)?;
+    prepare_git_clone(&clone_path, repo)?;
 
+    // If the user runs `gleam add --git`, then `ref_` will be a fully resolved
+    // commit hash already. However, this requirement might be coming from them
+    // editing `gleam.toml` directly, in which case `ref_` might still be a
+    // branch name, tag, or partial hash.
     let commit = resolve_git_ref(&clone_path, repo, ref_)?;
 
     // Delete any staging worktree left behind by a previous crash, and prune
@@ -1279,55 +1249,120 @@ fn download_git_package_to_staged_path(
             .arg(commit.as_str()),
     )?;
 
-    let Some(subdir_source) = resolve_git_subdir(&staging_path, subdir) else {
-        return Err(Error::GitDependencyPathNotFound {
-            package: package_name.into(),
-            path: subdir.to_string(),
-            repo: repo.into(),
-        });
+    let src_path = if let Some(subdir) = subdir {
+        let Some(subdir_path) = resolve_git_subdir(&staging_path, subdir) else {
+            return Err(Error::GitDependencyPathNotFound {
+                path: subdir.to_string(),
+                repo: repo.into(),
+            });
+        };
+
+        subdir_path
+    } else {
+        staging_path.clone()
     };
 
     let package_path = project_paths.build_packages_package(package_name);
     fs::delete_directory(&package_path)?;
     fs::mkdir(&package_path)?;
-    fs::hardlink_dir(&subdir_source, &package_path)?;
+    fs::hardlink_dir(&src_path, &package_path)?;
 
-    Ok(GitCheckout::Staged {
+    Ok(GitCheckout {
         commit,
         staging_path,
     })
 }
 
-#[derive(Clone, Copy)]
-enum CloneFormat {
-    /// A regular clone with a checked-out work tree.
-    WorkTree,
-    /// A bare repository with no work tree.
-    Bare,
+/// Returns the package name and fully resolved `Requirement` of a Git dependency
+pub fn resolve_git_requirement(
+    repo: &str,
+    ref_: Option<&str>,
+    subdir: Option<&Utf8Path>,
+    project_paths: &ProjectPaths,
+) -> Result<(EcoString, Requirement), Error> {
+    let clone_path = project_paths.build_git_repo(&git_repo_dir_name(repo));
+    prepare_git_clone(&clone_path, repo)?;
+
+    let ref_ = match ref_ {
+        Some(ref_) => ref_.into(),
+        None => {
+            let output = execute_command(
+                git_command(&clone_path)
+                    .arg("symbolic-ref")
+                    .arg("refs/remotes/origin/HEAD")
+                    .arg("--short"),
+            )?;
+
+            let default_branch = git_stdout(output);
+            default_branch
+                .strip_prefix("origin/")
+                .unwrap_or("main")
+                .to_owned()
+        }
+    };
+
+    let commit = resolve_git_ref(&clone_path, repo, &ref_)?;
+
+    // Delete any name resolution worktree left behind by a previous crash,
+    // and prune its registration from the clone so `git worktree add` can
+    // reuse the path.
+    let name_resolution_path = git_name_resolution_path(project_paths, repo);
+    fs::delete_directory(&name_resolution_path)?;
+    let _ = git_command(&clone_path)
+        .arg("worktree")
+        .arg("prune")
+        .output();
+
+    let _ = execute_command(
+        git_command(&clone_path)
+            .arg("worktree")
+            .arg("add")
+            .arg("--force")
+            .arg("--detach")
+            .arg(&name_resolution_path)
+            .arg(commit.as_str()),
+    )?;
+
+    let src_path = match subdir {
+        Some(subdir) => {
+            let Some(subdir_path) = resolve_git_subdir(&name_resolution_path, subdir) else {
+                return Err(Error::GitDependencyPathNotFound {
+                    path: subdir.to_string(),
+                    repo: repo.into(),
+                });
+            };
+
+            subdir_path
+        }
+        None => name_resolution_path.clone(),
+    };
+
+    let config = crate::config::read(src_path.join("gleam.toml"))?;
+
+    let _ = fs::delete_directory(&name_resolution_path)?;
+
+    Ok((
+        config.name,
+        Requirement::Git {
+            git: repo.into(),
+            ref_: commit,
+            path: subdir.map(Utf8Path::to_path_buf),
+        },
+    ))
 }
 
 /// Initialise (or reuse) a git clone at the given path and fetch from the
 /// remote repository.
-fn prepare_git_clone(clone_path: &Utf8Path, repo: &str, format: CloneFormat) -> Result<()> {
+fn prepare_git_clone(clone_path: &Utf8Path, repo: &str) -> Result<()> {
     // If the clone path exists but is not the kind of git repo we expect, we
     // need to remove the directory.
-    let reusable = match format {
-        CloneFormat::Bare => fs::is_bare_git_repo_root(clone_path),
-        CloneFormat::WorkTree => fs::is_git_work_tree_root(clone_path),
-    };
-
-    if !reusable {
+    if !fs::is_bare_git_repo_root(clone_path) {
         fs::delete_directory(clone_path)?;
     }
 
     fs::mkdir(clone_path)?;
 
-    let mut init = git_command(clone_path);
-    let _ = init.arg("init");
-    if matches!(format, CloneFormat::Bare) {
-        let _ = init.arg("--bare");
-    }
-    let _ = execute_command(&mut init)?;
+    let _ = execute_command(git_command(clone_path).arg("init").arg("--bare"))?;
 
     // If this directory already exists, but the remote URL has been edited in
     // `gleam.toml` without a `gleam clean`, `git remote add` will fail, causing
@@ -1349,7 +1384,12 @@ fn prepare_git_clone(clone_path: &Utf8Path, repo: &str, format: CloneFormat) -> 
             .arg(repo),
     )?;
 
-    let _ = execute_command(git_command(clone_path).arg("fetch").arg("origin"))?;
+    let _ = execute_command(
+        git_command(clone_path)
+            .arg("fetch")
+            .arg("--tags")
+            .arg("origin"),
+    )?;
 
     Ok(())
 }
@@ -1421,27 +1461,15 @@ fn provide_git_package(
     parents: &mut Vec<EcoString>,
 ) -> Result<hexpm::version::Range> {
     let checkout = download_git_package(&package_name, repo, ref_, path.as_deref(), project_paths)?;
-    let (commit, staging_path) = match &checkout {
-        GitCheckout::InPlace { commit } => (commit, None),
-        GitCheckout::Staged {
-            commit,
-            staging_path,
-        } => (commit, Some(staging_path)),
-    };
 
     // Use the package's location in the staging worktree, where its gleam.toml
     // lives, not build/packages/. A `../sibling` path dep is resolved next to
     // that gleam.toml, and the sibling is only present in the worktree.
-    let (package_path, repo_root) = match (&path, staging_path) {
-        (Some(subdir), Some(staging_path)) => {
-            let repo_root = fs::canonicalise(staging_path)?;
-            (fs::canonicalise(&staging_path.join(subdir))?, repo_root)
-        }
-        _ => {
-            let package_path =
-                fs::canonicalise(&project_paths.build_packages_package(&package_name))?;
-            (package_path.clone(), package_path)
-        }
+    let repo_root = fs::canonicalise(&checkout.staging_path)?;
+
+    let package_path = match &path {
+        Some(subdir) => fs::canonicalise(&checkout.staging_path.join(subdir))?,
+        _ => checkout.staging_path.clone(),
     };
 
     let version = provide_package(
@@ -1449,7 +1477,7 @@ fn provide_git_package(
         package_path,
         SourceContext::Git {
             repo: repo.into(),
-            commit: commit.clone(),
+            commit: checkout.commit.clone(),
             path,
             repo_root: &repo_root,
         },
@@ -1509,7 +1537,7 @@ fn provide_package(
     if config.name != package_name {
         return Err(Error::WrongDependencyProvided {
             expected: package_name.into(),
-            path: package_path.to_path_buf(),
+            path: package_path,
             found: config.name.into(),
         });
     }
@@ -1530,7 +1558,7 @@ fn provide_package(
                     ..
                 } => {
                     let (child_path, child_repo_path) =
-                        resolve_git_path_package(&name, &path, repo, &package_path, repo_root)?;
+                        resolve_git_path_package(&path, repo, &package_path, repo_root)?;
                     // A path dependency resolving to the repository root has an
                     // empty repo-relative path. Normalise it to `None` so it
                     // matches a package declared directly as a git dependency

--- a/compiler-cli/src/dependencies/dependency_manager.rs
+++ b/compiler-cli/src/dependencies/dependency_manager.rs
@@ -276,7 +276,7 @@ where
                         commit
                     } else {
                         // If the package is unlocked or we haven't resolved a version yet, we use
-                        // the ref specified in `gleam.toml`.
+                        // the ref specified in `gleam.toml` or via `gleam add ... --ref`.
                         &ref_
                     };
 

--- a/compiler-cli/src/dependencies/tests.rs
+++ b/compiler-cli/src/dependencies/tests.rs
@@ -821,7 +821,6 @@ fn provided_git_to_manifest() {
 fn provided_git_path_package_resolves_repo_relative_path() {
     let repo_root = fs::canonicalise(Utf8Path::new("./test")).unwrap();
     let result = resolve_git_path_package(
-        &"hello_world".into(),
         Utf8Path::new("../hello_world"),
         &"https://github.com/gleam-lang/wibble.git".into(),
         &repo_root.join("hello_world"),
@@ -960,7 +959,6 @@ fn provided_git_path_package_rejects_missing_directory() {
 
     let repo_root = fs::canonicalise(&repo).unwrap();
     let result = resolve_git_path_package(
-        &"missing".into(),
         Utf8Path::new("../missing"),
         &"https://github.com/gleam-lang/wibble.git".into(),
         &repo_root.join("parent"),
@@ -969,7 +967,6 @@ fn provided_git_path_package_rejects_missing_directory() {
     assert_eq!(
         result,
         Err(Error::GitDependencyPathNotFound {
-            package: "missing".into(),
             path: "../missing".into(),
             repo: "https://github.com/gleam-lang/wibble.git".into(),
         })
@@ -1025,7 +1022,6 @@ fn provided_git_path_package_rejects_escaping_path() {
 
     let repo_root = fs::canonicalise(&repo).unwrap();
     let result = resolve_git_path_package(
-        &"package_a".into(),
         Utf8Path::new("../../outside"),
         &"https://github.com/gleam-lang/wibble.git".into(),
         &repo_root.join("parent"),
@@ -1034,7 +1030,6 @@ fn provided_git_path_package_rejects_escaping_path() {
     assert_eq!(
         result,
         Err(Error::GitDependencyPathNotFound {
-            package: "package_a".into(),
             path: "../../outside".into(),
             repo: "https://github.com/gleam-lang/wibble.git".into(),
         })
@@ -1054,7 +1049,6 @@ fn provided_git_path_package_rejects_symlink_escaping_repo() {
 
     let repo_root = fs::canonicalise(&repo).unwrap();
     let result = resolve_git_path_package(
-        &"escape".into(),
         Utf8Path::new("../escape"),
         &"https://github.com/gleam-lang/wibble.git".into(),
         &repo_root.join("parent"),
@@ -1063,7 +1057,6 @@ fn provided_git_path_package_rejects_symlink_escaping_repo() {
     assert_eq!(
         result,
         Err(Error::GitDependencyPathNotFound {
-            package: "escape".into(),
             path: "../escape".into(),
             repo: "https://github.com/gleam-lang/wibble.git".into(),
         })
@@ -1105,6 +1098,20 @@ fn git_staging_path_is_clone_path_with_staging_suffix() {
 }
 
 #[test]
+fn git_name_resolution_path_is_clone_path_with_staging_suffix() {
+    let paths = ProjectPaths::new("/app".into());
+    let repo = "https://github.com/gleam-lang/gleam.git";
+    assert_eq!(
+        paths.build_git_repo(&git_repo_dir_name(repo)),
+        Utf8PathBuf::from("/app/build/git/gleam-ea2aeaa3761e8bc6")
+    );
+    assert_eq!(
+        git_name_resolution_path(&paths, repo),
+        Utf8PathBuf::from("/app/build/git/gleam-ea2aeaa3761e8bc6-name_resolution")
+    );
+}
+
+#[test]
 fn git_checkout_cleanup_deletes_staging_directory() {
     let tmp = tempfile::tempdir().unwrap();
     let base = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
@@ -1112,21 +1119,13 @@ fn git_checkout_cleanup_deletes_staging_directory() {
     fs::mkdir(&staging_path).unwrap();
     fs::write(&staging_path.join("gleam.toml"), "name = \"wibble\"").unwrap();
 
-    let checkout = GitCheckout::Staged {
+    let checkout = GitCheckout {
         commit: "95cd2c2f45907e5571e9b5fcdfb27ff35cdcdd29".into(),
         staging_path: staging_path.clone(),
     };
     assert_eq!(checkout.cleanup(), Ok(()));
 
     assert!(!staging_path.exists());
-}
-
-#[test]
-fn git_checkout_cleanup_without_staging_is_noop() {
-    let checkout = GitCheckout::InPlace {
-        commit: "95cd2c2f45907e5571e9b5fcdfb27ff35cdcdd29".into(),
-    };
-    assert_eq!(checkout.cleanup(), Ok(()));
 }
 
 #[test]

--- a/compiler-cli/src/fs.rs
+++ b/compiler-cli/src/fs.rs
@@ -828,11 +828,6 @@ fn is_inside_git_work_tree(path: &Utf8Path) -> Result<bool, Error> {
     }
 }
 
-pub(crate) fn is_git_work_tree_root(path: &Utf8Path) -> bool {
-    tracing::debug!(path=?path, "checking_for_git_repo_root");
-    exists(path.join(".git")).unwrap_or(false)
-}
-
 pub(crate) fn is_bare_git_repo_root(path: &Utf8Path) -> bool {
     tracing::debug!(path=?path, "checking_for_bare_git_repo_root");
     exists(path.join("HEAD")).unwrap_or(false) && exists(path.join("objects")).unwrap_or(false)

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -90,9 +90,8 @@ pub use gleam_core::error::{Error, Result};
 
 use camino::Utf8PathBuf;
 use clap::{
-    Args, CommandFactory, Parser, Subcommand,
+    Args, Parser, Subcommand,
     builder::{Styles, styling},
-    error::ErrorKind,
 };
 use gleam_core::{
     analyse::TargetSupport,
@@ -447,7 +446,7 @@ pub enum Command {
     )]
     Add {
         /// The names of Hex packages to add
-        #[arg()]
+        #[arg(required_unless_present = "git")]
         packages: Option<Vec<String>>,
 
         /// Add the packages as dev-only dependencies
@@ -455,15 +454,25 @@ pub enum Command {
         dev: bool,
 
         /// Add a package from a remote git repository
-        #[arg(long, value_name = "URI", help_heading = "Git Dependencies")]
+        #[arg(
+            long,
+            value_name = "URI",
+            help_heading = "Git Dependencies",
+            conflicts_with = "packages"
+        )]
         git: Option<String>,
 
         /// The tag, branch, or commit to check out
-        #[arg(long, alias = "ref", help_heading = "Git Dependencies")]
+        #[arg(
+            long,
+            alias = "ref",
+            help_heading = "Git Dependencies",
+            conflicts_with = "packages"
+        )]
         ref_: Option<String>,
 
         /// The path inside the git repo where the package is located
-        #[arg(long, help_heading = "Git Dependencies")]
+        #[arg(long, help_heading = "Git Dependencies", conflicts_with = "packages")]
         path: Option<String>,
     },
 
@@ -658,44 +667,6 @@ impl Command {
                 ref_: git_ref,
                 path,
             } => {
-                let mut cmd = Self::command();
-
-                if packages.is_some() == git_uri.is_some() {
-                    cmd.error(
-                        ErrorKind::ArgumentConflict,
-                        "Exactly one of PACKAGES and --git must be provided",
-                    )
-                    .exit();
-                }
-
-                if git_ref.is_some() && git_uri.is_none() {
-                    cmd.error(
-                        ErrorKind::MissingRequiredArgument,
-                        "--git must be provided for --ref",
-                    )
-                    .exit();
-                }
-
-                match path {
-                    Some(path) if path.is_empty() => {
-                        cmd.error(
-                            ErrorKind::InvalidValue,
-                            "Git dependency path must not be empty",
-                        )
-                        .exit();
-                    }
-
-                    Some(_) if git_uri.is_none() => {
-                        cmd.error(
-                            ErrorKind::MissingRequiredArgument,
-                            "--git must be provided for --path",
-                        )
-                        .exit();
-                    }
-
-                    _ => (),
-                }
-
                 let paths = find_project_paths(directory)?;
 
                 if let Some(packages) = packages {
@@ -1118,4 +1089,27 @@ fn download_dependencies(paths: &ProjectPaths) -> Result<()> {
         },
     )?;
     Ok(())
+}
+
+#[test]
+fn test_gleam_add_option_validation() {
+    assert!(Command::try_parse_from(&["gleam", "add", "lustre", "birdie"]).is_ok());
+    assert!(Command::try_parse_from(&["gleam", "add", "--dev", "lustre"]).is_ok());
+    assert!(
+        Command::try_parse_from(&[
+            "gleam",
+            "add",
+            "--git=repo",
+            "--ref=branch",
+            "--path=subdir"
+        ])
+        .is_ok()
+    );
+    assert!(
+        Command::try_parse_from(&["gleam", "add", "--dev", "--git=repo", "--ref=branch"]).is_ok()
+    );
+    assert!(Command::try_parse_from(&["gleam", "add", "--ref=12345"]).is_err());
+    assert!(Command::try_parse_from(&["gleam", "add", "lustre", "--git=repo"]).is_err());
+    assert!(Command::try_parse_from(&["gleam", "add"]).is_err());
+    assert!(Command::try_parse_from(&["gleam", "add", "lustre", "--ref=branch"]).is_err());
 }

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -102,8 +102,6 @@ use gleam_core::{
     version::COMPILER_VERSION,
 };
 
-use crate::add::PackagesToAdd;
-
 #[derive(Args, Debug, Clone)]
 pub struct UpdateOptions {
     /// (optional) Names of the packages to update
@@ -701,17 +699,9 @@ impl Command {
                 let paths = find_project_paths(directory)?;
 
                 if let Some(packages) = packages {
-                    add::command(&paths, PackagesToAdd::Hex(packages), dev)
+                    add::hex_dependencies(&paths, packages, dev)
                 } else if let Some(git_uri) = git_uri {
-                    add::command(
-                        &paths,
-                        PackagesToAdd::Git {
-                            repository: git_uri,
-                            ref_: git_ref,
-                            path: path.map(Utf8PathBuf::from),
-                        },
-                        dev,
-                    )
+                    add::git_dependency(&paths, git_uri, git_ref, path.map(Utf8PathBuf::from), dev)
                 } else {
                     unreachable!("Exactly one of PACKAGES and --git must be provided")
                 }

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -90,8 +90,9 @@ pub use gleam_core::error::{Error, Result};
 
 use camino::Utf8PathBuf;
 use clap::{
-    Args, Parser, Subcommand,
+    Args, CommandFactory, Parser, Subcommand,
     builder::{Styles, styling},
+    error::ErrorKind,
 };
 use gleam_core::{
     analyse::TargetSupport,
@@ -100,6 +101,8 @@ use gleam_core::{
     paths::ProjectPaths,
     version::COMPILER_VERSION,
 };
+
+use crate::add::PackagesToAdd;
 
 #[derive(Args, Debug, Clone)]
 pub struct UpdateOptions {
@@ -423,19 +426,47 @@ pub enum Command {
     /// Add a package as a non-production dependency:
     ///     gleam add --dev wibble
     ///
+    /// Add a package from a Git source:
+    ///     gleam add --git https://github.com/gleam-lang/json
+    ///
+    /// Add a package from Git, referencing a specific branch, commit, or tag:
+    ///     gleam add --git git@github.com:gleam-lang/crypto --ref main
+    ///
+    /// Without `--ref`, the dependency will be pinned to the newest commit on
+    /// the repository's default branch. If you would like to _track_ a branch
+    /// instead, use `--ref <branch>`.
+    ///
     /// You can also edit `gleam.toml` directly, for further control over your
     /// package dependencies. Run `gleam help deps` for documentation on the
     /// format.
     ///
-    #[command(verbatim_doc_comment)]
+    #[command(
+        verbatim_doc_comment,
+        override_usage = "
+        gleam add [OPTIONS] [PACKAGES]
+        gleam add [OPTIONS] --git <URI> [--ref <REF>] [--path <PATH>]
+    "
+    )]
     Add {
         /// The names of Hex packages to add
-        #[arg(required = true)]
-        packages: Vec<String>,
+        #[arg()]
+        packages: Option<Vec<String>>,
 
         /// Add the packages as dev-only dependencies
         #[arg(long)]
         dev: bool,
+
+        /// Add a package from a remote git repository
+        #[arg(long, value_name = "URI", help_heading = "Git Dependencies")]
+        git: Option<String>,
+
+        /// The tag, branch, or commit to check out
+        #[arg(long, alias = "ref", help_heading = "Git Dependencies")]
+        ref_: Option<String>,
+
+        /// The path inside the git repo where the package is located
+        #[arg(long, help_heading = "Git Dependencies")]
+        path: Option<String>,
     },
 
     /// Remove project dependencies
@@ -622,9 +653,68 @@ impl Command {
                 username_or_email,
             })) => owner::transfer(package, username_or_email),
 
-            Self::Add { packages, dev } => {
+            Self::Add {
+                packages,
+                dev,
+                git: git_uri,
+                ref_: git_ref,
+                path,
+            } => {
+                let mut cmd = Self::command();
+
+                if packages.is_some() == git_uri.is_some() {
+                    cmd.error(
+                        ErrorKind::ArgumentConflict,
+                        "Exactly one of PACKAGES and --git must be provided",
+                    )
+                    .exit();
+                }
+
+                if git_ref.is_some() && git_uri.is_none() {
+                    cmd.error(
+                        ErrorKind::MissingRequiredArgument,
+                        "--git must be provided for --ref",
+                    )
+                    .exit();
+                }
+
+                match path {
+                    Some(path) if path.is_empty() => {
+                        cmd.error(
+                            ErrorKind::InvalidValue,
+                            "Git dependency path must not be empty",
+                        )
+                        .exit();
+                    }
+
+                    Some(_) if git_uri.is_none() => {
+                        cmd.error(
+                            ErrorKind::MissingRequiredArgument,
+                            "--git must be provided for --path",
+                        )
+                        .exit();
+                    }
+
+                    _ => (),
+                }
+
                 let paths = find_project_paths(directory)?;
-                add::command(&paths, packages, dev)
+
+                if let Some(packages) = packages {
+                    add::command(&paths, PackagesToAdd::Hex(packages), dev)
+                } else if let Some(git_uri) = git_uri {
+                    add::command(
+                        &paths,
+                        PackagesToAdd::Git {
+                            repository: git_uri,
+                            ref_: git_ref,
+                            path: path.map(Utf8PathBuf::from),
+                        },
+                        dev,
+                    )
+                } else {
+                    unreachable!("Exactly one of PACKAGES and --git must be provided")
+                }
             }
 
             Self::Remove { packages } => {

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -275,6 +275,13 @@ pub enum Command {
     /// for bug fixes that have not yet been published to Hex.
     ///
     ///    [dependencies]
+    ///    wibble = { git = "https://example.com/wibble.git", path = "wibblewobble" }
+    ///
+    /// A Git dependency from a monorepo. This is useful if you like to organise
+    /// related packages in one shared Git repository. Provide the path from
+    /// the root of your repository to the Gleam package you wish to use.
+    ///
+    ///    [dependencies]
     ///    wibble = { path = "../wibble" }
     ///
     /// A local dependency, on your computer. This is useful for testing and

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -336,12 +336,8 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
         source_2: String,
     },
 
-    #[error("The path {path} does not exist in the git repository {repo} for package {package}")]
-    GitDependencyPathNotFound {
-        package: String,
-        path: String,
-        repo: String,
-    },
+    #[error("The path {path} does not exist in the git repository {repo}")]
+    GitDependencyPathNotFound { path: String, repo: String },
 
     #[error("The package was missing required fields for publishing")]
     MissingHexPublishFields {
@@ -2287,15 +2283,9 @@ manifest.toml and a version range specified in gleam.toml:
                 }]
             }
 
-            Error::GitDependencyPathNotFound {
-                package,
-                path,
-                repo,
-            } => {
-                let text = format!(
-                    "The path `{path}` does not exist in the git repository `{repo}` \
-for package `{package}`."
-                );
+            Error::GitDependencyPathNotFound { path, repo } => {
+                let text =
+                    format!("The path `{path}` does not exist in the git repository `{repo}`.");
 
                 vec![Diagnostic {
                     title: "Git dependency path not found".into(),


### PR DESCRIPTION
Closes #5678.

This adds new `--git`, `--ref`, and `--path` arguments to the `gleam add` subcommand, as discussed in the [linked issue](https://github.com/gleam-lang/gleam/issues/5678) and [initial discussion](https://github.com/gleam-lang/gleam/discussions/5619).
`--ref` and `--path` are both optional arguments. Without `--ref`, the dep is pinned to the tip of the default branch.

I only added one test; similar functions in the existing code are not tested either (presumably because they do network I/O). However, already-tested utility functions were reused and the bulk of the changes are in the params passed down from the command handler to the existing resolution+download code path. I might be wrong here, so I would appreciate suggestions on tests to add if required. 

I went ahead and added `--path`, but I'm also wondering—what will this look like if/when we want to add support for path deps to `gleam add`? Would we just reuse the `--path` argument and make it context-sensitive?

`gleam add --help` has been updated so it looks like this:

```
Usage:
        gleam add [OPTIONS] [PACKAGES]
        gleam add [OPTIONS] --git <URI> [--ref <REF>] [--path <PATH>]

Arguments:
  [PACKAGES]...
          The names of Hex packages to add

Options:
      --dev
          Add the packages as dev-only dependencies

  -h, --help
          Print help (see a summary with '-h')

Git Dependencies:
      --git <URI>
          Add a package from a remote git repository

      --ref <REF>
          The tag, branch, or commit to check out

      --path <PATH>
          The path inside the git repo where the package is located
```

`gleam help deps` has also been updated: 1. with information about the new behaviour and 2. with information about the `path` field in `gleam.toml` that was previously missing.

H/T @jtdowney for your fantastic work in #5632, it laid the groundwork for a lot of this!

🩷 

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
