### PR TITLE
Fix fuzzer bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   JavaScript target.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where a bit array segment with a size of zero would add a zero
+  byte to the bit array on the JavaScript target, instead of contributing
+  nothing.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.0-rc2 - 2026-07-25
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
   strings in bit array segments.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Fixed a bug where floats whose fraction rounded up would be encoded as half
+  their value in 16-bit bit array segments on the JavaScript target.
+  ([John Downey](https://github.com/jtdowney))
+
+- Fixed a bug where floats exactly halfway between two 16-bit floats would be
+  rounded away from zero rather than to even in bit array segments on the
+  JavaScript target.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.0-rc2 - 2026-07-25
 
 ### Bug fixes

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -597,14 +597,14 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
         // Collect all the values used in segments.
         let segments_array = array(
             arena,
-            segments.iter().map(|segment| {
+            segments.iter().filter_map(|segment| {
                 let value = self.not_in_tail_position(Some(Ordering::Strict), |this| {
                     this.wrap_expression(arena, &segment.value)
                 });
 
                 let details = self.bit_array_segment_details(arena, segment);
 
-                match details.type_ {
+                let document = match details.type_ {
                     BitArraySegmentType::BitArray => {
                         if segment.size().is_some() {
                             self.tracker.bit_array_slice_used = true;
@@ -622,6 +622,8 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                     }
                     BitArraySegmentType::Int => {
                         match (details.size_value, segment.value.as_ref()) {
+                            (Some(size_value), _) if size_value <= 0.into() => return None,
+
                             (Some(size_value), TypedExpr::Int { int_value, .. })
                                 if size_value <= SAFE_INT_SEGMENT_MAX_SIZE.into()
                                     && (&size_value % BigInt::from(8) == BigInt::ZERO) =>
@@ -636,8 +638,6 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                             }
 
                             (Some(size_value), _) if size_value == 8.into() => value,
-
-                            (Some(size_value), _) if size_value <= 0.into() => EMPTY_DOCUMENT,
 
                             _ => {
                                 self.tracker.sized_integer_segment_used = true;
@@ -737,7 +737,9 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                             CLOSE_PAREN_DOCUMENT
                         ]
                     }
-                }
+                };
+
+                Some(document)
             }),
         );
 
@@ -2873,7 +2875,7 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
         self.tracker.bit_array_literal_used = true;
         let segments_array = array(
             arena,
-            segments.iter().map(|segment| {
+            segments.iter().filter_map(|segment| {
                 let value = match context {
                     Context::Constant => self.constant_expression(arena, context, &segment.value),
                     Context::Guard => self.guard_constant_expression(arena, &segment.value),
@@ -2881,7 +2883,7 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
 
                 let details = self.constant_bit_array_segment_details(arena, segment, context);
 
-                match details.type_ {
+                let document = match details.type_ {
                     BitArraySegmentType::BitArray => {
                         if segment.size().is_some() {
                             self.tracker.bit_array_slice_used = true;
@@ -2899,6 +2901,8 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                     }
                     BitArraySegmentType::Int => {
                         match (details.size_value, segment.value.as_ref()) {
+                            (Some(size_value), _) if size_value <= 0.into() => return None,
+
                             (Some(size_value), Constant::Int { int_value, .. })
                                 if size_value <= SAFE_INT_SEGMENT_MAX_SIZE.into()
                                     && (&size_value % BigInt::from(8) == BigInt::ZERO) =>
@@ -2913,8 +2917,6 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                             }
 
                             (Some(size_value), _) if size_value == 8.into() => value,
-
-                            (Some(size_value), _) if size_value <= 0.into() => EMPTY_DOCUMENT,
 
                             _ => {
                                 self.tracker.sized_integer_segment_used = true;
@@ -3014,7 +3016,9 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                             CLOSE_PAREN_DOCUMENT
                         ]
                     }
-                }
+                };
+
+                Some(document)
             }),
         );
 

--- a/compiler-core/src/javascript/tests/bit_arrays.rs
+++ b/compiler-core/src/javascript/tests/bit_arrays.rs
@@ -2847,3 +2847,34 @@ pub fn main() {
 "
     );
 }
+
+#[test]
+fn zero_size_int_segment() {
+    assert_js!(
+        r#"
+pub fn go() {
+  <<0:size(0), 1:size(8)>>
+}
+"#,
+    );
+}
+
+#[test]
+fn zero_size_int_segment_with_variable_value() {
+    assert_js!(
+        r#"
+pub fn go(x: Int) {
+  <<x:size(0), 1:size(8)>>
+}
+"#,
+    );
+}
+
+#[test]
+fn zero_size_int_segment_constant() {
+    assert_js!(
+        r#"
+pub const value = <<0:size(0), 1:size(8)>>
+"#,
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__zero_size_int_segment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__zero_size_int_segment.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn go() {\n  <<0:size(0), 1:size(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  <<0:size(0), 1:size(8)>>
+}
+
+
+----- COMPILED JAVASCRIPT
+import { toBitArray } from "../gleam.mjs";
+
+export function go() {
+  return toBitArray([1]);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__zero_size_int_segment_constant.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__zero_size_int_segment_constant.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub const value = <<0:size(0), 1:size(8)>>\n"
+---
+----- SOURCE CODE
+
+pub const value = <<0:size(0), 1:size(8)>>
+
+
+----- COMPILED JAVASCRIPT
+import { toBitArray } from "../gleam.mjs";
+
+export const value = /* @__PURE__ */ toBitArray([1]);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__zero_size_int_segment_with_variable_value.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__zero_size_int_segment_with_variable_value.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/bit_arrays.rs
+expression: "\npub fn go(x: Int) {\n  <<x:size(0), 1:size(8)>>\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x: Int) {
+  <<x:size(0), 1:size(8)>>
+}
+
+
+----- COMPILED JAVASCRIPT
+import { toBitArray } from "../gleam.mjs";
+
+export function go(x) {
+  return toBitArray([1]);
+}

--- a/compiler-core/templates/prelude.mjs
+++ b/compiler-core/templates/prelude.mjs
@@ -1277,7 +1277,14 @@ function numberToFp16Uint(value, isBigEndian) {
       fraction = 0;
     }
 
-    fraction = Math.round(fraction * 1024);
+    fraction = roundTiesToEven(fraction * 1024);
+
+    // Rounding can push the fraction up to 1024, which doesn't fit in the bits
+    // it has, so it carries into the exponent.
+    if (fraction === 1024) {
+      fraction = 0;
+      exponent += 1;
+    }
 
     buffer[1] =
       (sign << 7) | ((exponent & 0x1f) << 2) | ((fraction >> 8) & 0x03);
@@ -1291,6 +1298,25 @@ function numberToFp16Uint(value, isBigEndian) {
   }
 
   return buffer;
+}
+
+/**
+ * Rounds to the nearest integer, with a value exactly halfway between two
+ * integers rounding to the even one.
+ *
+ * This is the rounding IEEE 754 specifies. `Math.round` rounds a half towards
+ * positive infinity instead.
+ *
+ * @param {number} value
+ * @returns {number}
+ */
+function roundTiesToEven(value) {
+  const rounded = Math.round(value);
+  if (rounded - value === 0.5 && rounded % 2 !== 0) {
+    return rounded - 1;
+  }
+
+  return rounded;
 }
 
 /**

--- a/test/javascript_prelude/main.mjs
+++ b/test/javascript_prelude/main.mjs
@@ -682,6 +682,21 @@ assertEqual(sizedFloat(NaN, 16, true), new Uint8Array([0x7e, 0x00]));
 assertEqual(sizedFloat(1_000_000.0, 16, true), new Uint8Array([0x7c, 0x00]));
 assertEqual(sizedFloat(-1_000_000.0, 16, true), new Uint8Array([0xfc, 0x00]));
 
+assertEqual(sizedFloat(2047.5, 16, true), new Uint8Array([0x68, 0x00]));
+assertEqual(sizedFloat(2049.0, 16, true), new Uint8Array([0x68, 0x00]));
+assertEqual(sizedFloat(1.00048828125, 16, true), new Uint8Array([0x3c, 0x00]));
+assertEqual(sizedFloat(1.0009765625, 16, true), new Uint8Array([0x3c, 0x01]));
+assertEqual(sizedFloat(3945.0, 16, true), new Uint8Array([0x6b, 0xb4]));
+assertEqual(sizedFloat(65_520.0, 16, true), new Uint8Array([0x7c, 0x00]));
+assertEqual(
+  sizedFloat(2.9802322387695312e-8, 16, true),
+  new Uint8Array([0x00, 0x00]),
+);
+assertEqual(
+  sizedFloat(8.940696716308594e-8, 16, true),
+  new Uint8Array([0x00, 0x02]),
+);
+
 assertEqual(sizedFloat(16.25, 32, true), new Uint8Array([65, 130, 0, 0]));
 assertEqual(sizedFloat(-16.25, 32, false), new Uint8Array([0, 0, 130, 193]));
 assertEqual(

--- a/test/language/test/language/bit_array_test.gleam
+++ b/test/language/test/language/bit_array_test.gleam
@@ -215,3 +215,8 @@ pub fn float_16_subnormal_rounds_ties_to_even_test() {
   assert <<2.9802322387695312e-8:float-16>> == <<0x00, 0x00>>
   assert <<8.940696716308594e-8:float-16>> == <<0x00, 0x02>>
 }
+
+pub fn zero_size_int_segment_test() {
+  assert <<0:size(0), 1:size(8)>> == <<1>>
+  assert bit_array.bit_size(<<0:size(0)>>) == 0
+}

--- a/test/language/test/language/bit_array_test.gleam
+++ b/test/language/test/language/bit_array_test.gleam
@@ -198,3 +198,20 @@ pub fn negative_zero_16_bits_test() {
   let data = <<-0.0:16>>
   assert data == <<0x8000:16>>
 }
+
+pub fn float_16_rounds_ties_to_even_test() {
+  assert <<2047.5:float-16>> == <<0x68, 0x00>>
+  assert <<2049.0:float-16>> == <<0x68, 0x00>>
+  assert <<1.00048828125:float-16>> == <<0x3c, 0x00>>
+  assert <<1.0009765625:float-16>> == <<0x3c, 0x01>>
+}
+
+pub fn float_16_rounding_carries_into_exponent_test() {
+  assert <<3945.0:float-16>> == <<0x6b, 0xb4>>
+  assert <<65_520.0:float-16>> == <<0x7c, 0x00>>
+}
+
+pub fn float_16_subnormal_rounds_ties_to_even_test() {
+  assert <<2.9802322387695312e-8:float-16>> == <<0x00, 0x00>>
+  assert <<8.940696716308594e-8:float-16>> == <<0x00, 0x02>>
+}


### PR DESCRIPTION
I have been writing a test suite that runs random values for bit arrays between Erlang and JS and spots differences in how they handle them. I hope to clean it up and contribute in the near future, but in the meantime, it has found these three bugs in how the JS target handles some bit array operations.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
