### PR TITLE
Migrate from bincode to bitcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
 
 ### Build tool
 
-- Cache size has been significantly reduced.
+- The build tool now stores its build cache in a more compact binary format,
+  making the cache files noticeably smaller.
   ([Andrey Kozhev](httos://github.com/ankddev))
 
 ### Language server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
 
 ### Build tool
 
+- Cache size has been significantly reduced.
+  ([Andrey Kozhev](httos://github.com/ankddev))
+
 ### Language server
 
 - The "Generate dynamic decoder" code action is now only offered when the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "askama"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,23 +327,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
+name = "bitcode"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+checksum = "0a6ed1b54d8dc333e7be604d00fa9262f4635485ffea923647b6521a5fff045d"
 dependencies = [
- "bincode_derive",
+ "arrayvec",
+ "bitcode_derive",
+ "bytemuck",
+ "glam",
  "serde",
- "unty",
 ]
 
 [[package]]
-name = "bincode_derive"
-version = "2.0.1"
+name = "bitcode_derive"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+checksum = "238b90427dfad9da4a9abd60f3ec1cdee6b80454bde49ed37f1781dd8e9dc7f9"
 dependencies = [
- "virtue",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -402,6 +412,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -1196,6 +1212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
+
+[[package]]
 name = "gleam"
 version = "1.18.0"
 dependencies = [
@@ -1265,7 +1287,7 @@ dependencies = [
  "async-trait",
  "base16",
  "bimap",
- "bincode",
+ "bitcode",
  "bitvec",
  "camino",
  "clap",
@@ -4015,12 +4037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,12 +4097,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -24,7 +24,7 @@ dirs-next = "2"
 # SPDX license parsing
 spdx = "0"
 # Binary format de-serialization
-bincode = { version = "2", features = ["alloc", "serde"] }
+bitcode = { version = "0.6", features = ["serde"] }
 # cross platform single glob and glob set matching
 globset = { version = "0", features = ["serde1"] }
 # Checksums

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -824,13 +824,12 @@ pub(crate) struct CacheMetadata {
 
 impl CacheMetadata {
     pub fn to_binary(&self) -> Vec<u8> {
-        bincode::serde::encode_to_vec(self, bincode::config::legacy())
-            .expect("Serializing cache info")
+        bitcode::serialize(self).expect("Serializing cache info")
     }
 
     pub fn from_binary(bytes: &[u8]) -> Result<Self, String> {
-        match bincode::serde::decode_from_slice(bytes, bincode::config::legacy()) {
-            Ok((data, _)) => Ok(data),
+        match bitcode::deserialize(bytes) {
+            Ok(data) => Ok(data),
             Err(e) => Err(e.to_string()),
         }
     }

--- a/compiler-core/src/metadata.rs
+++ b/compiler-core/src/metadata.rs
@@ -22,16 +22,12 @@ use crate::{
     uid::UniqueIdGenerator,
 };
 
-pub fn encode(module: &ModuleInterface) -> Result<Vec<u8>, bincode::error::EncodeError> {
-    bincode::serde::encode_to_vec(module, bincode::config::legacy())
+pub fn encode(module: &ModuleInterface) -> Result<Vec<u8>, bitcode::Error> {
+    bitcode::serialize(module)
 }
 
-pub fn decode(
-    bytes: &[u8],
-    ids: UniqueIdGenerator,
-) -> Result<ModuleInterface, bincode::error::DecodeError> {
-    bincode::serde::decode_from_slice(bytes, bincode::config::legacy())
-        .map(|(module, _)| remap_type_variable_ids(module, ids))
+pub fn decode(bytes: &[u8], ids: UniqueIdGenerator) -> Result<ModuleInterface, bitcode::Error> {
+    bitcode::deserialize(bytes).map(|module| remap_type_variable_ids(module, ids))
 }
 
 fn remap_type_variable_ids(module: ModuleInterface, ids: UniqueIdGenerator) -> ModuleInterface {

--- a/deny.toml
+++ b/deny.toml
@@ -29,18 +29,6 @@ https://github.com/gleam-lang/gleam/issues/5829
 FIX-DEADLINE: 2026-10-08
 """
 
-[[advisories.ignore]]
-id = "RUSTSEC-2025-0141"
-reason = """
-Bincode is currently unmaintained.
-https://rustsec.org/advisories/RUSTSEC-2025-0141.html
-
-We need to migrate to some other package.
-https://github.com/gleam-lang/gleam/issues/5827
-
-FIX-DEADLINE: 2026-10-08
-"""
-
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
 allow = [

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__alias_unqualified_import.snap
@@ -6,7 +6,7 @@ expression: "./cases/alias_unqualified_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<97 byte binary>
+<36 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -27,7 +27,7 @@ id(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<108 byte binary>
+<42 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__empty_module_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__empty_module_warning.snap
@@ -6,7 +6,7 @@ expression: "./cases/empty_module_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<65 byte binary>
+<28 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.erl
 -module(empty).
@@ -18,7 +18,7 @@ expression: "./cases/empty_module_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/internal.cache_meta
-<81 byte binary>
+<32 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/internal.erl
 -module(internal).
@@ -37,7 +37,7 @@ private_function() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/private.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/private.erl
 -module(private).
@@ -49,7 +49,7 @@ private_function() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/public.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/public.erl
 -module(public).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_app_generation"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<69 byte binary>
+<29 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation_with_argument.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_app_generation_with_argument.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_app_generation_with_argument"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<69 byte binary>
+<29 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_bug_752.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_bug_752"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -21,7 +21,7 @@ expression: "./cases/erlang_bug_752"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<104 byte binary>
+<41 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_empty.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_empty"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<69 byte binary>
+<29 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.erl
 -module(empty).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_escape_names.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_escape_names"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<81 byte binary>
+<32 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -24,7 +24,7 @@ expression: "./cases/erlang_escape_names"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<156 byte binary>
+<76 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<108 byte binary>
+<42 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -25,7 +25,7 @@ unbox(X) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_import_shadowing_prelude.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_import_shadowing_prelude"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<81 byte binary>
+<32 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -21,7 +21,7 @@ expression: "./cases/erlang_import_shadowing_prelude"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<108 byte binary>
+<42 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_nested"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__erlang_nested_qualified_constant.snap
@@ -6,7 +6,7 @@ expression: "./cases/erlang_nested_qualified_constant"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
@@ -21,7 +21,7 @@ expression: "./cases/erlang_nested_qualified_constant"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<120 byte binary>
+<62 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__hello_joe.snap
@@ -6,7 +6,7 @@ expression: "./cases/hello_joe"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello_joe.erl
 -module(hello_joe).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__import_shadowed_name_warning.snap
@@ -6,7 +6,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -21,7 +21,7 @@ expression: "./cases/import_shadowed_name_warning"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<140 byte binary>
+<70 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_constants.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<109 byte binary>
+<39 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -25,7 +25,7 @@ expression: "./cases/imported_constants"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<344 byte binary>
+<170 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_external_fns.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_external_fns"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.cache_meta
-<89 byte binary>
+<44 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one.erl
 -module(one).
@@ -29,7 +29,7 @@ escaped_thing() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/three.cache_meta
-<89 byte binary>
+<44 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/three.erl
 -module(three).
@@ -52,7 +52,7 @@ escaped_thing() ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<501 byte binary>
+<246 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__imported_record_constructors.snap
@@ -6,7 +6,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.cache_meta
-<109 byte binary>
+<39 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@one.erl
 -module(one@one).
@@ -25,7 +25,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<109 byte binary>
+<39 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.erl
 -module(one@two).
@@ -44,7 +44,7 @@ expression: "./cases/imported_record_constructors"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<511 byte binary>
+<254 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.erl
 -module(two).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_d_ts.snap
@@ -6,7 +6,7 @@ expression: "./cases/javascript_d_ts"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello.cache_meta
-<93 byte binary>
+<35 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
 export * from "../prelude.mjs";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_empty.snap
@@ -6,7 +6,7 @@ expression: "./cases/javascript_empty"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/empty.cache_meta
-<69 byte binary>
+<29 byte binary>
 
 //// /out/lib/the_package/empty.mjs
 export {}

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_import.snap
@@ -6,13 +6,13 @@ expression: "./cases/javascript_import"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/one@two.cache_meta
-<77 byte binary>
+<31 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/two.cache_meta
-<100 byte binary>
+<43 byte binary>
 
 //// /out/lib/the_package/gleam.d.mts
 export * from "../prelude.mjs";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_sourcemaps.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__javascript_sourcemaps.snap
@@ -6,7 +6,7 @@ expression: "./cases/javascript_sourcemaps"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/hello.cache_meta
-<93 byte binary>
+<35 byte binary>
 
 //// /out/lib/the_package/gleam.mjs
 export * from "../prelude.mjs";

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__not_overwriting_erlang_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__not_overwriting_erlang_module.snap
@@ -6,7 +6,7 @@ expression: "./cases/not_overwriting_erlang_module"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/app@code.cache_meta
-<85 byte binary>
+<42 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/app@code.erl
 -module(app@code).

--- a/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
+++ b/test-package-compiler/src/snapshots/test_package_compiler__generated_tests__variable_or_module.snap
@@ -6,7 +6,7 @@ expression: "./cases/variable_or_module"
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.cache_meta
-<138 byte binary>
+<68 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/main.erl
 -module(main).
@@ -29,7 +29,7 @@ record_field(Power) ->
 <.cache binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.cache_meta
-<97 byte binary>
+<36 byte binary>
 
 //// /out/lib/the_package/_gleam_artefacts/power.erl
 -module(power).


### PR DESCRIPTION
* Closes https://github.com/gleam-lang/gleam/issues/5827
* Note that it requires `gleam clean` if you have build cache with `bincode` build.
* I think that `bitcode` works fine here, and migration was so easy
* After local tests everything seems to work 
***
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked