### PR TITLE
fix: do not suggest wrapping in Ok()/Error() when expected type is unbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,7 +223,7 @@
   ([Andrey Kozhev](https://github.com/ankddev))
 
 - The language server now supports go-to-definition, find-references and
-  renaming for function argument labels.  
+  renaming for function argument labels.
   ([Alistair Smith](https://github.com/alii))
 
 ### Formatter
@@ -235,7 +235,6 @@
   ([John Downey](https://github.com/jtdowney))
 
 ### Bug fixes
-
 - Fixed a bug where on the JavaScript target a case clause whose guard's top
   level operator was `||` could run for a subject its pattern did not match.
   ([John Downey](https://github.com/jtdowney))
@@ -320,9 +319,15 @@
   ([Lillian Rose](https://github.com/lillianrubyrose) with
   [Mar Bloeiman](https://github.com/strawmelonjuice))
 
+- Fixed a bug where the compiler would suggest wrapping a mismatched type in
+  `Ok()` even when doing so would not fix the type unification error.
+  ([Hari Mohan](https://github.com/seafoamteal))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when
   referencing constants that are aliases to other constants in bit array
   segments, string concatenation and clause guards.
   ([Andrey Kozhev](https://github.com/ankddev))
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@
   ([John Downey](https://github.com/jtdowney))
 
 ### Bug fixes
+
 - Fixed a bug where on the JavaScript target a case clause whose guard's top
   level operator was `||` could run for a subject its pattern did not match.
   ([John Downey](https://github.com/jtdowney))
@@ -329,5 +330,3 @@
   referencing constants that are aliases to other constants in bit array
   segments, string concatenation and clause guards.
   ([Andrey Kozhev](https://github.com/ankddev))
-
-

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -5406,9 +5406,12 @@ fn hint_wrap_value_in_result(expected: &Arc<Type>, given: &Arc<Type>) -> Option<
     let expected = collapse_links(expected.clone());
     let (expected_ok_type, expected_error_type) = expected.result_types()?;
 
-    if given.same_as(expected_ok_type.as_ref()) {
+    // Unbound type variables are trivially matched by `same_as` to any other type,
+    // leading to confusing hints. Any `given` type could match one of the `expected`
+    // type variables, leading to false positives for the wrap hint.
+    if !expected_ok_type.is_unbound() && given.same_as(expected_ok_type.as_ref()) {
         Some("Did you mean to wrap this in an `Ok`?".into())
-    } else if given.same_as(expected_error_type.as_ref()) {
+    } else if !expected_error_type.is_unbound() && given.same_as(expected_error_type.as_ref()) {
         Some("Did you mean to wrap this in an `Error`?".into())
     } else {
         None

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2897,35 +2897,25 @@ pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
 fn do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound() {
     assert_module_error!(
         "
-pub fn try(
-  result: Result(a, e),
-  apply fun: fn(a) -> Result(b, e),
-) -> Result(b, e) {
-    todo
-}
-
-pub type WibbleError {
+pub type SomeError {
   WibbleError
 }
 
-pub type WobbleError {
+pub type OtherError {
   WobbleError
 }
 
 pub fn main() {
-  use _ <- try(wibble())
-  use _ <- try(wobble())
+  wibble(wobble(todo))
+}
+
+pub fn wobble(arg: a) -> Result(a, SomeError) {
   todo
 }
 
-pub fn wibble() -> Result(Int, WibbleError) {
+pub fn wibble(arg: Result(a, OtherError)) -> a {
   todo
-}
-
-pub fn wobble() -> Result(Int, WobbleError) {
-  todo
-}
-"
+}"
     );
 }
 
@@ -2933,33 +2923,23 @@ pub fn wobble() -> Result(Int, WobbleError) {
 fn do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound() {
     assert_module_error!(
         "
-
-pub fn try_recover(
-  result: Result(a, e),
-  with fun: fn(e) -> Result(a, f),
-) -> Result(a, f) {
-    todo
-}
-
-pub type WibbleError {
+pub type SomeError {
   WibbleError
 }
 
-pub type WobbleError {
+pub type OtherError {
   WobbleError
 }
 
 pub fn main() {
-  use _ <- try_recover(wibble())
-  use _ <- try_recover(wobble())
+  wibble(wobble(todo))
+}
+
+pub fn wobble(arg: a) -> Result(Int, a) {
   todo
 }
 
-pub fn wibble() -> Result(Int, WibbleError) {
-  todo
-}
-
-pub fn wobble() -> Result(Float, WibbleError) {
+pub fn wibble(arg: Result(Float, a)) -> a {
   todo
 }
 "

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2894,6 +2894,79 @@ pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
 }
 
 #[test]
+fn do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound() {
+    assert_module_error!(
+        "
+pub fn try(
+  result: Result(a, e),
+  apply fun: fn(a) -> Result(b, e),
+) -> Result(b, e) {
+    todo
+}
+
+pub type WibbleError {
+  WibbleError
+}
+
+pub type WobbleError {
+  WobbleError
+}
+
+pub fn main() {
+  use _ <- try(wibble())
+  use _ <- try(wobble())
+  todo
+}
+
+pub fn wibble() -> Result(Int, WibbleError) {
+  todo
+}
+
+pub fn wobble() -> Result(Int, WobbleError) {
+  todo
+}
+"
+    );
+}
+
+#[test]
+fn do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound() {
+    assert_module_error!(
+        "
+
+pub fn try_recover(
+  result: Result(a, e),
+  with fun: fn(e) -> Result(a, f),
+) -> Result(a, f) {
+    todo
+}
+
+pub type WibbleError {
+  WibbleError
+}
+
+pub type WobbleError {
+  WobbleError
+}
+
+pub fn main() {
+  use _ <- try_recover(wibble())
+  use _ <- try_recover(wobble())
+  todo
+}
+
+pub fn wibble() -> Result(Int, WibbleError) {
+  todo
+}
+
+pub fn wobble() -> Result(Float, WibbleError) {
+  todo
+}
+"
+    );
+}
+
+#[test]
 // https://github.com/gleam-lang/gleam/issues/4195
 fn let_assert_binding_cannot_be_used_in_panic_message() {
     assert_module_error!(

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2893,44 +2893,30 @@ pub fn want_result(wibble: fn() -> Result(Int, Bool)) {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5914
 #[test]
 fn do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound() {
     assert_module_error!(
         "
-pub type SomeError {
-  WibbleError
-}
-
-pub type OtherError {
-  WobbleError
-}
-
 pub fn main() {
   wibble(wobble(todo))
 }
 
-pub fn wobble(arg: a) -> Result(a, SomeError) {
+pub fn wobble(arg: a) -> Result(a, String) {
   todo
 }
 
-pub fn wibble(arg: Result(a, OtherError)) -> a {
+pub fn wibble(arg: Result(a, Int)) -> a {
   todo
 }"
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/5914
 #[test]
 fn do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound() {
     assert_module_error!(
         "
-pub type SomeError {
-  WibbleError
-}
-
-pub type OtherError {
-  WobbleError
-}
-
 pub fn main() {
   wibble(wobble(todo))
 }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound.snap
@@ -1,51 +1,41 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\n\npub fn try_recover(\n  result: Result(a, e),\n  with fun: fn(e) -> Result(a, f),\n) -> Result(a, f) {\n    todo\n}\n\npub type WibbleError {\n  WibbleError\n}\n\npub type WobbleError {\n  WobbleError\n}\n\npub fn main() {\n  use _ <- try_recover(wibble())\n  use _ <- try_recover(wobble())\n  todo\n}\n\npub fn wibble() -> Result(Int, WibbleError) {\n  todo\n}\n\npub fn wobble() -> Result(Float, WibbleError) {\n  todo\n}\n"
+expression: "\npub type SomeError {\n  WibbleError\n}\n\npub type OtherError {\n  WobbleError\n}\n\npub fn main() {\n  wibble(wobble(todo))\n}\n\npub fn wobble(arg: a) -> Result(Int, a) {\n  todo\n}\n\npub fn wibble(arg: Result(Float, a)) -> a {\n  todo\n}\n"
 ---
 ----- SOURCE CODE
 
-
-pub fn try_recover(
-  result: Result(a, e),
-  with fun: fn(e) -> Result(a, f),
-) -> Result(a, f) {
-    todo
-}
-
-pub type WibbleError {
+pub type SomeError {
   WibbleError
 }
 
-pub type WobbleError {
+pub type OtherError {
   WobbleError
 }
 
 pub fn main() {
-  use _ <- try_recover(wibble())
-  use _ <- try_recover(wobble())
+  wibble(wobble(todo))
+}
+
+pub fn wobble(arg: a) -> Result(Int, a) {
   todo
 }
 
-pub fn wibble() -> Result(Int, WibbleError) {
-  todo
-}
-
-pub fn wobble() -> Result(Float, WibbleError) {
+pub fn wibble(arg: Result(Float, a)) -> a {
   todo
 }
 
 
 ----- ERROR
 error: Type mismatch
-   ┌─ /src/one/two.gleam:20:3
+   ┌─ /src/one/two.gleam:11:10
    │
-20 │   use _ <- try_recover(wobble())
-   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 │   wibble(wobble(todo))
+   │          ^^^^^^^^^^^^
 
 Expected type:
 
-    Result(Int, f)
+    Result(Float, a)
 
 Found type:
 
-    Result(Float, f)
+    Result(Int, a)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound.snap
@@ -1,0 +1,51 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n\npub fn try_recover(\n  result: Result(a, e),\n  with fun: fn(e) -> Result(a, f),\n) -> Result(a, f) {\n    todo\n}\n\npub type WibbleError {\n  WibbleError\n}\n\npub type WobbleError {\n  WobbleError\n}\n\npub fn main() {\n  use _ <- try_recover(wibble())\n  use _ <- try_recover(wobble())\n  todo\n}\n\npub fn wibble() -> Result(Int, WibbleError) {\n  todo\n}\n\npub fn wobble() -> Result(Float, WibbleError) {\n  todo\n}\n"
+---
+----- SOURCE CODE
+
+
+pub fn try_recover(
+  result: Result(a, e),
+  with fun: fn(e) -> Result(a, f),
+) -> Result(a, f) {
+    todo
+}
+
+pub type WibbleError {
+  WibbleError
+}
+
+pub type WobbleError {
+  WobbleError
+}
+
+pub fn main() {
+  use _ <- try_recover(wibble())
+  use _ <- try_recover(wobble())
+  todo
+}
+
+pub fn wibble() -> Result(Int, WibbleError) {
+  todo
+}
+
+pub fn wobble() -> Result(Float, WibbleError) {
+  todo
+}
+
+
+----- ERROR
+error: Type mismatch
+   ┌─ /src/one/two.gleam:20:3
+   │
+20 │   use _ <- try_recover(wobble())
+   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Expected type:
+
+    Result(Int, f)
+
+Found type:
+
+    Result(Float, f)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_error_if_expected_error_type_is_unbound.snap
@@ -1,16 +1,8 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\npub type SomeError {\n  WibbleError\n}\n\npub type OtherError {\n  WobbleError\n}\n\npub fn main() {\n  wibble(wobble(todo))\n}\n\npub fn wobble(arg: a) -> Result(Int, a) {\n  todo\n}\n\npub fn wibble(arg: Result(Float, a)) -> a {\n  todo\n}\n"
+expression: "\npub fn main() {\n  wibble(wobble(todo))\n}\n\npub fn wobble(arg: a) -> Result(Int, a) {\n  todo\n}\n\npub fn wibble(arg: Result(Float, a)) -> a {\n  todo\n}\n"
 ---
 ----- SOURCE CODE
-
-pub type SomeError {
-  WibbleError
-}
-
-pub type OtherError {
-  WobbleError
-}
 
 pub fn main() {
   wibble(wobble(todo))
@@ -27,10 +19,10 @@ pub fn wibble(arg: Result(Float, a)) -> a {
 
 ----- ERROR
 error: Type mismatch
-   ┌─ /src/one/two.gleam:11:10
-   │
-11 │   wibble(wobble(todo))
-   │          ^^^^^^^^^^^^
+  ┌─ /src/one/two.gleam:3:10
+  │
+3 │   wibble(wobble(todo))
+  │          ^^^^^^^^^^^^
 
 Expected type:
 

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound.snap
@@ -1,40 +1,32 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\npub type SomeError {\n  WibbleError\n}\n\npub type OtherError {\n  WobbleError\n}\n\npub fn main() {\n  wibble(wobble(todo))\n}\n\npub fn wobble(arg: a) -> Result(a, SomeError) {\n  todo\n}\n\npub fn wibble(arg: Result(a, OtherError)) -> a {\n  todo\n}"
+expression: "\npub fn main() {\n  wibble(wobble(todo))\n}\n\npub fn wobble(arg: a) -> Result(a, String) {\n  todo\n}\n\npub fn wibble(arg: Result(a, Int)) -> a {\n  todo\n}"
 ---
 ----- SOURCE CODE
-
-pub type SomeError {
-  WibbleError
-}
-
-pub type OtherError {
-  WobbleError
-}
 
 pub fn main() {
   wibble(wobble(todo))
 }
 
-pub fn wobble(arg: a) -> Result(a, SomeError) {
+pub fn wobble(arg: a) -> Result(a, String) {
   todo
 }
 
-pub fn wibble(arg: Result(a, OtherError)) -> a {
+pub fn wibble(arg: Result(a, Int)) -> a {
   todo
 }
 
 ----- ERROR
 error: Type mismatch
-   ┌─ /src/one/two.gleam:11:10
-   │
-11 │   wibble(wobble(todo))
-   │          ^^^^^^^^^^^^
+  ┌─ /src/one/two.gleam:3:10
+  │
+3 │   wibble(wobble(todo))
+  │          ^^^^^^^^^^^^
 
 Expected type:
 
-    Result(a, OtherError)
+    Result(a, Int)
 
 Found type:
 
-    Result(a, SomeError)
+    Result(a, String)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound.snap
@@ -1,0 +1,50 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\npub fn try(\n  result: Result(a, e),\n  apply fun: fn(a) -> Result(b, e),\n) -> Result(b, e) {\n    todo\n}\n\npub type WibbleError {\n  WibbleError\n}\n\npub type WobbleError {\n  WobbleError\n}\n\npub fn main() {\n  use _ <- try(wibble())\n  use _ <- try(wobble())\n  todo\n}\n\npub fn wibble() -> Result(Int, WibbleError) {\n  todo\n}\n\npub fn wobble() -> Result(Int, WobbleError) {\n  todo\n}\n"
+---
+----- SOURCE CODE
+
+pub fn try(
+  result: Result(a, e),
+  apply fun: fn(a) -> Result(b, e),
+) -> Result(b, e) {
+    todo
+}
+
+pub type WibbleError {
+  WibbleError
+}
+
+pub type WobbleError {
+  WobbleError
+}
+
+pub fn main() {
+  use _ <- try(wibble())
+  use _ <- try(wobble())
+  todo
+}
+
+pub fn wibble() -> Result(Int, WibbleError) {
+  todo
+}
+
+pub fn wobble() -> Result(Int, WobbleError) {
+  todo
+}
+
+
+----- ERROR
+error: Type mismatch
+   ┌─ /src/one/two.gleam:19:3
+   │
+19 │   use _ <- try(wobble())
+   │   ^^^^^^^^^^^^^^^^^^^^^^
+
+Expected type:
+
+    Result(b, WibbleError)
+
+Found type:
+
+    Result(b, WobbleError)

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__do_not_suggest_wrapping_in_ok_if_expected_ok_type_is_unbound.snap
@@ -1,50 +1,40 @@
 ---
 source: compiler-core/src/type_/tests/errors.rs
-expression: "\npub fn try(\n  result: Result(a, e),\n  apply fun: fn(a) -> Result(b, e),\n) -> Result(b, e) {\n    todo\n}\n\npub type WibbleError {\n  WibbleError\n}\n\npub type WobbleError {\n  WobbleError\n}\n\npub fn main() {\n  use _ <- try(wibble())\n  use _ <- try(wobble())\n  todo\n}\n\npub fn wibble() -> Result(Int, WibbleError) {\n  todo\n}\n\npub fn wobble() -> Result(Int, WobbleError) {\n  todo\n}\n"
+expression: "\npub type SomeError {\n  WibbleError\n}\n\npub type OtherError {\n  WobbleError\n}\n\npub fn main() {\n  wibble(wobble(todo))\n}\n\npub fn wobble(arg: a) -> Result(a, SomeError) {\n  todo\n}\n\npub fn wibble(arg: Result(a, OtherError)) -> a {\n  todo\n}"
 ---
 ----- SOURCE CODE
 
-pub fn try(
-  result: Result(a, e),
-  apply fun: fn(a) -> Result(b, e),
-) -> Result(b, e) {
-    todo
-}
-
-pub type WibbleError {
+pub type SomeError {
   WibbleError
 }
 
-pub type WobbleError {
+pub type OtherError {
   WobbleError
 }
 
 pub fn main() {
-  use _ <- try(wibble())
-  use _ <- try(wobble())
+  wibble(wobble(todo))
+}
+
+pub fn wobble(arg: a) -> Result(a, SomeError) {
   todo
 }
 
-pub fn wibble() -> Result(Int, WibbleError) {
+pub fn wibble(arg: Result(a, OtherError)) -> a {
   todo
 }
-
-pub fn wobble() -> Result(Int, WobbleError) {
-  todo
-}
-
 
 ----- ERROR
 error: Type mismatch
-   ┌─ /src/one/two.gleam:19:3
+   ┌─ /src/one/two.gleam:11:10
    │
-19 │   use _ <- try(wobble())
-   │   ^^^^^^^^^^^^^^^^^^^^^^
+11 │   wibble(wobble(todo))
+   │          ^^^^^^^^^^^^
 
 Expected type:
 
-    Result(b, WibbleError)
+    Result(a, OtherError)
 
 Found type:
 
-    Result(b, WobbleError)
+    Result(a, SomeError)


### PR DESCRIPTION
Fixes #5914.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
