### PR TITLE
`Convert to documentation comment` code action is not offered if there are newlines between comment and definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 # Changelog
 
+## Unreleased
+
+### Language Server
+
+- The "Convert to documentation comment" code action now will not trigger if
+  there is a newline between the comment and definition.
+  ([Daniel Venable](https://github.com/DanielVenable))
+
 ## v1.18.0 - 2026-07-29
 
 ### Bug fixes

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -13089,33 +13089,37 @@ impl<'a> ConvertBetweenDocAndRegularComment<'a> {
 
     /// Check if the comment is before a node that can have a doc comment, e.g. a function.
     fn can_have_doc_comment(&self, end_line: u32) -> bool {
-        let Some(position) = self.line_start(end_line + 1) else {
+        let Some(mut position) = self.line_start(end_line + 1) else {
             return false;
         };
 
-        let next_node = next_nonwhitespace(&self.module.code, position);
+        let mut chars = self.module.code[position as usize..].chars();
+        while chars.next().is_some_and(|c| c.is_whitespace() && c != '\n') {
+            position += 1;
+        }
+
         let definitions = &self.module.ast.definitions;
         definitions
             .functions
             .iter()
-            .any(|function| function.location.contains(next_node))
+            .any(|function| function.location.contains(position))
             || definitions
                 .constants
                 .iter()
-                .any(|constant| constant.location.contains(next_node))
+                .any(|constant| constant.location.contains(position))
             || definitions
                 .type_aliases
                 .iter()
-                .any(|type_alias| type_alias.location.contains(next_node))
+                .any(|type_alias| type_alias.location.contains(position))
             || definitions.custom_types.iter().any(|custom_type| {
-                custom_type.location.contains(next_node)
+                custom_type.location.contains(position)
                     || custom_type.constructors.iter().any(|constructor| {
-                        constructor.location.contains(next_node)
+                        constructor.location.contains(position)
                             || constructor.arguments.iter().any(|argument| {
                                 argument
                                     .label
                                     .as_ref()
-                                    .is_some_and(|label| label.0.contains(next_node))
+                                    .is_some_and(|label| label.0.contains(position))
                             })
                     })
             })

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -15515,6 +15515,20 @@ fn convert_to_doc_comment_on_record_label_definition() {
 }
 
 #[test]
+fn no_convert_to_doc_comment_when_newlines_between_it_and_definition() {
+    assert_no_code_actions!(
+        CONVERT_TO_DOCUMENTATION_COMMENT,
+        "import wibble
+// wobble
+
+fn wubble() {
+    todo
+}",
+        find_position_of("wobble").to_selection()
+    );
+}
+
+#[test]
 fn no_convert_to_doc_comment_triggered_on_doc_comment() {
     assert_no_code_actions!(
         CONVERT_TO_DOCUMENTATION_COMMENT,


### PR DESCRIPTION
Fixes [https://github.com/gleam-lang/gleam/issues/6052](https://github.com/gleam-lang/gleam/issues/6052)
